### PR TITLE
feat(engine): Splice onto Arcane runtime (CR 702.47)

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  serialize-javascript@<7.0.5: 7.0.5
+  ws@<8.20.1: 8.20.1
+  picomatch: '>=4.0.4'
+  lodash: '>=4.18.0'
+  postcss: '>=8.5.10'
+
 importers:
 
   .:

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -4,13 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  serialize-javascript@<7.0.5: 7.0.5
-  ws@<8.20.1: 8.20.1
-  picomatch: '>=4.0.4'
-  lodash: '>=4.18.0'
-  postcss: '>=8.5.10'
-
 importers:
 
   .:
@@ -1261,89 +1254,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1519,66 +1528,79 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -1673,36 +1695,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.33':
     resolution: {integrity: sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.33':
     resolution: {integrity: sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.33':
     resolution: {integrity: sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.33':
     resolution: {integrity: sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.33':
     resolution: {integrity: sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.33':
     resolution: {integrity: sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==}
@@ -1778,24 +1806,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1856,30 +1888,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.1':
     resolution: {integrity: sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.1':
     resolution: {integrity: sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.1':
     resolution: {integrity: sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.1':
     resolution: {integrity: sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.1':
     resolution: {integrity: sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==}
@@ -2668,7 +2705,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3228,24 +3265,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3490,6 +3531,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3531,6 +3576,9 @@ packages:
 
   quick-temp@0.1.9:
     resolution: {integrity: sha512-yI0h7tIhKVObn03kD+Ln9JFi4OljD28lfaOsTdfpTR0xzrhGOod+q66CjGafUqYX2juUfT9oHIGrTBBo22mkRA==}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -3708,9 +3756,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@7.0.5:
-    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
-    engines: {node: '>=20.0.0'}
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -4346,6 +4393,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
@@ -5662,7 +5721,7 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@2.80.0)':
     dependencies:
-      serialize-javascript: 7.0.5
+      serialize-javascript: 6.0.2
       smob: 1.6.2
       terser: 5.48.0
     optionalDependencies:
@@ -5676,7 +5735,7 @@ snapshots:
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
-      picomatch: 4.0.4
+      picomatch: 2.3.2
       rollup: 2.80.0
 
   '@rollup/pluginutils@5.3.0(rollup@2.80.0)':
@@ -6314,7 +6373,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   argparse@2.0.1: {}
 
@@ -7630,7 +7689,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.8
       workerd: 1.20260507.1
-      ws: 8.20.1
+      ws: 8.18.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -7782,6 +7841,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -7815,6 +7876,10 @@ snapshots:
       mktemp: 2.0.3
       rimraf: 5.0.10
       underscore.string: 3.3.6
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -8015,7 +8080,9 @@ snapshots:
 
   semver@7.8.0: {}
 
-  serialize-javascript@7.0.5: {}
+  serialize-javascript@6.0.2:
+    dependencies:
+      randombytes: 2.1.0
 
   set-cookie-parser@2.7.2: {}
 
@@ -8829,6 +8896,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.18.0: {}
 
   ws@8.20.1: {}
 

--- a/client/src/adapter/__tests__/boundary-guardrails.test.ts
+++ b/client/src/adapter/__tests__/boundary-guardrails.test.ts
@@ -131,6 +131,22 @@ describe("adapter boundary guardrails", () => {
     expect(isWaitingForHandled(waitingFor)).toBe(true);
   });
 
+  it("handles the splice offer waiting payload", () => {
+    const waitingFor: WaitingFor = {
+      type: "SpliceOffer",
+      data: {
+        player: 0,
+        pending_cast: {} as Extract<
+          WaitingFor,
+          { type: "SpliceOffer" }
+        >["data"]["pending_cast"],
+        eligible: [2],
+      },
+    };
+
+    expect(isWaitingForHandled(waitingFor)).toBe(true);
+  });
+
   it("keeps the frontend GameAction union in lockstep with the engine enum", () => {
     const root = repoRoot();
     const rustSource = readFileSync(resolve(root, "crates/engine/src/types/actions.rs"), "utf8");

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1101,6 +1101,7 @@ export type WaitingFor =
   | { type: "AbilityModeChoice"; data: { player: PlayerId; modal: ModalChoice; source_id: ObjectId; mode_abilities: unknown[]; is_activated: boolean; ability_index?: number; ability_cost?: unknown; unavailable_modes?: number[] } }
   | { type: "DiscardToHandSize"; data: { player: PlayerId; count: number; cards: ObjectId[] } }
   | { type: "OptionalCostChoice"; data: { player: PlayerId; cost: AdditionalCost; times_kicked: number; pending_cast: PendingCast } }
+  | { type: "SpliceOffer"; data: { player: PlayerId; pending_cast: PendingCast; eligible: ObjectId[] } }
   | { type: "DefilerPayment"; data: { player: PlayerId; life_cost: number; mana_reduction: ManaCost; pending_cast: PendingCast } }
   | { type: "CastOffer"; data: { player: PlayerId; kind: CastOfferKind } }
   | { type: "ModalFaceChoice"; data: { player: PlayerId; object_id: ObjectId; card_id: CardId } }
@@ -1480,6 +1481,7 @@ export type GameAction =
   | { type: "ChooseDamageSource"; data: { source: ObjectId } }
   | { type: "SelectModes"; data: { indices: number[] } }
   | { type: "DecideOptionalCost"; data: { pay: boolean } }
+  | { type: "RespondToSpliceOffer"; data: { card: ObjectId | null } }
   | { type: "ChooseAdventureFace"; data: { creature: boolean } }
   | { type: "ChooseModalFace"; data: { back_face: boolean } }
   | { type: "ChooseAlternativeCast"; data: { choice: { type: "Normal" } | { type: "Alternative" } } }

--- a/client/src/components/modal/SpliceOfferModal.tsx
+++ b/client/src/components/modal/SpliceOfferModal.tsx
@@ -1,0 +1,75 @@
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+
+import type { GameAction, ObjectId, WaitingFor } from "../../adapter/types.ts";
+import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import { ChoiceModal } from "./ChoiceModal.tsx";
+
+type SpliceOfferWaitingFor = Extract<WaitingFor, { type: "SpliceOffer" }>;
+
+function respond(card: ObjectId | null): GameAction {
+  return { type: "RespondToSpliceOffer", data: { card } };
+}
+
+export function SpliceOfferModal() {
+  const { t } = useTranslation("game");
+  const dispatch = useGameDispatch();
+  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const objects = useGameStore((s) => s.gameState?.objects);
+
+  if (waitingFor?.type !== "SpliceOffer") return null;
+
+  return (
+    <SpliceOfferModalContent
+      waitingFor={waitingFor}
+      objectName={(id) =>
+        objects?.[id]?.name ?? t("gamePage.spliceOffer.unknownCard", { id })
+      }
+      dispatch={dispatch}
+      t={t}
+    />
+  );
+}
+
+function SpliceOfferModalContent({
+  waitingFor,
+  objectName,
+  dispatch,
+  t,
+}: {
+  waitingFor: SpliceOfferWaitingFor;
+  objectName: (id: ObjectId) => string;
+  dispatch: (action: GameAction) => void | Promise<void>;
+  t: TFunction<"game">;
+}) {
+  const options = [
+    ...waitingFor.data.eligible.map((card) => {
+      const name = objectName(card);
+      return {
+        id: String(card),
+        label: t("gamePage.spliceOffer.spliceCard", { name }),
+      };
+    }),
+    {
+      id: "decline",
+      label: t("gamePage.spliceOffer.decline"),
+      description: t("gamePage.spliceOffer.declineDescription"),
+    },
+  ];
+
+  const choose = (id: string) => {
+    const card = id === "decline" ? null : Number.parseInt(id, 10);
+    void dispatch(respond(card));
+  };
+
+  return (
+    <ChoiceModal
+      title={t("gamePage.spliceOffer.title")}
+      subtitle={t("gamePage.spliceOffer.subtitle")}
+      options={options}
+      onChoose={choose}
+      onClose={() => void dispatch(respond(null))}
+    />
+  );
+}

--- a/client/src/components/modal/__tests__/SpliceOfferModal.test.tsx
+++ b/client/src/components/modal/__tests__/SpliceOfferModal.test.tsx
@@ -1,0 +1,103 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameObject, GameState, WaitingFor } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { SpliceOfferModal } from "../SpliceOfferModal.tsx";
+
+const dispatchMock = vi.fn();
+
+vi.mock("../../../hooks/useGameDispatch.ts", () => ({
+  useGameDispatch: () => dispatchMock,
+}));
+
+function makeObject(id: number, name: string): GameObject {
+  return {
+    id,
+    card_id: id,
+    owner: 0,
+    controller: 0,
+    zone: "Hand",
+    tapped: false,
+    face_down: false,
+    flipped: false,
+    transformed: false,
+    damage_marked: 0,
+    dealt_deathtouch_damage: false,
+    attached_to: null,
+    attachments: [],
+    counters: {},
+    name,
+    power: null,
+    toughness: null,
+    loyalty: null,
+    card_types: { supertypes: [], core_types: ["Instant"], subtypes: ["Arcane"] },
+    mana_cost: { type: "Cost", shards: ["Blue"], generic: 1 },
+    keywords: [],
+    abilities: [],
+    trigger_definitions: [],
+    replacement_definitions: [],
+    static_definitions: [],
+    color: ["Blue"],
+    base_power: null,
+    base_toughness: null,
+    base_keywords: [],
+    base_color: ["Blue"],
+    timestamp: 1,
+    entered_battlefield_turn: null,
+  };
+}
+
+function setWaitingFor(waitingFor: WaitingFor) {
+  const gameState = {
+    active_player: 0,
+    objects: {
+      42: makeObject(42, "Peer Through Depths"),
+    },
+    priority_player: 0,
+    waiting_for: waitingFor,
+  } as unknown as GameState;
+
+  useGameStore.setState({
+    gameState,
+    waitingFor,
+  });
+}
+
+describe("SpliceOfferModal", () => {
+  beforeEach(() => {
+    dispatchMock.mockReset();
+    dispatchMock.mockResolvedValue(undefined);
+    setWaitingFor({
+      type: "SpliceOffer",
+      data: {
+        player: 0,
+        pending_cast: {} as Extract<
+          WaitingFor,
+          { type: "SpliceOffer" }
+        >["data"]["pending_cast"],
+        eligible: [42],
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("dispatches the selected splice card or decline response", () => {
+    render(<SpliceOfferModal />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Splice Peer Through Depths/ }));
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "RespondToSpliceOffer",
+      data: { card: 42 },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Don.t Splice/ }));
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "RespondToSpliceOffer",
+      data: { card: null },
+    });
+  });
+});

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -46,6 +46,7 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     "AbilityModeChoice",
     "ModalFaceChoice",
     "AlternativeCastChoice",
+    "SpliceOffer",
     // CR 702.140c + CR 730.2a: mutate top/bottom merge choice (MutateMergeChoiceModal).
     "MutateMergeChoice",
     // CR 702.99a: cipher encode-on-resolve choice (CipherEncodeChoiceModal).

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -727,6 +727,14 @@
       "dontPay": "Nicht bezahlen",
       "takeEffect": "Den Effekt hinnehmen"
     },
+    "spliceOffer": {
+      "title": "An Arkan koppeln?",
+      "subtitle": "Wähle eine Karte, die du vorzeigst und in diesen Zauberspruch einkoppelst, oder wirke ohne Kopplung.",
+      "spliceCard": "{{name}} einkoppeln",
+      "decline": "Nicht einkoppeln",
+      "declineDescription": "Wirke den Zauberspruch, ohne den Text einer anderen Karte hinzuzufügen.",
+      "unknownCard": "Karte #{{id}}"
+    },
     "activationCost": {
       "title": "Aktivierungskosten wählen"
     },

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -727,6 +727,14 @@
       "dontPay": "Don’t Pay",
       "takeEffect": "Take the Effect"
     },
+    "spliceOffer": {
+      "title": "Splice onto Arcane?",
+      "subtitle": "Choose a card to reveal and splice into this spell, or cast without splicing.",
+      "spliceCard": "Splice {{name}}",
+      "decline": "Don’t Splice",
+      "declineDescription": "Cast the spell without adding another card’s text.",
+      "unknownCard": "Card #{{id}}"
+    },
     "activationCost": {
       "title": "Choose Activation Cost"
     },

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -727,6 +727,14 @@
       "dontPay": "No pagar",
       "takeEffect": "Aceptar el efecto"
     },
+    "spliceOffer": {
+      "title": "¿Empalmar con arcano?",
+      "subtitle": "Elige una carta para revelar y empalmar en este hechizo, o lánzalo sin empalmar.",
+      "spliceCard": "Empalmar {{name}}",
+      "decline": "No empalmar",
+      "declineDescription": "Lanza el hechizo sin añadir el texto de otra carta.",
+      "unknownCard": "Carta #{{id}}"
+    },
     "activationCost": {
       "title": "Elegir coste de activación"
     },

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -727,6 +727,14 @@
       "dontPay": "Ne pas payer",
       "takeEffect": "Subir l'effet"
     },
+    "spliceOffer": {
+      "title": "Imprégner d’arcane ?",
+      "subtitle": "Choisissez une carte à révéler et à imprégner dans ce sort, ou lancez-le sans imprégnation.",
+      "spliceCard": "Imprégner {{name}}",
+      "decline": "Ne pas imprégner",
+      "declineDescription": "Lancez le sort sans ajouter le texte d’une autre carte.",
+      "unknownCard": "Carte #{{id}}"
+    },
     "activationCost": {
       "title": "Choisir le coût d'activation"
     },

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -727,6 +727,14 @@
       "dontPay": "Non pagare",
       "takeEffect": "Subisci l'effetto"
     },
+    "spliceOffer": {
+      "title": "Unire ad Arcano?",
+      "subtitle": "Scegli una carta da rivelare e unire a questa magia, oppure lanciala senza unire.",
+      "spliceCard": "Unisci {{name}}",
+      "decline": "Non unire",
+      "declineDescription": "Lancia la magia senza aggiungere il testo di un’altra carta.",
+      "unknownCard": "Carta #{{id}}"
+    },
     "activationCost": {
       "title": "Scegli il costo di attivazione"
     },

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -727,6 +727,14 @@
       "dontPay": "Nie płać",
       "takeEffect": "Przyjmij efekt"
     },
+    "spliceOffer": {
+      "title": "Połącz z Arcane?",
+      "subtitle": "Wybierz kartę do ujawnienia i połączenia z tym czarem albo rzuć go bez łączenia.",
+      "spliceCard": "Połącz {{name}}",
+      "decline": "Nie łącz",
+      "declineDescription": "Rzuć czar bez dodawania tekstu innej karty.",
+      "unknownCard": "Karta #{{id}}"
+    },
     "activationCost": {
       "title": "Wybierz koszt aktywacji"
     },

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -727,6 +727,14 @@
       "dontPay": "Não Pagar",
       "takeEffect": "Aceitar o Efeito"
     },
