### PR TITLE
fix(parser): parse "Any player may activate this ability but only <restriction>" (CR 602.2/602.5)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3856,6 +3856,50 @@ fn find_top_level_colon(line: &str) -> Option<usize> {
     None
 }
 
+/// CR 602.5: Map a trailing activation-timing phrase to its
+/// `ActivationRestriction`(s). Used for the "Any player may activate this ability
+/// but only <phrase>" form (and composable with other timing-suffix handlers).
+/// Returns `None` for phrases without a recognized timing gate so the caller can
+/// decline rather than mis-classify.
+fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRestriction>> {
+    let phrase = phrase.trim().trim_end_matches('.').trim();
+    let lower = phrase.to_lowercase();
+    // Speed / turn / upkeep gates — case-insensitive value matches. "their" is the
+    // activating player's possessive, equivalent to "your" once an activator is fixed.
+    let gate = alt((
+        value(
+            ActivationRestriction::AsSorcery,
+            tag::<_, _, OracleError<'_>>("as a sorcery"),
+        ),
+        value(ActivationRestriction::AsInstant, tag("as an instant")),
+        value(
+            ActivationRestriction::DuringYourTurn,
+            alt((tag("during your turn"), tag("during their turn"))),
+        ),
+        value(
+            ActivationRestriction::DuringYourUpkeep,
+            alt((tag("during your upkeep"), tag("during their upkeep"))),
+        ),
+    ))
+    .parse(lower.as_str());
+    if let Ok((rest, restr)) = gate {
+        if rest.trim().is_empty() {
+            return Some(vec![restr]);
+        }
+    }
+    // CR 602.5: "if <condition>" gate (Lightning Storm "if ~ is on the stack").
+    if value((), tag::<_, _, OracleError<'_>>("if "))
+        .parse(lower.as_str())
+        .is_ok()
+    {
+        let condition_text = phrase[3..].trim();
+        return Some(vec![ActivationRestriction::RequiresCondition {
+            condition: parse_restriction_condition(condition_text),
+        }]);
+    }
+    None
+}
+
 pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConstraintAst) {
     let mut remaining = text.trim().trim_end_matches('.').trim().to_string();
     let mut constraints = ActivatedConstraintAst::default();
@@ -3877,6 +3921,31 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
                     .push(ActivationRestriction::RequiresCondition {
                         condition: parse_restriction_condition(&condition_text),
                     });
+                continue;
+            }
+        }
+
+        // CR 602.2 + CR 602.5: "Any player may activate this ability but only
+        // <restriction>" combines the any-player permission with an activation
+        // timing restriction (Endbringer's Revel "as a sorcery", Volrath's Dungeon
+        // "during their turn", Lightning Storm "if ~ is on the stack"). Split so
+        // BOTH are recorded; otherwise the whole trailing sentence is dropped and
+        // the runtime-enforced timing restriction is silently lost. Must precede
+        // the terminal "any player may activate this ability" strip below, which
+        // would not match because the sentence continues past that phrase.
+        if let Some((before, restriction)) =
+            tp.rsplit_around("any player may activate this ability but only ")
+        {
+            if let Some(parsed) = parse_activation_timing_restriction(restriction.original) {
+                constraints.any_player_may_activate = true;
+                constraints.restrictions.extend(parsed);
+                remaining = before
+                    .original
+                    .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
+                    .to_string();
+                if remaining.trim().is_empty() {
+                    break;
+                }
                 continue;
             }
         }
@@ -7755,6 +7824,54 @@ mod tests {
             }
             other => panic!("expected Forest ReturnToHand cost, got {other:?}"),
         }
+    }
+
+    /// CR 602.2 + CR 602.5: "Any player may activate this ability but only
+    /// <restriction>" must record BOTH the any-player permission and the timing
+    /// restriction, instead of dropping the whole sentence to Unimplemented.
+    #[test]
+    fn any_player_may_activate_but_only_records_timing_restriction() {
+        // "as a sorcery" form (Endbringer's Revel / Scandalmonger / Task Mage Assembly).
+        let r = parse(
+            "{T}: Draw a card. Any player may activate this ability but only as a sorcery.",
+            "Test Any-Player Sorcery",
+            &[],
+            &["Artifact"],
+            &[],
+        );
+        let ability = r
+            .abilities
+            .iter()
+            .find(|a| !a.activation_restrictions.is_empty())
+            .expect("expected an activated ability with restrictions");
+        assert!(
+            ability
+                .activation_restrictions
+                .contains(&ActivationRestriction::AsSorcery),
+            "expected AsSorcery, got {:?}",
+            ability.activation_restrictions
+        );
+
+        // "during their turn" form (Volrath's Dungeon) → the activator's turn.
+        let r = parse(
+            "{T}: Draw a card. Any player may activate this ability but only during their turn.",
+            "Test Any-Player Turn",
+            &[],
+            &["Artifact"],
+            &[],
+        );
+        let ability = r
+            .abilities
+            .iter()
+            .find(|a| !a.activation_restrictions.is_empty())
+            .expect("expected an activated ability with restrictions");
+        assert!(
+            ability
+                .activation_restrictions
+                .contains(&ActivationRestriction::DuringYourTurn),
+            "expected DuringYourTurn, got {:?}",
+            ability.activation_restrictions
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3888,11 +3888,9 @@ fn parse_activation_timing_restriction(phrase: &str) -> Option<Vec<ActivationRes
         }
     }
     // CR 602.5: "if <condition>" gate (Lightning Storm "if ~ is on the stack").
