### PR TITLE
Implement Read Ahead keyword (CR 702.155)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8057,6 +8057,99 @@ pub fn synthesize_plot(face: &mut CardFace) {
     }
 }
 
+/// CR 702.155a-b + CR 714.3b: Read Ahead — a Saga with read ahead lets its
+/// controller choose which chapter it enters at. Replace the default Saga
+/// "enters with one lore counter" replacement (CR 714.3a, installed by
+/// `parse_saga_chapters`) with "as it enters, choose a number between one and
+/// this Saga's final chapter number; it enters with that many lore counters."
+///
+/// The choose-and-enter-with-N execute reuses the interactive-ETB-replacement
+/// pattern (Devour: a choice effect with a `PutCounter` sub-ability) and the
+/// `Effect::Choose { NumberRange, persist }` → `QuantityRef::ChosenNumber`
+/// number-choice primitive (Talion). `final` is the greatest chapter threshold
+/// among the Saga's parsed chapter triggers (CR 714.2d). The CR 702.155a
+/// suppression half — chapters 1..N-1 don't trigger the turn it enters at N —
+/// is enforced in `match_counter_added` (an exact-count gate for read-ahead
+/// Sagas that entered this turn), since the chapter triggers are
+/// `CounterAdded` + threshold and entering at N crosses thresholds 1..N at once.
+///
+/// CR 702.155c: multiple instances are redundant — this swaps the single ETB
+/// replacement once regardless of instance count, and is idempotent (the
+/// already-swapped replacement no longer matches `is_default_saga_lore_etb`).
+pub fn synthesize_read_ahead(face: &mut CardFace) {
+    if !face.keywords.contains(&Keyword::ReadAhead) {
+        return;
+    }
+    // CR 714.2d: final chapter number = greatest lore-counter threshold among
+    // this Saga's chapter triggers. No chapter abilities → nothing to read ahead to.
+    let Some(final_chapter) = face
+        .triggers
+        .iter()
+        .filter_map(|t| t.counter_filter.as_ref())
+        .filter(|f| f.counter_type == CounterType::Lore)
+        .filter_map(|f| f.threshold)
+        .max()
+    else {
+        return;
+    };
+
+    let read_ahead_execute = AbilityDefinition::new(
+        AbilityKind::Spell,
+        // CR 702.155b: "choose a number between one and this Saga's final
+        // chapter number"; the chosen value is persisted on the entering Saga
+        // so the `PutCounter` sub-ability can read it via `ChosenNumber`.
+        Effect::Choose {
+            choice_type: ChoiceType::NumberRange {
+                min: 1,
+                max: final_chapter.min(u8::MAX as u32) as u8,
+            },
+            persist: true,
+        },
+    )
+    .sub_ability(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PutCounter {
+            counter_type: CounterType::Lore,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::ChosenNumber,
+            },
+            target: TargetFilter::SelfRef,
+        },
+    ));
+
+    for replacement in face.replacements.iter_mut() {
+        if is_default_saga_lore_etb(replacement) {
+            replacement.execute = Some(Box::new(read_ahead_execute.clone()));
+            replacement.description = Some(
+                "CR 702.155b: Read ahead — enter with a chosen number of lore counters".to_string(),
+            );
+        }
+    }
+}
+
+/// True for the default Saga "enters with one lore counter" replacement
+/// installed by `parse_saga_chapters` (CR 714.3a): a `Moved` replacement on
+/// `SelfRef` whose execute puts exactly one `Lore` counter on `SelfRef`. After
+/// `synthesize_read_ahead` swaps the execute, this returns false (idempotency).
+fn is_default_saga_lore_etb(r: &ReplacementDefinition) -> bool {
+    if !matches!(r.event, ReplacementEvent::Moved)
+        || !matches!(r.valid_card, Some(TargetFilter::SelfRef))
+    {
+        return false;
+    }
+    let Some(execute) = r.execute.as_deref() else {
+        return false;
+    };
+    matches!(
+        &*execute.effect,
+        Effect::PutCounter {
+            counter_type: CounterType::Lore,
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::SelfRef,
+        }
+    )
+}
+
 /// Run all synthesis functions in canonical order on a card face.
 /// Both `oracle_loader.rs` and `oracle_gen.rs` call this to ensure the same
 /// complete set of synthesizers is applied.
