### PR TITLE
fix(keyword): support granted Conspire (CR 702.78)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -2333,7 +2333,7 @@ pub fn synthesize_conspire(face: &mut CardFace) {
 /// `SharesQuality`'s `reference` resolves `SelfRef` to the cost's source — the
 /// cast spell — so each candidate must share a color with the spell being cast
 /// (the color-comparison the engine already performs for Intimidate).
-fn conspire_tap_filter() -> TargetFilter {
+pub fn conspire_tap_filter() -> TargetFilter {
     TargetFilter::Typed(
         TypedFilter::creature()
             .controller(ControllerRef::You)
@@ -2348,7 +2348,7 @@ fn conspire_tap_filter() -> TargetFilter {
 /// CR 702.78a: "copy it" — once, with optional new targets, gated on the conspire
 /// cost having been paid. No `repeat_for`: Conspire copies exactly once, unlike
 /// Replicate (which copies per payment).
-fn conspire_copy_ability_definition() -> AbilityDefinition {
+pub fn conspire_copy_ability_definition() -> AbilityDefinition {
     AbilityDefinition::new(
         AbilityKind::Spell,
         Effect::CopySpell {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2179,6 +2179,7 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
         .clone()
         .or_else(|| replicate_additional.clone());
     let offering_additional = effective_offering_additional_cost(state, player, object_id);
+    let conspire_additional = effective_conspire_additional_cost(state, player, object_id);
 
     let (additional, deferred_required, additional_cost_source) =
         if let Some(AdditionalCost::Required(ref req)) = obj_additional {
@@ -2208,6 +2209,12 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
             // case is handled in the casting dispatch which routes to
             // `begin_required_cost_before_targets` before this function is reached).
             (Some(offering), None, SpellCostSource::Offering)
+        } else if let Some(conspire) = conspire_additional {
+            // CR 702.78a: statics-granted Conspire (Wort, the Raidmother /
+            // Rassilon, the War President). Printed Conspire sets
+            // `obj.additional_cost` and is caught by the `obj_additional.is_some()`
+            // arm above, so this arm fires only for the granted path.
+            (Some(conspire), None, SpellCostSource::Other)
         } else {
             (None, None, SpellCostSource::Other)
         };
@@ -3348,6 +3355,27 @@ pub(super) fn effective_casualty_additional_cost(
         },
         repeatable: false,
     })
+}
+
+/// CR 702.78a: Optional "tap two color-sharing creatures" additional cost from a
+/// spell's effective Conspire keyword, including statics-granted Conspire (Wort,
+/// the Raidmother / Rassilon, the War President). Mirrors
+/// `effective_casualty_additional_cost`.
+pub(super) fn effective_conspire_additional_cost(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+) -> Option<AdditionalCost> {
+    super::casting::effective_spell_keywords(state, player, object_id)
+        .into_iter()
+        .any(|keyword| matches!(keyword, Keyword::Conspire))
+        .then(|| AdditionalCost::Optional {
+            cost: AbilityCost::TapCreatures {
+                count: 2,
+                filter: crate::database::synthesis::conspire_tap_filter(),
+            },
+            repeatable: false,
+        })
 }
 
 /// CR 702.56a: Return the repeatable optional additional cost from a spell's
@@ -6820,6 +6848,122 @@ mod tests {
                     }
                 }
                 other => panic!("expected optional casualty sacrifice cost, got {other:?}"),
+            },
+            other => panic!("expected OptionalCostChoice, got {other:?}"),
+        }
+    }
+
+    /// CR 702.78a: Conspire granted by a `CastWithKeyword` static (Wort, the
+    /// Raidmother / Rassilon) must surface the optional "tap two color-sharing
+    /// creatures" additional cost (`TapCreatures { count: 2 }`) on a matching
+    /// spell — exactly the printed-Conspire offer, but driven by
+    /// `effective_conspire_additional_cost`. Discriminates CHANGE 2: without the
+    /// conspire ladder arm, no `OptionalCostChoice` is offered.
+    #[test]
+    fn granted_conspire_additional_cost_prompts_for_matching_spell() {
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Conspire Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        let grant = crate::types::ability::StaticDefinition::new(StaticMode::CastWithKeyword {
+            keyword: Keyword::Conspire,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Instant).controller(ControllerRef::You),
+        ));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        let spell = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Test Instant".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            // CR 702.78a: the spell must be colored so candidate creatures can
+            // "share a color with it"; red here.
+            obj.color = vec![ManaColor::Red];
+        }
+
+        // Two untapped red creatures the caster controls — eligible conspire tap
+        // targets. The optional offer is gated on payability
+        // (`AbilityCost::is_payable`), so the cost only surfaces when at least
+        // two color-sharing creatures exist.
+        for card in [CardId(3), CardId(4)] {
+            let creature = create_object(
+                &mut state,
+                card,
+                caster,
+                "Red Creature".to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&creature).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.color = vec![ManaColor::Red];
+        }
+
+        let mut events = Vec::new();
+        let waiting = check_additional_cost_or_pay_with_distribute(
+            &mut state,
+            caster,
+            spell,
+            CardId(2),
+            ResolvedAbility::new(
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+                Vec::new(),
+                spell,
+                caster,
+            ),
+            &ManaCost::NoCost,
+            None,
+            CastingVariant::Normal,
+            None,
+            None,
+            Zone::Hand,
+            CastPaymentMode::Auto,
+            &mut events,
+        )
+        .expect("granted conspire should be castable");
+
+        match waiting {
+            WaitingFor::OptionalCostChoice { cost, .. } => match cost {
+                AdditionalCost::Optional {
+                    cost: AbilityCost::TapCreatures { count, filter },
+                    repeatable: false,
+                } => {
+                    assert_eq!(count, 2, "conspire taps exactly two creatures");
+                    match filter {
+                        TargetFilter::Typed(tf) => {
+                            assert!(tf.type_filters.contains(&TypeFilter::Creature));
+                            assert!(tf.properties.iter().any(|p| matches!(
+                                p,
+                                FilterProp::SharesQuality {
+                                    quality: crate::types::ability::SharedQuality::Color,
+                                    ..
+                                }
+                            )));
+                        }
+                        other => panic!("expected typed conspire tap filter, got {other:?}"),
+                    }
+                }
+                other => panic!("expected optional conspire TapCreatures cost, got {other:?}"),
             },
             other => panic!("expected OptionalCostChoice, got {other:?}"),
         }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1671,6 +1671,74 @@ fn collect_pending_triggers(
                 }));
             }
 
