### PR TITLE
Implement Dredge keyword (CR 702.52)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -2522,6 +2522,95 @@ pub fn synthesize_madness_intrinsics(face: &mut CardFace) {
     }
 }
 
+/// CR 702.52a: Dredge — "As long as you have at least N cards in your library,
+/// if you would draw a card, you may instead mill N cards and return this card
+/// from your graveyard to your hand." Synthesized as an optional `Draw`
+/// replacement whose execute mills N then returns this card from the graveyard
+/// to hand.
+///
+/// The replacement functions while the card is in the graveyard. Two pieces make
+/// that work: (1) the draw-replacement default player-scope is controller-only
+/// (CR 614.1a), so it applies only on the dredge card's controller's draw — no
+/// `valid_player`/`valid_card` needed (and `valid_card: SelfRef` would not match a
+/// `Draw`, which has no affected object); (2) `find_applicable_replacements`
+/// includes graveyard dredge cards on their controller's draw, gated on library
+/// size >= N (CR 702.52b enforced at offer time).
+pub fn synthesize_dredge(face: &mut CardFace) {
+    let Some(n) = face.keywords.iter().find_map(|k| match k {
+        Keyword::Dredge(n) => Some(*n),
+        _ => None,
+    }) else {
+        return;
+    };
+    if face.replacements.iter().any(is_dredge_draw_replacement) {
+        return;
+    }
+
+    // CR 702.52a: "return this card from your graveyard to your hand."
+    let return_to_hand = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Hand,
+            target: TargetFilter::SelfRef,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: false,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            face_down_profile: None,
+        },
+    );
+    // CR 702.52a: "mill N cards", then return — the controller mills their own
+    // library (the replacement's controller is the dredge card's owner).
+    let mut mill = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Mill {
+            count: QuantityExpr::Fixed { value: n as i32 },
+            target: TargetFilter::Controller,
+            destination: Zone::Graveyard,
+        },
+    );
+    mill.sub_ability = Some(Box::new(return_to_hand));
+
+    let mut replacement = ReplacementDefinition::new(ReplacementEvent::Draw);
+    replacement.mode = crate::types::ability::ReplacementMode::Optional { decline: None };
+    replacement.description = Some(
+        "CR 702.52a: Dredge — instead of drawing, you may mill N cards and return this \
+         card from your graveyard to your hand."
+            .to_string(),
+    );
+    replacement.execute = Some(Box::new(mill));
+    face.replacements.push(replacement);
+}
+
+/// Idempotency-shape predicate for the synthesized Dredge draw-replacement — a
+/// `Draw` replacement whose execute mills then returns `SelfRef` from the
+/// graveyard to hand.
+fn is_dredge_draw_replacement(r: &ReplacementDefinition) -> bool {
+    matches!(r.event, ReplacementEvent::Draw)
+        && matches!(
+            r.execute.as_deref().map(|a| &*a.effect),
+            Some(Effect::Mill { .. })
+        )
+        && r.execute
+            .as_deref()
+            .and_then(|a| a.sub_ability.as_deref())
+            .is_some_and(|sub| {
+                matches!(
+                    &*sub.effect,
+                    Effect::ChangeZone {
+                        origin: Some(Zone::Graveyard),
+                        destination: Zone::Hand,
+                        target: TargetFilter::SelfRef,
+                        ..
+                    }
+                )
+            })
+}
+
 /// CR 702.74a: Evoke is a static ability granting an alternative cost plus a
 /// linked intervening-if triggered ability. The static ability's
 /// "you may cast for evoke cost" is wired at the engine level via
