### PR TITLE
Implement Forage keyword action (CR 701.61)

### DIFF
--- a/crates/engine/src/game/effects/forage.rs
+++ b/crates/engine/src/game/effects/forage.rs
@@ -18,12 +18,13 @@
 
 use crate::game::ability_utils::build_resolved_from_def;
 use crate::types::ability::{
-    AbilityDefinition, AbilityKind, ControllerRef, Effect, EffectError, EffectKind, FilterProp,
-    MultiTargetSpec, PlayerFilter, QuantityExpr, ResolvedAbility, TargetChoiceTiming, TargetFilter,
-    TargetRef, TypedFilter,
+    AbilityDefinition, AbilityKind, Comparator, ControllerRef, Effect, EffectError, EffectKind,
+    FilterProp, MultiTargetSpec, PlayerFilter, QuantityExpr, ResolvedAbility, TargetChoiceTiming,
+    TargetFilter, TargetRef, TypedFilter,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
@@ -38,12 +39,12 @@ fn graveyard_size(state: &GameState, player: PlayerId) -> usize {
         .unwrap_or(0)
 }
 
-fn controls_food(state: &GameState, player: PlayerId) -> bool {
-    state
-        .battlefield
-        .iter()
-        .filter_map(|id| state.objects.get(id))
-        .any(|obj| obj.controller == player && obj.card_types.subtypes.iter().any(|s| s == "Food"))
+fn controls_food(state: &GameState, player: PlayerId, source_id: ObjectId) -> bool {
+    // Reuse the layer-aware, phased-out-aware control-count building block
+    // (CR 702.26b) rather than a raw battlefield subtype scan, so the
+    // eligibility gate agrees with the `Sacrifice` resolver it gates.
+    let filter = TargetFilter::Typed(TypedFilter::permanent().subtype("Food".to_string()));
+    super::player_control_count_compares(state, player, &filter, Comparator::GE, 1, source_id)
 }
 
 /// CR 701.61a (exile mode): exile three chosen cards from the forager's
@@ -108,7 +109,7 @@ pub(crate) fn resolve(
     if graveyard_size(state, controller) >= FORAGE_EXILE_COUNT {
         branches.push(exile_three_branch());
     }
-    if controls_food(state, controller) {
+    if controls_food(state, controller, ability.source_id) {
         branches.push(sacrifice_food_branch());
     }
 
@@ -121,7 +122,11 @@ pub(crate) fn resolve(
             let mut resolved = build_resolved_from_def(&branch, ability.source_id, controller);
             resolved.context = ability.context.clone();
             resolved.set_scoped_player_recursive(controller);
-            super::resolve_ability_chain(state, &resolved, events, 0)?;
+            // Depth 1, not 0: `forage::resolve` already runs inside a resolution,
+            // so a depth-0 re-entry would re-run the depth-0 prelude mid-resolution
+            // (clearing chain-scoped state, re-bumping counters). Matches the
+            // depth-1 branch resolution the two-mode `choose_one_of` path uses.
+            super::resolve_ability_chain(state, &resolved, events, 1)?;
         }
         // CR 701.61a: both modes available — the forager chooses which.
         _ => {

--- a/crates/engine/src/game/effects/forage.rs
+++ b/crates/engine/src/game/effects/forage.rs
@@ -1,0 +1,301 @@
+//! CR 701.61a: Forage — "Exile three cards from your graveyard or sacrifice a
+//! Food." A modal keyword action, performed when an effect instructs a player
+//! to "forage."
+//!
+//! Implemented by composition over existing effects rather than a bespoke
+//! `WaitingFor`:
+//!   * the exile mode reuses `Effect::ChangeZone`'s resolution-time selection
+//!     (`multi_target` fixed at 3 + `TargetChoiceTiming::Resolution` + empty
+//!     targets), which routes through the shared `EffectZoneChoice` picker;
+//!   * the Food mode reuses `Effect::Sacrifice` (the same machinery Devour and
+//!     every "sacrifice a Food" cost use);
+//!   * when both modes are performable the controller chooses via
+//!     `Effect::ChooseOneOf`.
+//!
+//! CR 701.61a is atomic per mode — you exile *three* cards or sacrifice *a*
+//! Food — so a mode is offered only when it can be performed in full. If
+//! neither mode is performable, foraging does nothing.
+
+use crate::game::ability_utils::build_resolved_from_def;
+use crate::types::ability::{
+    AbilityDefinition, AbilityKind, ControllerRef, Effect, EffectError, EffectKind, FilterProp,
+    MultiTargetSpec, PlayerFilter, QuantityExpr, ResolvedAbility, TargetChoiceTiming, TargetFilter,
+    TargetRef, TypedFilter,
+};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+/// CR 701.61a: "exile three cards from your graveyard".
+const FORAGE_EXILE_COUNT: usize = 3;
+
+fn graveyard_size(state: &GameState, player: PlayerId) -> usize {
+    state
+        .players
+        .get(player.0 as usize)
+        .map(|p| p.graveyard.len())
+        .unwrap_or(0)
+}
+
+fn controls_food(state: &GameState, player: PlayerId) -> bool {
+    state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .any(|obj| obj.controller == player && obj.card_types.subtypes.iter().any(|s| s == "Food"))
+}
+
+/// CR 701.61a (exile mode): exile three chosen cards from the forager's
+/// graveyard. `Owned { You }` scopes the scan to the forager's own graveyard;
+/// `MultiTargetSpec::fixed(3, 3)` forces exactly three (eligibility is checked
+/// before this branch is offered).
+fn exile_three_branch() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Exile,
+            target: TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::Owned {
+                controller: ControllerRef::You,
+            }])),
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: false,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: Vec::new(),
+            face_down_profile: None,
+        },
+    )
+    .multi_target(MultiTargetSpec::fixed(
+        FORAGE_EXILE_COUNT,
+        FORAGE_EXILE_COUNT,
+    ))
+    .target_choice_timing(TargetChoiceTiming::Resolution)
+    .description("Exile three cards from your graveyard.".to_string())
+}
+
+/// CR 701.61a (Food mode): sacrifice a Food the forager controls.
+fn sacrifice_food_branch() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Sacrifice {
+            target: TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .controller(ControllerRef::You)
+                    .subtype("Food".to_string()),
+            ),
+            count: QuantityExpr::Fixed { value: 1 },
+            min_count: 1,
+        },
+    )
+    .description("Sacrifice a Food.".to_string())
+}
+
+/// CR 701.61a: resolve a "forage" instruction. Offers only the performable
+/// mode(s); performs the single mode directly, prompts a `ChooseOneOf` when
+/// both are available, and is a no-op when neither is.
+pub(crate) fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let controller = ability.controller;
+
+    let mut branches: Vec<AbilityDefinition> = Vec::new();
+    if graveyard_size(state, controller) >= FORAGE_EXILE_COUNT {
+        branches.push(exile_three_branch());
+    }
+    if controls_food(state, controller) {
+        branches.push(sacrifice_food_branch());
+    }
+
+    match branches.len() {
+        // CR 701.61a: neither mode performable — foraging does nothing.
+        0 => {}
+        // Exactly one performable mode — perform it directly (no modal prompt).
+        1 => {
+            let branch = branches.pop().expect("len checked == 1");
+            let mut resolved = build_resolved_from_def(&branch, ability.source_id, controller);
+            resolved.context = ability.context.clone();
+            resolved.set_scoped_player_recursive(controller);
+            super::resolve_ability_chain(state, &resolved, events, 0)?;
+        }
+        // CR 701.61a: both modes available — the forager chooses which.
+        _ => {
+            let mut choose = ResolvedAbility::new(
+                Effect::ChooseOneOf {
+                    chooser: PlayerFilter::Controller,
+                    branches,
+                },
+                vec![TargetRef::Player(controller)],
+                ability.source_id,
+                controller,
+            );
+            choose.context = ability.context.clone();
+            super::choose_one_of::resolve(state, &choose, events)?;
+        }
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::Forage,
+        source_id: ability.source_id,
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::card_type::CoreType;
+    use crate::types::game_state::WaitingFor;
+    use crate::types::identifiers::{CardId, ObjectId};
+
+    fn forage_ability(controller: PlayerId, source: ObjectId) -> ResolvedAbility {
+        ResolvedAbility::new(Effect::Forage, vec![], source, controller)
+    }
+
+    fn add_graveyard_card(state: &mut GameState, owner: PlayerId, n: u64) -> ObjectId {
+        create_object(state, CardId(n), owner, format!("GY{n}"), Zone::Graveyard)
+    }
+
+    fn add_food(state: &mut GameState, owner: PlayerId) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(900),
+            owner,
+            "Food Token".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.controller = owner;
+        obj.card_types.core_types = vec![CoreType::Artifact];
+        obj.card_types.subtypes = vec!["Food".to_string()];
+        id
+    }
+
+    fn pending_choice(state: &GameState) -> bool {
+        matches!(
+            state.waiting_for,
+            WaitingFor::EffectZoneChoice { .. } | WaitingFor::ChooseOneOfBranch { .. }
+        )
+    }
+
+    /// CR 701.61a: with neither three graveyard cards nor a Food, foraging does nothing.
+    #[test]
+    fn forage_with_neither_mode_is_noop() {
+        let mut state = GameState::new_two_player(1);
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &forage_ability(PlayerId(0), ObjectId(1)),
+            &mut events,
+        )
+        .unwrap();
+        assert!(!pending_choice(&state), "no choice should be set up");
+        assert!(events.iter().any(|e| matches!(
+            e,
+            GameEvent::EffectResolved {
+                kind: EffectKind::Forage,
+                ..
+            }
+        )));
+    }
+
+    /// CR 701.61a (exile mode): three graveyard cards and no Food prompts an
+    /// exile-three-from-your-graveyard selection (Graveyard -> Exile, count 3).
+    #[test]
+    fn forage_exile_only_prompts_exile_three_from_graveyard() {
+        let mut state = GameState::new_two_player(1);
+        for n in 1..=3 {
+            add_graveyard_card(&mut state, PlayerId(0), n);
+        }
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &forage_ability(PlayerId(0), ObjectId(50)),
+            &mut events,
+        )
+        .unwrap();
+        match &state.waiting_for {
+            WaitingFor::EffectZoneChoice {
+                count,
+                zone,
+                destination,
+                ..
+            } => {
+                assert_eq!(*count, 3);
+                assert_eq!(*zone, Zone::Graveyard);
+                assert_eq!(*destination, Some(Zone::Exile));
+            }
+            other => panic!("expected EffectZoneChoice, got {other:?}"),
+        }
+    }
+
+    /// CR 701.61a: the exile mode is atomic (three cards) — fewer than three
+    /// graveyard cards (and no Food) makes foraging a no-op, never a partial exile.
+    #[test]
+    fn forage_fewer_than_three_in_graveyard_does_nothing() {
+        let mut state = GameState::new_two_player(1);
+        add_graveyard_card(&mut state, PlayerId(0), 1);
+        add_graveyard_card(&mut state, PlayerId(0), 2);
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &forage_ability(PlayerId(0), ObjectId(51)),
+            &mut events,
+        )
+        .unwrap();
+        assert!(!pending_choice(&state));
+    }
+
+    /// CR 701.61a (Food mode): a Food with fewer than three graveyard cards
+    /// sacrifices the Food (the only performable mode), no modal prompt.
+    #[test]
+    fn forage_food_only_sacrifices_the_food() {
+        let mut state = GameState::new_two_player(1);
+        let food = add_food(&mut state, PlayerId(0));
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &forage_ability(PlayerId(0), ObjectId(52)),
+            &mut events,
+        )
+        .unwrap();
+        assert_eq!(
+            state.objects.get(&food).map(|o| o.zone),
+            Some(Zone::Graveyard),
+            "the only Food should have been sacrificed"
+        );
+        assert!(!matches!(
+            state.waiting_for,
+            WaitingFor::ChooseOneOfBranch { .. }
+        ));
+    }
+
+    /// CR 701.61a: both modes available — the forager chooses which via a modal prompt.
+    #[test]
+    fn forage_both_modes_prompts_choose_one_of() {
+        let mut state = GameState::new_two_player(1);
+        for n in 1..=3 {
+            add_graveyard_card(&mut state, PlayerId(0), n);
+        }
+        add_food(&mut state, PlayerId(0));
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &forage_ability(PlayerId(0), ObjectId(53)),
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(state.waiting_for, WaitingFor::ChooseOneOfBranch { .. }),
+            "expected a modal choice, got {:?}",
+            state.waiting_for
+        );
+    }
+}

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -84,6 +84,7 @@ pub mod explore;
 pub mod extra_turn;
 pub mod fight;
 pub mod flip_coin;
