### PR TITLE
Implement Time Travel keyword action (CR 701.56)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1203,6 +1203,7 @@ export type WaitingFor =
   | { type: "DrawnThisTurnTopdeckChoice"; data: { player: PlayerId; cards: ObjectId[]; count: number; min_count: number; life_payment: number; source_id: ObjectId } }
   | { type: "RetargetChoice"; data: { player: PlayerId; stack_entry_index: number; scope: RetargetScope; current_targets: TargetRef[]; legal_new_targets: TargetRef[] } }
   | { type: "ProliferateChoice"; data: { player: PlayerId; eligible: TargetRef[] } }
+  | { type: "TimeTravelChoice"; data: { player: PlayerId; eligible: TargetRef[]; adding: boolean } }
   | { type: "ChooseObjectsSelection"; data: { player: PlayerId; eligible: TargetRef[]; trigger_event?: GameEvent } }
   | { type: "ConniveDiscard"; data: { player: PlayerId; conniver_id: ObjectId; source_id: ObjectId; cards: ObjectId[]; count: number } }
   | { type: "DiscardChoice"; data: { player: PlayerId; count: number; cards: ObjectId[]; source_id: ObjectId; effect_kind: string; up_to?: boolean; unless_filter?: TargetFilter } }

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1203,7 +1203,7 @@ export type WaitingFor =
   | { type: "DrawnThisTurnTopdeckChoice"; data: { player: PlayerId; cards: ObjectId[]; count: number; min_count: number; life_payment: number; source_id: ObjectId } }
   | { type: "RetargetChoice"; data: { player: PlayerId; stack_entry_index: number; scope: RetargetScope; current_targets: TargetRef[]; legal_new_targets: TargetRef[] } }
   | { type: "ProliferateChoice"; data: { player: PlayerId; eligible: TargetRef[] } }
