### PR TITLE
Implement Compleated keyword (CR 702.150)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -31085,6 +31085,145 @@ mod tests {
         );
     }
 
+    fn create_compleated_planeswalker_in_hand(
+        state: &mut GameState,
+        player: PlayerId,
+        shards: Vec<ManaCostShard>,
+        loyalty: u32,
+    ) -> ObjectId {
+        let obj_id = create_object(
+            state,
+            CardId(0xC0DE),
+            player,
+            "Compleated Walker".to_string(),
+            Zone::Hand,
+        );
+        let obj = state.objects.get_mut(&obj_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Planeswalker);
+        obj.base_card_types = obj.card_types.clone();
+        obj.loyalty = Some(loyalty);
+        obj.base_loyalty = Some(loyalty);
+        obj.mana_cost = ManaCost::Cost { shards, generic: 0 };
+        obj.base_mana_cost = obj.mana_cost.clone();
+        obj.keywords.push(Keyword::Compleated);
+        obj.base_keywords.push(Keyword::Compleated);
+        obj_id
+    }
+
+    fn resolved_compleated_walker_loyalty(state: &GameState) -> u32 {
+        let pw_id = state
+            .battlefield
+            .iter()
+            .copied()
+            .find(|id| {
+                state
+                    .objects
+                    .get(id)
+                    .is_some_and(|o| o.has_keyword(&Keyword::Compleated))
+            })
+            .expect("a compleated walker must be on the battlefield after resolution");
+        state.objects[&pw_id]
+            .counters
+            .get(&crate::types::counter::CounterType::Loyalty)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// CR 702.150a: A compleated planeswalker cast by paying life for its
+    /// Phyrexian symbols enters with two fewer loyalty per symbol. Loyalty 5 and
+    /// two {U/P} both paid with life → enters with 5 - 2*2 = 1.
+    #[test]
+    fn compleated_planeswalker_paying_life_enters_with_reduced_loyalty() {
+        use crate::game::engine::apply_as_current;
+        use crate::types::game_state::ShardChoice;
+
+        let mut state = setup_game_at_main_phase();
+        let spell = create_compleated_planeswalker_in_hand(
+            &mut state,
+            PlayerId(0),
+            vec![ManaCostShard::PhyrexianBlue, ManaCostShard::PhyrexianBlue],
+            5,
+        );
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::CastSpell {
+                object_id: spell,
+                card_id: CardId(0xC0DE),
+                targets: Vec::new(),
+            },
+        )
+        .expect("announce cast");
+        assert!(
+            matches!(result.waiting_for, WaitingFor::PhyrexianPayment { .. }),
+            "empty pool should pause for Phyrexian life payment, got {:?}",
+            result.waiting_for
+        );
+
+        apply_as_current(
+            &mut state,
+            GameAction::SubmitPhyrexianChoices {
+                choices: vec![ShardChoice::PayLife, ShardChoice::PayLife],
+            },
+        )
+        .expect("submit PayLife x2");
+
+        let mut events = Vec::new();
+        crate::game::stack::resolve_top(&mut state, &mut events);
+
+        assert_eq!(
+            resolved_compleated_walker_loyalty(&state),
+            1,
+            "CR 702.150a: loyalty 5 minus 2 per life-paid Phyrexian symbol (x2) = 1"
+        );
+    }
+
+    /// CR 702.150a: Paying the Phyrexian symbols with MANA (not life) leaves the
+    /// compleated planeswalker's loyalty unreduced.
+    #[test]
+    fn compleated_planeswalker_paying_mana_enters_with_full_loyalty() {
+        use crate::game::engine::apply_as_current;
+        use crate::types::game_state::ShardChoice;
+
+        let mut state = setup_game_at_main_phase();
+        add_mana(&mut state, PlayerId(0), ManaType::Blue, 2);
+        let spell = create_compleated_planeswalker_in_hand(
+            &mut state,
+            PlayerId(0),
+            vec![ManaCostShard::PhyrexianBlue, ManaCostShard::PhyrexianBlue],
+            5,
+        );
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::CastSpell {
+                object_id: spell,
+                card_id: CardId(0xC0DE),
+                targets: Vec::new(),
+            },
+        )
+        .expect("announce cast");
+        // With mana available the shards may surface a ManaOrLife choice; pay mana.
+        if matches!(result.waiting_for, WaitingFor::PhyrexianPayment { .. }) {
+            apply_as_current(
+                &mut state,
+                GameAction::SubmitPhyrexianChoices {
+                    choices: vec![ShardChoice::PayMana, ShardChoice::PayMana],
+                },
+            )
+            .expect("submit PayMana x2");
+        }
+
+        let mut events = Vec::new();
+        crate::game::stack::resolve_top(&mut state, &mut events);
+
+        assert_eq!(
+            resolved_compleated_walker_loyalty(&state),
+            5,
+            "paying mana (not life) for the Phyrexian symbols leaves loyalty at 5"
+        );
+    }
+
     /// CR 107.4f + CR 118.3: With insufficient life and no mana of the color,
     /// the Phyrexian cast is denied.
     #[test]

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3873,9 +3873,9 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
 ) -> Result<WaitingFor, EngineError> {
     // CR 702.150a: Record how many of this spell's Phyrexian mana symbols are
     // being paid with life. A compleated planeswalker entering from this spell
-    // reads this at ETB to reduce its loyalty by two per such symbol (see
-    // `stack.rs`). Harmless for non-compleated spells (the field is only read for
-    // `Keyword::Compleated` planeswalkers).
+    // exposes this as an intrinsic AddCounter replacement so it can order with
+    // Doubling Season-class modifiers (CR 616.1). Harmless for non-compleated
+    // spells (the field is only read for `Keyword::Compleated` planeswalkers).
     {
         let phyrexian_life_paid = phyrexian_choices
             .map(|choices| {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3871,6 +3871,25 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    // CR 702.150a: Record how many of this spell's Phyrexian mana symbols are
+    // being paid with life. A compleated planeswalker entering from this spell
+    // reads this at ETB to reduce its loyalty by two per such symbol (see
+    // `stack.rs`). Harmless for non-compleated spells (the field is only read for
+    // `Keyword::Compleated` planeswalkers).
+    {
+        let phyrexian_life_paid = phyrexian_choices
+            .map(|choices| {
+                choices
+                    .iter()
+                    .filter(|c| matches!(**c, crate::types::game_state::ShardChoice::PayLife))
+                    .count() as u32
+            })
+            .unwrap_or(0);
+        if let Some(obj) = state.objects.get_mut(&object_id) {
+            obj.phyrexian_life_paid = phyrexian_life_paid;
+        }
+    }
+
     // CR 601.3d + CR 702.8a: When the cast was authorized as-though-it-had-flash
     // via a `SpellCastingOption` whose `condition` is target-dependent (e.g.,
     // Timely Ward — "you may cast this spell as though it had flash if it

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -7,6 +7,7 @@ use crate::types::counter::CounterType;
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
+use crate::types::keywords::Keyword;
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::ProposedEvent;
 use crate::types::replacements::ReplacementEvent;

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -956,6 +956,18 @@ pub(super) fn apply_etb_counters(
             events,
         );
     }
+    let replacement_choice_for_object = state
+        .pending_replacement
+        .as_ref()
+        .and_then(|pending| pending.proposed.affected_object_id())
+        == Some(object_id);
+    if !replacement_choice_for_object {
+        if let Some(obj) = state.objects.get_mut(&object_id) {
+            if obj.has_keyword(&Keyword::Compleated) {
+                obj.phyrexian_life_paid = 0;
+            }
+        }
+    }
 }
 
 fn find_copy_targets(

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -806,6 +806,15 @@ pub struct GameObject {
     #[serde(default, skip_serializing_if = "is_zero_u32_field")]
     pub mana_spent_to_cast_amount: u32,
 
+    /// CR 702.150a: Number of this object's Phyrexian mana symbols that the
+    /// caster chose to pay with **life** (2 life each). Set at cast finalization
+    /// from the `ShardChoice::PayLife` selections; read when the object enters as
+    /// a planeswalker with `Keyword::Compleated` to reduce its entering loyalty by
+    /// two per symbol. Like `mana_spent_to_cast_amount`, this is a historical cast
+    /// fact that persists through resolution; initialized to 0 by `GameObject::new`.
+    #[serde(default, skip_serializing_if = "is_zero_u32_field")]
+    pub phyrexian_life_paid: u32,
+
     /// CR 106.3 + CR 601.2h: Source snapshots for each mana spent to cast this
     /// object. One entry per spent mana lets source-qualified dynamic quantities
     /// count "mana from a Cave/Treasure/artifact source" without depending on
@@ -1048,6 +1057,7 @@ impl GameObject {
             mana_spent_to_cast: false,
             colors_spent_to_cast: ColoredManaCount::default(),
             mana_spent_to_cast_amount: 0,
+            phyrexian_life_paid: 0,
             mana_spent_source_snapshots: Vec::new(),
             phase_status: PhaseStatus::PhasedIn,
         }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1166,6 +1166,10 @@ impl GameObject {
         // CR 701.60a / CR 702.112b: Suspect and renowned are battlefield designations.
         self.is_suspected = false;
         self.is_renowned = false;
+        // CR 400.7 + CR 702.150a: Compleated's life-payment count belongs to
+        // the cast that created this permanent. Once it leaves the battlefield,
+        // a later entry has no memory of that payment.
+        self.phyrexian_life_paid = 0;
         // CR 702.171b: Saddled clears when the Mount leaves the battlefield.
         self.is_saddled = false;
         // CR 702.xxx: Prepared (Strixhaven) is a battlefield-only designation —

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -33,6 +33,22 @@ const SHIELD_COUNTER_DAMAGE_INDEX: usize = usize::MAX - 1;
 /// permanent (the `source` is the would-be-destroyed host, not the Aura). Reserved
 /// candidate id so the CR 616 replacement-ordering pipeline owns its application.
 const UMBRA_ARMOR_DESTROY_INDEX: usize = usize::MAX - 2;
+/// CR 702.150a: Compleated — virtual loyalty-counter replacement keyed on the
+/// resolving planeswalker. Compleated is an intrinsic cast-payment replacement,
+/// not a battlefield `ReplacementDefinition`, but it must still participate in
+/// CR 616 ordering against AddCounter replacements such as Doubling Season.
+const COMPLEATED_LOYALTY_INDEX: usize = usize::MAX - 3;
+
+fn compleated_replacement_id(object_id: ObjectId) -> ReplacementId {
+    ReplacementId {
+        source: object_id,
+        index: COMPLEATED_LOYALTY_INDEX,
+    }
+}
+
+fn is_compleated_replacement(rid: ReplacementId) -> bool {
+    rid.index == COMPLEATED_LOYALTY_INDEX
+}
 
 fn umbra_armor_replacement_id(aura_id: ObjectId) -> ReplacementId {
     ReplacementId {
@@ -85,6 +101,14 @@ fn object_has_shield_counter(state: &GameState, object_id: ObjectId) -> bool {
         .get(&object_id)
         .and_then(|obj| obj.counters.get(&CounterType::Shield))
         .is_some_and(|count| *count > 0)
+}
+
+fn compleated_life_paid(state: &GameState, object_id: ObjectId) -> Option<u32> {
+    state.objects.get(&object_id).and_then(|obj| {
+        (obj.phyrexian_life_paid > 0
+            && obj.has_keyword(&crate::types::keywords::Keyword::Compleated))
+        .then_some(obj.phyrexian_life_paid)
+    })
 }
 
 fn is_functioning_umbra_armor_aura(state: &GameState, aura_id: ObjectId) -> bool {
@@ -142,6 +166,43 @@ pub(crate) fn consume_shield_counter(
         count: 1,
     });
     true
+}
+
+fn apply_compleated_replacement(
+    state: &mut GameState,
+    event: ProposedEvent,
+    rid: ReplacementId,
+    events: &mut Vec<GameEvent>,
+) -> ProposedEvent {
+    let Some(life_paid) = compleated_life_paid(state, rid.source) else {
+        return event;
+    };
+    match event {
+        ProposedEvent::AddCounter {
+            actor,
+            object_id,
+            counter_type: CounterType::Loyalty,
+            count,
+            mut applied,
+        } if object_id == rid.source => {
+            applied.insert(rid);
+            if let Some(obj) = state.objects.get_mut(&rid.source) {
+                obj.phyrexian_life_paid = 0;
+            }
+            events.push(GameEvent::ReplacementApplied {
+                source_id: rid.source,
+                event_type: ReplacementEvent::AddCounter.to_string(),
+            });
+            ProposedEvent::AddCounter {
+                actor,
+                object_id,
+                counter_type: CounterType::Loyalty,
+                count: count.saturating_sub(life_paid.saturating_mul(2)),
+                applied,
+            }
+        }
+        other => other,
+    }
 }
 
 /// CR 614.1: Replacement effects modify events as they would occur.
@@ -349,6 +410,9 @@ fn replacement_choice_label(repl: &ReplacementDefinition) -> String {
 }
 
 fn replacement_choice_label_for_rid(state: &GameState, rid: ReplacementId) -> String {
+    if is_compleated_replacement(rid) {
+        return "Compleated: enter with fewer loyalty counters".to_string();
+    }
     if is_umbra_armor_replacement(rid) {
         return state
             .objects
@@ -3115,6 +3179,28 @@ pub fn find_applicable_replacements(
         _ => {}
     }
 
+    // CR 702.150a: Compleated replaces the loyalty counters a permanent enters
+    // with when life was paid for its Phyrexian mana symbols. In this engine,
+    // ETB counters are delivered through the shared AddCounter replacement
+    // authority (`apply_etb_counters`), so the intrinsic Compleated replacement
+    // is exposed as a virtual AddCounter candidate there. This lets it order
+    // correctly with Doubling Season-class count modifiers (CR 616.1).
+    if let ProposedEvent::AddCounter {
+        object_id,
+        counter_type: CounterType::Loyalty,
+        count,
+        ..
+    } = event
+    {
+        let rid = compleated_replacement_id(*object_id);
+        if *count > 0
+            && compleated_life_paid(state, *object_id).is_some()
+            && !event.already_applied(&rid)
+        {
+            candidates.push(rid);
+        }
+    }
+
     // CR 702.89a: Umbra armor — a destroy of a permanent enchanted by an Umbra is
     // a candidate for the virtual umbra-armor replacement. Offered independently of
     // the shield-counter match above so a permanent carrying both a shield counter
@@ -3904,6 +3990,10 @@ fn apply_single_replacement(
         return apply_empty_mana_pool_replacement(state, proposed, rid, events);
     }
 
+    if is_compleated_replacement(rid) {
+        return Ok(apply_compleated_replacement(state, proposed, rid, events));
+    }
+
     if let Some(kind) = shield_counter_replacement_kind(rid) {
         return apply_shield_counter_replacement(state, proposed, rid, kind, events);
     }
@@ -4304,6 +4394,13 @@ fn candidate_materiality(
     rid: ReplacementId,
     proposed_to: Option<Zone>,
 ) -> CandidateMateriality {
+    if is_compleated_replacement(rid) {
+        return CandidateMateriality::Writes {
+            field: EventField::Count,
+            commute: CommuteClass::Subtractive,
+        };
+    }
+
     match shield_counter_replacement_kind(rid) {
         Some(ShieldCounterReplacementKind::Destroy) => return CandidateMateriality::Unconditional,
         Some(ShieldCounterReplacementKind::Damage) => {
@@ -4746,10 +4843,13 @@ mod tests {
     use crate::game::game_object::{AttachTarget, GameObject};
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, Effect, QuantityExpr,
-        ReplacementDefinition, ReplacementPlayerScope, TargetFilter, TargetRef,
+        QuantityModification, ReplacementDefinition, ReplacementPlayerScope, TargetFilter,
+        TargetRef,
     };
+    use crate::types::card_type::CoreType;
     use crate::types::game_state::DamageRecord;
     use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::keywords::Keyword;
     use crate::types::player::PlayerId;
     use crate::types::proposed_event::{EtbTapState, TokenSpec};
     use crate::types::replacements::ReplacementEvent;
@@ -5115,6 +5215,69 @@ mod tests {
             panic!("expected NeedsChoice for material ordering, got {result:?}");
         };
         assert_eq!(player, PlayerId(0));
+    }
+
+    fn compleated_doubling_order_result(choice: usize) -> u32 {
+        let compleated = ObjectId(10);
+        let doubling_season = ObjectId(20);
+
+        let mut state = GameState::new_two_player(42);
+        let mut walker = GameObject::new(
+            compleated,
+            CardId(1),
+            PlayerId(0),
+            "Compleated Walker".to_string(),
+            Zone::Battlefield,
+        );
+        walker.card_types.core_types.push(CoreType::Planeswalker);
+        walker.keywords.push(Keyword::Compleated);
+        walker.phyrexian_life_paid = 3;
+        state.objects.insert(compleated, walker);
+        state.battlefield.push_back(compleated);
+
+        let mut doubler = GameObject::new(
+            doubling_season,
+            CardId(2),
+            PlayerId(0),
+            "Doubling Season".to_string(),
+            Zone::Battlefield,
+        );
+        doubler.replacement_definitions =
+            vec![ReplacementDefinition::new(ReplacementEvent::AddCounter)
+                .quantity_modification(QuantityModification::Double)]
+            .into();
+        state.objects.insert(doubling_season, doubler);
+        state.battlefield.push_back(doubling_season);
+
+        let proposed = ProposedEvent::AddCounter {
+            actor: PlayerId(0),
+            object_id: compleated,
+            counter_type: CounterType::Loyalty,
+            count: 5,
+            applied: HashSet::new(),
+        };
+        let mut events = Vec::new();
+        let result = replace_event(&mut state, proposed, &mut events);
+        let ReplacementResult::NeedsChoice(player) = result else {
+            panic!("expected Compleated/Doubling replacement choice, got {result:?}");
+        };
+        assert_eq!(player, PlayerId(0));
+
+        let result = continue_replacement(&mut state, choice, &mut events);
+        let ReplacementResult::Execute(ProposedEvent::AddCounter { count, .. }) = result else {
+            panic!("expected accepted AddCounter after replacement choice, got {result:?}");
+        };
+        count
+    }
+
+    #[test]
+    fn compleated_and_doubling_season_order_is_material() {
+        // CR 702.150a + CR 616.1: Compleated's loyalty reduction and a Doubling
+        // Season-class counter doubler do not commute. Loyalty 5 with three
+        // Phyrexian symbols paid by life is either (5 - 6) * 2 = 0 or
+        // (5 * 2) - 6 = 4 depending on the affected player's chosen order.
+        assert_eq!(compleated_doubling_order_result(0), 0);
+        assert_eq!(compleated_doubling_order_result(1), 4);
     }
 
     #[test]

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -584,32 +584,6 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                         enter_with_counters.extend(intrinsic);
                     }
                 }
-
-                // CR 702.150a: Compleated — "If this permanent would enter with
-                // one or more loyalty counters on it and the player who cast it
-                // chose to pay life for any part of its cost represented by
-                // Phyrexian mana symbols, it instead enters with that many
-                // loyalty counters minus two for each of those mana symbols."
-                // Applied to the seeded loyalty BEFORE the replacement pipeline so
-                // Doubling-Season-class replacements (CR 614.1a) operate on the
-                // reduced amount. `phyrexian_life_paid` was recorded at cast
-                // finalization from the `ShardChoice::PayLife` selections.
-                if obj.phyrexian_life_paid > 0
-                    && obj.has_keyword(&crate::types::keywords::Keyword::Compleated)
-                {
-                    let reduction = obj.phyrexian_life_paid.saturating_mul(2);
-                    if let crate::types::proposed_event::ProposedEvent::ZoneChange {
-                        enter_with_counters,
-                        ..
-                    } = &mut proposed
-                    {
-                        for (counter_type, count) in enter_with_counters.iter_mut() {
-                            if *counter_type == CounterType::Loyalty && *count >= 1 {
-                                *count = count.saturating_sub(reduction);
-                            }
-                        }
-                    }
-                }
             }
 
             // CR 702.176a: Impending — seed the N time counters into the ZoneChange

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -584,6 +584,32 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                         enter_with_counters.extend(intrinsic);
                     }
                 }
+
+                // CR 702.150a: Compleated — "If this permanent would enter with
+                // one or more loyalty counters on it and the player who cast it
+                // chose to pay life for any part of its cost represented by
+                // Phyrexian mana symbols, it instead enters with that many
+                // loyalty counters minus two for each of those mana symbols."
+                // Applied to the seeded loyalty BEFORE the replacement pipeline so
+                // Doubling-Season-class replacements (CR 614.1a) operate on the
+                // reduced amount. `phyrexian_life_paid` was recorded at cast
+                // finalization from the `ShardChoice::PayLife` selections.
+                if obj.phyrexian_life_paid > 0
+                    && obj.has_keyword(&crate::types::keywords::Keyword::Compleated)
+                {
+                    let reduction = obj.phyrexian_life_paid.saturating_mul(2);
+                    if let crate::types::proposed_event::ProposedEvent::ZoneChange {
+                        enter_with_counters,
+                        ..
+                    } = &mut proposed
+                    {
+                        for (counter_type, count) in enter_with_counters.iter_mut() {
+                            if *counter_type == CounterType::Loyalty && *count >= 1 {
+                                *count = count.saturating_sub(reduction);
+                            }
+                        }
+                    }
+                }
             }
 
             // CR 702.176a: Impending — seed the N time counters into the ZoneChange

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -224,12 +224,15 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
             state.layers_dirty.mark_full();
         }
 
-        // CR 400.7 + CR 702.150a: Compleated's Phyrexian life-payment count is
-        // cast metadata. Preserve it only while a resolving permanent spell is
-        // becoming the battlefield object whose ETB counter replacement will
-        // consume it; every other zone change creates an object with no memory
-        // of that payment.
-        if !(from == Zone::Stack && to == Zone::Battlefield) {
+        // CR 400.7d + CR 702.150a: Compleated's Phyrexian life-payment count
+        // is cast metadata. Preserve it while the cast object moves to the
+        // stack, and while the resolving permanent spell becomes the
+        // battlefield object whose ETB counter replacement will consume it.
+        // Every other zone change creates an object with no memory of that
+        // payment.
+        let preserve_phyrexian_life_paid =
+            to == Zone::Stack || (from == Zone::Stack && to == Zone::Battlefield);
+        if !preserve_phyrexian_life_paid {
             obj_mut.phyrexian_life_paid = 0;
         }
 

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -224,6 +224,15 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
             state.layers_dirty.mark_full();
         }
 
+        // CR 400.7 + CR 702.150a: Compleated's Phyrexian life-payment count is
+        // cast metadata. Preserve it only while a resolving permanent spell is
+        // becoming the battlefield object whose ETB counter replacement will
+        // consume it; every other zone change creates an object with no memory
+        // of that payment.
+        if !(from == Zone::Stack && to == Zone::Battlefield) {
+            obj_mut.phyrexian_life_paid = 0;
+        }
+
         // CR 122.2: Counters cease to exist when an object changes zones.
         obj_mut.counters.clear();
     }


### PR DESCRIPTION
## Summary

Implements the **Compleated** keyword (CR 702.150), closing #2539. `Keyword::Compleated` was parsed but inert — a compleated planeswalker cast by paying **life** for its Phyrexian mana symbols entered with its **full** printed loyalty instead of two fewer per symbol (a wrong-board-state bug, e.g. Vraska, Betrayal's Sting entering at 7 instead of 3).

## CR

**CR 702.150a** (verified against `docs/MagicCompRules.txt:5092`): *"If this permanent would enter with one or more loyalty counters on it and the player who cast it chose to pay life for any part of its cost represented by Phyrexian mana symbols, it instead enters the battlefield with that many loyalty counters minus two for each of those mana symbols."*

## How the count flows (cast → ETB)

- **`game/game_object.rs`**: new `GameObject::phyrexian_life_paid: u32`, mirroring `mana_spent_to_cast_amount` — a cast fact that persists through resolution.
- **`game/casting_costs.rs`**: in `finalize_cast_with_phyrexian_choices`, record the number of `ShardChoice::PayLife` selections on the spell object.
- **`game/stack.rs`**: at the planeswalker ETB loyalty-seeding site — right after the intrinsic loyalty is seeded into `enter_with_counters`, **before** the replacement pipeline so Doubling-Season-class effects (CR 614.1a) operate on the reduced amount — reduce the seeded `Loyalty` by `2 ×` the life-paid Phyrexian symbol count (floored at 0; only when it would enter with ≥1 loyalty).

Reuses the existing Phyrexian-payment flow (`SubmitPhyrexianChoices`/`ShardChoice`) and the intrinsic loyalty-counter seeding. No new `Effect` or subsystem — one new persisted cast-context field.

## Coverage

~6 Phyrexia: All Will Be One compleated planeswalkers (Jace, the Perfected Mind; Nissa, Ascended Animist; Vraska, Betrayal's Sting; Tyvar, Jubilant Brawler; Lukka, Bound to Ruin; …).

## Tests

End-to-end: a compleated walker (loyalty 5, two `{U/P}`) cast paying **life** for both enters with **1** (5 − 2·2); cast paying **mana** enters with **5** (control). Robust to object-id changes (the resolved walker is found by keyword on the battlefield).

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — clean.
- Unit tests run in CI (local toolchain has a binutils/dlltool gap); the end-to-end tests pin the cast→pay-life→resolve→ETB path to the correct reduced loyalty.

Closes #2539