+pub mod forage;
 pub mod force_attack;
 pub mod force_block;
 pub mod gain_control;
@@ -2022,11 +2023,7 @@ pub fn resolve_effect(
         Effect::Learn => learn::resolve(state, ability, events),
         Effect::BlightEffect { .. } => blight::resolve(state, ability, events),
         Effect::Endure { .. } => endure::resolve(state, ability, events),
-        Effect::Forage => {
-            // This keyword action is recognized by the parser but not yet implemented.
-            // It's a no-op at runtime but counts as supported for coverage.
-            Ok(())
-        }
+        Effect::Forage => forage::resolve(state, ability, events),
         Effect::CollectEvidence { .. } => collect_evidence::resolve(state, ability, events),
         Effect::SetLifeTotal { .. } => life::resolve_set_life_total(state, ability, events),
         Effect::ExchangeLifeWithStat { .. } => exchange_life::resolve(state, ability, events),

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -656,12 +656,24 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
         }
     }
 
-    // "Forage" — exile three cards from graveyard or sacrifice a Food (CR 701.61)
+    // "Forage" — exile three cards from your graveyard or sacrifice a Food
+    // (CR 701.61a). A modal cost: both ways are offered, so a player who can't
+    // exile three cards can still forage by sacrificing a Food (and vice versa).
     if lower == "forage" {
-        return AbilityCost::Exile {
-            count: 3,
-            zone: Some(Zone::Graveyard),
-            filter: None,
+        return AbilityCost::OneOf {
+            costs: vec![
+                AbilityCost::Exile {
+                    count: 3,
+                    zone: Some(Zone::Graveyard),
+                    filter: None,
+                },
+                AbilityCost::Sacrifice {
+                    target: TargetFilter::Typed(
+                        TypedFilter::permanent().subtype("Food".to_string()),
+                    ),
+                    count: 1,
+                },
+            ],
         };
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5508,7 +5508,7 @@ pub(super) fn parse_imperative_family_ast(
                 count,
             }))
         }
