### PR TITLE
perf(cloud-sync): cut Supabase egress with revision-check pull + realtime projection table

### DIFF
--- a/client/src/services/cloudSync/__tests__/supabaseProvider.test.ts
+++ b/client/src/services/cloudSync/__tests__/supabaseProvider.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Supabase client so the provider's query-builder chain
+// (getSupabaseClient().from(...).select(...).maybeSingle()) is fully captured
+// without a live backend or the build-time __SUPABASE_*__ defines.
+const { maybeSingleMock, selectMock, getClientMock } = vi.hoisted(() => {
+  const maybeSingleMock = vi.fn();
+  const selectMock = vi.fn(() => ({ maybeSingle: maybeSingleMock }));
+  const fromMock = vi.fn(() => ({ select: selectMock }));
+  const getClientMock = vi.fn(() => ({ from: fromMock }));
+  return { maybeSingleMock, selectMock, getClientMock };
+});
+
+vi.mock("../supabaseClient", () => ({
+  getSupabaseClient: getClientMock,
+  isSupabaseConfigured: () => true,
+}));
+
+import { SupabaseSyncProvider } from "../supabaseProvider";
+
+describe("SupabaseSyncProvider.pullMeta", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reads only revision + updated_at, never the payload column", async () => {
+    maybeSingleMock.mockResolvedValue({
+      data: { revision: 6, updated_at: "t" },
+      error: null,
+    });
+
+    await new SupabaseSyncProvider().pullMeta();
+
+    // The egress win depends on the payload column being omitted from the wire.
+    expect(selectMock).toHaveBeenCalledWith("revision, updated_at");
+  });
+
+  it("coerces a bigint-as-string revision to a number", async () => {
+    // Postgres bigint can serialize as a JSON string; without coercion the
+    // store's `meta.revision !== lastSyncedRevision` would see "6" !== 6 and
+    // force an unnecessary full pull (re-introducing the egress) or a false
+    // conflict.
+    maybeSingleMock.mockResolvedValue({
+      data: { revision: "6", updated_at: "t" },
+      error: null,
+    });
+
+    const m = await new SupabaseSyncProvider().pullMeta();
+
+    expect(m).toEqual({ revision: 6, updatedAt: "t" });
+    expect(typeof m?.revision).toBe("number");
+  });
+
+  it("returns null when the account has never synced", async () => {
+    maybeSingleMock.mockResolvedValue({ data: null, error: null });
+
+    expect(await new SupabaseSyncProvider().pullMeta()).toBeNull();
+  });
+});
+
+describe("SupabaseSyncProvider.pull", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("coerces a bigint-as-string revision to a number", async () => {
+    maybeSingleMock.mockResolvedValue({
+      data: { payload: { version: 1 }, revision: "6", updated_at: "t" },
+      error: null,
+    });
+
+    const snap = await new SupabaseSyncProvider().pull();
+
+    expect(snap?.meta.revision).toBe(6);
+    expect(typeof snap?.meta.revision).toBe("number");
+  });
+});