+    "spliceOffer": {
+      "title": "Unir com Arcano?",
+      "subtitle": "Escolha uma carta para revelar e unir a esta mágica, ou conjure sem unir.",
+      "spliceCard": "Unir {{name}}",
+      "decline": "Não Unir",
+      "declineDescription": "Conjure a mágica sem adicionar o texto de outra carta.",
+      "unknownCard": "Carta #{{id}}"
+    },
     "activationCost": {
       "title": "Escolher Custo de Ativação"
     },

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -57,6 +57,7 @@ import { ModalFaceModal } from "../components/modal/ModalFaceModal.tsx";
 import { AlternativeCostModal } from "../components/modal/AlternativeCostModal.tsx";
 import { CastingVariantModal } from "../components/modal/CastingVariantModal.tsx";
 import { MiracleRevealModal } from "../components/modal/MiracleRevealModal.tsx";
+import { SpliceOfferModal } from "../components/modal/SpliceOfferModal.tsx";
 import { CardChoiceModal } from "../components/modal/CardChoiceModal.tsx";
 import { ChoiceModal } from "../components/modal/ChoiceModal.tsx";
 import { OptionalEffectModalContent } from "../components/modal/OptionalEffectModal.tsx";
@@ -1395,6 +1396,10 @@ function GamePageContent({
         <CascadeChoiceModal />
         <ModalFaceModal />
         <MiracleRevealModal />
+        {waitingFor?.type === "SpliceOffer" &&
+          canActForWaitingState && (
+            <SpliceOfferModal />
+          )}
 
         {/* Scry/Dig/Surveil card choice modal */}
         <CardChoiceModal />

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1337,6 +1337,24 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
                 Some(*player),
             ),
         ],
