### PR TITLE
feat(keyword): implement Frenzy (CR 702.68)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -253,6 +253,10 @@ impl KeywordTriggerInstaller {
                 build_bushido_trigger(TriggerMode::Blocks, *n),
                 build_bushido_trigger(TriggerMode::BecomesBlocked, *n),
             ],
+            // CR 702.68a: Frenzy N — whenever this creature attacks and isn't
+            // blocked, it gets +N/+0 until end of turn. CR 702.68b: each instance
+            // triggers separately; one trigger per `Frenzy`.
+            Keyword::Frenzy(n) => vec![build_frenzy_trigger(*n)],
             // CR 702.91a: Battle cry — whenever this creature attacks, each
             // other attacking creature gets +1/+0 until end of turn. CR 702.91b:
             // each instance triggers separately; one trigger per `Battlecry`.
@@ -354,6 +358,7 @@ impl KeywordTriggerInstaller {
             // removed.
             Keyword::Graft(_) => is_graft_enters_trigger(trigger),
             Keyword::Bushido(n) => is_bushido_trigger(trigger, *n),
+            Keyword::Frenzy(n) => is_frenzy_trigger(trigger, *n),
             Keyword::Battlecry => is_battlecry_trigger(trigger),
             Keyword::Rampage(n) => is_rampage_trigger(trigger, *n),
             Keyword::Melee => is_melee_trigger(trigger),
@@ -3877,6 +3882,14 @@ pub fn synthesize_bushido(face: &mut CardFace) {
     KeywordTriggerInstaller::install_matching(face, |kw| matches!(kw, Keyword::Bushido(_)));
 }
 
+/// CR 702.68a: Frenzy N — "Whenever this creature attacks and isn't blocked, it
+/// gets +N/+0 until end of turn." One self-trigger per instance. CR 702.68b: each
+/// instance triggers separately, so one trigger is synthesized per
+/// `Keyword::Frenzy`.
+pub fn synthesize_frenzy(face: &mut CardFace) {
+    KeywordTriggerInstaller::install_matching(face, |kw| matches!(kw, Keyword::Frenzy(_)));
+}
+
 /// CR 702.91a: Battle cry — "whenever this creature attacks, each other
 /// attacking creature gets +1/+0 until end of turn." CR 702.91b: each instance
 /// triggers separately, so one trigger is synthesized per `Keyword::Battlecry`.
@@ -4742,6 +4755,51 @@ fn is_bushido_trigger(t: &TriggerDefinition, n: u32) -> bool {
                 toughness: PtValue::Fixed(tough),
                 target: TargetFilter::SelfRef,
             }) if *p == n as i32 && *tough == n as i32
+        )
+}
+
+/// CR 702.68a: Frenzy N self-trigger — "whenever this creature attacks and isn't
+/// blocked, it gets +N/+0 until end of turn." Scoped via `valid_card` SelfRef, pumps
+/// SelfRef. No duration override — `Effect::Pump` defaults to `UntilEndOfTurn`
+/// (CR 702.68a). Mirrors the single-trigger Battle cry builder (Frenzy is one
+/// trigger, unlike Bushido's two block events). The `AttackerUnblocked` mode fires
+/// on `BlockersDeclared` when the source attacked and is unblocked — the exact
+/// "attacks and isn't blocked" timing.
+fn build_frenzy_trigger(n: u32) -> TriggerDefinition {
+    let pump = Effect::Pump {
+        power: PtValue::Fixed(n as i32),
+        // CR 702.68a: +N/+0 — toughness is unchanged.
+        toughness: PtValue::Fixed(0),
+        target: TargetFilter::SelfRef,
+    };
+    let execute = AbilityDefinition::new(AbilityKind::Spell, pump).description(format!(
+        "CR 702.68a: Frenzy {n} — +{n}/+0 until end of turn"
+    ));
+    TriggerDefinition::new(TriggerMode::AttackerUnblocked)
+        .valid_card(TargetFilter::SelfRef)
+        .execute(execute)
+        .description(format!(
+            "CR 702.68a: Frenzy {n} — whenever this creature attacks and isn't \
+             blocked, it gets +{n}/+0 until end of turn."
+        ))
+}
+
+/// CR 702.68a: A Frenzy `n` trigger — a self-scoped (`valid_card: SelfRef`)
+/// attacker-unblocked trigger that pumps the source creature +n/+0. Used by
+/// `RemoveKeyword` symmetric removal so a granted-then-removed `Frenzy(n)` strips
+/// exactly its own trigger — parameterized by `n` (and asserting `valid_card`) so
+/// it never matches a different Frenzy level or a coincidental printed
+/// attacker-unblocked pump on the same face.
+fn is_frenzy_trigger(t: &TriggerDefinition, n: u32) -> bool {
+    matches!(t.mode, TriggerMode::AttackerUnblocked)
+        && matches!(t.valid_card, Some(TargetFilter::SelfRef))
+        && matches!(
+            t.execute.as_deref().map(|a| &*a.effect),
+            Some(Effect::Pump {
+                power: PtValue::Fixed(p),
+                toughness: PtValue::Fixed(tough),
+                target: TargetFilter::SelfRef,
+            }) if *p == n as i32 && *tough == 0
         )
 }
 
