### PR TITLE
Fix Demanding Dragon ETB unless-sacrifice prompt (#2422)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1597,6 +1597,14 @@ fn infer_pronoun_unless_payer(
     if scan_contains(effect_before_unless, "each opponent ") {
         return Some(TargetFilter::ScopedPlayer);
     }
+    // CR 608.2b + CR 115.4: "... deals damage to target opponent/player
+    // unless that player/they sacrifice ..." — the chosen player target pays
+    // the unless cost (Demanding Dragon, Tergrid's Lantern-style punishers).
+    if scan_contains(effect_before_unless, "target opponent")
+        || scan_contains(effect_before_unless, "target player")
+    {
+        return Some(TargetFilter::Player);
+    }
     if scan_contains(effect_before_unless, "creature's controller ") {
         return Some(TargetFilter::ParentTargetController);
     }
@@ -18669,6 +18677,25 @@ mod tests {
             panic!("sacrifice target should be typed, got {target:?}");
         };
         assert_eq!(tf.controller, Some(ControllerRef::You));
+    }
+
+    #[test]
+    fn demanding_dragon_etb_unless_sacrifice_binds_target_player_payer() {
+        let def = parse_trigger_line(
+            "When this creature enters, it deals 5 damage to target opponent unless that player sacrifices a creature of their choice.",
+            "Demanding Dragon",
+        );
+        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
+        assert_eq!(
+            unless_pay.payer,
+            TargetFilter::Player,
+            "target-opponent punishers bind unless payer to the chosen player target (#2422)"
+        );
+        assert!(
+            matches!(unless_pay.cost, AbilityCost::Sacrifice { count: 1, .. }),
+            "cost should be Sacrifice, got {:?}",
+            unless_pay.cost
+        );
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_2422_demanding_dragon.rs
+++ b/crates/engine/tests/integration/issue_2422_demanding_dragon.rs
@@ -3,17 +3,18 @@
 //!
 //! https://github.com/phase-rs/phase/issues/2422
 
-use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::ability::{AbilityCost, TargetFilter};
 use engine::types::actions::GameAction;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::zones::Zone;
 
 const DEMANDING_DRAGON_ORACLE: &str = "Flying\nWhen this creature enters, it deals 5 damage to target opponent unless that player sacrifices a creature of their choice.";
 
-fn add_mana(runner: &mut engine::game::scenario::GameRunner, mana: &[ManaType]) {
+fn add_mana(runner: &mut GameRunner, mana: &[ManaType]) {
     let dummy = ObjectId(0);
     let pool = &mut runner
         .state_mut()
@@ -27,35 +28,12 @@ fn add_mana(runner: &mut engine::game::scenario::GameRunner, mana: &[ManaType]) 
     }
 }
 
-#[test]
-fn demanding_dragon_parsed_etb_carries_unless_sacrifice_for_target_player() {
-    let mut scenario = GameScenario::new();
-    let dragon = scenario
-        .add_creature_to_hand_from_oracle(P0, "Demanding Dragon", 5, 5, DEMANDING_DRAGON_ORACLE)
-        .with_mana_cost(ManaCost::Cost {
-            shards: vec![ManaCostShard::Red, ManaCostShard::Red],
-            generic: 3,
-        })
-        .id();
-    let runner = scenario.build();
-    let etb = runner.state().objects[&dragon]
-        .trigger_definitions
-        .iter_unchecked()
-        .find(|t| t.unless_pay.is_some())
-        .expect("Demanding Dragon must have an ETB unless-pay trigger");
-    let unless_pay = etb
-        .unless_pay
-        .as_ref()
-        .expect("ETB must carry unless_pay (#2422)");
-    assert_eq!(unless_pay.payer, TargetFilter::Player);
-    assert!(matches!(unless_pay.cost, AbilityCost::Sacrifice { .. }));
-}
-
-#[test]
-fn demanding_dragon_etb_surfaces_unless_sacrifice_before_damage() {
+fn cast_demanding_dragon_to_unless_prompt() -> (GameRunner, ObjectId) {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
-    scenario.add_creature_from_oracle(P1, "P1 Bear", 2, 2, "");
+    let bear = scenario
+        .add_creature_from_oracle(P1, "P1 Bear", 2, 2, "")
+        .id();
 
     let dragon = scenario
         .add_creature_to_hand_from_oracle(P0, "Demanding Dragon", 5, 5, DEMANDING_DRAGON_ORACLE)
@@ -103,8 +81,11 @@ fn demanding_dragon_etb_surfaces_unless_sacrifice_before_damage() {
     runner.advance_until_stack_empty();
 
     assert!(
-        matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
-        "Demanding Dragon ETB must offer unless-sacrifice before dealing damage, got {:?}",
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player: P1, .. }
+        ),
+        "Demanding Dragon ETB must offer target-player unless-sacrifice before dealing damage, got {:?}",
         runner.state().waiting_for
     );
     assert_eq!(
@@ -117,5 +98,99 @@ fn demanding_dragon_etb_surfaces_unless_sacrifice_before_damage() {
             .life,
         20,
         "no damage should be dealt before the unless choice"
+    );
+
+    (runner, bear)
+}
+
+#[test]
+fn demanding_dragon_parsed_etb_carries_unless_sacrifice_for_target_player() {
+    let mut scenario = GameScenario::new();
+    let dragon = scenario
+        .add_creature_to_hand_from_oracle(P0, "Demanding Dragon", 5, 5, DEMANDING_DRAGON_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+            generic: 3,
+        })
+        .id();
+    let runner = scenario.build();
+    let etb = runner.state().objects[&dragon]
+        .trigger_definitions
+        .iter_unchecked()
+        .find(|t| t.unless_pay.is_some())
+        .expect("Demanding Dragon must have an ETB unless-pay trigger");
+    let unless_pay = etb
+        .unless_pay
+        .as_ref()
+        .expect("ETB must carry unless_pay (#2422)");
+    assert_eq!(unless_pay.payer, TargetFilter::Player);
+    assert!(matches!(unless_pay.cost, AbilityCost::Sacrifice { .. }));
+}
+
+#[test]
+fn demanding_dragon_declined_unless_payment_deals_damage_to_targeted_opponent() {
+    let (mut runner, bear) = cast_demanding_dragon_to_unless_prompt();
+    runner
+        .act(GameAction::PayUnlessCost { pay: false })
+        .expect("decline sacrifice payment");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner
+            .state()
+            .players
+            .iter()
+            .find(|p| p.id == P1)
+            .unwrap()
+            .life,
+        15,
+        "declining the target-player unless cost must allow the 5 damage"
+    );
+    assert_eq!(
+        runner.state().objects[&bear].zone,
+        Zone::Battlefield,
+        "declining the payment must not sacrifice the targeted opponent's creature"
+    );
+}
+
+#[test]
+fn demanding_dragon_paid_unless_payment_sacrifices_creature_and_prevents_damage() {
+    let (mut runner, bear) = cast_demanding_dragon_to_unless_prompt();
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("choose to pay sacrifice cost");
+
+    let WaitingFor::WardSacrificeChoice {
+        player, permanents, ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "paying Demanding Dragon's unless cost must ask P1 which creature to sacrifice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(*player, P1);
+    assert_eq!(permanents.as_slice(), [bear]);
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![bear] })
+        .expect("sacrifice P1 Bear");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner
+            .state()
+            .players
+            .iter()
+            .find(|p| p.id == P1)
+            .unwrap()
+            .life,
+        20,
+        "paying the unless cost must prevent Demanding Dragon's damage"
+    );
+    assert_eq!(
+        runner.state().objects[&bear].zone,
+        Zone::Graveyard,
+        "paying the unless cost must sacrifice P1's chosen creature"
     );
 }

