### PR TITLE
Implement Enlist keyword (CR 702.154)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -230,6 +230,9 @@ impl KeywordTriggerInstaller {
             // CR 702.39a: Provoke — attacks trigger that may untap a creature the
             // defending player controls and force it to block this attacker.
             Keyword::Provoke => vec![build_provoke_trigger()],
+            // CR 702.154a: Enlist — optional attacks trigger that taps an
+            // untapped creature you control and pumps the attacker by its power.
+            Keyword::Enlist => vec![build_enlist_trigger()],
             Keyword::Renown(n) => vec![build_renown_trigger(*n)],
             Keyword::Mentor => vec![build_mentor_trigger()],
             // CR 702.58a + CR 604.1: granted Graft installs only the
@@ -341,6 +344,7 @@ impl KeywordTriggerInstaller {
             Keyword::Soulshift(n) => is_soulshift_trigger_for_value(trigger, *n),
             Keyword::Annihilator(_) => is_annihilator_attack_trigger(trigger),
             Keyword::Provoke => is_provoke_attack_trigger(trigger),
+            Keyword::Enlist => is_enlist_trigger(trigger),
             Keyword::Renown(_) => is_renown_trigger(trigger),
             Keyword::Mentor => is_mentor_trigger(trigger),
             // CR 702.58a + CR 604.1: symmetric removal — `RemoveKeyword`
@@ -3763,6 +3767,14 @@ pub fn synthesize_melee(face: &mut CardFace) {
     KeywordTriggerInstaller::install_matching(face, |kw| matches!(kw, Keyword::Melee));
 }
 
+/// CR 702.154a: Enlist — install the optional attacks trigger that taps an
+/// untapped creature you control and pumps this creature by that creature's
+/// power. CR 702.154 is a single static+triggered ability; one trigger is
+/// synthesized per `Keyword::Enlist`.
+pub fn synthesize_enlist(face: &mut CardFace) {
+    KeywordTriggerInstaller::install_matching(face, |kw| matches!(kw, Keyword::Enlist));
+}
+
 /// CR 702.101a: Extort — a spell-cast trigger that lets you pay {W/B} to drain
 /// each opponent for 1 life. CR 702.101b: each instance triggers separately,
 /// so one trigger is synthesized per `Keyword::Extort` instance.
@@ -4307,6 +4319,94 @@ fn is_provoke_attack_trigger(t: &TriggerDefinition) -> bool {
             target: TargetFilter::ParentTarget,
         })
     )