@@ -8377,6 +8435,9 @@ pub fn synthesize_all(face: &mut CardFace) {
     // CR 702.45a: Bushido N — self blocks / becomes-blocked triggers that pump
     // the creature +N/+N until end of turn.
     synthesize_bushido(face);
+    // CR 702.68a: Frenzy N — attacks-and-isn't-blocked self pump of +N/+0 until
+    // end of turn.
+    synthesize_frenzy(face);
     // CR 702.91a: Battle cry — attack trigger pumping each other attacking
     // creature +1/+0 until end of turn.
     synthesize_battlecry(face);
@@ -12840,6 +12901,65 @@ mod bushido_synthesis_tests {
         let mut bare = CardFace::default();
         synthesize_bushido(&mut bare);
         assert!(bare.triggers.iter().all(|t| !is_bushido_trigger(t, 1)));
+    }
+
+    #[test]
+    fn synthesize_frenzy_adds_single_attacker_unblocked_pump_trigger() {
+        // CR 702.68a: Frenzy N installs ONE self-trigger (attacks and isn't
+        // blocked) pumping the source +N/+0 until end of turn. CR 702.68b would
+        // synthesize one per instance, but a single Frenzy(2) yields exactly one.
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Frenzy(2));
+        synthesize_frenzy(&mut face);
+
+        let frenzy: Vec<_> = face
+            .triggers
+            .iter()
+            .filter(|t| is_frenzy_trigger(t, 2))
+            .collect();
+        assert_eq!(frenzy.len(), 1, "exactly one attacker-unblocked trigger");
+        let t = frenzy[0];
+        assert!(matches!(t.mode, TriggerMode::AttackerUnblocked));
+        assert!(matches!(t.valid_card, Some(TargetFilter::SelfRef)));
+        let Some(Effect::Pump {
+            power,
+            toughness,
+            target,
+        }) = t.execute.as_deref().map(|a| &*a.effect)
+        else {
+            panic!("frenzy execute must be Effect::Pump");
+        };
+        assert!(matches!(power, PtValue::Fixed(2)));
+        // CR 702.68a: +N/+0 — toughness unchanged.
+        assert!(matches!(toughness, PtValue::Fixed(0)));
+        assert!(matches!(target, TargetFilter::SelfRef));
+        // CR 702.68a: until end of turn — Effect::Pump defaults the duration, so
+        // the execute carries no explicit duration override.
+        assert!(t
+            .execute
+            .as_deref()
+            .and_then(|a| a.duration.as_ref())
+            .is_none());
+    }
+
+    #[test]
+    fn synthesize_frenzy_is_idempotent_and_noop_without_keyword() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Frenzy(1));
+        synthesize_frenzy(&mut face);
+        synthesize_frenzy(&mut face);
+        assert_eq!(
+            face.triggers
+                .iter()
+                .filter(|t| is_frenzy_trigger(t, 1))
+                .count(),
+            1,
+            "one trigger, deduped across passes"
+        );
+
+        let mut bare = CardFace::default();
+        synthesize_frenzy(&mut bare);
+        assert!(bare.triggers.iter().all(|t| !is_frenzy_trigger(t, 1)));
     }
 }
 

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1022,6 +1022,18 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
         return Some(Keyword::Renown(n));
     }
 