+            // CR 702.78a: Conspire's copy trigger is synthesized onto printed
+            // Conspire cards by `synthesize_conspire`. Dynamically granted
+            // Conspire (StaticMode::CastWithKeyword — Wort, the Raidmother /
+            // Rassilon, the War President) has no face-level trigger, so mirror
+            // the dynamic Casualty seam here and reuse the canonical Conspire
+            // ability definition. Skip cards with a printed Conspire keyword:
+            // those already carry the face-synthesized copy trigger.
+            let dynamically_granted_conspire_instances = state
+                .objects
+                .get(cast_obj_id)
+                .filter(|obj| !obj.keywords.iter().any(|k| matches!(k, Keyword::Conspire)))
+                .and_then(|obj| {
+                    let paid = state
+                        .stack
+                        .iter()
+                        .find(|entry| entry.id == *cast_obj_id)
+                        .is_some_and(|entry| {
+                            entry
+                                .ability()
+                                .is_some_and(|ability| ability.context.additional_cost_paid)
+                        });
+                    paid.then_some(obj.controller)
+                })
+                .map(|controller| {
+                    let n =
+                        super::casting::effective_spell_keywords(state, controller, *cast_obj_id)
+                            .iter()
+                            .filter(|keyword| matches!(keyword, Keyword::Conspire))
+                            .count();
+                    (n, controller)
+                })
+                .unwrap_or((0, PlayerId(0)));
+            // CR 702.78b: multiple Conspire instances require per-instance separate
+            // payment, but the engine tracks a single aggregate
+            // `additional_cost_paid` flag, so N instances produce N copies off one
+            // payment here (Casualty-parity). Both grantors today grant at most one
+            // instance (StaticMode upsert), so N=1 is the only live path; this
+            // mirrors `synthesize_conspire`'s count>1 deferral.
+            for _ in 0..dynamically_granted_conspire_instances.0 {
+                let mut conspire_ability = build_resolved_from_def(
+                    &crate::database::synthesis::conspire_copy_ability_definition(),
+                    *cast_obj_id,
+                    dynamically_granted_conspire_instances.1,
+                );
+                // CR 702.78a: surface the paid additional cost on the copy ability's
+                // OWN context so the embedded `additional_cost_paid_any` condition
+                // (re-evaluated at resolution against this copy, not the source
+                // spell) passes. Omitting this fizzles every granted-Conspire copy.
+                conspire_ability.context.additional_cost_paid = true;
+                let timestamp = state.next_timestamp() as u32;
+                pending.push(PendingTriggerContext::single(PendingTrigger {
+                    source_id: *cast_obj_id,
+                    controller: dynamically_granted_conspire_instances.1,
+                    condition: None,
+                    ability: conspire_ability,
+                    timestamp,
+                    target_constraints: Vec::new(),
+                    distribute: None,
+                    trigger_event: Some(event.clone()),
+                    modal: None,
+                    mode_abilities: vec![],
+                    description: Some("Conspire".to_string()),
+                    may_trigger_origin: None,
+                    subject_match_count: None,
+                    die_result: None,
+                }));
+            }
+
             // CR 702.56a: Replicate's copy trigger is synthesized onto printed
             // Replicate cards by `synthesize_replicate`. Dynamically granted
             // Replicate (StaticMode::CastWithKeyword) has no face-level trigger,
