### PR TITLE
fix(engine): exclude phased-out permanents from devotion (CR 702.26b)

### DIFF
--- a/crates/engine/src/game/devotion.rs
+++ b/crates/engine/src/game/devotion.rs
@@ -11,8 +11,12 @@ use crate::types::player::PlayerId;
 pub fn count_devotion(state: &GameState, player: PlayerId, colors: &[ManaColor]) -> u32 {
     let mut total = 0u32;
     for &id in &state.battlefield {
+        // CR 702.26b: a phased-out permanent "is treated as though it does not
+        // exist," so its mana symbols drop out of devotion. Phased-out permanents
+        // remain in `state.battlefield` (only `phase_status` flips), so this guard
+        // is required — mirroring `filter.rs` and `targeting.rs::zone_object_ids`.
         let obj = match state.objects.get(&id) {
-            Some(o) if o.controller == player => o,
+            Some(o) if o.controller == player && o.is_phased_in() => o,
             _ => continue,
         };
         if let ManaCost::Cost { ref shards, .. } = obj.mana_cost {
@@ -177,6 +181,42 @@ mod tests {
             count_devotion(&state, PlayerId(0), &[ManaColor::Black, ManaColor::Red]),
             4
         );
+    }
+
+    /// CR 702.26b: a phased-out permanent is treated as though it doesn't exist —
+    /// "it can't affect or be affected by anything else in the game." Its mana
+    /// symbols therefore drop out of devotion (CR 700.5) while it is phased out.
+    /// (Phased-out permanents stay in `state.battlefield` with `phase_status`
+    /// flipped, so a raw battlefield scan that ignores phasing over-counts them —
+    /// corrupting Gray Merchant's drain, the Theros Gods' creature-ness CDA, and
+    /// any `QuantityRef::Devotion`.)
+    #[test]
+    fn devotion_excludes_phased_out_permanents() {
+        use crate::game::game_object::{PhaseOutCause, PhaseStatus};
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Nightveil Specter".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().mana_cost = ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::BlueBlack,
+                ManaCostShard::BlueBlack,
+                ManaCostShard::BlueBlack,
+            ],
+            generic: 0,
+        };
+        // Phased in: the three {U/B} pips count.
+        assert_eq!(count_devotion(&state, PlayerId(0), &[ManaColor::Blue]), 3);
+
+        // Phase it out — CR 702.26b: its pips no longer exist for devotion.
+        state.objects.get_mut(&id).unwrap().phase_status = PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Directly,
+        };
+        assert_eq!(count_devotion(&state, PlayerId(0), &[ManaColor::Blue]), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`count_devotion` scanned `state.battlefield` filtering **only** on controller, with no phasing guard:

```rust
for &id in &state.battlefield {
    let obj = match state.objects.get(&id) {
        Some(o) if o.controller == player => o,
        _ => continue,
    };
    ...
}
```

Phased-out permanents **remain in `state.battlefield`** - phasing only flips `phase_status` to `PhasedOut`; it doesn't remove the object from the battlefield set. So a phased-out permanent's colored mana symbols were still counted toward devotion. Per **CR 702.26b** a phased-out permanent "is treated as though it does not exist," so its pips must drop out of devotion (**CR 700.5**) while it's phased out.

Every other count/filter path guards this at the choke point - `filter.rs` (`if obj.is_phased_out() { return false; }`) and `targeting.rs::zone_object_ids` (`is_phased_in()`). `count_devotion` was the lone outlier reading the battlefield raw.

## Impact (a class, not one card)

`count_devotion` feeds Gray Merchant of Asphodel / Mogis drains, the **Theros Gods'** creature-ness static + P/T characteristic-defining ability (`layers.rs`), and any `QuantityRef::Devotion` (`quantity.rs`). Manifests whenever phasing meets devotion - e.g. **Teferi's Protection** (a Commander staple), Vanishing, Out of Time, Reality Ripple.

## Fix

Add the same phasing guard the rest of the engine uses:

```rust
Some(o) if o.controller == player && o.is_phased_in() => o,
```

## Testing

- New `devotion_excludes_phased_out_permanents`: a `{U/B}{U/B}{U/B}` permanent counts 3 phased in, **0** phased out - fails on `main` (gets 3), passes after the fix.
- All 26 devotion tests stay green.
- CR 702.26b and 700.5 verified against `docs/MagicCompRules.txt`.

Fixes #2589
