### PR TITLE
fix(cloud-sync): address Gemini review on egress PR (#2565)

### DIFF
--- a/client/src/services/cloudSync/supabaseProvider.ts
+++ b/client/src/services/cloudSync/supabaseProvider.ts
@@ -135,6 +135,10 @@ export class SupabaseSyncProvider implements CloudSyncProvider {
       throw error;
     }
     const row = Array.isArray(data) ? data[0] : data;
+    // upsert_backup always returns one row or raises, but this is a network/DB
+    // boundary — guard so a malformed empty response throws a clear error
+    // instead of a cryptic `Cannot read properties of undefined`.
+    if (!row) throw new Error("upsert_backup returned no row");
     return {
       revision: Number(row.revision), // bigint-as-string guard (see pullMeta)
       updatedAt: row.updated_at as string,

--- a/client/src/stores/cloudSyncStore.ts
+++ b/client/src/stores/cloudSyncStore.ts
@@ -83,6 +83,15 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null;
  */
 let syncInFlight: Promise<void> | null = null;
 /**
+ * Set when a sync is requested while one is already in flight. The in-flight
+ * sync may have already taken its `pullMeta` snapshot before the newer remote
+ * revision landed, so coalescing onto it would leave this device silently
+ * behind (e.g. a realtime tick for rev 6 arrives mid-flight while the running
+ * sync reconciles rev 5). The trailing-edge re-trigger below runs one more sync
+ * after the current one drains so the latest revision is always reconciled.
+ */
+let syncNeededAfter = false;
+/**
  * Active realtime CDC channel for the current session. Held at module scope
  * so signIn/signOut can re-arm or tear down without going through `init()`.
  */
@@ -257,8 +266,13 @@ export const useCloudSyncStore = create<CloudSyncState>()(
 
       syncNow: async () => {
         // Coalesce concurrent callers onto the in-flight promise so the
-        // pull→push window can't be straddled by a stale snapshot.
-        if (syncInFlight) return syncInFlight;
+        // pull→push window can't be straddled by a stale snapshot. Record that a
+        // sync was requested mid-flight so the finally block re-runs once — the
+        // running sync may have snapshotted an older revision than this caller saw.
+        if (syncInFlight) {
+          syncNeededAfter = true;
+          return syncInFlight;
+        }
         const provider = getCloudSyncProvider();
         const identity = provider?.identity() ?? null;
         if (!provider || !identity) return;
@@ -401,6 +415,16 @@ export const useCloudSyncStore = create<CloudSyncState>()(
           await syncInFlight;
         } finally {
           syncInFlight = null;
+          // A sync requested while this one ran may have seen a newer revision
+          // than we reconciled. Re-run once (a cheap pullMeta confirms in-sync
+          // and no-ops when nothing actually changed). Deferred to a microtask
+          // so the mutex is fully cleared before the follow-up acquires it.
+          if (syncNeededAfter) {
+            syncNeededAfter = false;
+            queueMicrotask(() => {
+              void get().syncNow();
+            });
+          }
         }
       },
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -143,9 +143,14 @@ grant execute on function public.upsert_backup(jsonb, bigint) to authenticated;
 -- a user_backups row without a projection row is inside this single SQL-editor
 -- apply, and any such row self-heals on that account's next push (the
 -- visibility/pullMeta fallback keeps sync correct meanwhile).
+-- `do update` (not `do nothing`) makes re-runs self-healing: the projection is
+-- always derived from user_backups (same transaction in the RPC), so it can
+-- only ever equal or lag the source — overwriting with the source's current
+-- (revision, updated_at) repairs any stale row and is a no-op when already equal.
 insert into public.user_backup_revisions (user_id, revision, updated_at)
 select user_id, revision, updated_at from public.user_backups
-on conflict (user_id) do nothing;
+on conflict (user_id) do update
+  set revision = excluded.revision, updated_at = excluded.updated_at;
 
 -- Realtime: peer devices receive Postgres CDC notifications via the lightweight
 -- user_backup_revisions projection, NOT user_backups — so the heavy `payload`


### PR DESCRIPTION
Follow-up to #2565 addressing the three Gemini Code Assist review comments. **Stacked on #2565** — until that PR squash-merges, the diff here includes its base commit; once it lands, this collapses to just the three fixes below. Do not enqueue until #2565 has merged.

### Addressed
- **[HIGH] Coalesced sync can miss concurrent remote updates** (`cloudSyncStore.ts`). A `syncNow()` coalesced onto an in-flight sync may have seen a newer revision than the running sync snapshotted (e.g. a realtime CDC tick for rev 6 arriving while rev 5 reconciles). Added a `syncNeededAfter` trailing-edge flag that re-runs one sync after the mutex drains. The re-run is a cheap `pullMeta` that no-ops when already in sync.
- **[MED] Guard empty/null row from `upsert_backup`** (`supabaseProvider.ts`). The RPC always returns a row or raises, but it's a network/DB boundary — added `if (!row) throw` so a malformed empty response gives a clear error instead of a cryptic undefined-property crash.
- **[MED] Self-healing backfill** (`schema.sql`). Changed `on conflict do nothing` → `do update`. The projection is RPC-derived from `user_backups` in the same transaction, so it can only equal or lag the source; overwriting repairs any stale row and is a no-op when already equal.

### Notes
- Tests not run (no-build request). The HIGH fix would benefit from a coalescing regression test (mock a mid-flight second `syncNow` and assert a trailing re-run) — flagged as a quick follow-up.
- `supabase/schema.sql` is still hand-applied; the `do update` backfill is idempotent and safe to re-run.