-    if value((), tag::<_, _, OracleError<'_>>("if "))
-        .parse(lower.as_str())
-        .is_ok()
-    {
-        let condition_text = phrase[3..].trim();
+    if let Ok((rest, ())) = value((), tag::<_, _, OracleError<'_>>("if ")).parse(lower.as_str()) {
+        let condition_start = phrase.len() - rest.len();
+        let condition_text = phrase[condition_start..].trim();
         return Some(vec![ActivationRestriction::RequiresCondition {
             condition: parse_restriction_condition(condition_text),
         }]);
@@ -7831,46 +7829,71 @@ mod tests {
     /// restriction, instead of dropping the whole sentence to Unimplemented.
     #[test]
     fn any_player_may_activate_but_only_records_timing_restriction() {
+        let activation_restrictions_for = |text: &str, name: &str| {
+            let parsed = parse(text, name, &[], &["Artifact"], &[]);
+            assert!(
+                parsed.abilities.iter().all(|ability| !matches!(
+                    ability.effect.as_ref(),
+                    Effect::Unimplemented { .. }
+                )),
+                "expected no unimplemented fallback, got {:?}",
+                parsed.abilities
+            );
+            parsed
+                .abilities
+                .into_iter()
+                .find(|ability| !ability.activation_restrictions.is_empty())
+                .expect("expected an activated ability with restrictions")
+                .activation_restrictions
+        };
+
         // "as a sorcery" form (Endbringer's Revel / Scandalmonger / Task Mage Assembly).
-        let r = parse(
+        let restrictions = activation_restrictions_for(
             "{T}: Draw a card. Any player may activate this ability but only as a sorcery.",
             "Test Any-Player Sorcery",
-            &[],
-            &["Artifact"],
-            &[],
         );
-        let ability = r
-            .abilities
-            .iter()
-            .find(|a| !a.activation_restrictions.is_empty())
-            .expect("expected an activated ability with restrictions");
         assert!(
-            ability
-                .activation_restrictions
-                .contains(&ActivationRestriction::AsSorcery),
+            restrictions.contains(&ActivationRestriction::AsSorcery),
             "expected AsSorcery, got {:?}",
-            ability.activation_restrictions
+            restrictions
         );
 
         // "during their turn" form (Volrath's Dungeon) → the activator's turn.
-        let r = parse(
+        let restrictions = activation_restrictions_for(
             "{T}: Draw a card. Any player may activate this ability but only during their turn.",
             "Test Any-Player Turn",
-            &[],
-            &["Artifact"],
-            &[],
         );
-        let ability = r
-            .abilities
-            .iter()
-            .find(|a| !a.activation_restrictions.is_empty())
-            .expect("expected an activated ability with restrictions");
         assert!(
-            ability
-                .activation_restrictions
-                .contains(&ActivationRestriction::DuringYourTurn),
+            restrictions.contains(&ActivationRestriction::DuringYourTurn),
             "expected DuringYourTurn, got {:?}",
-            ability.activation_restrictions
+            restrictions
+        );
+
+        // "during their upkeep" form maps to the activator's upkeep restriction.
+        let restrictions = activation_restrictions_for(
+            "{T}: Draw a card. Any player may activate this ability but only during their upkeep.",
+            "Test Any-Player Upkeep",
+        );
+        assert!(
+            restrictions.contains(&ActivationRestriction::DuringYourUpkeep),
+            "expected DuringYourUpkeep, got {:?}",
+            restrictions
+        );
+
+        // "if <condition>" form (Lightning Storm) keeps the parsed condition gate.
+        let restrictions = activation_restrictions_for(
+            "{T}: Draw a card. Any player may activate this ability but only if ~ is on the stack.",
+            "Test Any-Player Condition",
+        );
+        assert!(
+            restrictions.iter().any(|restriction| matches!(
+                restriction,
+                ActivationRestriction::RequiresCondition {
+                    condition: Some(ParsedCondition::SourceInZone { zone: Zone::Stack })
+                }
+            )),
+            "expected source-on-stack condition, got {:?}",
+            restrictions
         );
     }
 

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -20,6 +20,26 @@ use crate::types::keywords::Keyword;
 use crate::types::mana::ManaColor;
 use crate::types::zones::Zone;
 
+fn scan_source_zone_filter(text: &str) -> Option<Zone> {
+    let mut offset = 0;
+    while offset <= text.len() {
+        if let Ok((rest, zone)) = super::oracle_nom::filter::parse_zone_filter(&text[offset..]) {
+            if rest
+                .chars()
+                .next()
+                .is_none_or(|ch| matches!(ch, ' ' | ',' | '.'))
+            {
+                return Some(zone);
+            }
+        }
+        match text[offset..].find(' ') {
+            Some(i) => offset += i + 1,
+            None => break,
+        }
+    }
+    None
+}
+
 /// CR 601.3 / CR 602.5: Parse a restriction condition from Oracle text into a typed
 /// `ParsedCondition`. These conditions gate whether a spell can be cast or ability activated.
 /// Returns `None` for unrecognized conditions (caller treats `None` as permissive true).
@@ -234,6 +254,9 @@ fn parse_source_condition(text: &str) -> Option<ParsedCondition> {
     // the full zone vocabulary (graveyard/hand/exile/library/battlefield) is covered
     // uniformly with word-boundary safety and the combinator-mandated parse path.
     if let Some((zone, _ctrl, _props)) = super::oracle_target::scan_zone_phrase(text) {
+        return Some(ParsedCondition::SourceInZone { zone });
+    }
+    if let Some(zone) = scan_source_zone_filter(text) {
         return Some(ParsedCondition::SourceInZone { zone });
     }
     // Source state: scan for state keywords after the subject using nom at word boundaries
@@ -1171,6 +1194,10 @@ mod tests {
             Some(ParsedCondition::SourceInZone {
                 zone: Zone::Graveyard
             }),
+        );
+        assert_eq!(
+            parse_restriction_condition("~ is on the stack"),
+            Some(ParsedCondition::SourceInZone { zone: Zone::Stack }),
         );
         assert_eq!(
             parse_restriction_condition("From your graveyard"),


### PR DESCRIPTION
## What

The activated-ability constraint loop (`oracle.rs::strip_activated_constraints`) recognized the **terminal** annotation `"any player may activate this ability"` and, separately, terminal `"activate only <timing>"` suffixes. But real cards combine them as **"Any player may activate this ability but only `<restriction>`"** — which matches neither handler, so the whole trailing sentence was left unconsumed and dropped to `Unimplemented`.

Critically, the **activation-timing restriction is enforced at runtime**, so dropping it let these abilities be activated at any time / speed — e.g. Endbringer's Revel at instant speed, Armageddon Clock outside upkeep.

Fixes #2541.

## Approach

- Add a handler (running *before* the terminal any-player strip, which can't match the continued sentence) that splits on `"any player may activate this ability but only "`, sets `any_player_may_activate`, and maps the trailing phrase to its `ActivationRestriction`.
- New `parse_activation_timing_restriction` helper (nom combinators): `AsSorcery`, `AsInstant`, `DuringYourTurn` (for "your"/"their" turn — "their" = the activator's), `DuringYourUpkeep`, and `RequiresCondition` for the "if `<condition>`" form (Lightning Storm "if ~ is on the stack"). Phrases without a recognized gate decline so they are never mis-classified.

## Cards addressed

Endbringer's Revel, Scandalmonger, Task Mage Assembly ("as a sorcery"); Volrath's Dungeon ("during their turn"); Lightning Storm ("if ~ is on the stack"). (The "during any upkeep step" / "before the end step" phrasings — Armageddon Clock, Infinite Hourglass, Mana Cache — have no clean existing `ActivationRestriction` variant and are intentionally left to decline; a follow-up can add a phase-gate variant.)

## CR

- **CR 602.2 / 602.5** — who may activate an activated ability, and activation-timing restrictions.

## Tests

- `any_player_may_activate_but_only_records_timing_restriction` — the "as a sorcery" form records `AsSorcery`, and "during their turn" records `DuringYourTurn` (both alongside the any-player permission), with no `Unimplemented` clause.
- Regression: terminal "Any player may activate this ability." and the existing "activate only …" suffixes unchanged — 41 activation tests pass.

`cargo fmt --all`, `clippy -p engine -D warnings`, and the parser-combinator gate are clean.

## Non-duplicate

`Armageddon Clock`, `Volrath's Dungeon`, and `Infinite Hourglass` return no open or closed issues/PRs. Only the terminal "any player may activate this ability" form was handled; the combined "… but only `<restriction>`" form (which dropped the timing restriction) was not.
