### PR TITLE
fix(engine): fire bare "becomes blocked" triggers once per combat (CR 509.3c)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2823,6 +2823,14 @@ pub(super) fn matching_becomes_blocked_events(
     state: &GameState,
 ) -> Vec<GameEvent> {
     if let GameEvent::BlockersDeclared { assignments } = event {
+        // CR 509.3d: the "becomes blocked by a creature [with quality]" form
+        // (carries a `valid_target` blocker filter) triggers once for each
+        // matching blocker. CR 509.3c: the bare "becomes blocked" form (no
+        // blocker qualifier, `valid_target: None`) triggers only once each combat
+        // for the attacker, regardless of how many creatures block it — so the
+        // matching assignments are collapsed to a single event per attacker.
+        let per_blocker = trigger.valid_target.is_some();
+        let mut emitted_attackers: Vec<ObjectId> = Vec::new();
         assignments
             .iter()
             .filter_map(|(blocker, attacker)| {
@@ -2831,13 +2839,26 @@ pub(super) fn matching_becomes_blocked_events(
                 } else {
                     *attacker == source_id
                 };
+                if !attacker_matches {
+                    return None;
+                }
                 let blocker_matches = match &trigger.valid_target {
                     Some(filter) => {
                         target_filter_matches_object(state, *blocker, filter, source_id)
                     }
                     None => true,
                 };
-                (attacker_matches && blocker_matches).then_some(GameEvent::BlockersDeclared {
+                if !blocker_matches {
+                    return None;
+                }
+                // CR 509.3c: only the first matching blocker fires the bare form.
+                if !per_blocker {
+                    if emitted_attackers.contains(attacker) {
+                        return None;
+                    }
+                    emitted_attackers.push(*attacker);
+                }
+                Some(GameEvent::BlockersDeclared {
                     assignments: vec![(*blocker, *attacker)],
                 })
             })
@@ -6712,6 +6733,62 @@ mod tests {
                     assignments: vec![(second_blocker, attacker)]
                 },
             ]
+        );
+    }
+
+    /// CR 509.3c: a bare "becomes blocked" trigger (no by-a-creature qualifier,
+    /// i.e. `valid_target: None` — Bushido CR 702.45a, Rampage CR 702.23a) triggers
+    /// only ONCE per combat for the attacker, even when multiple creatures block it.
+    /// The matcher must collapse a multi-blocker assignment to a single event;
+    /// firing once per blocker double-pumps Bushido (a double-blocked Bushido 2
+    /// would wrongly become 6/6 instead of 4/4) and over-counts Rampage.
+    #[test]
+    fn becomes_blocked_trigger_fires_once_for_bare_form_when_multi_blocked() {
+        let mut state = setup();
+        let attacker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bushido Samurai".to_string(),
+            Zone::Battlefield,
+        );
+        let first_blocker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "First Blocker".to_string(),
+            Zone::Battlefield,
+        );
+        let second_blocker = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Second Blocker".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [attacker, first_blocker, second_blocker] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+        // Bare "becomes blocked": self-scoped, no blocker qualifier (valid_target None).
+        let trigger = make_trigger(TriggerMode::BecomesBlocked).valid_card(TargetFilter::SelfRef);
+        let event = GameEvent::BlockersDeclared {
+            assignments: vec![(first_blocker, attacker), (second_blocker, attacker)],
+        };
+
+        let matched = matching_becomes_blocked_events(&event, &trigger, attacker, &state);
+
+        assert_eq!(
+            matched,
+            vec![GameEvent::BlockersDeclared {
+                assignments: vec![(first_blocker, attacker)]
+            }],
+            "CR 509.3c: bare 'becomes blocked' fires once per combat, not once per blocker"
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6445,6 +6445,13 @@ fn try_parse_event(
         )))
         .parse(input)
     }
