### PR TITLE
Add Teferi, Time Raveler

### DIFF
--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -410,6 +410,22 @@ fn effect_has_internal_optionality(effect: &Effect) -> bool {
         // Veil's "you may activate one of its loyalty abilities once this turn"
         // is the permission itself; the player still decides each activation.
         | Effect::GrantExtraLoyaltyActivations { .. } => true,
+        // CR 117.3a + CR 601.3b + CR 702.8a: a `GenericEffect` that grants a
+        // casting permission carries the "you may cast … as though …" opt-in
+        // inside the granted static, exactly like `GrantCastingPermission` /
+        // `CastFromZone` above. Teferi, Time Raveler's [+1] ("you may cast
+        // sorcery spells as though they had flash") lowers to a `GenericEffect`
+        // whose static grants `StaticMode::CastWithKeyword { Flash }` (directly,
+        // or via `GrantStaticAbility`), so the "may" is the permission itself —
+        // no def-level `optional` flag is needed.
+        //
+        // NARROW BY DESIGN: only casting-permission modes count here. A
+        // `GenericEffect` granting an unrelated static (CantGainLife, +1/+1,
+        // etc.) does NOT carry a "you may" and must remain subject to the
+        // Optional_YouMay detector.
+        Effect::GenericEffect {
+            static_abilities, ..
+        } => static_abilities.iter().any(static_grants_cast_permission),
         Effect::ChooseOneOf { branches, .. } => branches.iter().any(def_tree_has_optional),
         Effect::CreateDelayedTrigger { effect, .. } => def_tree_has_optional(effect),
         Effect::CreateEmblem { statics, triggers } => {
@@ -418,6 +434,28 @@ fn effect_has_internal_optionality(effect: &Effect) -> bool {
         }
         _ => false,
     }
+}
+
+/// CR 117.3a + CR 601.3b + CR 702.8a: True when a `StaticDefinition` IS (or,
+/// via `GrantStaticAbility`, grants) a casting-permission static of the
+/// "cast as though it had <keyword>" family (`StaticMode::CastWithKeyword`).
+/// Such permissions inherently encode the "you may cast" opt-in, so a
+/// `GenericEffect` carrying one accounts for the "you may " marker without a
+/// def-level `optional` flag (Teferi, Time Raveler's flash grant).
+///
+/// Deliberately narrow: only `CastWithKeyword` permission modes match. This
+/// must NOT exempt grants of unrelated modes (CantGainLife, AddPower, etc.),
+/// or it would suppress legitimate Optional_YouMay detection elsewhere.
+fn static_grants_cast_permission(s: &StaticDefinition) -> bool {
+    if matches!(s.mode, StaticMode::CastWithKeyword { .. }) {
+        return true;
+    }
+    s.modifications.iter().any(|m| match m {
+        ContinuousModification::GrantStaticAbility { definition } => {
+            matches!(definition.mode, StaticMode::CastWithKeyword { .. })
+        }
+        _ => false,
+    })
 }
 
 /// Recursive walk: does any def in the tree carry an `AddTargetReplacement`
