### PR TITLE
fix(ai): reserve largest-toughness blockers for trample in block_is_futile (CR 510.1c)

### DIFF
--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -1389,7 +1389,15 @@ fn block_is_futile(
 
     let chump_count = chumpable_powers.len().min(blocker_toughnesses.len());
     let chump_absorption: i32 = chumpable_powers.iter().take(chump_count).sum();
-    let remaining_blocker_toughness: i32 = blocker_toughnesses.iter().skip(chump_count).sum();
+    // CR 510.1c: Chumping a non-trample attacker absorbs its full power regardless
+    // of the blocker's toughness, so chump with the SMALLEST blockers and reserve
+    // the LARGEST-toughness ones to soak trample. `blocker_toughnesses` is sorted
+    // descending, so the trample blockers are the leading `len - chump_count`
+    // entries. (Skipping them — using the smallest for trample — under-counted
+    // absorption and wrongly reported survivable boards as futile.)
+    let trample_blocker_count = blocker_toughnesses.len() - chump_count;
+    let remaining_blocker_toughness: i32 =
+        blocker_toughnesses.iter().take(trample_blocker_count).sum();
     let trample_absorption = trample_power.min(remaining_blocker_toughness);
 
     let max_absorption = chump_absorption + trample_absorption;
@@ -2995,6 +3003,34 @@ mod tests {
         assert!(
             !blockers.is_empty(),
             "5/5 wall must block 3/3 bear; got empty assignment"
+        );
+    }
+
+    /// CR 509.1 + CR 510.1c: `block_is_futile` must reserve the LARGEST-toughness
+    /// blockers to soak tramplers and chump with the smallest, since chumping a
+    /// non-trample attacker absorbs its full power regardless of the blocker's
+    /// toughness. A survivable assignment here (chump the 1/1 with the 1/1, block
+    /// the 5/5 trampler with the 10-toughness wall → 0 trample-through) must NOT
+    /// be reported as futile. The bug reserved the SMALLEST blockers for trample,
+    /// under-counting absorption and conceding survivable boards to lethal.
+    #[test]
+    fn block_is_futile_reserves_largest_blockers_for_trample() {
+        let mut state = setup();
+        state.players[1].life = 2;
+        let wall = add_creature(&mut state, PlayerId(1), "Wall", 0, 10, vec![]);
+        let small = add_creature(&mut state, PlayerId(1), "Small", 1, 1, vec![]);
+        let trampler = add_creature(
+            &mut state,
+            PlayerId(0),
+            "Trampler",
+            5,
+            5,
+            vec![Keyword::Trample],
+        );
+        let bear = add_creature(&mut state, PlayerId(0), "Bear", 1, 1, vec![]);
+        assert!(
+            !block_is_futile(&state, PlayerId(1), &[trampler, bear], &[wall, small]),
+            "Wall absorbs the trampler and Small chumps the Bear (residual 0 < life 2); not futile"
         );
     }
 


### PR DESCRIPTION
## What

`block_is_futile` (`crates/phase-ai/src/combat_ai.rs`) is the combat-AI "hopeless block" fast-path: under the `Stabilize` objective, a `true` result makes `choose_blockers` immediately `return Vec::new()` — **declare no blocks**. Its doc promises an *optimistic upper bound* on absorption so "false positives (bailing when a save existed) cannot happen."

It did. After chumping it summed the trample-soak toughness from the wrong blockers:

```rust
// blocker_toughnesses is sorted DESCENDING
let remaining_blocker_toughness = blocker_toughnesses.iter().skip(chump_count).sum();
```

`skip(chump_count)` reserves the **smallest**-toughness blockers for trample. But chumping a non-trample attacker absorbs its full power **regardless of the blocker's toughness** (CR 510.1c), so the optimum chumps with the *smallest* blockers and soaks trample with the *largest*. Reserving the smallest under-counts absorption → inflates the residual → returns `true` on survivable boards → the AI makes **no blocks and takes lethal it could have prevented**.

Fixes #2562.

## Reproduction

Defender at 2 life. Attackers: 5/5 **trampler** + 1/1. Blockers: 0/10 **wall** + 1/1.
- **Survivable:** chump the 1/1 with the 1/1; block the trampler with the 0/10 wall → 0 tramples through, residual 0 < 2.
- **Buggy `block_is_futile`:** `skip(1)` on `[10, 1]` reserves `[1]` for trample → absorbs only 1 → residual `6 - 2 = 4 > 2` → `true` → AI concedes.

## Fix

Reserve the largest-toughness blockers for trample (the leading `len - chump_count` entries of the descending list):

```rust
let trample_blocker_count = blocker_toughnesses.len() - chump_count;
let remaining_blocker_toughness =
    blocker_toughnesses.iter().take(trample_blocker_count).sum();
```

This counts *more* absorption — the safe direction for an upper bound (false negatives only cost CPU, per the function's own contract).

## CR

- **CR 510.1c** — lethal damage to a blocker is its toughness; the rest may trample.
- **CR 509.1** — declaring blockers.

## Tests

Adds `block_is_futile_reserves_largest_blockers_for_trample` (fails on the old code, passes on the fix). The function's `debug_assert_eq!` residual invariant and both existing `block_is_futile_*` tests still hold; all 77 combat tests pass.

`cargo fmt --all` and the **full-workspace** `clippy --all-targets --features engine/proptest -D warnings` are clean.

## Non-duplicate

No open/closed issues/PRs reference `block_is_futile` or this combat-futility behavior. A distinct AI combat-evaluation defect (cf. the crackback over-count, #2517).