+}
+
+/// CR 702.154a: Enlist — "As this creature attacks, you may tap up to one
+/// untapped creature you control that you didn't choose to attack with and that
+/// either has haste or has been under your control continuously since this turn
+/// began. When you do, this creature gets +X/+0 until end of turn, where X is the
+/// tapped creature's power."
+///
+/// Synthesized as an optional `Attacks` trigger (the Provoke shape): the optional
+/// parent body taps an eligible creature; the reflexive sub-ability pumps the
+/// attacker (`SelfRef`) by that creature's power, read anaphorically — the
+/// just-tapped permanent is captured as the resolution's "that creature" referent
+/// (CR 608.2c) and reached via `QuantityRef::Power { scope: Anaphoric }`.
+///
+/// Eligibility note: the tap filter is "another untapped creature you control."
+/// CR 702.154a's "didn't choose to attack with" is largely covered (attackers tap
+/// unless they have vigilance), but the "haste or controlled since the turn began"
+/// (summoning-sickness) refinement is not yet expressible as a `FilterProp`; it is
+/// left as a follow-up tightening rather than blocking the core mechanic.
+fn build_enlist_trigger() -> TriggerDefinition {
+    // CR 702.154a: "up to one untapped creature you control."
+    let tap_target = TargetFilter::Typed(
+        TypedFilter::creature()
+            .controller(ControllerRef::You)
+            .properties(vec![FilterProp::Untapped]),
+    );
+
+    // CR 702.154a: "this creature gets +X/+0 until end of turn, where X is the
+    // tapped creature's power." `Power { scope: Anaphoric }` reads the
+    // just-tapped creature (the chain's `effect_context_object` referent).
+    let pump = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Pump {
+            power: PtValue::Quantity(QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::Anaphoric,
+                },
+            }),
+            toughness: PtValue::Fixed(0),
+            target: TargetFilter::SelfRef,
+        },
+    )
+    .description(
+        "CR 702.154a: Enlist — this creature gets +X/+0 until end of turn, where X \
+         is the tapped creature's power"
+            .to_string(),
+    );
+
+    // CR 702.154a: "you may tap … when you do, [pump]." The optional parent taps
+    // the eligible creature; the reflexive pump rides as its sub-ability.
+    let execute = AbilityDefinition::new(AbilityKind::Spell, Effect::Tap { target: tap_target })
+        .optional()
+        .sub_ability(pump)
+        .description(
+            "Enlist — you may tap an untapped creature you control; if you do, this \
+             creature gets +X/+0 where X is that creature's power"
+                .to_string(),
+        );
+
+    TriggerDefinition::new(TriggerMode::Attacks)
+        .valid_card(TargetFilter::SelfRef)
+        .execute(execute)
+        .description(
+            "CR 702.154a: Enlist — as this creature attacks, you may tap an untapped \
+             creature you control; this creature gets +X/+0 until end of turn, where X \
+             is the tapped creature's power."
+                .to_string(),
+        )
+}
+
+/// CR 702.154a: Identity predicate for a synthesized Enlist trigger — an optional
+/// `Attacks` self-trigger whose body taps a creature and whose reflexive
+/// sub-ability is a `Pump`. Used for idempotent synthesis / symmetric removal.
+fn is_enlist_trigger(t: &TriggerDefinition) -> bool {
+    if !matches!(t.mode, TriggerMode::Attacks)
+        || !matches!(t.valid_card, Some(TargetFilter::SelfRef))
+    {
+        return false;
+    }
+    let Some(execute) = t.execute.as_deref() else {
+        return false;
+    };
+    execute.optional
+        && matches!(&*execute.effect, Effect::Tap { .. })
+        && execute
+            .sub_ability
+            .as_deref()
+            .is_some_and(|sub| matches!(&*sub.effect, Effect::Pump { .. }))
 }
 
 /// CR 702.39a: Provoke — "Whenever this creature attacks, you may have target
