### PR TITLE
fix(parser): parse controller same-name multi-zone extraction (CR 701.23/701.24)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1652,6 +1652,7 @@ fn try_parse_multi_zone_same_name_exile(lower: &str) -> Option<()> {
         let (input, _) = tag::<_, _, OracleError<'_>>("search ").parse(input)?;
         let (input, _) = alt((
             tag::<_, _, OracleError<'_>>("its owner's "),
+            tag("its controller's "),
             tag("their "),
             tag("that player's "),
             tag("target player's "),
@@ -1676,15 +1677,35 @@ fn try_parse_multi_zone_same_name_exile(lower: &str) -> Option<()> {
             value((), tag("a card")),
         ))
         .parse(input)?;
-        // Match the trailing same-name suffix in either of two synonymous forms:
-        //   " with that name and exile them"            (Deadly Cover-Up, Lost Legacy)
-        //   " with the same name as that card and exile them"  (Surgical Extraction)
+        // Match the trailing same-name suffix. The name source is either a
+        // previously-named card ("with that name", Lost Legacy / Deadly Cover-Up)
+        // or the spell's exiled/countered target referenced by its card type
+        // ("with the same name as that card/creature/land/spell/…", Surgical
+        // Extraction / Eradicate / Crumble to Dust / Counterbore / Deicide). The
+        // card-type is composed as one `alt` axis rather than enumerated as full
+        // strings; all forms lower to the same `SameNameAsParentTarget` effect.
         let (input, _) = alt((
             value(
                 (),
                 tag::<_, _, OracleError<'_>>(" with that name and exile them"),
             ),
-            value((), tag(" with the same name as that card and exile them")),
+            value(
+                (),
+                (
+                    tag::<_, _, OracleError<'_>>(" with the same name as that "),
+                    alt((
+                        tag("creature"),
+                        tag("permanent"),
+                        tag("planeswalker"),
+                        tag("artifact"),
+                        tag("enchantment"),
+                        tag("land"),
+                        tag("spell"),
+                        tag("card"),
+                    )),
+                    tag(" and exile them"),
+                ),
+            ),
         ))
         .parse(input)?;
         Ok((input, ()))
@@ -10660,6 +10681,13 @@ mod tests {
             "search target player's graveyard, hand, and library for all cards with that name and exile them",
             "search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them",
             "search their graveyard, hand, and library for a card with that name and exile them",
+            // CR 201.2: "its controller's" possessive + card-type name source —
+            // Eradicate ("that creature"), Crumble to Dust ("that land"),
+            // Counterbore ("that spell"), Deicide ("its controller's … that card").
+            "search its controller's graveyard, hand, and library for all cards with the same name as that creature and exile them",
+            "search its controller's graveyard, hand, and library for any number of cards with the same name as that land and exile them",
+            "search its controller's graveyard, hand, and library for all cards with the same name as that spell and exile them",
+            "search its controller's graveyard, hand, and library for any number of cards with the same name as that card and exile them",
         ];
         for text in positives {
             assert!(

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -10681,7 +10681,7 @@ mod tests {
             "search target player's graveyard, hand, and library for all cards with that name and exile them",
             "search its owner's graveyard, hand, and library for any number of cards with the same name as that card and exile them",
             "search their graveyard, hand, and library for a card with that name and exile them",
-            // CR 201.2: "its controller's" possessive + card-type name source —
+            // CR 201.2a: "its controller's" possessive + card-type name source —
             // Eradicate ("that creature"), Crumble to Dust ("that land"),
             // Counterbore ("that spell"), Deicide ("its controller's … that card").
             "search its controller's graveyard, hand, and library for all cards with the same name as that creature and exile them",


### PR DESCRIPTION
## What

`try_parse_multi_zone_same_name_exile` (`oracle_effect/imperative.rs`) recognized the multi-zone search-and-exile effect for some phrasings, but missed the most common one on two counts:

1. Its possessive list lacked **`"its controller's"`** — exactly what these cards use.
2. The name-source suffix matched only `" with that name …"` and `" with the same name as that card …"` — not the exiled/countered target referenced by its **card type** (`"the same name as that creature / land / spell"`).

Either gap dropped the whole effect to `Unimplemented`.

Fixes #2550.

## Cards unlocked

| Card | Phrasing |
|---|---|
| **Eradicate** | "Search **its controller's** … with the same name as **that creature** and exile them." |
| **Crumble to Dust** | "… with the same name as **that land** …" |
| **Counterbore** | "… with the same name as **that spell** …" |
| **Deicide** | "… its controller's … same name as that card …" (failed only on the missing possessive) |

## Approach

- Added `"its controller's "` to the possessive `alt`.
- Composed the name-source suffix so the card-type is a single `alt` axis (`"that {creature|permanent|planeswalker|artifact|enchantment|land|spell|card}"`) per the nom-combinator mandate, alongside the existing `"with that name"`.

Both forms continue to lower to the existing `SearchCreationImperativeAst::MultiZoneSameNameExile` → `Effect::ChangeZoneAll { destination: Exile, target: InAnyZone[Graveyard,Hand,Library] + SameNameAsParentTarget }`. The name source (`SameNameAsParentTarget`) is the spell's exiled/countered target, correct for all four cards — **no new effect or runtime change**, consistent with the already-handled "its owner's … that card" form (Surgical Extraction).

## CR

- **CR 400.7 / CR 701.23/701.24** — multi-zone search & exile.
- **CR 201.2a** — name matching.

## Tests

Extended the building-block `parse_multi_zone_same_name_exile_pattern` with the "its controller's" + card-type positives (creature / land / spell / card). Existing "that name" / "that card" forms unchanged.

`cargo fmt --all`, the parser-combinator gate, and the **full-workspace** `clippy --all-targets --features engine/proptest -D warnings` are all clean; 624 search/exile/same-name tests pass.

## Non-duplicate

`Eradicate`, `Crumble to Dust`, `Counterbore`, and `Cranial Extraction` return no open/closed issues/PRs. The effect and the "that name"/"that card" phrasings were already handled; the "its controller's" possessive and the "same name as that `<type>`" name source were the gap.

(Follow-up out of scope: the "name a card … same name as **the chosen card**" (Lobotomy) and "**the exiled card**" (Pick the Brain) forms reference a chosen/exiled card rather than the parent target.)