--- a/client/src/services/cloudSync/supabaseProvider.ts
+++ b/client/src/services/cloudSync/supabaseProvider.ts
@@ -11,6 +11,13 @@ import {
 import { getSupabaseClient, isSupabaseConfigured } from "./supabaseClient";
 
 const BACKUP_TABLE = "user_backups";
+/**
+ * Lightweight projection of (user_id, revision, updated_at) maintained
+ * transactionally by `upsert_backup`. Realtime CDC watches this table instead
+ * of `user_backups` so the heavy `payload` jsonb is never broadcast over the
+ * WebSocket. See `supabase/schema.sql`.
+ */
+const REVISION_TABLE = "user_backup_revisions";
 /** PostgREST surfaces a PL/pgSQL `raise exception` as this SQLSTATE. */
 const PG_RAISE_EXCEPTION = "P0001";
 
@@ -74,6 +81,24 @@ export class SupabaseSyncProvider implements CloudSyncProvider {
     return this.current;
   }
 
+  async pullMeta(): Promise<RemoteMeta | null> {
+    // Metadata-only read: omit the `payload` column so the common "did anything
+    // change?" check transfers a handful of bytes instead of the whole backup.
+    // RLS + PK make this at most one row; null = never synced.
+    const { data, error } = await getSupabaseClient()
+      .from(BACKUP_TABLE)
+      .select("revision, updated_at")
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return null;
+    return {
+      // Postgres `bigint` may serialize as a JSON string; coerce so the value
+      // compares (===) against lastSyncedRevision and is safe as expectedRevision.
+      revision: Number(data.revision),
+      updatedAt: data.updated_at as string,
+    };
+  }
+
   async pull(): Promise<RemoteSnapshot | null> {
     // RLS scopes the table to auth.uid(); the PK is user_id so there is at most
     // one row. maybeSingle() returns null when the account has never synced.
@@ -86,7 +111,7 @@ export class SupabaseSyncProvider implements CloudSyncProvider {
     return {
       backup: data.payload as PhaseBackup,
       meta: {
-        revision: data.revision as number,
+        revision: Number(data.revision), // bigint-as-string guard (see pullMeta)
         updatedAt: data.updated_at as string,
       },
     };
@@ -111,19 +136,21 @@ export class SupabaseSyncProvider implements CloudSyncProvider {
     }
     const row = Array.isArray(data) ? data[0] : data;
     return {
-      revision: row.revision as number,
+      revision: Number(row.revision), // bigint-as-string guard (see pullMeta)
       updatedAt: row.updated_at as string,
     };
   }
 
   /**
    * Subscribe to Postgres CDC (Postgres Change Data Capture) on
-   * `public.user_backups` filtered to this user's row. Supabase Realtime
-   * delivers INSERT/UPDATE payloads over a single WebSocket; we map them to
-   * a revision number for the caller to compare against its lastSyncedRevision.
+   * `public.user_backup_revisions` filtered to this user's row — the
+   * lightweight projection, NOT `user_backups`, so the heavy `payload` jsonb is
+   * never streamed over the WebSocket. Supabase Realtime delivers INSERT/UPDATE
+   * rows over a single WebSocket; we map them to a revision number for the
+   * caller to compare against its lastSyncedRevision.
    *
-   * Requires the table to be in the `supabase_realtime` publication — see
-   * `supabase/schema.sql` for the ALTER PUBLICATION statement. Without it,
+   * Requires the projection table to be in the `supabase_realtime` publication —
+   * see `supabase/schema.sql` for the ALTER PUBLICATION statement. Without it,
    * `subscribe` succeeds but no events ever fire (silent degrade).
    */
   subscribe(onChange: (newRevision: number) => void): () => void {
@@ -131,7 +158,7 @@ export class SupabaseSyncProvider implements CloudSyncProvider {
     const userId = this.current.userId;
     const client = getSupabaseClient();
     const channel = client
-      .channel(`user_backups:${userId}`)
+      .channel(`user_backup_revisions:${userId}`)
       // Postgres `bigint` may be serialized as a JSON string to preserve
       // precision past 2^53, so type the payload column as `number | string`
       // and coerce at the boundary. The revision counter is realistically
@@ -141,7 +168,7 @@ export class SupabaseSyncProvider implements CloudSyncProvider {
         {
           event: "*",
           schema: "public",
-          table: BACKUP_TABLE,
+          table: REVISION_TABLE,
           filter: `user_id=eq.${userId}`,
         },
         (payload) => {

--- a/client/src/services/cloudSync/types.ts
+++ b/client/src/services/cloudSync/types.ts
@@ -52,7 +52,16 @@ export interface CloudSyncProvider {
   signIn(provider: SyncAuthProvider): Promise<void>;
   signOut(): Promise<void>;
   identity(): SyncIdentity | null;
-  /** Read the remote envelope, or null if the account has never synced. */
+  /**
+   * Cheap metadata-only read — the revision marker + timestamp, never the
+   * payload. null if the account has never synced. This is the routine
+   * change-detection path: `syncNow` compares `revision` against its last-seen
+   * value and only falls through to the full `pull()` when reconciliation
+   * actually needs the envelope body. Reading the 8-byte revision must not cost
+   * the whole backup over the wire on every sync trigger.
+   */
+  pullMeta(): Promise<RemoteMeta | null>;
+  /** Read the full remote envelope, or null if the account has never synced. */
   pull(): Promise<RemoteSnapshot | null>;
   /**
    * Write the envelope with optimistic concurrency. `expectedRevision` is the

--- a/client/src/stores/__tests__/cloudSyncStore.test.ts
+++ b/client/src/stores/__tests__/cloudSyncStore.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PhaseBackup } from "../../services/backup";
-import type { CloudSyncProvider, RemoteSnapshot } from "../../services/cloudSync";
+import type {
+  CloudSyncProvider,
+  RemoteMeta,
+  RemoteSnapshot,
+} from "../../services/cloudSync";
 
 // Hoisted mock fns so the vi.mock factories below can reference them.
 const { buildBackupMock, applyBackupMock, getProvider } = vi.hoisted(() => ({
@@ -48,8 +52,14 @@ function remote(revision: number): RemoteSnapshot {
   };
 }
 
+/** The cheap metadata-only read syncNow now leads with. */
+function meta(revision: number): RemoteMeta {
+  return { revision, updatedAt: "2026-05-26T01:00:00.000Z" };
+}
+
 let provider: {
   identity: ReturnType<typeof vi.fn>;
+  pullMeta: ReturnType<typeof vi.fn>;
   pull: ReturnType<typeof vi.fn>;
   push: ReturnType<typeof vi.fn>;
 };
@@ -62,6 +72,7 @@ beforeEach(() => {
   });
   provider = {
     identity: vi.fn(() => ({ userId: "u1", label: "Tester" })),
+    pullMeta: vi.fn(),
     pull: vi.fn(),
     push: vi.fn(),
   };
@@ -80,13 +91,15 @@ beforeEach(() => {
 
 describe("cloudSyncStore.syncNow reconciliation", () => {
   it("seeds an empty account by pushing local with no expected revision", async () => {
-    provider.pull.mockResolvedValue(null);
+    provider.pullMeta.mockResolvedValue(null);
     buildBackupMock.mockReturnValue(fakeBackup({ decks: { Local: "{}" } }));
     provider.push.mockResolvedValue({ revision: 1, updatedAt: "t" });
 
     await useCloudSyncStore.getState().syncNow();
 
     expect(provider.push).toHaveBeenCalledWith(expect.anything(), null);
+    // Seeding never needs the remote body.
+    expect(provider.pull).not.toHaveBeenCalled();
     const s = useCloudSyncStore.getState();
     expect(s.status).toBe("synced");
     expect(s.lastSyncedRevision).toBe(1);
@@ -96,6 +109,7 @@ describe("cloudSyncStore.syncNow reconciliation", () => {
   it("first sign-in with ONLY local preferences (no decks) conflicts instead of overwriting", async () => {
     // Regression guard for the data-loss bug: prefs-only local must not be
     // silently replaced by a remote pull.
+    provider.pullMeta.mockResolvedValue(meta(5));
     provider.pull.mockResolvedValue(remote(5));
     buildBackupMock.mockReturnValue(fakeBackup({ preferences: "{\"vol\":1}" }));
 
@@ -107,39 +121,81 @@ describe("cloudSyncStore.syncNow reconciliation", () => {
   });
 
   it("adopts the cloud copy when local is genuinely empty", async () => {
+    provider.pullMeta.mockResolvedValue(meta(5));
     provider.pull.mockResolvedValue(remote(5));
     buildBackupMock.mockReturnValue(fakeBackup()); // nothing local at all
 
     await useCloudSyncStore.getState().syncNow();
 
     expect(applyBackupMock).toHaveBeenCalledWith(expect.anything(), "overwrite");
+    // The body is fetched exactly once to adopt it — no redundant re-pull.
+    expect(provider.pull).toHaveBeenCalledTimes(1);
     const s = useCloudSyncStore.getState();
     expect(s.lastSyncedRevision).toBe(5);
     expect(s.status).toBe("synced");
   });
 
-  it("fast-forwards local changes when the remote is unchanged", async () => {
+  it("fast-forwards local changes when the remote is unchanged WITHOUT pulling the body", async () => {
     useCloudSyncStore.setState({ lastSyncedRevision: 5, dirty: true });
-    provider.pull.mockResolvedValue(remote(5));
+    provider.pullMeta.mockResolvedValue(meta(5));
     buildBackupMock.mockReturnValue(fakeBackup({ decks: { Local: "{}" } }));
     provider.push.mockResolvedValue({ revision: 6, updatedAt: "t" });
 
     await useCloudSyncStore.getState().syncNow();
 
     expect(provider.push).toHaveBeenCalledWith(expect.anything(), 5);
+    // Egress guarantee: a local-only push must not fetch the remote envelope.
+    expect(provider.pull).not.toHaveBeenCalled();
     expect(useCloudSyncStore.getState().lastSyncedRevision).toBe(6);
   });
 
-  it("surfaces a lost write race as a conflict, not an error", async () => {
+  it("confirms in-sync state from the metadata read alone, never pulling the body", async () => {
+    // The hot path: revision unchanged and nothing dirty (e.g. a tab refocus).
+    // This is the egress win — it must cost a pullMeta and nothing else.
+    useCloudSyncStore.setState({ lastSyncedRevision: 5, dirty: false });
+    provider.pullMeta.mockResolvedValue(meta(5));
+    buildBackupMock.mockReturnValue(fakeBackup({ decks: { Local: "{}" } }));
+
+    await useCloudSyncStore.getState().syncNow();
+
+    expect(provider.pull).not.toHaveBeenCalled();
+    expect(provider.push).not.toHaveBeenCalled();
+    expect(useCloudSyncStore.getState().status).toBe("synced");
+  });
+
+  it("surfaces a lost write race as a conflict, pulling the body only in the catch", async () => {
     useCloudSyncStore.setState({ lastSyncedRevision: 5, dirty: true });
-    provider.pull
-      .mockResolvedValueOnce(remote(5)) // initial read: not ahead
-      .mockResolvedValueOnce(remote(6)); // re-read after the failed push
+    // Meta read says not-ahead → local-only push path; the push loses the race
+    // and the catch re-pulls the full body to build the conflict diff.
+    provider.pullMeta.mockResolvedValue(meta(5));
+    provider.pull.mockResolvedValue(remote(6));
     buildBackupMock.mockReturnValue(fakeBackup({ decks: { Local: "{}" } }));
     provider.push.mockRejectedValue(new SyncConflictError());
 
     await useCloudSyncStore.getState().syncNow();
 
     expect(useCloudSyncStore.getState().status).toBe("conflict");
+    // The body is fetched exactly once — in the catch, not on the routine path.
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+  });
+
+  it("reseeds instead of erroring when the row vanished mid-conflict", async () => {
+    // Lost the write race, but the re-pull finds the row gone (account deletion
+    // or a delete+reinsert race). Reseed this device's data rather than
+    // dead-ending at status:"error".
+    useCloudSyncStore.setState({ lastSyncedRevision: 5, dirty: true });
+    provider.pullMeta.mockResolvedValue(meta(5));
+    provider.pull.mockResolvedValue(null); // row gone on the catch re-pull
+    buildBackupMock.mockReturnValue(fakeBackup({ decks: { Local: "{}" } }));
+    provider.push
+      .mockRejectedValueOnce(new SyncConflictError()) // the racing push
+      .mockResolvedValueOnce({ revision: 1, updatedAt: "t" }); // the reseed
+
+    await useCloudSyncStore.getState().syncNow();
+
+    const s = useCloudSyncStore.getState();
+    expect(s.status).toBe("synced");
+    expect(s.lastSyncedRevision).toBe(1);
+    expect(provider.push).toHaveBeenLastCalledWith(expect.anything(), null);
   });
 });

--- a/client/src/stores/cloudSyncStore.ts
+++ b/client/src/stores/cloudSyncStore.ts
@@ -265,23 +265,27 @@ export const useCloudSyncStore = create<CloudSyncState>()(
         set({ status: "syncing", error: null, identity });
         syncInFlight = (async () => {
           try {
-            const remote = await provider.pull();
+            // Cheap metadata-only read first. The full payload is fetched only
+            // in the two branches below that actually reconcile remote data, so
+            // the common "nothing changed" tab-focus/realtime sync transfers a
+            // few bytes instead of the entire backup envelope.
+            const meta = await provider.pullMeta();
             const local = buildBackup();
             const { lastSyncedRevision, dirty } = get();
 
-            if (!remote) {
+            if (!meta) {
               // Account is empty — seed it with this device's data.
-              const meta = await provider.push(local, null);
+              const seeded = await provider.push(local, null);
               set({
                 status: "synced",
                 dirty: false,
-                lastSyncedRevision: meta.revision,
+                lastSyncedRevision: seeded.revision,
                 lastSyncedAt: new Date().toISOString(),
               });
               return;
             }
 
-            const remoteAhead = remote.meta.revision !== lastSyncedRevision;
+            const remoteAhead = meta.revision !== lastSyncedRevision;
             // On first sign-in (no revision history here) treat any existing
             // local profile data — decks, prefs, or feeds — as unsynced changes
             // so we never silently discard them to a remote pull.
@@ -290,6 +294,19 @@ export const useCloudSyncStore = create<CloudSyncState>()(
               (lastSyncedRevision === null && backupHasUserData(local));
 
             if (remoteAhead && localChanged) {
+              // Diverged: need the remote body for the digest + conflict diff.
+              const remote = await provider.pull();
+              if (!remote) {
+                // Row deleted between pullMeta and pull — reseed as empty.
+                const seeded = await provider.push(local, null);
+                set({
+                  status: "synced",
+                  dirty: false,
+                  lastSyncedRevision: seeded.revision,
+                  lastSyncedAt: new Date().toISOString(),
+                });
+                return;
+              }
               // Suppress false conflicts: if local and remote payloads are
               // byte-identical (after excluding the volatile exportedAt
               // timestamp), there's nothing to reconcile — just adopt the
@@ -315,20 +332,35 @@ export const useCloudSyncStore = create<CloudSyncState>()(
               return;
             }
             if (remoteAhead && !localChanged) {
+              // Remote moved, nothing local to preserve: fetch the body and
+              // adopt it wholesale.
+              const remote = await provider.pull();
+              if (!remote) {
+                const seeded = await provider.push(local, null);
+                set({
+                  status: "synced",
+                  dirty: false,
+                  lastSyncedRevision: seeded.revision,
+                  lastSyncedAt: new Date().toISOString(),
+                });
+                return;
+              }
               applyRemote(set, remote);
               return;
             }
             if (!remoteAhead && localChanged) {
-              const meta = await provider.push(local, remote.meta.revision);
+              // Local-only changes: push with the meta revision as the CAS
+              // guard — no remote body needed.
+              const pushed = await provider.push(local, meta.revision);
               set({
                 status: "synced",
                 dirty: false,
-                lastSyncedRevision: meta.revision,
+                lastSyncedRevision: pushed.revision,
                 lastSyncedAt: new Date().toISOString(),
               });
               return;
             }
-            // Already in sync: nothing moved over the wire, but the pull
+            // Already in sync: nothing moved over the wire, but the meta read
             // confirmed both sides agree on the current revision. That IS a
             // successful reconciliation — stamp lastSyncedAt so the user
             // pressing "Sync now" gets visible confirmation.
@@ -346,6 +378,21 @@ export const useCloudSyncStore = create<CloudSyncState>()(
                 });
                 return;
               }
+              // The row is gone (deleted, or a delete+reinsert race that turned
+              // our null-revision reseed into P0001). Reseed this device's data
+              // as the new account state rather than dead-ending at an error.
+              try {
+                const seeded = await provider.push(buildBackup(), null);
+                set({
+                  status: "synced",
+                  dirty: false,
+                  lastSyncedRevision: seeded.revision,
+                  lastSyncedAt: new Date().toISOString(),
+                });
+              } catch (reseedErr) {
+                set({ status: "error", error: errorMessage(reseedErr) });
+              }
+              return;
             }
             set({ status: "error", error: errorMessage(e) });
           }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -24,6 +24,35 @@ create policy own_backup on public.user_backups
   using (auth.uid() = user_id)
   with check (auth.uid() = user_id);
 
+-- Lightweight realtime signal. Mirrors (revision, updated_at) from
+-- user_backups, maintained atomically by upsert_backup (below). It exists ONLY
+-- so peer devices get a tiny CDC event on every push: Supabase Realtime
+-- (wal2json/WALRUS) broadcasts the full changed row and ignores publication
+-- column lists, so the heavy `payload` jsonb must not live in any
+-- realtime-published table. Realtime watches THIS table; user_backups remains
+-- the system of record and is removed from the publication below.
+create table if not exists public.user_backup_revisions (
+  user_id    uuid        primary key references auth.users (id) on delete cascade,
+  revision   bigint      not null,
+  updated_at timestamptz not null
+);
+
+alter table public.user_backup_revisions enable row level security;
+
+-- Realtime postgres_changes delivery is gated by the SELECT RLS policy AND a
+-- table-level GRANT SELECT to the token role; the user must be able to read
+-- their own signal row to receive its CDC events. (RLS enabled with no policy =
+-- deny-all = no events, so both this policy and the grant below are required.)
+drop policy if exists own_revision on public.user_backup_revisions;
+create policy own_revision on public.user_backup_revisions
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Read-only to clients; the projection is written exclusively by upsert_backup
+-- (security definer). No INSERT/UPDATE grant keeps the single write authority.
+grant select on public.user_backup_revisions to authenticated;
+
 -- Atomic compare-and-set upsert. Inserts when the caller has no row yet
 -- (p_expected_revision is null); otherwise updates only when the stored
 -- revision matches what the caller last saw, bumping the revision. A mismatch
@@ -66,6 +95,15 @@ begin
     exception when unique_violation then
       raise exception 'revision conflict: row created concurrently';
     end;
+    -- Mirror the new revision into the realtime signal table. Placed AFTER the
+    -- begin/exception block (not inside it) so a projection-side violation is
+    -- never mislabeled as the concurrent-insert P0001 above. `return query`
+    -- does not exit the function, so this runs after the result set is built.
+    -- on conflict do update self-heals if a stale projection row pre-exists.
+    insert into public.user_backup_revisions (user_id, revision, updated_at)
+    values (v_uid, 1, now())
+    on conflict (user_id) do update
+      set revision = excluded.revision, updated_at = excluded.updated_at;
   elsif p_expected_revision is distinct from v_current then
     raise exception 'revision conflict: expected %, found %',
       p_expected_revision, v_current;
@@ -77,6 +115,15 @@ begin
         updated_at = now()
     where user_id = v_uid
     returning user_backups.revision, user_backups.updated_at;
+    -- Mirror the bumped revision (v_current + 1, matching the row above) into
+    -- the realtime signal table, same transaction → the projection can never
+    -- diverge from the source of record. The two now() calls differ by
+    -- microseconds; updated_at is display-only (clients key change-detection on
+    -- revision), so the skew is acceptable.
+    insert into public.user_backup_revisions (user_id, revision, updated_at)
+    values (v_uid, v_current + 1, now())
+    on conflict (user_id) do update
+      set revision = excluded.revision, updated_at = excluded.updated_at;
   end if;
 end;
 $$;
@@ -89,20 +136,41 @@ $$;
 grant select on public.user_backups to authenticated;
 grant execute on function public.upsert_backup(jsonb, bigint) to authenticated;
 
--- Realtime: enroll user_backups in the supabase_realtime publication so peer
--- devices receive Postgres CDC notifications when this user's row updates.
--- The client subscribes via `supabase.channel(...).on('postgres_changes', ...)`;
--- without this membership, `subscribe()` returns silently but no events ever
--- fire. Guard with a do-block so re-running the schema is idempotent.
+-- Backfill the realtime signal table for accounts that synced before it
+-- existed, so they keep getting peer-device CDC notifications. Idempotent.
+-- Runs AFTER `create or replace function upsert_backup` above: once the
+-- mirror-writing function is in place, the only window where a push could land
+-- a user_backups row without a projection row is inside this single SQL-editor
+-- apply, and any such row self-heals on that account's next push (the
+-- visibility/pullMeta fallback keeps sync correct meanwhile).
+insert into public.user_backup_revisions (user_id, revision, updated_at)
+select user_id, revision, updated_at from public.user_backups
+on conflict (user_id) do nothing;
+
+-- Realtime: peer devices receive Postgres CDC notifications via the lightweight
+-- user_backup_revisions projection, NOT user_backups — so the heavy `payload`
+-- jsonb is never streamed over the WebSocket. The client subscribes via
+-- `supabase.channel(...).on('postgres_changes', ...)` on user_backup_revisions;
+-- without this membership, `subscribe()` returns silently but no events fire.
+-- Drop + add live in one do-block so they roll back as a unit on error (a failed
+-- add can't strand user_backups half-removed from realtime); idempotent guards
+-- make re-running the schema safe.
 do $$
 begin
-  if not exists (
-    select 1
-    from pg_publication_tables
+  -- The payload-bearing table must NOT broadcast: remove it from realtime.
+  if exists (
+    select 1 from pg_publication_tables
     where pubname = 'supabase_realtime'
-      and schemaname = 'public'
-      and tablename = 'user_backups'
+      and schemaname = 'public' and tablename = 'user_backups'
   ) then
-    alter publication supabase_realtime add table public.user_backups;
+    alter publication supabase_realtime drop table public.user_backups;
+  end if;
+  -- The lightweight projection IS the realtime signal source.
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public' and tablename = 'user_backup_revisions'
+  ) then
+    alter publication supabase_realtime add table public.user_backup_revisions;
   end if;
 end $$;


### PR DESCRIPTION
Cloud sync drove free-tier egress over quota. Two structural fixes (compression
was rejected — Supabase already Brotli-compresses text at the CDN edge):

1. Revision-check before payload-pull. `syncNow()` called `pull()` (the full
   PhaseBackup envelope) on every trigger — tab focus, realtime tick, debounced
   edit, boot — then discarded the payload in the common "nothing changed"
   branches. Add `pullMeta()` (revision + updated_at only) to CloudSyncProvider;
   `syncNow()` leads with it and only fetches the full body in the two branches
   that reconcile remote data. Coerce revision with `Number()` in
   pullMeta/pull/push (bigint can serialize as a JSON string, which would force
   a false remoteAhead or conflict). On a post-conflict re-pull returning null
   (row gone), reseed instead of dead-ending at status:"error".

2. Keep payload out of the realtime stream. `postgres_changes` broadcasts the
   full changed row — including the heavy payload jsonb — to every device on
   every push. Supabase Realtime (wal2json) ignores publication column lists, so
   add an additive `user_backup_revisions` projection table maintained
   transactionally by `upsert_backup`, and repoint realtime + the client
   subscription at it. user_backups stays the system of record; no data
   migration.

Note: supabase/schema.sql is hand-applied — the schema block must be run in the
project SQL editor for the realtime half to take effect (frontend ships
independently; visibility/pullMeta fallback keeps sync correct meanwhile).