+    fn parse_becomes_blocked_by_filter(input: &str) -> Option<TargetFilter> {
+        let (type_phrase, _) = alt((tag::<_, _, OracleError<'_>>(" by a "), tag(" by an ")))
+            .parse(input)
+            .ok()?;
+        let (filter, rest) = parse_type_phrase(type_phrase);
+        rest.trim().is_empty().then_some(filter)
+    }
     if let Ok((remaining, event)) = parse_simple_event.parse(rest) {
         let mut def = make_base();
         match event {
@@ -6460,17 +6467,7 @@ fn try_parse_event(
                 // further qualifier) were indistinguishable from the bare form.
                 // Only the singular-article form qualifies — a threshold like
                 // "by two or more creatures" stays the bare once-per-combat form.
-                let is_by_a_type = alt((tag::<_, _, OracleError<'_>>(" by a "), tag(" by an ")))
-                    .parse(remaining)
-                    .is_ok();
-                if is_by_a_type {
-                    if let Ok((after_by, ())) =
-                        value((), tag::<_, _, OracleError<'_>>(" by ")).parse(remaining)
-                    {
-                        let (blocker_filter, _) = parse_type_phrase(after_by);
-                        def.valid_target = Some(blocker_filter);
-                    }
-                }
+                def.valid_target = parse_becomes_blocked_by_filter(remaining);
             }
             SimpleEvent::BecomesTargetSpellOrAbility => {
                 def.mode = TriggerMode::BecomesTarget;
@@ -11193,6 +11190,7 @@ mod tests {
     };
     use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::game_state::WaitingFor;
+    use crate::types::keywords::Keyword;
     use crate::types::mana::{ManaCost, ManaType, ManaUnit};
     use crate::types::replacements::ReplacementEvent;
     use crate::types::statics::CastFrequency;
@@ -15116,6 +15114,44 @@ mod tests {
             }
             other => panic!("expected a creature blocker filter, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn trigger_becomes_blocked_by_a_qualified_creature_preserves_blocker_filter() {
+        let def = parse_trigger_line(
+            "Whenever Quagmire Lamprey becomes blocked by a creature without flying, that creature gets a -1/-1 counter.",
+            "Quagmire Lamprey",
+        );
+
+        assert_eq!(def.mode, TriggerMode::BecomesBlocked);
+        match def.valid_target {
+            Some(TargetFilter::Typed(ref tf)) => {
+                assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+                assert!(
+                    tf.properties
+                        .iter()
+                        .any(|p| matches!(p, FilterProp::WithoutKeyword { value } if *value == Keyword::Flying)),
+                    "expected WithoutKeyword(Flying) in {:?}",
+                    tf.properties
+                );
+            }
+            other => panic!("expected a qualified creature blocker filter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trigger_becomes_blocked_by_two_or_more_creatures_stays_bare() {
+        let def = parse_trigger_line(
+            "Whenever Vicious Battlerager becomes blocked by two or more creatures, draw a card.",
+            "Vicious Battlerager",
+        );
+
+        assert_eq!(def.mode, TriggerMode::BecomesBlocked);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert!(
+            def.valid_target.is_none(),
+            "threshold wording must not be treated as a per-blocker qualifier"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -6451,6 +6451,26 @@ fn try_parse_event(
             SimpleEvent::BecomesBlocked => {
                 def.mode = TriggerMode::BecomesBlocked;
                 def.valid_card = Some(subject.clone());
+                // CR 509.3c vs 509.3d: a bare "becomes blocked" triggers once per
+                // combat, while "becomes blocked by a <type>" triggers once for
+                // each matching blocker. Capture the "by a/an <type phrase>"
+                // qualifier as the blocker filter so the runtime matcher can tell
+                // the two apart (a present `valid_target` => per-blocker). Without
+                // this, plain "becomes blocked by a creature" cards (which carry no
+                // further qualifier) were indistinguishable from the bare form.
+                // Only the singular-article form qualifies — a threshold like
+                // "by two or more creatures" stays the bare once-per-combat form.
+                let is_by_a_type = alt((tag::<_, _, OracleError<'_>>(" by a "), tag(" by an ")))
+                    .parse(remaining)
+                    .is_ok();
+                if is_by_a_type {
+                    if let Ok((after_by, ())) =
+                        value((), tag::<_, _, OracleError<'_>>(" by ")).parse(remaining)
+                    {
+                        let (blocker_filter, _) = parse_type_phrase(after_by);
+                        def.valid_target = Some(blocker_filter);
+                    }
+                }
             }
             SimpleEvent::BecomesTargetSpellOrAbility => {
                 def.mode = TriggerMode::BecomesTarget;
@@ -15071,6 +15091,31 @@ mod tests {
         );
         assert_eq!(def.mode, TriggerMode::BecomesBlocked);
         assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        // CR 509.3c: bare "becomes blocked" has no blocker qualifier, so
+        // `valid_target` stays None — the runtime reads this as once-per-combat.
+        assert!(def.valid_target.is_none());
+    }
+
+    /// CR 509.3d: "becomes blocked by a creature" carries a blocker qualifier and
+    /// triggers once per matching blocker. The parser must populate `valid_target`
+    /// with the (creature) blocker filter so the runtime matcher distinguishes it
+    /// from the bare CR 509.3c form (which fires once per combat). Regression guard
+    /// for the ~29 plain "by a creature" cards (Quagmire Lamprey, Order of the
+    /// Alabaster Host, Cave Tiger, …) that would otherwise collapse to once-per-combat.
+    #[test]
+    fn trigger_becomes_blocked_by_a_creature_sets_blocker_filter() {
+        let def = parse_trigger_line(
+            "Whenever Quagmire Lamprey becomes blocked by a creature, that creature gets a -1/-1 counter.",
+            "Quagmire Lamprey",
+        );
+        assert_eq!(def.mode, TriggerMode::BecomesBlocked);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        match def.valid_target {
+            Some(TargetFilter::Typed(ref tf)) => {
+                assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+            }
+            other => panic!("expected a creature blocker filter, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/tests/integration/rules/combat.rs
+++ b/crates/engine/tests/integration/rules/combat.rs
@@ -137,6 +137,59 @@ fn bushido_becomes_blocked_fires_once_when_double_blocked() {
     assert_eq!(state.objects[&attacker_id].toughness, Some(4));
 }
 
+/// CR 509.3d: "Whenever this creature becomes blocked by a creature" triggers
+/// once for each creature that blocks it.
+#[test]
+fn becomes_blocked_by_creature_fires_for_each_blocker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let attacker_id = scenario
+        .add_creature(P0, "Acolyte of the Inferno", 2, 2)
+        .from_oracle_text(
+            "Whenever Acolyte of the Inferno becomes blocked by a creature, \
+             Acolyte of the Inferno deals 2 damage to that creature.",
+        )
+        .id();
+    let blocker_a = scenario.add_creature(P1, "Bear A", 3, 3).id();
+    let blocker_b = scenario.add_creature(P1, "Bear B", 3, 3).id();
+    let mut runner = scenario.build();
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker_id, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("trigger source should be able to attack");
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareBlockers {
+            assignments: vec![(blocker_a, attacker_id), (blocker_b, attacker_id)],
+        })
+        .expect("both blockers should be able to block the trigger source");
+
+    match &runner.state().waiting_for {
+        WaitingFor::OrderTriggers { player, triggers } => {
+            assert_eq!(*player, P0);
+            assert_eq!(
+                triggers.len(),
+                2,
+                "CR 509.3d: by-a-creature trigger fires once for each blocker"
+            );
+        }
+        other => panic!("expected CR 603.3b OrderTriggers for two blocker triggers, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::OrderTriggers { order: vec![0, 1] })
+        .expect("submitting trigger order should succeed");
+    runner.advance_until_stack_empty();
+
+    let state = runner.state();
+    assert_eq!(state.objects[&blocker_a].damage_marked, 2);
+    assert_eq!(state.objects[&blocker_b].damage_marked, 2);
+}
+
 #[test]
 fn decayed_attacker_sacrifices_at_end_of_combat() {
     let mut scenario = GameScenario::new();

--- a/crates/engine/tests/integration/rules/combat.rs
+++ b/crates/engine/tests/integration/rules/combat.rs
@@ -93,6 +93,50 @@ fn bushido_becomes_blocked_pumps_attacker_not_blocker() {
     assert_eq!(state.objects[&blocker_id].toughness, Some(2));
 }
 
+/// CR 509.3c: "Whenever this creature becomes blocked" triggers ONLY ONCE per
+/// combat, even when multiple creatures block it. A Bushido 2 creature that is
+/// double-blocked must end at +2/+2 (→ 4/4), not +4/+4 (→ 6/6) from firing once
+/// per blocker.
+#[test]
+fn bushido_becomes_blocked_fires_once_when_double_blocked() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let attacker_id = scenario
+        .add_creature(P0, "Ronin", 2, 2)
+        .from_oracle_text_with_keywords(&["bushido"], "Bushido 2")
+        .id();
+    let blocker_a = scenario.add_creature(P1, "Bear A", 2, 2).id();
+    let blocker_b = scenario.add_creature(P1, "Bear B", 2, 2).id();
+    let mut runner = scenario.build();
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker_id, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("Bushido creature should be able to attack");
+    // CR 508.2: Active player gets priority after attackers before blockers.
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareBlockers {
+            assignments: vec![(blocker_a, attacker_id), (blocker_b, attacker_id)],
+        })
+        .expect("both blockers should be able to block the Bushido creature");
+
+    // CR 509.3c: exactly one becomes-blocked trigger, regardless of blocker count.
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "becomes-blocked Bushido trigger fires once per combat, not once per blocker"
+    );
+    runner.resolve_top();
+
+    let state = runner.state();
+    assert_eq!(state.objects[&attacker_id].power, Some(4));
+    assert_eq!(state.objects[&attacker_id].toughness, Some(4));
+}
+
 #[test]
 fn decayed_attacker_sacrifices_at_end_of_combat() {
     let mut scenario = GameScenario::new();


### PR DESCRIPTION
## Summary

`matching_becomes_blocked_events` emitted **one event per blocker** for every "becomes blocked" trigger, and the trigger queueing in `triggers.rs` turns each event into a separate pending triggered ability. So a creature blocked by *N* creatures fired the ability *N* times.

Per **CR 509.3c**, the bare "Whenever ~ becomes blocked" form triggers **only once each combat** for that creature, no matter how many block it. Only the qualified "becomes blocked **by a creature** ." form (**CR 509.3d**) triggers once per blocker. The engine already encodes the qualifier as `TriggerDefinition.valid_target` (`None` = bare form, `Some(filter)` = by-a-creature form), but the matcher ignored it and treated every assignment as a separate trigger.

This over-fired every synthesized keyword using `BecomesBlocked` with `valid_target: None`:

- **Bushido N** (CR 702.45a) - "it gets +N/+N". A double-blocked **Bushido 2** creature became **+4/+4** (a 2/2 ? **6/6**) instead of the correct **+2/+2** (? **4/4**); triple-blocked ? +6/+6.
- **Rampage N** (CR 702.23a) - "+N/+N for each creature blocking it beyond the first". Fired per blocker *and* recomputed the count each firing, compounding the overcount.

**Flanking** is unaffected - its trigger carries a `valid_target` ("by a creature without flanking"), the genuine CR 509.3d per-blocker form. **Afflict** is unaffected - it uses the separate `AttackerBlocked` mode (fires once).

## Fix

In `matching_becomes_blocked_events`, when `trigger.valid_target.is_none()` (CR 509.3c bare form), collapse the matching assignments to a single event per distinct attacker. When `valid_target.is_some()` (CR 509.3d), keep the existing one-event-per-blocker behavior.

## Testing

- New matcher unit test `becomes_blocked_trigger_fires_once_for_bare_form_when_multi_blocked` - fails on `main` (returns 2 events for a double-block), passes after the fix (1 event).
- New integration test `bushido_becomes_blocked_fires_once_when_double_blocked` - a double-blocked Bushido 2 ends at **4/4**, with exactly one trigger on the stack (was 6/6 / two triggers).
- Existing per-blocker flanking tests (`becomes_blocked_trigger_events_split_per_non_flanking_blocker`, `becomes_blocked_trigger_collects_once_per_non_flanking_blocker`) and the single-block Bushido test stay green.
- CR numbers verified against `docs/MagicCompRules.txt` (509.3c, 509.3d, 702.45a, 702.23a).

Fixes #2575
