### PR TITLE
fix(synthesis): strip level-gated keywords from base keyword list (CR 711)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1412,6 +1412,13 @@ fn specialize_discard_filter() -> TargetFilter {
 /// CR 702.87a: Synthesize level up activated ability — "Pay {cost}: Put a level counter
 /// on this permanent. Activate only as a sorcery."
 pub fn synthesize_level_up(face: &mut CardFace) {
+    // CR 711.4 / CR 711.5: strip keywords printed inside {LEVEL} striations out of
+    // the base list before reading `face.keywords` — they belong to the level-gated
+    // statics, not the unconditional base abilities. Single call site fixes both the
+    // production and scenario pipelines, which reach here via `synthesize_all` after
+    // `keywords` + `static_abilities` are populated.
+    strip_level_gated_keywords(face);
+
     let level_up_abilities: Vec<AbilityDefinition> = face
         .keywords
         .iter()
@@ -8888,6 +8895,63 @@ pub(crate) fn merge_extracted_keywords(base: &mut Vec<Keyword>, extracted: Vec<K
         }
     }
     base.extend(extracted);
+}
+
+/// Strip level-gated keywords out of a leveler card's base `keywords` list.
+///
+/// CR 711.4 / CR 711.5: Keywords printed inside a {LEVEL} symbol are level-gated
+/// static abilities, not base abilities — below the lowest level the creature has
+/// only its base characteristics, so these must not be granted unconditionally.
+///
+/// MTGJSON's `keywords` array lists *every* keyword printed anywhere on the card,
+/// including those inside {LEVEL} striations (e.g. First strike on Student of
+/// Warfare, Flying on Coralhelm Commander). Those keywords reach `face.keywords`
+/// (and therefore the runtime object's `base_keywords`) and would be granted at
+/// level 0, before the leveler has any level counters. The level-gated static
+/// abilities the parser produced (`HasCounters` on the "level" generic counter)
+/// are the *only* legitimate source of those keywords; this helper removes the
+/// unconditional copies so the layer system grants them solely through the gated
+/// statics.
+///
+/// This is the leveler analog of `merge_extracted_keywords` / the Craft
+/// MTGJSON-vs-parser carve-out: a single authority so the production pipeline
+/// (`build_oracle_face_inner`) and the scenario test harness
+/// (`build_face_from_oracle`) cannot diverge.
+///
+/// Equality, not `kind()`/discriminant: Hexdrinker grants the parameterized
+/// `Protection { instants }` and a separate `Protection` (everything) in distinct
+/// level blocks, so full `Keyword` equality strips only the exact gated variant
+/// rather than collapsing all Protection. `Keyword::LevelUp` never appears in an
+/// `AddKeyword` modification, so it is structurally preserved — synthesis still
+/// finds it to build the level-up activated ability.
+///
+/// Residual assumption: this presumes a gated keyword is never *also* a
+/// legitimate base-text (level-0) keyword on the same card. True for all 26
+/// current levelers — none print a keyword both outside and inside a {LEVEL}
+/// striation.
+pub(crate) fn strip_level_gated_keywords(face: &mut CardFace) {
+    let gated: Vec<Keyword> = face
+        .static_abilities
+        .iter()
+        .filter(|stat| {
+            matches!(
+                &stat.condition,
+                Some(StaticCondition::HasCounters { counters, .. })
+                    if matches!(
+                        counters,
+                        CounterMatch::OfType(CounterType::Generic(s)) if s == "level"
+                    )
+            )
+        })
+        .flat_map(|stat| {
+            stat.modifications.iter().filter_map(|m| match m {
+                ContinuousModification::AddKeyword { keyword } => Some(keyword.clone()),
+                _ => None,
+            })
+        })
+        .collect();
+
+    face.keywords.retain(|kw| !gated.contains(kw));
 }
 
 /// Build a `CardFace` from MTGJSON data, running the Oracle text parser and all synthesis.
