### PR TITLE
Exclude phased-out permanents from control conditions (CR 702.26b)

### DIFF
--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1501,7 +1501,9 @@ fn you_control_land_with_any_subtype(
 ) -> bool {
     state.battlefield.iter().any(|object_id| {
         state.objects.get(object_id).is_some_and(|obj| {
+            // CR 702.26b: a phased-out land "does not exist" for this condition.
             obj.controller == player
+                && obj.is_phased_in()
                 && obj.card_types.core_types.contains(&CoreType::Land)
                 && obj.card_types.subtypes.iter().any(|subtype| {
                     subtypes
@@ -1551,7 +1553,8 @@ fn controlled_objects_matching_count(
             state
                 .objects
                 .get(object_id)
-                .is_some_and(|obj| obj.controller == player && predicate(obj))
+                // CR 702.26b: a phased-out permanent "does not exist" — exclude it.
+                .is_some_and(|obj| obj.controller == player && obj.is_phased_in() && predicate(obj))
         })
         .count()
 }
@@ -1600,7 +1603,10 @@ fn total_power_of_controlled_creatures(
         .iter()
         .filter_map(|object_id| state.objects.get(object_id))
         .filter(|obj| {
-            obj.controller == player && obj.card_types.core_types.contains(&CoreType::Creature)
+            // CR 702.26b: phased-out creatures do not contribute to the total.
+            obj.controller == player
+                && obj.is_phased_in()
+                && obj.card_types.core_types.contains(&CoreType::Creature)
         })
         .map(|obj| obj.power.unwrap_or(0))
         .sum()
@@ -1843,6 +1849,71 @@ mod tests {
 
         state.objects.get_mut(&source_id).unwrap().attached_to = Some(land_id.into());
         assert!(!evaluate_condition(&state, player, source_id, &condition));
+    }
+
+    /// CR 702.26b: a phased-out permanent "does not exist" — it must not satisfy
+    /// or contribute to "you control …" activation/casting conditions.
+    #[test]
+    fn phased_out_permanents_excluded_from_control_conditions() {
+        use crate::game::game_object::{PhaseOutCause, PhaseStatus};
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            player,
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+
+        let land = create_object(
+            &mut state,
+            CardId(2),
+            player,
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&land).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Forest".to_string());
+        }
+        let land_cond = ParsedCondition::YouControlLandSubtypeAny {
+            subtypes: vec!["forest".to_string()],
+        };
+
+        let creature = create_object(
+            &mut state,
+            CardId(3),
+            player,
+            "Beast".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&creature).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(4);
+        }
+        let power_cond = ParsedCondition::CreaturesYouControlTotalPowerAtLeast { minimum: 4 };
+
+        // Phased in: both conditions hold.
+        assert!(evaluate_condition(&state, player, source_id, &land_cond));
+        assert!(evaluate_condition(&state, player, source_id, &power_cond));
+
+        // Phase both out: neither holds (CR 702.26b).
+        for id in [land, creature] {
+            state.objects.get_mut(&id).unwrap().phase_status = PhaseStatus::PhasedOut {
+                cause: PhaseOutCause::Directly,
+            };
+        }
+        assert!(
+            !evaluate_condition(&state, player, source_id, &land_cond),
+            "phased-out Forest must not satisfy YouControlLandSubtypeAny"
+        );
+        assert!(
+            !evaluate_condition(&state, player, source_id, &power_cond),
+            "phased-out creature must not contribute to total power"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1525,7 +1525,8 @@ fn you_control_subtype_count(
         .iter()
         .filter(|object_id| {
             state.objects.get(object_id).is_some_and(|obj| {
-                if obj.controller != player {
+                // CR 702.26b: a phased-out permanent does not exist for "you control" counts.
+                if obj.controller != player || !obj.is_phased_in() {
                     return false;
                 }
                 if subtype.eq_ignore_ascii_case("commander") {
@@ -1568,7 +1569,11 @@ fn controlled_creature_power_count(
         let Some(obj) = state.objects.get(object_id) else {
             continue;
         };
-        if obj.controller != player || !obj.card_types.core_types.contains(&CoreType::Creature) {
+        // CR 702.26b: phased-out creatures do not contribute to controlled-creature counts.
+        if obj.controller != player
+            || !obj.is_phased_in()
+            || !obj.card_types.core_types.contains(&CoreType::Creature)
+        {
             continue;
         }
         if let Some(power) = obj.power {
@@ -1587,7 +1592,11 @@ fn controlled_land_same_name_count(
         let Some(obj) = state.objects.get(object_id) else {
             continue;
         };
-        if obj.controller == player && obj.card_types.core_types.contains(&CoreType::Land) {
+        // CR 702.26b: phased-out lands do not contribute to controlled-land counts.
+        if obj.controller == player
+            && obj.is_phased_in()
+            && obj.card_types.core_types.contains(&CoreType::Land)
+        {
             *counts.entry(obj.name.clone()).or_insert(0) += 1;
         }
     }
@@ -1736,6 +1745,7 @@ pub(crate) fn attack_target_matches_defended_scope(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::game_object::{PhaseOutCause, PhaseStatus};
     use crate::game::zones::create_object;
     use crate::parser::oracle_condition::parse_restriction_condition;
     use crate::types::ability::{AbilityKind, Effect, ParsedCondition, QuantityExpr};
@@ -1855,7 +1865,6 @@ mod tests {
     /// or contribute to "you control …" activation/casting conditions.
     #[test]
     fn phased_out_permanents_excluded_from_control_conditions() {
-        use crate::game::game_object::{PhaseOutCause, PhaseStatus};
         let mut state = crate::types::game_state::GameState::new_two_player(42);
         let player = PlayerId(0);
         let source_id = create_object(
@@ -1882,9 +1891,25 @@ mod tests {
             subtypes: vec!["forest".to_string()],
         };
 
-        let creature = create_object(
+        let matching_land = create_object(
             &mut state,
             CardId(3),
+            player,
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&matching_land)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+        let same_name_land_cond = ParsedCondition::YouControlLandsWithSameNameAtLeast { count: 2 };
+
+        let creature = create_object(
+            &mut state,
+            CardId(4),
             player,
             "Beast".to_string(),
             Zone::Battlefield,
@@ -1896,12 +1921,63 @@ mod tests {
         }
         let power_cond = ParsedCondition::CreaturesYouControlTotalPowerAtLeast { minimum: 4 };
 
-        // Phased in: both conditions hold.
-        assert!(evaluate_condition(&state, player, source_id, &land_cond));
-        assert!(evaluate_condition(&state, player, source_id, &power_cond));
+        let goblin = create_object(
+            &mut state,
+            CardId(5),
+            player,
+            "Goblin One".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&goblin).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Goblin".to_string());
+            obj.power = Some(1);
+        }
+        let other_goblin = create_object(
+            &mut state,
+            CardId(6),
+            player,
+            "Goblin Two".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&other_goblin).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Goblin".to_string());
+            obj.power = Some(2);
+        }
+        let subtype_count_cond = ParsedCondition::YouControlSubtypeCountAtLeast {
+            subtype: "Goblin".to_string(),
+            count: 2,
+        };
+        let different_power_cond =
+            ParsedCondition::YouControlDifferentPowerCreatureCountAtLeast { count: 3 };
 
-        // Phase both out: neither holds (CR 702.26b).
-        for id in [land, creature] {
+        // Phased in: all conditions hold.
+        assert!(evaluate_condition(&state, player, source_id, &land_cond));
+        assert!(evaluate_condition(
+            &state,
+            player,
+            source_id,
+            &same_name_land_cond
+        ));
+        assert!(evaluate_condition(&state, player, source_id, &power_cond));
+        assert!(evaluate_condition(
+            &state,
+            player,
+            source_id,
+            &subtype_count_cond
+        ));
+        assert!(evaluate_condition(
+            &state,
+            player,
+            source_id,
+            &different_power_cond
+        ));
+
+        // Phase them out: none of these "you control" conditions hold (CR 702.26b).
+        for id in [land, matching_land, creature, goblin, other_goblin] {
             state.objects.get_mut(&id).unwrap().phase_status = PhaseStatus::PhasedOut {
                 cause: PhaseOutCause::Directly,
             };
@@ -1913,6 +1989,18 @@ mod tests {
         assert!(
             !evaluate_condition(&state, player, source_id, &power_cond),
             "phased-out creature must not contribute to total power"
+        );
+        assert!(
+            !evaluate_condition(&state, player, source_id, &subtype_count_cond),
+            "phased-out Goblins must not satisfy YouControlSubtypeCountAtLeast"
+        );
+        assert!(
+            !evaluate_condition(&state, player, source_id, &different_power_cond),
+            "phased-out creatures must not satisfy YouControlDifferentPowerCreatureCountAtLeast"
+        );
+        assert!(
+            !evaluate_condition(&state, player, source_id, &same_name_land_cond),
+            "phased-out lands must not satisfy YouControlLandsWithSameNameAtLeast"
         );
     }
 


### PR DESCRIPTION
## Summary

`restrictions.rs` evaluated "you control …" / "activate only if …" / "cast only if …" conditions by scanning `state.battlefield` with only a controller filter and **no phasing guard**. Phased-out permanents remain in `state.battlefield` (phasing only flips `phase_status`), so per **CR 702.26b** — a phased-out permanent "is treated as though it does not exist" — they were wrongly counted, letting condition-gated activations/casts proceed (or meet total-power thresholds) when they shouldn't. Closes #2595.

Same bug class as the merged **devotion** fix (#2589/#2590) and the open **domain** report (#2591); the #2590 commit's "lone outlier" note missed these — they're additional raw-scan outliers, in the **action-legality** path.

## Comprehensive Rules

**CR 702.26b:** "Except for rules and effects that specifically mention phased-out permanents, a phased-out permanent is treated as though it does not exist. It can't affect or be affected by anything else in the game."

## Fix

Add the existing `obj.is_phased_in()` guard (mirroring `filter.rs:730/1047` and `devotion.rs:19`) to the three raw battlefield scans:

- **`controlled_objects_matching_count`** — the shared counter behind "you control a creature with [keyword]" and "you control N+ [subtype]" conditions.
- **`total_power_of_controlled_creatures`** — "creatures you control have total power ≥ N".
- **`you_control_land_with_any_subtype`** — "you control a [land subtype]".

No new mechanism, no signature change — internal logic only (so no downstream/`phase-ai` impact).

## Tests

`restrictions.rs`: a phased-in Forest satisfies `YouControlLandSubtypeAny` and a phased-in 4-power creature meets `CreaturesYouControlTotalPowerAtLeast { 4 }`; after both phase out, neither condition holds.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` clean.

Note: the full suite runs in CI (local toolchain has a binutils/dlltool gap blocking the test/audit binaries). The guard is identical to the already-shipped devotion fix, so blast radius is contained to these three helpers.