@@ -8281,6 +8374,11 @@ pub fn synthesize_all(face: &mut CardFace) {
     // permanent (deterministic reveal-all of the strictly-beneficial reveal).
     // Each instance functions independently (CR 702.38b).
     synthesize_amplify(face);
+    // CR 702.155a-b: Read Ahead — swap a Saga's default "enters with one lore
+    // counter" replacement for a "choose 1..final, enter with that many lore
+    // counters" replacement. Must run after Saga chapters/ETB are parsed (they
+    // are, pre-synthesis). The chapter-suppression half is in match_counter_added.
+    synthesize_read_ahead(face);
     // CR 702.62a: Suspend — hand-activated alt-cost + upkeep counter-removal +
     // last-counter free-cast. Runs after Evoke to keep alt-cost synthesizers
     // grouped; idempotent so order against Cycling/Madness is irrelevant.
@@ -20367,6 +20465,125 @@ mod devour_synthesis_tests {
                 .any(|r| is_amplify_etb_replacement(r, 2)),
             "Amplify(1) replacement must not match the Amplify(2) predicate"
         );
+    }
+
+    /// Build a Saga face mirroring what `parse_saga_chapters` produces: one
+    /// `CounterAdded` chapter trigger per chapter number, plus the default
+    /// CR 714.3a "enters with one lore counter" replacement.
+    fn saga_face_with_chapters(chapters: &[u32], read_ahead: bool) -> CardFace {
+        let mut face = CardFace::default();
+        if read_ahead {
+            face.keywords.push(Keyword::ReadAhead);
+        }
+        for &n in chapters {
+            face.triggers.push(
+                TriggerDefinition::new(TriggerMode::CounterAdded)
+                    .valid_card(TargetFilter::SelfRef)
+                    .counter_filter(CounterTriggerFilter {
+                        counter_type: CounterType::Lore,
+                        threshold: Some(n),
+                    }),
+            );
+        }
+        face.replacements.push(
+            ReplacementDefinition::new(ReplacementEvent::Moved)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::PutCounter {
+                        counter_type: CounterType::Lore,
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::SelfRef,
+                    },
+                ))
+                .valid_card(TargetFilter::SelfRef)
+                .destination_zone(Zone::Battlefield),
+        );
+        face
+    }
+
+    /// CR 702.155b: a read-ahead Saga's default fixed lore ETB replacement is
+    /// swapped for "choose 1..final chapter, enter with that many lore counters".
+    #[test]
+    fn synthesize_read_ahead_swaps_lore_etb_for_choose_to_final_chapter() {
+        let mut face = saga_face_with_chapters(&[1, 2, 3], true);
+        synthesize_read_ahead(&mut face);
+
+        assert!(
+            !face.replacements.iter().any(is_default_saga_lore_etb),
+            "default fixed lore ETB replacement should be swapped"
+        );
+        let etb = face
+            .replacements
+            .iter()
+            .find(|r| matches!(r.event, ReplacementEvent::Moved))
+            .expect("read-ahead ETB replacement");
+        let execute = etb.execute.as_deref().expect("execute body");
+        let Effect::Choose {
+            choice_type: ChoiceType::NumberRange { min, max },
+            persist,
+        } = &*execute.effect
+        else {
+            panic!("read-ahead ETB should choose a number");
+        };
+        // CR 702.155b + CR 714.2d: between one and the final chapter number (3).
+        assert_eq!((*min, *max), (1, 3));
+        assert!(*persist, "chosen number must persist for ChosenNumber");
+
+        let sub = execute
+            .sub_ability
+            .as_deref()
+            .expect("PutCounter sub-ability");
+        assert!(matches!(
+            &*sub.effect,
+            Effect::PutCounter {
+                counter_type: CounterType::Lore,
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::ChosenNumber
+                },
+                target: TargetFilter::SelfRef,
+            }
+        ));
+    }
+
+    /// A Saga without read ahead keeps the default fixed "enters with 1 lore" ETB.
+    #[test]
+    fn synthesize_read_ahead_is_noop_without_keyword() {
+        let mut face = saga_face_with_chapters(&[1, 2, 3], false);
+        synthesize_read_ahead(&mut face);
+        assert!(
+            face.replacements.iter().any(is_default_saga_lore_etb),
+            "non-read-ahead Saga keeps the default fixed lore ETB"
+        );
+    }
+
+    /// CR 702.155c: redundant — re-running synthesis swaps exactly once.
+    #[test]
+    fn synthesize_read_ahead_is_idempotent() {
+        let mut face = saga_face_with_chapters(&[1, 2], true);
+        synthesize_read_ahead(&mut face);
+        synthesize_read_ahead(&mut face);
+        let choose_etbs = face
+            .replacements
+            .iter()
+            .filter(|r| {
+                r.execute
+                    .as_deref()
+                    .is_some_and(|e| matches!(&*e.effect, Effect::Choose { .. }))
+            })
+            .count();
+        assert_eq!(
+            choose_etbs, 1,
+            "exactly one swapped read-ahead ETB replacement"
+        );
+    }
+
+    /// No chapters → nothing to read ahead to (final chapter undefined) → no-op.
+    #[test]
+    fn synthesize_read_ahead_no_chapters_is_noop() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::ReadAhead);
+        synthesize_read_ahead(&mut face);
+        assert!(face.replacements.is_empty());
     }
 }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1577,6 +1577,21 @@ pub(super) fn match_counter_added(
                 if !(previous < threshold && threshold <= current) {
                     return false;
                 }
+                // CR 702.155a: A Saga with read ahead can't have its chapter
+                // abilities trigger the turn it entered the battlefield unless its
+                // lore count equals that chapter's number exactly. Entering at
+                // chapter N seeds N lore counters at once (0 -> N), which crosses
+                // every threshold 1..N; suppress all but the exact-count chapter
+                // on the enter-turn. After the enter-turn (one counter per turn)
+                // current == threshold holds at each crossing, so the gate is inert.
+                if threshold != current
+                    && state.objects.get(object_id).is_some_and(|obj| {
+                        obj.entered_battlefield_turn == Some(state.turn_number)
+                            && obj.has_keyword(&crate::types::keywords::Keyword::ReadAhead)
+                    })
+                {
+                    return false;
+                }
             }
         }
         true
