### PR TITLE
fix(parser): parse variable (X) count in "create X tokens that are copies of …" (CR 707.2)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -1028,7 +1028,7 @@ pub(super) fn push_unique_string(values: &mut Vec<String>, value: impl Into<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef, RoundingMode};
+    use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef, RoundingMode, TypeFilter};
     use crate::types::card_type::CoreType;
 
     #[test]
@@ -1062,14 +1062,21 @@ mod tests {
         let Effect::CopyTokenOf { count, .. } = effect else {
             panic!("expected CopyTokenOf")
         };
-        assert_ne!(
-            count,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Variable {
-                    name: "X".to_string()
-                }
-            },
-            "X must be bound to the where-clause, not left as bare X"
+        let QuantityExpr::Ref {
+            qty:
+                QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(tf),
+                },
+        } = count
+        else {
+            panic!("expected where-clause to bind X to an ObjectCount, got {count:?}");
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(
+            tf.type_filters
+                .contains(&TypeFilter::Subtype("Clue".to_string())),
+            "X must count controlled Clues, got {:?}",
+            tf.type_filters
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
-use nom::combinator::{map, opt, rest, value};
+use nom::combinator::{opt, rest, value};
 use nom::Parser;
 
 use crate::parser::oracle_ir::context::ParseContext;
@@ -41,7 +41,8 @@ pub(super) fn try_parse_token(_lower: &str, text: &str, ctx: &mut ParseContext) 
     let lower = text.to_lowercase();
 
     // "create a token that's a copy of {target}"
-    if let Ok((_, (tapped, enters_attacking, count))) = parse_copy_token_entry_modifiers(&lower) {
+    if let Ok((_, (tapped, enters_attacking, mut count))) = parse_copy_token_entry_modifiers(&lower)
+    {
         let tp = TextPair::new(&text, &lower);
         let after_copy_tp = tp
             .strip_after("copy of ")
@@ -97,6 +98,24 @@ pub(super) fn try_parse_token(_lower: &str, text: &str, ctx: &mut ParseContext) 
         if let (TargetFilter::ParentTarget, Some(host)) = (&target, &ctx.host_self_reference) {
             target = host.clone();
         }
+        // CR 107.3: bind a variable "X" count to its "where X is <quantity>"
+        // clause (Devastating Onslaught, Nacatl War-Pride, Rionya), mirroring the
+        // non-copy token path. A bare X with no where-clause (Aggressive Biomancy)
+        // is left as `Variable("X")` for the spell's X cost to resolve.
+        if matches!(&count, QuantityExpr::Ref { qty: QuantityRef::Variable { ref name } } if name == "X")
+        {
+            if let Some(where_expression) = extract_token_where_x_expression(&text) {
+                count = super::parse_where_x_quantity_expression(&where_expression)
+                    .or_else(|| {
+                        crate::parser::oracle_quantity::parse_cda_quantity(&where_expression)
+                    })
+                    .unwrap_or(QuantityExpr::Ref {
+                        qty: QuantityRef::Variable {
+                            name: where_expression,
+                        },
+                    });
+            }
+        }
         return Some(Effect::CopyTokenOf {
             target,
             // CR 109.4: Default to the controller; a "target [player] creates"
@@ -140,16 +159,20 @@ pub(super) fn parse_copy_token_entry_modifiers(
     input: &str,
 ) -> OracleResult<'_, (bool, bool, QuantityExpr)> {
     let (rest, _) = tag("create ").parse(input)?;
-    let (rest, count) = opt(alt((
-        value(
-            QuantityExpr::Fixed { value: 1 },
-            alt((tag("a "), tag("one "))),
-        ),
-        map(nom_primitives::parse_number, |value| QuantityExpr::Fixed {
-            value: value as i32,
-        }),
-    )))
-    .parse(rest)?;
+    // The bare article "a"/"one" → a count of 1. `parse_count_expr` intentionally
+    // excludes the article (to avoid matching the "a" in "another"), so handle it
+    // here; otherwise delegate to the shared count grammar so "X", "two", "twice
+    // X", "that many", etc. all parse uniformly — mirroring the non-copy token
+    // path's `parse_token_count_prefix`. Without this, "Create X tokens that are
+    // copies of …" failed to parse and the whole effect was dropped.
+    let (rest, count) =
+        if let Ok((rest, _)) = alt((tag::<_, _, OracleError<'_>>("a "), tag("one "))).parse(rest) {
+            (rest, Some(QuantityExpr::Fixed { value: 1 }))
+        } else if let Some((expr, rest_after)) = parse_count_expr(rest) {
+            (rest_after, Some(expr))
+        } else {
+            (rest, None)
+        };
     let (rest, _) = if count.is_some() {
         opt(tag(" ")).parse(rest)?
     } else {
@@ -1007,6 +1030,48 @@ mod tests {
     use super::*;
     use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef, RoundingMode};
     use crate::types::card_type::CoreType;
+
+    #[test]
+    fn copy_x_tokens_of_target_parses_variable_count() {
+        // CR 707.2 + CR 107.3: variable X count in copy-token creation.
+        let effect = try_parse_token(
+            "create x tokens that are copies of target creature you control",
+            "Create X tokens that are copies of target creature you control",
+            &mut ParseContext::default(),
+        )
+        .expect("expected CopyTokenOf");
+        let Effect::CopyTokenOf { count, .. } = effect else {
+            panic!("expected CopyTokenOf, got {effect:?}");
+        };
+        assert_eq!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string()
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn copy_x_tokens_binds_where_clause() {
+        // CR 107.3: X bound to a trailing "where X is <quantity>" clause.
+        let txt = "Create X tokens that are copies of target creature you control, where X is the number of Clues you control.";
+        let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
+            .expect("expected CopyTokenOf");
+        let Effect::CopyTokenOf { count, .. } = effect else {
+            panic!("expected CopyTokenOf")
+        };
+        assert_ne!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string()
+                }
+            },
+            "X must be bound to the where-clause, not left as bare X"
+        );
+    }
 
     #[test]
     fn copy_tokens_of_exiled_cost_card_use_cost_paid_object_source() {


### PR DESCRIPTION
## What

The copy-token count helper `parse_copy_token_entry_modifiers` (`oracle_effect/token.rs`) accepted only `"a"` / `"one"` / a literal digit, so **"Create X tokens that are copies of `<target>`"** failed to parse and the whole effect was dropped — the spell resolved with no effect.

The regular (non-copy) token path already routes its count through the shared `parse_count_expr`, which handles `"X"`, `"twice X"`, `"that many"`, etc. The copy path simply didn't reuse it.

Fixes #2536.

## Approach

- Route the copy-token count through the shared `parse_count_expr` building block (keeping the bare-article `"a"`/`"one"` → 1 case, which `parse_count_expr` intentionally excludes to avoid matching the "a" in "another").
- Bind a variable `X` count to its trailing `", where X is <quantity>"` clause via the existing `parse_where_x_quantity_expression` / `parse_cda_quantity` helpers — mirroring the non-copy token path. A bare `X` with no where-clause (X-cost spells like Aggressive Biomancy) is left as `Variable("X")` for the spell's X to resolve.

## Cards unlocked

Devastating Onslaught, Nacatl War-Pride, Rionya, Fire Dancer, For the Common Good, Aggressive Biomancy, The Good Gamers, and similar "create X tokens that are copies of …" effects.

## CR

- **CR 707.2 / 707.9** — copying a permanent / token copies.
- **CR 107.3** — the value of X (here defined by the "where X is …" clause, or the spell's X cost).

## Tests

- `copy_x_tokens_of_target_parses_variable_count` — `"create x tokens that are copies of target creature you control"` → `CopyTokenOf` with `count: Variable("X")`.
- `copy_x_tokens_binds_where_clause` — the `", where X is the number of Clues you control"` form binds X (not left as bare `X`).
- Regression: existing literal-count (`"two"`) and article (`"a"`) copy-token forms unchanged — 495 token/copy tests pass.

`cargo fmt --all`, `clippy -p engine -D warnings`, and the parser-combinator gate are clean.

## Non-duplicate

`Rionya`, `Devastating Onslaught`, `Nacatl War-Pride`, and `Aggressive Biomancy` return no open or closed issues/PRs. The existing "create X tokens that are copies" issues (#2169, #1735, #1424) concern runtime token-count doubling / X-resolution, not the parser's inability to recognize the `X` count — a distinct, parser-only gap.