+        // CR 702.47a–e: splice another eligible card onto the spell, or finish.
+        WaitingFor::SpliceOffer {
+            player, eligible, ..
+        } => {
+            let mut actions = vec![candidate(
+                GameAction::RespondToSpliceOffer { card: None },
+                TacticalClass::Selection,
+                Some(*player),
+            )];
+            actions.extend(eligible.iter().map(|&card| {
+                candidate(
+                    GameAction::RespondToSpliceOffer { card: Some(card) },
+                    TacticalClass::Selection,
+                    Some(*player),
+                )
+            }));
+            actions
+        }
         // CR 107.4f + CR 601.2f: AI picks per-shard Phyrexian payment.
         // Heuristic (life threshold): with life > 6, the AI prefers 2-life per shard for
         // tempo (keep mana for other plays); with life <= 6, the AI preserves life.

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -275,6 +275,7 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
         | (WaitingFor::ClashChooseOpponent { .. }, GameAction::ChooseClashOpponent { .. })
         | (WaitingFor::ClashCardPlacement { .. }, GameAction::ChooseTopOrBottom { .. })
         | (WaitingFor::OptionalCostChoice { .. }, GameAction::DecideOptionalCost { .. })
+        | (WaitingFor::SpliceOffer { .. }, GameAction::RespondToSpliceOffer { .. })
         | (WaitingFor::DefilerPayment { .. }, GameAction::DecideOptionalCost { .. })
         | (WaitingFor::OptionalEffectChoice { .. }, GameAction::DecideOptionalEffect { .. })
         | (

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -43,6 +43,7 @@ use super::mana_payment;
 use super::quantity::resolve_quantity;
 use super::restrictions;
 use super::speed::{effective_speed, set_speed};
+use super::splice;
 use super::stack;
 use super::targeting;
 
@@ -7691,6 +7692,32 @@ fn continue_with_prepared(
     }
 
     // CR 702.119a-c + CR 601.2b/h: Emerge requires choosing which creature to
+    // CR 702.47a–e + CR 601.2b: Splice onto [subtype] is announced as the spell
+    // is cast, before targets are chosen and before the total cost is locked. If
+    // the caster holds any card that can be spliced onto this spell, offer the
+    // reveal-and-merge choice now; accepting merges the spliced text box into
+    // `resolved` so the deferred-target step below collects its targets too.
+    let splice_eligible = splice::eligible_splice_cards(state, player, prepared.object_id);
+    if !splice_eligible.is_empty() {
+        return Ok(splice::begin_offer(
+            prepared.object_id,
+            prepared.card_id,
+            resolved,
+            prepared.mana_cost.clone(),
+            prepared.base_mana_cost.clone(),
+            prepared.casting_variant,
+            prepared.cast_timing_permission,
+            prepared
+                .ability_def
+                .as_ref()
+                .and_then(|a| a.distribute.clone()),
+            prepared.origin_zone,
+            prepared.payment_mode,
+            player,
+            splice_eligible,
+        ));
+    }
+
     // sacrifice as the player chooses to pay the emerge cost, then sacrificing
     // it as that cost is paid. Route this before any target selection so the
     // required sacrifice is declared on the CR 601.2b axis.

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7691,12 +7691,11 @@ fn continue_with_prepared(
         }
     }
 
-    // CR 702.119a-c + CR 601.2b/h: Emerge requires choosing which creature to
     // CR 702.47a–e + CR 601.2b: Splice onto [subtype] is announced as the spell
