### PR TITLE
fix(parser): Affinity for card types and type combinations (CR 205.2)

### DIFF
--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1286,6 +1286,31 @@ fn parse_keyword_mana_cost(s: &str) -> ManaCost {
 
 /// CR 702.41a: Parse the text from "Affinity for [text]" into the permanents
 /// counted for the cost reduction.
+/// CR 205.2: Map a single (possibly plural) card-type word to its `TypeFilter`.
+/// Used by `parse_affinity_type` to recognize "affinity for planeswalkers" /
+/// "affinity for artifact creatures" as card types rather than subtypes. Returns
+/// `None` for any word that is not a card type (e.g. a creature subtype), so a
+/// multi-word phrase only becomes a type conjunction when every word is a type.
+fn affinity_card_type_word(word: &str) -> Option<super::ability::TypeFilter> {
+    use super::ability::TypeFilter;
+    // Singularize: "sorceries" → "sorcery"; otherwise strip a trailing plural 's'.
+    let singular = word
+        .strip_suffix("ies")
+        .map(|stem| format!("{stem}y"))
+        .unwrap_or_else(|| word.strip_suffix('s').unwrap_or(word).to_string());
+    Some(match singular.as_str() {
+        "artifact" => TypeFilter::Artifact,
+        "creature" => TypeFilter::Creature,
+        "land" => TypeFilter::Land,
+        "enchantment" => TypeFilter::Enchantment,
+        "planeswalker" => TypeFilter::Planeswalker,
+        "instant" => TypeFilter::Instant,
+        "sorcery" => TypeFilter::Sorcery,
+        "battle" => TypeFilter::Battle,
+        _ => return None,
+    })
+}
+
 fn parse_affinity_type(s: &str) -> Option<TypedFilter> {
     use super::ability::TypeFilter;
     // MTGJSON provides "Affinity for artifacts" — FromStr splits on first ':' giving
@@ -1302,11 +1327,30 @@ fn parse_affinity_type(s: &str) -> Option<TypedFilter> {
             Some(TypedFilter::new(TypeFilter::Artifact).subtype("Equipment".to_string()))
         }
         _ => {
-            // CR 702.41a + CR 205.3: "Affinity for [text]" counts permanents
-            // matching the text. Unknown names are subtypes, but not always
-            // land subtypes ("Daleks", "Cats", "Birds"). Keep this as a bare
-            // subtype constraint so it covers land, artifact, enchantment, and
-            // creature subtype affinity without adding a false type conjunct.
+            // CR 205.2 + CR 702.41a: "Affinity for <card type(s)>" — a card type
+            // ("planeswalkers", Tomik, Wielder of Law) or a type combination
+            // ("artifact creatures", Urza, Chief Artificer). Tokenize and map each
+            // singularized word to a card type; if EVERY word is a card type, build
+            // a conjunctive type filter (CR 205: all type constraints must match),
+            // not a bogus multi-word subtype. Otherwise fall through to subtype.
+            if let Some(types) = lower
+                .split_whitespace()
+                .map(affinity_card_type_word)
+                .collect::<Option<Vec<TypeFilter>>>()
+            {
+                if let Some((first, rest)) = types.split_first() {
+                    let mut filter = TypedFilter::new(first.clone());
+                    for ty in rest {
+                        filter = filter.with_type(ty.clone());
+                    }
+                    return Some(filter);
+                }
+            }
+            // CR 702.41a + CR 205.3: otherwise the text is a subtype. Unknown names
+            // are subtypes, but not always land subtypes ("Daleks", "Cats",
+            // "Birds"). Keep this as a bare subtype constraint so it covers land,
+            // artifact, enchantment, and creature subtype affinity without adding a
+            // false type conjunct.
             let capitalized = format!("{}{}", &s[..1].to_uppercase(), &s[1..]);
             // Strip trailing 's' for plural subtype words (e.g., "Daleks" →
             // "Dalek", "Islands" → "Island"; "Plains" stays "Plains").
@@ -2779,6 +2823,44 @@ mod tests {
             island_filter.type_filters,
             vec![TypeFilter::Subtype("Island".to_string())],
             "land subtype affinity still matches by subtype without requiring an explicit Land conjunct"
+        );
+    }
+
+    #[test]
+    fn parse_affinity_for_card_type_and_type_combination() {
+        // CR 205.2: Tomik, Wielder of Law — "affinity for planeswalkers" is a card
+        // TYPE, not a subtype. (Regression: previously parsed as Subtype("Planeswalker").)
+        let Keyword::Affinity(pw) = Keyword::from_str("Affinity for planeswalkers").unwrap() else {
+            panic!("expected Affinity keyword");
+        };
+        assert_eq!(
+            pw.type_filters,
+            vec![TypeFilter::Planeswalker],
+            "affinity for planeswalkers is the Planeswalker card type"
+        );
+
+        // CR 205: Urza, Chief Artificer — "affinity for artifact creatures" is a
+        // type COMBINATION (conjunction), not the bogus Subtype("Artifact creature").
+        let Keyword::Affinity(ac) = Keyword::from_str("Affinity for artifact creatures").unwrap()
+        else {
+            panic!("expected Affinity keyword");
+        };
+        assert_eq!(
+            ac.type_filters,
+            vec![TypeFilter::Artifact, TypeFilter::Creature],
+            "affinity for artifact creatures is Artifact AND Creature"
+        );
+
+        // Regression guard: a genuine subtype still falls through to Subtype, not a
+        // type conjunction (only words that are ALL card types build a conjunction).
+        let Keyword::Affinity(citizens) = Keyword::from_str("Affinity for Citizens").unwrap()
+        else {
+            panic!("expected Affinity keyword");
+        };
+        assert_eq!(
+            citizens.type_filters,
+            vec![TypeFilter::Subtype("Citizen".to_string())],
+            "a non-type word remains a subtype"
         );
     }
 


### PR DESCRIPTION
"Affinity for planeswalkers" (Tomik, Wielder of Law) is a card TYPE and
"affinity for artifact creatures" (Urza, Chief Artificer) is a type
COMBINATION — both previously fell through to a bogus subtype. Add
affinity_card_type_word and tokenize the phrase: when every word is a card
type, build a conjunctive type filter (CR 205); otherwise keep the subtype.

Reported in Discord keyword audit (thread 1512861737416785920).