@@ -13571,6 +13639,101 @@ pub mod tests {
                 )
             }),
             "paid granted casualty should create a copy trigger"
+        );
+    }
+
+    /// CR 702.78a: Conspire granted by a `CastWithKeyword` static (Wort, the
+    /// Raidmother) with its additional cost paid must enqueue a copy-on-cast
+    /// trigger, exactly like granted Casualty. Discriminates CHANGE 3 — without
+    /// the granted-Conspire block in `process_triggers`, no copy trigger is
+    /// produced.
+    #[test]
+    fn granted_conspire_triggers_copy_when_paid() {
+        let mut state = setup();
+        let caster = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Conspire Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        let grant = StaticDefinition::new(StaticMode::CastWithKeyword {
+            keyword: Keyword::Conspire,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Instant).controller(ControllerRef::You),
+        ));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        let spell = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Test Instant".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            obj.cast_from_zone = Some(Zone::Hand);
+        }
+        let mut ability = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            Vec::new(),
+            spell,
+            caster,
+        );
+        // CR 702.78a: the conspire cost was paid — surfaced on the cast spell's
+        // stack-entry context, which the granted-Conspire block reads to gate
+        // the copy trigger.
+        ability.context.additional_cost_paid = true;
+        state.stack.push_back(StackEntry {
+            id: spell,
+            source_id: spell,
+            controller: caster,
+            kind: StackEntryKind::Spell {
+                card_id: CardId(2),
+                ability: Some(ability),
+                casting_variant: Default::default(),
+                actual_mana_spent: 0,
+            },
+        });
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::SpellCast {
+                object_id: spell,
+                controller: caster,
+                card_id: CardId(2),
+            }],
+        );
+
+        // CR 702.78a: the copy trigger must exist AND its ability context must
+        // carry additional_cost_paid = true (CHANGE 3 binding requirement) so the
+        // embedded `additional_cost_paid_any` condition passes at resolution.
+        let copy_trigger_paid = state.stack.iter().any(|entry| {
+            matches!(
+                &entry.kind,
+                StackEntryKind::TriggeredAbility { ability, .. }
+                    if matches!(
+                        ability.effect,
+                        Effect::CopySpell { target: TargetFilter::SelfRef, .. }
+                    ) && ability.context.additional_cost_paid
+            )
+        });
+        assert!(
+            copy_trigger_paid,
+            "paid granted conspire should create a copy trigger whose context has \
+             additional_cost_paid = true"
         );
     }
 