@@ -16393,6 +16457,74 @@ mod sorcery_speed_invariant_tests {
         assert!(def
             .activation_restrictions
             .contains(&ActivationRestriction::AsSorcery));
+    }
+
+    /// Build a level-gated static carrying `AddKeyword(keyword)` on the "level"
+    /// generic counter — the exact shape `parse_level_blocks` produces for keyword
+    /// lines inside a {LEVEL} striation.
+    fn level_gated_keyword_static(keyword: Keyword, minimum: u32) -> StaticDefinition {
+        StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .condition(StaticCondition::HasCounters {
+                counters: CounterMatch::OfType(CounterType::Generic("level".to_string())),
+                minimum,
+                maximum: None,
+            })
+            .modifications(vec![ContinuousModification::AddKeyword { keyword }])
+    }
+
+    /// CR 711.4 / CR 711.5: `strip_level_gated_keywords` must remove keywords that
+    /// are sourced from a level-gated static (so they are not granted at level 0),
+    /// while structurally preserving `LevelUp` (never an `AddKeyword`).
+    #[test]
+    fn strip_level_gated_keywords_removes_only_gated_keywords() {
+        let level_up = Keyword::LevelUp(ManaCost::Cost {
+            shards: vec![ManaCostShard::White],
+            generic: 0,
+        });
+        let mut face = CardFace {
+            keywords: vec![
+                Keyword::FirstStrike,
+                Keyword::DoubleStrike,
+                level_up.clone(),
+            ],
+            static_abilities: vec![
+                level_gated_keyword_static(Keyword::FirstStrike, 2),
+                level_gated_keyword_static(Keyword::DoubleStrike, 7),
+            ],
+            ..Default::default()
+        };
+
+        strip_level_gated_keywords(&mut face);
+
+        // Both gated keywords stripped; the LevelUp keyword survives.
+        assert_eq!(face.keywords, vec![level_up]);
+    }
+
+    /// Negative case: a `HasCounters` static on a NON-"level" generic counter
+    /// (e.g. "charge") must NOT strip its keyword — only `{LEVEL}`-gated statics
+    /// (CR 711) are level abilities.
+    #[test]
+    fn strip_level_gated_keywords_ignores_non_level_counters() {
+        let mut face = CardFace {
+            keywords: vec![Keyword::Flying],
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .condition(StaticCondition::HasCounters {
+                    counters: CounterMatch::OfType(CounterType::Generic("charge".to_string())),
+                    minimum: 1,
+                    maximum: None,
+                })
+                .modifications(vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Flying,
+                }])],
+            ..Default::default()
+        };
+
+        strip_level_gated_keywords(&mut face);
+
+        // Flying is gated on a charge counter, not a level counter — preserved.
+        assert_eq!(face.keywords, vec![Keyword::Flying]);
     }
 
     /// CR 702.97a: Scavenge synthesis must carry AsSorcery (single `.sorcery_speed()`