@@ -7880,6 +7980,9 @@ pub fn synthesize_all(face: &mut CardFace) {
     // CR 702.121a: Melee — attack-trigger self pump +1/+1 per opponent attacked
     // this combat.
     synthesize_melee(face);
+    // CR 702.154a: Enlist — optional attacks trigger that taps a creature you
+    // control and pumps this creature by that creature's power.
+    synthesize_enlist(face);
     // CR 702.95a: Soulbond — two optional ETB triggers that create pair
     // relationships under the resolution checks in CR 702.95c-d.
     synthesize_soulbond(face);
@@ -11558,6 +11661,129 @@ mod provoke_synthesis_tests {
         assert!(!KeywordTriggerInstaller::trigger_matches_keyword_kind(
             &triggers[0],
             &Keyword::Mentor
+        ));
+    }
+
+    fn enlist_face() -> CardFace {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Enlist);
+        face
+    }
+
+    /// CR 702.154a: synthesizer emits an optional `Attacks` trigger whose body
+    /// taps an untapped creature you control, with a reflexive `Pump` of the
+    /// attacker (`SelfRef`) by `Power { Anaphoric }` (the tapped creature).
+    #[test]
+    fn synthesize_enlist_adds_optional_tap_and_anaphoric_pump_attack_trigger() {
+        let mut face = enlist_face();
+        synthesize_enlist(&mut face);
+
+        let trigger = face
+            .triggers
+            .iter()
+            .find(|t| matches!(t.mode, TriggerMode::Attacks))
+            .expect("enlist should add an Attacks trigger");
+        assert!(
+            matches!(trigger.valid_card, Some(TargetFilter::SelfRef)),
+            "valid_card must be SelfRef (only when the enlisting creature attacks)"
+        );
+
+        let execute = trigger.execute.as_deref().expect("execute body required");
+        // CR 702.154a: "you may tap …" — optional.
+        assert!(
+            execute.optional,
+            "Enlist is a 'you may' trigger (CR 702.154a)"
+        );
+
+        // Parent body taps an untapped creature you control.
+        let Effect::Tap {
+            target: TargetFilter::Typed(tf),
+        } = &*execute.effect
+        else {
+            panic!("execute body must be Effect::Tap over a TypedFilter");
+        };
+        assert_eq!(
+            tf.controller,
+            Some(ControllerRef::You),
+            "tap target must be a creature you control (CR 702.154a)"
+        );
+        assert!(
+            tf.properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::Untapped)),
+            "tap target must be untapped (CR 702.154a), got {:?}",
+            tf.properties
+        );
+
+        // Reflexive sub-ability: pump SelfRef by Power{Anaphoric} (the tapped
+        // creature's power, CR 608.2c).
+        let pump = execute
+            .sub_ability
+            .as_deref()
+            .expect("pump sub-ability required");
+        let Effect::Pump {
+            power,
+            toughness,
+            target,
+        } = &*pump.effect
+        else {
+            panic!("sub-ability must be Effect::Pump, got {:?}", pump.effect);
+        };
+        assert!(
+            matches!(target, TargetFilter::SelfRef),
+            "pump must affect the attacker"
+        );
+        assert!(
+            matches!(
+                power,
+                PtValue::Quantity(QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::Anaphoric
+                    }
+                })
+            ),
+            "X must be the tapped creature's power via Power{{Anaphoric}}, got {power:?}"
+        );
+        assert!(
+            matches!(toughness, PtValue::Fixed(0)),
+            "toughness bonus must be +0 (CR 702.154a: +X/+0)"
+        );
+    }
+
+    #[test]
+    fn synthesize_enlist_is_idempotent() {
+        let mut face = enlist_face();
+        synthesize_enlist(&mut face);
+        synthesize_enlist(&mut face);
+        assert_eq!(
+            face.triggers
+                .iter()
+                .filter(|t| is_enlist_trigger(t))
+                .count(),
+            1,
+            "enlist trigger should be deduped"
+        );
+    }
+
+    #[test]
+    fn synthesize_enlist_is_noop_without_keyword() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Flying);
+        synthesize_enlist(&mut face);
+        assert!(face.triggers.is_empty());
+    }
+
+    #[test]
+    fn enlist_triggers_for_and_matcher_roundtrip() {
+        let triggers = KeywordTriggerInstaller::triggers_for(&Keyword::Enlist);
+        assert_eq!(triggers.len(), 1, "Enlist installs exactly one trigger");
+        assert!(
+            KeywordTriggerInstaller::trigger_matches_keyword_kind(&triggers[0], &Keyword::Enlist),
+            "matcher must recognize the synthesized Enlist trigger"
+        );
+        assert!(!KeywordTriggerInstaller::trigger_matches_keyword_kind(
+            &triggers[0],
+            &Keyword::Provoke
         ));
     }
 

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -4333,18 +4333,8 @@ fn is_provoke_attack_trigger(t: &TriggerDefinition) -> bool {
 /// just-tapped permanent is captured as the resolution's "that creature" referent
 /// (CR 608.2c) and reached via `QuantityRef::Power { scope: Anaphoric }`.
 ///
-/// Eligibility note: the tap filter is "another untapped creature you control."
-/// CR 702.154a's "didn't choose to attack with" is largely covered (attackers tap
-/// unless they have vigilance), but the "haste or controlled since the turn began"
-/// (summoning-sickness) refinement is not yet expressible as a `FilterProp`; it is
-/// left as a follow-up tightening rather than blocking the core mechanic.
 fn build_enlist_trigger() -> TriggerDefinition {
-    // CR 702.154a: "up to one untapped creature you control."
-    let tap_target = TargetFilter::Typed(
-        TypedFilter::creature()
-            .controller(ControllerRef::You)
-            .properties(vec![FilterProp::Untapped]),
-    );
+    let tap_target = enlist_tap_target_filter();
 
     // CR 702.154a: "this creature gets +X/+0 until end of turn, where X is the
     // tapped creature's power." `Power { scope: Anaphoric }` reads the
@@ -4387,6 +4377,30 @@ fn build_enlist_trigger() -> TriggerDefinition {
              is the tapped creature's power."
                 .to_string(),
         )
+}
+
+fn enlist_tap_target_filter() -> TargetFilter {
+    // CR 702.154a-c: the enlisted creature must be another untapped creature you
+    // control, must not be a creature you chose to attack with, and must either
+    // have haste or have been controlled continuously since turn began.
+    TargetFilter::And {
+        filters: vec![
+            TargetFilter::Typed(
+                TypedFilter::creature()
+                    .controller(ControllerRef::You)
+                    .properties(vec![
+                        FilterProp::Another,
+                        FilterProp::Untapped,
+                        FilterProp::HasHasteOrControlledSinceTurnBegan,
+                    ]),
+            ),
+            TargetFilter::Not {
+                filter: Box::new(TargetFilter::Typed(
+                    TypedFilter::creature().properties(vec![FilterProp::Attacking]),
+                )),
+            },
+        ],
+    }
 }
 
 /// CR 702.154a: Identity predicate for a synthesized Enlist trigger — an optional
@@ -11695,23 +11709,54 @@ mod provoke_synthesis_tests {
             "Enlist is a 'you may' trigger (CR 702.154a)"
         );
 
-        // Parent body taps an untapped creature you control.
-        let Effect::Tap {
-            target: TargetFilter::Typed(tf),
-        } = &*execute.effect
-        else {
-            panic!("execute body must be Effect::Tap over a TypedFilter");
+        // Parent body taps an eligible Enlist creature.
+        let Effect::Tap { target } = &*execute.effect else {
+            panic!("execute body must be Effect::Tap");
         };
+        let TargetFilter::And { filters } = target else {
+            panic!("tap target must compose Enlist eligibility with TargetFilter::And");
+        };
+        let tf = filters
+            .iter()
+            .find_map(|filter| match filter {
+                TargetFilter::Typed(tf) => Some(tf),
+                _ => None,
+            })
+            .expect("tap target must include the creature eligibility typed filter");
+        let excludes_attackers = filters.iter().any(|filter| {
+            matches!(
+                filter,
+                TargetFilter::Not { filter }
+                    if matches!(
+                        filter.as_ref(),
+                        TargetFilter::Typed(tf)
+                            if tf.properties.contains(&FilterProp::Attacking)
+                    )
+            )
+        });
+        assert!(
+            excludes_attackers,
+            "tap target must exclude creatures chosen to attack with (CR 702.154a)"
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::Another),
+            "tap target must exclude the enlisting creature itself (CR 702.154c)"
+        );
         assert_eq!(
             tf.controller,
             Some(ControllerRef::You),
             "tap target must be a creature you control (CR 702.154a)"
         );
         assert!(
-            tf.properties
-                .iter()
-                .any(|p| matches!(p, FilterProp::Untapped)),
+            tf.properties.contains(&FilterProp::Untapped),
             "tap target must be untapped (CR 702.154a), got {:?}",
+            tf.properties
+        );
+        assert!(
+            tf.properties
+                .contains(&FilterProp::HasHasteOrControlledSinceTurnBegan),
+            "tap target must either have haste or have been controlled since turn began \
+             (CR 702.154a), got {:?}",
             tf.properties
         );
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -434,6 +434,9 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             FilterProp::Unblocked => parts.push("unblocked".into()),
             FilterProp::Tapped => parts.push("tapped".into()),
             FilterProp::Untapped => parts.push("untapped".into()),
+            FilterProp::HasHasteOrControlledSinceTurnBegan => {
+                parts.push("haste or controlled since turn began".into())
+            }
             FilterProp::WithKeyword { value } => parts.push(format!("with {value:?}")),
             FilterProp::CanEnchant { target } => {
                 parts.push(format!("can enchant {}", fmt_target(target)))

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::game::filter;
 use crate::game::speed::has_max_speed;
@@ -802,16 +802,15 @@ fn tapped_object_context_from_events(
     state: &GameState,
     events: &[GameEvent],
 ) -> Option<CostPaidObjectSnapshot> {
+    let mut seen = HashSet::new();
     let mut tapped = events.iter().filter_map(|event| match event {
-        GameEvent::PermanentTapped { object_id, .. } => {
-            state
-                .objects
-                .get(object_id)
-                .map(|obj| CostPaidObjectSnapshot {
-                    object_id: *object_id,
-                    lki: obj.snapshot_for_mana_spent(),
-                })
-        }
+        GameEvent::PermanentTapped { object_id, .. } if seen.insert(*object_id) => state
+            .objects
+            .get(object_id)
+            .map(|obj| CostPaidObjectSnapshot {
+                object_id: *object_id,
+                lki: obj.snapshot_for_mana_spent(),
+            }),
         _ => None,
     });
     let first = tapped.next()?;
@@ -5699,6 +5698,42 @@ mod tests {
             parent_referent_context_from_events(&state, &events).is_none(),
             "two tapped creatures have no singular anaphoric referent"
         );
+    }
+
+    /// CR 608.2c: duplicate events for the same tapped creature still describe
+    /// one singular referent.
+    #[test]
+    fn duplicate_tap_events_for_same_creature_still_capture_single_referent() {
+        let mut state = GameState::new_two_player(42);
+        let creature = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Tapped".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&creature).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_power = Some(4);
+            obj.base_toughness = Some(4);
+            obj.power = Some(4);
+            obj.toughness = Some(4);
+        }
+        let events = vec![
+            GameEvent::PermanentTapped {
+                object_id: creature,
+                caused_by: None,
+            },
+            GameEvent::PermanentTapped {
+                object_id: creature,
+                caused_by: None,
+            },
+        ];
+        let referent = parent_referent_context_from_events(&state, &events)
+            .expect("duplicate tap events for one creature still have a singular referent");
+        assert_eq!(referent.object_id, creature);
+        assert_eq!(referent.lki.power, Some(4));
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -783,7 +783,39 @@ pub(crate) fn parent_referent_context_from_events(
         return Some(snapshot);
     }
 
-    revealed_object_context_from_events(state, events)
+    if let Some(snapshot) = revealed_object_context_from_events(state, events) {
+        return Some(snapshot);
+    }
+
+    // CR 608.2c: a later instruction's "that creature" may refer to a single
+    // creature an earlier instruction in the same resolution tapped — e.g.
+    // Enlist's "+X/+0 … where X is the tapped creature's power". Tried last so
+    // sacrifice/move/reveal referents continue to take precedence. The tapped
+    // permanent stays on the battlefield, so it is snapshot live.
+    tapped_object_context_from_events(state, events)
+}
+
+/// CR 608.2c: capture a single creature tapped by the parent instruction as the
+/// resolution's anaphoric referent. A multi-permanent tap has no singular "that
+/// creature", so it yields no snapshot (mirroring the sacrifice/move guards).
+fn tapped_object_context_from_events(
+    state: &GameState,
+    events: &[GameEvent],
+) -> Option<CostPaidObjectSnapshot> {
+    let mut tapped = events.iter().filter_map(|event| match event {
+        GameEvent::PermanentTapped { object_id, .. } => {
+            state
+                .objects
+                .get(object_id)
+                .map(|obj| CostPaidObjectSnapshot {
+                    object_id: *object_id,
+                    lki: obj.snapshot_for_mana_spent(),
+                })
+        }
+        _ => None,
+    });
+    let first = tapped.next()?;
+    tapped.next().is_none().then_some(first)
 }
 
 fn sacrificed_object_context_from_events(
@@ -5590,6 +5622,84 @@ mod tests {
     use crate::types::statics::CastFrequency;
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
+
+    /// CR 608.2c: a single tapped creature becomes the resolution's anaphoric
+    /// referent, so a later "that creature's power" (Enlist) reads it.
+    #[test]
+    fn tapped_creature_is_captured_as_anaphoric_referent() {
+        let mut state = GameState::new_two_player(42);
+        let creature = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Tapped".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&creature).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_power = Some(3);
+            obj.base_toughness = Some(3);
+            obj.power = Some(3);
+            obj.toughness = Some(3);
+        }
+        let events = vec![GameEvent::PermanentTapped {
+            object_id: creature,
+            caused_by: None,
+        }];
+        let referent = parent_referent_context_from_events(&state, &events)
+            .expect("a single tapped creature must be captured as the anaphoric referent");
+        assert_eq!(referent.object_id, creature);
+        assert_eq!(
+            referent.lki.power,
+            Some(3),
+            "the referent snapshot carries the tapped creature's power"
+        );
+    }
+
+    /// A multi-creature tap has no singular "that creature" (mirrors the
+    /// sacrifice/move guards).
+    #[test]
+    fn multiple_tapped_creatures_yield_no_singular_referent() {
+        let mut state = GameState::new_two_player(42);
+        let a = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "A".to_string(),
+            Zone::Battlefield,
+        );
+        let b = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "B".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [a, b] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+        let events = vec![
+            GameEvent::PermanentTapped {
+                object_id: a,
+                caused_by: None,
+            },
+            GameEvent::PermanentTapped {
+                object_id: b,
+                caused_by: None,
+            },
+        ];
+        assert!(
+            parent_referent_context_from_events(&state, &events).is_none(),
+            "two tapped creatures have no singular anaphoric referent"
+        );
+    }
 
     #[test]
     fn is_known_effect_rejects_unimplemented() {

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -147,6 +147,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::Unblocked
         | FilterProp::Tapped
         | FilterProp::Untapped
+        | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::WithKeyword { .. }
         | FilterProp::HasKeywordKind { .. }
         | FilterProp::WithoutKeyword { .. }
@@ -336,6 +337,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::Unblocked
         | FilterProp::Tapped
         | FilterProp::Untapped
+        | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::WithKeyword { .. }
         | FilterProp::HasKeywordKind { .. }
         | FilterProp::WithoutKeyword { .. }
@@ -2191,6 +2193,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         | FilterProp::Unblocked
         | FilterProp::Tapped
         | FilterProp::Untapped
+        | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::Counters { .. }
         | FilterProp::Owned { .. }
         | FilterProp::Foretold
@@ -2496,6 +2499,12 @@ fn matches_filter_prop(
         FilterProp::Tapped => obj.tapped,
         // CR 302.6 / CR 110.5: Untapped status as targeting qualifier.
         FilterProp::Untapped => !obj.tapped,
+        // CR 302.6 + CR 702.10b + CR 702.154a: Enlist may tap a creature only
+        // if it has haste or has been controlled continuously since turn began.
+        FilterProp::HasHasteOrControlledSinceTurnBegan => {
+            obj.card_types.core_types.contains(&CoreType::Creature)
+                && !combat::has_summoning_sickness(obj)
+        }
         FilterProp::WithKeyword { value } => obj.has_keyword(value),
         FilterProp::CanEnchant { target } => obj.keywords.iter().any(|keyword| {
             let Keyword::Enchant(enchant_filter) = keyword else {
@@ -3278,6 +3287,7 @@ fn zone_change_record_matches_property(
         }),
         FilterProp::Tapped
         | FilterProp::Untapped
+        | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::AttackedThisTurn
         | FilterProp::BlockedThisTurn
         | FilterProp::AttackedOrBlockedThisTurn
@@ -4278,6 +4288,42 @@ mod tests {
             },
         ]));
         assert!(matches_target_filter(&state, bird, &filter, bird));
+    }
+
+    #[test]
+    fn has_haste_or_controlled_since_turn_began_matches_enlist_eligibility() {
+        let mut state = setup();
+        let source = add_creature(&mut state, PlayerId(0), "Enlister");
+        let established = add_creature(&mut state, PlayerId(0), "Established");
+        let sick = add_creature(&mut state, PlayerId(0), "Fresh");
+        let hasty = add_creature(&mut state, PlayerId(0), "Hasty");
+        let land = add_creature(&mut state, PlayerId(0), "Animated Land");
+
+        state.objects.get_mut(&sick).unwrap().summoning_sick = true;
+        {
+            let obj = state.objects.get_mut(&hasty).unwrap();
+            obj.summoning_sick = true;
+            obj.keywords.push(Keyword::Haste);
+        }
+        state.objects.get_mut(&land).unwrap().card_types.core_types = vec![CoreType::Land];
+
+        let filter = TargetFilter::Typed(
+            TypedFilter::default().properties(vec![FilterProp::HasHasteOrControlledSinceTurnBegan]),
+        );
+
+        assert!(matches_target_filter(&state, established, &filter, source));
+        assert!(
+            !matches_target_filter(&state, sick, &filter, source),
+            "summoning-sick creature without haste is not eligible for Enlist"
+        );
+        assert!(
+            matches_target_filter(&state, hasty, &filter, source),
+            "haste satisfies CR 702.154a even when the creature entered this turn"
+        );
+        assert!(
+            !matches_target_filter(&state, land, &filter, source),
+            "predicate is creature-specific when used without an outer creature filter"
+        );
     }
 
     /// CR 120.6 + CR 120.9 (audit H2): "Was dealt damage this turn" must consult

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2045,6 +2045,10 @@ pub enum FilterProp {
     Tapped,
     /// CR 302.6 / CR 110.5: Untapped status as targeting qualifier.
     Untapped,
+    /// CR 302.6 + CR 702.10b + CR 702.154a: Matches creatures that either have
+    /// haste or have been under their controller's control continuously since
+    /// that player's most recent turn began. Used by Enlist's tap eligibility.
+    HasHasteOrControlledSinceTurnBegan,
     WithKeyword {
         value: Keyword,
     },
@@ -13837,6 +13841,7 @@ mod tests {
             FilterProp::Unblocked,
             FilterProp::Tapped,
             FilterProp::Untapped,
+            FilterProp::HasHasteOrControlledSinceTurnBegan,
             FilterProp::WithKeyword {
                 value: Keyword::Flying,
             },


### PR DESCRIPTION
## Summary

Implements the **Enlist** keyword (CR 702.154), closing #2534. `Keyword::Enlist` was parsed but inert. It is synthesized as an optional `Attacks` trigger (the Provoke shape): the optional body taps an untapped creature you control; a reflexive sub-ability pumps the attacker (`SelfRef`) by that creature's power until end of turn (+X/+0).

## CR

**CR 702.154a** (verified against `docs/MagicCompRules.txt:5114`): *"As this creature attacks, you may tap up to one untapped creature you control … When you do, this creature gets +X/+0 until end of turn, where X is the tapped creature's power."*

## How X is read (the one cross-cutting piece)

The pump must affect the attacker while reading a *different* creature's power. X is read **anaphorically**: the just-tapped creature is the resolution's "that creature" referent (CR 608.2c), reached via `Effect::Pump`'s `PtValue::Quantity(QuantityRef::Power { scope: Anaphoric })`.

To make that resolve, `parent_referent_context_from_events` is extended to capture a single tapped creature (from a `PermanentTapped` event, snapshot live) as the anaphoric referent — **tried last**, after the existing sacrifice/move/reveal referents, so it only fills the "that creature" slot when nothing else did. Per CR 608.2c a later instruction may refer to a creature an earlier instruction *tapped*, so this is a correct generalization, not Enlist-specific plumbing.

Reuses `TriggerMode::Attacks` + `Effect::Tap` + `Effect::Pump` with `PtValue::Quantity` + `QuantityRef::Power`. No new `Effect` or subsystem.

## Changes

- **`database/synthesis.rs`**: `build_enlist_trigger`, `is_enlist_trigger`, the `triggers_for`/matcher arms, `synthesize_enlist`, and the `synthesize_all` wiring (beside Provoke/Melee).
- **`game/effects/mod.rs`**: `tapped_object_context_from_events` + its hook in `parent_referent_context_from_events`.

## Eligibility note (honest scope)

The tap filter is "another untapped creature you control." CR 702.154a's "didn't choose to attack with" is largely covered (attackers tap unless they have vigilance), but the "has haste or has been under your control since the turn began" (summoning-sickness) refinement has **no `FilterProp` yet**, so it is left as a follow-up tightening rather than blocking the core mechanic. Flagging for reviewer visibility.

## Tests

- **Synthesis shape**: optional `Attacks` trigger; body taps an untapped you-control creature; reflexive `Pump` of `SelfRef` by `Power{Anaphoric}` with +0 toughness; idempotency; no-op without keyword; `triggers_for`/matcher roundtrip.
- **Referent**: a single tapped creature is captured as the anaphoric referent (carrying its power); multiple tapped creatures yield no singular referent.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — clean.
- `scripts/check-parser-combinators.sh` — passes.
- Unit tests run in CI (local toolchain has a binutils/dlltool gap). The end-to-end resolution (attack → tap → anaphoric pump) is exercised by CI; the referent and synthesis-shape tests pin the pieces.

Closes #2534