### PR TITLE
fix(sync): await trailing cloud sync callers

### DIFF
--- a/client/src/stores/__tests__/cloudSyncStore.test.ts
+++ b/client/src/stores/__tests__/cloudSyncStore.test.ts
@@ -57,6 +57,20 @@ function meta(revision: number): RemoteMeta {
   return { revision, updatedAt: "2026-05-26T01:00:00.000Z" };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function flushAsync() {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 let provider: {
   identity: ReturnType<typeof vi.fn>;
   pullMeta: ReturnType<typeof vi.fn>;
@@ -161,6 +175,42 @@ describe("cloudSyncStore.syncNow reconciliation", () => {
     expect(provider.pull).not.toHaveBeenCalled();
     expect(provider.push).not.toHaveBeenCalled();
     expect(useCloudSyncStore.getState().status).toBe("synced");
+  });
+
+  it("coalesced callers wait for the trailing sync they requested", async () => {
+    useCloudSyncStore.setState({ lastSyncedRevision: 5, dirty: false });
+    const firstMeta = deferred<RemoteMeta>();
+    const secondMeta = deferred<RemoteMeta>();
+    provider.pullMeta
+      .mockReturnValueOnce(firstMeta.promise)
+      .mockReturnValueOnce(secondMeta.promise);
+    provider.pull.mockResolvedValue(remote(6));
+    buildBackupMock.mockReturnValue(fakeBackup());
+
+    const firstSync = useCloudSyncStore.getState().syncNow();
+    expect(provider.pullMeta).toHaveBeenCalledTimes(1);
+
+    let secondResolved = false;
+    const secondSync = useCloudSyncStore
+      .getState()
+      .syncNow()
+      .then(() => {
+        secondResolved = true;
+      });
+
+    firstMeta.resolve(meta(5));
+    await firstSync;
+    await flushAsync();
+
+    expect(provider.pullMeta).toHaveBeenCalledTimes(2);
+    expect(secondResolved).toBe(false);
+    secondMeta.resolve(meta(6));
+    await secondSync;
+
+    expect(provider.pullMeta).toHaveBeenCalledTimes(2);
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+    expect(useCloudSyncStore.getState().lastSyncedRevision).toBe(6);
+    expect(secondResolved).toBe(true);
   });
 
   it("surfaces a lost write race as a conflict, pulling the body only in the catch", async () => {

--- a/client/src/stores/cloudSyncStore.ts
+++ b/client/src/stores/cloudSyncStore.ts
@@ -83,14 +83,12 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null;
  */
 let syncInFlight: Promise<void> | null = null;
 /**
- * Set when a sync is requested while one is already in flight. The in-flight
- * sync may have already taken its `pullMeta` snapshot before the newer remote
- * revision landed, so coalescing onto it would leave this device silently
- * behind (e.g. a realtime tick for rev 6 arrives mid-flight while the running
- * sync reconciles rev 5). The trailing-edge re-trigger below runs one more sync
- * after the current one drains so the latest revision is always reconciled.
+ * Latest trailing-edge sync requested by a caller that arrived while another
+ * sync was in flight. Each coalesced caller gets back a promise that resolves
+ * after its follow-up sync, not merely after the older snapshot drains.
  */
-let syncNeededAfter = false;
+let nextSyncInFlight: Promise<void> | null = null;
+let nextSyncBase: Promise<void> | null = null;
 /**
  * Active realtime CDC channel for the current session. Held at module scope
  * so signIn/signOut can re-arm or tear down without going through `init()`.
@@ -266,12 +264,26 @@ export const useCloudSyncStore = create<CloudSyncState>()(
 
       syncNow: async () => {
         // Coalesce concurrent callers onto the in-flight promise so the
-        // pull→push window can't be straddled by a stale snapshot. Record that a
-        // sync was requested mid-flight so the finally block re-runs once — the
-        // running sync may have snapshotted an older revision than this caller saw.
+        // pull→push window can't be straddled by a stale snapshot. A caller that
+        // arrives mid-flight may have observed a newer remote revision than the
+        // running sync snapshotted, so chain a trailing sync and return that
+        // promise to the caller.
         if (syncInFlight) {
-          syncNeededAfter = true;
-          return syncInFlight;
+          if (nextSyncInFlight && nextSyncBase === syncInFlight) {
+            return nextSyncInFlight;
+          }
+          const base = syncInFlight;
+          const followUp = base
+            .then(() => get().syncNow())
+            .finally(() => {
+              if (nextSyncInFlight === followUp) {
+                nextSyncInFlight = null;
+                nextSyncBase = null;
+              }
+            });
+          nextSyncBase = base;
+          nextSyncInFlight = followUp;
+          return followUp;
         }
         const provider = getCloudSyncProvider();
         const identity = provider?.identity() ?? null;
@@ -415,16 +427,6 @@ export const useCloudSyncStore = create<CloudSyncState>()(
           await syncInFlight;
         } finally {
           syncInFlight = null;
-          // A sync requested while this one ran may have seen a newer revision
-          // than we reconciled. Re-run once (a cheap pullMeta confirms in-sync
-          // and no-ops when nothing actually changed). Deferred to a microtask
-          // so the mutex is fully cleared before the follow-up acquires it.
-          if (syncNeededAfter) {
-            syncNeededAfter = false;
-            queueMicrotask(() => {
-              void get().syncNow();
-            });
-          }
         }
       },
 


### PR DESCRIPTION
Follow-up for #2573 after it merged while the Gemini remediation was being prepared.

This addresses Gemini feedback on the cloud-sync egress follow-up:
- replaces the boolean trailing-sync flag with a promise-chain reference so callers that arrive during an active sync resolve only after the follow-up reconciliation they triggered
- coalesces callers for the same active sync while still allowing another trailing pass if requests arrive during the trailing sync itself
- adds a regression test that holds the second pullMeta open and proves the coalesced caller does not resolve before the trailing sync completes

Verification:
- git diff --check origin/main...HEAD
- Tilt check-frontend logs: type-check and lint completed with 0 errors; existing fast-refresh warnings only.

GitHub CI should run the broad validation.