--- a/crates/engine/tests/level_up_keywords.rs
+++ b/crates/engine/tests/level_up_keywords.rs
@@ -1,0 +1,197 @@
+//! Regression coverage for the leveler keyword bug (CR 711): a leveler card must
+//! NOT grant the keywords printed inside its {LEVEL} striations until it has the
+//! required number of level counters.
+//!
+//! THE BUG: MTGJSON's `keywords` array lists every keyword printed anywhere on the
+//! card, including those inside {LEVEL} blocks. That array seeds the runtime
+//! object's `base_keywords`, so a freshly-cast leveler (0 level counters) carried
+//! its level-gated keywords unconditionally — Student of Warfare had First strike
+//! at level 0, Coralhelm Commander had Flying at level 0. CR 711.5: below the
+//! lowest level, the creature has only its uppermost (base) P/T and its base
+//! abilities; the {LEVEL} keywords are level-gated static abilities (CR 711.2a /
+//! CR 711.2b), not base abilities (CR 711.4).
+//!
+//! THE FIX (`database::synthesis::strip_level_gated_keywords`, called from
+//! `synthesize_level_up`): strip every keyword that is sourced from a level-gated
+//! static out of the base `keywords` list, so the layer system grants those
+//! keywords ONLY through the gated statics once the level threshold is met.
+//!
+//! These tests drive the real pipeline: build the leveler from Oracle text (the
+//! scenario harness runs the same `synthesize_all` as production), then activate
+//! the level-up ability the required number of times and read the *effective*
+//! (post-layer) power/toughness and keywords. They are runtime tests, not AST
+//! shape tests.
+//!
+//! WHY THESE FAIL ON main (the discrimination gate): on main, `face.keywords`
+//! retains the {LEVEL}-printed keywords, so `base_keywords` carries them and they
+//! survive layer evaluation at every level — including level 0. Every "level 0,
+//! NO <keyword>" assertion below therefore fails on main (the keyword is present
+//! ungated). The P/T assertions pass on main (P/T is driven by the gated
+//! `SetPower`/`SetToughness` statics, which were already correct); only the
+//! keyword assertions discriminate the fix.
+
+use engine::game::keywords::has_keyword;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+/// Add one unit of `ty` mana to P0's pool (mirrors the Sheoldred's Edict harness —
+/// deterministic payment without modelling lands).
+fn add_mana(runner: &mut GameRunner, ty: ManaType) {
+    let unit = ManaUnit::new(ty, ObjectId(0), false, vec![]);
+    runner.state_mut().players[0].mana_pool.add(unit);
+}
+
+/// Recompute layers and read the leveler's effective (post-layer) power/toughness.
+/// CR 711.2a / CR 711.2b: the gated `SetPower`/`SetToughness` modifications apply
+/// here once the level threshold is met; below it (CR 711.5) the base P/T stands.
+fn effective_pt(runner: &mut GameRunner, id: ObjectId) -> (i32, i32) {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    let obj = &runner.state().objects[&id];
+    (
+        obj.power.expect("leveler has power"),
+        obj.toughness.expect("leveler has toughness"),
+    )
+}
+
+/// True iff the leveler currently has `keyword` after a fresh layer evaluation.
+/// CR 711.2a / CR 711.2b: keywords inside a {LEVEL} striation are only present
+/// once the level threshold is met.
+fn has_kw(runner: &mut GameRunner, id: ObjectId, keyword: &Keyword) -> bool {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    has_keyword(&runner.state().objects[&id], keyword)
+}
+
+/// Activate the leveler's level-up ability once (ability index 0 — it is the only
+/// synthesized activated ability). Funds the pool via `add_mana` first, then drives
+/// the activation + resolution so a level counter lands (CR 702.87a).
+fn level_up(runner: &mut GameRunner, id: ObjectId, fund: impl Fn(&mut GameRunner)) {
+    fund(runner);
+    runner.activate(id, 0).resolve();
+}
+
+/// Student of Warfare — base 1/1; "Level up {W}"; LEVEL 2-6 → 3/3 First strike;
+/// LEVEL 7+ → 4/4 Double strike.
+const STUDENT_OF_WARFARE: &str = "Level up {W}\n\
+LEVEL 2-6\n\
+3/3\n\
+First strike\n\
+LEVEL 7+\n\
+4/4\n\
+Double strike";
+
+#[test]
+fn student_of_warfare_first_strike_is_level_gated() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let id = scenario
+        .add_creature_from_oracle(P0, "Student of Warfare", 1, 1, STUDENT_OF_WARFARE)
+        .id();
+    let mut runner = scenario.build();
+
+    // CR 711.5 / CR 711.4: at level 0 the creature is its base 1/1 with NO
+    // level-gated keywords. This is the assertion that fails on main (First strike
+    // ungated in base_keywords).
+    assert_eq!(effective_pt(&mut runner, id), (1, 1), "base P/T at level 0");
+    assert!(
+        !has_kw(&mut runner, id, &Keyword::FirstStrike),
+        "CR 711.4: First strike is level-gated (LEVEL 2-6) — absent at level 0"
+    );
+    assert!(
+        !has_kw(&mut runner, id, &Keyword::DoubleStrike),
+        "CR 711.4: Double strike is level-gated (LEVEL 7+) — absent at level 0"
+    );
+
+    // Level up to 2: enter the LEVEL 2-6 band.
+    for _ in 0..2 {
+        level_up(&mut runner, id, |r| add_mana(r, ManaType::White));
+    }
+
+    // CR 711.2a: at 2 level counters → base 3/3, First strike, still NO Double strike.
+    assert_eq!(effective_pt(&mut runner, id), (3, 3), "LEVEL 2-6 sets 3/3");
+    assert!(
+        has_kw(&mut runner, id, &Keyword::FirstStrike),
+        "CR 711.2a: First strike granted within LEVEL 2-6"
+    );
+    assert!(
+        !has_kw(&mut runner, id, &Keyword::DoubleStrike),
+        "CR 711.2b: Double strike (LEVEL 7+) still absent below 7 counters"
+    );
+
+    // Level up to 7: enter the LEVEL 7+ band (5 more activations).
+    for _ in 0..5 {
+        level_up(&mut runner, id, |r| add_mana(r, ManaType::White));
+    }
+
+    // CR 711.2b: at 7 level counters → base 4/4, Double strike.
+    assert_eq!(effective_pt(&mut runner, id), (4, 4), "LEVEL 7+ sets 4/4");
+    assert!(
+        has_kw(&mut runner, id, &Keyword::DoubleStrike),
+        "CR 711.2b: Double strike granted within LEVEL 7+"
+    );
+}
+
+/// Coralhelm Commander — base 2/2; "Level up {1}{U}"; LEVEL 2-3 → 4/4 Flying;
+/// LEVEL 4+ → 6/6 Flying. (Both bands grant Flying; the gate is what is under test.)
+const CORALHELM_COMMANDER: &str = "Level up {1}{U}\n\
+LEVEL 2-3\n\
+4/4\n\
+Flying\n\
+LEVEL 4+\n\
+6/6\n\
+Flying";
+
+#[test]
+fn coralhelm_commander_flying_is_level_gated() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let id = scenario
+        .add_creature_from_oracle(P0, "Coralhelm Commander", 2, 2, CORALHELM_COMMANDER)
+        .id();
+    let mut runner = scenario.build();
+
+    // CR 711.5 / CR 711.4: base 2/2 with NO Flying at level 0 (fails on main).
+    assert_eq!(effective_pt(&mut runner, id), (2, 2), "base P/T at level 0");
+    assert!(
+        !has_kw(&mut runner, id, &Keyword::Flying),
+        "CR 711.4: Flying is level-gated (LEVEL 2-3 / 4+) — absent at level 0"
+    );
+
+    // Pay {1}{U} per level — one Colorless for the generic, one Blue.
+    let pay_blue = |r: &mut GameRunner| {
+        add_mana(r, ManaType::Colorless);
+        add_mana(r, ManaType::Blue);
+    };
+
+    // Level up to 2: enter LEVEL 2-3.
+    for _ in 0..2 {
+        level_up(&mut runner, id, pay_blue);
+    }
+
+    // CR 711.2a: at 2 level counters → 4/4, Flying.
+    assert_eq!(effective_pt(&mut runner, id), (4, 4), "LEVEL 2-3 sets 4/4");
+    assert!(
+        has_kw(&mut runner, id, &Keyword::Flying),
+        "CR 711.2a: Flying granted within LEVEL 2-3"
+    );
+
+    // Level up to 4: enter LEVEL 4+ (2 more activations).
+    for _ in 0..2 {
+        level_up(&mut runner, id, pay_blue);
+    }
+
+    // CR 711.2b: at 4 level counters → 6/6, still Flying.
+    assert_eq!(effective_pt(&mut runner, id), (6, 6), "LEVEL 4+ sets 6/6");
+    assert!(
+        has_kw(&mut runner, id, &Keyword::Flying),
+        "CR 711.2b: Flying granted within LEVEL 4+"
+    );
+}