--- a/crates/engine/tests/conspire_granted_keyword.rs
+++ b/crates/engine/tests/conspire_granted_keyword.rs
@@ -1,0 +1,191 @@
+//! CR 702.78 — Conspire granted by a static ability (Wort, the Raidmother /
+//! Rassilon, the War President) must offer its optional additional cost and copy
+//! the spell when that cost is paid, exactly like printed Conspire.
+//!
+//! Conspire was previously synthesized only from a card's *printed* Conspire
+//! keyword (`synthesize_conspire`). A spell that gains Conspire from a
+//! `StaticMode::CastWithKeyword` static never had the cost offered or the copy
+//! produced, because the synthesis path keys off printed keywords and the
+//! casting ladder / `process_triggers` had no granted-Conspire seam. This
+//! mirrors the working granted-Casualty path (CR 702.153).
+//!
+//! CR 702.78a (docs/MagicCompRules.txt:4564): "Conspire" = an additional cost
+//! ("tap two untapped creatures you control that each share a color with it")
+//! plus a reflexive "when you cast this spell, if its conspire cost was paid,
+//! copy it" trigger.
+//!
+//! CARD TEXT: Wort's oracle text below is this engine's authoritative card data
+//! (`client/public/card-data.json`): "Each red or green instant or sorcery spell
+//! you cast has conspire." The spell under test is a *red* instant, so Wort's
+//! static grants it Conspire regardless of the pre-existing parser quirk in the
+//! red Or-branch (which drops the instant/sorcery type constraint — out of
+//! scope; a red instant matches either way).
+
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::types::ability::{Effect, QuantityExpr, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
+use engine::types::game_state::{PayCostKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+/// Wort, the Raidmother's authoritative oracle text (verified in
+/// `client/public/card-data.json`). The conspire-granting clause is the second
+/// sentence; the ETB token clause is harmless here (no DB token lookup runs in
+/// this scenario, and the cast spell drives the assertions).
+const WORT_ORACLE: &str = "When Wort enters, create two 1/1 red and green Goblin \
+Warrior creature tokens.\nEach red or green instant or sorcery spell you cast has \
+conspire. (As you cast the spell, you may tap two untapped creatures you control \
+that share a color with it. When you do, copy it and you may choose new targets \
+for the copy.)";
+
+/// Add `count` units of `ty` mana to P0's pool (deterministic payment without
+/// modelling lands; mirrors the `add_mana` helper in `chord_of_calling.rs`).
+fn add_mana(runner: &mut GameRunner, ty: ManaType, count: usize) {
+    for _ in 0..count {
+        let unit = ManaUnit::new(ty, ObjectId(0), false, vec![]);
+        runner.state_mut().players[0].mana_pool.add(unit);
+    }
+}
+
+/// Force `id`'s color to red so it (a) matches Wort's "red ... spell you cast"
+/// static and (b) shares a color with the red creatures for the conspire tap
+/// cost (CR 702.78a). The scenario builder leaves `colors` empty and does not
+/// run the load-time color derivation, so set it explicitly.
+fn make_red(runner: &mut GameRunner, id: ObjectId) {
+    runner.state_mut().objects.get_mut(&id).unwrap().color = vec![ManaColor::Red];
+}
+
+/// Count `SpellCopied` events emitted while resolving the stack to empty (each
+/// `Effect::CopySpell` iteration emits exactly one, CR 707.10).
+fn drain_counting_spell_copies(runner: &mut GameRunner) -> usize {
+    let mut copies = 0usize;
+    for _ in 0..40 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        match runner.act(GameAction::PassPriority) {
+            Ok(result) => {
+                copies += result
+                    .events
+                    .iter()
+                    .filter(|e| matches!(e, GameEvent::SpellCopied { .. }))
+                    .count();
+            }
+            Err(_) => break,
+        }
+    }
+    copies
+}
+
+/// End-to-end: Wort grants Conspire to a red instant; paying the optional
+/// tap-two-red-creatures cost copies the spell once (CR 702.78a). Both
+/// assertions FAIL on origin/main — no conspire cost arm (CHANGE 2) and no
+/// granted-Conspire copy trigger (CHANGE 3).
+#[test]
+fn wort_grants_conspire_offers_cost_and_copies_when_paid() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Wort, the Raidmother on P0's battlefield — its CastWithKeyword{Conspire}
+    // static registers from the parsed oracle text.
+    scenario.add_creature_from_oracle(P0, "Wort, the Raidmother", 3, 3, WORT_ORACLE);
+
+    // Two red creatures P0 controls — the conspire tap targets. They must share
+    // a color with the red spell (CR 702.78a).
+    let red_a = scenario.add_creature(P0, "Red Bear A", 2, 2).id();
+    let red_b = scenario.add_creature(P0, "Red Bear B", 2, 2).id();
+
+    // A red instant that just draws — targetless, so conspire's copy resolves
+    // straight through and the copy count is observable via SpellCopied alone.
+    let mut builder = scenario.add_spell_to_hand(P0, "Red Draw", true);
+    builder.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 1,
+    });
+    builder.with_ability(Effect::Draw {
+        count: QuantityExpr::Fixed { value: 1 },
+        target: TargetFilter::Controller,
+    });
+    let spell_id = builder.id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell_id].card_id;
+    make_red(&mut runner, red_a);
+    make_red(&mut runner, red_b);
+    make_red(&mut runner, spell_id);
+    add_mana(&mut runner, ManaType::Colorless, 1); // {1} base cost
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+        })
+        .expect("casting the red instant under Wort must be accepted");
+
+    // (1) CR 702.78a: the granted conspire cost is offered as an OptionalCostChoice
+    //     of TapCreatures { count: 2 }. FAILS on origin/main (no conspire arm).
+    match runner.state().waiting_for.clone() {
+        WaitingFor::OptionalCostChoice { cost, .. } => assert!(
+            matches!(
+                cost,
+                engine::types::ability::AdditionalCost::Optional {
+                    cost: engine::types::ability::AbilityCost::TapCreatures { count: 2, .. },
+                    repeatable: false,
+                }
+            ),
+            "granted Conspire must surface an optional TapCreatures{{2}} cost: {cost:?}"
+        ),
+        other => panic!("expected granted-Conspire OptionalCostChoice, got {other:?}"),
+    }
+
+    // (2) Pay the conspire cost by tapping the two red creatures.
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("electing to pay conspire must be accepted");
+
+    match runner.state().waiting_for.clone() {
+        WaitingFor::PayCost {
+            kind: PayCostKind::TapCreatures,
+            choices,
+            count,
+            ..
+        } => {
+            assert_eq!(count, 2, "conspire taps exactly two creatures");
+            assert!(
+                choices.contains(&red_a) && choices.contains(&red_b),
+                "both red creatures must be eligible conspire tap targets: {choices:?}"
+            );
+        }
+        other => panic!("expected PayCost TapCreatures after paying conspire, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![red_a, red_b],
+        })
+        .expect("tapping two red creatures for conspire must succeed");
+
+    // (3) Both creatures tapped, the original spell is on the stack.
+    assert!(
+        runner.state().objects[&red_a].tapped && runner.state().objects[&red_b].tapped,
+        "both conspire tap targets must be tapped"
+    );
+    assert!(
+        runner.state().stack.iter().any(|e| e.id == spell_id),
+        "the original spell must be on the stack after conspire is paid"
+    );
+
+    // (4) CR 702.78a: resolving the cast trigger copies the spell exactly once.
+    //     FAILS on origin/main (no granted-Conspire copy trigger).
+    let copies = drain_counting_spell_copies(&mut runner);
+    assert_eq!(
+        copies, 1,
+        "granted Conspire paid once must create exactly one copy"
+    );
+}