-  | { type: "TimeTravelChoice"; data: { player: PlayerId; eligible: TargetRef[]; adding: boolean } }
+  | { type: "TimeTravelChoice"; data: { player: PlayerId; eligible: TargetRef[]; phase: "Remove" | "Add" } }
   | { type: "ChooseObjectsSelection"; data: { player: PlayerId; eligible: TargetRef[]; trigger_event?: GameEvent } }
   | { type: "ConniveDiscard"; data: { player: PlayerId; conniver_id: ObjectId; source_id: ObjectId; cards: ObjectId[]; count: number } }
   | { type: "DiscardChoice"; data: { player: PlayerId; count: number; cards: ObjectId[]; source_id: ObjectId; effect_kind: string; up_to?: boolean; unless_filter?: TargetFilter } }

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -343,6 +343,14 @@ export function CardChoiceModal() {
     case "ProliferateChoice":
       if (!canActForWaitingState) return null;
       return <ProliferateModal data={waitingFor.data} />;
+    case "TimeTravelChoice":
+      if (!canActForWaitingState) return null;
+      return (
+        <ProliferateModal
+          data={waitingFor.data}
+          variant={waitingFor.data.phase === "Add" ? "timeTravelAdd" : "timeTravelRemove"}
+        />
+      );
     case "ChooseObjectsSelection":
       if (!canActForWaitingState) return null;
       return (

--- a/client/src/components/modal/ProliferateModal.tsx
+++ b/client/src/components/modal/ProliferateModal.tsx
@@ -11,6 +11,7 @@ import { gameButtonClass } from "../ui/buttonStyles.ts";
 import { filterTargetsByController, targetKey, targetLabel } from "./targetRef.ts";
 
 type ProliferateChoice = Extract<WaitingFor, { type: "ProliferateChoice" }>;
+type TimeTravelChoice = Extract<WaitingFor, { type: "TimeTravelChoice" }>;
 type ChooseObjectsSelection = Extract<
   WaitingFor,
   { type: "ChooseObjectsSelection" }
@@ -19,20 +20,26 @@ type ChooseObjectsSelection = Extract<
 // CR 701.34a: Proliferate — choose any number (including zero) of permanents
 // and players that have counters; each chosen target gets one more counter of
 // each kind already there.
+// CR 701.56a: Time travel — choose any number of eligible objects for the
+// current remove/add phase; each selected object gets exactly that phase's
+// counter operation.
 // CR 603.7e: ChooseObjectsSelection — choose any number of battlefield
-// permanents (Magnetic Mountain class). Both prompts carry the identical
-// `{ player, eligible: TargetRef[] }` shape and dispatch `SelectTargets`, so a
-// single modal serves both; `variant` only adapts the title/subtitle copy.
+// permanents (Magnetic Mountain class). These prompts share the same
+// `SelectTargets` dispatch over an engine-provided `eligible` list, so a single
+// modal serves them; `variant` adapts copy and default selection.
 // Engine pre-filters `eligible`; the modal is purely a chooser. Default-select-
 // all is a UX choice (one-click confirm for the common case), not a rules
 // requirement.
 type ProliferateModalData =
   | ProliferateChoice["data"]
+  | TimeTravelChoice["data"]
   | ChooseObjectsSelection["data"];
 
 /** Maps the variant prop to its i18n leaf pair under `proliferate.*`. */
 const VARIANT_KEYS = {
   proliferate: { title: "proliferateTitle", subtitle: "proliferateSubtitle" },
+  timeTravelRemove: { title: "timeTravelTitle", subtitle: "timeTravelRemoveSubtitle" },
+  timeTravelAdd: { title: "timeTravelTitle", subtitle: "timeTravelAddSubtitle" },
   chooseObjects: { title: "chooseObjectsTitle", subtitle: "chooseObjectsSubtitle" },
 } as const;
 
@@ -49,13 +56,17 @@ export function ProliferateModal({
   const playerId = usePlayerId();
   const hoverProps = useInspectHoverProps();
 
-  const [selected, setSelected] = useState<TargetRef[]>(data.eligible);
+  const defaultSelection = useCallback(
+    () => (variant === "timeTravelAdd" ? [] : data.eligible),
+    [data.eligible, variant],
+  );
+  const [selected, setSelected] = useState<TargetRef[]>(() => defaultSelection());
 
   // Reset selection when a fresh choice arrives (back-to-back prompts from one
   // ability resolution don't remount this component).
   useEffect(() => {
-    setSelected(data.eligible);
-  }, [data.eligible]);
+    setSelected(defaultSelection());
+  }, [defaultSelection]);
 
   const handleToggle = useCallback((target: TargetRef) => {
     const key = targetKey(target);

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -111,6 +111,7 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     "ClashCardPlacement",
     "TopOrBottomChoice",
     "ProliferateChoice",
+    "TimeTravelChoice",
     "ChooseObjectsSelection",
     "CategoryChoice",
     "DistributeAmong",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1436,6 +1436,9 @@
   "proliferate": {
     "proliferateTitle": "Wuchern",
     "proliferateSubtitle": "Wähle eine beliebige Anzahl bleibender Karten und Spieler mit Marken. Jedes gewählte Ziel erhält eine weitere Marke jeder Art, die bereits dort vorhanden ist.",
+    "timeTravelTitle": "Zeitreise",
+    "timeTravelRemoveSubtitle": "Wähle eine beliebige Anzahl gültiger Objekte, von denen eine Zeitmarke entfernt werden soll.",
+    "timeTravelAddSubtitle": "Wähle eine beliebige Anzahl verbleibender gültiger Objekte, auf die eine Zeitmarke gelegt werden soll.",
     "chooseObjectsTitle": "Bleibende Karten wählen",
     "chooseObjectsSubtitle": "Wähle eine beliebige Anzahl bleibender Karten. Du zahlst für jede gewählte Karte Kosten.",
     "selectAll": "Alle",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1441,6 +1441,9 @@
   "proliferate": {
     "proliferateTitle": "Proliferate",
     "proliferateSubtitle": "Choose any number of permanents and players with counters. Each chosen target gets one more counter of each kind already there.",
+    "timeTravelTitle": "Time Travel",
+    "timeTravelRemoveSubtitle": "Choose any number of eligible objects to remove a time counter from.",
+    "timeTravelAddSubtitle": "Choose any number of remaining eligible objects to add a time counter to.",
     "chooseObjectsTitle": "Choose Permanents",
     "chooseObjectsSubtitle": "Choose any number of permanents. You pay a cost for each one chosen.",
     "selectAll": "All",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1436,6 +1436,9 @@
   "proliferate": {
     "proliferateTitle": "Proliferar",
     "proliferateSubtitle": "Elige cualquier número de permanentes y jugadores con contadores. Cada objetivo elegido recibe un contador más de cada tipo que ya tenga.",
+    "timeTravelTitle": "Viaje en el Tiempo",
+    "timeTravelRemoveSubtitle": "Elige cualquier número de objetos elegibles de los que retirar un contador de tiempo.",
+    "timeTravelAddSubtitle": "Elige cualquier número de objetos elegibles restantes a los que añadir un contador de tiempo.",
     "chooseObjectsTitle": "Elegir permanentes",
     "chooseObjectsSubtitle": "Elige cualquier número de permanentes. Pagas un coste por cada uno elegido.",
     "selectAll": "Todos",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1436,6 +1436,9 @@
   "proliferate": {
     "proliferateTitle": "Prolifération",
     "proliferateSubtitle": "Choisissez n'importe quel nombre de permanents et de joueurs ayant des marqueurs. Chaque cible choisie reçoit un marqueur de plus de chaque sorte déjà présente.",
+    "timeTravelTitle": "Voyage temporel",
+    "timeTravelRemoveSubtitle": "Choisissez n'importe quel nombre d'objets éligibles auxquels retirer un marqueur temps.",
+    "timeTravelAddSubtitle": "Choisissez n'importe quel nombre d'objets éligibles restants auxquels ajouter un marqueur temps.",
     "chooseObjectsTitle": "Choisir des permanents",
     "chooseObjectsSubtitle": "Choisissez n'importe quel nombre de permanents. Vous payez un coût pour chacun choisi.",
     "selectAll": "Tout",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1436,6 +1436,9 @@
   "proliferate": {
     "proliferateTitle": "Proliferare",
     "proliferateSubtitle": "Scegli un numero qualsiasi di permanenti e giocatori con segnalini. Ogni bersaglio scelto riceve un altro segnalino di ciascun tipo già presente.",
+    "timeTravelTitle": "Viaggio Temporale",
+    "timeTravelRemoveSubtitle": "Scegli un numero qualsiasi di oggetti idonei da cui rimuovere un segnalino tempo.",
+    "timeTravelAddSubtitle": "Scegli un numero qualsiasi di oggetti idonei rimanenti a cui aggiungere un segnalino tempo.",
     "chooseObjectsTitle": "Scegli permanenti",
     "chooseObjectsSubtitle": "Scegli un numero qualsiasi di permanenti. Paghi un costo per ciascuno scelto.",
     "selectAll": "Tutti",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1436,6 +1436,9 @@
   "proliferate": {
     "proliferateTitle": "Proliferate",
     "proliferateSubtitle": "Wybierz dowolną liczbę trwałych i graczy ze znacznikami. Każdy wybrany cel otrzymuje po jednym dodatkowym znaczniku każdego rodzaju, który już tam jest.",
+    "timeTravelTitle": "Podróż w czasie",
+    "timeTravelRemoveSubtitle": "Wybierz dowolną liczbę kwalifikujących się obiektów, z których usunąć znacznik czasu.",
+    "timeTravelAddSubtitle": "Wybierz dowolną liczbę pozostałych kwalifikujących się obiektów, na które dodać znacznik czasu.",
     "chooseObjectsTitle": "Wybierz trwałe",
     "chooseObjectsSubtitle": "Wybierz dowolną liczbę trwałych. Płacisz koszt za każdego wybranego.",
     "selectAll": "Wszystko",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1436,6 +1436,9 @@
   "proliferate": {
     "proliferateTitle": "Proliferar",
     "proliferateSubtitle": "Escolha qualquer número de permanentes e jogadores com marcadores. Cada alvo escolhido recebe mais um marcador de cada tipo já presente.",
+    "timeTravelTitle": "Viagem no Tempo",
+    "timeTravelRemoveSubtitle": "Escolha qualquer número de objetos elegíveis para remover um marcador temporal.",
+    "timeTravelAddSubtitle": "Escolha qualquer número de objetos elegíveis restantes para adicionar um marcador temporal.",
     "chooseObjectsTitle": "Escolher Permanentes",
     "chooseObjectsSubtitle": "Escolha qualquer número de permanentes. Você paga um custo por cada um escolhido.",
     "selectAll": "Todos",

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1915,6 +1915,39 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             }
             actions
         }
+        // CR 701.56a: Time travel — choose any subset of eligible objects for the
+        // current phase (remove a time counter, then add). Mirrors the
+        // ProliferateChoice subset offer over `GameAction::SelectTargets`.
+        WaitingFor::TimeTravelChoice {
+            player, eligible, ..
+        } => {
+            let mut actions = vec![
+                candidate(
+                    GameAction::SelectTargets {
+                        targets: eligible.clone(),
+                    },
+                    TacticalClass::Selection,
+                    Some(*player),
+                ),
+                candidate(
+                    GameAction::SelectTargets {
+                        targets: Vec::new(),
+                    },
+                    TacticalClass::Selection,
+                    Some(*player),
+                ),
+            ];
+            for target in eligible {
+                actions.push(candidate(
+                    GameAction::SelectTargets {
+                        targets: vec![target.clone()],
+                    },
+                    TacticalClass::Selection,
+                    Some(*player),
+                ));
+            }
+            actions
+        }
         // CR 608.2c: ChooseObjectsIntoTrackedSet — choose any subset of the
         // eligible battlefield permanents (or decline with an empty selection).
         WaitingFor::ChooseObjectsSelection {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -147,6 +147,7 @@ pub mod surveil;
 pub mod suspect;
 pub mod switch_pt;
 pub mod tap_untap;
+pub mod time_travel;
 pub mod token;
 pub mod token_copy;
 pub mod transform_effect;
@@ -985,6 +986,7 @@ fn waits_for_resolution_choice(waiting_for: &WaitingFor) -> bool {
             }
             | WaitingFor::TopOrBottomChoice { .. }
             | WaitingFor::ProliferateChoice { .. }
+            | WaitingFor::TimeTravelChoice { .. }
             | WaitingFor::ChooseObjectsSelection { .. }
             | WaitingFor::ExploreChoice { .. }
             | WaitingFor::CopyRetarget { .. }
@@ -1862,7 +1864,7 @@ pub fn resolve_effect(
         Effect::Tribute { .. } => tribute::resolve(state, ability, events),
         // CR 701.56a: Time travel — interactive counter manipulation on suspended/time-countered permanents.
         // Currently a no-op; full interactive implementation requires WaitingFor infrastructure.
-        Effect::TimeTravel => Ok(()),
+        Effect::TimeTravel => time_travel::resolve(state, ability, events),
         Effect::BecomeMonarch => become_monarch::resolve(state, ability, events),
         Effect::Proliferate => proliferate::resolve(state, ability, events),
         Effect::ProliferateTarget { .. } => proliferate::resolve_target(state, ability, events),

--- a/crates/engine/src/game/effects/time_travel.rs
+++ b/crates/engine/src/game/effects/time_travel.rs
@@ -6,10 +6,10 @@
 //! Modeled like Proliferate (`WaitingFor::ProliferateChoice`), but with a
 //! per-object add/remove decision. To reuse `GameAction::SelectTargets` without
 //! a new action variant, the choice runs in two phases over
-//! `WaitingFor::TimeTravelChoice`. The remove phase (`adding == false`) is
-//! offered first: the player selects the objects to remove a time counter from
-//! (the common case — advancing suspended cards toward casting). The add phase
-//! (`adding == true`) then runs over the still-eligible remainder, selecting the
+//! `WaitingFor::TimeTravelChoice`. `TimeTravelPhase::Remove` is offered first:
+//! the player selects the objects to remove a time counter from (the common
+//! case — advancing suspended cards toward casting). `TimeTravelPhase::Add`
+//! then runs over the still-eligible remainder, selecting the
 //! objects to add a time counter to. An object selected in the remove phase is
 //! excluded from the add phase, so each object gets at most one of add/remove
 //! (CR 701.56a "for each of those objects, put ... or remove ...").
@@ -22,7 +22,7 @@
 use crate::types::ability::{EffectError, EffectKind, ResolvedAbility, TargetRef};
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{GameState, TimeTravelPhase, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
@@ -73,19 +73,19 @@ pub(crate) fn resolve(
     state.waiting_for = WaitingFor::TimeTravelChoice {
         player,
         eligible,
-        adding: false,
+        phase: TimeTravelPhase::Remove,
     };
     Ok(())
 }
 
-/// Apply one phase: put (`adding`) or remove a time counter on each selected
-/// object. The resulting counter events drive the existing suspend/vanishing
-/// triggers (free-cast on last removal, sacrifice, etc.).
+/// Apply one phase: put or remove a time counter on each selected object. The
+/// resulting counter events drive the existing suspend/vanishing triggers
+/// (free-cast on last removal, sacrifice, etc.).
 pub(crate) fn apply_phase(
     state: &mut GameState,
     player: PlayerId,
     selected: &[TargetRef],
-    adding: bool,
+    phase: TimeTravelPhase,
     events: &mut Vec<GameEvent>,
 ) {
     for target in selected {
@@ -94,20 +94,23 @@ pub(crate) fn apply_phase(
         };
         // Re-validate: an object may have left its zone between phases (e.g. a
         // suspended card whose last time counter was just removed and was cast).
-        if time_counters(state, *id) == 0 && !adding {
-            continue;
-        }
-        if adding {
-            super::counters::apply_counter_addition(
-                state,
-                player,
-                *id,
-                CounterType::Time,
-                1,
-                events,
-            );
-        } else {
-            super::counters::apply_counter_removal(state, *id, CounterType::Time, 1, events);
+        match phase {
+            TimeTravelPhase::Remove => {
+                if time_counters(state, *id) == 0 {
+                    continue;
+                }
+                super::counters::apply_counter_removal(state, *id, CounterType::Time, 1, events);
+            }
+            TimeTravelPhase::Add => {
+                super::counters::apply_counter_addition(
+                    state,
+                    player,
+                    *id,
+                    CounterType::Time,
+                    1,
+                    events,
+                );
+            }
         }
     }
 }
@@ -197,9 +200,13 @@ mod tests {
         resolve(&mut state, &ability, &mut events).unwrap();
         match &state.waiting_for {
             WaitingFor::TimeTravelChoice {
-                adding, eligible, ..
+                phase, eligible, ..
             } => {
-                assert!(!adding, "remove phase is offered first");
+                assert_eq!(
+                    *phase,
+                    TimeTravelPhase::Remove,
+                    "remove phase is offered first"
+                );
                 assert!(eligible.contains(&TargetRef::Object(perm)));
             }
             other => panic!("expected TimeTravelChoice, got {other:?}"),
@@ -209,7 +216,7 @@ mod tests {
             &mut state,
             PlayerId(0),
             &[TargetRef::Object(perm)],
-            false,
+            TimeTravelPhase::Remove,
             &mut events,
         );
         assert_eq!(time_counters(&state, perm), 1, "remove decrements 2 -> 1");
@@ -217,7 +224,7 @@ mod tests {
             &mut state,
             PlayerId(0),
             &[TargetRef::Object(perm)],
-            true,
+            TimeTravelPhase::Add,
             &mut events,
         );
         assert_eq!(time_counters(&state, perm), 2, "add increments 1 -> 2");

--- a/crates/engine/src/game/effects/time_travel.rs
+++ b/crates/engine/src/game/effects/time_travel.rs
@@ -1,0 +1,238 @@
+//! CR 701.56a: Time travel — "choose any number of permanents you control with
+//! one or more time counters on them and/or suspended cards you own in exile
+//! with one or more time counters on them and, for each of those objects, put a
+//! time counter on it or remove a time counter from it."
+//!
+//! Modeled like Proliferate (`WaitingFor::ProliferateChoice`), but with a
+//! per-object add/remove decision. To reuse `GameAction::SelectTargets` without
+//! a new action variant, the choice runs in two phases over
+//! `WaitingFor::TimeTravelChoice`. The remove phase (`adding == false`) is
+//! offered first: the player selects the objects to remove a time counter from
+//! (the common case — advancing suspended cards toward casting). The add phase
+//! (`adding == true`) then runs over the still-eligible remainder, selecting the
+//! objects to add a time counter to. An object selected in the remove phase is
+//! excluded from the add phase, so each object gets at most one of add/remove
+//! (CR 701.56a "for each of those objects, put ... or remove ...").
+//!
+//! All consequences of the counter changes — the suspend last-counter free-cast
+//! trigger and Vanishing's last-counter sacrifice — are handled by the existing
+//! `CounterAdded`/`CounterRemoved` triggers; this resolver only drives the
+//! counter primitives.
+
+use crate::types::ability::{EffectError, EffectKind, ResolvedAbility, TargetRef};
+use crate::types::counter::CounterType;
+use crate::types::events::GameEvent;
+use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+fn time_counters(state: &GameState, id: ObjectId) -> u32 {
+    state
+        .objects
+        .get(&id)
+        .and_then(|o| o.counters.get(&CounterType::Time).copied())
+        .unwrap_or(0)
+}
+
+/// CR 701.56a: the time-travel-eligible objects for `player` — permanents they
+/// control with a time counter, and suspended cards they own in exile with a
+/// time counter (CR 702.62b: a suspended card is in exile with time counters).
+/// Sorted by id for deterministic ordering.
+pub(crate) fn eligible_objects(state: &GameState, player: PlayerId) -> Vec<TargetRef> {
+    let mut eligible: Vec<ObjectId> = state
+        .objects
+        .iter()
+        .filter(|(_, obj)| {
+            obj.counters.get(&CounterType::Time).copied().unwrap_or(0) > 0
+                && ((obj.zone == Zone::Battlefield && obj.controller == player)
+                    || (obj.zone == Zone::Exile && obj.owner == player))
+        })
+        .map(|(id, _)| *id)
+        .collect();
+    eligible.sort_by_key(|id| id.0);
+    eligible.into_iter().map(TargetRef::Object).collect()
+}
+
+/// CR 701.56a: resolve a time-travel instruction. Offers the eligible objects
+/// for the remove phase; if none are eligible, time travel does nothing.
+pub(crate) fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let player = ability.controller;
+    let eligible = eligible_objects(state, player);
+    if eligible.is_empty() {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::TimeTravel,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+    state.waiting_for = WaitingFor::TimeTravelChoice {
+        player,
+        eligible,
+        adding: false,
+    };
+    Ok(())
+}
+
+/// Apply one phase: put (`adding`) or remove a time counter on each selected
+/// object. The resulting counter events drive the existing suspend/vanishing
+/// triggers (free-cast on last removal, sacrifice, etc.).
+pub(crate) fn apply_phase(
+    state: &mut GameState,
+    player: PlayerId,
+    selected: &[TargetRef],
+    adding: bool,
+    events: &mut Vec<GameEvent>,
+) {
+    for target in selected {
+        let TargetRef::Object(id) = target else {
+            continue;
+        };
+        // Re-validate: an object may have left its zone between phases (e.g. a
+        // suspended card whose last time counter was just removed and was cast).
+        if time_counters(state, *id) == 0 && !adding {
+            continue;
+        }
+        if adding {
+            super::counters::apply_counter_addition(
+                state,
+                player,
+                *id,
+                CounterType::Time,
+                1,
+                events,
+            );
+        } else {
+            super::counters::apply_counter_removal(state, *id, CounterType::Time, 1, events);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::ability::Effect;
+    use crate::types::identifiers::CardId;
+
+    fn with_time(state: &mut GameState, id: ObjectId, n: u32) {
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .counters
+            .insert(CounterType::Time, n);
+    }
+
+    /// CR 701.56a: eligible = controller's permanents with a time counter +
+    /// controller's suspended exile cards with a time counter; not opponents',
+    /// not objects without time counters.
+    #[test]
+    fn eligible_covers_controlled_perm_and_owned_exile_only() {
+        let mut state = GameState::new_two_player(1);
+        let perm = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Vanisher".into(),
+            Zone::Battlefield,
+        );
+        with_time(&mut state, perm, 2);
+        let suspended = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Suspended".into(),
+            Zone::Exile,
+        );
+        with_time(&mut state, suspended, 3);
+        let opp = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Opp Suspended".into(),
+            Zone::Exile,
+        );
+        with_time(&mut state, opp, 1);
+        let plain = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Plain".into(),
+            Zone::Battlefield,
+        );
+
+        let eligible = eligible_objects(&state, PlayerId(0));
+        assert!(eligible.contains(&TargetRef::Object(perm)));
+        assert!(eligible.contains(&TargetRef::Object(suspended)));
+        assert!(
+            !eligible.contains(&TargetRef::Object(opp)),
+            "an opponent's suspended card is not yours to time travel"
+        );
+        assert!(
+            !eligible.contains(&TargetRef::Object(plain)),
+            "an object without a time counter is not eligible"
+        );
+    }
+
+    /// CR 701.56a: resolve offers the remove phase first; apply adjusts the counter.
+    #[test]
+    fn resolve_sets_remove_phase_and_apply_adjusts_counter() {
+        let mut state = GameState::new_two_player(1);
+        let perm = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Vanisher".into(),
+            Zone::Battlefield,
+        );
+        with_time(&mut state, perm, 2);
+
+        let ability = ResolvedAbility::new(Effect::TimeTravel, vec![], perm, PlayerId(0));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        match &state.waiting_for {
+            WaitingFor::TimeTravelChoice {
+                adding, eligible, ..
+            } => {
+                assert!(!adding, "remove phase is offered first");
+                assert!(eligible.contains(&TargetRef::Object(perm)));
+            }
+            other => panic!("expected TimeTravelChoice, got {other:?}"),
+        }
+
+        apply_phase(
+            &mut state,
+            PlayerId(0),
+            &[TargetRef::Object(perm)],
+            false,
+            &mut events,
+        );
+        assert_eq!(time_counters(&state, perm), 1, "remove decrements 2 -> 1");
+        apply_phase(
+            &mut state,
+            PlayerId(0),
+            &[TargetRef::Object(perm)],
+            true,
+            &mut events,
+        );
+        assert_eq!(time_counters(&state, perm), 2, "add increments 1 -> 2");
+    }
+
+    /// CR 701.56a: with no eligible objects, time travel does nothing (no prompt).
+    #[test]
+    fn no_eligible_is_noop() {
+        let mut state = GameState::new_two_player(1);
+        let ability = ResolvedAbility::new(Effect::TimeTravel, vec![], ObjectId(99), PlayerId(0));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert!(!matches!(
+            state.waiting_for,
+            WaitingFor::TimeTravelChoice { .. }
+        ));
+    }
+}

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4081,6 +4081,65 @@ fn apply_action(
             effects::drain_pending_continuation(state, &mut events);
             state.waiting_for.clone()
         }
+        // CR 701.56a: Time travel — player selected objects for the current phase
+        // (remove a time counter, then add). Validate against the eligible set,
+        // apply the per-object counter change, then advance to the add phase or
+        // finish. Counter changes drive the existing suspend/vanishing triggers.
+        (
+            WaitingFor::TimeTravelChoice {
+                player,
+                eligible,
+                adding,
+            },
+            GameAction::SelectTargets { targets },
+        ) => {
+            let p = *player;
+            let adding_phase = *adding;
+            let eligible_set = eligible.clone();
+            for t in &targets {
+                if !eligible_set.contains(t) {
+                    return Err(EngineError::InvalidAction(
+                        "Selected object not eligible for time travel".to_string(),
+                    ));
+                }
+            }
+            effects::time_travel::apply_phase(state, p, &targets, adding_phase, &mut events);
+
+            if !adding_phase {
+                // CR 701.56a: after the remove phase, offer the add phase over the
+                // still-eligible objects, excluding any just chosen to remove.
+                let add_eligible: Vec<_> = effects::time_travel::eligible_objects(state, p)
+                    .into_iter()
+                    .filter(|t| !targets.contains(t))
+                    .collect();
+                if !add_eligible.is_empty() {
+                    state.waiting_for = WaitingFor::TimeTravelChoice {
+                        player: p,
+                        eligible: add_eligible,
+                        adding: true,
+                    };
+                    state.waiting_for.clone()
+                } else {
+                    events.push(GameEvent::EffectResolved {
+                        kind: crate::types::ability::EffectKind::TimeTravel,
+                        source_id: ObjectId(0),
+                    });
+                    state.waiting_for = WaitingFor::Priority { player: p };
+                    state.priority_player = p;
+                    effects::drain_pending_continuation(state, &mut events);
+                    state.waiting_for.clone()
+                }
+            } else {
+                events.push(GameEvent::EffectResolved {
+                    kind: crate::types::ability::EffectKind::TimeTravel,
+                    source_id: ObjectId(0),
+                });
+                state.waiting_for = WaitingFor::Priority { player: p };
+                state.priority_player = p;
+                effects::drain_pending_continuation(state, &mut events);
+                state.waiting_for.clone()
+            }
+        }
         // CR 608.2c: ChooseObjectsIntoTrackedSet — player submitted their
         // battlefield-permanent selection. Publish a fresh tracked set so the
         // downstream `PayCost { ScaledMana }` and the `IfYouDo`/`Untap` tail

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4089,12 +4089,12 @@ fn apply_action(
             WaitingFor::TimeTravelChoice {
                 player,
                 eligible,
-                adding,
+                phase,
             },
             GameAction::SelectTargets { targets },
         ) => {
             let p = *player;
-            let adding_phase = *adding;
+            let phase = *phase;
             let eligible_set = eligible.clone();
             for t in &targets {
                 if !eligible_set.contains(t) {
@@ -4103,9 +4103,9 @@ fn apply_action(
                     ));
                 }
             }
-            effects::time_travel::apply_phase(state, p, &targets, adding_phase, &mut events);
+            effects::time_travel::apply_phase(state, p, &targets, phase, &mut events);
 
-            if !adding_phase {
+            if phase == crate::types::game_state::TimeTravelPhase::Remove {
                 // CR 701.56a: after the remove phase, offer the add phase over the
                 // still-eligible objects, excluding any just chosen to remove.
                 let add_eligible: Vec<_> = effects::time_travel::eligible_objects(state, p)
@@ -4116,7 +4116,7 @@ fn apply_action(
                     state.waiting_for = WaitingFor::TimeTravelChoice {
                         player: p,
                         eligible: add_eligible,
-                        adding: true,
+                        phase: crate::types::game_state::TimeTravelPhase::Add,
                     };
                     state.waiting_for.clone()
                 } else {

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1532,6 +1532,7 @@ impl GameRunner {
             WaitingFor::ChooseLegend { .. } => "ChooseLegend",
             WaitingFor::BattleProtectorChoice { .. } => "BattleProtectorChoice",
             WaitingFor::ProliferateChoice { .. } => "ProliferateChoice",
+            WaitingFor::TimeTravelChoice { .. } => "TimeTravelChoice",
             WaitingFor::ChooseObjectsSelection { .. } => "ChooseObjectsSelection",
             WaitingFor::CopyRetarget { .. } => "CopyRetarget",
             WaitingFor::AssignCombatDamage { .. } => "AssignCombatDamage",

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1924,6 +1924,15 @@ pub enum CastOfferKind {
     },
 }
 
+/// CR 701.56a: Which half of a time-travel choice is currently being
+/// presented. Typed instead of boolean so serialized engine state says whether
+/// the player is adding or removing counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TimeTravelPhase {
+    Remove,
+    Add,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum WaitingFor {
@@ -3093,13 +3102,14 @@ pub enum WaitingFor {
     /// objects (permanents they control with a time counter and/or suspended
     /// cards they own in exile with a time counter) and, for each, puts or
     /// removes a time counter. Modeled in two phases over
-    /// `GameAction::SelectTargets`: `adding == false` first selects objects to
-    /// remove a time counter from; then `adding == true` selects (from the
-    /// still-eligible remainder) objects to add a time counter to.
+    /// `GameAction::SelectTargets`: `TimeTravelPhase::Remove` first selects
+    /// objects to remove a time counter from; then `TimeTravelPhase::Add`
+    /// selects (from the still-eligible remainder) objects to add a time
+    /// counter to.
     TimeTravelChoice {
         player: PlayerId,
         eligible: Vec<TargetRef>,
-        adding: bool,
+        phase: TimeTravelPhase,
     },
     /// CR 603.7e: The affected player of a `ChooseObjectsIntoTrackedSet` effect
     /// selects any number of battlefield permanents from `eligible`. The

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3089,6 +3089,18 @@ pub enum WaitingFor {
         /// Eligible permanents (with counters) and players (with poison/energy).
         eligible: Vec<TargetRef>,
     },
+    /// CR 701.56a: Time travel — the player chooses any number of eligible
+    /// objects (permanents they control with a time counter and/or suspended
+    /// cards they own in exile with a time counter) and, for each, puts or
+    /// removes a time counter. Modeled in two phases over
+    /// `GameAction::SelectTargets`: `adding == false` first selects objects to
+    /// remove a time counter from; then `adding == true` selects (from the
+    /// still-eligible remainder) objects to add a time counter to.
+    TimeTravelChoice {
+        player: PlayerId,
+        eligible: Vec<TargetRef>,
+        adding: bool,
+    },
     /// CR 603.7e: The affected player of a `ChooseObjectsIntoTrackedSet` effect
     /// selects any number of battlefield permanents from `eligible`. The
     /// chosen objects are written into a fresh tracked set so a downstream
@@ -3446,6 +3458,7 @@ impl WaitingFor {
             WaitingFor::CommanderZoneChoice { .. } => "CommanderZoneChoice",
             WaitingFor::BattleProtectorChoice { .. } => "BattleProtectorChoice",
             WaitingFor::ProliferateChoice { .. } => "ProliferateChoice",
+            WaitingFor::TimeTravelChoice { .. } => "TimeTravelChoice",
             WaitingFor::ChooseObjectsSelection { .. } => "ChooseObjectsSelection",
             WaitingFor::CategoryChoice { .. } => "CategoryChoice",
             WaitingFor::CopyRetarget { .. } => "CopyRetarget",
@@ -3565,6 +3578,7 @@ impl WaitingFor {
             | WaitingFor::ChooseLegend { player, .. }
             | WaitingFor::BattleProtectorChoice { player, .. }
             | WaitingFor::ProliferateChoice { player, .. }
+            | WaitingFor::TimeTravelChoice { player, .. }
             | WaitingFor::ChooseObjectsSelection { player, .. }
             | WaitingFor::CategoryChoice { player, .. }
             | WaitingFor::CopyRetarget { player, .. }

--- a/crates/phase-ai/src/decision_kind.rs
+++ b/crates/phase-ai/src/decision_kind.rs
@@ -138,6 +138,7 @@ pub fn classify(waiting_for: &WaitingFor, action: &GameAction) -> DecisionKind {
         | WaitingFor::CommanderZoneChoice { .. }
         | WaitingFor::BattleProtectorChoice { .. }
         | WaitingFor::ProliferateChoice { .. }
+        | WaitingFor::TimeTravelChoice { .. }
         | WaitingFor::ChooseObjectsSelection { .. }
         | WaitingFor::CategoryChoice { .. }
         | WaitingFor::AssignCombatDamage { .. }

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -705,6 +705,12 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
             targets: Vec::new(),
         }),
 
+        // CR 701.56a: Time travel — default to changing nothing this phase
+        // (an empty selection is legal: "choose any number").
+        WaitingFor::TimeTravelChoice { .. } => Some(GameAction::SelectTargets {
+            targets: Vec::new(),
+        }),
+
         // ChooseObjectsIntoTrackedSet: default to declining (empty selection).
         WaitingFor::ChooseObjectsSelection { .. } => Some(GameAction::SelectTargets {
             targets: Vec::new(),


### PR DESCRIPTION
## Summary

`Effect::TimeTravel` was a runtime no-op (`Effect::TimeTravel => Ok(())`), so the Doctor Who **time travel** keyword action (~10 cards) did nothing — suspended cards never advanced toward casting and Vanishing/Fading permanents were never affected. Closes #2586.

## Comprehensive Rules

**CR 701.56a:** "To time travel means to choose any number of permanents you control with one or more time counters on them and/or suspended cards you own in exile with one or more time counters on them and, for each of those objects, put a time counter on it or remove a time counter from it."

## Implementation

Implemented as an interactive resolver modeled on **Proliferate** (`WaitingFor::ProliferateChoice`), with a per-object add/remove decision. The counters and *all* their consequences already exist — so this only drives the existing primitives:

- **Eligibility** (`time_travel::eligible_objects`): permanents the controller controls with a `Time` counter, plus suspended cards they own in exile with a `Time` counter (CR 702.62b). Not opponents', not counterless objects.
- **Two-phase choice** over `WaitingFor::TimeTravelChoice`, reusing `GameAction::SelectTargets` (no new action variant): a **remove** phase first (the common case — advancing suspended cards), then an **add** phase over the still-eligible remainder. An object chosen to remove is excluded from add, so each gets at most one change.
- **Consequences reused**: removing the last time counter from a suspended card fires the existing suspend last-counter free-cast trigger (`CounterTriggerFilter { Time, threshold: Some(0) }`); Vanishing's last-counter sacrifice and timer advancement likewise fire from the `CounterAdded`/`CounterRemoved` events. No new `Effect`, counter type, or trigger.

Wired through the effect dispatch (`Effect::TimeTravel` → `time_travel::resolve`), the engine answer handler (remove→add phase transition), AI candidate generation, the scenario driver, and the `WaitingFor` classification/match arms.

## Tests

`time_travel.rs`: eligibility (controlled perms + owned suspended exile cards with time counters; excludes opponents' and counterless objects); resolve offers the remove phase, and apply adjusts the counter (2→1 remove, 1→2 add); no eligible objects → no-op (no prompt).

## Verification

- `cargo fmt --all` clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` clean.
- No parser change.

Note: the full unit-test suite runs in CI (local toolchain has a binutils/dlltool gap that blocks the test/audit binaries). The interactive flow is modeled directly on the Proliferate choice machinery; CI's suite exercises the full path.