### PR TITLE
fix(keyword): implement Echo non-mana costs (CR 702.30)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -25,7 +25,9 @@ use crate::types::card::{CardFace, CardLayout, CleaveVariant};
 use crate::types::card_type::{CardType, CoreType, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::format::DeckCopyLimit;
-use crate::types::keywords::{BloodthirstValue, BuybackCost, CyclingCost, Keyword, PartnerType};
+use crate::types::keywords::{
+    BloodthirstValue, BuybackCost, CyclingCost, EchoCost, Keyword, PartnerType,
+};
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use crate::types::phase::Phase;
 use crate::types::player::PlayerCounterKind;
@@ -4229,7 +4231,7 @@ fn build_double_team_trigger() -> TriggerDefinition {
         )
 }
 
-fn build_echo_trigger(cost: ManaCost) -> TriggerDefinition {
+fn build_echo_trigger(cost: EchoCost) -> TriggerDefinition {
     let sac = AbilityDefinition::new(
         AbilityKind::Spell,
         Effect::Sacrifice {
@@ -4248,7 +4250,13 @@ fn build_echo_trigger(cost: ManaCost) -> TriggerDefinition {
                 .to_string(),
         );
     trigger.unless_pay = Some(UnlessPayModifier {
-        cost: AbilityCost::Mana { cost },
+        // CR 702.30a: echo cost may be mana (errata/Urza-block) or non-mana
+        // ("Echo—Discard a card"). Map both to the general AbilityCost the
+        // unless-pay interceptor + handle_unless_payment already understand.
+        cost: match cost {
+            EchoCost::Mana(c) => AbilityCost::Mana { cost: c },
+            EchoCost::NonMana(c) => c,
+        },
         payer: TargetFilter::Controller,
     });
     trigger
@@ -14377,10 +14385,11 @@ mod echo_synthesis_tests {
 
     fn echo_face() -> CardFace {
         let mut face = CardFace::default();
-        face.keywords.push(Keyword::Echo(ManaCost::Cost {
-            shards: vec![ManaCostShard::White, ManaCostShard::White],
-            generic: 3,
-        }));
+        face.keywords
+            .push(Keyword::Echo(EchoCost::Mana(ManaCost::Cost {
+                shards: vec![ManaCostShard::White, ManaCostShard::White],
+                generic: 3,
+            })));
         face
     }
 
@@ -15876,10 +15885,10 @@ mod suspend_synthesis_tests {
             &suspend,
         ));
         // An unrelated trigger (echo) is not a suspend trigger.
-        let echo = build_echo_trigger(ManaCost::Cost {
+        let echo = build_echo_trigger(EchoCost::Mana(ManaCost::Cost {
             shards: vec![],
             generic: 1,
-        });
+        }));
         assert!(!KeywordTriggerInstaller::trigger_matches_keyword_kind(
             &echo, &suspend,
         ));

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -15654,6 +15654,137 @@ When this creature enters or dies, create a 1/1 red Goblin creature token.";
     }
 
     #[test]
+    fn rakdos_headliner_non_mana_echo_reaches_discard_payment() {
+        // CR 702.30a: "Echo—Discard a card." is a *non-mana* echo cost. On
+        // origin/main the parser drops the Echo keyword entirely for the em-dash
+        // (non-mana) form, so synthesis never installs the upkeep trigger and the
+        // permanent is never on the hook for a discard. This drives the real
+        // pipeline (parse -> synthesize_echo -> battlefield with echo due ->
+        // controller upkeep) and asserts the engine reaches the discard payment.
+        let mut state = new_game(42);
+        state.turn_number = 2;
+        state.phase = Phase::Untap;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let headliner = create_object(
+            &mut state,
+            CardId(1982),
+            PlayerId(0),
+            "Rakdos Headliner".to_string(),
+            Zone::Battlefield,
+        );
+
+        // A spare card in P0's hand so the discard cost has an eligible target
+        // (the engine surfaces the choice rather than auto-failing the payment).
+        let _spare = create_object(
+            &mut state,
+            CardId(1983),
+            PlayerId(0),
+            "Spare Card".to_string(),
+            Zone::Hand,
+        );
+
+        let oracle = "Haste\n\
+Echo—Discard a card. (At the beginning of your upkeep, if this came under your control since the beginning of your last upkeep, sacrifice it unless you pay its echo cost.)";
+        let parsed = parse_oracle_text(
+            oracle,
+            "Rakdos Headliner",
+            &[],
+            &["Creature".to_string()],
+            &["Devil".to_string()],
+        );
+
+        // Discriminating assertion: on origin/main the non-mana echo keyword is
+        // dropped, so this `Echo(NonMana(Discard))` is absent.
+        assert!(
+            parsed.extracted_keywords.iter().any(|kw| matches!(
+                kw,
+                Keyword::Echo(crate::types::keywords::EchoCost::NonMana(
+                    AbilityCost::Discard { .. }
+                ))
+            )),
+            "Rakdos Headliner must parse Echo(NonMana(Discard)) — got {:?}",
+            parsed.extracted_keywords
+        );
+
+        let mut face = CardFace {
+            keywords: parsed.extracted_keywords.clone(),
+            triggers: parsed.triggers.clone(),
+            ..CardFace::default()
+        };
+        crate::database::synthesis::synthesize_echo(&mut face);
+
+        {
+            let obj = state.objects.get_mut(&headliner).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Devil".to_string());
+            obj.power = Some(3);
+            obj.toughness = Some(1);
+            obj.base_power = Some(3);
+            obj.base_toughness = Some(1);
+            obj.keywords = face.keywords.clone();
+            obj.base_keywords = obj.keywords.clone();
+            for trigger in face.triggers.clone() {
+                obj.trigger_definitions.push(trigger);
+            }
+            obj.base_trigger_definitions =
+                Arc::new(obj.trigger_definitions.iter_all().cloned().collect());
+            // CR 702.30a: the next controller-upkeep echo payment is due.
+            obj.echo_due = true;
+        }
+
+        let mut events = Vec::new();
+        crate::game::turns::auto_advance(&mut state, &mut events);
+        assert_eq!(state.phase, Phase::Upkeep);
+        assert!(
+            !state.stack.is_empty(),
+            "echo trigger must be on the stack at the beginning of upkeep"
+        );
+
+        events.clear();
+        crate::game::stack::resolve_top(&mut state, &mut events);
+
+        // CR 702.30a: the echo trigger resolves to an unless-payment carrying the
+        // *non-mana* discard cost (not mana). On origin/main the Echo keyword is
+        // dropped for the em-dash form, so no echo trigger exists and this
+        // UnlessPayment-with-Discard never appears — the discriminating proof
+        // that the non-mana echo cost flowed through synthesis into the payment
+        // pipeline.
+        assert!(
+            matches!(
+                state.waiting_for,
+                WaitingFor::UnlessPayment {
+                    player: PlayerId(0),
+                    cost: AbilityCost::Discard { .. },
+                    ..
+                }
+            ),
+            "non-mana echo must surface an UnlessPayment carrying a Discard cost — got {:?}",
+            state.waiting_for
+        );
+
+        // CR 701.9: choosing to pay routes the discard cost through
+        // `handle_unless_payment`, which surfaces the discard-card choice — a
+        // discard cost, not a mana payment.
+        apply_as_current(&mut state, GameAction::PayUnlessCost { pay: true }).unwrap();
+        assert!(
+            matches!(
+                state.waiting_for,
+                WaitingFor::WardDiscardChoice {
+                    player: PlayerId(0),
+                    ..
+                }
+            ),
+            "paying the non-mana echo must reach the discard-choice payment — got {:?}",
+            state.waiting_for
+        );
+    }
+
+    #[test]
     fn attack_trigger_resolves_before_combat_damage_and_only_once() {
         let mut state = new_game(42);
         state.turn_number = 5;

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -670,6 +670,31 @@ fn parse_evoke_cost(cost_text: &str) -> Option<crate::types::keywords::EvokeCost
     }
 }
 
+/// CR 702.30a: Parse an echo cost following the em-dash separator
+/// (e.g., "echo—discard a card" on Rakdos Headliner / Deepcavern Imp).
+/// Mirrors `parse_evoke_cost`: delegates to `parse_oracle_cost` so
+/// comma-separated parts compose into `AbilityCost::Composite`, and wraps the
+/// result in `EchoCost::Mana` when it's a pure mana cost or `EchoCost::NonMana`
+/// otherwise.
+fn parse_echo_cost(cost_text: &str) -> Option<crate::types::keywords::EchoCost> {
+    use crate::types::keywords::EchoCost;
+    let trimmed = cost_text.trim().trim_end_matches('.').trim_end_matches(')');
+    let clean = opt(take_until::<_, _, OracleError<'_>>(" ("))
+        .parse(trimmed)
+        .map(|(_, before)| before.unwrap_or(trimmed))
+        .unwrap_or(trimmed)
+        .trim();
+    if clean.is_empty() {
+        return None;
+    }
+    let cost = super::oracle_cost::parse_oracle_cost(clean);
+    match cost {
+        AbilityCost::Mana { cost: mana_cost } => Some(EchoCost::Mana(mana_cost)),
+        AbilityCost::Unimplemented { .. } => None,
+        other => Some(EchoCost::NonMana(other)),
+    }
+}
+
 fn parse_cycling_cost(cost_text: &str) -> Option<CyclingCost> {
     let trimmed = cost_text.trim().trim_end_matches('.').trim_end_matches(')');
     // Strip reminder text in parentheses: take everything before the first " (".
@@ -1092,6 +1117,16 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("evoke\u{2014}").parse(text) {
         if let Some(ev_cost) = parse_evoke_cost(rest) {
             return Some(Keyword::Evoke(ev_cost));
+        }
+    }
+
+    // CR 702.30a: Echo with em-dash cost — non-mana echo ("echo—discard a card"
+    // on Rakdos Headliner / Deepcavern Imp). Pure-mana echo ("Echo {R}") arrives
+    // via the space-mana fallback below. Placed before that fallback because the
+    // generic space-split mangles "echo—discard a card".
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("echo\u{2014}").parse(text) {
+        if let Some(echo_cost) = parse_echo_cost(rest) {
+            return Some(Keyword::Echo(echo_cost));
         }
     }
 

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -65,6 +65,18 @@ pub enum EvokeCost {
     NonMana(AbilityCost),
 }
 
+/// CR 702.30a: Echo cost — either a mana cost (Urza-block / errata cards, e.g.
+/// Orcish Hellraiser "Echo {R}") or a non-mana cost ("Echo—Discard a card" on
+/// Rakdos Headliner, Deepcavern Imp). Mirrors `EvokeCost`/`BuybackCost`/
+/// `CyclingCost`/`FlashbackCost` so non-mana costs compose through the existing
+/// `AbilityCost` unless-pay pipeline in `build_echo_trigger`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum EchoCost {
+    Mana(ManaCost),
+    NonMana(AbilityCost),
+}
+
 /// Discriminant-level keyword identity used when the Oracle text refers to a keyword class
 /// without caring about its parameter payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -588,7 +600,11 @@ pub enum Keyword {
     /// CR 702.153a: Casualty N — as an additional cost, you may sacrifice a creature
     /// with power N or greater. When you do, copy this spell.
     Casualty(u32),
-    Echo(ManaCost),
+    /// CR 702.30a: see `EchoCost` for the mana / non-mana split. Urza-block /
+    /// errata cards (e.g. Orcish Hellraiser "Echo {R}") use `EchoCost::Mana`;
+    /// "Echo—Discard a card" cards (Rakdos Headliner, Deepcavern Imp) carry
+    /// `EchoCost::NonMana(AbilityCost::Discard { .. })`.
+    Echo(EchoCost),
     /// CR 702.42a: Entwine — pay additional cost to choose all modes of a modal spell.
     Entwine(ManaCost),
     Outlast(ManaCost),
@@ -1708,7 +1724,7 @@ impl FromStr for Keyword {
                     }
                     // Fall through to Unknown for unrecognized affinity types
                 }
-                "echo" => return Ok(Keyword::Echo(parse_keyword_mana_cost(p))),
+                "echo" => return Ok(Keyword::Echo(EchoCost::Mana(parse_keyword_mana_cost(p)))),
                 "outlast" => return Ok(Keyword::Outlast(parse_keyword_mana_cost(p))),
                 "scavenge" => return Ok(Keyword::Scavenge(parse_keyword_mana_cost(p))),
                 "reinforce" => {
@@ -2423,7 +2439,14 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
                 serde_json::from_value(data.clone()).map_err(|e| format!("Affinity: {e}"))?;
             Ok(Keyword::Affinity(tf))
         }
-        "Echo" => Ok(Keyword::Echo(mana(data)?)),
+        // CR 702.30a: accept both legacy ManaCost format and new EchoCost tagged format.
+        "Echo" => {
+            if let Ok(echo_cost) = serde_json::from_value::<EchoCost>(data.clone()) {
+                Ok(Keyword::Echo(echo_cost))
+            } else {
+                Ok(Keyword::Echo(EchoCost::Mana(mana(data)?)))
+            }
+        }
         "Outlast" => Ok(Keyword::Outlast(mana(data)?)),
         "Scavenge" => Ok(Keyword::Scavenge(mana(data)?)),
         // CR 702.77a: Reinforce N—[cost]. Data is { "count": N, "cost": "..." }.

--- a/crates/engine/tests/integration/mogg_war_marshal_echo_dies_trigger.rs
+++ b/crates/engine/tests/integration/mogg_war_marshal_echo_dies_trigger.rs
@@ -31,7 +31,7 @@ use engine::types::ability::{
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
 use engine::types::game_state::WaitingFor;
-use engine::types::keywords::Keyword;
+use engine::types::keywords::{EchoCost, Keyword};
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
 use engine::types::triggers::TriggerMode;
@@ -100,14 +100,15 @@ fn goblin_tokens(state: &engine::types::game_state::GameState) -> usize {
 /// trigger and the dies → Goblin trigger, with `echo_due` set so the echo
 /// trigger's intervening-if (`TriggerCondition::EchoDue`) is satisfied.
 fn build_echo_creature(scenario: &mut GameScenario) -> engine::types::identifiers::ObjectId {
-    let echo_trigger = KeywordTriggerInstaller::triggers_for(&Keyword::Echo(echo_cost()))
-        .into_iter()
-        .next()
-        .expect("echo keyword synthesizes one upkeep trigger");
+    let echo_trigger =
+        KeywordTriggerInstaller::triggers_for(&Keyword::Echo(EchoCost::Mana(echo_cost())))
+            .into_iter()
+            .next()
+            .expect("echo keyword synthesizes one upkeep trigger");
 
     scenario
         .add_creature(P0, "Mogg War Marshal", 1, 1)
-        .with_keyword(Keyword::Echo(echo_cost()))
+        .with_keyword(Keyword::Echo(EchoCost::Mana(echo_cost())))
         .with_trigger_definition(echo_trigger)
         .with_trigger_definition(dies_create_goblin_trigger())
         .id()

--- a/crates/mtgish-import/src/convert/keyword.rs
+++ b/crates/mtgish-import/src/convert/keyword.rs
@@ -178,7 +178,11 @@ pub fn try_convert(rule: &Rule, path: &str) -> ConvResult<Option<Keyword>> {
         Rule::Dash(c) => Keyword::Dash(pure_mana(c, "Rule::Dash", path)?),
         Rule::Disturb(c) => Keyword::Disturb(pure_mana(c, "Rule::Disturb", path)?),
         Rule::Disguise(c) => Keyword::Disguise(pure_mana(c, "Rule::Disguise", path)?),
-        Rule::Echo(c) => Keyword::Echo(pure_mana(c, "Rule::Echo", path)?),
+        Rule::Echo(c) => Keyword::Echo(engine::types::keywords::EchoCost::Mana(pure_mana(
+            c,
+            "Rule::Echo",
+            path,
+        )?)),
         Rule::Embalm(c) => Keyword::Embalm(pure_mana(c, "Rule::Embalm", path)?),
         Rule::Emerge(c) => Keyword::Emerge(pure_mana(c, "Rule::Emerge", path)?),
         Rule::Encore(c) => Keyword::Encore(pure_mana(c, "Rule::Encore", path)?),


### PR DESCRIPTION
Cards with non-mana echo ("Echo—Discard a card": Rakdos Headliner,
Deepcavern Imp) dropped the Echo keyword entirely. `Keyword::Echo`
only carried a `ManaCost`, and the keyword parser's generic space-split
mangled the em-dash form "echo—discard a card" into name="echo—discard"
→ Unknown → Echo discarded, so the upkeep echo trigger never fired.
Plain mana echo ("Echo {R}") parsed and ran correctly.

Mirror the established {Keyword}Cost { Mana(ManaCost), NonMana(AbilityCost) }
sibling pattern (EvokeCost/FlashbackCost/BuybackCost/CyclingCost):

- types/keywords.rs: new `EchoCost` enum; `Echo(ManaCost)` → `Echo(EchoCost)`;
  FromStr mana arm wraps `EchoCost::Mana`; mtgjson builder uses the
  tagged-deser-then-legacy-mana fallback (verbatim Evoke builder), so a
  stale card-data.json with the legacy bare-ManaCost shape still loads.
- parser/oracle_keyword.rs: new `parse_echo_cost` (sibling of
  `parse_evoke_cost`) + an em-dash dispatch arm `tag("echo\u{2014}")`
  placed before the generic space-split so the em-dash form is consumed
  before it can be mangled. Pure-mana echo still falls through to the
  space-split colon-form path unchanged.
- database/synthesis.rs: `build_echo_trigger` maps `EchoCost::Mana(c)`
  → `AbilityCost::Mana { cost: c }` and `EchoCost::NonMana(c)` → `c`,
  feeding the existing `UnlessPayModifier`. No new runtime payment
  plumbing — `handle_unless_payment`'s `AbilityCost::Discard` arm already
  routes to `WardDiscardChoice`.

The type models the general non-mana case (`NonMana(AbilityCost)`), not a
Discard special case, so any future non-mana echo is representable;
"Echo—Discard a card" (the only printed non-mana echo cost) is covered by
`AbilityCost::Discard { count: 1 }`.

CR 702.30a: "Echo [cost]" — the cost is generic and need not be mana.
CR 702.30b: Urza-block errata (mana echo), unaffected.

Runtime coverage: rakdos_headliner_non_mana_echo_reaches_discard_payment
drives the real pipeline (parse → synthesize_echo → upkeep trigger →
unless-payment) and asserts the discard payment is reached. Fails on
origin/main (Echo absent), passes with the fix. Mana-echo tests
(issue_1981, echo_synthesis_tests) stay green.

The one-line mtgish-import wrap is a zero-functionality compile-keep-alive
for the enum retype (mirrors the existing Rule::Evoke line); mtgish stays
dormant.