### PR DESCRIPTION
Cards that grant conspire to other spells — Wort, the Raidmother ("Each
red or green instant or sorcery spell you cast has conspire") and
Rassilon, the War President — did nothing: the granted spell was never
offered the conspire additional cost (tap two creatures that each share a
color with it) and never produced the copy-on-cast trigger. Conspire was
wired only at synthesis time from PRINTED keywords (synthesize_conspire),
so nothing consumed the keyword when it was granted via a CastWithKeyword
static — even though granted Conspire already surfaces in
effective_spell_keywords.

Mirror the Casualty (CR 702.153) granted path, which has the identical
shape (optional additional cost + copy-on-cast trigger) and already works
for granted keywords:
- effective_conspire_additional_cost reads effective_spell_keywords for
  Keyword::Conspire and returns the same Optional { TapCreatures { 2,
  shares-color }, repeatable: false } cost synthesis builds; a new
  cost-detection ladder arm offers it. Printed Conspire sets
  obj.additional_cost and is caught by the earlier arm, so the new arm
  runs only for granted Conspire — no double-offer.
- A granted-Conspire copy-trigger block on SpellCast (mirroring the
  granted-Casualty block) skips objects with printed Conspire, gates on
  the cast's additional_cost_paid, and pushes one copy per effective
  instance. The copy ability's own context is marked additional_cost_paid
  so its intervening-if (CR 603.4 "if its conspire cost was paid",
  encoded as additional_cost_paid_any()) holds at resolution.
- conspire_tap_filter / conspire_copy_ability_definition are exposed pub
  (mirroring casualty_copy_ability_definition); the tap filter's
  shares-a-color reference resolves against the cast spell identically on
  the printed and granted paths.

CR 702.78a: conspire = additional cost (tap two color-sharing creatures)
+ reflexive copy trigger. CR 702.78b: multiple instances are each paid
separately. The granted loop produces N copies for N instances
(Casualty-parity); true per-instance SEPARATE payment is deferred (the
engine's single aggregate additional_cost_paid cannot express it — the
same gap Replicate and synthesize_conspire's count>1 path defer), and
both grantors grant at most one instance per spell today, so N=1 is the
only live path.

Runtime coverage: conspire_granted_keyword.rs drives Wort end-to-end
through the real pipeline (cast a red spell with Wort out → conspire cost
offered → pay by tapping two red creatures → exactly one copy). Plus
co-located unit tests for the cost offer and the paid-copy trigger. Fails
on origin/main (no granted-conspire consumer), passes with the fix.
Printed Conspire (synthesis path) is unchanged.