--- a/crates/engine/tests/integration/issue_2422_demanding_dragon.rs
+++ b/crates/engine/tests/integration/issue_2422_demanding_dragon.rs
@@ -1,0 +1,121 @@
+//! Regression for issue #2422: Demanding Dragon's ETB unless-sacrifice must
+//! prompt the targeted opponent before dealing damage.
+//!
+//! https://github.com/phase-rs/phase/issues/2422
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{AbilityCost, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const DEMANDING_DRAGON_ORACLE: &str = "Flying\nWhen this creature enters, it deals 5 damage to target opponent unless that player sacrifices a creature of their choice.";
+
+fn add_mana(runner: &mut engine::game::scenario::GameRunner, mana: &[ManaType]) {
+    let dummy = ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+#[test]
+fn demanding_dragon_parsed_etb_carries_unless_sacrifice_for_target_player() {
+    let mut scenario = GameScenario::new();
+    let dragon = scenario
+        .add_creature_to_hand_from_oracle(P0, "Demanding Dragon", 5, 5, DEMANDING_DRAGON_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+            generic: 3,
+        })
+        .id();
+    let runner = scenario.build();
+    let etb = runner.state().objects[&dragon]
+        .trigger_definitions
+        .iter_unchecked()
+        .find(|t| t.unless_pay.is_some())
+        .expect("Demanding Dragon must have an ETB unless-pay trigger");
+    let unless_pay = etb
+        .unless_pay
+        .as_ref()
+        .expect("ETB must carry unless_pay (#2422)");
+    assert_eq!(unless_pay.payer, TargetFilter::Player);
+    assert!(matches!(unless_pay.cost, AbilityCost::Sacrifice { .. }));
+}
+
+#[test]
+fn demanding_dragon_etb_surfaces_unless_sacrifice_before_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P1, "P1 Bear", 2, 2, "");
+
+    let dragon = scenario
+        .add_creature_to_hand_from_oracle(P0, "Demanding Dragon", 5, 5, DEMANDING_DRAGON_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+            generic: 3,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    add_mana(
+        &mut runner,
+        &[
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Red,
+            ManaType::Red,
+        ],
+    );
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: dragon,
+            card_id: runner.state().objects[&dragon].card_id,
+            targets: vec![],
+        })
+        .expect("cast Demanding Dragon");
+
+    for _ in 0..24 {
+        match &runner.state().waiting_for {
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .choose_first_legal_target()
+                    .expect("choose P1 as target opponent");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner.act(GameAction::PassPriority).expect("pay mana");
+            }
+            WaitingFor::Priority { .. } => break,
+            other => panic!("unexpected pre-resolution prompt: {other:?}"),
+        }
+    }
+
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+        "Demanding Dragon ETB must offer unless-sacrifice before dealing damage, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        runner
+            .state()
+            .players
+            .iter()
+            .find(|p| p.id == P1)
+            .unwrap()
+            .life,
+        20,
+        "no damage should be dealt before the unless choice"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -90,6 +90,7 @@ mod issue_2374_fblthp_library_origin;
 mod issue_2376_pyromancers_ascension;
 mod issue_2415_rottenmouth_viper_sacrifice_cost;
 mod issue_2417_satoru_intervening_if;
+mod issue_2422_demanding_dragon;
 mod issue_2425_fable_chapter_iii_transform;
 mod issue_2430_shifting_woodland;
 mod issue_2431_ultima_tap_land_for_c;


### PR DESCRIPTION
## Summary

- Fixes [#2422](https://github.com/phase-rs/phase/issues/2422): Demanding Dragon's ETB trigger now prompts the targeted opponent to sacrifice a creature before dealing 5 damage.
- Root cause: trigger-side `infer_pronoun_unless_payer` did not bind `"target opponent"` effects to `TargetFilter::Player`, so the unless payer defaulted to `TriggeringPlayer` (the caster) and resolution silently skipped the unless clause.
- Bind payer to `TargetFilter::Player` when the primary effect text contains `"target opponent"` or `"target player"`.

## Test plan

- [x] `cargo test -p engine demanding_dragon`
- [x] Parser: `demanding_dragon_etb_unless_sacrifice_binds_target_player_payer`
- [x] Integration: ETB cast → target P1 → `WaitingFor::UnlessPayment` before life loss