### PR DESCRIPTION
Leveler cards granted their level-gated keywords at level 0. MTGJSON's
keyword list enumerates every keyword printed anywhere on the card,
including those inside LEVEL symbol blocks, so the base `keywords` vec
carried (e.g.) First strike / Double strike / Flying unconditionally —
while parse_level_blocks ALSO emitted them as level-gated statics. Net
effect: the keyword was live both at level 0 and gated, violating CR
711.2a/711.2b (only the abilities of the creature's current level band
apply).

strip_level_gated_keywords collects every Keyword the level-block parser
placed inside a HasCounters{ Generic("level") } static (matched by full
Keyword equality, so Hexdrinker's two distinct Protection variants are
handled independently) and retains only base keywords not in that set.
LevelUp itself is structurally preserved so synthesize_level_up still
finds it. Called as the first statement of synthesize_level_up, the
shared seam both build pipelines route through, so the fix covers the
whole leveler class (26 cards), not one.

CR 711.4: a leveler's non-level abilities apply at all times.
CR 711.5: the uppermost level band whose threshold is met sets P/T.

Runtime coverage: crates/engine/tests/level_up_keywords.rs drives
Student of Warfare and Coralhelm Commander through the real synthesis +
layer pipeline — vanilla at level 0, gated keywords switching on at the
correct thresholds. Fails on origin/main, passes with the fix.
