### PR TITLE
Exclude phased-out permanents from control conditions (CR 702.26b)

### DIFF
--- a/crates/engine/src/game/attractions.rs
+++ b/crates/engine/src/game/attractions.rs
@@ -102,7 +102,10 @@ fn controls_attraction(state: &GameState, player: PlayerId) -> bool {
         state
             .objects
             .get(id)
-            .is_some_and(|o| o.controller == player && is_attraction_permanent(o))
+            // CR 702.26b: a phased-out permanent is treated as though it does not exist.
+            .is_some_and(|o| {
+                o.controller == player && o.is_phased_in() && is_attraction_permanent(o)
+            })
     })
 }
 
@@ -112,7 +115,8 @@ fn visited_attraction_ids(state: &GameState, player: PlayerId, roll: u8) -> Vec<
         .iter()
         .filter_map(|id| {
             let obj = state.objects.get(id)?;
-            if obj.controller != player || !is_attraction_permanent(obj) {
+            // CR 702.26b: a phased-out permanent is treated as though it does not exist.
+            if obj.controller != player || !obj.is_phased_in() || !is_attraction_permanent(obj) {
                 return None;
             }
             if obj.attraction_lights.contains(&roll) {

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -64,7 +64,8 @@ pub fn controls_any_commander(state: &GameState, player: PlayerId) -> bool {
         state
             .objects
             .get(id)
-            .is_some_and(|obj| obj.controller == player && obj.is_commander)
+            // CR 702.26b: a phased-out permanent is treated as though it does not exist.
+            .is_some_and(|obj| obj.controller == player && obj.is_phased_in() && obj.is_commander)
     })
 }
 
@@ -77,7 +78,13 @@ pub fn controls_own_commander(state: &GameState, player: PlayerId) -> bool {
         state
             .objects
             .get(id)
-            .is_some_and(|obj| obj.is_commander && obj.owner == player && obj.controller == player)
+            // CR 702.26b: a phased-out permanent is treated as though it does not exist.
+            .is_some_and(|obj| {
+                obj.is_commander
+                    && obj.owner == player
+                    && obj.controller == player
+                    && obj.is_phased_in()
+            })
     })
 }
 
@@ -528,6 +535,29 @@ mod tests {
 
         assert!(commander_eligible_for_zone_return(&state).is_none());
         let _ = obj_id; // suppress unused warning
+    }
+
+    // --- Control-Condition Phasing Tests (CR 702.26b) ---
+
+    #[test]
+    fn phased_out_commander_excluded_from_control_conditions() {
+        use crate::game::game_object::{PhaseOutCause, PhaseStatus};
+
+        let mut state = setup_commander_game();
+        let cmd_id = create_commander_in_command_zone(&mut state, PlayerId(0), "Kaalia", vec![]);
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Battlefield, &mut events);
+
+        // Phased in: both "you control a commander" conditions hold.
+        assert!(controls_any_commander(&state, PlayerId(0)));
+        assert!(controls_own_commander(&state, PlayerId(0)));
+
+        // CR 702.26b: a phased-out commander is treated as though it does not exist.
+        state.objects.get_mut(&cmd_id).unwrap().phase_status = PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Directly,
+        };
+        assert!(!controls_any_commander(&state, PlayerId(0)));
+        assert!(!controls_own_commander(&state, PlayerId(0)));
     }
 
     // --- Color Identity Tests ---

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -65,7 +65,7 @@ pub fn controls_any_commander(state: &GameState, player: PlayerId) -> bool {
             .objects
             .get(id)
             // CR 702.26b: a phased-out permanent is treated as though it does not exist.
-            .is_some_and(|obj| obj.controller == player && obj.is_phased_in() && obj.is_commander)
+            .is_some_and(|obj| obj.is_commander && obj.controller == player && obj.is_phased_in())
     })
 }
 
@@ -541,7 +541,8 @@ mod tests {
 
     #[test]
     fn phased_out_commander_excluded_from_control_conditions() {
-        use crate::game::game_object::{PhaseOutCause, PhaseStatus};
+        use crate::game::game_object::PhaseOutCause;
+        use crate::game::phasing::phase_out_object;
 
         let mut state = setup_commander_game();
         let cmd_id = create_commander_in_command_zone(&mut state, PlayerId(0), "Kaalia", vec![]);
@@ -553,9 +554,7 @@ mod tests {
         assert!(controls_own_commander(&state, PlayerId(0)));
 
         // CR 702.26b: a phased-out commander is treated as though it does not exist.
-        state.objects.get_mut(&cmd_id).unwrap().phase_status = PhaseStatus::PhasedOut {
-            cause: PhaseOutCause::Directly,
-        };
+        phase_out_object(&mut state, cmd_id, PhaseOutCause::Directly, &mut events);
         assert!(!controls_any_commander(&state, PlayerId(0)));
         assert!(!controls_own_commander(&state, PlayerId(0)));
     }

--- a/crates/engine/src/game/speed.rs
+++ b/crates/engine/src/game/speed.rs
@@ -111,7 +111,10 @@ pub fn decrease_speed(
 pub fn controls_start_your_engines(state: &GameState, player: PlayerId) -> bool {
     state.battlefield.iter().any(|id| {
         state.objects.get(id).is_some_and(|obj| {
-            obj.controller == player && obj.has_keyword(&Keyword::StartYourEngines)
+            // CR 702.26b: a phased-out permanent is treated as though it does not exist.
+            obj.controller == player
+                && obj.is_phased_in()
+                && obj.has_keyword(&Keyword::StartYourEngines)
         })
     })
 }


### PR DESCRIPTION
## Summary

A phased-out permanent is treated as though it does not exist (CR 702.26b), so it must not satisfy "you control a [permanent]" conditions. Several such predicates scanned the raw battlefield with only a controller/owner filter and **no phased-out guard**, so a permanent phased out (e.g. by Teferi's Protection) wrongly kept satisfying them:

- `commander.rs::controls_any_commander` / `controls_own_commander` — gate "you control [your] commander" conditions (CR 903.3).
- `speed.rs::controls_start_your_engines` (CR 702.179a).
- `attractions.rs::controls_attraction` — and `visited_attraction_ids`, so a phased-out Attraction is no longer rolled to visit.

This is the same bug class as the merged devotion (#2590) and activation/casting-condition (#2596) fixes and the open domain report (#2591). Each predicate now requires `obj.is_phased_in()`, mirroring the canonical `filter.rs` exclusion.

## Testing

- `cargo fmt --all`, `clippy -p engine --all-targets --features proptest -- -D warnings` clean.
- New regression test `phased_out_commander_excluded_from_control_conditions` in `commander.rs`: a controlled commander satisfies both conditions while phased in, neither while phased out.
- Internal-only change (no signature/enum changes), so no `phase-ai` or frontend ripple.

Closes #2605