### PR TITLE
fix(parser): treat 'a X, a Y, or a Z card' search as single-card disjunction

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -30600,6 +30600,67 @@ mod tests {
         assert_library_change_destination(move_found, Zone::Graveyard);
     }
 
+    /// CR 701.23a: Search for Glory — "a snow permanent card, a legendary card,
+    /// or a Saga card" is a disjunctive series describing ONE card matching any
+    /// of three co-equal filters. It must lower to a single `SearchLibrary` with
+    /// `count: Fixed{1}`, an `Or` of three branches, and `selection_constraint:
+    /// None` (NOT `MatchEachFilter` / three required picks). The destination /
+    /// shuffle / gain-life sub_ability chain stays intact.
+    #[test]
+    fn search_for_glory_disjunctive_series_lowers_to_single_or_choice() {
+        let def = parse_effect_chain(
+            "Search your library for a snow permanent card, a legendary card, or a Saga card, reveal it, put it into your hand, then shuffle. You gain 1 life for each {S} spent to cast this spell.",
+            AbilityKind::Spell,
+        );
+
+        let Effect::SearchLibrary {
+            filter,
+            count,
+            selection_constraint,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected SearchLibrary, got {:?}", def.effect);
+        };
+        assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+        assert_eq!(*selection_constraint, SearchSelectionConstraint::None);
+        let TargetFilter::Or { filters } = filter else {
+            panic!("expected Or search filter, got {filter:?}");
+        };
+        assert_eq!(
+            filters.len(),
+            3,
+            "expected 3 disjunctive branches: {filters:?}"
+        );
+
+        // sub_ability chain: ChangeZone (Library -> Hand) -> Shuffle -> GainLife.
+        let move_found = def
+            .sub_ability
+            .as_deref()
+            .expect("expected move ChangeZone");
+        assert_library_change_destination(move_found, Zone::Hand);
+
+        let shuffle = move_found
+            .sub_ability
+            .as_deref()
+            .expect("expected Shuffle after move");
+        assert!(
+            matches!(*shuffle.effect, Effect::Shuffle { .. }),
+            "expected Shuffle, got {:?}",
+            shuffle.effect
+        );
+
+        let gain_life = shuffle
+            .sub_ability
+            .as_deref()
+            .expect("expected GainLife after shuffle");
+        assert!(
+            matches!(*gain_life.effect, Effect::GainLife { .. }),
+            "expected GainLife, got {:?}",
+            gain_life.effect
+        );
+    }
+
     fn assert_filter_has_color(filter: &TargetFilter, expected: ManaColor) {
         let TargetFilter::Typed(typed) = filter else {
             panic!("expected typed search filter, got {filter:?}");

--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -414,6 +414,16 @@ fn parse_search_filter_with_extras(
         return filters;
     }
 
+    // CR 701.23a: A disjunctive series ("a X card, a Y card, or a Z card")
+    // describes ONE card matching any listed property — try the disjunction
+    // split before the conjunction split so it isn't mis-classified as N separate
+    // cards (count + MatchEachFilter). parse_search_filter_disjunction returns
+    // None for <2 disjunction segments, so "and"-lists and single filters fall
+    // through to the conjunction path unchanged.
+    if let Some(or_filter) = parse_search_filter_disjunction(tail, ctx) {
+        return (or_filter, Vec::new());
+    }
+
     // Split on `" and a "` / `" and an "` / `" and basic "` at filter-region
     // boundaries only. The "and basic" branch preserves the supertype prefix so
     // the downstream filter parser sees e.g. `"basic plains card"` intact.
@@ -1093,6 +1103,19 @@ fn split_filter_disjunctions(filter_region: &str) -> Vec<&str> {
         leading: Leading,
     }
 
+    // Leading-article dispatch on a single alt() — also reused by the
+    // comma-member peel below to recover the article-stripped (or supertype)
+    // form of each enumerated member.
+    fn parse_leading_article(i: &str) -> nom::IResult<&str, Leading, OracleError<'_>> {
+        alt((
+            value(Leading::A, tag::<_, _, OracleError<'_>>("a ")),
+            value(Leading::An, tag::<_, _, OracleError<'_>>("an ")),
+            value(Leading::Basic, tag::<_, _, OracleError<'_>>("basic ")),
+            value(Leading::None, tag::<_, _, OracleError<'_>>("")),
+        ))
+        .parse(i)
+    }
+
     // Sub-combinator that dispatches the leading-article axis on a single
     // alt() — shared between the and/or and or scans so future leading
     // variants (e.g., AndOrBasic) require one arm, not one per connector.
@@ -1102,13 +1125,7 @@ fn split_filter_disjunctions(filter_region: &str) -> Vec<&str> {
     ) -> impl Parser<&'a str, Output = Disjunction, Error = OracleError<'a>> {
         move |i: &'a str| {
             let (i, _) = tag::<_, _, OracleError<'a>>(connector_tag).parse(i)?;
-            let (i, leading) = alt((
-                value(Leading::A, tag::<_, _, OracleError<'a>>("a ")),
-                value(Leading::An, tag::<_, _, OracleError<'a>>("an ")),
-                value(Leading::Basic, tag::<_, _, OracleError<'a>>("basic ")),
-                value(Leading::None, tag::<_, _, OracleError<'a>>("")),
-            ))
-            .parse(i)?;
+            let (i, leading) = parse_leading_article(i)?;
             Ok((i, Disjunction { connector, leading }))
         }
     }
@@ -1164,7 +1181,32 @@ fn split_filter_disjunctions(filter_region: &str) -> Vec<&str> {
             break;
         }
 
-        segments.push(before.trim());
+        // CR 701.23a: a disjunctive series "a X, a Y, or a Z" is one choice
+        // among co-equal filters (count 1). The left side may itself enumerate
+        // co-members ("a snow permanent card, a legendary card") that the comma
+        // upstream did not split out — peel each member here so every co-equal
+        // filter becomes its own flat segment.
+        // structural: not dispatch (comma-member enumeration) — mirrors the
+        // structural `as_bytes().contains(&b',')` gate above.
+        for member in before.split(',') {
+            let m = member.trim();
+            if m.is_empty() {
+                continue;
+            }
+            let cleaned = match parse_leading_article(m) {
+                // "basic" is a supertype, not an article — recover the full
+                // "basic <type> card" so the type-phrase parser sees it intact.
+                Ok((rest, Leading::Basic)) => {
+                    let start = m.len() - rest.len() - "basic ".len();
+                    &m[start..]
+                }
+                Ok((rest, _)) => rest,
+                Err(_) => m,
+            };
+            if !cleaned.is_empty() {
+                segments.push(cleaned);
+            }
+        }
         remaining = if disjunction.leading == Leading::Basic {
             // "basic" is a supertype, not an article — recover it into the
             // right segment so the type-phrase parser sees "basic <type>".
@@ -3887,6 +3929,106 @@ mod tests {
         assert_filter_has_color(&details.extra_filters[0], ManaColor::Green);
         assert_filter_has_color(&details.extra_filters[1], ManaColor::Blue);
         assert_eq!(details.multi_destination, Zone::Graveyard);
+    }
+
+    /// CR 701.23a: Search for Glory — "a snow permanent card, a legendary card,
+    /// or a Saga card" is a single choice among three co-equal filters, NOT
+    /// three required picks. Must lower to count 1 + `Or` of three branches with
+    /// no `MatchEachFilter` selection constraint and no extra filters.
+    #[test]
+    fn search_for_glory_disjunctive_series_is_single_choice_or() {
+        let details = parse_search_library_details(
+            "search your library for a snow permanent card, a legendary card, or a saga card, reveal it, put it into your hand, then shuffle",
+            &mut ParseContext::default(),
+        );
+        assert!(
+            details.extra_filters.is_empty(),
+            "disjunctive series must not produce extra (required) filters: {:?}",
+            details.extra_filters
+        );
+        assert_eq!(details.count, QuantityExpr::Fixed { value: 1 });
+        assert_eq!(
+            details.selection_constraint,
+            SearchSelectionConstraint::None
+        );
+        let TargetFilter::Or { filters } = &details.filter else {
+            panic!("expected Or filter, got {:?}", details.filter);
+        };
+        assert_eq!(
+            filters.len(),
+            3,
+            "expected 3 disjunctive branches: {filters:?}"
+        );
+
+        // Branch 0: snow permanent.
+        let TargetFilter::Typed(snow) = &filters[0] else {
+            panic!("expected typed snow branch, got {:?}", filters[0]);
+        };
+        assert!(
+            snow.properties.iter().any(|property| matches!(
+                property,
+                FilterProp::HasSupertype {
+                    value: Supertype::Snow
+                }
+            )),
+            "first branch should carry Snow supertype: {snow:?}"
+        );
+
+        // Branch 1: legendary.
+        let TargetFilter::Typed(legendary) = &filters[1] else {
+            panic!("expected typed legendary branch, got {:?}", filters[1]);
+        };
+        assert!(
+            legendary.properties.iter().any(|property| matches!(
+                property,
+                FilterProp::HasSupertype {
+                    value: Supertype::Legendary
+                }
+            )),
+            "second branch should carry Legendary supertype: {legendary:?}"
+        );
+
+        // Branch 2: Saga subtype.
+        let TargetFilter::Typed(saga) = &filters[2] else {
+            panic!("expected typed Saga branch, got {:?}", filters[2]);
+        };
+        assert_eq!(saga.get_subtype(), Some("Saga"));
+    }
+
+    /// CR 701.23a (GAP2 coverage): the comma-member peel must recover the
+    /// `basic` supertype on a non-land mixed series — "a basic land card, a
+    /// plains card, or a saga card" lowers to an `Or` of three branches with the
+    /// first carrying `Basic` + `Land`.
+    #[test]
+    fn search_basic_leading_disjunctive_series_recovers_supertype() {
+        let details = parse_search_library_details(
+            "search your library for a basic land card, a plains card, or a saga card, reveal it, put it into your hand, then shuffle",
+            &mut ParseContext::default(),
+        );
+        assert!(details.extra_filters.is_empty());
+        assert_eq!(details.count, QuantityExpr::Fixed { value: 1 });
+        let TargetFilter::Or { filters } = &details.filter else {
+            panic!("expected Or filter, got {:?}", details.filter);
+        };
+        assert_eq!(
+            filters.len(),
+            3,
+            "expected 3 disjunctive branches: {filters:?}"
+        );
+
+        let TargetFilter::Typed(basic_land) = &filters[0] else {
+            panic!("expected typed basic land branch, got {:?}", filters[0]);
+        };
+        assert!(basic_land.type_filters.contains(&TypeFilter::Land));
+        assert!(
+            basic_land.properties.iter().any(|property| matches!(
+                property,
+                FilterProp::HasSupertype {
+                    value: Supertype::Basic
+                }
+            )),
+            "first branch should carry Basic supertype: {basic_land:?}"
+        );
     }
 
     /// CR 701.23a + CR 205.3i: "a land card of each basic land type" is a


### PR DESCRIPTION
Search for Glory ('Search your library for a snow permanent card, a
legendary card, or a Saga card, ...') misparsed to count:2 +
MatchEachFilter([snow-permanent, Or([legendary, Saga])]) - demanding two
distinct cards. In a library with no snow card the legal-action generator
yielded zero SearchChoice options, hard-deadlocking the game (real 4-player
Commander report).

A comma series terminated by 'or'/'and/or' is a flat N-way disjunction
describing ONE card (CR 701.23a), not a multi-card conjunction. Extend
split_filter_disjunctions to peel each comma member into a co-equal segment,
and try the disjunction interpretation in parse_search_filter_with_extras
before the conjunction split. The 'and'-series mirror (e.g. Lotuslight
Dancers 'a black card, a green card, and a blue card' -> count:3) is
unaffected: the splitter scans only ' or '/' and/or ', never bare ' and '.

Factors parse_leading_article out of parse_leading so the comma peel reuses
the same article/basic-supertype recognition. Adds parser + lowered-effect
tests for the disjunction class and a basic-leading-member case.