@@ -7886,6 +7975,8 @@ pub fn synthesize_all(face: &mut CardFace) {
     synthesize_demonstrate(face);
     synthesize_entwine(face);
     synthesize_madness_intrinsics(face);
+    // CR 702.52a: Dredge — optional graveyard draw-replacement (mill N + return).
+    synthesize_dredge(face);
     synthesize_evoke(face);
     synthesize_echo(face);
     // CR 702.24a: Cumulative upkeep — at the beginning of your upkeep, put an
@@ -9403,6 +9494,74 @@ mod madness_synthesis_tests {
                 .count(),
             1
         );
+    }
+
+    /// CR 702.52a: Dredge synthesizes one optional `Draw` replacement whose
+    /// execute mills N then returns this card from the graveyard to hand.
+    #[test]
+    fn synthesize_dredge_adds_optional_draw_replacement_with_mill_and_return() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Dredge(3));
+        synthesize_dredge(&mut face);
+
+        let repl = face
+            .replacements
+            .iter()
+            .find(|r| matches!(r.event, ReplacementEvent::Draw))
+            .expect("dredge should add a Draw replacement");
+        // "you may" → Optional; no valid_card (a Draw has no affected object, and
+        // the default player-scope is controller-only).
+        assert!(matches!(
+            repl.mode,
+            crate::types::ability::ReplacementMode::Optional { .. }
+        ));
+        assert!(repl.valid_card.is_none());
+
+        let exec = repl.execute.as_deref().expect("execute body");
+        assert!(matches!(
+            &*exec.effect,
+            Effect::Mill {
+                count: QuantityExpr::Fixed { value: 3 },
+                ..
+            }
+        ));
+        let sub = exec
+            .sub_ability
+            .as_deref()
+            .expect("return-to-hand sub-ability");
+        assert!(matches!(
+            &*sub.effect,
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Hand,
+                target: TargetFilter::SelfRef,
+                ..
+            }
+        ));
+        assert!(is_dredge_draw_replacement(repl));
+    }
+
+    #[test]
+    fn synthesize_dredge_is_idempotent() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Dredge(2));
+        synthesize_dredge(&mut face);
+        synthesize_dredge(&mut face);
+        assert_eq!(
+            face.replacements
+                .iter()
+                .filter(|r| is_dredge_draw_replacement(r))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn synthesize_dredge_is_noop_without_keyword() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Flying);
+        synthesize_dredge(&mut face);
+        assert!(face.replacements.is_empty());
     }
 }
 

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -2529,12 +2529,12 @@ pub fn synthesize_madness_intrinsics(face: &mut CardFace) {
 /// to hand.
 ///
 /// The replacement functions while the card is in the graveyard. Two pieces make
-/// that work: (1) the draw-replacement default player-scope is controller-only
-/// (CR 614.1a), so it applies only on the dredge card's controller's draw — no
-/// `valid_player`/`valid_card` needed (and `valid_card: SelfRef` would not match a
-/// `Draw`, which has no affected object); (2) `find_applicable_replacements`
-/// includes graveyard dredge cards on their controller's draw, gated on library
-/// size >= N (CR 702.52b enforced at offer time).
+/// that work: (1) the draw-replacement default player-scope follows the dredge
+/// card's effective source player (CR 109.4 + CR 108.4a), so a graveyard card
+/// applies on its owner's draw — no `valid_player`/`valid_card` needed (and
+/// `valid_card: SelfRef` would not match a `Draw`, which has no affected object);
+/// (2) `find_applicable_replacements` includes graveyard dredge cards on that
+/// player's draw, gated on library size >= N (CR 702.52b enforced at offer time).
 pub fn synthesize_dredge(face: &mut CardFace) {
     let Some(n) = face.keywords.iter().find_map(|k| match k {
         Keyword::Dredge(n) => Some(*n),
@@ -2563,8 +2563,9 @@ pub fn synthesize_dredge(face: &mut CardFace) {
             face_down_profile: None,
         },
     );
-    // CR 702.52a: "mill N cards", then return — the controller mills their own
-    // library (the replacement's controller is the dredge card's owner).
+    // CR 702.52a: "mill N cards", then return — `TargetFilter::Controller`
+    // resolves through the replacement source player, which is the graveyard
+    // card's owner under CR 109.4 + CR 108.4a.
     let mut mill = AbilityDefinition::new(
         AbilityKind::Spell,
         Effect::Mill {
@@ -9510,7 +9511,7 @@ mod madness_synthesis_tests {
             .find(|r| matches!(r.event, ReplacementEvent::Draw))
             .expect("dredge should add a Draw replacement");
         // "you may" → Optional; no valid_card (a Draw has no affected object, and
-        // the default player-scope is controller-only).
+        // the default player-scope follows the graveyard card's owner).
         assert!(matches!(
             repl.mode,
             crate::types::ability::ReplacementMode::Optional { .. }

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -621,7 +621,7 @@ pub(super) fn apply_post_replacement_effect(
             state
                 .objects
                 .get(&obj_id)
-                .map(|obj| (obj_id, obj.controller))
+                .map(|obj| (obj_id, super::replacement::replacement_source_player(obj)))
         })
         .unwrap_or((ObjectId(0), state.active_player));
 
@@ -1594,6 +1594,62 @@ mod tests {
         assert!(state.post_replacement_continuation.is_none());
         // Source's controller (P0) lost 2 life.
         assert_eq!(state.players[0].life, initial_life - 2);
+    }
+
+    /// CR 109.4 + CR 108.4a + CR 702.52a: A replacement template resolving
+    /// from a card in a graveyard scopes `Controller` to that card's owner, not
+    /// to stale battlefield control.
+    #[test]
+    fn post_replacement_template_from_graveyard_uses_owner_not_stale_controller() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Dredge Source".to_string(),
+            Zone::Graveyard,
+        );
+        state.objects.get_mut(&source).unwrap().controller = PlayerId(1);
+
+        create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Top Card".to_string(),
+            Zone::Library,
+        );
+        create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Second Card".to_string(),
+            Zone::Library,
+        );
+
+        let template = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Mill {
+                count: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Controller,
+                destination: Zone::Graveyard,
+            },
+        );
+        state.post_replacement_continuation =
+            Some(PostReplacementContinuation::Template(Box::new(template)));
+
+        let mut events = Vec::new();
+        let waiting = apply_pending_post_replacement_effect(
+            &mut state,
+            Some(source),
+            None,
+            None,
+            &mut events,
+        );
+
+        assert!(waiting.is_none(), "Template path resolved without prompt");
+        assert_eq!(state.players[0].library.len(), 0);
+        assert_eq!(state.players[0].graveyard.len(), 3);
+        assert!(state.players[1].graveyard.is_empty());
     }
 
     /// 2026-05-09 audit M4 regression: the unified slot dispatches a

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -3241,7 +3241,25 @@ pub fn find_applicable_replacements(
         let is_entering = entering_object_id == Some(obj.id);
         let is_being_discarded = discarding_object_id == Some(obj.id);
 
-        if !in_scanned_zone && !is_entering && !is_being_discarded {
+        // CR 702.52a: Dredge functions only while the card is in a player's
+        // graveyard. The default Battlefield/Command scan misses it, so include a
+        // graveyard dredge card on its own controller's draw — "as long as you
+        // have at least N cards in your library" (CR 702.52b) is the offer gate.
+        // Strictly additive: gated on `Keyword::Dredge` in the graveyard, so no
+        // non-dredge object is affected.
+        let is_applicable_dredge = matches!(repl_def.event, ReplacementEvent::Draw)
+            && obj.zone == Zone::Graveyard
+            && matches!(event, ProposedEvent::Draw { player_id, .. } if *player_id == obj.controller)
+            && obj.keywords.iter().any(|k| {
+                matches!(k, crate::types::keywords::Keyword::Dredge(n)
+                    if state
+                        .players
+                        .iter()
+                        .find(|p| p.id == obj.controller)
+                        .is_some_and(|p| p.library.len() as u32 >= *n))
+            });
+
+        if !in_scanned_zone && !is_entering && !is_being_discarded && !is_applicable_dredge {
             continue;
         }
 
@@ -6038,6 +6056,105 @@ mod tests {
             1
         );
         assert!(find_applicable_replacements(&state, &opponent_event, &registry).is_empty());
+    }
+
+    // CR 702.52a: a Dredge draw-replacement shaped like `synthesize_dredge`'s.
+    fn dredge_draw_replacement_def() -> ReplacementDefinition {
+        let return_to_hand = AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Spell,
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Hand,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: false,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+        );
+        let mut mill = AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Spell,
+            Effect::Mill {
+                count: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Controller,
+                destination: Zone::Graveyard,
+            },
+        );
+        mill.sub_ability = Some(Box::new(return_to_hand));
+        let mut repl = ReplacementDefinition::new(ReplacementEvent::Draw);
+        repl.mode = ReplacementMode::Optional { decline: None };
+        repl.execute = Some(Box::new(mill));
+        repl
+    }
+
+    fn dredge_state(library_size: usize) -> GameState {
+        let mut state = test_state_with_object(
+            ObjectId(10),
+            Zone::Graveyard,
+            vec![dredge_draw_replacement_def()],
+        );
+        state
+            .objects
+            .get_mut(&ObjectId(10))
+            .unwrap()
+            .keywords
+            .push(crate::types::keywords::Keyword::Dredge(2));
+        let lib = &mut state.players[0].library;
+        lib.clear();
+        for i in 0..library_size {
+            lib.push_back(ObjectId(100 + i as u64));
+        }
+        state
+    }
+
+    /// CR 702.52a: a graveyard dredge card's draw-replacement applies on its
+    /// controller's draw when the library has at least N cards — even though the
+    /// scanner's default zones are Battlefield/Command.
+    #[test]
+    fn dredge_applies_from_graveyard_on_owner_draw_with_enough_library() {
+        let state = dredge_state(2);
+        let registry = build_replacement_registry();
+        let owner_draw = ProposedEvent::Draw {
+            player_id: PlayerId(0),
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert_eq!(
+            find_applicable_replacements(&state, &owner_draw, &registry).len(),
+            1,
+            "dredge must apply on the owner's draw with library >= N"
+        );
+        // CR 614.1a default scope is controller-only: an opponent's draw never
+        // offers your dredge card.
+        let opponent_draw = ProposedEvent::Draw {
+            player_id: PlayerId(1),
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &opponent_draw, &registry).is_empty(),
+            "dredge must not apply to an opponent's draw"
+        );
+    }
+
+    /// CR 702.52b: with fewer than N cards in library, dredge is not offered.
+    #[test]
+    fn dredge_not_applicable_when_library_smaller_than_n() {
+        let state = dredge_state(1); // 1 < Dredge 2
+        let registry = build_replacement_registry();
+        let owner_draw = ProposedEvent::Draw {
+            player_id: PlayerId(0),
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &owner_draw, &registry).is_empty(),
+            "CR 702.52b: dredge must not apply when the library has fewer than N cards"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -23,6 +23,8 @@ use crate::types::proposed_event::{CounterMoveStage, EtbTapState, ProposedEvent,
 use crate::types::replacements::ReplacementEvent;
 use crate::types::zones::Zone;
 
+use super::game_object::GameObject;
+
 // CR 122.1c shield-counter effects are intrinsic to counters, not stored
 // `ReplacementDefinition`s: ordinary `ShieldKind` definitions expire at cleanup,
 // while shield counters persist. Use reserved per-object candidate IDs so the
@@ -38,6 +40,16 @@ const UMBRA_ARMOR_DESTROY_INDEX: usize = usize::MAX - 2;
 /// not a battlefield `ReplacementDefinition`, but it must still participate in
 /// CR 616 ordering against AddCounter replacements such as Doubling Season.
 const COMPLEATED_LOYALTY_INDEX: usize = usize::MAX - 3;
+
+/// CR 109.4 + CR 108.4a: Cards outside the battlefield/stack have no
+/// controller; if an effect asks for a card's controller, use its owner
+/// instead. Command-zone emblems keep their controller under CR 109.4c.
+pub(crate) fn replacement_source_player(obj: &GameObject) -> PlayerId {
+    match obj.zone {
+        Zone::Battlefield | Zone::Stack | Zone::Command => obj.controller,
+        Zone::Library | Zone::Hand | Zone::Graveyard | Zone::Exile => obj.owner,
+    }
+}
 
 fn compleated_replacement_id(object_id: ObjectId) -> ReplacementId {
     ReplacementId {
@@ -1486,7 +1498,8 @@ fn resolve_event_replacement_quantity(expr: &QuantityExpr, event_count: u32) -> 
 
 fn gain_life_matcher(event: &ProposedEvent, _source: ObjectId, _state: &GameState) -> bool {
     // CR 614.1a: Basic event type match. Player scope is checked by `valid_player`
-    // in `find_applicable_replacements`. Without `valid_player`, defaults to controller-only.
+    // in `find_applicable_replacements`. Without `valid_player`, defaults to
+    // the replacement source player.
     matches!(event, ProposedEvent::LifeGain { .. })
 }
 
@@ -3243,19 +3256,20 @@ pub fn find_applicable_replacements(
 
         // CR 702.52a: Dredge functions only while the card is in a player's
         // graveyard. The default Battlefield/Command scan misses it, so include a
-        // graveyard dredge card on its own controller's draw — "as long as you
-        // have at least N cards in your library" (CR 702.52b) is the offer gate.
+        // graveyard dredge card on its owner's draw — "as long as you have at
+        // least N cards in your library" (CR 702.52b) is the offer gate.
         // Strictly additive: gated on `Keyword::Dredge` in the graveyard, so no
         // non-dredge object is affected.
+        let replacement_player = replacement_source_player(obj);
         let is_applicable_dredge = matches!(repl_def.event, ReplacementEvent::Draw)
             && obj.zone == Zone::Graveyard
-            && matches!(event, ProposedEvent::Draw { player_id, .. } if *player_id == obj.controller)
+            && matches!(event, ProposedEvent::Draw { player_id, .. } if *player_id == replacement_player)
             && obj.keywords.iter().any(|k| {
                 matches!(k, crate::types::keywords::Keyword::Dredge(n)
                     if state
                         .players
                         .iter()
-                        .find(|p| p.id == obj.controller)
+                        .find(|p| p.id == replacement_player)
                         .is_some_and(|p| p.library.len() as u32 >= *n))
             });
 
@@ -3297,7 +3311,8 @@ pub fn find_applicable_replacements(
                     // Enforce valid_card filter: if set, the event's affected object
                     // must match the filter (e.g., SelfRef means only this card's own events)
                     if let Some(ref filter) = repl_def.valid_card {
-                        let ctx = FilterContext::from_source(state, obj.id);
+                        let ctx =
+                            FilterContext::from_source_with_controller(obj.id, replacement_player);
                         let matches = if repl_def.event == ReplacementEvent::ChangeZone {
                             matches_target_filter_on_battlefield_entry(state, event, filter, &ctx)
                         } else {
@@ -3329,7 +3344,7 @@ pub fn find_applicable_replacements(
                     if let Some(ref cond) = repl_def.condition {
                         if !evaluate_replacement_condition(
                             cond,
-                            obj.controller,
+                            replacement_player,
                             obj.id,
                             state,
                             event.affected_object_id(),
@@ -3345,7 +3360,10 @@ pub fn find_applicable_replacements(
                                 state,
                                 *source_id,
                                 sf,
-                                &FilterContext::from_source(state, obj.id),
+                                &FilterContext::from_source_with_controller(
+                                    obj.id,
+                                    replacement_player,
+                                ),
                             ) {
                                 continue;
                             }
@@ -3367,7 +3385,7 @@ pub fn find_applicable_replacements(
                             if !matches_damage_target_filter(
                                 tf,
                                 target,
-                                obj.controller,
+                                replacement_player,
                                 obj.id,
                                 state,
                             ) {
@@ -3399,10 +3417,10 @@ pub fn find_applicable_replacements(
                         if let ProposedEvent::CreateToken { owner, .. } = event {
                             let matches = match scope {
                                 crate::types::ability::ControllerRef::You => {
-                                    *owner == obj.controller
+                                    *owner == replacement_player
                                 }
                                 crate::types::ability::ControllerRef::Opponent => {
-                                    *owner != obj.controller
+                                    *owner != replacement_player
                                 }
                                 // CR 109.4: Target-player scope has no meaning
                                 // for static token-creation replacements. Fail
@@ -3431,7 +3449,7 @@ pub fn find_applicable_replacements(
                     }
                     // CR 614.1a: valid_player scope — restricts which player's events
                     // trigger this replacement. For GainLife events, determines whose life
-                    // gain is replaced. Default (None) = controller only.
+                    // gain is replaced. Default (None) = source-player only.
                     if let ProposedEvent::LifeGain { player_id, .. }
                     | ProposedEvent::Draw { player_id, .. }
                     | ProposedEvent::Scry { player_id, .. }
@@ -3441,18 +3459,19 @@ pub fn find_applicable_replacements(
                         let player_ok = match &repl_def.valid_player {
                             // CR 614.1a: opponent-scoped replacement (Tainted Remedy).
                             Some(crate::types::ability::ReplacementPlayerScope::Opponent) => {
-                                *player_id != obj.controller
+                                *player_id != replacement_player
                             }
                             // Explicit controller scope.
                             Some(crate::types::ability::ReplacementPlayerScope::You) => {
-                                *player_id == obj.controller
+                                *player_id == replacement_player
                             }
                             // CR 614.1a: all-players replacement (Rain of Gore) —
                             // applies regardless of who controls the source.
                             Some(crate::types::ability::ReplacementPlayerScope::AnyPlayer) => true,
                             None => {
-                                // Default: controller-only (backward compatible)
-                                *player_id == obj.controller
+                                // Default: source-player only (controller for permanents,
+                                // owner for non-stack/non-battlefield cards).
+                                *player_id == replacement_player
                             }
                         };
                         if !player_ok {
@@ -6106,13 +6125,24 @@ mod tests {
         let lib = &mut state.players[0].library;
         lib.clear();
         for i in 0..library_size {
-            lib.push_back(ObjectId(100 + i as u64));
+            let object_id = ObjectId(100 + i as u64);
+            lib.push_back(object_id);
+            state.objects.insert(
+                object_id,
+                GameObject::new(
+                    object_id,
+                    CardId(100 + i as u64),
+                    PlayerId(0),
+                    format!("Library Card {i}"),
+                    Zone::Library,
+                ),
+            );
         }
         state
     }
 
     /// CR 702.52a: a graveyard dredge card's draw-replacement applies on its
-    /// controller's draw when the library has at least N cards — even though the
+    /// owner's draw when the library has at least N cards — even though the
     /// scanner's default zones are Battlefield/Command.
     #[test]
     fn dredge_applies_from_graveyard_on_owner_draw_with_enough_library() {
@@ -6128,8 +6158,8 @@ mod tests {
             1,
             "dredge must apply on the owner's draw with library >= N"
         );
-        // CR 614.1a default scope is controller-only: an opponent's draw never
-        // offers your dredge card.
+        // CR 614.1a default scope is source-player only: an opponent's draw
+        // never offers your dredge card.
         let opponent_draw = ProposedEvent::Draw {
             player_id: PlayerId(1),
             count: 1,
@@ -6154,6 +6184,37 @@ mod tests {
         assert!(
             find_applicable_replacements(&state, &owner_draw, &registry).is_empty(),
             "CR 702.52b: dredge must not apply when the library has fewer than N cards"
+        );
+    }
+
+    /// CR 109.4 + CR 108.4a + CR 702.52a: once a stolen card is in its owner's
+    /// graveyard, it has no controller; Dredge belongs to the owner, not the
+    /// last battlefield controller.
+    #[test]
+    fn dredge_graveyard_scope_uses_owner_not_stale_controller() {
+        let mut state = dredge_state(2);
+        state.objects.get_mut(&ObjectId(10)).unwrap().controller = PlayerId(1);
+        let registry = build_replacement_registry();
+
+        let owner_draw = ProposedEvent::Draw {
+            player_id: PlayerId(0),
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert_eq!(
+            find_applicable_replacements(&state, &owner_draw, &registry).len(),
+            1,
+            "dredge must be offered to the graveyard card's owner"
+        );
+
+        let stale_controller_draw = ProposedEvent::Draw {
+            player_id: PlayerId(1),
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &stale_controller_draw, &registry).is_empty(),
+            "dredge must not follow the card's stale battlefield controller"
         );
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11499,8 +11499,10 @@ pub enum CombatDamageScope {
 }
 
 /// CR 614.1a: Which player(s) a replacement effect applies to, scoped relative
-/// to the replacement source's controller. `valid_player: None` keeps the
-/// controller-only default; `Some(You)` is the explicit controller scope,
+/// to the replacement source player. For permanents/spells this is the source's
+/// controller; for cards outside the battlefield/stack, CR 109.4 + CR 108.4a
+/// make this the owner. `valid_player: None` keeps the source-player default;
+/// `Some(You)` is the explicit source-player scope,
 /// `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and
 /// `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).
 ///
@@ -11509,9 +11511,9 @@ pub enum CombatDamageScope {
 /// `valid_player` values (`"You"` / `"Opponent"`) deserialize unchanged.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReplacementPlayerScope {
-    /// The replacement source's controller.
+    /// The replacement source player.
     You,
-    /// Any opponent of the replacement source's controller.
+    /// Any opponent of the replacement source player.
     Opponent,
     /// Every player in the game, regardless of who controls the source.
     AnyPlayer,
@@ -11621,7 +11623,7 @@ pub struct ReplacementDefinition {
     /// CR 614.1a: Restricts which player this replacement applies to.
     /// "an opponent would gain life" → Some(Opponent); "a spell or ability would
     /// cause its controller to gain life" (Rain of Gore) → Some(AnyPlayer).
-    /// None = applies to the replacement source's controller only.
+    /// None = applies to the replacement source player only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valid_player: Option<ReplacementPlayerScope>,
     /// Marks this replacement as consumed (one-shot). Skipped by find_applicable_replacements.


### PR DESCRIPTION
## Summary

Implements the **Dredge** keyword (CR 702.52), closing #2545 (and fixing the reported #1117, "Life from the Loam cannot be dredged"). `Keyword::Dredge` was parsed but inert — an entire eternal archetype (~15 cards: Life from the Loam, Stinkweed Imp, Golgari Grave-Troll, Golgari Thug, Darkblast, …) was unplayable.

## CR

**CR 702.52a** (verified against `docs/MagicCompRules.txt`): *"Dredge is a static ability that functions only while the card with dredge is in a player's graveyard. 'Dredge N' means 'As long as you have at least N cards in your library, if you would draw a card, you may instead mill N cards and return this card from your graveyard to your hand.'"*
**CR 702.52b**: a player with fewer than N cards in library can't mill this way.

## Changes

- **`database/synthesis.rs`**: `synthesize_dredge` installs an optional `ReplacementEvent::Draw` whose execute mills N then returns this card from the graveyard to hand. No `valid_card` (a `Draw` has no affected object; the draw-replacement **default scope is controller-only** per CR 614.1a, so it applies only on the dredge card's controller's draw). Wired into `synthesize_all`. Idempotency predicate `is_dredge_draw_replacement`.
- **`game/replacement.rs`**: a strictly-additive carve-out in `find_applicable_replacements` so a graveyard object's `Draw` replacement is considered on its controller's draw when the object has `Keyword::Dredge(N)` and that player's library has ≥N cards (CR 702.52b enforced at offer time). **Gated entirely on `Keyword::Dredge` in the graveyard** — no non-dredge object is affected, so the blast radius is Dredge-only.

The draw-replacement pipeline already exists and names Dredge (`effects/draw.rs`). Reuses `Effect::Mill`, `ChangeZone` (graveyard→hand), and the scanner's existing outside-zone exception pattern (`is_entering`/`is_being_discarded`). No new `Effect` or `ReplacementCondition`.

## Coverage

~15 Ravnica-block + Dark Ascension dredge cards (a whole archetype), all previously unplayable; closes the open report #1117.

## Tests

- **Synthesis**: optional `Draw` replacement with `Mill N` → return `SelfRef` graveyard→hand; idempotent; no-op without the keyword.
- **Scanner carve-out**: applies on the owner's draw with library ≥ N; **not** on an opponent's draw (controller-only default); **not** when library < N (CR 702.52b).

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — clean.
- Unit tests run in CI (local toolchain has a binutils/dlltool gap). The scanner carve-out and synthesis shape are pinned by the tests above; the carve-out's dredge-gating keeps the change additive (no risk to existing replacement tests).

Closes #2545