@@ -2450,6 +2488,105 @@ mod tests {
         );
 
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_teferi_flash_grant_generic_effect() {
+        // CR 117.3a + CR 702.8a: Teferi, Time Raveler's [+1] ("you may cast
+        // sorcery spells as though they had flash") lowers to a `GenericEffect`
+        // granting `StaticMode::CastWithKeyword { Flash }`. The granted casting
+        // permission IS the "you may cast" opt-in, so the "you may " marker must
+        // NOT be reported as a swallowed clause.
+        let parsed = parse_named(
+            "Each opponent can cast spells only any time they could cast a sorcery.\n\
+             [+1]: Until your next turn, you may cast sorcery spells as though they had flash.\n\
+             [\u{2212}3]: Return up to one target artifact, creature, or enchantment to its owner's hand. Draw a card.",
+            "Teferi, Time Raveler",
+            &["Planeswalker"],
+        );
+
+        // Pin the structural shape the exemption keys on: the [+1] must lower to
+        // a GenericEffect granting CastWithKeyword (directly or via
+        // GrantStaticAbility). Guards against a silent regression where the
+        // grant stops parsing — then the negative assertion below would pass
+        // vacuously.
+        assert!(
+            parsed
+                .abilities
+                .iter()
+                .any(def_tree_grants_cast_with_keyword),
+            "expected Teferi [+1] to lower to a GenericEffect granting \
+             CastWithKeyword, parsed abilities: {:#?}",
+            parsed.abilities
+        );
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_still_flags_unrepresented_optional_verb() {
+        // Guard the exemption did NOT over-broaden: a genuine "you may <verb>"
+        // optional effect with no AST representation must still be flagged.
+        // `Effect::Unimplemented` suppression is avoided by pairing the bogus
+        // clause with a fully-parsed primary effect.
+        let parsed = parse_named(
+            "Each opponent can cast spells only any time they could cast a sorcery.\n\
+             [+1]: You may wibble the frobnicator until your next turn.\n\
+             [\u{2212}3]: Return up to one target artifact, creature, or enchantment to its owner's hand. Draw a card.",
+            "Not Teferi",
+            &["Planeswalker"],
+        );
+
+        // Only meaningful if the bogus +1 did NOT itself become Unimplemented
+        // (which would suppress all swallow detectors). If parsing classified it
+        // as Unimplemented, the test is inconclusive — skip rather than assert a
+        // false positive.
+        let plus_one_unimplemented = parsed.abilities.iter().any(def_tree_has_unimplemented);
+        if !plus_one_unimplemented {
+            assert!(
+                has_swallowed_detector(&parsed, "Optional_YouMay"),
+                "an unrepresented 'you may <verb>' must still be flagged; \
+                 the CastWithKeyword exemption must not over-broaden. \
+                 warnings: {:#?}",
+                parsed.parse_warnings
+            );
+        }
+    }
+
+    /// Walk a def tree for a `GenericEffect` granting `CastWithKeyword` (directly
+    /// or via `GrantStaticAbility`) — the flash-grant shape Teferi's [+1] lowers
+    /// to and the swallow-check exemption keys on.
+    fn def_tree_grants_cast_with_keyword(def: &AbilityDefinition) -> bool {
+        let here = if let Effect::GenericEffect {
+            ref static_abilities,
+            ..
+        } = &*def.effect
+        {
+            static_abilities.iter().any(|s| {
+                matches!(s.mode, StaticMode::CastWithKeyword { .. })
+                    || s.modifications.iter().any(|m| {
+                        matches!(
+                            m,
+                            crate::types::ability::ContinuousModification::GrantStaticAbility {
+                                definition,
+                            } if matches!(definition.mode, StaticMode::CastWithKeyword { .. })
+                        )
+                    })
+            })
+        } else {
+            false
+        };
+        here || def
+            .sub_ability
+            .as_deref()
+            .is_some_and(def_tree_grants_cast_with_keyword)
+            || def
+                .else_ability
+                .as_deref()
+                .is_some_and(def_tree_grants_cast_with_keyword)
+            || def
+                .mode_abilities
+                .iter()
+                .any(def_tree_grants_cast_with_keyword)
     }
 
     #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -155,6 +155,7 @@ mod steadfast_armasaur_lki_toughness;
 mod support;
 mod swans_prevention_followup;
 mod talon_gates_from_hand_activation;
+mod teferi_time_raveler_sorcery_speed_lock;
 mod tempt_with_discovery;
 mod terra_herald_optional_prompt;
 mod terra_magical_adept_milled_enchantment;

--- a/crates/engine/tests/integration/teferi_time_raveler_sorcery_speed_lock.rs
+++ b/crates/engine/tests/integration/teferi_time_raveler_sorcery_speed_lock.rs
@@ -1,0 +1,167 @@
+//! Discriminating end-to-end guard for Teferi, Time Raveler's static
+//! restriction: "Each opponent can cast spells only any time they could cast a
+//! sorcery."
+//!
+//! This drives the REAL Teferi Oracle text through the full synthesis pipeline
+//! (`from_oracle_text` → `synthesize_all`) onto a battlefield permanent, then
+//! exercises the production cast action (`GameAction::CastSpell`) — the same
+//! path the engine uses for a human/AI cast. The static lowers to
+//! `StaticMode::CantCastDuring { who: opponents, when: NotSorcerySpeed }`, which
+//! the cast handler enforces via `is_blocked_by_cant_cast_during`
+//! (`game/casting.rs`, CR 101.2 + CR 307.5).
+//!
+//! The Teferi fix under test (`swallow_check.rs`) is DIAGNOSTIC-ONLY — it stops
+//! a false-positive `Optional_YouMay` swallow on the [+1] flash grant. The
+//! runtime restriction was already correct; this test proves that
+//! independently, and is structured fail-first: a baseline opponent with NO
+//! Teferi on the battlefield CAN cast the same instant at instant speed, so a
+//! green run is attributable to the static, not the harness.
+
+use engine::game::engine::EngineError;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+use engine::types::PlayerId;
+
+const TEFERI_ORACLE: &str = "Each opponent can cast spells only any time they could cast a sorcery.\n\
+     [+1]: Until your next turn, you may cast sorcery spells as though they had flash.\n\
+     [\u{2212}3]: Return up to one target artifact, creature, or enchantment to its owner's hand. Draw a card.";
+
+fn one_blue() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![ManaCostShard::Blue],
+        generic: 0,
+    }
+}
+
+/// Give `player` priority in a `Priority` window so `apply_as_current` routes
+/// the next action AS that player (CR 117 priority — non-active players hold
+/// priority during the active player's turn too).
+fn grant_priority(runner: &mut GameRunner, player: PlayerId) {
+    let state = runner.state_mut();
+    state.priority_player = player;
+    state.waiting_for = WaitingFor::Priority { player };
+}
+
+fn cast_instant(runner: &mut GameRunner, spell: ObjectId) -> Result<(), EngineError> {
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+        })
+        .map(|_| ())
+}
+
+/// CR 101.2 + CR 307.5: With Teferi on P0's battlefield, P1 (an opponent) may
+/// only cast at sorcery speed. During P0's turn with P1 holding priority, P1's
+/// instant is BLOCKED — the production cast action returns the prohibition
+/// error from `is_blocked_by_cant_cast_during`.
+#[test]
+fn opponent_instant_blocked_during_controllers_turn_with_teferi() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain); // active = P0, empty stack.
+
+    // Real Teferi on P0's battlefield. The static line parses independently of
+    // the planeswalker type; pin that the CantCastDuring static actually
+    // attached so a green test can't pass vacuously on a no-static permanent.
+    let mut teferi = scenario.add_creature(P0, "Teferi, Time Raveler", 0, 0);
+    let teferi_id = teferi.from_oracle_text(TEFERI_ORACLE).id();
+
+    // P1's instant + the blue mana to pay for it (so affordability is never the
+    // gate — only the static restriction).
+    scenario.add_basic_land(P1, ManaColor::Blue);
+    let instant = scenario
+        .add_spell_to_hand(P1, "Opposing Instant", true)
+        .with_mana_cost(one_blue())
+        .id();
+
+    let mut runner = scenario.build();
+
+    assert!(
+        runner.state().objects[&teferi_id]
+            .static_definitions
+            .iter_unchecked()
+            .any(|d| matches!(d.mode, StaticMode::CantCastDuring { .. })),
+        "Teferi must contribute a CantCastDuring static, got: {:?}",
+        runner.state().objects[&teferi_id].static_definitions
+    );
+
+    // P1 holds priority during P0's turn (legal per CR 117) and tries the cast.
+    grant_priority(&mut runner, P1);
+    let result = cast_instant(&mut runner, instant);
+
+    assert!(
+        matches!(result, Err(EngineError::ActionNotAllowed(_))),
+        "Teferi must block an opponent's instant at instant speed during the \
+         controller's turn (CR 101.2 + CR 307.5); got {result:?}"
+    );
+}
+
+/// Fail-first baseline: WITHOUT Teferi, the identical opponent instant in the
+/// identical timing window is castable. Pins that the harness itself does not
+/// reject the cast — the block above is attributable to Teferi's static.
+#[test]
+fn opponent_instant_castable_during_controllers_turn_without_teferi() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain); // active = P0.
+
+    scenario.add_basic_land(P1, ManaColor::Blue);
+    let instant = scenario
+        .add_spell_to_hand(P1, "Opposing Instant", true)
+        .with_mana_cost(one_blue())
+        .id();
+
+    let mut runner = scenario.build();
+
+    grant_priority(&mut runner, P1);
+    let result = cast_instant(&mut runner, instant);
+
+    assert!(
+        result.is_ok(),
+        "Without Teferi, an opponent's instant must be castable at instant \
+         speed during the controller's turn; got {result:?}"
+    );
+}
+
+/// CR 307.5: Teferi restricts opponents to SORCERY speed, not no-casting. On
+/// P1's OWN turn (active = P1, P1's main phase, empty stack, P1 holding
+/// priority) P1 CAN cast the instant — sorcery-speed timing is satisfied — even
+/// with Teferi still on P0's battlefield.
+#[test]
+fn opponent_can_cast_at_sorcery_speed_on_their_own_turn_with_teferi() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let mut teferi = scenario.add_creature(P0, "Teferi, Time Raveler", 0, 0);
+    teferi.from_oracle_text(TEFERI_ORACLE);
+
+    scenario.add_basic_land(P1, ManaColor::Blue);
+    let instant = scenario
+        .add_spell_to_hand(P1, "Opposing Instant", true)
+        .with_mana_cost(one_blue())
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Make it P1's turn: active = P1, P1's main phase, empty stack. NotSorcerySpeed
+    // is satisfied (active player + main phase + empty stack), so the restriction
+    // does not bite.
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+    }
+    grant_priority(&mut runner, P1);
+
+    let result = cast_instant(&mut runner, instant);
+    assert!(
+        result.is_ok(),
+        "Teferi restricts opponents to sorcery speed, not silence: P1 must be \
+         able to cast on their own main phase with an empty stack; got {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Adds engine support for **Teferi, Time Raveler**.

The card was already *functionally complete* — the static lowers to `StaticMode::CantCastDuring { who: opponents, when: NotSorcerySpeed }` (enforced at runtime, CR 117.x), the [+1] lowers to a `GenericEffect` granting `StaticMode::CastWithKeyword{Flash}` to your sorceries, and the [−3] is a bounce + draw. It was only marked `supported: false` by a **false-positive `Optional_YouMay` swallow** on "[+1]: …you may cast sorcery spells as though they had flash."

`effect_has_internal_optionality` already exempts `Effect::GrantCastingPermission`/`CastFromZone` (CR 117.3a — a granted cast permission inherently encodes the "you may cast" opt-in), but Teferi's [+1] uses a `GenericEffect`→`CastWithKeyword{Flash}` representation the exemption didn't recognize. Fix: extend the exemption to that shape, **narrowly** (only `CastWithKeyword` permission modes; an unrelated grant like `CantGainLife`/+1/+1 is NOT exempted). Diagnostic-only — AST and runtime were already correct; the card just stops being mis-flagged.

Also flips **A-Teferi, Time Raveler** (same card).

## Files changed
- crates/engine/src/parser/swallow_check.rs
- crates/engine/tests/integration/teferi_time_raveler_sorcery_speed_lock.rs (+ main.rs registration)

## CR references
- CR 117.3a — a granted cast permission is the "you may cast" opt-in
- CR 601.3b — "…cast as though it had flash…"; CR 702.8a — Flash
- CR 101.2 / CR 307.5 — opponent sorcery-speed restriction enforcement basis

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine` — 10715 lib + 725 integration passed / 0 failed (adds 2 swallow-check unit tests + a discriminating integration test)
- **Discriminating integration test** drives the real card via `GameAction::CastSpell`: an opponent's instant during the controller's turn is **blocked** by `NotSorcerySpeed`; the same instant with **no Teferi** is allowed (fail-first baseline); the opponent **can** cast on their own main phase (sorcery speed, not silence).
- `cargo coverage` — Teferi + A-Teferi `supported: true`, `gap_count: 0`
- `cargo semantic-audit` — Teferi 0 findings

## Scope Expansion
None. (Diagnostic-only swallow-exemption; structurally can only remove a false-positive swallow — no card loses support.)

## Validation Failures
None.

## CI Failures
None.

Tier: Frontier
