### PR TITLE
Draft Mana Curve Fix

### DIFF
--- a/client/src/components/draft/LimitedDeckBuilder.tsx
+++ b/client/src/components/draft/LimitedDeckBuilder.tsx
@@ -344,7 +344,7 @@ export function LimitedDeckBuilder({
 
           {/* Mana curve */}
           <section>
-            <ManaCurve cards={mainDeck} />
+            <ManaCurve pool={pool} cards={mainDeck} />
           </section>
 
           {/* Actions */}

--- a/client/src/components/draft/LimitedDeckBuilder.tsx
+++ b/client/src/components/draft/LimitedDeckBuilder.tsx
@@ -344,7 +344,7 @@ export function LimitedDeckBuilder({
 
           {/* Mana curve */}
           <section>
-            <ManaCurve pool={pool} cards={mainDeck} />
+            <ManaCurve pool={pool} pool={pool} cards={mainDeck} />
           </section>
 
           {/* Actions */}

--- a/client/src/components/draft/LimitedDeckBuilder.tsx
+++ b/client/src/components/draft/LimitedDeckBuilder.tsx
@@ -344,7 +344,7 @@ export function LimitedDeckBuilder({
 
           {/* Mana curve */}
           <section>
-            <ManaCurve pool={pool} pool={pool} cards={mainDeck} />
+            <ManaCurve pool={pool} cards={mainDeck} />
           </section>
 
           {/* Actions */}

--- a/client/src/components/draft/ManaCurve.tsx
+++ b/client/src/components/draft/ManaCurve.tsx
@@ -50,7 +50,15 @@ export function ManaCurve({ pool, cards }: ManaCurveProps) {
       </div>
       <div className="flex items-end gap-1.5" style={{ height: MAX_BAR_HEIGHT + 24 }}>
         {counts.map(({ label, count }) => (
-          <div key={label} className="flex flex-1 flex-col items-center gap-0.5">
+          <div
+            key={label}
+            role="meter"
+            aria-label={t("manaCurve.bucketLabel", { bucket: label })}
+            aria-valuemin={0}
+            aria-valuemax={maxCount}
+            aria-valuenow={count}
+            className="flex flex-1 flex-col items-center gap-0.5"
+          >
             <span className="h-4 text-[10px] leading-4 text-white/50">
               {count > 0 ? count : ""}
             </span>

--- a/client/src/components/draft/ManaCurve.tsx
+++ b/client/src/components/draft/ManaCurve.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useDraftStore } from "../../stores/draftStore";
+import type { DraftCardInstance } from "../../adapter/draft-adapter";
 
 // ── Types ───────────────────────────────────────────────────────────────
 
 interface ManaCurveProps {
+  pool: DraftCardInstance[];
   cards: string[];
 }
 
@@ -16,11 +17,8 @@ const MAX_BAR_HEIGHT = 100;
 
 // ── Component ───────────────────────────────────────────────────────────
 
-const EMPTY_POOL: never[] = [];
-
-export function ManaCurve({ cards }: ManaCurveProps) {
+export function ManaCurve({ pool, cards }: ManaCurveProps) {
   const { t } = useTranslation("draft");
-  const pool = useDraftStore((s) => s.view?.pool) ?? EMPTY_POOL;
 
   const counts = useMemo(() => {
     const cmcByName = new Map<string, number>();

--- a/client/src/components/draft/ManaCurve.tsx
+++ b/client/src/components/draft/ManaCurve.tsx
@@ -7,6 +7,7 @@ import type { DraftCardInstance } from "../../adapter/draft-adapter";
 
 interface ManaCurveProps {
   pool: DraftCardInstance[];
+  pool: DraftCardInstance[];
   cards: string[];
 }
 
@@ -16,11 +17,8 @@ const CMC_BUCKETS = ["0", "1", "2", "3", "4", "5", "6+"] as const;
 const MAX_BAR_HEIGHT = 100;
 
 // ── Component ───────────────────────────────────────────────────────────
-
 export function ManaCurve({ pool, cards }: ManaCurveProps) {
-  const { t } = useTranslation("draft");
-
-  const counts = useMemo(() => {
+  const { t } = useTranslation("draft")
     const cmcByName = new Map<string, number>();
     for (const card of pool) {
       cmcByName.set(card.name, card.cmc);

--- a/client/src/components/draft/ManaCurve.tsx
+++ b/client/src/components/draft/ManaCurve.tsx
@@ -7,7 +7,6 @@ import type { DraftCardInstance } from "../../adapter/draft-adapter";
 
 interface ManaCurveProps {
   pool: DraftCardInstance[];
-  pool: DraftCardInstance[];
   cards: string[];
 }
 
@@ -17,8 +16,11 @@ const CMC_BUCKETS = ["0", "1", "2", "3", "4", "5", "6+"] as const;
 const MAX_BAR_HEIGHT = 100;
 
 // ── Component ───────────────────────────────────────────────────────────
+
 export function ManaCurve({ pool, cards }: ManaCurveProps) {
-  const { t } = useTranslation("draft")
+  const { t } = useTranslation("draft");
+
+  const counts = useMemo(() => {
     const cmcByName = new Map<string, number>();
     for (const card of pool) {
       cmcByName.set(card.name, card.cmc);

--- a/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
+++ b/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { LimitedDeckBuilder } from "../LimitedDeckBuilder";
+
+vi.mock("../../../stores/draftStore", () => ({
+  useDraftStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      view: null,
+      mainDeck: [],
+      landCounts: {},
+      addToDeck: () => {},
+      removeFromDeck: () => {},
+      setLandCount: () => {},
+      autoSuggestDeck: async () => {},
+      autoSuggestLands: async () => {},
+      submitDeck: async () => {},
+    }),
+}));
+
+type BuilderView = NonNullable<NonNullable<Parameters<typeof LimitedDeckBuilder>[0]>["view"]>;
+
+const TEST_VIEW: BuilderView = {
+  status: "Deckbuilding",
+  kind: "Quick",
+  current_pack_number: 1,
+  pick_number: 1,
+  pass_direction: "Left",
+  current_pack: null,
+  pool: [
+    {
+      instance_id: "card-1",
+      name: "Wind Drake",
+      set_code: "dmu",
+      collector_number: "58",
+      rarity: "common",
+      colors: ["U"],
+      cmc: 3,
+      type_line: "Creature - Drake",
+    },
+  ],
+  seats: [],
+  cards_per_pack: 14,
+  pack_count: 3,
+  min_deck_size: 40,
+  addable_cards: ["Plains", "Island", "Swamp", "Mountain", "Forest"],
+  timer_remaining_ms: null,
+  standings: [],
+  current_round: 0,
+  tournament_format: "Swiss",
+  pod_policy: "Competitive",
+  pairings: [],
+};
+
+function bucketCount(curveRoot: HTMLElement, label: string): string {
+  const labelNode = within(curveRoot).getByText(label);
+  const bucket = labelNode.parentElement;
+  if (!bucket) return "";
+  const countNode = bucket.querySelector("span.h-4");
+  return countNode?.textContent ?? "";
+}
+
+function Harness() {
+  const [mainDeck, setMainDeck] = useState<string[]>([]);
+
+  return (
+    <LimitedDeckBuilder
+      view={TEST_VIEW}
+      mainDeck={mainDeck}
+      landCounts={{}}
+      onAddToDeck={(cardName) => setMainDeck((prev) => [...prev, cardName])}
+      onRemoveFromDeck={(cardName) =>
+        setMainDeck((prev) => {
+          const idx = prev.indexOf(cardName);
+          if (idx < 0) return prev;
+          const next = prev.slice();
+          next.splice(idx, 1);
+          return next;
+        })
+      }
+      onSetLandCount={() => {}}
+      onSubmitDeck={() => {}}
+      showSuggestions={false}
+    />
+  );
+}
+
+describe("LimitedDeckBuilder", () => {
+  it("updates mana curve when a card is added from pool", () => {
+    render(<Harness />);
+
+    const curveTitle = screen.getByText(/mana curve/i);
+    const curveRoot = curveTitle.parentElement;
+    expect(curveRoot).not.toBeNull();
+    if (!curveRoot) return;
+
+    expect(bucketCount(curveRoot, "3")).toBe("");
+
+    fireEvent.click(screen.getByRole("button", { name: /wind drake/i }));
+
+    expect(bucketCount(curveRoot, "3")).toBe("1");
+  });
+});

--- a/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
+++ b/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import { LimitedDeckBuilder } from "../LimitedDeckBuilder";
 
@@ -53,14 +53,6 @@ const TEST_VIEW: BuilderView = {
   pairings: [],
 };
 
-function bucketCount(curveRoot: HTMLElement, label: string): string {
-  const labelNode = within(curveRoot).getByText(label);
-  const bucket = labelNode.parentElement;
-  if (!bucket) return "";
-  const countNode = bucket.querySelector("span.h-4");
-  return countNode?.textContent ?? "";
-}
-
 function Harness() {
   const [mainDeck, setMainDeck] = useState<string[]>([]);
 
@@ -90,15 +82,11 @@ describe("LimitedDeckBuilder", () => {
   it("updates mana curve when a card is added from pool", () => {
     render(<Harness />);
 
-    const curveTitle = screen.getByText(/mana curve/i);
-    const curveRoot = curveTitle.parentElement;
-    expect(curveRoot).not.toBeNull();
-    if (!curveRoot) return;
-
-    expect(bucketCount(curveRoot, "3")).toBe("");
+    const threeDropBucket = screen.getByRole("meter", { name: "Mana value 3" });
+    expect(threeDropBucket).toHaveAttribute("aria-valuenow", "0");
 
     fireEvent.click(screen.getByRole("button", { name: /wind drake/i }));
 
-    expect(bucketCount(curveRoot, "3")).toBe("1");
+    expect(threeDropBucket).toHaveAttribute("aria-valuenow", "1");
   });
 });

--- a/client/src/i18n/locales/de/draft.json
+++ b/client/src/i18n/locales/de/draft.json
@@ -44,7 +44,8 @@
     "endDraftConfirm": "Diesen Draft fuer alle beenden? Das kann nicht rueckgaengig gemacht werden."
   },
   "manaCurve": {
-    "title": "Manakurve"
+    "title": "Manakurve",
+    "bucketLabel": "Manawert {{bucket}}"
   },
   "pickTimer": {
     "label": "Pick-Timer",

--- a/client/src/i18n/locales/en/draft.json
+++ b/client/src/i18n/locales/en/draft.json
@@ -44,7 +44,8 @@
     "endDraftConfirm": "End this draft for everyone? This cannot be undone."
   },
   "manaCurve": {
-    "title": "Mana Curve"
+    "title": "Mana Curve",
+    "bucketLabel": "Mana value {{bucket}}"
   },
   "pickTimer": {
     "label": "Pick Timer",

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -44,7 +44,8 @@
     "endDraftConfirm": "¿Terminar este draft para todos? Esta acción no se puede deshacer."
   },
   "manaCurve": {
-    "title": "Curva de maná"
+    "title": "Curva de maná",
+    "bucketLabel": "Valor de maná {{bucket}}"
   },
   "pickTimer": {
     "label": "Temporizador de elección",

--- a/client/src/i18n/locales/fr/draft.json
+++ b/client/src/i18n/locales/fr/draft.json
@@ -44,7 +44,8 @@
     "endDraftConfirm": "Terminer ce draft pour tout le monde ? Cette action est irreversible."
   },
   "manaCurve": {
-    "title": "Courbe de mana"
+    "title": "Courbe de mana",
+    "bucketLabel": "Valeur de mana {{bucket}}"
   },
   "pickTimer": {
     "label": "Minuteur de sélection",

--- a/client/src/i18n/locales/it/draft.json
+++ b/client/src/i18n/locales/it/draft.json
@@ -44,7 +44,8 @@
     "endDraftConfirm": "Terminare questo draft per tutti? L'azione non puo essere annullata."
   },
   "manaCurve": {
-    "title": "Curva del mana"
+    "title": "Curva del mana",
+    "bucketLabel": "Valore di mana {{bucket}}"
   },
   "pickTimer": {
     "label": "Timer di scelta",

--- a/client/src/i18n/locales/pl/draft.json
+++ b/client/src/i18n/locales/pl/draft.json
@@ -44,7 +44,8 @@
     "endDraftConfirm": "Zakonczyc ten draft dla wszystkich? Tej akcji nie mozna cofnac."
   },
   "manaCurve": {
-    "title": "Krzywa many"
+    "title": "Krzywa many",
+    "bucketLabel": "Wartość many {{bucket}}"
   },
   "pickTimer": {
     "label": "Czas na wybór",

--- a/client/src/i18n/locales/pt/draft.json
+++ b/client/src/i18n/locales/pt/draft.json
@@ -44,7 +44,8 @@
     "endDraftConfirm": "Encerrar este draft para todos? Isso nao pode ser desfeito."
   },
   "manaCurve": {
-    "title": "Curva de Mana"
+    "title": "Curva de Mana",
+    "bucketLabel": "Valor de mana {{bucket}}"
   },
   "pickTimer": {
     "label": "Cronômetro de Escolha",


### PR DESCRIPTION
Noticed when playing draft i have a deck of 23 0 mana cards. I would like to be able too see my curve to help me make more mana responsible draft choices. Despite the green player in me wanted to slam down an 8 mana 10/10.

Old Behaviour: 
<img width="1007" height="610" alt="Screenshot 2026-06-06 at 3 33 52 PM" src="https://github.com/user-attachments/assets/323e9547-f3ec-48b6-b15e-024ef380ce83" />


New Behaviour:
https://github.com/user-attachments/assets/75a20701-8700-40e8-af37-270312448242