+    // CR 702.68a: Frenzy N — parameterized keyword from Oracle/reminder/grant text.
+    // MTGJSON's keyword list carries only "Frenzy"; the Oracle line supplies N.
+    if let Ok((_, (_, _, n))) = all_consuming((
+        tag::<_, _, OracleError<'_>>("frenzy"),
+        space1,
+        nom_primitives::parse_number,
+    ))
+    .parse(text)
+    {
+        return Some(Keyword::Frenzy(n));
+    }
+
     // CR 702.167a/b: Craft with [materials] [cost] — the Oracle line carries the
     // materials class and activation cost that the bare "Craft" keyword lacks.
     if let Some(kw) = parse_craft_keyword_line(text) {
@@ -1434,6 +1446,7 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Fabricate(_) => "fabricate".to_string(),
         Keyword::Annihilator(_) => "annihilator".to_string(),
         Keyword::Bushido(_) => "bushido".to_string(),
+        Keyword::Frenzy(_) => "frenzy".to_string(),
         Keyword::Tribute(_) => "tribute".to_string(),
         Keyword::Afterlife(_) => "afterlife".to_string(),
         Keyword::Fading(_) => "fading".to_string(),
@@ -2042,6 +2055,17 @@ mod tests {
         // CR 702.112a: Renown N — parameterized keyword from Oracle text.
         let kw = parse_keyword_from_oracle("renown 2").unwrap();
         assert_eq!(kw, Keyword::Renown(2));
+    }
+
+    #[test]
+    fn parse_keyword_from_oracle_frenzy() {
+        // CR 702.68a: Frenzy N — parameterized keyword from Oracle/grant text.
+        let kw = parse_keyword_from_oracle("frenzy 2").unwrap();
+        assert_eq!(kw, Keyword::Frenzy(2));
+        // CR 702.68a: the Frenzy Sliver grant line "frenzy 1" must resolve to
+        // Frenzy(1), not fall to Unknown/Unimplemented.
+        let kw1 = parse_keyword_from_oracle("frenzy 1").unwrap();
+        assert_eq!(kw1, Keyword::Frenzy(1));
     }
 
     #[test]

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -125,6 +125,7 @@ pub enum KeywordKind {
     Graft,
     Annihilator,
     Bushido,
+    Frenzy,
     Tribute,
     Soulbond,
     Unearth,
@@ -473,6 +474,8 @@ pub enum Keyword {
     Fabricate(u32),
     Annihilator(u32),
     Bushido(u32),
+    /// CR 702.68a: Frenzy N — "Whenever this creature attacks and isn't blocked, it gets +N/+0 until end of turn." CR 702.68b: each instance triggers separately.
+    Frenzy(u32),
     Tribute(u32),
     Soulbond,
     Unearth(ManaCost),
@@ -985,6 +988,7 @@ impl Keyword {
             Keyword::Fabricate(_) => KeywordKind::Fabricate,
             Keyword::Annihilator(_) => KeywordKind::Annihilator,
             Keyword::Bushido(_) => KeywordKind::Bushido,
+            Keyword::Frenzy(_) => KeywordKind::Frenzy,
             Keyword::Tribute(_) => KeywordKind::Tribute,
             Keyword::Soulbond => KeywordKind::Soulbond,
             Keyword::Unearth(_) => KeywordKind::Unearth,
@@ -1651,6 +1655,7 @@ impl FromStr for Keyword {
                 "landwalk" => return Ok(Keyword::Landwalk(p.clone())),
                 "rampage" => return Ok(Keyword::Rampage(p.parse().unwrap_or(1))),
                 "bushido" => return Ok(Keyword::Bushido(p.parse().unwrap_or(1))),
+                "frenzy" => return Ok(Keyword::Frenzy(p.parse().unwrap_or(1))),
                 "absorb" => return Ok(Keyword::Absorb(p.parse().unwrap_or(1))),
                 "fading" => return Ok(Keyword::Fading(p.parse().unwrap_or(0))),
                 "vanishing" => return Ok(Keyword::Vanishing(p.parse().unwrap_or(0))),
@@ -1948,6 +1953,7 @@ impl FromStr for Keyword {
             "wither" => Ok(Keyword::Wither),
             "infect" => Ok(Keyword::Infect),
             "afflict" => Ok(Keyword::Afflict(1)),
+            "frenzy" => Ok(Keyword::Frenzy(1)),
             "prowess" => Ok(Keyword::Prowess),
             "undying" => Ok(Keyword::Undying),
             "persist" => Ok(Keyword::Persist),
@@ -2564,6 +2570,7 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Fabricate" => Ok(Keyword::Fabricate(uint(data))),
         "Annihilator" => Ok(Keyword::Annihilator(uint(data))),
         "Bushido" => Ok(Keyword::Bushido(uint(data))),
+        "Frenzy" => Ok(Keyword::Frenzy(uint(data))),
         "Tribute" => Ok(Keyword::Tribute(uint(data))),
         "Afterlife" => Ok(Keyword::Afterlife(uint(data))),
         "Fading" => Ok(Keyword::Fading(uint(data))),
@@ -2897,6 +2904,16 @@ mod tests {
             }
         );
         assert_eq!(Keyword::from_str("Rampage:2").unwrap(), Keyword::Rampage(2));
+    }
+
+    #[test]
+    fn parse_frenzy_colon_and_bare() {
+        // CR 702.68a: colon-form carries N.
+        assert_eq!(Keyword::from_str("Frenzy:2").unwrap(), Keyword::Frenzy(2));
+        // CR 702.68a: bare MTGJSON keyword-list form defaults to Frenzy(1),
+        // mirroring the bare `afflict` arm — must NOT fall to Unknown.
+        assert_eq!(Keyword::from_str("frenzy").unwrap(), Keyword::Frenzy(1));
+        assert_eq!(Keyword::from_str("Frenzy").unwrap(), Keyword::Frenzy(1));
     }
 
     #[test]

--- a/crates/engine/tests/integration/frenzy_attacker_unblocked_pump.rs
+++ b/crates/engine/tests/integration/frenzy_attacker_unblocked_pump.rs
@@ -1,0 +1,243 @@
+//! CR 702.68 — Frenzy N.
+//!
+//! "Frenzy N" means "Whenever this creature attacks and isn't blocked, it gets
+//! +N/+0 until end of turn." (CR 702.68a). If a creature has multiple instances
+//! of frenzy, each triggers separately (CR 702.68b).
+//!
+//! Before this change "Frenzy N" fell to `Keyword::Unknown` (a silent no-op) and
+//! the Frenzy Sliver static grant ("All Sliver creatures have frenzy 1") fell to
+//! `Effect::Unimplemented` because `parse_keyword_from_oracle("frenzy 1")`
+//! returned `None`. The fix adds the `Keyword::Frenzy(u32)` variant, the
+//! parser/`FromStr` arms, and the synthesis builder
+//! (`build_frenzy_trigger` → `TriggerMode::AttackerUnblocked` self-pump).
+//!
+//! These tests drive the REAL combat pipeline through `apply`:
+//! declare-attackers (and, where relevant, declare-blockers) → the
+//! `BlockersDeclared` event → the `AttackerUnblocked` trigger → stack →
+//! resolution → layer system. They assert the *post-layer* `power`/`toughness`
+//! of the attacker (the layer system writes effective P/T into
+//! `obj.power`/`obj.toughness`), never the parsed `Pump` effect — so a missing
+//! synthesized trigger fails the assertion.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+/// A Frenzy 2 creature in the real MTGJSON Oracle form: the keyword line carries
+/// the numeral plus reminder text. Paired with the `["frenzy"]` keyword-name
+/// hint (the inline-Oracle analog of MTGJSON's keyword list), the parser's
+/// `parse_keyword_from_oracle` recovers N = 2 from this line.
+const FRENZY_2_ORACLE: &str = "Frenzy 2 (Whenever this creature attacks and isn't \
+blocked, it gets +2/+0 until end of turn.)";
+/// Frenzy Sliver's real Oracle text — a static grant of `frenzy 1` to all
+/// Slivers. Before this change `parse_keyword_from_oracle("frenzy 1")` returned
+/// `None`, so the grant fell to `Effect::Unimplemented` (a silent no-op).
+const FRENZY_SLIVER_GRANT: &str = "All Sliver creatures have frenzy 1. \
+(Whenever a Sliver attacks and isn't blocked, it gets +1/+0 until end of turn.)";
+/// CR 702.68b: two instances of Frenzy (each triggers separately → +1/+0 twice
+/// = +2/+0 total). Written as two bare `Frenzy` keyword lines so each infers to
+/// `Frenzy(1)` and both survive `merge_extracted_keywords` (Frenzy carries no
+/// MTGJSON-deduped multi-instance recovery, so the two printed instances stand).
+const FRENZY_BARE_TWICE: &str = "Frenzy\nFrenzy";
+
+/// Drive a runner from PreCombatMain through declaring `attacker` as an attacker
+/// and then through the declare-blockers step with an EMPTY block, so the
+/// attacker is unblocked and the `BlockersDeclared` event (which the
+/// `AttackerUnblocked` matcher keys on) fires. Then resolve the stack so the
+/// trigger applies.
+///
+/// `advance_until_stack_empty` alone is insufficient: `AttackerUnblocked` does
+/// not fire at declare-attackers (unlike `Attacks`), so the stack is empty right
+/// after `DeclareAttackers`. The defending player must have at least one
+/// (non-blocking) creature so the `WaitingFor::DeclareBlockers` prompt appears;
+/// we then declare no blockers to leave the attacker unblocked. (With zero
+/// defending creatures the engine auto-resolves the empty-blockers step and
+/// lands back in Priority, so the caller seeds an idle defender.)
+fn declare_attacker_unblocked(runner: &mut engine::game::scenario::GameRunner, attacker: ObjectId) {
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("DeclareAttackers should succeed");
+    if matches!(
+        runner.state().waiting_for,
+        engine::types::game_state::WaitingFor::Priority { .. }
+    ) {
+        runner.pass_both_players();
+    }
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            engine::types::game_state::WaitingFor::DeclareBlockers { .. }
+        ),
+        "expected DeclareBlockers, got {:?}",
+        runner.state().waiting_for
+    );
+    // CR 509.1: the defending player declares no blockers — the attacker is
+    // unblocked. This emits `GameEvent::BlockersDeclared`.
+    runner
+        .act(GameAction::DeclareBlockers {
+            assignments: vec![],
+        })
+        .expect("empty DeclareBlockers should succeed");
+    runner.advance_until_stack_empty();
+}
+
+/// CR 702.68a: a Frenzy 2 creature that attacks and isn't blocked gets +2/+0
+/// until end of turn. A 2/2 becomes an effective 4/2 (power +2, toughness
+/// unchanged) after the trigger resolves and the layer system applies the pump.
+#[test]
+fn frenzy_pumps_unblocked_attacker_power_only() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let mut attacker_b = scenario.add_creature(P0, "Frenzied Bear", 2, 2);
+    attacker_b.from_oracle_text_with_keywords(&["frenzy"], FRENZY_2_ORACLE);
+    let attacker = attacker_b.id();
+    // Idle defender so the DeclareBlockers prompt appears (it declares no blocks).
+    scenario.add_creature(P1, "Idle Bystander", 1, 1);
+
+    let mut runner = scenario.build();
+    declare_attacker_unblocked(&mut runner, attacker);
+
+    let obj = &runner.state().objects[&attacker];
+    assert_eq!(
+        obj.power,
+        Some(4),
+        "CR 702.68a: unblocked Frenzy 2 attacker is pumped +2 → power 4"
+    );
+    assert_eq!(
+        obj.toughness,
+        Some(2),
+        "CR 702.68a: Frenzy is +N/+0 — toughness is unchanged at 2"
+    );
+}
+
+/// CR 702.68a: a Frenzy 2 creature that attacks and IS blocked does not trigger
+/// (the ability requires "isn't blocked"), so it receives no pump.
+#[test]
+fn frenzy_does_not_pump_blocked_attacker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let mut attacker_b = scenario.add_creature(P0, "Frenzied Bear", 2, 2);
+    attacker_b.from_oracle_text_with_keywords(&["frenzy"], FRENZY_2_ORACLE);
+    let attacker = attacker_b.id();
+    let blocker = scenario.add_creature(P1, "Hostile Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("DeclareAttackers should succeed");
+    if matches!(
+        runner.state().waiting_for,
+        engine::types::game_state::WaitingFor::Priority { .. }
+    ) {
+        runner.pass_both_players();
+    }
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            engine::types::game_state::WaitingFor::DeclareBlockers { .. }
+        ),
+        "expected DeclareBlockers, got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::DeclareBlockers {
+            assignments: vec![(blocker, attacker)],
+        })
+        .expect("DeclareBlockers should succeed");
+    runner.advance_until_stack_empty();
+
+    let obj = &runner.state().objects[&attacker];
+    assert_eq!(
+        obj.power,
+        Some(2),
+        "CR 702.68a: a BLOCKED Frenzy attacker does not trigger → power stays 2"
+    );
+    assert_eq!(
+        obj.toughness,
+        Some(2),
+        "CR 702.68a: a BLOCKED Frenzy attacker does not trigger → toughness stays 2"
+    );
+}
+
+/// CR 702.68b: two instances of Frenzy 1 each trigger separately. An unblocked
+/// attacker with Frenzy 1 twice gets +1/+0 twice = +2/+0 → a 2/2 becomes 4/2.
+#[test]
+fn frenzy_multiple_instances_stack_per_cr_702_68b() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let attacker = scenario
+        .add_creature_from_oracle(P0, "Doubly Frenzied Bear", 2, 2, FRENZY_BARE_TWICE)
+        .id();
+    // Idle defender so the DeclareBlockers prompt appears (it declares no blocks).
+    scenario.add_creature(P1, "Idle Bystander", 1, 1);
+
+    let mut runner = scenario.build();
+    declare_attacker_unblocked(&mut runner, attacker);
+
+    let obj = &runner.state().objects[&attacker];
+    assert_eq!(
+        obj.power,
+        Some(4),
+        "CR 702.68b: two Frenzy 1 instances each fire → +1/+0 twice → power 4"
+    );
+    assert_eq!(
+        obj.toughness,
+        Some(2),
+        "CR 702.68a: each instance is +N/+0 — toughness unchanged at 2"
+    );
+}
+
+/// CR 702.68a + CR 702.68 grant: Frenzy Sliver grants `frenzy 1` to all Slivers
+/// via a static ability. A granted-frenzy Sliver that attacks unblocked gets
+/// +1/+0. This exercises the grant → layer-system `AddKeyword` → synthesis
+/// (`triggers_for` at `layers.rs:3417`) → combat path, and is the regression
+/// guard that `map_keyword`/`parse_keyword_from_oracle` no longer drops
+/// "frenzy 1" to Unknown/Unimplemented.
+#[test]
+fn frenzy_sliver_grant_pumps_unblocked_sliver() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Frenzy Sliver is itself a Sliver, so its own grant applies to it. A 1/1
+    // attacking unblocked should become an effective 2/1 (+1/+0).
+    let mut grantor =
+        scenario.add_creature_from_oracle(P0, "Frenzy Sliver", 1, 1, FRENZY_SLIVER_GRANT);
+    grantor.with_subtypes(vec!["Sliver"]);
+    let grantor_id = grantor.id();
+    // Idle defender so the DeclareBlockers prompt appears (it declares no blocks).
+    scenario.add_creature(P1, "Idle Bystander", 1, 1);
+
+    let mut runner = scenario.build();
+    // Pass priority once so the static grant's layer modification (AddKeyword
+    // Frenzy(1)) is applied and `triggers_for` installs the synthesized trigger
+    // before combat.
+    runner.act(GameAction::PassPriority).ok();
+    declare_attacker_unblocked(&mut runner, grantor_id);
+
+    let obj = &runner.state().objects[&grantor_id];
+    assert_eq!(
+        obj.power,
+        Some(2),
+        "granted frenzy 1 Sliver attacking unblocked is pumped +1 → power 2 \
+         (regression: 'frenzy 1' grant must not fall to Unimplemented)"
+    );
+    assert_eq!(
+        obj.toughness,
+        Some(1),
+        "CR 702.68a: granted frenzy is +1/+0 — toughness unchanged at 1"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -62,6 +62,7 @@ mod exquisite_blood_routing;
 mod flickerwisp_delayed_return;
 mod floodpits_drowner;
 mod foretell_pipeline;
+mod frenzy_attacker_unblocked_pump;
 mod frostcliff_siege_anchor_word_modes;
 mod gatta_and_luzzu_regression;
 mod gemstone_caverns_begin_game;


### PR DESCRIPTION
Frenzy was unimplemented: "Frenzy N" fell through Keyword::from_str to
Keyword::Unknown (a silent no-op), and the static grant "All Sliver
creatures have frenzy 1" (Frenzy Sliver) fell to Effect::Unimplemented
because parse_keyword_from_oracle("frenzy 1") returned None.

Frenzy is a synthesis-only triggered-ability keyword, structurally a
sibling of Bushido/Battle cry: register Keyword::Frenzy(u32) and
synthesize one AttackerUnblocked self-trigger pumping +N/+0 until end of
turn. Every building block already exists and is wired —
TriggerMode::AttackerUnblocked (fires on BlockersDeclared when the source
attacked and was assigned no blockers), Effect::Pump (defaults to
Duration::UntilEndOfTurn when no duration is set), and the
KeywordTriggerInstaller — so no new trigger mode, effect, or runtime code
is needed.

- types/keywords.rs: Keyword::Frenzy(u32) + KeywordKind::Frenzy + the two
  compile-forced arms (kind, keyword_name); colon-form and bare-form
  FromStr arms (Frenzy:2 and the MTGJSON keyword-list "Frenzy"); typed
  deserialize.
- parser/oracle_keyword.rs: a nom arm (tag/space1/parse_number) that
  recovers N from "frenzy N" Oracle/reminder/grant text — which also
  repairs the Frenzy Sliver grant (map_keyword no longer drops it).
- database/synthesis.rs: build_frenzy_trigger (mirrors the single-trigger
  build_battlecry_trigger, with +N/+0 — toughness Fixed(0), not Bushido's
  +N/+N), is_frenzy_trigger removal matcher, dispatch + removal-matcher
  arms, synthesize_frenzy, and the master-sequence call. Granted Frenzy
  installs automatically through the generic triggers_for chokepoint
  (layers AddKeyword), so no separate granted seam is required.

CR 702.68a: Frenzy N — "Whenever this creature attacks and isn't blocked,
it gets +N/+0 until end of turn." CR 702.68b: each instance triggers
separately.

Runtime coverage: frenzy_attacker_unblocked_pump.rs drives real combat
(declare attackers → declare blockers → trigger resolution, reading
effective post-layer P/T): an unblocked Frenzy 2 attacker gets +2/+0; the
same attacker when blocked gets nothing; two instances stack to +4/+0;
and a Sliver granted frenzy 1 pumps +1/+0 unblocked. All fail on
origin/main (Frenzy is Unknown, no trigger synthesized).