@@ -7492,6 +7507,82 @@ mod tests {
                 threshold: Some(2),
             });
         assert!(!match_counter_added(&event, &trigger_ch2, saga_id, &state));
+    }
+
+    /// CR 702.155a: a read-ahead Saga that entered at chapter N this turn
+    /// (0 -> N lore counters) triggers only the exact-count chapter N; the
+    /// crossed-over chapters 1..N-1 are suppressed. A non-read-ahead Saga that
+    /// jumps to N this turn still fires every crossed chapter.
+    #[test]
+    fn read_ahead_suppresses_skipped_chapters_on_enter_turn() {
+        use crate::types::ability::CounterTriggerFilter;
+        use crate::types::triggers::TriggerMode;
+
+        let mut state = GameState::new_two_player(42);
+        let chapter = |n: u32| {
+            TriggerDefinition::new(TriggerMode::CounterAdded)
+                .valid_card(TargetFilter::SelfRef)
+                .counter_filter(CounterTriggerFilter {
+                    counter_type: crate::types::counter::CounterType::Lore,
+                    threshold: Some(n),
+                })
+        };
+
+        // Read-ahead Saga that entered this turn at chapter 3 (0 -> 3 at once).
+        let saga_id = crate::game::zones::create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Read-Ahead Saga".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&saga_id).unwrap();
+            obj.keywords.push(Keyword::ReadAhead);
+            obj.counters
+                .insert(crate::types::counter::CounterType::Lore, 3);
+        }
+        let event = GameEvent::CounterAdded {
+            object_id: saga_id,
+            counter_type: crate::types::counter::CounterType::Lore,
+            count: 3,
+        };
+        assert!(
+            match_counter_added(&event, &chapter(3), saga_id, &state),
+            "chapter 3 (exact count) fires"
+        );
+        assert!(
+            !match_counter_added(&event, &chapter(1), saga_id, &state),
+            "chapter 1 suppressed on read-ahead enter-turn"
+        );
+        assert!(
+            !match_counter_added(&event, &chapter(2), saga_id, &state),
+            "chapter 2 suppressed on read-ahead enter-turn"
+        );
+
+        // A non-read-ahead Saga that jumps 0 -> 3 this turn still fires chapter 1.
+        let normal_id = crate::game::zones::create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Normal Saga".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&normal_id)
+            .unwrap()
+            .counters
+            .insert(crate::types::counter::CounterType::Lore, 3);
+        let normal_event = GameEvent::CounterAdded {
+            object_id: normal_id,
+            counter_type: crate::types::counter::CounterType::Lore,
+            count: 3,
+        };
+        assert!(
+            match_counter_added(&normal_event, &chapter(1), normal_id, &state),
+            "non-read-ahead Saga still fires chapter 1 on a 0->3 jump"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1584,7 +1584,13 @@ pub(super) fn match_counter_added(
                 // every threshold 1..N; suppress all but the exact-count chapter
                 // on the enter-turn. After the enter-turn (one counter per turn)
                 // current == threshold holds at each crossing, so the gate is inert.
+                //
+                // Scoped to Lore: CR 702.155a restricts only chapter abilities
+                // (which trigger on lore counters). A Read-Ahead Saga with a
+                // thresholded trigger on some other counter type must not be
+                // suppressed on its enter turn.
                 if threshold != current
+                    && *counter_type == crate::types::counter::CounterType::Lore
                     && state.objects.get(object_id).is_some_and(|obj| {
                         obj.entered_battlefield_turn == Some(state.turn_number)
                             && obj.has_keyword(&crate::types::keywords::Keyword::ReadAhead)
@@ -7582,6 +7588,32 @@ mod tests {
         assert!(
             match_counter_added(&normal_event, &chapter(1), normal_id, &state),
             "non-read-ahead Saga still fires chapter 1 on a 0->3 jump"
+        );
+
+        // CR 702.155a is scoped to chapter (lore) abilities: a non-Lore
+        // thresholded trigger on the same Read-Ahead Saga must NOT be suppressed
+        // on its enter turn. Give the read-ahead Saga a 0 -> 2 +1/+1 jump and a
+        // +1/+1 threshold-1 trigger; it fires (0 < 1 <= 2) despite threshold != current.
+        state
+            .objects
+            .get_mut(&saga_id)
+            .unwrap()
+            .counters
+            .insert(crate::types::counter::CounterType::Plus1Plus1, 2);
+        let p1p1_event = GameEvent::CounterAdded {
+            object_id: saga_id,
+            counter_type: crate::types::counter::CounterType::Plus1Plus1,
+            count: 2,
+        };
+        let p1p1_trigger = TriggerDefinition::new(TriggerMode::CounterAdded)
+            .valid_card(TargetFilter::SelfRef)
+            .counter_filter(CounterTriggerFilter {
+                counter_type: crate::types::counter::CounterType::Plus1Plus1,
+                threshold: Some(1),
+            });
+        assert!(
+            match_counter_added(&p1p1_event, &p1p1_trigger, saga_id, &state),
+            "non-Lore thresholded trigger on a Read-Ahead Saga is not suppressed (CR 702.155a is lore-only)"
         );
     }
 


### PR DESCRIPTION
## Summary

`Keyword::ReadAhead` (March of the Machine, ~11 Sagas) was parsed but inert: read-ahead Sagas fell through to the default Saga ETB ("enters with one lore counter", CR 714.3a) and always started at chapter I, and the chapter-suppression clause (CR 702.155a) was unimplemented. Closes #2566.

## Comprehensive Rules

**CR 702.155b:** read-ahead Sagas have the intrinsic abilities "As this Saga enters, choose a number between one and this Saga's final chapter number" and "This Saga enters with the chosen number of lore counters on it."
**CR 702.155a:** "Chapter abilities of this Saga can't trigger the turn it entered the battlefield unless it has exactly the number of lore counters on it specified in the chapter symbol of that ability."
**CR 714.2d:** final chapter number = greatest chapter value. **CR 714.3b:** both intrinsics are replacement effects.

## Implementation

Two changes, composed entirely from existing Saga/choice primitives — no new `Effect`, trigger mode, or replacement event:

**1. `synthesize_read_ahead` (`database/synthesis.rs`)** — when a Saga has `Keyword::ReadAhead`, swap its default fixed "enter with 1 lore counter" replacement (installed by `parse_saga_chapters`) for: choose a number between 1 and the final chapter number, then enter with that many lore counters. This reuses:
- the interactive-ETB-replacement pattern (Devour: a choice effect with a `PutCounter` sub-ability),
- `Effect::Choose { NumberRange, persist: true }` → `QuantityRef::ChosenNumber` (Talion's "choose a number"),
- `final` = greatest chapter `threshold` among the Saga's parsed `CounterAdded` chapter triggers (CR 714.2d).

Idempotent (the swapped replacement no longer matches `is_default_saga_lore_etb`); CR 702.155c redundancy handled.

**2. CR 702.155a suppression (`game/trigger_matchers.rs::match_counter_added`)** — Saga chapters are `CounterAdded` + threshold triggers, so entering at chapter N seeds N counters at once (0→N) and would otherwise cross and fire every chapter 1..N. Added a gate: for a Saga with `Keyword::ReadAhead` that entered the battlefield **this turn**, a chapter triggers only when the current lore count equals its threshold exactly — so only chapter N fires. Non-read-ahead Sagas, and post-enter-turn lore additions (one per turn, where count == threshold at each crossing anyway), are unaffected.

## Tests

- Synthesis: read-ahead Saga's lore ETB is swapped to `Choose{NumberRange{1,final}}` + `PutCounter{Lore, ChosenNumber}`; no-op without the keyword; no-op with no chapters; idempotent.
- Matcher: a read-ahead Saga that entered this turn at chapter 3 fires only chapter 3 (1 and 2 suppressed); a non-read-ahead Saga that jumps 0→3 still fires chapter 1.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` clean.
- `scripts/check-parser-combinators.sh` passes (no parser change).

Note: the full unit-test suite runs in CI (local toolchain has a binutils/dlltool gap that blocks the test/audit binaries). The composed interactive-ETB path rests on the Devour (interactive effect + sub-ability in an ETB replacement) and Thriving Grove (as-enters `Choose` in a replacement) precedents.