-        // Forage keyword action (CR 702.166a)
+        // Forage keyword action (CR 701.61a)
         "forage" => Some(ImperativeFamilyAst::GainKeyword(Effect::Forage)),
         // Collect evidence N keyword action (CR 702.163a)
         "collect" => {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7382,7 +7382,7 @@ pub enum Effect {
     },
     /// CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.
     Learn,
-    /// CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.
+    /// CR 701.61a: Forage — exile three cards from your graveyard or sacrifice a Food.
     Forage,
     /// CR 702.163a: Collect evidence N — exile cards with total mana value N or more from graveyard.
     CollectEvidence {


### PR DESCRIPTION
## Summary

Forage (Bloomburrow keyword action, ~16 cards) was a runtime no-op:

1. **As an effect** (`Effect::Forage`): the resolver returned `Ok(())` without doing anything (the code flagged it "not yet implemented … no-op at runtime but counts as supported for coverage"). "When this enters, forage" cards did nothing.
2. **As a cost** (`oracle_cost.rs`): "forage" parsed to a bare `AbilityCost::Exile { count: 3, zone: Graveyard }`, silently dropping the "or sacrifice a Food" alternative — making some Forage costs wrongly unpayable.

Closes #2555.

## Comprehensive Rules

**CR 701.61a:** "To forage means 'Exile three cards from your graveyard or sacrifice a Food.'" It is modal (the forager chooses which way) and each way is atomic — exile *three* or sacrifice *a* Food.

## Implementation

Implemented by composition over existing, tested effects — no new `WaitingFor`, no engine/answer-handler/driver changes:

- **Exile mode** reuses `Effect::ChangeZone`'s resolution-time selection (`multi_target` fixed at 3 + `TargetChoiceTiming::Resolution` + empty targets, Graveyard -> Exile), scoped to the forager's own graveyard via `FilterProp::Owned { You }`. This routes through the shared `EffectZoneChoice` picker.
- **Food mode** reuses `Effect::Sacrifice` of a Food the forager controls (the same machinery Devour and every "sacrifice a Food" cost use).
- **Modality**: when both modes are performable, the forager chooses via `Effect::ChooseOneOf`. Each mode is offered only when it can be performed in full (CR 701.61a is atomic per mode); a single performable mode runs directly with no modal prompt; foraging is a no-op when neither mode is possible.
- **Cost form** fixed to a modal `AbilityCost::OneOf` of the two ways, so a player who can't exile three cards can still forage with a Food.

`Effect::Forage` now routes to `forage::resolve` instead of the no-op stub.

## Tests

`forage.rs` unit tests: no-op when neither mode is possible; exile-only prompts an exile-three-from-graveyard selection (count 3, Graveyard -> Exile); fewer than three graveyard cards (no Food) does nothing rather than a partial exile; Food-only sacrifices the Food; both modes prompt a `ChooseOneOf`.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` clean.
- `scripts/check-parser-combinators.sh` passes (cost-path change adds no string-method dispatch).

Note: the full unit-test suite runs in CI (local toolchain has a binutils/dlltool gap that blocks the test/audit binaries).