-    // is cast, before targets are chosen and before the total cost is locked. If
-    // the caster holds any card that can be spliced onto this spell, offer the
-    // reveal-and-merge choice now; accepting merges the spliced text box into
-    // `resolved` so the deferred-target step below collects its targets too.
+    // is cast on the same pre-target declaration axis as Emerge/Casualty/etc.
+    // It runs after the host ability is built and before later additional-cost
+    // prompts because accepting merges text that may add targets to collect in
+    // CR 601.2c and cost inputs to lock in CR 601.2f.
     let splice_eligible = splice::eligible_splice_cards(state, player, prepared.object_id);
     if !splice_eligible.is_empty() {
         return Ok(splice::begin_offer(
@@ -7718,6 +7717,7 @@ fn continue_with_prepared(
         ));
     }
 
+    // CR 702.119a-c + CR 601.2b/h: Emerge requires choosing which creature to
     // sacrifice as the player chooses to pay the emerge cost, then sacrificing
     // it as that cost is paid. Route this before any target selection so the
     // required sacrifice is declared on the CR 601.2b axis.

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -739,7 +739,7 @@ pub(super) fn drain_deferred_triggers_after_stack_object_announcement(
         .unwrap_or(waiting_for)
 }
 
-fn begin_deferred_target_selection(
+pub(crate) fn begin_deferred_target_selection(
     state: &mut GameState,
     player: PlayerId,
     mut pending: PendingCast,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -43,6 +43,7 @@ use super::public_state::{
     mark_public_state_from_events, sync_waiting_for,
 };
 use super::sba;
+use super::splice;
 use super::triggers;
 use super::turn_control;
 use super::turns;
@@ -2056,6 +2057,31 @@ fn apply_action(
         )?,
         (
             WaitingFor::OptionalCostChoice {
+                player,
+                pending_cast,
+                ..
+            },
+            GameAction::CancelCast,
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        // CR 702.47a–e: Splice — caster reveals a card to splice onto the spell
+        // (re-offering for the rest), or declines to finish and proceed to targets.
+        (
+            WaitingFor::SpliceOffer {
+                player,
+                pending_cast,
+                eligible,
+            },
+            GameAction::RespondToSpliceOffer { card },
+        ) => splice::resolve_offer(
+            state,
+            *player,
+            *pending_cast.clone(),
+            eligible.clone(),
+            card,
+            &mut events,
+        )?,
+        (
+            WaitingFor::SpliceOffer {
                 player,
                 pending_cast,
                 ..

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -92,6 +92,9 @@ pub mod scenario;
 pub mod scenario_db;
 pub mod specialize;
 pub mod speed;
+pub mod splice;
+#[cfg(test)]
+mod splice_tests;
 pub mod stack;
 pub mod static_abilities;
 pub mod static_source_index;

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1452,6 +1452,7 @@ impl GameRunner {
             WaitingFor::ModeChoice { .. } => "ModeChoice",
             WaitingFor::DiscardToHandSize { .. } => "DiscardToHandSize",
             WaitingFor::OptionalCostChoice { .. } => "OptionalCostChoice",
+            WaitingFor::SpliceOffer { .. } => "SpliceOffer",
             WaitingFor::DefilerPayment { .. } => "DefilerPayment",
             WaitingFor::CastOffer {
                 kind: CastOfferKind::Adventure { .. },

--- a/crates/engine/src/game/splice.rs
+++ b/crates/engine/src/game/splice.rs
@@ -141,6 +141,10 @@ pub(crate) fn resolve_offer(
         .ok_or_else(|| EngineError::InvalidAction("Splice card object missing".to_string()))?;
     let (_, splice_cost) = splice_grant(obj)
         .ok_or_else(|| EngineError::InvalidAction("Splice card lost its keyword".to_string()))?;
+    let def = combined_spell_ability_def(obj).ok_or_else(|| {
+        EngineError::InvalidAction("Splice card has no spell ability to copy".to_string())
+    })?;
+    let card_name = obj.name.clone();
 
     // CR 702.47b: the splice cost is an additional cost. Spliced cards never
     // carry {X}, so folding the fixed mana into both the working cost and the
@@ -153,13 +157,10 @@ pub(crate) fn resolve_offer(
     // CR 702.47c: copy the card's text box onto the host spell. The cloned
     // ability is sourced to the host spell object and controlled by the caster
     // so its effects resolve as part of that spell.
-    if let Some(def) = combined_spell_ability_def(obj) {
-        let spliced = build_resolved_from_def(&def, pending.object_id, player);
-        append_to_sub_chain(&mut pending.ability, spliced);
-    }
+    let spliced = build_resolved_from_def(&def, pending.object_id, player);
+    append_to_sub_chain(&mut pending.ability, spliced);
 
     // CR 702.47a: the card is revealed and stays in hand.
-    let card_name = obj.name.clone();
     events.push(GameEvent::CardsRevealed {
         player,
         card_ids: vec![card],

--- a/crates/engine/src/game/splice.rs
+++ b/crates/engine/src/game/splice.rs
@@ -1,0 +1,181 @@
+//! CR 702.47: Splice onto [subtype] — reveal a card from hand and copy its text
+//! box onto a spell of the matching subtype you're casting, paying its splice
+//! cost as an additional cost.
+//!
+//! Splice is announced during CR 601.2b (as the spell is cast, before targets
+//! and before the total cost is locked), so this module hooks the cast pipeline
+//! at the same pre-target seam that Emerge and Casualty use. When the caster
+//! reveals a splice card:
+//!
+//! * its splice cost is folded into the host spell's mana cost (CR 702.47b);
+//! * its text-box spell ability is cloned and appended to the host spell's
+//!   resolved-ability chain (CR 702.47c) so it resolves as part of that spell;
+//! * the card is revealed and **stays in the caster's hand** (CR 702.47a).
+//!
+//! Because the spliced abilities are merged into `PendingCast::ability` *before*
+//! target selection, the existing deferred-target machinery
+//! ([`casting_costs::begin_deferred_target_selection`]) collects targets for the
+//! spliced effects alongside the host spell's own targets (CR 702.47c–d). Any
+//! number of cards may be spliced onto one spell (CR 702.47e) — the offer is
+//! re-presented after each acceptance until the caster declines or the hand runs
+//! out of eligible cards.
+
+use crate::game::ability_utils::{append_to_sub_chain, build_resolved_from_def};
+use crate::game::casting::combined_spell_ability_def;
+use crate::game::casting_costs::begin_deferred_target_selection;
+use crate::game::engine::EngineError;
+use crate::game::game_object::GameObject;
+use crate::types::ability::{CastTimingPermission, ResolvedAbility};
+use crate::types::events::GameEvent;
+use crate::types::game_state::{
+    CastPaymentMode, CastingVariant, DistributionUnit, GameState, PendingCast, WaitingFor,
+};
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::keywords::Keyword;
+use crate::types::mana::ManaCost;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+/// CR 702.47a: Extract the splice subtype and cost an object grants while in
+/// hand, if any.
+fn splice_grant(obj: &GameObject) -> Option<(&str, &ManaCost)> {
+    obj.keywords.iter().find_map(|k| match k {
+        Keyword::Splice { subtype, cost } => Some((subtype.as_str(), cost)),
+        _ => None,
+    })
+}
+
+/// CR 702.47a: Cards in `player`'s hand that may be spliced onto the spell with
+/// id `spell_obj_id` — i.e. cards whose "Splice onto [subtype]" subtype matches
+/// one of the spell's subtypes. Returns them in hand order so the offer is
+/// stable. The spell being cast is never itself a candidate (it is on the stack,
+/// not in hand, but the guard makes the intent explicit).
+pub(crate) fn eligible_splice_cards(
+    state: &GameState,
+    player: PlayerId,
+    spell_obj_id: ObjectId,
+) -> Vec<ObjectId> {
+    let Some(spell) = state.objects.get(&spell_obj_id) else {
+        return Vec::new();
+    };
+    let spell_subtypes = spell.card_types.subtypes.clone();
+    state.players[player.0 as usize]
+        .hand
+        .iter()
+        .copied()
+        .filter(|&id| id != spell_obj_id)
+        .filter(|id| {
+            state.objects.get(id).is_some_and(|card| {
+                splice_grant(card)
+                    .is_some_and(|(subtype, _)| spell_subtypes.iter().any(|s| s == subtype))
+            })
+        })
+        .collect()
+}
+
+/// CR 601.2b + CR 702.47a: Present the splice offer for a freshly announced
+/// Arcane (or other matching-subtype) spell. Builds the in-flight `PendingCast`
+/// for the host spell — mirroring the pre-target cost branches in
+/// `continue_with_prepared` — and pauses on [`WaitingFor::SpliceOffer`]. Callers
+/// must only invoke this when `eligible` is non-empty.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn begin_offer(
+    object_id: ObjectId,
+    card_id: CardId,
+    ability: ResolvedAbility,
+    mana_cost: ManaCost,
+    base_mana_cost: ManaCost,
+    casting_variant: CastingVariant,
+    cast_timing_permission: Option<CastTimingPermission>,
+    distribute: Option<DistributionUnit>,
+    origin_zone: Zone,
+    payment_mode: CastPaymentMode,
+    player: PlayerId,
+    eligible: Vec<ObjectId>,
+) -> WaitingFor {
+    let mut pending = PendingCast::new(object_id, card_id, ability, mana_cost);
+    pending.base_cost = Some(base_mana_cost);
+    pending.casting_variant = casting_variant;
+    pending.cast_timing_permission = cast_timing_permission;
+    pending.distribute = distribute;
+    pending.origin_zone = origin_zone;
+    pending.payment_mode = payment_mode;
+    WaitingFor::SpliceOffer {
+        player,
+        pending_cast: Box::new(pending),
+        eligible,
+    }
+}
+
+/// CR 702.47b–e: Resolve the caster's response to a splice offer.
+///
+/// * `Some(card)` — splice `card` onto the host spell: fold its splice cost into
+///   the host's total cost (CR 702.47b), clone its text-box spell ability onto
+///   the host's resolved-ability chain (CR 702.47c), reveal it (it stays in
+///   hand, CR 702.47a), then re-offer the remaining eligible cards (CR 702.47e).
+/// * `None` — the caster is done splicing: proceed to target selection for the
+///   merged ability and on into cost payment (CR 601.2c onward).
+pub(crate) fn resolve_offer(
+    state: &mut GameState,
+    player: PlayerId,
+    mut pending: PendingCast,
+    mut eligible: Vec<ObjectId>,
+    card: Option<ObjectId>,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let Some(card) = card else {
+        // CR 601.2c: done splicing — collect targets for the merged ability,
+        // then pay the (splice-inclusive) cost.
+        return begin_deferred_target_selection(state, player, pending, events);
+    };
+
+    if !eligible.contains(&card) {
+        return Err(EngineError::ActionNotAllowed(
+            "Card is not an eligible splice card for this spell".to_string(),
+        ));
+    }
+
+    let obj = state
+        .objects
+        .get(&card)
+        .ok_or_else(|| EngineError::InvalidAction("Splice card object missing".to_string()))?;
+    let (_, splice_cost) = splice_grant(obj)
+        .ok_or_else(|| EngineError::InvalidAction("Splice card lost its keyword".to_string()))?;
+
+    // CR 702.47b: the splice cost is an additional cost. Spliced cards never
+    // carry {X}, so folding the fixed mana into both the working cost and the
+    // tax/X base keeps the eventual concrete-cost recompute correct.
+    pending.cost = pending.cost.plus(splice_cost);
+    if let Some(base) = pending.base_cost.as_mut() {
+        *base = base.plus(splice_cost);
+    }
+
+    // CR 702.47c: copy the card's text box onto the host spell. The cloned
+    // ability is sourced to the host spell object and controlled by the caster
+    // so its effects resolve as part of that spell.
+    if let Some(def) = combined_spell_ability_def(obj) {
+        let spliced = build_resolved_from_def(&def, pending.object_id, player);
+        append_to_sub_chain(&mut pending.ability, spliced);
+    }
+
+    // CR 702.47a: the card is revealed and stays in hand.
+    let card_name = obj.name.clone();
+    events.push(GameEvent::CardsRevealed {
+        player,
+        card_ids: vec![card],
+        card_names: vec![card_name],
+    });
+
+    eligible.retain(|&id| id != card);
+
+    // CR 702.47e: more than one card may be spliced onto the same spell.
+    if eligible.is_empty() {
+        begin_deferred_target_selection(state, player, pending, events)
+    } else {
+        Ok(WaitingFor::SpliceOffer {
+            player,
+            pending_cast: Box::new(pending),
+            eligible,
+        })
+    }
+}

--- a/crates/engine/src/game/splice_tests.rs
+++ b/crates/engine/src/game/splice_tests.rs
@@ -1,0 +1,200 @@
+//! Tests for Splice onto Arcane (CR 702.47). Declared from `game/mod.rs` so
+//! `splice.rs` stays implementation-only.
+
+use super::splice::{eligible_splice_cards, resolve_offer};
+use crate::database::mtgjson::parse_mtgjson_mana_cost;
+use crate::game::zones::create_object;
+use crate::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, ResolvedAbility, TargetFilter,
+};
+use crate::types::game_state::{GameState, PendingCast, WaitingFor};
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::keywords::Keyword;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+/// A simple controller-targeted spell effect, so a built `ResolvedAbility`
+/// resolves without an interactive target slot.
+fn gain_two_life() -> Effect {
+    Effect::GainLife {
+        amount: crate::types::ability::QuantityExpr::Fixed { value: 2 },
+        player: TargetFilter::Controller,
+    }
+}
+
+/// Create an Arcane instant being cast (host spell) on the stack, owned by p0.
+fn arcane_host(state: &mut GameState, subtype: &str) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(1),
+        PlayerId(0),
+        "Host Spell".to_string(),
+        Zone::Stack,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.subtypes.push(subtype.to_string());
+    id
+}
+
+/// Put a "Splice onto [subtype] [cost]" card with a spell ability into p0's hand.
+fn splice_card_in_hand(state: &mut GameState, card: u64, subtype: &str, cost: &str) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(card),
+        PlayerId(0),
+        format!("Splicer {card}"),
+        Zone::Hand,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.keywords.push(Keyword::Splice {
+        subtype: subtype.to_string(),
+        cost: parse_mtgjson_mana_cost(cost),
+    });
+    obj.abilities = std::sync::Arc::new(vec![AbilityDefinition::new(
+        AbilityKind::Spell,
+        gain_two_life(),
+    )]);
+    id
+}
+
+fn host_pending(state: &GameState, host: ObjectId, cost: &str) -> PendingCast {
+    let ability = ResolvedAbility::new(gain_two_life(), Vec::new(), host, PlayerId(0));
+    let mut pending = PendingCast::new(host, CardId(1), ability, parse_mtgjson_mana_cost(cost));
+    pending.base_cost = Some(parse_mtgjson_mana_cost(cost));
+    let _ = state;
+    pending
+}
+
+#[test]
+fn eligible_detects_matching_arcane_splice_card() {
+    // CR 702.47a: a "Splice onto Arcane" card in hand is offered when casting
+    // an Arcane spell; an unrelated hand card is not.
+    let mut state = GameState::new_two_player(42);
+    let host = arcane_host(&mut state, "Arcane");
+    let splicer = splice_card_in_hand(&mut state, 2, "Arcane", "{1}{R}");
+    let _vanilla = create_object(
+        &mut state,
+        CardId(9),
+        PlayerId(0),
+        "Bear".to_string(),
+        Zone::Hand,
+    );
+
+    let eligible = eligible_splice_cards(&state, PlayerId(0), host);
+    assert_eq!(eligible, vec![splicer]);
+}
+
+#[test]
+fn eligible_rejects_non_arcane_spell() {
+    // CR 702.47a: the host spell's subtype must match the splice subtype.
+    let mut state = GameState::new_two_player(42);
+    let host = arcane_host(&mut state, "Trap");
+    splice_card_in_hand(&mut state, 2, "Arcane", "{1}{R}");
+
+    assert!(eligible_splice_cards(&state, PlayerId(0), host).is_empty());
+}
+
+#[test]
+fn eligible_rejects_subtype_mismatch() {
+    // CR 702.47a: a "Splice onto Trap" card is not offered for an Arcane spell.
+    let mut state = GameState::new_two_player(42);
+    let host = arcane_host(&mut state, "Arcane");
+    splice_card_in_hand(&mut state, 2, "Trap", "{1}{R}");
+
+    assert!(eligible_splice_cards(&state, PlayerId(0), host).is_empty());
+}
+
+#[test]
+fn splicing_folds_cost_merges_ability_and_reoffers() {
+    // CR 702.47b/c/e: splicing one of two eligible cards folds its cost into the
+    // host cost, appends its text box to the host ability chain, reveals it (it
+    // stays in hand), and re-presents the offer for the remaining card.
+    let mut state = GameState::new_two_player(42);
+    let host = arcane_host(&mut state, "Arcane");
+    let first = splice_card_in_hand(&mut state, 2, "Arcane", "{2}");
+    let second = splice_card_in_hand(&mut state, 3, "Arcane", "{1}");
+    let pending = host_pending(&state, host, "{1}");
+    let eligible = eligible_splice_cards(&state, PlayerId(0), host);
+    assert_eq!(eligible.len(), 2);
+
+    let mut events = Vec::new();
+    let next = resolve_offer(
+        &mut state,
+        PlayerId(0),
+        pending,
+        eligible,
+        Some(first),
+        &mut events,
+    )
+    .expect("splice should resolve");
+
+    let WaitingFor::SpliceOffer {
+        pending_cast,
+        eligible,
+        ..
+    } = next
+    else {
+        panic!("expected the offer to be re-presented for the remaining card");
+    };
+
+    // CR 702.47b: {1} host + {2} splice = {3}.
+    assert_eq!(pending_cast.cost, parse_mtgjson_mana_cost("{3}"));
+    // CR 702.47c: the spliced text box is appended to the host ability chain.
+    assert!(pending_cast.ability.sub_ability.is_some());
+    // CR 702.47e: only the not-yet-spliced card remains eligible.
+    assert_eq!(eligible, vec![second]);
+    // CR 702.47a: the spliced card was revealed and stays in hand.
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, crate::types::events::GameEvent::CardsRevealed { .. })));
+    assert!(state.players[0].hand.contains(&first));
+}
+
+#[test]
+fn declining_proceeds_past_the_offer() {
+    // CR 601.2c: declining the offer (card: None) leaves the splice step and
+    // advances the cast — it does not loop back to another SpliceOffer.
+    let mut state = GameState::new_two_player(42);
+    let host = arcane_host(&mut state, "Arcane");
+    splice_card_in_hand(&mut state, 2, "Arcane", "{2}");
+    let pending = host_pending(&state, host, "{1}");
+    let eligible = eligible_splice_cards(&state, PlayerId(0), host);
+
+    let mut events = Vec::new();
+    let result = resolve_offer(
+        &mut state,
+        PlayerId(0),
+        pending,
+        eligible,
+        None,
+        &mut events,
+    );
+
+    // Declining leaves the splice step and advances the cast (here into cost
+    // payment); it must never loop back to another SpliceOffer.
+    assert!(
+        !matches!(result, Ok(WaitingFor::SpliceOffer { .. })),
+        "declining must not re-present the splice offer"
+    );
+}
+
+#[test]
+fn unknown_card_is_rejected() {
+    // A card not in the eligible set cannot be spliced.
+    let mut state = GameState::new_two_player(42);
+    let host = arcane_host(&mut state, "Arcane");
+    splice_card_in_hand(&mut state, 2, "Arcane", "{2}");
+    let pending = host_pending(&state, host, "{1}");
+    let eligible = eligible_splice_cards(&state, PlayerId(0), host);
+
+    let mut events = Vec::new();
+    let result = resolve_offer(
+        &mut state,
+        PlayerId(0),
+        pending,
+        eligible,
+        Some(ObjectId(9999)),
+        &mut events,
+    );
+    assert!(result.is_err());
+}

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1517,7 +1517,7 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Casualty(n) => format!("casualty {n}"),
         Keyword::Entwine(_) => "entwine".to_string(),
         Keyword::Affinity(_) => "affinity".to_string(),
-        Keyword::Splice(_) => "splice".to_string(),
+        Keyword::Splice { .. } => "splice".to_string(),
         Keyword::Bargain => "bargain".to_string(),
         Keyword::Sunburst => "sunburst".to_string(),
         Keyword::Champion(_) => "champion".to_string(),
@@ -2662,7 +2662,17 @@ mod tests {
         assert!(result.is_some(), "Should recognize as keyword line");
         let keywords = result.unwrap();
         assert_eq!(keywords.len(), 1);
-        assert!(matches!(keywords[0], Keyword::Splice(_)));
+        // CR 702.47a: the splice subtype AND its cost must both be captured.
+        match &keywords[0] {
+            Keyword::Splice { subtype, cost } => {
+                assert_eq!(subtype, "Arcane");
+                assert_eq!(
+                    *cost,
+                    crate::database::mtgjson::parse_mtgjson_mana_cost("{1}{W}")
+                );
+            }
+            other => panic!("expected Keyword::Splice, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -426,6 +426,13 @@ pub enum GameAction {
     DecideOptionalEffect {
         accept: bool,
     },
+    /// CR 702.47a–e: Respond to a `WaitingFor::SpliceOffer`. `Some(card)` splices
+    /// that card from hand onto the spell being cast (re-presenting the offer for
+    /// any remaining eligible cards, CR 702.47e); `None` declines/finishes
+    /// splicing and proceeds to target selection.
+    RespondToSpliceOffer {
+        card: Option<ObjectId>,
+    },
     DecideOptionalEffectAndRemember {
         choice: AutoMayChoice,
     },
@@ -1249,6 +1256,7 @@ impl GameAction {
             | GameAction::ChooseBranch { .. }
             | GameAction::SelectModes { .. }
             | GameAction::DecideOptionalCost { .. }
+            | GameAction::RespondToSpliceOffer { .. }
             | GameAction::ChooseAdventureFace { .. }
             | GameAction::ChooseModalFace { .. }
             | GameAction::ChooseAlternativeCast { .. }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2482,6 +2482,17 @@ pub enum WaitingFor {
         times_kicked: u32,
         pending_cast: Box<PendingCast>,
     },
+    /// CR 702.47a–e: As an Arcane (or other matching-subtype) spell is cast, its
+    /// controller may reveal a "Splice onto [subtype]" card from hand to copy its
+    /// text box onto the spell and pay its splice cost as an additional cost.
+    /// `eligible` are the hand cards still available to splice; the prompt is
+    /// re-presented after each acceptance until the caster declines (`card: None`)
+    /// or `eligible` is exhausted.
+    SpliceOffer {
+        player: PlayerId,
+        pending_cast: Box<PendingCast>,
+        eligible: Vec<ObjectId>,
+    },
     /// CR 601.2b: Defiler cycle — player may pay life to reduce mana cost of a colored
     /// permanent spell. Presented when a controlled Defiler matches the spell's color.
     DefilerPayment {
@@ -3423,6 +3434,7 @@ impl WaitingFor {
             WaitingFor::ModeChoice { .. } => "ModeChoice",
             WaitingFor::DiscardToHandSize { .. } => "DiscardToHandSize",
             WaitingFor::OptionalCostChoice { .. } => "OptionalCostChoice",
+            WaitingFor::SpliceOffer { .. } => "SpliceOffer",
             WaitingFor::DefilerPayment { .. } => "DefilerPayment",
             WaitingFor::CastOffer { .. } => "CastOffer",
             WaitingFor::ModalFaceChoice { .. } => "ModalFaceChoice",
@@ -3551,6 +3563,7 @@ impl WaitingFor {
             | WaitingFor::ModeChoice { player, .. }
             | WaitingFor::DiscardToHandSize { player, .. }
             | WaitingFor::OptionalCostChoice { player, .. }
+            | WaitingFor::SpliceOffer { player, .. }
             | WaitingFor::DefilerPayment { player, .. }
             | WaitingFor::AbilityModeChoice { player, .. }
             | WaitingFor::MultiTargetSelection { player, .. }
@@ -3664,6 +3677,7 @@ impl WaitingFor {
             | WaitingFor::TargetSelection { pending_cast, .. }
             | WaitingFor::ModeChoice { pending_cast, .. }
             | WaitingFor::OptionalCostChoice { pending_cast, .. }
+            | WaitingFor::SpliceOffer { pending_cast, .. }
             | WaitingFor::DefilerPayment { pending_cast, .. }
             | WaitingFor::ActivationCostOneOfChoice { pending_cast, .. }
             | WaitingFor::BlightChoice { pending_cast, .. }
@@ -3694,6 +3708,7 @@ impl WaitingFor {
             | WaitingFor::TargetSelection { pending_cast, .. }
             | WaitingFor::ModeChoice { pending_cast, .. }
             | WaitingFor::OptionalCostChoice { pending_cast, .. }
+            | WaitingFor::SpliceOffer { pending_cast, .. }
             | WaitingFor::DefilerPayment { pending_cast, .. }
             | WaitingFor::ActivationCostOneOfChoice { pending_cast, .. }
             | WaitingFor::BlightChoice { pending_cast, .. }

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -763,9 +763,13 @@ pub enum Keyword {
     /// Firebending N — produces N {R} when this creature attacks (Avatar crossover).
     Firebending(QuantityExpr),
 
-    /// CR 702.46a: Splice onto [type] — reveal from hand and pay splice cost while casting
-    /// a spell of the specified type to add this card's effects to that spell.
-    Splice(String),
+    /// CR 702.47a: Splice onto [type] [cost] — reveal this card from hand and pay
+    /// its splice cost as you cast a spell of the specified type to copy this
+    /// card's text box onto that spell.
+    Splice {
+        subtype: String,
+        cost: ManaCost,
+    },
     /// CR 702.166a: Bargain — you may sacrifice an artifact, enchantment, or token
     /// as an additional cost to cast this spell.
     Bargain,
@@ -1047,7 +1051,7 @@ impl Keyword {
             Keyword::Warp(_) => KeywordKind::Warp,
             Keyword::Devour(_) => KeywordKind::Devour,
             Keyword::Offspring(_) => KeywordKind::Offspring,
-            Keyword::Splice(_) => KeywordKind::Splice,
+            Keyword::Splice { .. } => KeywordKind::Splice,
             Keyword::Bargain => KeywordKind::Bargain,
             Keyword::Sunburst => KeywordKind::Sunburst,
             Keyword::Champion(_) => KeywordKind::Champion,
@@ -1861,12 +1865,18 @@ impl FromStr for Keyword {
                     // Strip "onto " prefix if present (e.g., "onto arcane {w}" → "arcane {w}")
                     let after_onto = p.strip_prefix("onto ").unwrap_or(p);
                     // Separate type name from cost — cost starts with '{'
-                    let type_str = match after_onto.find('{') {
-                        Some(brace_idx) => after_onto[..brace_idx].trim(),
-                        None => after_onto.trim(),
+                    let (type_str, cost_str) = match after_onto.find('{') {
+                        Some(brace_idx) => {
+                            (after_onto[..brace_idx].trim(), &after_onto[brace_idx..])
+                        }
+                        None => (after_onto.trim(), ""),
                     };
                     let capitalized = capitalize_first(type_str);
-                    return Ok(Keyword::Splice(capitalized));
+                    let cost = parse_keyword_mana_cost(cost_str);
+                    return Ok(Keyword::Splice {
+                        subtype: capitalized,
+                        cost,
+                    });
                 }
                 // CR 702.72a: Champion a [type]
                 "champion" => {
@@ -2673,7 +2683,28 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         }
         // CR 702.47a / CR 702.166a / CR 702.43a / CR 702.72a / CR 702.149a
         // CR 702.132a / CR 702.133a / CR 702.99a / CR 702.53a / CR 702.148a / CR 702.125a
-        "Splice" => Ok(Keyword::Splice(data.as_str().unwrap_or("").to_string())),
+        "Splice" => {
+            // Struct form `{ "subtype": "Arcane", "cost": {..} }` (mirrors Typecycling).
+            // A bare string is treated as a costless legacy subtype.
+            if let Some(subtype) = data.as_str() {
+                return Ok(Keyword::Splice {
+                    subtype: subtype.to_string(),
+                    cost: ManaCost::zero(),
+                });
+            }
+            let obj = data
+                .as_object()
+                .ok_or("Splice: expected object or string")?;
+            let cost: ManaCost =
+                serde_json::from_value(obj.get("cost").cloned().unwrap_or_default())
+                    .map_err(|e| format!("Splice cost: {e}"))?;
+            let subtype = obj
+                .get("subtype")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Ok(Keyword::Splice { subtype, cost })
+        }
         "Bargain" => Ok(Keyword::Bargain),
         "Sunburst" => Ok(Keyword::Sunburst),
         "Champion" => Ok(Keyword::Champion(data.as_str().unwrap_or("").to_string())),

--- a/crates/mtgish-import/src/convert/keyword.rs
+++ b/crates/mtgish-import/src/convert/keyword.rs
@@ -300,10 +300,13 @@ pub fn try_convert(rule: &Rule, path: &str) -> ConvResult<Option<Keyword>> {
         // the cost as `Box<Cost>`; engine takes only the mana cost.
         Rule::WebSlinging(c) => Keyword::WebSlinging(pure_mana(c, "Rule::WebSlinging", path)?),
 
-        // CR 702.47a: Splice onto [quality] [cost]. The engine keyword
-        // stores the quality string only (matching the native parser);
-        // splice-cost payment is not represented in the current keyword type.
-        Rule::SpliceOnto(spells, _cost) => Keyword::Splice(splice_quality(spells, path)?),
+        // CR 702.47a: Splice onto [quality] [cost]. The engine keyword carries
+        // both the quality string and the splice cost paid as an additional
+        // cost when the card is spliced onto a host spell.
+        Rule::SpliceOnto(spells, cost) => Keyword::Splice {
+            subtype: splice_quality(spells, path)?,
+            cost: pure_mana(cost, "Rule::SpliceOnto", path)?,
+        },
 
         // CR 702.56a: Replicate {cost} — additional-cost-on-cast copy
         // mechanic. Engine carries only the mana cost.

--- a/crates/phase-ai/src/decision_kind.rs
+++ b/crates/phase-ai/src/decision_kind.rs
@@ -90,6 +90,7 @@ pub fn classify(waiting_for: &WaitingFor, action: &GameAction) -> DecisionKind {
         | WaitingFor::ModeChoice { .. }
         | WaitingFor::DiscardToHandSize { .. }
         | WaitingFor::OptionalCostChoice { .. }
+        | WaitingFor::SpliceOffer { .. }
         | WaitingFor::DefilerPayment { .. }
         | WaitingFor::AbilityModeChoice { .. }
         // CR 715.3a + CR 702.94a + CR 702.35a + CR 702.85a + CR 701.57a + CR 702.xxx:

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -978,6 +978,7 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
         // for exhaustive match. ManaPayment is a pending-cast state.
         WaitingFor::ManaPayment { .. }
         | WaitingFor::OptionalCostChoice { .. }
+        | WaitingFor::SpliceOffer { .. }
         | WaitingFor::DefilerPayment { .. }
         | WaitingFor::PayCost {
             resume: CostResume::Spell { .. } | CostResume::SpellCost { .. },

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -367,6 +367,7 @@ pub fn guard_game_action_payload(action: &GameAction) -> Result<(), String> {
         | GameAction::ChooseBranch { .. }
         | GameAction::ChooseDamageSource { .. }
         | GameAction::DecideOptionalCost { .. }
+        | GameAction::RespondToSpliceOffer { .. }
         | GameAction::ChooseAdventureFace { .. }
         | GameAction::ChooseModalFace { .. }
         | GameAction::ChooseAlternativeCast { .. }


### PR DESCRIPTION
## Summary

Closes: #2612 

Implements the **Splice onto Arcane** keyword end-to-end. Previously `Keyword::Splice` was parsed but a complete no-op — and its splice **cost was discarded at parse time**. As you cast an Arcane spell, you may now reveal "Splice onto [subtype]" cards from hand to copy their text box onto that spell and pay their splice cost as an additional cost. This unlocks **32 Kamigawa Arcane cards** (Desperate Ritual, Glacial Ray, Goryo's Vengeance, Dampen Thought, Evermind, …).

Closes the Splice gap. Verified still-unimplemented on `main` (no `splice` module, no `synthesize_splice`, `Keyword::Splice(String)` discarded the cost).

## Rules (CR 702.47a–e)
"Splice onto [subtype] [cost]" — you may reveal this card from hand as you cast a spell of the matching subtype (CR 702.47a); copy its text box onto that spell and pay its splice cost as an additional cost (CR 702.47b–c); choose targets for the spliced instructions (CR 702.47c–d); the spliced card **stays in hand**; multiple cards may be spliced onto one spell (CR 702.47e).

## Design
Splice is announced during **CR 601.2b** — before targets are chosen and before the total cost locks — so it hooks the cast pipeline at the **same pre-target seam Emerge and Casualty use**, reusing the existing deferred-target/payment machinery rather than building a parallel system.

On accepting a splice card, the new `game/splice.rs` module:
- **folds** its splice cost into the host's mana cost (`ManaCost::plus`) — CR 702.47b;
- **clones** its text-box spell ability (`combined_spell_ability_def` → `build_resolved_from_def` → `append_to_sub_chain`) onto the host's resolved-ability chain so it resolves as part of that spell — CR 702.47c;
- **reveals** it (`CardsRevealed`; the card stays in hand) — CR 702.47a;
- **re-offers** the remaining eligible cards (CR 702.47e), then on decline routes to `begin_deferred_target_selection`.

Because spliced abilities merge into `PendingCast::ability` *before* target selection, the existing target machinery collects the spliced effects' targets alongside the host spell's own targets — no new targeting/payment code.

Also fixed: `Keyword::Splice(String)` → `Keyword::Splice { subtype, cost }` (mirrors `Typecycling`), so the splice cost is captured by both the native parser and the mtgish converter instead of being dropped.

## Changes
**New (the runtime core):**
- `crates/engine/src/game/splice.rs` — eligibility detection, offer construction, cost-fold + ability-merge + reveal, multi-splice loop, decline→targets handoff.
- `crates/engine/src/game/splice_tests.rs` — 6 tests (declared from the parent `game/mod.rs` so `splice.rs` stays implementation-only).

**Cost capture:**
- `types/keywords.rs`, `parser/oracle_keyword.rs`, `mtgish-import/convert/keyword.rs` — `Splice { subtype, cost }` + cost parsing/round-trip.

**Types & wiring:**
- `types/game_state.rs` — `WaitingFor::SpliceOffer { player, pending_cast, eligible }`.
- `types/actions.rs` — `GameAction::RespondToSpliceOffer { card: Option<ObjectId> }`.
- `game/casting.rs` — pre-target offer hook (fires only for matching-subtype spells with eligible splice cards in hand).
- `game/casting_costs.rs` — `begin_deferred_target_selection` made `pub(crate)`.
- `game/engine.rs` — resume + cancel dispatch.

**Downstream (AI / server / contract):**
- `ai_support/candidates.rs` + `ai_support/mod.rs` — legal-action generation + validation allowlist.
- `phase-ai/decision_kind.rs`, `phase-ai/search.rs` — decision routing + fallback.
- `server-core/game_action_payload_guard.rs` — payload bound.
- `client/src/adapter/types.ts` — TS contract for both new variants.

## Testing & verification
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -D warnings` → **clean**
- `cargo check --workspace` → **clean** (all downstream crates)
- **splice tests 6/6 pass**; casting regression **587/587 pass**; keyword cost-capture test passes
- Full engine lib suite: **10776 pass** (the 3 failures are pre-existing stale-`card-data.json` DB-load cases — `station_32_tdm`, `cathars_crusade_db_load`, `walking_ballista_db_load` — all non-splice, present on main before this change)
- `tsc -b --noEmit` → **clean**; parser-combinator gate → **clean**

## Notes
- **`data/card-data.json`** must be regenerated (the `Keyword::Splice` serialized shape changed) — Tilt's `card-data` resource / CI do this automatically; it is gitignored and not part of this diff.
- **AI plays splice fully** (candidate generation wired). The dedicated human-play `SpliceOffer` modal is a scoped display-layer follow-up; `UnhandledWaitingForModal` covers it safely in the meantime.
