### PR TITLE
Add Solemnity

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9832,14 +9832,18 @@ fn pay_ability_cost_inner(
                     target: TargetFilter::SelfRef,
                 } => {
                     let count = super::quantity::resolve_quantity(state, count, player, source_id);
-                    super::effects::counters::add_counter_with_replacement(
+                    if !super::effects::counters::add_counter_with_replacement(
                         state,
                         player,
                         source_id,
                         counter_type.clone(),
                         count.unsigned_abs(),
                         events,
-                    );
+                    ) {
+                        return Ok(AbilityCostPaymentOutcome::Paused {
+                            remaining_cost: None,
+                        });
+                    }
                 }
                 _ => {
                     return Err(EngineError::ActionNotAllowed(format!(
@@ -9919,14 +9923,18 @@ fn pay_ability_cost_inner(
             let amount = *amount;
             match amount.cmp(&0) {
                 std::cmp::Ordering::Greater => {
-                    super::effects::counters::add_counter_with_replacement(
+                    if !super::effects::counters::add_counter_with_replacement(
                         state,
                         player,
                         source_id,
                         crate::types::counter::CounterType::Loyalty,
                         amount as u32,
                         events,
-                    );
+                    ) {
+                        return Ok(AbilityCostPaymentOutcome::Paused {
+                            remaining_cost: None,
+                        });
+                    }
                 }
                 std::cmp::Ordering::Less => {
                     super::effects::counters::remove_counter_with_replacement(

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1350,17 +1350,6 @@ pub(crate) fn handle_blight_choice(
     // on N > 0 for exact parity with the #497 effect-form handler
     // (engine_resolution_choices.rs `EffectKind::BlightEffect`); the parser
     // does not structurally exclude a degenerate `Blight 0`.
-    if counters > 0 {
-        add_counter_with_replacement(
-            state,
-            player,
-            chosen[0],
-            crate::types::counter::CounterType::Minus1Minus1,
-            counters,
-            events,
-        );
-    }
-
     // CR 117.1 + CR 608.2k: snapshot the blighted creature as this ability's
     // cost-paid object so later `CostPaidObject` target filters / quantity
     // refs ("the creature you blighted") resolve to it. This writes the
@@ -1376,6 +1365,20 @@ pub(crate) fn handle_blight_choice(
                 object_id: chosen[0],
                 lki: obj.snapshot_for_mana_spent(),
             });
+    }
+
+    if counters > 0
+        && !add_counter_with_replacement(
+            state,
+            player,
+            chosen[0],
+            crate::types::counter::CounterType::Minus1Minus1,
+            counters,
+            events,
+        )
+    {
+        state.pending_cast = Some(Box::new(pending));
+        return Ok(state.waiting_for.clone());
     }
 
     finish_pending_cost_or_cast(state, player, pending, events)

--- a/crates/engine/src/game/effects/adapt.rs
+++ b/crates/engine/src/game/effects/adapt.rs
@@ -1,4 +1,6 @@
-use crate::game::effects::counters::add_counter_with_replacement;
+use crate::game::effects::counters::{
+    add_counter_with_replacement, stash_pending_counter_completion,
+};
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::counter::CounterType;
@@ -41,15 +43,18 @@ pub fn resolve(
     let n = resolve_quantity_with_targets(state, &count_expr, ability).max(0) as u32;
 
     // CR 701.46a: Put N +1/+1 counters on the permanent.
-    if n > 0 {
-        add_counter_with_replacement(
+    if n > 0
+        && !add_counter_with_replacement(
             state,
             ability.controller,
             source_id,
             CounterType::Plus1Plus1,
             n,
             events,
-        );
+        )
+    {
+        stash_pending_counter_completion(state, EffectKind::Adapt, source_id);
+        return Ok(());
     }
 
     // CR 701.46a: Emit EffectResolved so "When ~ adapts" triggers can fire.

--- a/crates/engine/src/game/effects/amass.rs
+++ b/crates/engine/src/game/effects/amass.rs
@@ -1,4 +1,6 @@
-use crate::game::effects::counters::add_counter_with_replacement;
+use crate::game::effects::counters::{
+    add_counter_with_replacement, stash_pending_counter_completion_with_actions,
+};
 use crate::game::effects::token::apply_create_token_after_replacement;
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::game::replacement::{self, ReplacementResult};
@@ -6,7 +8,7 @@ use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCounterPostAction};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaColor;
 use crate::types::proposed_event::{EtbTapState, ProposedEvent, TokenCharacteristics, TokenSpec};
@@ -44,15 +46,26 @@ pub fn resolve(
     };
 
     // CR 701.47a: Put N +1/+1 counters on the chosen Army.
-    if n > 0 {
-        add_counter_with_replacement(
+    if n > 0
+        && !add_counter_with_replacement(
             state,
             ability.controller,
             target_id,
             CounterType::Plus1Plus1,
             n,
             events,
+        )
+    {
+        stash_pending_counter_completion_with_actions(
+            state,
+            EffectKind::Amass,
+            ability.source_id,
+            vec![PendingCounterPostAction::AddSubtype {
+                object_id: target_id,
+                subtype: subtype.clone(),
+            }],
         );
+        return Ok(());
     }
 
     // CR 701.47a: If it isn't a [subtype], it becomes a [subtype] in addition to its other types.

--- a/crates/engine/src/game/effects/become_copy.rs
+++ b/crates/engine/src/game/effects/become_copy.rs
@@ -4,7 +4,7 @@ use crate::types::ability::{
     TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCounterAddition, PendingEffectResolved};
 
 /// CR 707.2 / CR 613.1a: Become a copy of target permanent via a layer-1 copy effect.
 pub fn resolve(
@@ -107,6 +107,7 @@ pub fn resolve(
     crate::game::layers::evaluate_layers(state);
 
     if !resolution_mods.is_empty() {
+        let mut additions = Vec::new();
         for modification in resolution_mods {
             // RemoveManaCost was already consumed into `values`; only the
             // counter-placement exceptions remain to apply here.
@@ -137,14 +138,41 @@ pub fn resolve(
                 if !gate_passes {
                     continue;
                 }
-                super::counters::add_counter_with_replacement(
-                    state,
-                    ability.controller,
-                    ability.source_id,
+                additions.push(PendingCounterAddition::Object {
+                    actor: ability.controller,
+                    object_id: ability.source_id,
                     counter_type,
-                    n,
-                    events,
+                    count: n,
+                });
+            }
+        }
+        for (index, addition) in additions.iter().cloned().enumerate() {
+            let PendingCounterAddition::Object {
+                actor,
+                object_id,
+                counter_type,
+                count,
+            } = addition
+            else {
+                continue;
+            };
+            if !super::counters::add_counter_with_replacement(
+                state,
+                actor,
+                object_id,
+                counter_type,
+                count,
+                events,
+            ) {
+                super::counters::stash_pending_counter_additions(
+                    state,
+                    additions[index + 1..].to_vec(),
+                    PendingEffectResolved::new(
+                        EffectKind::from(&ability.effect),
+                        ability.source_id,
+                    ),
                 );
+                return Ok(());
             }
         }
     }

--- a/crates/engine/src/game/effects/bolster.rs
+++ b/crates/engine/src/game/effects/bolster.rs
@@ -1,4 +1,6 @@
-use crate::game::effects::counters::add_counter_with_replacement;
+use crate::game::effects::counters::{
+    add_counter_with_replacement, stash_pending_counter_completion,
+};
 use crate::game::quantity::resolve_quantity;
 use crate::types::ability::{Effect, EffectError, EffectKind, QuantityExpr, ResolvedAbility};
 use crate::types::counter::CounterType;
@@ -65,15 +67,18 @@ pub fn resolve(
 
     if tied.len() == 1 {
         // CR 701.39a: Unique minimum — auto-choose and add counters.
-        if n > 0 {
-            add_counter_with_replacement(
+        if n > 0
+            && !add_counter_with_replacement(
                 state,
                 ability.controller,
                 tied[0],
                 CounterType::Plus1Plus1,
                 n,
                 events,
-            );
+            )
+        {
+            stash_pending_counter_completion(state, EffectKind::Bolster, source_id);
+            return Ok(());
         }
 
         events.push(GameEvent::EffectResolved {

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -9,7 +9,10 @@ use crate::types::ability::{
 };
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{ExileLink, ExileLinkKind, GameState, WaitingFor};
+use crate::types::game_state::{
+    ExileLink, ExileLinkKind, GameState, PendingCounterPostAction, WaitingFor,
+    ZoneDeliveryExileTracking,
+};
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::keywords::Keyword;
 use crate::types::player::PlayerId;
@@ -60,7 +63,7 @@ fn enters_with_additional_counters_for_entry(
     additional
 }
 
-/// CR 401.3: Shuffle a player's library using the game's seeded RNG.
+/// CR 701.24a: Shuffle a player's library using the game's seeded RNG.
 /// Reusable helper for auto-shuffle after zone moves to Library.
 pub fn shuffle_library(state: &mut GameState, player: PlayerId, events: &mut Vec<GameEvent>) {
     let GameState { players, rng, .. } = state;
@@ -154,6 +157,107 @@ pub(crate) enum ZoneMoveResult {
     NeedsAuraAttachmentChoice,
 }
 
+pub(crate) enum ZoneDeliveryResult {
+    Done,
+    NeedsChoice(PlayerId),
+}
+
+fn append_effect_resolved_after_counter_pause(
+    state: &mut GameState,
+    kind: EffectKind,
+    source_id: ObjectId,
+) {
+    super::counters::append_pending_counter_post_actions(
+        state,
+        vec![PendingCounterPostAction::EmitEffectResolved { kind, source_id }],
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_zone_delivery_tail_after_counter_pause(
+    state: &mut GameState,
+    object_id: ObjectId,
+    from: Zone,
+    to: Zone,
+    cause: Option<ObjectId>,
+    source_id: Option<ObjectId>,
+    duration: Option<&Duration>,
+    exile_tracking: ZoneDeliveryExileTracking,
+    clear_pending_etb_counters: Option<ObjectId>,
+) -> ZoneDeliveryResult {
+    let mut actions = Vec::new();
+    if let Some(object_id) = clear_pending_etb_counters {
+        actions.push(PendingCounterPostAction::ClearPendingEtbCounters { object_id });
+    }
+    actions.push(PendingCounterPostAction::ContinueZoneDeliveryTail {
+        object_id,
+        from,
+        to,
+        cause,
+        source_id,
+        duration: duration.cloned(),
+        exile_tracking,
+    });
+    super::counters::append_pending_counter_post_actions(state, actions);
+    replacement_pause_delivery_result(state)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn apply_zone_delivery_tail(
+    state: &mut GameState,
+    object_id: ObjectId,
+    from: Zone,
+    to: Zone,
+    cause: Option<ObjectId>,
+    source_id: Option<ObjectId>,
+    duration: Option<&Duration>,
+    exile_tracking: ZoneDeliveryExileTracking,
+    events: &mut Vec<GameEvent>,
+) {
+    // CR 701.24a: To shuffle a library, randomize the cards within it so that
+    // no player knows their order.
+    if to == Zone::Library {
+        let owner = state.objects.get(&object_id).map(|o| o.owner);
+        if let Some(owner) = owner {
+            shuffle_library(state, owner, events);
+        }
+    }
+    // Track cards exiled by the source. Some linked exiles return when the
+    // source leaves; others are just remembered as "exiled with" the source.
+    if to == Zone::Exile {
+        if let Some(source_id) = cause.or(source_id) {
+            let kind = match duration {
+                Some(Duration::UntilHostLeavesPlay) => {
+                    ExileLinkKind::UntilSourceLeaves { return_zone: from }
+                }
+                _ if matches!(exile_tracking, ZoneDeliveryExileTracking::TrackBySource) => {
+                    ExileLinkKind::TrackedBySource
+                }
+                _ => return,
+            };
+            state.exile_links.push(ExileLink {
+                exiled_id: object_id,
+                source_id,
+                kind,
+            });
+        }
+    }
+    // CR 614.12a: Drain mandatory replacement post-effects after the zone
+    // change completes. This shared delivery path covers effect-driven moves
+    // (`ChangeZone`) in the same way stack resolution and land play already
+    // do, so as-enters work such as "enters prepared" or persisted choices
+    // applies before triggers and priority.
+    if state.post_replacement_continuation.is_some() {
+        let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
+            state,
+            Some(object_id),
+            None,
+            Some(crate::types::replacements::ReplacementEvent::Moved),
+            events,
+        );
+    }
+}
+
 fn aura_enchant_filter(state: &GameState, object_id: ObjectId) -> Option<TargetFilter> {
     let obj = state.objects.get(&object_id)?;
     if !obj.card_types.subtypes.iter().any(|s| s == "Aura") {
@@ -226,7 +330,7 @@ pub(crate) fn deliver_replaced_zone_change(
     duration: Option<&Duration>,
     track_exiled_by_source: bool,
     events: &mut Vec<GameEvent>,
-) {
+) -> ZoneDeliveryResult {
     if let ProposedEvent::ZoneChange {
         object_id,
         from,
@@ -241,6 +345,12 @@ pub(crate) fn deliver_replaced_zone_change(
         ..
     } = event
     {
+        let exile_tracking = if track_exiled_by_source {
+            ZoneDeliveryExileTracking::TrackBySource
+        } else {
+            ZoneDeliveryExileTracking::None
+        };
+
         // CR 614.1c: Static replacement effects that modify how an object enters
         // must already be functioning before that object enters. Snapshot the
         // definitions before `move_to_zone` so a newly-entered permanent cannot
@@ -341,12 +451,7 @@ pub(crate) fn deliver_replaced_zone_change(
         // CR 614.1c: Apply counters from replacement pipeline (e.g., saga lore counters,
         // planeswalker intrinsic loyalty, battle intrinsic defense).
         if to == Zone::Battlefield {
-            crate::game::engine_replacement::apply_etb_counters(
-                state,
-                object_id,
-                &enter_with_counters,
-                events,
-            );
+            let mut counters_to_apply = enter_with_counters;
             // CR 614.1c + CR 122.1: Apply additional counters from continuous
             // "[scope] creatures you control enter with an additional [counter]
             // counter on them" statics (Kalain, Bard Class, Gorma the Gullet,
@@ -359,14 +464,7 @@ pub(crate) fn deliver_replaced_zone_change(
                 object_id,
                 &enters_with_additional_counter_statics,
             );
-            if !additional.is_empty() {
-                crate::game::engine_replacement::apply_etb_counters(
-                    state,
-                    object_id,
-                    &additional,
-                    events,
-                );
-            }
+            counters_to_apply.extend(additional);
             // CR 614.1c: Apply pending ETB counters from delayed triggers
             // (e.g., "that creature enters with an additional +1/+1 counter").
             let pending: Vec<_> = state
@@ -375,10 +473,33 @@ pub(crate) fn deliver_replaced_zone_change(
                 .filter(|(oid, _, _)| *oid == object_id)
                 .map(|(_, ct, n)| (ct.clone(), *n))
                 .collect();
-            if !pending.is_empty() {
-                crate::game::engine_replacement::apply_etb_counters(
-                    state, object_id, &pending, events,
+            let pending_etb_cleanup = if pending.is_empty() {
+                None
+            } else {
+                Some(object_id)
+            };
+            counters_to_apply.extend(pending);
+            if !counters_to_apply.is_empty()
+                && !crate::game::engine_replacement::apply_etb_counters(
+                    state,
+                    object_id,
+                    &counters_to_apply,
+                    events,
+                )
+            {
+                return append_zone_delivery_tail_after_counter_pause(
+                    state,
+                    object_id,
+                    from,
+                    to,
+                    cause,
+                    source_id,
+                    duration,
+                    exile_tracking,
+                    pending_etb_cleanup,
                 );
+            }
+            if pending_etb_cleanup.is_some() {
                 state
                     .pending_etb_counters
                     .retain(|(oid, _, _)| *oid != object_id);
@@ -390,53 +511,45 @@ pub(crate) fn deliver_replaced_zone_change(
             // shared single-authority resolver so counter-doubling
             // replacements (Doubling Season, Hardened Scales) and
             // event emission stay consistent.
-            crate::game::engine_replacement::apply_etb_counters(
+            if !crate::game::engine_replacement::apply_etb_counters(
                 state,
                 object_id,
                 &enter_with_counters,
                 events,
-            );
-        }
-        // CR 401.3: If an object is put into a library (not at a specific
-        // position), that library is shuffled afterward.
-        if to == Zone::Library {
-            let owner = state.objects.get(&object_id).map(|o| o.owner);
-            if let Some(owner) = owner {
-                shuffle_library(state, owner, events);
-            }
-        }
-        // Track cards exiled by the source. Some linked exiles return when the
-        // source leaves; others are just remembered as "exiled with" the source.
-        if to == Zone::Exile {
-            if let Some(source_id) = cause.or(source_id) {
-                let kind = match duration {
-                    Some(Duration::UntilHostLeavesPlay) => {
-                        ExileLinkKind::UntilSourceLeaves { return_zone: from }
-                    }
-                    _ if track_exiled_by_source => ExileLinkKind::TrackedBySource,
-                    _ => return,
-                };
-                state.exile_links.push(ExileLink {
-                    exiled_id: object_id,
+            ) {
+                return append_zone_delivery_tail_after_counter_pause(
+                    state,
+                    object_id,
+                    from,
+                    to,
+                    cause,
                     source_id,
-                    kind,
-                });
+                    duration,
+                    exile_tracking,
+                    None,
+                );
             }
         }
-        // CR 614.12a: Drain mandatory replacement post-effects after the zone
-        // change completes. This shared delivery path covers effect-driven moves
-        // (`ChangeZone`) in the same way stack resolution and land play already
-        // do, so as-enters work such as "enters prepared" or persisted choices
-        // applies before triggers and priority.
-        if state.post_replacement_continuation.is_some() {
-            let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
-                state,
-                Some(object_id),
-                None,
-                Some(crate::types::replacements::ReplacementEvent::Moved),
-                events,
-            );
-        }
+        apply_zone_delivery_tail(
+            state,
+            object_id,
+            from,
+            to,
+            cause,
+            source_id,
+            duration,
+            exile_tracking,
+            events,
+        );
+    }
+    ZoneDeliveryResult::Done
+}
+
+fn replacement_pause_delivery_result(state: &GameState) -> ZoneDeliveryResult {
+    if let WaitingFor::ReplacementChoice { player, .. } = &state.waiting_for {
+        ZoneDeliveryResult::NeedsChoice(*player)
+    } else {
+        ZoneDeliveryResult::NeedsChoice(state.active_player)
     }
 }
 
@@ -599,14 +712,19 @@ pub(crate) fn execute_zone_move(
                 }
             }
             if let Some((controller, aura_id, legal_targets)) = pending_aura_choice {
-                deliver_replaced_zone_change(
+                match deliver_replaced_zone_change(
                     state,
                     event,
                     Some(source_id),
                     duration,
                     track_exiled_by_source,
                     events,
-                );
+                ) {
+                    ZoneDeliveryResult::Done => {}
+                    ZoneDeliveryResult::NeedsChoice(player) => {
+                        return ZoneMoveResult::NeedsChoice(player);
+                    }
+                }
                 state.waiting_for = WaitingFor::ReturnAsAuraTarget {
                     player: controller,
                     source_id,
@@ -624,14 +742,19 @@ pub(crate) fn execute_zone_move(
                 };
                 return ZoneMoveResult::NeedsAuraAttachmentChoice;
             }
-            deliver_replaced_zone_change(
+            match deliver_replaced_zone_change(
                 state,
                 event,
                 Some(source_id),
                 duration,
                 track_exiled_by_source,
                 events,
-            );
+            ) {
+                ZoneDeliveryResult::Done => {}
+                ZoneDeliveryResult::NeedsChoice(player) => {
+                    return ZoneMoveResult::NeedsChoice(player);
+                }
+            }
             ZoneMoveResult::Done
         }
         ReplacementResult::Prevented => ZoneMoveResult::Done,
@@ -914,6 +1037,11 @@ pub fn resolve(
                     }
                 }
                 ZoneMoveResult::NeedsChoice(player) => {
+                    append_effect_resolved_after_counter_pause(
+                        state,
+                        EffectKind::from(&ability.effect),
+                        ability.source_id,
+                    );
                     state.waiting_for =
                         crate::game::replacement::replacement_choice_waiting_for(player, state);
                     return Ok(());
@@ -963,6 +1091,11 @@ pub fn resolve(
                     }
                 }
                 ZoneMoveResult::NeedsChoice(player) => {
+                    append_effect_resolved_after_counter_pause(
+                        state,
+                        EffectKind::from(&ability.effect),
+                        ability.source_id,
+                    );
                     state.waiting_for =
                         crate::game::replacement::replacement_choice_waiting_for(player, state);
                     return Ok(());
@@ -1422,6 +1555,11 @@ pub fn resolve_all(
                 }
             }
             ZoneMoveResult::NeedsChoice(player) => {
+                append_effect_resolved_after_counter_pause(
+                    state,
+                    EffectKind::from(&ability.effect),
+                    ability.source_id,
+                );
                 state.waiting_for =
                     crate::game::replacement::replacement_choice_waiting_for(player, state);
                 return Ok(());
@@ -2532,7 +2670,7 @@ mod tests {
 
     #[test]
     fn auto_shuffle_after_library_destination() {
-        // CR 401.3: Moving an object to a library should shuffle that library afterward
+        // CR 701.24a: Moving an object to a library should shuffle that library afterward.
         let mut state = GameState::new_two_player(42);
         // Add some cards to player 0's library so we can detect shuffle
         for i in 0..5 {

--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -7,7 +7,7 @@ use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
-use crate::types::proposed_event::ProposedEvent;
+use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
 use crate::types::zones::Zone;
 
 /// CR 701.50a: Connive — draw N cards, then discard N cards. For each nonland
@@ -211,20 +211,25 @@ pub(crate) fn add_connive_counters(
     }
 
     let proposed = ProposedEvent::AddCounter {
-        actor: state
-            .objects
-            .get(&conniver_id)
-            .map(|obj| obj.controller)
-            .unwrap_or(crate::types::player::PlayerId(0)),
-        object_id: conniver_id,
-        counter_type: CounterType::Plus1Plus1,
+        placement: CounterPlacement::Object {
+            actor: state
+                .objects
+                .get(&conniver_id)
+                .map(|obj| obj.controller)
+                .unwrap_or(crate::types::player::PlayerId(0)),
+            object_id: conniver_id,
+            counter_type: CounterType::Plus1Plus1,
+        },
         count,
         applied: HashSet::new(),
     };
     if let ReplacementResult::Execute(ProposedEvent::AddCounter {
-        actor,
-        object_id,
-        counter_type,
+        placement:
+            CounterPlacement::Object {
+                actor,
+                object_id,
+                counter_type,
+            },
         count: final_count,
         ..
     }) = replacement::replace_event(state, proposed, events)

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -3,20 +3,22 @@ use std::collections::HashSet;
 use crate::game::game_object::GameObject;
 use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{
-    AbilityTag, CounterMoveSelection, CounterTransferMode, Effect, EffectError, EffectKind,
-    ResolvedAbility, TargetChoiceTiming, TargetFilter, TargetRef,
+    AbilityTag, CounterMoveSelection, CounterTransferMode, DelayedTriggerCondition, Duration,
+    Effect, EffectError, EffectKind, QuantityExpr, ResolvedAbility, TargetChoiceTiming,
+    TargetFilter, TargetRef,
 };
 #[cfg(test)]
 use crate::types::counter::parse_counter_type;
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    CounterAddedRecord, CounterMoveChoice, GameState, PendingCounterMove, PendingCounterMoveQueue,
-    WaitingFor,
+    CounterAddedRecord, CounterMoveChoice, DelayedTrigger, GameState, PendingCounterAddition,
+    PendingCounterAdditionQueue, PendingCounterMove, PendingCounterMoveQueue,
+    PendingCounterPostAction, PendingEffectResolutionEvent, PendingEffectResolved, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
-use crate::types::proposed_event::{CounterMoveStage, ProposedEvent};
+use crate::types::proposed_event::{CounterMoveStage, CounterPlacement, ProposedEvent};
 
 /// CR 306.5c + CR 310.4c: After mutating the counter map, re-derive the
 /// `obj.loyalty` / `obj.defense` field so the counter count and the cached
@@ -103,14 +105,16 @@ pub fn add_counter_with_replacement(
     counter_type: CounterType,
     count: u32,
     events: &mut Vec<GameEvent>,
-) {
+) -> bool {
     if count == 0 {
-        return;
+        return true;
     }
     let proposed = ProposedEvent::AddCounter {
-        actor,
-        object_id,
-        counter_type,
+        placement: CounterPlacement::Object {
+            actor,
+            object_id,
+            counter_type,
+        },
         count,
         applied: HashSet::new(),
     };
@@ -118,22 +122,512 @@ pub fn add_counter_with_replacement(
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(event) => {
             if let ProposedEvent::AddCounter {
-                actor,
-                object_id,
-                counter_type,
+                placement:
+                    CounterPlacement::Object {
+                        actor,
+                        object_id,
+                        counter_type,
+                    },
                 count,
                 ..
             } = event
             {
                 apply_counter_addition(state, actor, object_id, counter_type, count, events);
             }
+            true
         }
-        ReplacementResult::Prevented => {}
+        ReplacementResult::Prevented => true,
         ReplacementResult::NeedsChoice(player) => {
             state.waiting_for =
                 crate::game::replacement::replacement_choice_waiting_for(player, state);
+            false
         }
     }
+}
+
+pub(crate) fn stash_pending_counter_additions(
+    state: &mut GameState,
+    remaining: Vec<PendingCounterAddition>,
+    completion: PendingEffectResolved,
+) {
+    if remaining.is_empty() {
+        state.pending_counter_additions = Some(PendingCounterAdditionQueue {
+            remaining,
+            completion: Some(completion),
+        });
+        return;
+    }
+    state.pending_counter_additions = Some(PendingCounterAdditionQueue {
+        remaining,
+        completion: Some(completion),
+    });
+}
+
+pub(crate) fn stash_pending_counter_completion(
+    state: &mut GameState,
+    kind: EffectKind,
+    source_id: ObjectId,
+) {
+    stash_pending_counter_additions(
+        state,
+        Vec::new(),
+        PendingEffectResolved::new(kind, source_id),
+    );
+}
+
+pub(crate) fn stash_pending_counter_completion_with_actions(
+    state: &mut GameState,
+    kind: EffectKind,
+    source_id: ObjectId,
+    post_actions: Vec<PendingCounterPostAction>,
+) {
+    stash_pending_counter_additions(
+        state,
+        Vec::new(),
+        PendingEffectResolved::with_post_actions(kind, source_id, post_actions),
+    );
+}
+
+pub(crate) fn stash_pending_counter_post_actions(
+    state: &mut GameState,
+    kind: EffectKind,
+    source_id: ObjectId,
+    post_actions: Vec<PendingCounterPostAction>,
+) {
+    stash_pending_counter_additions(
+        state,
+        Vec::new(),
+        PendingEffectResolved::with_post_actions_without_effect(kind, source_id, post_actions),
+    );
+}
+
+pub(crate) fn append_pending_counter_post_actions(
+    state: &mut GameState,
+    post_actions: Vec<PendingCounterPostAction>,
+) {
+    if post_actions.is_empty() {
+        return;
+    }
+    if let Some(completion) = state
+        .pending_counter_additions
+        .as_mut()
+        .and_then(|queue| queue.completion.as_mut())
+    {
+        completion.post_actions.extend(post_actions);
+    }
+}
+
+fn object_counter_addition(
+    actor: PlayerId,
+    object_id: ObjectId,
+    counter_type: CounterType,
+    count: u32,
+) -> PendingCounterAddition {
+    PendingCounterAddition::Object {
+        actor,
+        object_id,
+        counter_type,
+        count,
+    }
+}
+
+fn apply_object_counter_addition(
+    state: &mut GameState,
+    addition: PendingCounterAddition,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    let PendingCounterAddition::Object {
+        actor,
+        object_id,
+        counter_type,
+        count,
+    } = addition
+    else {
+        return true;
+    };
+    add_counter_with_replacement(state, actor, object_id, counter_type, count, events)
+}
+
+fn merge_pending_counter_completion_after_nested_pause(
+    state: &mut GameState,
+    completion: PendingEffectResolved,
+) {
+    let Some(queue) = state.pending_counter_additions.as_mut() else {
+        stash_pending_counter_additions(state, Vec::new(), completion);
+        return;
+    };
+
+    let Some(nested_completion) = queue.completion.as_mut() else {
+        queue.completion = Some(completion);
+        return;
+    };
+
+    nested_completion
+        .post_actions
+        .extend(completion.post_actions);
+    match completion.resolution_event {
+        PendingEffectResolutionEvent::Emit => {
+            nested_completion
+                .post_actions
+                .push(PendingCounterPostAction::EmitEffectResolved {
+                    kind: completion.kind,
+                    source_id: completion.source_id,
+                });
+        }
+        PendingEffectResolutionEvent::Suppress => {}
+    }
+    if let Some(action) = completion.player_action {
+        nested_completion
+            .post_actions
+            .push(PendingCounterPostAction::RecordPlayerAction {
+                player_id: action.player_id,
+                action: action.action,
+            });
+    }
+}
+
+pub(crate) fn drain_pending_counter_additions(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    while let Some(mut queue) = state.pending_counter_additions.take() {
+        let Some(next) = queue.remaining.first().cloned() else {
+            if let Some(PendingEffectResolved {
+                kind,
+                source_id,
+                resolution_event,
+                mut post_actions,
+                player_action,
+            }) = queue.completion.take()
+            {
+                while let Some(action) = post_actions.first().cloned() {
+                    post_actions.remove(0);
+                    if !apply_pending_counter_post_action(state, action, events) {
+                        merge_pending_counter_completion_after_nested_pause(
+                            state,
+                            PendingEffectResolved {
+                                kind,
+                                source_id,
+                                resolution_event,
+                                post_actions,
+                                player_action,
+                            },
+                        );
+                        return;
+                    }
+                }
+                match resolution_event {
+                    PendingEffectResolutionEvent::Emit => {
+                        events.push(GameEvent::EffectResolved { kind, source_id });
+                    }
+                    PendingEffectResolutionEvent::Suppress => {}
+                }
+                if let Some(action) = player_action {
+                    events.push(GameEvent::PlayerPerformedAction {
+                        player_id: action.player_id,
+                        action: action.action,
+                    });
+                }
+            }
+            continue;
+        };
+        queue.remaining.remove(0);
+        state.pending_counter_additions = Some(queue);
+        let completed = match next {
+            PendingCounterAddition::Object {
+                actor,
+                object_id,
+                counter_type,
+                count,
+            } => add_counter_with_replacement(state, actor, object_id, counter_type, count, events),
+            PendingCounterAddition::Player {
+                actor,
+                player_id,
+                counter_kind,
+                count,
+            } => super::player_counter::add_player_counter_with_replacement(
+                state,
+                actor,
+                player_id,
+                counter_kind,
+                count,
+                events,
+            ),
+            PendingCounterAddition::Energy {
+                actor,
+                player_id,
+                count,
+            } => super::energy::add_energy_with_replacement(state, actor, player_id, count, events),
+        };
+        if !completed {
+            return;
+        }
+    }
+}
+
+fn apply_pending_counter_post_action(
+    state: &mut GameState,
+    action: PendingCounterPostAction,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    match action {
+        PendingCounterPostAction::EmitEffectResolved { kind, source_id } => {
+            events.push(GameEvent::EffectResolved { kind, source_id });
+            true
+        }
+        PendingCounterPostAction::RecordPlayerAction { player_id, action } => {
+            events.push(GameEvent::PlayerPerformedAction { player_id, action });
+            true
+        }
+        PendingCounterPostAction::AddSubtype { object_id, subtype } => {
+            if let Some(obj) = state.objects.get_mut(&object_id) {
+                if !obj
+                    .card_types
+                    .subtypes
+                    .iter()
+                    .any(|s| s.eq_ignore_ascii_case(&subtype))
+                {
+                    obj.card_types.subtypes.push(subtype.clone());
+                    obj.base_card_types.subtypes.push(subtype);
+                }
+            }
+            true
+        }
+        PendingCounterPostAction::InjectPredefinedTokenAbilities { object_id } => {
+            // CR 111.10 + CR 400.7: Incubator tokens get predefined
+            // subtype abilities and battlefield-entry bookkeeping after their
+            // replacement-processed counters finish.
+            super::token::inject_predefined_token_abilities(state, object_id);
+            crate::game::layers::mark_layers_entered(state, object_id);
+            crate::game::restrictions::record_battlefield_entry(state, object_id);
+            crate::game::restrictions::record_token_created(state, object_id);
+            true
+        }
+        PendingCounterPostAction::FinalizeTokenEntry {
+            object_id,
+            name,
+            attach_to,
+            sacrifice_at,
+            source_id,
+            controller,
+        } => {
+            // CR 111.1 + CR 111.10 + CR 603.6a: once ETB counters finish,
+            // complete token entry exactly as the uninterrupted token path
+            // does: abilities/bookkeeping, attachment, ETB events, and any
+            // delayed sacrifice trigger.
+            super::token::inject_predefined_token_abilities(state, object_id);
+            crate::game::layers::mark_layers_entered(state, object_id);
+            crate::game::restrictions::record_battlefield_entry(state, object_id);
+            crate::game::restrictions::record_token_created(state, object_id);
+            if let Some(host) = attach_to {
+                match host {
+                    crate::game::game_object::AttachTarget::Object(id) => {
+                        super::attach::attach_to(state, object_id, id);
+                    }
+                    crate::game::game_object::AttachTarget::Player(pid) => {
+                        super::attach::attach_to_player(state, object_id, pid);
+                    }
+                }
+            }
+            push_token_entry_events(state, events, object_id, name);
+            if matches!(sacrifice_at, Some(Duration::UntilEndOfCombat)) {
+                state.delayed_triggers.push(DelayedTrigger {
+                    condition: DelayedTriggerCondition::AtNextPhase {
+                        phase: crate::types::phase::Phase::EndCombat,
+                    },
+                    ability: ResolvedAbility::new(
+                        Effect::Sacrifice {
+                            target: TargetFilter::Any,
+                            count: QuantityExpr::Fixed { value: 1 },
+                            min_count: 0,
+                        },
+                        vec![TargetRef::Object(object_id)],
+                        source_id,
+                        controller,
+                    ),
+                    controller,
+                    source_id,
+                    one_shot: true,
+                });
+            }
+            state.last_created_token_ids.push(object_id);
+            true
+        }
+        PendingCounterPostAction::ContinueTokenCreation {
+            owner,
+            spec,
+            enter_tapped,
+            remaining_count,
+        } => {
+            if remaining_count == 0 {
+                return true;
+            }
+            let event = ProposedEvent::CreateToken {
+                owner,
+                spec,
+                copy: None,
+                enter_tapped,
+                count: remaining_count,
+                applied: HashSet::new(),
+            };
+            let created_ids = state.last_created_token_ids.clone();
+            super::token::apply_create_token_after_replacement_with_created_ids(
+                state,
+                event,
+                created_ids,
+                PendingEffectResolutionEvent::Suppress,
+                events,
+            )
+        }
+        PendingCounterPostAction::FinalizeCopyTokenEntry {
+            object_id,
+            name,
+            enters_attacking,
+            source_id,
+            controller,
+        } => {
+            // CR 508.4 + CR 111.1 + CR 603.6a: complete copy-token entry after
+            // replacement-processed counters finish, preserving attacking
+            // placement and the normal token ETB events.
+            if enters_attacking {
+                crate::game::combat::enter_attacking(state, object_id, source_id, controller);
+            }
+            super::token::inject_predefined_token_abilities(state, object_id);
+            crate::game::layers::mark_layers_entered(state, object_id);
+            crate::game::restrictions::record_battlefield_entry(state, object_id);
+            crate::game::restrictions::record_token_created(state, object_id);
+            push_token_entry_events(state, events, object_id, name);
+            state.last_created_token_ids.push(object_id);
+            if let Some(pending) = state.pending_copy_token_resolution.as_mut() {
+                pending.created_ids.push(object_id);
+            }
+            true
+        }
+        PendingCounterPostAction::ContinueCopyTokenCreation {
+            owner,
+            copy,
+            enter_tapped,
+            enter_with_counters,
+            remaining_count,
+        } => {
+            if remaining_count == 0 {
+                return true;
+            }
+            let status = super::token_copy::apply_copy_token_after_replacement(
+                state,
+                owner,
+                *copy,
+                enter_tapped,
+                enter_with_counters,
+                remaining_count,
+                events,
+            );
+            let completion = status.completion;
+            if let Some(pending) = state.pending_copy_token_resolution.as_mut() {
+                pending.created_ids.extend(status.created_ids);
+            } else {
+                state.last_created_token_ids.extend(status.created_ids);
+            }
+            match completion {
+                super::token_copy::CopyTokenApplyCompletion::Completed => true,
+                super::token_copy::CopyTokenApplyCompletion::Paused => false,
+            }
+        }
+        PendingCounterPostAction::ApplyCopyTokenModificationsAndFinalize {
+            object_id,
+            name,
+            enters_attacking,
+            source_id,
+            controller,
+            remaining_modifications,
+        } => super::token_copy::apply_remaining_token_modifications_after_counter_pause(
+            state,
+            object_id,
+            name,
+            enters_attacking,
+            source_id,
+            controller,
+            remaining_modifications,
+            events,
+        ),
+        PendingCounterPostAction::ClearPendingEtbCounters { object_id } => {
+            state
+                .pending_etb_counters
+                .retain(|(pending_id, _, _)| *pending_id != object_id);
+            true
+        }
+        PendingCounterPostAction::ContinueZoneDeliveryTail {
+            object_id,
+            from,
+            to,
+            cause,
+            source_id,
+            duration,
+            exile_tracking,
+        } => {
+            super::change_zone::apply_zone_delivery_tail(
+                state,
+                object_id,
+                from,
+                to,
+                cause,
+                source_id,
+                duration.as_ref(),
+                exile_tracking,
+                events,
+            );
+            true
+        }
+        PendingCounterPostAction::RecordStationed {
+            spacecraft_id,
+            creature_id,
+            counters_added,
+        } => {
+            // CR 702.184a: Station records the completed keyword action after
+            // its replacement-processed charge counters finish.
+            events.push(GameEvent::Stationed {
+                spacecraft_id,
+                creature_id,
+                counters_added,
+            });
+            true
+        }
+        PendingCounterPostAction::MarkMonstrous { object_id } => {
+            // CR 701.37a: a creature becomes monstrous after the monstrosity
+            // instruction resolves, even if counter placement was modified or
+            // prevented.
+            if let Some(obj) = state.objects.get_mut(&object_id) {
+                obj.monstrous = true;
+            }
+            true
+        }
+        PendingCounterPostAction::MarkRenowned { object_id } => {
+            // CR 702.112a: a creature becomes renowned after the renown
+            // instruction resolves, even if counter placement was modified or
+            // prevented.
+            if let Some(obj) = state.objects.get_mut(&object_id) {
+                obj.is_renowned = true;
+            }
+            true
+        }
+    }
+}
+
+fn push_token_entry_events(
+    state: &GameState,
+    events: &mut Vec<GameEvent>,
+    object_id: ObjectId,
+    name: String,
+) {
+    let Some(obj) = state.objects.get(&object_id) else {
+        return;
+    };
+    let zone_change_record =
+        obj.snapshot_for_zone_change(object_id, None, crate::types::zones::Zone::Battlefield);
+    events.push(GameEvent::ZoneChanged {
+        object_id,
+        from: None,
+        to: crate::types::zones::Zone::Battlefield,
+        record: Box::new(zone_change_record),
+    });
+    events.push(GameEvent::TokenCreated { object_id, name });
 }
 
 /// CR 122.1 + CR 122.6: Apply an already-accepted counter addition and record
@@ -518,44 +1012,57 @@ pub fn resolve_add(
     };
 
     // CR 601.2d: If distribution was assigned at cast time, apply per-target counter counts.
-    if let Some(distribution) = &ability.distribution {
-        for (target, count) in distribution {
-            if let crate::types::ability::TargetRef::Object(obj_id) = target {
-                let event_start = events.len();
-                add_counter_with_replacement(
-                    state,
-                    ability.controller,
-                    *obj_id,
-                    counter_type.clone(),
-                    *count,
-                    events,
-                );
-                emit_evolved_event_for_counter_addition(
-                    ability,
-                    events,
-                    event_start,
-                    *obj_id,
-                    &counter_type,
-                );
-            }
-        }
+    let additions: Vec<PendingCounterAddition> = if let Some(distribution) = &ability.distribution {
+        distribution
+            .iter()
+            .filter_map(|(target, count)| {
+                if let crate::types::ability::TargetRef::Object(obj_id) = target {
+                    Some(object_counter_addition(
+                        ability.controller,
+                        *obj_id,
+                        counter_type.clone(),
+                        *count,
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect()
     } else {
         let targets = resolve_defined_or_targets(state, ability);
-        for obj_id in targets {
-            let event_start = events.len();
-            add_counter_with_replacement(
-                state,
-                ability.controller,
-                obj_id,
-                counter_type.clone(),
-                counter_num,
-                events,
-            );
+        targets
+            .into_iter()
+            .map(|obj_id| {
+                object_counter_addition(
+                    ability.controller,
+                    obj_id,
+                    counter_type.clone(),
+                    counter_num,
+                )
+            })
+            .collect()
+    };
+
+    let completion =
+        PendingEffectResolved::new(EffectKind::from(&ability.effect), ability.source_id);
+    for (index, addition) in additions.iter().cloned().enumerate() {
+        let PendingCounterAddition::Object {
+            object_id, count, ..
+        } = addition
+        else {
+            continue;
+        };
+        let event_start = events.len();
+        if !apply_object_counter_addition(state, addition, events) {
+            stash_pending_counter_additions(state, additions[index + 1..].to_vec(), completion);
+            return Ok(());
+        }
+        if count > 0 {
             emit_evolved_event_for_counter_addition(
                 ability,
                 events,
                 event_start,
-                obj_id,
+                object_id,
                 &counter_type,
             );
         }
@@ -698,27 +1205,37 @@ pub fn resolve_add_all(
     // binding scope the parser stamps on per-recipient counts.
     let count_uses_recipient = crate::game::quantity::quantity_expr_uses_recipient(&count);
 
-    for obj_id in matching_ids {
-        let counter_num = if count_uses_recipient {
-            crate::game::quantity::resolve_quantity_with_recipient(
-                state,
-                &count,
+    let additions: Vec<PendingCounterAddition> = matching_ids
+        .into_iter()
+        .map(|obj_id| {
+            let counter_num = if count_uses_recipient {
+                crate::game::quantity::resolve_quantity_with_recipient(
+                    state,
+                    &count,
+                    ability.controller,
+                    ability.source_id,
+                    obj_id,
+                )
+                .max(0) as u32
+            } else {
+                counter_num_shared
+            };
+            object_counter_addition(
                 ability.controller,
-                ability.source_id,
                 obj_id,
+                counter_type.clone(),
+                counter_num,
             )
-            .max(0) as u32
-        } else {
-            counter_num_shared
-        };
-        add_counter_with_replacement(
-            state,
-            ability.controller,
-            obj_id,
-            counter_type.clone(),
-            counter_num,
-            events,
-        );
+        })
+        .collect();
+
+    let completion =
+        PendingEffectResolved::new(EffectKind::from(&ability.effect), ability.source_id);
+    for (index, addition) in additions.iter().cloned().enumerate() {
+        if !apply_object_counter_addition(state, addition, events) {
+            stash_pending_counter_additions(state, additions[index + 1..].to_vec(), completion);
+            return Ok(());
+        }
     }
 
     events.push(GameEvent::EffectResolved {
@@ -744,8 +1261,8 @@ pub fn resolve_multiply(
         _ => (CounterType::Plus1Plus1, 2),
     };
 
-    let targets = resolve_defined_or_targets(state, ability);
-    for obj_id in targets {
+    let mut additions = Vec::new();
+    for obj_id in resolve_defined_or_targets(state, ability) {
         let current = state
             .objects
             .get(&obj_id)
@@ -760,14 +1277,21 @@ pub fn resolve_multiply(
             // additional counters, so this must flow through the central
             // counter-addition path for replacement effects and per-turn
             // "counters you've put" history.
-            add_counter_with_replacement(
-                state,
+            additions.push(object_counter_addition(
                 ability.controller,
                 obj_id,
                 counter_type.clone(),
                 to_add,
-                events,
-            );
+            ));
+        }
+    }
+
+    let completion =
+        PendingEffectResolved::new(EffectKind::from(&ability.effect), ability.source_id);
+    for (index, addition) in additions.iter().cloned().enumerate() {
+        if !apply_object_counter_addition(state, addition, events) {
+            stash_pending_counter_additions(state, additions[index + 1..].to_vec(), completion);
+            return Ok(());
         }
     }
 
@@ -947,6 +1471,49 @@ pub fn resolve_move(
         .map(|expr| crate::game::quantity::resolve_quantity_with_targets(state, expr, ability))
         .map(|value| value.max(0) as u32);
 
+    if mode != CounterTransferMode::Move {
+        let mut additions = Vec::new();
+        for source_id in source_ids {
+            let source_counters =
+                counter_transfer_source_counters(state, source_id, mode, counter_type_filter);
+            if source_counters.is_empty() {
+                continue;
+            }
+            let mut remaining = transfer_limit;
+            for dest_id in &dest_ids {
+                for (ct, available) in &source_counters {
+                    let count = remaining.map_or(*available, |limit| limit.min(*available));
+                    if count == 0 {
+                        continue;
+                    }
+                    additions.push(object_counter_addition(
+                        ability.controller,
+                        *dest_id,
+                        ct.clone(),
+                        count,
+                    ));
+                    if let Some(limit) = remaining.as_mut() {
+                        *limit = limit.saturating_sub(count);
+                    }
+                }
+            }
+        }
+
+        let completion =
+            PendingEffectResolved::new(EffectKind::from(&ability.effect), ability.source_id);
+        for (index, addition) in additions.iter().cloned().enumerate() {
+            if !apply_object_counter_addition(state, addition, events) {
+                stash_pending_counter_additions(state, additions[index + 1..].to_vec(), completion);
+                return Ok(());
+            }
+        }
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
     for source_id in source_ids {
         let source_counters =
             counter_transfer_source_counters(state, source_id, mode, counter_type_filter);
@@ -971,31 +1538,17 @@ pub fn resolve_move(
                 if count == 0 {
                     continue;
                 }
-                if mode == CounterTransferMode::Move {
-                    if !move_counter_with_replacement(
-                        state,
-                        ability.controller,
-                        source_id,
-                        dest_id,
-                        ct.clone(),
-                        count,
-                        events,
-                    ) {
-                        return Ok(());
-                    }
-                    if let Some(limit) = remaining.as_mut() {
-                        *limit = limit.saturating_sub(count);
-                    }
-                    continue;
-                }
-                add_counter_with_replacement(
+                if !move_counter_with_replacement(
                     state,
                     ability.controller,
+                    source_id,
                     dest_id,
                     ct.clone(),
                     count,
                     events,
-                );
+                ) {
+                    return Ok(());
+                }
                 if let Some(limit) = remaining.as_mut() {
                     *limit = limit.saturating_sub(count);
                 }
@@ -1373,11 +1926,13 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        ControllerRef, FilterProp, QuantityExpr, TargetChoiceTiming, TargetFilter, TypedFilter,
+        ControllerRef, FilterProp, QuantityExpr, QuantityModification, ReplacementDefinition,
+        TargetChoiceTiming, TargetFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
+    use crate::types::replacements::ReplacementEvent;
     use crate::types::zones::Zone;
 
     fn make_counter_ability(effect: Effect, target: ObjectId) -> ResolvedAbility {
@@ -1397,6 +1952,42 @@ mod tests {
             .card_types
             .core_types
             .push(CoreType::Creature);
+    }
+
+    fn install_noncommuting_counter_replacements(state: &mut GameState) {
+        let doubler_id = create_object(
+            state,
+            CardId(900),
+            PlayerId(0),
+            "Counter Doubler".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&doubler_id)
+            .unwrap()
+            .replacement_definitions
+            .push(
+                ReplacementDefinition::new(ReplacementEvent::AddCounter)
+                    .quantity_modification(QuantityModification::Double),
+            );
+
+        let plus_id = create_object(
+            state,
+            CardId(901),
+            PlayerId(0),
+            "Counter Plus".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&plus_id)
+            .unwrap()
+            .replacement_definitions
+            .push(
+                ReplacementDefinition::new(ReplacementEvent::AddCounter)
+                    .quantity_modification(QuantityModification::Plus { value: 1 }),
+            );
     }
 
     /// Issue #1675 — Canopy Gargantuan: "put a number of +1/+1 counters on each
@@ -1718,6 +2309,197 @@ mod tests {
     }
 
     #[test]
+    fn add_counter_replacement_choice_stashes_remaining_targets_and_completion() {
+        let mut state = GameState::new_two_player(42);
+        install_noncommuting_counter_replacements(&mut state);
+        let first = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "First Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let second = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Second Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::AddCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Any,
+            },
+            vec![TargetRef::Object(first), TargetRef::Object(second)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_add(&mut state, &ability, &mut events).unwrap();
+
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ));
+        let pending = state
+            .pending_counter_additions
+            .as_ref()
+            .expect("remaining target should be queued");
+        assert_eq!(pending.remaining.len(), 1);
+        assert!(matches!(
+            pending.remaining[0],
+            PendingCounterAddition::Object {
+                object_id,
+                counter_type: CounterType::Plus1Plus1,
+                count: 1,
+                ..
+            } if object_id == second
+        ));
+        assert!(matches!(
+            pending.completion,
+            Some(PendingEffectResolved {
+                kind: EffectKind::AddCounter,
+                source_id: ObjectId(100),
+                player_action: None,
+                ..
+            })
+        ));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, GameEvent::EffectResolved { .. })));
+    }
+
+    #[test]
+    fn nested_post_action_pause_preserves_parent_completion() {
+        let mut state = GameState::new_two_player(42);
+        state.pending_counter_additions = Some(PendingCounterAdditionQueue {
+            remaining: vec![PendingCounterAddition::Object {
+                actor: PlayerId(0),
+                object_id: ObjectId(10),
+                counter_type: CounterType::Plus1Plus1,
+                count: 1,
+            }],
+            completion: Some(PendingEffectResolved::with_post_actions_without_effect(
+                EffectKind::Token,
+                ObjectId(20),
+                vec![PendingCounterPostAction::MarkRenowned {
+                    object_id: ObjectId(30),
+                }],
+            )),
+        });
+
+        merge_pending_counter_completion_after_nested_pause(
+            &mut state,
+            PendingEffectResolved::with_post_actions(
+                EffectKind::AddCounter,
+                ObjectId(40),
+                vec![PendingCounterPostAction::MarkMonstrous {
+                    object_id: ObjectId(50),
+                }],
+            ),
+        );
+
+        let queue = state
+            .pending_counter_additions
+            .as_ref()
+            .expect("nested queue remains installed");
+        assert_eq!(queue.remaining.len(), 1);
+        let completion = queue
+            .completion
+            .as_ref()
+            .expect("nested completion remains installed");
+        assert_eq!(completion.kind, EffectKind::Token);
+        assert_eq!(
+            completion.resolution_event,
+            PendingEffectResolutionEvent::Suppress
+        );
+        assert!(matches!(
+            completion.post_actions.as_slice(),
+            [
+                PendingCounterPostAction::MarkRenowned {
+                    object_id: ObjectId(30)
+                },
+                PendingCounterPostAction::MarkMonstrous {
+                    object_id: ObjectId(50)
+                },
+                PendingCounterPostAction::EmitEffectResolved {
+                    kind: EffectKind::AddCounter,
+                    source_id: ObjectId(40)
+                }
+            ]
+        ));
+    }
+
+    #[test]
+    fn add_all_counter_replacement_choice_stashes_remaining_objects_and_completion() {
+        let mut state = GameState::new_two_player(42);
+        install_noncommuting_counter_replacements(&mut state);
+        let first = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "First Creature".to_string(),
+            Zone::Battlefield,
+        );
+        mark_creature(&mut state, first);
+        let second = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Second Creature".to_string(),
+            Zone::Battlefield,
+        );
+        mark_creature(&mut state, second);
+        let ability = ResolvedAbility::new(
+            Effect::PutCounterAll {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Typed(TypedFilter::creature()),
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_add_all(&mut state, &ability, &mut events).unwrap();
+
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ));
+        let pending = state
+            .pending_counter_additions
+            .as_ref()
+            .expect("remaining object should be queued");
+        assert_eq!(pending.remaining.len(), 1);
+        assert!(matches!(
+            pending.remaining[0],
+            PendingCounterAddition::Object {
+                object_id,
+                counter_type: CounterType::Plus1Plus1,
+                count: 1,
+                ..
+            } if object_id == second
+        ));
+        assert!(matches!(
+            pending.completion,
+            Some(PendingEffectResolved {
+                kind: EffectKind::PutCounterAll,
+                source_id: ObjectId(100),
+                player_action: None,
+                ..
+            })
+        ));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, GameEvent::EffectResolved { .. })));
+    }
+
+    #[test]
     fn multiply_counter_records_added_counter_history() {
         let mut state = GameState::new_two_player(42);
         let obj_id = create_object(
@@ -1758,6 +2540,78 @@ mod tests {
             CounterType::Plus1Plus1
         );
         assert_eq!(state.counter_added_this_turn[0].count, 2);
+    }
+
+    #[test]
+    fn multiply_counter_replacement_choice_stashes_remaining_targets_and_completion() {
+        let mut state = GameState::new_two_player(42);
+        install_noncommuting_counter_replacements(&mut state);
+        let first = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "First Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let second = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Second Creature".to_string(),
+            Zone::Battlefield,
+        );
+        for obj_id in [first, second] {
+            state
+                .objects
+                .get_mut(&obj_id)
+                .unwrap()
+                .counters
+                .insert(CounterType::Plus1Plus1, 1);
+        }
+        let ability = ResolvedAbility::new(
+            Effect::MultiplyCounter {
+                counter_type: CounterType::Plus1Plus1,
+                multiplier: 2,
+                target: TargetFilter::Any,
+            },
+            vec![TargetRef::Object(first), TargetRef::Object(second)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_multiply(&mut state, &ability, &mut events).unwrap();
+
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ));
+        let pending = state
+            .pending_counter_additions
+            .as_ref()
+            .expect("remaining target should be queued");
+        assert_eq!(pending.remaining.len(), 1);
+        assert!(matches!(
+            pending.remaining[0],
+            PendingCounterAddition::Object {
+                object_id,
+                counter_type: CounterType::Plus1Plus1,
+                count: 1,
+                ..
+            } if object_id == second
+        ));
+        assert!(matches!(
+            pending.completion,
+            Some(PendingEffectResolved {
+                kind: EffectKind::MultiplyCounter,
+                source_id: ObjectId(100),
+                player_action: None,
+                ..
+            })
+        ));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, GameEvent::EffectResolved { .. })));
     }
 
     #[test]

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -150,13 +150,6 @@ pub(crate) fn stash_pending_counter_additions(
     remaining: Vec<PendingCounterAddition>,
     completion: PendingEffectResolved,
 ) {
-    if remaining.is_empty() {
-        state.pending_counter_additions = Some(PendingCounterAdditionQueue {
-            remaining,
-            completion: Some(completion),
-        });
-        return;
-    }
     state.pending_counter_additions = Some(PendingCounterAdditionQueue {
         remaining,
         completion: Some(completion),
@@ -1472,6 +1465,9 @@ pub fn resolve_move(
         .map(|value| value.max(0) as u32);
 
     if mode != CounterTransferMode::Move {
+        // CR 122.1 / CR 122.5: Non-move counter transfers copy counters by
+        // placing new counters, so each addition goes through the replacement
+        // pipeline rather than the atomic move-counter path.
         let mut additions = Vec::new();
         for source_id in source_ids {
             let source_counters =

--- a/crates/engine/src/game/effects/double.rs
+++ b/crates/engine/src/game/effects/double.rs
@@ -4,7 +4,7 @@ use crate::types::ability::{
 };
 use crate::types::counter::CounterType;
 use crate::types::events::{GameEvent, ManaTapState};
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCounterAddition, PendingEffectResolved};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{ManaColor, ManaType, ManaUnit};
 use crate::types::player::PlayerId;
@@ -44,6 +44,7 @@ fn resolve_double_counters(
     counter_type: Option<&CounterType>,
 ) -> Result<(), EffectError> {
     let obj_ids = resolve_object_targets(ability, target, state);
+    let mut additions = Vec::new();
 
     for obj_id in obj_ids {
         // Snapshot current counters to avoid borrow issues
@@ -77,14 +78,40 @@ fn resolve_double_counters(
         // `MultiplyCounter` path (`counters::resolve_multiply`). The raw
         // `apply_counter_addition` primitive bypassed replacements.
         for (ct, current_count) in counters_snapshot {
-            super::counters::add_counter_with_replacement(
+            additions.push(PendingCounterAddition::Object {
+                actor: ability.controller,
+                object_id: obj_id,
+                counter_type: ct,
+                count: current_count,
+            });
+        }
+    }
+
+    let completion = PendingEffectResolved::new(EffectKind::Double, ability.source_id);
+    for (index, addition) in additions.iter().cloned().enumerate() {
+        let PendingCounterAddition::Object {
+            actor,
+            object_id,
+            counter_type,
+            count,
+        } = addition
+        else {
+            continue;
+        };
+        if !super::counters::add_counter_with_replacement(
+            state,
+            actor,
+            object_id,
+            counter_type,
+            count,
+            events,
+        ) {
+            super::counters::stash_pending_counter_additions(
                 state,
-                ability.controller,
-                obj_id,
-                ct,
-                current_count,
-                events,
+                additions[index + 1..].to_vec(),
+                completion,
             );
+            return Ok(());
         }
     }
 
@@ -262,7 +289,7 @@ mod tests {
     use super::*;
     use crate::game::game_object::GameObject;
     use crate::types::ability::{
-        AbilityKind, QuantityModification, ReplacementDefinition, SpellContext,
+        AbilityKind, QuantityModification, ReplacementDefinition, SpellContext, TypedFilter,
     };
     use crate::types::counter::CounterType;
     use crate::types::identifiers::{CardId, ObjectId};
@@ -356,6 +383,137 @@ mod tests {
                 .copied()
                 .unwrap_or(0),
             6
+        );
+    }
+
+    #[test]
+    fn double_counters_replacement_choice_stashes_remaining_counter_additions() {
+        let mut state = GameState::default();
+        for (id, modification) in [
+            (ObjectId(90), QuantityModification::Double),
+            (ObjectId(91), QuantityModification::Plus { value: 1 }),
+        ] {
+            let mut source = GameObject::new(
+                id,
+                CardId(id.0),
+                PlayerId(0),
+                "Counter Modifier".into(),
+                Zone::Battlefield,
+            );
+            source.replacement_definitions =
+                vec![ReplacementDefinition::new(ReplacementEvent::AddCounter)
+                    .valid_card(TargetFilter::Typed(TypedFilter::creature()))
+                    .quantity_modification(modification)]
+                .into();
+            state.objects.insert(id, source);
+            state.battlefield.push_back(id);
+        }
+
+        let obj_id = ObjectId(1);
+        let mut obj = GameObject::new(
+            obj_id,
+            CardId(1),
+            PlayerId(0),
+            "Test Creature".into(),
+            Zone::Battlefield,
+        );
+        obj.card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+        obj.counters.insert(CounterType::Plus1Plus1, 1);
+        obj.counters.insert(CounterType::Stun, 1);
+        state.objects.insert(obj_id, obj);
+        state.battlefield.push_back(obj_id);
+
+        let mut events = Vec::new();
+        let ability = make_double_ability(
+            DoubleTarget::Counters { counter_type: None },
+            TargetFilter::Any,
+            PlayerId(0),
+            vec![TargetRef::Object(obj_id)],
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(matches!(
+            state.waiting_for,
+            crate::types::game_state::WaitingFor::ReplacementChoice { .. }
+        ));
+        let pending = state
+            .pending_counter_additions
+            .as_ref()
+            .expect("remaining double-counter additions should be queued");
+        assert_eq!(pending.remaining.len(), 1);
+        assert!(matches!(
+            pending.completion,
+            Some(PendingEffectResolved {
+                kind: EffectKind::Double,
+                source_id: ObjectId(100),
+                player_action: None,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn double_counters_is_prevented_by_solemnity() {
+        let mut state = GameState::default();
+        let solemnity_id = ObjectId(99);
+        let mut solemnity = GameObject::new(
+            solemnity_id,
+            CardId(99),
+            PlayerId(0),
+            "Solemnity".into(),
+            Zone::Battlefield,
+        );
+        solemnity.replacement_definitions =
+            vec![ReplacementDefinition::new(ReplacementEvent::AddCounter)
+                .valid_card(TargetFilter::Typed(TypedFilter::creature()))
+                .quantity_modification(QuantityModification::Prevent)]
+            .into();
+        state.objects.insert(solemnity_id, solemnity);
+        state.battlefield.push_back(solemnity_id);
+
+        let obj_id = ObjectId(1);
+        let mut obj = GameObject::new(
+            obj_id,
+            CardId(0),
+            PlayerId(0),
+            "Test Creature".into(),
+            Zone::Battlefield,
+        );
+        obj.card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+        obj.counters.insert(CounterType::Plus1Plus1, 3);
+        state.objects.insert(obj_id, obj);
+        state.battlefield.push_back(obj_id);
+
+        let mut events = Vec::new();
+        let ability = make_double_ability(
+            DoubleTarget::Counters {
+                counter_type: Some(CounterType::Plus1Plus1),
+            },
+            TargetFilter::Any,
+            PlayerId(0),
+            vec![TargetRef::Object(obj_id)],
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.objects[&obj_id]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            3
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, GameEvent::CounterAdded { .. })),
+            "Solemnity must prevent doubling counters from adding counters"
         );
     }
 

--- a/crates/engine/src/game/effects/energy.rs
+++ b/crates/engine/src/game/effects/energy.rs
@@ -1,7 +1,69 @@
+use std::collections::HashSet;
+
 use crate::game::quantity::resolve_quantity_with_targets;
+use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCounterAddition, PendingEffectResolved};
+use crate::types::player::PlayerId;
+use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
+
+pub(crate) fn add_energy_with_replacement(
+    state: &mut GameState,
+    actor: PlayerId,
+    player_id: PlayerId,
+    amount: u32,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    if amount == 0 {
+        return true;
+    }
+
+    // CR 122.1 + CR 107.14 + CR 614.17: Energy is a counter a player has, so
+    // gaining energy passes through the counter-placement pipeline before the
+    // dedicated player energy field is mutated.
+    let proposed = ProposedEvent::AddCounter {
+        placement: CounterPlacement::Energy { actor, player_id },
+        count: amount,
+        applied: HashSet::new(),
+    };
+
+    match replacement::replace_event(state, proposed, events) {
+        ReplacementResult::Execute(ProposedEvent::AddCounter {
+            placement: CounterPlacement::Energy { player_id, .. },
+            count,
+            ..
+        }) => {
+            apply_energy_addition(state, player_id, count, events);
+            true
+        }
+        ReplacementResult::Execute(_) | ReplacementResult::Prevented => true,
+        ReplacementResult::NeedsChoice(player) => {
+            state.waiting_for = replacement::replacement_choice_waiting_for(player, state);
+            false
+        }
+    }
+}
+
+pub(crate) fn apply_energy_addition(
+    state: &mut GameState,
+    player_id: PlayerId,
+    amount: u32,
+    events: &mut Vec<GameEvent>,
+) {
+    if amount == 0 {
+        return;
+    }
+
+    let player = &mut state.players[player_id.0 as usize];
+    player.energy += amount;
+
+    // CR 122.1 + CR 107.14: Energy counters are counters placed on a player.
+    events.push(GameEvent::EnergyChanged {
+        player: player_id,
+        delta: amount as i32,
+    });
+}
 
 /// CR 122.1: Gain energy counters. Increments the controller's energy pool.
 pub fn resolve_gain(
@@ -15,15 +77,20 @@ pub fn resolve_gain(
     };
     let amount = amount.max(0) as u32;
 
-    // CR 122.1: Energy counters are a kind of counter that a player may have.
-    let player = &mut state.players[ability.controller.0 as usize];
-    player.energy += amount;
-
-    // CR 122.1 + CR 107.14: Energy counters are counters placed on a player.
-    events.push(GameEvent::EnergyChanged {
-        player: ability.controller,
-        delta: amount as i32,
-    });
+    if !add_energy_with_replacement(
+        state,
+        ability.controller,
+        ability.controller,
+        amount,
+        events,
+    ) {
+        super::counters::stash_pending_counter_additions(
+            state,
+            Vec::<PendingCounterAddition>::new(),
+            PendingEffectResolved::new(EffectKind::GainEnergy, ability.source_id),
+        );
+        return Ok(());
+    }
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::GainEnergy,
         source_id: ability.source_id,
@@ -37,11 +104,13 @@ mod tests {
     use super::*;
     use crate::game::zones;
     use crate::types::ability::{
-        ControllerRef, QuantityExpr, QuantityRef, TargetFilter, TypedFilter,
+        ControllerRef, QuantityExpr, QuantityModification, QuantityRef, ReplacementDefinition,
+        ReplacementPlayerScope, TargetFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
+    use crate::types::replacements::ReplacementEvent;
     use crate::types::zones::Zone;
 
     fn gain_energy_ability(amount: QuantityExpr) -> ResolvedAbility {
@@ -115,5 +184,38 @@ mod tests {
         resolve_gain(&mut state, &ability, &mut events).unwrap();
 
         assert_eq!(state.players[0].energy, 2);
+    }
+
+    #[test]
+    fn gain_energy_is_prevented_by_player_counter_prohibition() {
+        let mut state = GameState::new_two_player(42);
+        let source = zones::create_object(
+            &mut state,
+            CardId(88),
+            PlayerId(1),
+            "Solemnity".to_string(),
+            Zone::Battlefield,
+        );
+        let mut replacement = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Prevent);
+        replacement.valid_player = Some(ReplacementPlayerScope::AnyPlayer);
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .replacement_definitions = vec![replacement].into();
+
+        let ability = gain_energy_ability(QuantityExpr::Fixed { value: 2 });
+        let mut events = Vec::new();
+
+        resolve_gain(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.players[0].energy, 0);
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, GameEvent::EnergyChanged { .. })),
+            "prevented energy-counter additions must not emit energy-change events"
+        );
     }
 }

--- a/crates/engine/src/game/effects/explore.rs
+++ b/crates/engine/src/game/effects/explore.rs
@@ -11,28 +11,33 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
-use crate::types::proposed_event::ProposedEvent;
+use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
 
 use super::resolve_ability_chain;
 
 /// Add a +1/+1 counter to the exploring creature via the replacement pipeline.
 fn add_explore_counter(state: &mut GameState, explorer_id: ObjectId, events: &mut Vec<GameEvent>) {
     let proposed = ProposedEvent::AddCounter {
-        actor: state
-            .objects
-            .get(&explorer_id)
-            .map(|obj| obj.controller)
-            .unwrap_or(PlayerId(0)),
-        object_id: explorer_id,
-        counter_type: CounterType::Plus1Plus1,
+        placement: CounterPlacement::Object {
+            actor: state
+                .objects
+                .get(&explorer_id)
+                .map(|obj| obj.controller)
+                .unwrap_or(PlayerId(0)),
+            object_id: explorer_id,
+            counter_type: CounterType::Plus1Plus1,
+        },
         count: 1,
         applied: HashSet::new(),
     };
 
     if let ReplacementResult::Execute(ProposedEvent::AddCounter {
-        actor,
-        object_id,
-        counter_type,
+        placement:
+            CounterPlacement::Object {
+                actor,
+                object_id,
+                counter_type,
+            },
         count,
         ..
     }) = replacement::replace_event(state, proposed, events)

--- a/crates/engine/src/game/effects/incubate.rs
+++ b/crates/engine/src/game/effects/incubate.rs
@@ -1,4 +1,6 @@
-use crate::game::effects::counters::add_counter_with_replacement;
+use crate::game::effects::counters::{
+    add_counter_with_replacement, stash_pending_counter_completion_with_actions,
+};
 use crate::game::game_object::DisplaySource;
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::game::zones;
@@ -7,7 +9,7 @@ use crate::types::card_type::CardType;
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCounterPostAction};
 use crate::types::identifiers::CardId;
 use crate::types::zones::Zone;
 
@@ -59,15 +61,23 @@ pub fn resolve(
     }
 
     // CR 701.53a: The Incubator enters with N +1/+1 counters.
-    if n > 0 {
-        add_counter_with_replacement(
+    if n > 0
+        && !add_counter_with_replacement(
             state,
             ability.controller,
             obj_id,
             CounterType::Plus1Plus1,
             n,
             events,
+        )
+    {
+        stash_pending_counter_completion_with_actions(
+            state,
+            EffectKind::Incubate,
+            ability.source_id,
+            vec![PendingCounterPostAction::InjectPredefinedTokenAbilities { object_id: obj_id }],
         );
+        return Ok(());
     }
 
     super::token::inject_predefined_token_abilities(state, obj_id);

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -433,6 +433,7 @@ pub(crate) fn mark_pending_continuation_parent(state: &mut GameState, kind: Effe
 /// event is never silently dropped.
 pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec<GameEvent>) {
     counters::drain_pending_counter_moves(state, events);
+    counters::drain_pending_counter_additions(state, events);
     if waits_for_resolution_choice(&state.waiting_for) {
         return;
     }
@@ -970,6 +971,7 @@ fn waits_for_resolution_choice(waiting_for: &WaitingFor) -> bool {
             | WaitingFor::NamedChoice { .. }
             | WaitingFor::DamageSourceChoice { .. }
             | WaitingFor::MultiTargetSelection { .. }
+            | WaitingFor::ReplacementChoice { .. }
             | WaitingFor::OptionalEffectChoice { .. }
             | WaitingFor::PairChoice { .. }
             | WaitingFor::OpponentMayChoice { .. }

--- a/crates/engine/src/game/effects/monstrosity.rs
+++ b/crates/engine/src/game/effects/monstrosity.rs
@@ -1,9 +1,11 @@
-use crate::game::effects::counters::add_counter_with_replacement;
+use crate::game::effects::counters::{
+    add_counter_with_replacement, stash_pending_counter_completion_with_actions,
+};
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCounterPostAction};
 
 /// CR 701.37a: Monstrosity N.
 ///
@@ -36,15 +38,25 @@ pub fn resolve(
     let n = resolve_quantity_with_targets(state, &count_expr, ability).max(0) as u32;
 
     // CR 701.37a: Put N +1/+1 counters on the permanent.
-    if n > 0 {
-        add_counter_with_replacement(
+    if n > 0
+        && !add_counter_with_replacement(
             state,
             ability.controller,
             source_id,
             CounterType::Plus1Plus1,
             n,
             events,
+        )
+    {
+        stash_pending_counter_completion_with_actions(
+            state,
+            EffectKind::Monstrosity,
+            source_id,
+            vec![PendingCounterPostAction::MarkMonstrous {
+                object_id: source_id,
+            }],
         );
+        return Ok(());
     }
 
     // CR 701.37a + CR 701.37b: Set the monstrous designation.

--- a/crates/engine/src/game/effects/player_counter.rs
+++ b/crates/engine/src/game/effects/player_counter.rs
@@ -1,8 +1,82 @@
-use crate::game::quantity;
+use std::collections::HashSet;
+
+use crate::game::{quantity, replacement};
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetRef};
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCounterAddition, PendingEffectResolved};
 use crate::types::player::{PlayerCounterKind, PlayerId};
+use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
+
+pub fn add_player_counter_with_replacement(
+    state: &mut GameState,
+    actor: PlayerId,
+    player_id: PlayerId,
+    counter_kind: PlayerCounterKind,
+    count: u32,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    if count == 0 {
+        return true;
+    }
+
+    // CR 122.1 + CR 614.17: Player-counter additions pass through the
+    // replacement pipeline so "players can't get counters" effects can prevent
+    // the event before any player state is mutated.
+    let proposed = ProposedEvent::AddCounter {
+        placement: CounterPlacement::Player {
+            actor,
+            player_id,
+            counter_kind,
+        },
+        count,
+        applied: HashSet::new(),
+    };
+
+    match replacement::replace_event(state, proposed, events) {
+        replacement::ReplacementResult::Execute(event) => {
+            if let ProposedEvent::AddCounter {
+                placement:
+                    CounterPlacement::Player {
+                        player_id,
+                        counter_kind,
+                        ..
+                    },
+                count,
+                ..
+            } = event
+            {
+                apply_player_counter_addition(state, player_id, counter_kind, count, events);
+            }
+            true
+        }
+        replacement::ReplacementResult::Prevented => true,
+        replacement::ReplacementResult::NeedsChoice(player) => {
+            state.waiting_for = replacement::replacement_choice_waiting_for(player, state);
+            false
+        }
+    }
+}
+
+pub fn apply_player_counter_addition(
+    state: &mut GameState,
+    player_id: PlayerId,
+    counter_kind: PlayerCounterKind,
+    amount: u32,
+    events: &mut Vec<GameEvent>,
+) {
+    if amount == 0 {
+        return;
+    }
+    let player = &mut state.players[player_id.0 as usize];
+    player.add_player_counters(&counter_kind, amount);
+
+    // CR 122.1: Emit event for counter change.
+    events.push(GameEvent::PlayerCounterChanged {
+        player: player_id,
+        counter_kind,
+        delta: amount as i32,
+    });
+}
 
 /// CR 122.1: Give player counters of a named type.
 /// Poison counters dispatch to the dedicated field (CR 104.3d SBA).
@@ -56,16 +130,41 @@ pub fn resolve(
         targeted
     };
 
-    for player_id in &players {
-        let player = &mut state.players[player_id.0 as usize];
-        player.add_player_counters(counter_kind, amount);
-
-        // CR 122.1: Emit event for counter change.
-        events.push(GameEvent::PlayerCounterChanged {
-            player: *player_id,
+    let additions: Vec<_> = players
+        .iter()
+        .map(|player_id| PendingCounterAddition::Player {
+            actor: ability.controller,
+            player_id: *player_id,
             counter_kind: *counter_kind,
-            delta: amount as i32,
-        });
+            count: amount,
+        })
+        .collect();
+    let completion = PendingEffectResolved::new(EffectKind::GivePlayerCounter, ability.source_id);
+    for (index, addition) in additions.iter().cloned().enumerate() {
+        let PendingCounterAddition::Player {
+            actor,
+            player_id,
+            counter_kind,
+            count,
+        } = addition
+        else {
+            continue;
+        };
+        if !add_player_counter_with_replacement(
+            state,
+            actor,
+            player_id,
+            counter_kind,
+            count,
+            events,
+        ) {
+            super::counters::stash_pending_counter_additions(
+                state,
+                additions[index + 1..].to_vec(),
+                completion,
+            );
+            return Ok(());
+        }
     }
 
     events.push(GameEvent::EffectResolved {
@@ -171,9 +270,15 @@ fn clear_all_player_counters(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::game_object::GameObject;
     use crate::types::ability::{AbilityKind, QuantityExpr, SpellContext, TargetFilter};
-    use crate::types::identifiers::ObjectId;
+    use crate::types::ability::{
+        QuantityModification, ReplacementDefinition, ReplacementPlayerScope,
+    };
+    use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::{PlayerCounterKind, PlayerId};
+    use crate::types::replacements::ReplacementEvent;
+    use crate::types::zones::Zone;
 
     fn make_ability(
         counter_kind: PlayerCounterKind,
@@ -266,6 +371,43 @@ mod tests {
         assert_eq!(
             state.players[0].player_counter(&PlayerCounterKind::Experience),
             2
+        );
+    }
+
+    #[test]
+    fn player_counter_addition_is_prevented_by_global_replacement() {
+        let mut state = GameState::new_two_player(42);
+        let mut events = Vec::new();
+        let solemnity_id = ObjectId(99);
+        let mut solemnity = GameObject::new(
+            solemnity_id,
+            CardId(99),
+            PlayerId(0),
+            "Solemnity".to_string(),
+            Zone::Battlefield,
+        );
+        let mut replacement = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Prevent);
+        replacement.valid_player = Some(ReplacementPlayerScope::AnyPlayer);
+        solemnity.replacement_definitions = vec![replacement].into();
+        state.objects.insert(solemnity_id, solemnity);
+        state.battlefield.push_back(solemnity_id);
+
+        let ability = make_ability(
+            PlayerCounterKind::Poison,
+            QuantityExpr::Fixed { value: 1 },
+            TargetFilter::Controller,
+            PlayerId(1),
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.players[1].poison_counters, 0);
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, GameEvent::PlayerCounterChanged { .. })),
+            "prevented player-counter additions must not emit counter-change events"
         );
     }
 

--- a/crates/engine/src/game/effects/proliferate.rs
+++ b/crates/engine/src/game/effects/proliferate.rs
@@ -3,7 +3,9 @@ use crate::types::counter::{
     has_positive_counters, positive_counter_types, prune_zero_counters, CounterType,
 };
 use crate::types::events::{GameEvent, PlayerActionKind};
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{
+    GameState, PendingCounterAddition, PendingEffectResolved, WaitingFor,
+};
 use crate::types::player::{Player, PlayerCounterKind, PlayerId};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -114,14 +116,45 @@ pub fn apply_proliferate(
     actor: PlayerId,
     selected: &[TargetRef],
     events: &mut Vec<GameEvent>,
-) {
+) -> bool {
+    for target in selected {
+        if let TargetRef::Object(obj_id) = target {
+            if let Some(obj) = state.objects.get_mut(obj_id) {
+                prune_zero_counters(&mut obj.counters);
+            }
+        }
+    }
+
+    let additions = proliferate_addition_plan(state, actor, selected);
+    let completion = PendingEffectResolved::with_player_action(
+        EffectKind::Proliferate,
+        crate::types::identifiers::ObjectId(0),
+        actor,
+        PlayerActionKind::Proliferate,
+    );
+
+    for (index, addition) in additions.iter().cloned().enumerate() {
+        if !apply_counter_addition_plan_item(state, addition, events) {
+            super::counters::stash_pending_counter_additions(
+                state,
+                additions[index + 1..].to_vec(),
+                completion,
+            );
+            return false;
+        }
+    }
+    true
+}
+
+fn proliferate_addition_plan(
+    state: &GameState,
+    actor: PlayerId,
+    selected: &[TargetRef],
+) -> Vec<PendingCounterAddition> {
+    let mut additions = Vec::new();
     for target in selected {
         match target {
             TargetRef::Object(obj_id) => {
-                if let Some(obj) = state.objects.get_mut(obj_id) {
-                    prune_zero_counters(&mut obj.counters);
-                }
-
                 let counter_types: Vec<CounterType> = state
                     .objects
                     .get(obj_id)
@@ -129,7 +162,12 @@ pub fn apply_proliferate(
                     .unwrap_or_default();
 
                 for ct in counter_types {
-                    super::counters::apply_counter_addition(state, actor, *obj_id, ct, 1, events);
+                    additions.push(PendingCounterAddition::Object {
+                        actor,
+                        object_id: *obj_id,
+                        counter_type: ct,
+                        count: 1,
+                    });
                 }
             }
             TargetRef::Player(pid) => {
@@ -141,28 +179,67 @@ pub fn apply_proliferate(
                     .unwrap_or_default();
 
                 for counter in counters {
-                    if let Some(player) = state.players.iter_mut().find(|p| p.id == *pid) {
-                        match counter {
-                            PlayerCounterSource::Kind(kind) => {
-                                player.add_player_counters(&kind, 1);
-                                events.push(GameEvent::PlayerCounterChanged {
-                                    player: *pid,
-                                    counter_kind: kind,
-                                    delta: 1,
-                                });
-                            }
-                            PlayerCounterSource::Energy => {
-                                player.energy += 1;
-                                events.push(GameEvent::EnergyChanged {
-                                    player: *pid,
-                                    delta: 1,
-                                });
-                            }
+                    match counter {
+                        PlayerCounterSource::Kind(kind) => {
+                            additions.push(PendingCounterAddition::Player {
+                                actor,
+                                player_id: *pid,
+                                counter_kind: kind,
+                                count: 1,
+                            });
+                        }
+                        PlayerCounterSource::Energy => {
+                            additions.push(PendingCounterAddition::Energy {
+                                actor,
+                                player_id: *pid,
+                                count: 1,
+                            });
                         }
                     }
                 }
             }
         }
+    }
+    additions
+}
+
+fn apply_counter_addition_plan_item(
+    state: &mut GameState,
+    addition: PendingCounterAddition,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    match addition {
+        PendingCounterAddition::Object {
+            actor,
+            object_id,
+            counter_type,
+            count,
+        } => super::counters::add_counter_with_replacement(
+            state,
+            actor,
+            object_id,
+            counter_type,
+            count,
+            events,
+        ),
+        PendingCounterAddition::Player {
+            actor,
+            player_id,
+            counter_kind,
+            count,
+        } => super::player_counter::add_player_counter_with_replacement(
+            state,
+            actor,
+            player_id,
+            counter_kind,
+            count,
+            events,
+        ),
+        PendingCounterAddition::Energy {
+            actor,
+            player_id,
+            count,
+        } => super::energy::add_energy_with_replacement(state, actor, player_id, count, events),
     }
 }
 
@@ -170,9 +247,13 @@ pub fn apply_proliferate(
 mod tests {
     use super::*;
     use crate::game::zones::create_object;
-    use crate::types::ability::Effect;
+    use crate::types::ability::{
+        Effect, QuantityModification, ReplacementDefinition, ReplacementPlayerScope, TargetFilter,
+        TypedFilter,
+    };
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
+    use crate::types::replacements::ReplacementEvent;
     use crate::types::zones::Zone;
 
     fn make_proliferate_ability() -> ResolvedAbility {
@@ -447,6 +528,198 @@ mod tests {
                 delta: 1,
             }
         )));
+    }
+
+    #[test]
+    fn apply_proliferate_replacement_choice_stashes_remaining_counter_additions() {
+        let mut state = GameState::new_two_player(42);
+        for (id, modification) in [
+            (ObjectId(90), QuantityModification::Double),
+            (ObjectId(91), QuantityModification::Plus { value: 1 }),
+        ] {
+            let source = create_object(
+                &mut state,
+                CardId(id.0),
+                PlayerId(0),
+                "Counter Modifier".to_string(),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&source)
+                .unwrap()
+                .replacement_definitions =
+                vec![ReplacementDefinition::new(ReplacementEvent::AddCounter)
+                    .valid_card(TargetFilter::Typed(TypedFilter::creature()))
+                    .quantity_modification(modification)]
+                .into();
+        }
+
+        let obj = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let object = state.objects.get_mut(&obj).unwrap();
+        object
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+        object.counters.insert(CounterType::Plus1Plus1, 1);
+        object.counters.insert(CounterType::Stun, 1);
+
+        let mut events = Vec::new();
+        assert!(!apply_proliferate(
+            &mut state,
+            PlayerId(0),
+            &[TargetRef::Object(obj)],
+            &mut events,
+        ));
+
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ));
+        let pending = state
+            .pending_counter_additions
+            .as_ref()
+            .expect("remaining proliferate additions should be queued");
+        assert_eq!(pending.remaining.len(), 1);
+        assert!(matches!(
+            pending.completion,
+            Some(PendingEffectResolved {
+                kind: EffectKind::Proliferate,
+                source_id: ObjectId(0),
+                player_action: Some(_),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn apply_proliferate_object_counter_is_prevented_by_solemnity() {
+        let mut state = GameState::new_two_player(42);
+        let solemnity = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Solemnity".to_string(),
+            Zone::Battlefield,
+        );
+        let replacement = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .valid_card(TargetFilter::Typed(TypedFilter::creature()))
+            .quantity_modification(QuantityModification::Prevent);
+        state
+            .objects
+            .get_mut(&solemnity)
+            .unwrap()
+            .replacement_definitions = vec![replacement].into();
+
+        let obj = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let object = state.objects.get_mut(&obj).unwrap();
+        object
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+        object.counters.insert(CounterType::Plus1Plus1, 1);
+
+        let mut events = Vec::new();
+        apply_proliferate(
+            &mut state,
+            PlayerId(0),
+            &[TargetRef::Object(obj)],
+            &mut events,
+        );
+
+        assert_eq!(state.objects[&obj].counters[&CounterType::Plus1Plus1], 1);
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, GameEvent::CounterAdded { .. })),
+            "Solemnity must prevent proliferate from adding object counters"
+        );
+    }
+
+    #[test]
+    fn apply_proliferate_player_counter_is_prevented_by_solemnity() {
+        let mut state = GameState::new_two_player(42);
+        let solemnity = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Solemnity".to_string(),
+            Zone::Battlefield,
+        );
+        let mut replacement = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Prevent);
+        replacement.valid_player = Some(ReplacementPlayerScope::AnyPlayer);
+        state
+            .objects
+            .get_mut(&solemnity)
+            .unwrap()
+            .replacement_definitions = vec![replacement].into();
+        state.players[1].poison_counters = 1;
+
+        let mut events = Vec::new();
+        apply_proliferate(
+            &mut state,
+            PlayerId(0),
+            &[TargetRef::Player(PlayerId(1))],
+            &mut events,
+        );
+
+        assert_eq!(state.players[1].poison_counters, 1);
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, GameEvent::PlayerCounterChanged { .. })),
+            "Solemnity must prevent proliferate from adding player counters"
+        );
+    }
+
+    #[test]
+    fn apply_proliferate_energy_counter_is_prevented_by_solemnity() {
+        let mut state = GameState::new_two_player(42);
+        let solemnity = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Solemnity".to_string(),
+            Zone::Battlefield,
+        );
+        let mut replacement = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Prevent);
+        replacement.valid_player = Some(ReplacementPlayerScope::AnyPlayer);
+        state
+            .objects
+            .get_mut(&solemnity)
+            .unwrap()
+            .replacement_definitions = vec![replacement].into();
+        state.players[1].energy = 1;
+
+        let mut events = Vec::new();
+        apply_proliferate(
+            &mut state,
+            PlayerId(0),
+            &[TargetRef::Player(PlayerId(1))],
+            &mut events,
+        );
+
+        assert_eq!(state.players[1].energy, 1);
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, GameEvent::EnergyChanged { .. })),
+            "Solemnity must prevent proliferate from adding energy counters"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/renown.rs
+++ b/crates/engine/src/game/effects/renown.rs
@@ -1,9 +1,11 @@
-use crate::game::effects::counters::add_counter_with_replacement;
+use crate::game::effects::counters::{
+    add_counter_with_replacement, stash_pending_counter_completion_with_actions,
+};
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, PendingCounterPostAction};
 use crate::types::zones::Zone;
 
 /// CR 702.112a: Renown N.
@@ -38,15 +40,25 @@ pub fn resolve(
 
     let n = resolve_quantity_with_targets(state, &count_expr, ability).max(0) as u32;
 
-    if n > 0 {
-        add_counter_with_replacement(
+    if n > 0
+        && !add_counter_with_replacement(
             state,
             ability.controller,
             source_id,
             CounterType::Plus1Plus1,
             n,
             events,
+        )
+    {
+        stash_pending_counter_completion_with_actions(
+            state,
+            EffectKind::Renown,
+            source_id,
+            vec![PendingCounterPostAction::MarkRenowned {
+                object_id: source_id,
+            }],
         );
+        return Ok(());
     }
 
     if let Some(obj) = state.objects.get_mut(&source_id) {

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -17,7 +17,9 @@ use crate::types::ability::{
 use crate::types::card_type::{CardType, CoreType, Supertype};
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{DelayedTrigger, GameState};
+use crate::types::game_state::{
+    DelayedTrigger, GameState, PendingCounterPostAction, PendingEffectResolutionEvent,
+};
 use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
 use crate::types::keywords::{Keyword, WardCost};
 use crate::types::mana::{ManaColor, ManaCost};
@@ -450,7 +452,9 @@ pub fn resolve(
 
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(event) => {
-            apply_create_token_after_replacement(state, event, events);
+            if !apply_create_token_after_replacement(state, event, events) {
+                return Ok(());
+            }
         }
         ReplacementResult::Prevented => {
             // Token creation was prevented entirely
@@ -578,7 +582,23 @@ pub fn apply_create_token_after_replacement(
     state: &mut GameState,
     event: ProposedEvent,
     events: &mut Vec<GameEvent>,
-) {
+) -> bool {
+    apply_create_token_after_replacement_with_created_ids(
+        state,
+        event,
+        Vec::new(),
+        PendingEffectResolutionEvent::Emit,
+        events,
+    )
+}
+
+pub(crate) fn apply_create_token_after_replacement_with_created_ids(
+    state: &mut GameState,
+    event: ProposedEvent,
+    initial_created_ids: Vec<ObjectId>,
+    pause_completion_event: PendingEffectResolutionEvent,
+    events: &mut Vec<GameEvent>,
+) -> bool {
     let ProposedEvent::CreateToken {
         owner,
         spec,
@@ -588,11 +608,11 @@ pub fn apply_create_token_after_replacement(
         ..
     } = event
     else {
-        return;
+        return true;
     };
 
     if let Some(copy) = copy {
-        let created = super::token_copy::apply_copy_token_after_replacement(
+        let status = super::token_copy::apply_copy_token_after_replacement(
             state,
             owner,
             *copy,
@@ -602,16 +622,20 @@ pub fn apply_create_token_after_replacement(
             events,
         );
         if let Some(pending) = state.pending_copy_token_resolution.as_mut() {
-            pending.created_ids.extend(created);
+            pending.created_ids.extend(status.created_ids);
         } else {
-            state.last_created_token_ids = created;
+            state.last_created_token_ids = status.created_ids;
         }
-        return;
+        return match status.completion {
+            super::token_copy::CopyTokenApplyCompletion::Completed => true,
+            super::token_copy::CopyTokenApplyCompletion::Paused => false,
+        };
     }
 
-    let mut created_ids = Vec::with_capacity(final_count as usize);
+    let mut created_ids = initial_created_ids;
+    created_ids.reserve(final_count as usize);
 
-    for _ in 0..final_count {
+    for index in 0..final_count {
         let ch = &spec.characteristics;
         let token_image_ref =
             crate::game::token_presets::find_exact_token_ref(state, spec.source_id, ch);
@@ -680,20 +704,73 @@ pub fn apply_create_token_after_replacement(
         }
 
         // CR 122.6a: Place counters on the token as it enters the battlefield.
-        for (counter_type, counter_count) in &spec.enter_with_counters {
-            if *counter_count > 0 {
-                super::counters::add_counter_with_replacement(
+        for (counter_index, (counter_type, counter_count)) in
+            spec.enter_with_counters.iter().enumerate()
+        {
+            if *counter_count > 0
+                && !super::counters::add_counter_with_replacement(
                     state,
                     owner,
                     obj_id,
                     counter_type.clone(),
                     *counter_count,
                     events,
+                )
+            {
+                state.last_created_token_ids = created_ids.clone();
+                let remaining_counters = spec.enter_with_counters[counter_index + 1..]
+                    .iter()
+                    .filter(|(_, count)| *count > 0)
+                    .map(|(counter_type, count)| {
+                        crate::types::game_state::PendingCounterAddition::Object {
+                            actor: owner,
+                            object_id: obj_id,
+                            counter_type: counter_type.clone(),
+                            count: *count,
+                        }
+                    })
+                    .collect();
+                let remaining_count = final_count.saturating_sub(index + 1);
+                let post_actions = vec![
+                    PendingCounterPostAction::FinalizeTokenEntry {
+                        object_id: obj_id,
+                        name: spec.characteristics.display_name.clone(),
+                        attach_to: spec.attach_to,
+                        sacrifice_at: spec.sacrifice_at.clone(),
+                        source_id: spec.source_id,
+                        controller: spec.controller,
+                    },
+                    PendingCounterPostAction::ContinueTokenCreation {
+                        owner,
+                        spec: spec.clone(),
+                        enter_tapped,
+                        remaining_count,
+                    },
+                ];
+                let completion = match pause_completion_event {
+                    PendingEffectResolutionEvent::Emit => {
+                        crate::types::game_state::PendingEffectResolved::with_post_actions(
+                            EffectKind::Token,
+                            spec.source_id,
+                            post_actions,
+                        )
+                    }
+                    PendingEffectResolutionEvent::Suppress => crate::types::game_state::PendingEffectResolved::with_post_actions_without_effect(
+                        EffectKind::Token,
+                        spec.source_id,
+                        post_actions,
+                    ),
+                };
+                super::counters::stash_pending_counter_additions(
+                    state,
+                    remaining_counters,
+                    completion,
                 );
+                return false;
             }
         }
 
-        // CR 111.10a–v: Inject predefined abilities for known token subtypes.
+        // CR 111.10: Inject predefined abilities for known token subtypes.
         inject_predefined_token_abilities(state, obj_id);
         // Battlefield entry: request an incremental layer re-derive for just this
         // token. `flush_layers` escalates to a full pass if the token sources a
@@ -776,6 +853,7 @@ pub fn apply_create_token_after_replacement(
     // CR 603.7: Record created token IDs for sub-abilities that reference
     // TargetFilter::LastCreated (e.g., Job select, suspect).
     state.last_created_token_ids = created_ids;
+    true
 }
 
 // ── Layer B: token-handler batch purity gate (Tier 3) ────────────────────
@@ -1530,7 +1608,7 @@ fn resolve_pt_value(
     }
 }
 
-// ── Predefined token abilities (CR 111.10a–v) ─────────────────────────
+// ── Predefined token abilities (CR 111.10) ────────────────────────────
 // Data-driven lookup: subtype → ability constructors.
 
 /// CR 111.10a: Treasure — "{T}, Sacrifice this artifact: Add one mana of any color."
@@ -1964,7 +2042,7 @@ fn shard_ability() -> AbilityDefinition {
     })
 }
 
-/// CR 111.10a–v: Predefined token abilities keyed by subtype.
+/// CR 111.10: Predefined token abilities keyed by subtype.
 /// Returns ability definitions to inject for the given subtype, or empty if none.
 pub fn predefined_token_abilities(subtype: &str) -> Vec<AbilityDefinition> {
     match subtype {
@@ -1985,7 +2063,7 @@ pub fn predefined_token_abilities(subtype: &str) -> Vec<AbilityDefinition> {
     }
 }
 
-/// CR 111.10a–v: human-readable rules text for predefined tokens, keyed by
+/// CR 111.10: human-readable rules text for predefined tokens, keyed by
 /// subtype. Mirrors `predefined_token_abilities` arm-for-arm — keep the two
 /// `match` blocks edited together (single source of truth). Returns `None`
 /// for subtypes whose printed text has not been backfilled; the frontend
@@ -2262,7 +2340,7 @@ fn wicked_role_spec() -> RoleSpec {
     }
 }
 
-/// CR 111.10j–r: Return the predefined Role token spec by display name, or
+/// CR 111.10: Return the predefined Role token spec by display name, or
 /// `None` if `name` is not an implemented Role.
 ///
 /// All Role tokens share the `Role` subtype, so dispatch must be by display
@@ -2283,10 +2361,10 @@ fn predefined_role_token_spec(name: &str) -> Option<RoleSpec> {
 /// Inject predefined token abilities based on the token's subtypes and name.
 ///
 /// Two dispatch paths:
-/// - **Subtype** (CR 111.10a–i, s–v): Treasure, Food, Clue, Blood, Powerstone,
+/// - **Subtype** (CR 111.10): Treasure, Food, Clue, Blood, Powerstone,
 ///   Map, Spawn — each subtype contributes a single activated ability
 ///   (`predefined_token_abilities`).
-/// - **Name** (CR 111.10j–r): Role tokens. All seven Roles share the `Role`
+/// - **Name** (CR 111.10): Role tokens. All seven Roles share the `Role`
 ///   subtype, so dispatch is by display name via `predefined_role_token_spec`.
 ///   Roles contribute static abilities that modify the enchanted creature
 ///   (Cursed/Monster/Royal/Sorcerer/Virtuous/Young Hero) and may also
@@ -3479,7 +3557,7 @@ mod tests {
         assert!(abilities.is_empty());
     }
 
-    // ── Role token predefined statics (CR 111.10j–r) ────────────────────
+    // ── Role token predefined statics (CR 111.10) ───────────────────────
 
     /// Test helper — most Role tests only need the statics half of the spec.
     /// Wraps the typical "fetch spec, drop triggers, assert statics" idiom
@@ -3771,7 +3849,7 @@ mod tests {
 
     #[test]
     fn all_seven_role_token_variants_are_implemented() {
-        // CR 111.10j–r: every named Role token must have a spec. Unknown
+        // CR 111.10: every named Role token must have a spec. Unknown
         // names still return None (the dispatch is exhaustive over Roles,
         // not a catch-all).
         for name in [
@@ -3785,7 +3863,7 @@ mod tests {
         ] {
             assert!(
                 predefined_role_token_spec(name).is_some(),
-                "{name} Role must be implemented (CR 111.10j–r)"
+                "{name} Role must be implemented (CR 111.10)"
             );
         }
         assert!(predefined_role_token_spec("Not A Role").is_none());
@@ -4089,6 +4167,92 @@ mod tests {
         );
         // The created token should be on the battlefield
         assert!(state.objects.contains_key(&state.last_created_token_ids[0]));
+    }
+
+    #[test]
+    fn paused_token_etb_counters_preserve_batch_ledger_and_effect_resolution() {
+        use std::sync::Arc;
+
+        use crate::types::ability::{QuantityModification, ReplacementDefinition, ReplacementMode};
+        use crate::types::replacements::ReplacementEvent;
+
+        let mut state = GameState::new_two_player(42);
+        let replacement_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Counter Choice".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let mut def = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+                .valid_card(TargetFilter::Any)
+                .quantity_modification(QuantityModification::Prevent);
+            def.mode = ReplacementMode::Optional { decline: None };
+            let obj = state.objects.get_mut(&replacement_source).unwrap();
+            obj.base_replacement_definitions = Arc::new(vec![def.clone()]);
+            obj.replacement_definitions = vec![def].into();
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::Token {
+                name: "soldier".to_string(),
+                power: PtValue::Fixed(1),
+                toughness: PtValue::Fixed(1),
+                types: vec!["Creature".to_string(), "Soldier".to_string()],
+                colors: vec![],
+                keywords: vec![],
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 2 },
+                owner: TargetFilter::Controller,
+                attach_to: None,
+                enters_attacking: false,
+                supertypes: vec![],
+                static_abilities: vec![],
+                enter_with_counters: vec![(
+                    CounterType::Plus1Plus1,
+                    QuantityExpr::Fixed { value: 1 },
+                )],
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ));
+
+        let mut choice_events = Vec::new();
+        for _ in 0..2 {
+            let result =
+                apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 }).unwrap();
+            choice_events.extend(result.events);
+        }
+
+        assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+        assert_eq!(
+            state.last_created_token_ids.len(),
+            2,
+            "paused ETB-counter choices must preserve every token created by the batch"
+        );
+        assert_eq!(
+            choice_events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    GameEvent::EffectResolved {
+                        kind: EffectKind::Token,
+                        source_id: ObjectId(100),
+                    }
+                ))
+                .count(),
+            1,
+            "the token effect should resolve once after the paused batch finishes"
+        );
     }
 
     // CR 111.1 + CR 616.1: The Brass's Bounty fix, end to end. A folded

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -557,6 +557,8 @@ struct CopyTokenFinalization {
     controller: crate::types::player::PlayerId,
 }
 
+/// CR 707.2 / CR 707.9: Complete copy-token entry and apply remaining copy
+/// modifications after resuming from a counter-placement replacement pause.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn apply_remaining_token_modifications_after_counter_pause(
     state: &mut GameState,

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -10,7 +10,9 @@ use crate::types::card_type::SubtypeSet;
 #[cfg(test)]
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, PendingCopyTokenBatch, PendingCopyTokenResolution};
+use crate::types::game_state::{
+    GameState, PendingCopyTokenBatch, PendingCopyTokenResolution, PendingCounterPostAction,
+};
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::proposed_event::{CopyTokenSpec, EtbTapState, ProposedEvent};
 use crate::types::zones::Zone;
@@ -268,7 +270,13 @@ fn drain_copy_token_resolution(
 
         match crate::game::replacement::replace_event(state, proposed, events) {
             crate::game::replacement::ReplacementResult::Execute(event) => {
-                super::token::apply_create_token_after_replacement(state, event, events);
+                if !super::token::apply_create_token_after_replacement(state, event, events) {
+                    pending
+                        .created_ids
+                        .extend(state.last_created_token_ids.clone());
+                    state.pending_copy_token_resolution = Some(pending);
+                    return;
+                }
                 pending
                     .created_ids
                     .extend(state.last_created_token_ids.clone());
@@ -304,7 +312,7 @@ pub(crate) fn apply_copy_token_after_replacement(
     enter_with_counters: Vec<(crate::types::counter::CounterType, u32)>,
     final_count: u32,
     events: &mut Vec<GameEvent>,
-) -> Vec<ObjectId> {
+) -> CopyTokenApplyStatus {
     let CopyTokenSpec {
         values,
         display_source,
@@ -313,14 +321,14 @@ pub(crate) fn apply_copy_token_after_replacement(
         additional_modifications,
         tapped,
         enters_attacking,
+        sacrifice_at,
         source_id,
         controller,
-        ..
     } = copy;
     let name = values.name.clone();
     let mut created_ids = Vec::with_capacity(final_count as usize);
 
-    for _ in 0..final_count {
+    for index in 0..final_count {
         let token_id = zones::create_object(
             state,
             CardId(0),
@@ -377,26 +385,120 @@ pub(crate) fn apply_copy_token_after_replacement(
             }
         }
 
-        let _ = token;
-        apply_token_modifications(state, token_id, &additional_modifications, events);
-
-        let token = state.objects.get_mut(&token_id).unwrap();
         token.tapped = enter_tapped.resolve(tapped);
         let _ = token;
+        let finalization = CopyTokenFinalization {
+            name: name.clone(),
+            enters_attacking,
+            source_id,
+            controller,
+        };
+        if !apply_token_modifications(
+            state,
+            token_id,
+            &finalization,
+            &additional_modifications,
+            events,
+        ) {
+            let remaining_count = final_count.saturating_sub(index + 1);
+            if remaining_count > 0 {
+                super::counters::append_pending_counter_post_actions(
+                    state,
+                    vec![PendingCounterPostAction::ContinueCopyTokenCreation {
+                        owner: token_owner,
+                        copy: Box::new(CopyTokenSpec {
+                            values: values.clone(),
+                            display_source,
+                            printed_ref: printed_ref.clone(),
+                            extra_keywords: extra_keywords.clone(),
+                            additional_modifications: additional_modifications.clone(),
+                            tapped,
+                            enters_attacking,
+                            sacrifice_at: sacrifice_at.clone(),
+                            source_id,
+                            controller,
+                        }),
+                        enter_tapped,
+                        enter_with_counters: enter_with_counters.clone(),
+                        remaining_count,
+                    }],
+                );
+            }
+            state.last_created_token_ids = created_ids.clone();
+            return CopyTokenApplyStatus {
+                created_ids,
+                completion: CopyTokenApplyCompletion::Paused,
+            };
+        }
 
         // CR 614.1c + CR 122.6a: ETB-counter replacement mutations are carried
         // on the accepted CreateToken spec, even for copy tokens whose full
         // CR 707 payload lives in `CopyTokenSpec`.
-        for (counter_type, counter_count) in &enter_with_counters {
-            if *counter_count > 0 {
-                super::counters::add_counter_with_replacement(
+        for (counter_index, (counter_type, counter_count)) in enter_with_counters.iter().enumerate()
+        {
+            if *counter_count > 0
+                && !super::counters::add_counter_with_replacement(
                     state,
                     token_owner,
                     token_id,
                     counter_type.clone(),
                     *counter_count,
                     events,
+                )
+            {
+                state.last_created_token_ids = created_ids.clone();
+                let remaining_counters = enter_with_counters[counter_index + 1..]
+                    .iter()
+                    .filter(|(_, count)| *count > 0)
+                    .map(|(counter_type, count)| {
+                        crate::types::game_state::PendingCounterAddition::Object {
+                            actor: token_owner,
+                            object_id: token_id,
+                            counter_type: counter_type.clone(),
+                            count: *count,
+                        }
+                    })
+                    .collect();
+                let remaining_count = final_count.saturating_sub(index + 1);
+                super::counters::stash_pending_counter_additions(
+                    state,
+                    remaining_counters,
+                    crate::types::game_state::PendingEffectResolved::with_post_actions_without_effect(
+                        EffectKind::CopyTokenOf,
+                        source_id,
+                        vec![
+                            PendingCounterPostAction::FinalizeCopyTokenEntry {
+                                object_id: token_id,
+                                name: name.clone(),
+                                enters_attacking,
+                                source_id,
+                                controller,
+                            },
+                            PendingCounterPostAction::ContinueCopyTokenCreation {
+                                owner: token_owner,
+                                copy: Box::new(CopyTokenSpec {
+                                    values: values.clone(),
+                                    display_source,
+                                    printed_ref: printed_ref.clone(),
+                                    extra_keywords: extra_keywords.clone(),
+                                    additional_modifications: additional_modifications.clone(),
+                                    tapped,
+                                    enters_attacking,
+                                    sacrifice_at: sacrifice_at.clone(),
+                                    source_id,
+                                    controller,
+                                }),
+                                enter_tapped,
+                                enter_with_counters: enter_with_counters.clone(),
+                                remaining_count,
+                            },
+                        ],
+                    ),
                 );
+                return CopyTokenApplyStatus {
+                    created_ids,
+                    completion: CopyTokenApplyCompletion::Paused,
+                };
             }
         }
 
@@ -405,7 +507,7 @@ pub(crate) fn apply_copy_token_after_replacement(
             crate::game::combat::enter_attacking(state, token_id, source_id, controller);
         }
 
-        // CR 111.10a-v: Predefined token abilities for known subtypes (Treasure, Food, etc.).
+        // CR 111.10: Predefined token abilities for known subtypes (Treasure, Food, etc.).
         super::token::inject_predefined_token_abilities(state, token_id);
         // Battlefield entry of a copy token: request an incremental re-derive
         // for just this token. `flush_layers` escalates to a full pass when
@@ -432,7 +534,80 @@ pub(crate) fn apply_copy_token_after_replacement(
         created_ids.push(token_id);
     }
 
-    created_ids
+    CopyTokenApplyStatus {
+        created_ids,
+        completion: CopyTokenApplyCompletion::Completed,
+    }
+}
+
+pub(crate) struct CopyTokenApplyStatus {
+    pub(crate) created_ids: Vec<ObjectId>,
+    pub(crate) completion: CopyTokenApplyCompletion,
+}
+
+pub(crate) enum CopyTokenApplyCompletion {
+    Completed,
+    Paused,
+}
+
+struct CopyTokenFinalization {
+    name: String,
+    enters_attacking: bool,
+    source_id: ObjectId,
+    controller: crate::types::player::PlayerId,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn apply_remaining_token_modifications_after_counter_pause(
+    state: &mut GameState,
+    token_id: ObjectId,
+    name: String,
+    enters_attacking: bool,
+    source_id: ObjectId,
+    controller: crate::types::player::PlayerId,
+    remaining_modifications: Vec<ContinuousModification>,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    let finalization = CopyTokenFinalization {
+        name: name.clone(),
+        enters_attacking,
+        source_id,
+        controller,
+    };
+    if !apply_token_modifications(
+        state,
+        token_id,
+        &finalization,
+        &remaining_modifications,
+        events,
+    ) {
+        return false;
+    }
+    if enters_attacking {
+        crate::game::combat::enter_attacking(state, token_id, source_id, controller);
+    }
+    super::token::inject_predefined_token_abilities(state, token_id);
+    crate::game::layers::mark_layers_entered(state, token_id);
+    crate::game::restrictions::record_battlefield_entry(state, token_id);
+    crate::game::restrictions::record_token_created(state, token_id);
+    if let Some(token) = state.objects.get(&token_id) {
+        let zone_change_record = token.snapshot_for_zone_change(token_id, None, Zone::Battlefield);
+        events.push(GameEvent::ZoneChanged {
+            object_id: token_id,
+            from: None,
+            to: Zone::Battlefield,
+            record: Box::new(zone_change_record),
+        });
+    }
+    events.push(GameEvent::TokenCreated {
+        object_id: token_id,
+        name,
+    });
+    state.last_created_token_ids.push(token_id);
+    if let Some(pending) = state.pending_copy_token_resolution.as_mut() {
+        pending.created_ids.push(token_id);
+    }
+    true
 }
 
 /// CR 707.2: Compute the longest contiguous prefix of `source_ids` (top-down
@@ -503,10 +678,11 @@ pub(crate) fn compute_copy_batch_prefix(
 fn apply_token_modifications(
     state: &mut GameState,
     token_id: ObjectId,
+    finalization: &CopyTokenFinalization,
     modifications: &[ContinuousModification],
     events: &mut Vec<GameEvent>,
-) {
-    for modification in modifications {
+) -> bool {
+    for (index, modification) in modifications.iter().enumerate() {
         match modification {
             // CR 205.4 + CR 707.9b: "the token isn't legendary" (Miirym class).
             ContinuousModification::RemoveSupertype { supertype } => {
@@ -535,12 +711,12 @@ fn apply_token_modifications(
                 count,
                 if_type,
             } => {
-                let controller = state
+                let counter_actor = state
                     .objects
                     .get(&token_id)
                     .map(|o| o.controller)
                     .unwrap_or(crate::types::player::PlayerId(0));
-                let n = resolve_quantity(state, count, controller, token_id).max(0) as u32;
+                let n = resolve_quantity(state, count, counter_actor, token_id).max(0) as u32;
                 if n == 0 {
                     continue;
                 }
@@ -555,14 +731,31 @@ fn apply_token_modifications(
                 if !gate_passes {
                     continue;
                 }
-                super::counters::add_counter_with_replacement(
+                if !super::counters::add_counter_with_replacement(
                     state,
-                    controller,
+                    counter_actor,
                     token_id,
                     counter_type.clone(),
                     n,
                     events,
-                );
+                ) {
+                    super::counters::stash_pending_counter_post_actions(
+                        state,
+                        EffectKind::CopyTokenOf,
+                        finalization.source_id,
+                        vec![
+                            PendingCounterPostAction::ApplyCopyTokenModificationsAndFinalize {
+                                object_id: token_id,
+                                name: finalization.name.clone(),
+                                enters_attacking: finalization.enters_attacking,
+                                source_id: finalization.source_id,
+                                controller: finalization.controller,
+                                remaining_modifications: modifications[index + 1..].to_vec(),
+                            },
+                        ],
+                    );
+                    return false;
+                }
             }
             // CR 707.9b: Name override applied at copy time.
             ContinuousModification::SetName { name } => {
@@ -743,6 +936,7 @@ fn apply_token_modifications(
             _ => {}
         }
     }
+    true
 }
 
 /// CR 205.1a + CR 613.1d: remove every subtype belonging to the given
@@ -2328,6 +2522,108 @@ mod tests {
             p1p1, 1,
             "token should have one +1/+1 counter; counters={:?}",
             token.counters
+        );
+    }
+
+    #[test]
+    fn paused_copy_token_add_counter_on_enter_preserves_remaining_batch() {
+        let mut state = GameState::new_two_player(42);
+        let replacement_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Counter Choice".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let mut def = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+                .valid_card(TargetFilter::Any)
+                .quantity_modification(QuantityModification::Prevent);
+            def.mode = crate::types::ability::ReplacementMode::Optional { decline: None };
+            let obj = state.objects.get_mut(&replacement_source).unwrap();
+            obj.base_replacement_definitions = Arc::new(vec![def.clone()]);
+            obj.replacement_definitions = vec![def].into();
+        }
+
+        let source_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Soldier".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.base_power = Some(2);
+            source.base_toughness = Some(2);
+            source.power = Some(2);
+            source.toughness = Some(2);
+            source.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec!["Soldier".to_string()],
+            };
+            source.card_types = source.base_card_types.clone();
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::Any,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 2 },
+                extra_keywords: vec![],
+                additional_modifications: vec![ContinuousModification::AddCounterOnEnter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    if_type: None,
+                }],
+            },
+            vec![TargetRef::Object(source_id)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ));
+
+        let mut choice_events = Vec::new();
+        for _ in 0..2 {
+            let result =
+                apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 }).unwrap();
+            choice_events.extend(result.events);
+        }
+
+        assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+        assert_eq!(
+            state.last_created_token_ids.len(),
+            2,
+            "copy-token counter pauses must preserve the current token and remaining copies"
+        );
+        for token_id in &state.last_created_token_ids {
+            let token = state.objects.get(token_id).unwrap();
+            assert!(token.is_token);
+            assert_eq!(token.name, "Soldier");
+        }
+        assert_eq!(
+            choice_events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    GameEvent::EffectResolved {
+                        kind: EffectKind::CopyTokenOf,
+                        source_id: ObjectId(100),
+                    }
+                ))
+                .count(),
+            1,
+            "the copy-token effect should resolve once after the paused batch finishes"
         );
     }
 

--- a/crates/engine/src/game/effects/tribute.rs
+++ b/crates/engine/src/game/effects/tribute.rs
@@ -88,18 +88,21 @@ pub(crate) fn apply_paid(
     source_id: crate::types::identifiers::ObjectId,
     count: u32,
     events: &mut Vec<GameEvent>,
-) {
-    if count > 0 {
-        super::counters::add_counter_with_replacement(
+) -> bool {
+    record_outcome(state, source_id, TributeOutcome::Paid);
+    if count > 0
+        && !super::counters::add_counter_with_replacement(
             state,
             actor,
             source_id,
             crate::types::counter::CounterType::Plus1Plus1,
             count,
             events,
-        );
+        )
+    {
+        return false;
     }
-    record_outcome(state, source_id, TributeOutcome::Paid);
+    true
 }
 
 /// Apply the declined outcome: persist `TributeOutcome::Declined` so the

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4092,7 +4092,13 @@ fn apply_action(
                     ));
                 }
             }
-            effects::proliferate::apply_proliferate(state, p, &targets, &mut events);
+            if !effects::proliferate::apply_proliferate(state, p, &targets, &mut events) {
+                return Ok(ActionResult {
+                    events,
+                    waiting_for: state.waiting_for.clone(),
+                    log_entries: vec![],
+                });
+            }
             events.push(GameEvent::EffectResolved {
                 kind: crate::types::ability::EffectKind::Proliferate,
                 source_id: ObjectId(0), // Source not tracked through choice state
@@ -5086,12 +5092,14 @@ fn handle_play_land(
                     }
                 }
                 // CR 614.1c: Apply counters from replacement pipeline.
-                engine_replacement::apply_etb_counters(
+                if !engine_replacement::apply_etb_counters(
                     state,
                     object_id,
                     &enter_with_counters,
                     events,
-                );
+                ) {
+                    return Ok(state.waiting_for.clone());
+                }
                 // CR 614.1c: Apply pending ETB counters from delayed triggers
                 // (e.g., "that creature enters with an additional +1/+1 counter").
                 let pending: Vec<_> = state
@@ -5101,7 +5109,9 @@ fn handle_play_land(
                     .map(|(_, ct, n)| (ct.clone(), *n))
                     .collect();
                 if !pending.is_empty() {
-                    engine_replacement::apply_etb_counters(state, object_id, &pending, events);
+                    if !engine_replacement::apply_etb_counters(state, object_id, &pending, events) {
+                        return Ok(state.waiting_for.clone());
+                    }
                     state
                         .pending_etb_counters
                         .retain(|(oid, _, _)| *oid != object_id);

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -222,9 +222,9 @@ pub(super) fn handle_tribute_choice(
         ));
     };
 
-    if accept {
-        effects::tribute::apply_paid(state, player, source_id, count, events);
-    } else {
+    if accept && !effects::tribute::apply_paid(state, player, source_id, count, events) {
+        return Ok(action_result(events, state.waiting_for.clone()));
+    } else if !accept {
         effects::tribute::apply_declined(state, source_id);
     }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -9,7 +9,7 @@ use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::player::PlayerId;
-use crate::types::proposed_event::ProposedEvent;
+use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
 use crate::types::replacements::ReplacementEvent;
 use crate::types::zones::Zone;
 
@@ -73,7 +73,9 @@ pub(super) fn handle_replacement_choice(
                             );
                         }
                         // CR 614.1c: Apply counters from replacement pipeline.
-                        apply_etb_counters(state, object_id, &enter_with_counters, events);
+                        if !apply_etb_counters(state, object_id, &enter_with_counters, events) {
+                            return Ok(state.waiting_for.clone());
+                        }
                         // CR 614.1c: Apply pending ETB counters from delayed triggers
                         // (e.g., "that creature enters with an additional +1/+1 counter").
                         let pending: Vec<_> = state
@@ -83,7 +85,9 @@ pub(super) fn handle_replacement_choice(
                             .map(|(_, ct, n)| (ct.clone(), *n))
                             .collect();
                         if !pending.is_empty() {
-                            apply_etb_counters(state, object_id, &pending, events);
+                            if !apply_etb_counters(state, object_id, &pending, events) {
+                                return Ok(state.waiting_for.clone());
+                            }
                             state
                                 .pending_etb_counters
                                 .retain(|(oid, _, _)| *oid != object_id);
@@ -127,21 +131,35 @@ pub(super) fn handle_replacement_choice(
                 // CR 122.1: Counter addition accepted after replacement choice (e.g.,
                 // Corpsejack Menace doubler on a prompted counter-placement).
                 ProposedEvent::AddCounter {
-                    actor,
-                    object_id,
-                    counter_type,
-                    count,
-                    ..
-                } => {
-                    effects::counters::apply_counter_addition(
+                    placement, count, ..
+                } => match placement {
+                    CounterPlacement::Object {
+                        actor,
+                        object_id,
+                        counter_type,
+                    } => effects::counters::apply_counter_addition(
                         state,
                         actor,
                         object_id,
                         counter_type,
                         count,
                         events,
-                    );
-                }
+                    ),
+                    CounterPlacement::Player {
+                        player_id,
+                        counter_kind,
+                        ..
+                    } => effects::player_counter::apply_player_counter_addition(
+                        state,
+                        player_id,
+                        counter_kind,
+                        count,
+                        events,
+                    ),
+                    CounterPlacement::Energy { player_id, .. } => {
+                        effects::energy::apply_energy_addition(state, player_id, count, events)
+                    }
+                },
                 // CR 122.1: Counter removal accepted after replacement choice.
                 ProposedEvent::RemoveCounter {
                     object_id,
@@ -296,7 +314,9 @@ pub(super) fn handle_replacement_choice(
                 // — the `spec` field carries the full self-describing token
                 // characteristics. Delegate to the shared helper.
                 create @ ProposedEvent::CreateToken { .. } => {
-                    apply_create_token_after_replacement(state, create, events);
+                    if !apply_create_token_after_replacement(state, create, events) {
+                        return Ok(state.waiting_for.clone());
+                    }
                 }
                 // CR 703.4q + CR 616.1 / CR 616.1e: EmptyManaPool resume.
                 // The player has chosen one handler ordering; apply the
@@ -375,6 +395,15 @@ pub(super) fn handle_replacement_choice(
             }
 
             if matches!(waiting_for, WaitingFor::Priority { .. })
+                && state.pending_counter_additions.is_some()
+            {
+                effects::counters::drain_pending_counter_additions(state, events);
+                if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                    waiting_for = state.waiting_for.clone();
+                }
+            }
+
+            if matches!(waiting_for, WaitingFor::Priority { .. })
                 && state.pending_copy_token_resolution.is_some()
             {
                 effects::token_copy::drain_pending_copy_token_resolution(state, events);
@@ -431,6 +460,18 @@ pub(super) fn handle_replacement_choice(
             super::replacement::replacement_choice_waiting_for(player, state),
         ),
         super::replacement::ReplacementResult::Prevented => {
+            if state.pending_counter_additions.is_some() {
+                state.waiting_for = WaitingFor::Priority {
+                    player: state.active_player,
+                };
+                effects::counters::drain_pending_counter_additions(state, events);
+                if matches!(state.waiting_for, WaitingFor::Priority { .. })
+                    && state.pending_copy_token_resolution.is_some()
+                {
+                    effects::token_copy::drain_pending_copy_token_resolution(state, events);
+                }
+                return Ok(state.waiting_for.clone());
+            }
             if pending_was_counter_move {
                 state.waiting_for = WaitingFor::Priority {
                     player: state.active_player,
@@ -519,7 +560,9 @@ pub(super) fn handle_copy_target_choice(
             obj.tapped = tapped;
         }
     }
-    apply_etb_counters(state, source_id, &enter_modifiers.counters, events);
+    if !apply_etb_counters(state, source_id, &enter_modifiers.counters, events) {
+        return Ok(state.waiting_for.clone());
+    }
     crate::game::layers::mark_layers_full(state);
     // CR 614.12a + CR 707.9: The battlefield-entry `ZoneChanged` event was
     // captured into `state.deferred_entry_events` when `CopyTargetChoice` was
@@ -941,21 +984,44 @@ pub(super) fn apply_etb_counters(
     object_id: ObjectId,
     counters: &[(CounterType, u32)],
     events: &mut Vec<GameEvent>,
-) {
+) -> bool {
     let actor = state
         .objects
         .get(&object_id)
         .map(|obj| obj.controller)
         .unwrap_or(PlayerId(0));
-    for (counter_type, count) in counters {
-        super::effects::counters::add_counter_with_replacement(
+    for (index, (counter_type, count)) in counters.iter().enumerate() {
+        if !super::effects::counters::add_counter_with_replacement(
             state,
             actor,
             object_id,
             counter_type.clone(),
             *count,
             events,
-        );
+        ) {
+            let remaining = counters[index + 1..]
+                .iter()
+                .filter(|(_, count)| *count > 0)
+                .map(|(counter_type, count)| {
+                    crate::types::game_state::PendingCounterAddition::Object {
+                        actor,
+                        object_id,
+                        counter_type: counter_type.clone(),
+                        count: *count,
+                    }
+                })
+                .collect();
+            super::effects::counters::stash_pending_counter_additions(
+                state,
+                remaining,
+                crate::types::game_state::PendingEffectResolved::with_post_actions_without_effect(
+                    crate::types::ability::EffectKind::GenericEffect,
+                    object_id,
+                    Vec::new(),
+                ),
+            );
+            return false;
+        }
     }
     let replacement_choice_for_object = state
         .pending_replacement
@@ -969,6 +1035,7 @@ pub(super) fn apply_etb_counters(
             }
         }
     }
+    true
 }
 
 fn find_copy_targets(
@@ -1062,9 +1129,11 @@ mod tests {
 
         let mut events = Vec::new();
         let proposed = ProposedEvent::AddCounter {
-            actor: PlayerId(0),
-            object_id: target,
-            counter_type: CounterType::Plus1Plus1,
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: target,
+                counter_type: CounterType::Plus1Plus1,
+            },
             count: 2,
             applied: std::collections::HashSet::new(),
         };

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2142,20 +2142,10 @@ pub(super) fn handle_resolution_choice(
                 // so counter-doubling/modifying replacement effects apply.
                 EffectKind::BlightEffect => {
                     let blighted = chosen[0];
-                    if count_param > 0 {
-                        effects::counters::add_counter_with_replacement(
-                            state,
-                            player,
-                            blighted,
-                            crate::types::counter::CounterType::Minus1Minus1,
-                            count_param,
-                            events,
-                        );
-                    }
-                    // CR 701.68c: Snapshot the chosen creature so spells and
-                    // abilities that refer back to "the creature you blighted"
-                    // resolve to it. The creature stays on the battlefield, so
-                    // the snapshot is taken from its live characteristics.
+                    // CR 701.68c: Snapshot the chosen creature before the
+                    // counter-placement replacement pipeline can pause, so
+                    // "the creature you blighted" remains available when the
+                    // continuation resumes.
                     if let Some(obj) = state.objects.get(&blighted) {
                         let snapshot = crate::types::ability::CostPaidObjectSnapshot {
                             object_id: blighted,
@@ -2164,6 +2154,25 @@ pub(super) fn handle_resolution_choice(
                         if let Some(cont) = state.pending_continuation.as_mut() {
                             cont.chain.set_effect_context_object_recursive(snapshot);
                         }
+                    }
+                    if count_param > 0
+                        && !effects::counters::add_counter_with_replacement(
+                            state,
+                            player,
+                            blighted,
+                            crate::types::counter::CounterType::Minus1Minus1,
+                            count_param,
+                            events,
+                        )
+                    {
+                        effects::counters::stash_pending_counter_completion(
+                            state,
+                            effect_kind,
+                            source_id,
+                        );
+                        return Ok(ResolutionChoiceOutcome::WaitingFor(
+                            state.waiting_for.clone(),
+                        ));
                     }
                 }
                 other => {

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -19,7 +19,9 @@ use crate::types::game_state::{GameState, PendingReplacement, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{StepEndManaAction, UnitDisposition};
 use crate::types::player::PlayerId;
-use crate::types::proposed_event::{CounterMoveStage, EtbTapState, ProposedEvent, ReplacementId};
+use crate::types::proposed_event::{
+    CounterMoveStage, CounterPlacement, EtbTapState, ProposedEvent, ReplacementId,
+};
 use crate::types::replacements::ReplacementEvent;
 use crate::types::zones::Zone;
 
@@ -191,9 +193,12 @@ fn apply_compleated_replacement(
     };
     match event {
         ProposedEvent::AddCounter {
-            actor,
-            object_id,
-            counter_type: CounterType::Loyalty,
+            placement:
+                CounterPlacement::Object {
+                    actor,
+                    object_id,
+                    counter_type: CounterType::Loyalty,
+                },
             count,
             mut applied,
         } if object_id == rid.source => {
@@ -206,9 +211,11 @@ fn apply_compleated_replacement(
                 event_type: ReplacementEvent::AddCounter.to_string(),
             });
             ProposedEvent::AddCounter {
-                actor,
-                object_id,
-                counter_type: CounterType::Loyalty,
+                placement: CounterPlacement::Object {
+                    actor,
+                    object_id,
+                    counter_type: CounterType::Loyalty,
+                },
                 count: count.saturating_sub(life_paid.saturating_mul(2)),
                 applied,
             }
@@ -1769,15 +1776,11 @@ fn add_counter_applier(
 
     match event {
         ProposedEvent::AddCounter {
-            actor,
-            object_id,
-            counter_type,
+            placement,
             count,
             applied,
         } => ApplyResult::Modified(ProposedEvent::AddCounter {
-            actor,
-            object_id,
-            counter_type,
+            placement,
             count: new_count(count),
             applied,
         }),
@@ -3226,8 +3229,12 @@ pub fn find_applicable_replacements(
     // is exposed as a virtual AddCounter candidate there. This lets it order
     // correctly with Doubling Season-class count modifiers (CR 616.1).
     if let ProposedEvent::AddCounter {
-        object_id,
-        counter_type: CounterType::Loyalty,
+        placement:
+            CounterPlacement::Object {
+                object_id,
+                counter_type: CounterType::Loyalty,
+                ..
+            },
         count,
         ..
     } = event
@@ -3505,6 +3512,34 @@ pub fn find_applicable_replacements(
                             continue;
                         }
                     }
+                    if let ProposedEvent::AddCounter { placement, .. } = event {
+                        if placement.player_id().is_some() {
+                            let Some(valid_player) = &repl_def.valid_player else {
+                                continue;
+                            };
+                            let affected_player = placement.player_id().expect(
+                                "CounterPlacement::player_id is Some for player counter events",
+                            );
+                            let player_ok = match valid_player {
+                                crate::types::ability::ReplacementPlayerScope::Opponent => {
+                                    affected_player != obj.controller
+                                }
+                                crate::types::ability::ReplacementPlayerScope::You => {
+                                    affected_player == obj.controller
+                                }
+                                crate::types::ability::ReplacementPlayerScope::AnyPlayer => true,
+                            };
+                            if !player_ok {
+                                continue;
+                            }
+                        } else if repl_def.valid_player.is_some() {
+                            continue;
+                        }
+                    } else if repl_def.event == ReplacementEvent::AddCounter
+                        && repl_def.valid_player.is_some()
+                    {
+                        continue;
+                    }
                     // CR 614.7: Skip an Optional replacement whose decline branch is a
                     // no-op on the current event. E.g., a shock land whose `enter_tapped`
                     // is already set by an Earthbending return: declining would tap it,
@@ -3532,7 +3567,11 @@ pub fn find_applicable_replacements(
                         (
                             ReplacementEvent::AddCounter,
                             ProposedEvent::AddCounter {
-                                counter_type: ev_ct,
+                                placement:
+                                    CounterPlacement::Object {
+                                        counter_type: ev_ct,
+                                        ..
+                                    },
                                 ..
                             },
                         )
@@ -4592,6 +4631,32 @@ fn effect_overrides_controller(effect: &Effect) -> bool {
     )
 }
 
+fn is_counter_placement_event(event: &ProposedEvent) -> bool {
+    matches!(event, ProposedEvent::AddCounter { count, .. } if *count > 0)
+        || matches!(
+            event,
+            ProposedEvent::MoveCounter {
+                stage: CounterMoveStage::Add,
+                add_count,
+                ..
+            } if *add_count > 0
+        )
+}
+
+fn counter_placement_prevention_applies(state: &GameState, candidates: &[ReplacementId]) -> bool {
+    candidates.iter().any(|rid| {
+        state
+            .objects
+            .get(&rid.source)
+            .and_then(|obj| obj.replacement_definitions.get(rid.index))
+            .is_some_and(|def| {
+                def.event == ReplacementEvent::AddCounter
+                    && def.quantity_modification == Some(QuantityModification::Prevent)
+                    && !replacement_mode_is_optional(&def.mode)
+            })
+    })
+}
+
 fn pipeline_loop(
     state: &mut GameState,
     mut proposed: ProposedEvent,
@@ -4608,6 +4673,17 @@ fn pipeline_loop(
 
         if candidates.is_empty() {
             break;
+        }
+
+        // CR 614.17c + CR 122.1: If a matching "can't get/have counters put
+        // on" effect prevents this counter-placement event, non-self
+        // replacement/prevention effects such as Doubling Season or Hardened
+        // Scales cannot modify or replace it. The event simply cannot happen,
+        // so there is no CR 616 ordering prompt.
+        if is_counter_placement_event(&proposed)
+            && counter_placement_prevention_applies(state, &candidates)
+        {
+            return ReplacementResult::Prevented;
         }
 
         if candidates.len() == 1 {
@@ -4906,9 +4982,9 @@ mod tests {
     use crate::game::effects::token::apply_create_token_after_replacement;
     use crate::game::game_object::{AttachTarget, GameObject};
     use crate::types::ability::{
-        AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, Effect, QuantityExpr,
-        QuantityModification, ReplacementDefinition, ReplacementPlayerScope, TargetFilter,
-        TargetRef,
+        AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, Effect, FilterProp,
+        QuantityExpr, QuantityModification, ReplacementDefinition, ReplacementMode,
+        ReplacementPlayerScope, TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
     use crate::types::game_state::DamageRecord;
@@ -5314,9 +5390,11 @@ mod tests {
         state.battlefield.push_back(doubling_season);
 
         let proposed = ProposedEvent::AddCounter {
-            actor: PlayerId(0),
-            object_id: compleated,
-            counter_type: CounterType::Loyalty,
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: compleated,
+                counter_type: CounterType::Loyalty,
+            },
             count: 5,
             applied: HashSet::new(),
         };
@@ -5432,9 +5510,11 @@ mod tests {
 
         let mut events = Vec::new();
         let proposed = ProposedEvent::AddCounter {
-            actor: PlayerId(0),
-            object_id: ObjectId(30),
-            counter_type: CounterType::Plus1Plus1,
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: ObjectId(30),
+                counter_type: CounterType::Plus1Plus1,
+            },
             count: 1,
             applied: HashSet::new(),
         };
@@ -5443,6 +5523,65 @@ mod tests {
             panic!("expected NeedsChoice for non-commuting count modification, got {result:?}");
         };
         assert_eq!(player, PlayerId(0));
+    }
+
+    /// CR 614.17c + CR 122.1: A matching "can't have counters put on it"
+    /// effect makes the counter-placement event impossible before ordinary
+    /// counter replacement ordering. Count modifiers such as Doubling Season
+    /// therefore cannot create a CR 616 prompt against the prohibition.
+    #[test]
+    fn counter_prohibition_short_circuits_count_modifier_prompt() {
+        let prevent_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Prevent);
+        let double_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Double);
+
+        let mut state = GameState::new_two_player(42);
+        let mut solemnity = GameObject::new(
+            ObjectId(10),
+            CardId(1),
+            PlayerId(0),
+            "Solemnity".to_string(),
+            Zone::Battlefield,
+        );
+        solemnity.replacement_definitions = vec![prevent_repl].into();
+        let mut doubling_season = GameObject::new(
+            ObjectId(20),
+            CardId(2),
+            PlayerId(0),
+            "Doubling Season".to_string(),
+            Zone::Battlefield,
+        );
+        doubling_season.replacement_definitions = vec![double_repl].into();
+        state.objects.insert(ObjectId(10), solemnity);
+        state.objects.insert(ObjectId(20), doubling_season);
+        state.battlefield.push_back(ObjectId(10));
+        state.battlefield.push_back(ObjectId(20));
+
+        let target = GameObject::new(
+            ObjectId(30),
+            CardId(3),
+            PlayerId(0),
+            "Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.insert(ObjectId(30), target);
+
+        let proposed = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: ObjectId(30),
+                counter_type: CounterType::Plus1Plus1,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+
+        let mut events = Vec::new();
+        assert_eq!(
+            replace_event(&mut state, proposed, &mut events),
+            ReplacementResult::Prevented
+        );
     }
 
     #[test]
@@ -9859,9 +9998,11 @@ mod tests {
         state.objects.insert(ObjectId(30), target);
 
         let proposed = ProposedEvent::AddCounter {
-            actor: PlayerId(0),
-            object_id: ObjectId(30),
-            counter_type: CounterType::Plus1Plus1,
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: ObjectId(30),
+                counter_type: CounterType::Plus1Plus1,
+            },
             count: 1,
             applied: HashSet::new(),
         };
@@ -10342,9 +10483,11 @@ mod tests {
 
         let registry = build_replacement_registry();
         let proposed = ProposedEvent::AddCounter {
-            actor: PlayerId(0),
-            object_id: target,
-            counter_type: CounterType::Minus1Minus1,
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: target,
+                counter_type: CounterType::Minus1Minus1,
+            },
             count: 1,
             applied: HashSet::new(),
         };
@@ -10355,9 +10498,11 @@ mod tests {
 
         // Sanity: the same replacement DOES fire on a +1/+1 counter event.
         let proposed_p1p1 = ProposedEvent::AddCounter {
-            actor: PlayerId(0),
-            object_id: target,
-            counter_type: CounterType::Plus1Plus1,
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: target,
+                counter_type: CounterType::Plus1Plus1,
+            },
             count: 1,
             applied: HashSet::new(),
         };
@@ -10400,9 +10545,11 @@ mod tests {
         let registry = build_replacement_registry();
 
         let proposed_p1p1 = ProposedEvent::AddCounter {
-            actor: PlayerId(0),
-            object_id: target,
-            counter_type: CounterType::Plus1Plus1,
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: target,
+                counter_type: CounterType::Plus1Plus1,
+            },
             count: 1,
             applied: HashSet::new(),
         };
@@ -10412,9 +10559,11 @@ mod tests {
         );
 
         let proposed_m1m1 = ProposedEvent::AddCounter {
-            actor: PlayerId(0),
-            object_id: target,
-            counter_type: CounterType::Minus1Minus1,
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: target,
+                counter_type: CounterType::Minus1Minus1,
+            },
             count: 1,
             applied: HashSet::new(),
         };
@@ -10461,9 +10610,11 @@ mod tests {
             CounterType::Generic("charge".to_string()),
         ] {
             let proposed = ProposedEvent::AddCounter {
-                actor: PlayerId(0),
-                object_id: target,
-                counter_type: ct.clone(),
+                placement: CounterPlacement::Object {
+                    actor: PlayerId(0),
+                    object_id: target,
+                    counter_type: ct.clone(),
+                },
                 count: 1,
                 applied: HashSet::new(),
             };
@@ -10473,6 +10624,272 @@ mod tests {
                 "counter_match=None must accept any counter type, including {ct:?}"
             );
         }
+    }
+
+    #[test]
+    fn global_object_counter_prohibition_prevents_listed_types_only() {
+        let source = ObjectId(90);
+        let target = ObjectId(91);
+        let unrelated = ObjectId(92);
+        let type_filter = TypeFilter::AnyOf(vec![
+            TypeFilter::Artifact,
+            TypeFilter::Creature,
+            TypeFilter::Enchantment,
+            TypeFilter::Land,
+        ]);
+        let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .valid_card(TargetFilter::Typed(
+                TypedFilter::new(type_filter).properties(vec![FilterProp::InZone {
+                    zone: Zone::Battlefield,
+                }]),
+            ))
+            .quantity_modification(QuantityModification::Prevent);
+        let mut state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
+
+        let mut artifact = GameObject::new(
+            target,
+            CardId(91),
+            PlayerId(1),
+            "Target Artifact".to_string(),
+            Zone::Battlefield,
+        );
+        artifact.card_types.core_types = vec![CoreType::Artifact];
+        state.objects.insert(target, artifact);
+        state.battlefield.push_back(target);
+
+        let mut planeswalker = GameObject::new(
+            unrelated,
+            CardId(92),
+            PlayerId(1),
+            "Unrelated Planeswalker".to_string(),
+            Zone::Battlefield,
+        );
+        planeswalker.card_types.core_types = vec![CoreType::Planeswalker];
+        state.objects.insert(unrelated, planeswalker);
+        state.battlefield.push_back(unrelated);
+
+        let exiled_artifact_id = ObjectId(93);
+        let mut exiled_artifact = GameObject::new(
+            exiled_artifact_id,
+            CardId(93),
+            PlayerId(1),
+            "Exiled Artifact".to_string(),
+            Zone::Exile,
+        );
+        exiled_artifact.card_types.core_types = vec![CoreType::Artifact];
+        state.objects.insert(exiled_artifact_id, exiled_artifact);
+        state.exile.push_back(exiled_artifact_id);
+
+        let registry = build_replacement_registry();
+        let listed_type_event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: target,
+                counter_type: CounterType::Plus1Plus1,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            !find_applicable_replacements(&state, &listed_type_event, &registry).is_empty(),
+            "artifact counter placement should match Solemnity's listed-type prohibition"
+        );
+        let mut events = Vec::new();
+        assert_eq!(
+            replace_event(&mut state, listed_type_event, &mut events),
+            ReplacementResult::Prevented
+        );
+
+        let unlisted_type_event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: unrelated,
+                counter_type: CounterType::Loyalty,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &unlisted_type_event, &registry).is_empty(),
+            "planeswalker counter placement should not match the artifact/creature/enchantment/land filter"
+        );
+
+        let exiled_artifact_event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: exiled_artifact_id,
+                counter_type: CounterType::Generic("egg".to_string()),
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &exiled_artifact_event, &registry).is_empty(),
+            "unqualified artifact/creature/enchantment/land wording must only match battlefield permanents"
+        );
+    }
+
+    #[test]
+    fn optional_counter_prevention_prompts_instead_of_auto_preventing() {
+        let source = ObjectId(90);
+        let target = ObjectId(91);
+        let mut repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .valid_card(TargetFilter::Any)
+            .quantity_modification(QuantityModification::Prevent);
+        repl.mode = ReplacementMode::Optional { decline: None };
+        let mut state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
+
+        let mut creature = GameObject::new(
+            target,
+            CardId(91),
+            PlayerId(1),
+            "Target Creature".to_string(),
+            Zone::Battlefield,
+        );
+        creature.card_types.core_types = vec![CoreType::Creature];
+        state.objects.insert(target, creature);
+        state.battlefield.push_back(target);
+
+        let event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: target,
+                counter_type: CounterType::Plus1Plus1,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        let mut events = Vec::new();
+
+        assert_eq!(
+            replace_event(&mut state, event, &mut events),
+            ReplacementResult::NeedsChoice(PlayerId(1)),
+            "optional counter prevention must use the normal replacement choice path"
+        );
+        assert!(state
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| pending.is_optional));
+    }
+
+    #[test]
+    fn player_counter_prohibition_does_not_match_object_counter_placement() {
+        let source = ObjectId(90);
+        let planeswalker_id = ObjectId(91);
+        let mut repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Prevent);
+        repl.valid_player = Some(ReplacementPlayerScope::AnyPlayer);
+        let mut state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
+
+        let mut planeswalker = GameObject::new(
+            planeswalker_id,
+            CardId(91),
+            PlayerId(1),
+            "Target Planeswalker".to_string(),
+            Zone::Battlefield,
+        );
+        planeswalker.card_types.core_types = vec![CoreType::Planeswalker];
+        state.objects.insert(planeswalker_id, planeswalker);
+        state.battlefield.push_back(planeswalker_id);
+
+        let registry = build_replacement_registry();
+        let event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: planeswalker_id,
+                counter_type: CounterType::Loyalty,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &event, &registry).is_empty(),
+            "player-scoped counter replacements must not match object counter placement"
+        );
+    }
+
+    #[test]
+    fn player_counter_replacement_scope_uses_recipient_not_actor() {
+        let source = ObjectId(90);
+        let mut repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Prevent);
+        repl.valid_player = Some(ReplacementPlayerScope::You);
+        let state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
+        let registry = build_replacement_registry();
+
+        let controlled_actor_puts_counter_on_opponent = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Player {
+                actor: PlayerId(0),
+                player_id: PlayerId(1),
+                counter_kind: crate::types::player::PlayerCounterKind::Poison,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(
+                &state,
+                &controlled_actor_puts_counter_on_opponent,
+                &registry
+            )
+            .is_empty(),
+            "controller-scoped player-counter replacement must not match only the actor placing counters"
+        );
+
+        let opponent_actor_puts_counter_on_controller = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Player {
+                actor: PlayerId(1),
+                player_id: PlayerId(0),
+                counter_kind: crate::types::player::PlayerCounterKind::Poison,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            !find_applicable_replacements(
+                &state,
+                &opponent_actor_puts_counter_on_controller,
+                &registry
+            )
+            .is_empty(),
+            "controller-scoped player-counter replacement should match the recipient receiving counters"
+        );
+    }
+
+    #[test]
+    fn object_counter_replacement_without_player_scope_ignores_player_counter_events() {
+        let source = ObjectId(90);
+        let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .quantity_modification(QuantityModification::Double);
+        let state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
+        let registry = build_replacement_registry();
+
+        let poison_event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Player {
+                actor: PlayerId(0),
+                player_id: PlayerId(0),
+                counter_kind: crate::types::player::PlayerCounterKind::Poison,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &poison_event, &registry).is_empty(),
+            "object-counter replacement without valid_player must not match player counters"
+        );
+
+        let energy_event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Energy {
+                actor: PlayerId(0),
+                player_id: PlayerId(0),
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &energy_event, &registry).is_empty(),
+            "object-counter replacement without valid_player must not match energy counters"
+        );
     }
 
     /// SHAPE: `empty_mana_pool_matcher` returns true for an EmptyManaPool event

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -6,8 +6,8 @@ use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    CastingVariant, ExileLink, ExileLinkKind, GameState, StackEntry, StackEntryKind,
-    StackPaidSnapshot,
+    CastingVariant, ExileLink, ExileLinkKind, GameState, PendingCounterPostAction, StackEntry,
+    StackEntryKind, StackPaidSnapshot,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
@@ -703,12 +703,14 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                             // (e.g., saga lore counters per CR 714.3a, planeswalker
                             // intrinsic loyalty per CR 306.5b, battle intrinsic
                             // defense per CR 310.4b).
-                            super::engine_replacement::apply_etb_counters(
+                            if !super::engine_replacement::apply_etb_counters(
                                 state,
                                 object_id,
                                 &enter_with_counters,
                                 events,
-                            );
+                            ) {
+                                return;
+                            }
                             // CR 712.14a + CR 310.11b: Apply transformation if entering
                             // transformed (propagated from ExileWithAltCost permission).
                             if enter_transformed && to == Zone::Battlefield {
@@ -752,9 +754,11 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                                 .map(|(_, ct, n)| (ct.clone(), *n))
                                 .collect();
                             if !pending.is_empty() {
-                                super::engine_replacement::apply_etb_counters(
+                                if !super::engine_replacement::apply_etb_counters(
                                     state, object_id, &pending, events,
-                                );
+                                ) {
+                                    return;
+                                }
                                 state
                                     .pending_etb_counters
                                     .retain(|(oid, _, _)| *oid != object_id);
@@ -1279,14 +1283,26 @@ fn resolve_keyword_action(
                 .filter(|sc| sc.zone == Zone::Battlefield)
                 .map(|sc| sc.controller);
             if let (Some(controller), true) = (spacecraft_controller, counters_added > 0) {
-                effects::counters::add_counter_with_replacement(
+                if !effects::counters::add_counter_with_replacement(
                     state,
                     controller,
                     spacecraft_id,
                     CounterType::Generic("charge".to_string()),
                     counters_added,
                     events,
-                );
+                ) {
+                    effects::counters::stash_pending_counter_completion_with_actions(
+                        state,
+                        EffectKind::Station,
+                        spacecraft_id,
+                        vec![PendingCounterPostAction::RecordStationed {
+                            spacecraft_id,
+                            creature_id: paid_creature_id,
+                            counters_added,
+                        }],
+                    );
+                    return;
+                }
             }
             events.push(GameEvent::Stationed {
                 spacecraft_id,

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1,11 +1,13 @@
 use std::collections::HashSet;
 
 use crate::game::replacement::{self, ReplacementResult};
-use crate::types::ability::{ReplacementDefinition, RestrictionExpiry};
+use crate::types::ability::{EffectKind, ReplacementDefinition, RestrictionExpiry};
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::format::GameFormat;
-use crate::types::game_state::{AutoPassMode, GameState, WaitingFor};
+use crate::types::game_state::{
+    AutoPassMode, GameState, PendingCounterAddition, PendingEffectResolved, WaitingFor,
+};
 use crate::types::identifiers::ObjectId;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
@@ -1324,7 +1326,7 @@ fn should_skip_step_now(state: &mut GameState, step: Phase) -> bool {
 
 /// CR 714.3b: As the precombat main phase begins, put a lore counter on each Saga
 /// the active player controls. This is a turn-based action, not a triggered ability.
-fn add_lore_counters_to_sagas(state: &mut GameState, events: &mut Vec<GameEvent>) {
+fn add_lore_counters_to_sagas(state: &mut GameState, events: &mut Vec<GameEvent>) -> bool {
     let active = state.active_player;
     let saga_ids: Vec<_> = state
         .battlefield
@@ -1342,16 +1344,38 @@ fn add_lore_counters_to_sagas(state: &mut GameState, events: &mut Vec<GameEvent>
         .collect();
 
     // CR 614.1: Route through replacement pipeline so Vorinclex-class effects apply.
-    for saga_id in saga_ids {
-        super::effects::counters::add_counter_with_replacement(
+    for (index, saga_id) in saga_ids.iter().copied().enumerate() {
+        if !super::effects::counters::add_counter_with_replacement(
             state,
             active,
             saga_id,
             CounterType::Lore,
             1,
             events,
-        );
+        ) {
+            let remaining = saga_ids[index + 1..]
+                .iter()
+                .copied()
+                .map(|object_id| PendingCounterAddition::Object {
+                    actor: active,
+                    object_id,
+                    counter_type: CounterType::Lore,
+                    count: 1,
+                })
+                .collect();
+            super::effects::counters::stash_pending_counter_additions(
+                state,
+                remaining,
+                PendingEffectResolved::with_post_actions_without_effect(
+                    EffectKind::GenericEffect,
+                    saga_id,
+                    Vec::new(),
+                ),
+            );
+            return false;
+        }
     }
+    true
 }
 
 /// CR 503.1 / CR 504.2 / CR 507.1 / CR 513.1: Process phase triggers for the current step.
@@ -1503,7 +1527,9 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 // CR 714.3b: As the precombat main phase begins, add a lore counter
                 // to each Saga the active player controls (turn-based action).
                 if state.phase == Phase::PreCombatMain {
-                    add_lore_counters_to_sagas(state, events);
+                    if !add_lore_counters_to_sagas(state, events) {
+                        return state.waiting_for.clone();
+                    }
                     super::attractions::perform_roll_to_visit_turn_based_action(state, events);
                     // CR 702.xxx: Paradigm (Strixhaven) — turn-based action at
                     // the start of the active player's first precombat main

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -503,17 +503,13 @@ const REPLACEMENT_CONTAINS_PATTERNS: &[&str] = &[
     // `parse_replacement_line` even when its suffix carries a static keyword
     // pattern like "has haste" that would otherwise classify it as static.
     "become a copy of",
-    // CR 614.6 + CR 614.7 + CR 122.1: Self-targeted counter-prohibition
-    // replacements ("~ can't have counters put on it." — Melira's Keepers
-    // class). The line lacks "would"/"instead" so it does not match the
-    // damage/destroy/draw replacement surface phrases, and the static
-    // classifier's `can't have ` pattern (if any) would otherwise miscategorize
-    // it as a static. Routing it as a replacement keeps it in the CR 614
-    // pipeline where `add_counter_applier` short-circuits the proposed event.
-    "can't have counters put on",
 ];
 
 pub(crate) fn is_replacement_pattern(lower: &str) -> bool {
+    if is_counter_prohibition_replacement_pattern(lower) {
+        return true;
+    }
+
     if REPLACEMENT_CONTAINS_PATTERNS
         .iter()
         .any(|pattern| scan_contains(lower, pattern))
@@ -556,6 +552,20 @@ fn is_replacement_compound_pattern(lower: &str) -> bool {
         return true;
     }
     false
+}
+
+fn is_counter_prohibition_replacement_pattern(lower: &str) -> bool {
+    // CR 614.17 + CR 122.1: Counter-prohibition effects lack "would" or
+    // "instead" but still route through the replacement pipeline.
+    nom_primitives::scan_at_word_boundaries(lower, |input| {
+        alt((
+            tag::<_, _, OracleError>("can't have counters put on"),
+            tag("players can't get counters"),
+            tag("counters can't be put on"),
+        ))
+        .parse(input)
+    })
+    .is_some()
 }
 
 fn is_as_enters_choose_pattern(lower: &str) -> bool {

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 
-use crate::parser::oracle_nom::error::OracleError;
+use crate::parser::oracle_nom::error::{oracle_err, OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{char, multispace1};
 use nom::combinator::{all_consuming, eof, opt, peek, value};
+use nom::multi::separated_list1;
 use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
 
@@ -18,6 +19,7 @@ use super::oracle_nom::bridge::{nom_on_lower, split_once_on_lower};
 use super::oracle_nom::condition::{parse_attached_subject_target_filter, parse_inner_condition};
 use super::oracle_nom::duration::parse_duration;
 use super::oracle_nom::primitives as nom_primitives;
+use super::oracle_nom::target::parse_type_filter_word;
 use super::oracle_quantity::capitalize_first;
 use super::oracle_target::parse_type_phrase;
 use super::oracle_util::{
@@ -29,8 +31,9 @@ use crate::types::ability::{
     Comparator, ContinuousModification, ControllerRef, CopyManaValueLimit, DamageModification,
     DamageRedirectTarget, DamageTargetFilter, DamageTargetPlayerScope, Duration, Effect,
     FilterProp, ManaModification, ManaReplacementScope, PlayerFilter, PreventionAmount,
-    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition, ReplacementMode,
-    ReplacementPlayerScope, StaticCondition, TargetFilter, TypeFilter, TypedFilter,
+    QuantityExpr, QuantityModification, QuantityRef, ReplacementCondition, ReplacementDefinition,
+    ReplacementMode, ReplacementPlayerScope, StaticCondition, TargetFilter, TypeFilter,
+    TypedFilter,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::mana::{ManaColor, ManaCost, ManaType};
@@ -463,14 +466,19 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         }
     }
 
+    // --- Global counter-prohibition replacements: Solemnity class ---
+    if let Some(def) = parse_global_player_counter_prohibition(&lower, &text) {
+        return Some(def);
+    }
+    if let Some(def) = parse_global_object_counter_prohibition(&lower, &text) {
+        return Some(def);
+    }
+
     // --- Counter-prohibition replacement: "~ can't have counters put on it." ---
     // CR 614.6 + CR 614.7 + CR 122.1: A self-targeted counter-placement
     // prohibition. The proposed `AddCounter` event never happens
     // (CR 614.6 — "if an event is replaced, it never happens"). Melira's
-    // Keepers class. The Solemnity-class global variant (no player gets
-    // counters anywhere) lifts the SelfRef scope to a wider filter and is
-    // out of scope for this PR — the typed shape (Prevent + valid_card)
-    // composes cleanly for it.
+    // Keepers class.
     if let Some(def) = parse_no_counters_replacement(&norm_lower, &text) {
         return Some(def);
     }
@@ -4644,6 +4652,78 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
     }
 
     Some(def)
+}
+
+/// CR 614.17 + CR 614.6 + CR 122.1: Parse "Players can't get counters."
+/// into a global player-counter prohibition. The runtime models the "can't"
+/// event through `ReplacementEvent::AddCounter` with `valid_player` scope so
+/// player-counter effects are suppressed before mutating player state.
+fn parse_global_player_counter_prohibition(
+    lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    let mut combinator = all_consuming(terminated(
+        tag::<_, _, OracleError<'_>>("players can't get counters"),
+        opt(tag(".")),
+    ));
+    combinator.parse(lower.trim()).ok()?;
+
+    let mut def = ReplacementDefinition::new(ReplacementEvent::AddCounter)
+        .quantity_modification(QuantityModification::Prevent)
+        .description(original_text.to_string());
+    def.valid_player = Some(ReplacementPlayerScope::AnyPlayer);
+    Some(def)
+}
+
+/// CR 614.17 + CR 614.6 + CR 122.1: Parse global object-counter prohibitions
+/// such as "Counters can't be put on artifacts, creatures, enchantments, or
+/// lands." into an `AddCounter` prevention scoped to the named type list.
+fn parse_global_object_counter_prohibition(
+    lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    let mut combinator = all_consuming(terminated(
+        preceded(
+            tag::<_, _, OracleError<'_>>("counters can't be put on "),
+            separated_list1(
+                parse_counter_prohibition_type_separator,
+                parse_counter_prohibition_type,
+            ),
+        ),
+        opt(tag(".")),
+    ));
+    let (_rest, type_filters) = combinator.parse(lower.trim()).ok()?;
+    let type_filter = match type_filters.as_slice() {
+        [single] => single.clone(),
+        _ => TypeFilter::AnyOf(type_filters),
+    };
+
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::AddCounter)
+            .valid_card(attach_zone_to_filter(
+                TargetFilter::Typed(TypedFilter::new(type_filter)),
+                Zone::Battlefield,
+            ))
+            .quantity_modification(QuantityModification::Prevent)
+            .description(original_text.to_string()),
+    )
+}
+
+fn parse_counter_prohibition_type_separator(input: &str) -> OracleResult<'_, &str> {
+    alt((tag(", or "), tag(", "), tag(" or "))).parse(input)
+}
+
+fn parse_counter_prohibition_type(input: &str) -> OracleResult<'_, TypeFilter> {
+    let (rest, type_filter) = parse_type_filter_word(input)?;
+    match type_filter {
+        TypeFilter::Artifact
+        | TypeFilter::Creature
+        | TypeFilter::Enchantment
+        | TypeFilter::Land
+        | TypeFilter::Planeswalker
+        | TypeFilter::Battle => Ok((rest, type_filter)),
+        _ => Err(oracle_err(input)),
+    }
 }
 
 /// CR 122.1a + CR 614.1a: Extract the counter-type token named in a counter
@@ -9665,6 +9745,52 @@ mod tests {
                 controller: Some(ControllerRef::You),
                 ..
             })) if type_filters == vec![TypeFilter::Creature]
+        ));
+    }
+
+    #[test]
+    fn solemnity_players_cant_get_counters_replacement() {
+        let def = parse_replacement_line("Players can't get counters.", "Solemnity")
+            .expect("Solemnity player-counter line must parse");
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Prevent)
+        );
+        assert_eq!(
+            def.valid_player,
+            Some(ReplacementPlayerScope::AnyPlayer),
+            "Solemnity must apply to every player, not only its controller"
+        );
+    }
+
+    #[test]
+    fn solemnity_permanent_types_cant_get_counters_replacement() {
+        let def = parse_replacement_line(
+            "Counters can't be put on artifacts, creatures, enchantments, or lands.",
+            "Solemnity",
+        )
+        .expect("Solemnity object-counter line must parse");
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Prevent)
+        );
+        assert!(matches!(
+            def.valid_card,
+            Some(TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: None,
+                properties,
+                ..
+            })) if type_filters == vec![TypeFilter::AnyOf(vec![
+                TypeFilter::Artifact,
+                TypeFilter::Creature,
+                TypeFilter::Enchantment,
+                TypeFilter::Land,
+            ])] && properties == vec![FilterProp::InZone {
+                zone: Zone::Battlefield
+            }]
         ));
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -24,15 +24,15 @@ use super::keywords::{Keyword, KeywordKind};
 use super::mana::{ManaColor, ManaCost, ManaType, StepEndManaAction};
 use super::match_config::{MatchConfig, MatchPhase, MatchScore};
 use super::phase::Phase;
-use super::player::{Player, PlayerId};
-use super::proposed_event::{CopyTokenSpec, ProposedEvent, ReplacementId};
+use super::player::{Player, PlayerCounterKind, PlayerId};
+use super::proposed_event::{CopyTokenSpec, EtbTapState, ProposedEvent, ReplacementId, TokenSpec};
 use super::zones::{ExileCostSourceZone, Zone};
 
 use crate::game::bracket_estimate::CommanderBracketTier;
 use crate::game::combat::{AttackTarget, CombatState};
 use crate::game::deck_loading::DeckEntry;
 
-use crate::game::game_object::GameObject;
+use crate::game::game_object::{AttachTarget, GameObject};
 
 fn default_rng() -> ChaCha20Rng {
     ChaCha20Rng::seed_from_u64(0)
@@ -999,6 +999,199 @@ pub struct PendingCounterMoveQueue {
     pub remaining: Vec<PendingCounterMove>,
     pub effect_kind: EffectKind,
     pub source_id: ObjectId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingEffectResolved {
+    pub kind: EffectKind,
+    pub source_id: ObjectId,
+    #[serde(default)]
+    pub resolution_event: PendingEffectResolutionEvent,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_actions: Vec<PendingCounterPostAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub player_action: Option<PendingPlayerAction>,
+}
+
+impl PendingEffectResolved {
+    pub fn new(kind: EffectKind, source_id: ObjectId) -> Self {
+        Self {
+            kind,
+            source_id,
+            resolution_event: PendingEffectResolutionEvent::Emit,
+            post_actions: Vec::new(),
+            player_action: None,
+        }
+    }
+
+    pub fn with_post_actions(
+        kind: EffectKind,
+        source_id: ObjectId,
+        post_actions: Vec<PendingCounterPostAction>,
+    ) -> Self {
+        Self {
+            kind,
+            source_id,
+            resolution_event: PendingEffectResolutionEvent::Emit,
+            post_actions,
+            player_action: None,
+        }
+    }
+
+    pub fn with_post_actions_without_effect(
+        kind: EffectKind,
+        source_id: ObjectId,
+        post_actions: Vec<PendingCounterPostAction>,
+    ) -> Self {
+        Self {
+            kind,
+            source_id,
+            resolution_event: PendingEffectResolutionEvent::Suppress,
+            post_actions,
+            player_action: None,
+        }
+    }
+
+    pub fn with_player_action(
+        kind: EffectKind,
+        source_id: ObjectId,
+        player_id: PlayerId,
+        action: PlayerActionKind,
+    ) -> Self {
+        Self {
+            kind,
+            source_id,
+            resolution_event: PendingEffectResolutionEvent::Emit,
+            post_actions: Vec::new(),
+            player_action: Some(PendingPlayerAction { player_id, action }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum PendingEffectResolutionEvent {
+    #[default]
+    Emit,
+    Suppress,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingPlayerAction {
+    pub player_id: PlayerId,
+    pub action: PlayerActionKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PendingCounterPostAction {
+    EmitEffectResolved {
+        kind: EffectKind,
+        source_id: ObjectId,
+    },
+    RecordPlayerAction {
+        player_id: PlayerId,
+        action: PlayerActionKind,
+    },
+    AddSubtype {
+        object_id: ObjectId,
+        subtype: String,
+    },
+    InjectPredefinedTokenAbilities {
+        object_id: ObjectId,
+    },
+    FinalizeTokenEntry {
+        object_id: ObjectId,
+        name: String,
+        attach_to: Option<AttachTarget>,
+        sacrifice_at: Option<Duration>,
+        source_id: ObjectId,
+        controller: PlayerId,
+    },
+    ContinueTokenCreation {
+        owner: PlayerId,
+        spec: Box<TokenSpec>,
+        enter_tapped: EtbTapState,
+        remaining_count: u32,
+    },
+    FinalizeCopyTokenEntry {
+        object_id: ObjectId,
+        name: String,
+        enters_attacking: bool,
+        source_id: ObjectId,
+        controller: PlayerId,
+    },
+    ContinueCopyTokenCreation {
+        owner: PlayerId,
+        copy: Box<CopyTokenSpec>,
+        enter_tapped: EtbTapState,
+        enter_with_counters: Vec<(CounterType, u32)>,
+        remaining_count: u32,
+    },
+    ApplyCopyTokenModificationsAndFinalize {
+        object_id: ObjectId,
+        name: String,
+        enters_attacking: bool,
+        source_id: ObjectId,
+        controller: PlayerId,
+        remaining_modifications: Vec<ContinuousModification>,
+    },
+    ClearPendingEtbCounters {
+        object_id: ObjectId,
+    },
+    ContinueZoneDeliveryTail {
+        object_id: ObjectId,
+        from: Zone,
+        to: Zone,
+        cause: Option<ObjectId>,
+        source_id: Option<ObjectId>,
+        duration: Option<Duration>,
+        exile_tracking: ZoneDeliveryExileTracking,
+    },
+    RecordStationed {
+        spacecraft_id: ObjectId,
+        creature_id: ObjectId,
+        counters_added: u32,
+    },
+    MarkMonstrous {
+        object_id: ObjectId,
+    },
+    MarkRenowned {
+        object_id: ObjectId,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum ZoneDeliveryExileTracking {
+    #[default]
+    None,
+    TrackBySource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PendingCounterAddition {
+    Object {
+        actor: PlayerId,
+        object_id: ObjectId,
+        counter_type: CounterType,
+        count: u32,
+    },
+    Player {
+        actor: PlayerId,
+        player_id: PlayerId,
+        counter_kind: PlayerCounterKind,
+        count: u32,
+    },
+    Energy {
+        actor: PlayerId,
+        player_id: PlayerId,
+        count: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingCounterAdditionQueue {
+    pub remaining: Vec<PendingCounterAddition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion: Option<PendingEffectResolved>,
 }
 
 /// CR 603.7: A delayed triggered ability created during resolution of a spell or ability.
@@ -5280,6 +5473,13 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_counter_moves: Option<PendingCounterMoveQueue>,
 
+    /// CR 122.1 + CR 616.1e: Pending counter-addition batch paused by a
+    /// replacement choice. Drained before normal pending continuations so
+    /// multi-recipient effects such as proliferate and double counters resume
+    /// their remaining counter placements after the current choice resolves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_counter_additions: Option<PendingCounterAdditionQueue>,
+
     /// Pending optional effect ability chain, awaiting player accept/decline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_optional_effect: Option<Box<crate::types::ability::ResolvedAbility>>,
@@ -6031,6 +6231,7 @@ impl GameState {
             pending_repeat_until: None,
             pending_choose_one_of: None,
             pending_counter_moves: None,
+            pending_counter_additions: None,
             pending_optional_effect: None,
             pending_optional_trigger_event: None,
             pending_optional_trigger_match_count: None,
@@ -6446,6 +6647,7 @@ impl PartialEq for GameState {
             && self.pending_repeat_until == other.pending_repeat_until
             && self.pending_choose_one_of == other.pending_choose_one_of
             && self.pending_counter_moves == other.pending_counter_moves
+            && self.pending_counter_additions == other.pending_counter_additions
             && self.may_trigger_auto_choices == other.may_trigger_auto_choices
             && self.pending_begin_game_abilities == other.pending_begin_game_abilities
             && self.resolving_begin_game_abilities == other.resolving_begin_game_abilities

--- a/crates/engine/src/types/proposed_event.rs
+++ b/crates/engine/src/types/proposed_event.rs
@@ -15,7 +15,7 @@ use super::identifiers::ObjectId;
 use super::keywords::Keyword;
 use super::mana::{ManaColor, ManaType, UnitDecision};
 use super::phase::Phase;
-use super::player::PlayerId;
+use super::player::{PlayerCounterKind, PlayerId};
 use super::zones::Zone;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -28,6 +28,51 @@ pub struct ReplacementId {
 pub enum CounterMoveStage {
     Remove,
     Add,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CounterPlacement {
+    Object {
+        #[serde(default)]
+        actor: PlayerId,
+        object_id: ObjectId,
+        counter_type: CounterType,
+    },
+    Player {
+        actor: PlayerId,
+        player_id: PlayerId,
+        counter_kind: PlayerCounterKind,
+    },
+    Energy {
+        actor: PlayerId,
+        player_id: PlayerId,
+    },
+}
+
+impl CounterPlacement {
+    pub fn object_id(&self) -> Option<ObjectId> {
+        match self {
+            CounterPlacement::Object { object_id, .. } => Some(*object_id),
+            CounterPlacement::Player { .. } | CounterPlacement::Energy { .. } => None,
+        }
+    }
+
+    pub fn player_id(&self) -> Option<PlayerId> {
+        match self {
+            CounterPlacement::Player { player_id, .. }
+            | CounterPlacement::Energy { player_id, .. } => Some(*player_id),
+            CounterPlacement::Object { .. } => None,
+        }
+    }
+
+    pub fn actor(&self) -> PlayerId {
+        match self {
+            CounterPlacement::Object { actor, .. }
+            | CounterPlacement::Player { actor, .. }
+            | CounterPlacement::Energy { actor, .. } => *actor,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
@@ -241,10 +286,11 @@ pub enum ProposedEvent {
         applied: HashSet<ReplacementId>,
     },
     AddCounter {
-        #[serde(default)]
-        actor: PlayerId,
-        object_id: ObjectId,
-        counter_type: CounterType,
+        /// CR 122.1 + CR 107.14: Counter placement may affect an object or a
+        /// player. Energy is represented as a dedicated player field at runtime
+        /// but is still a counter-placement event for replacement purposes.
+        #[serde(flatten)]
+        placement: CounterPlacement,
         count: u32,
         applied: HashSet<ReplacementId>,
     },
@@ -545,12 +591,20 @@ impl ProposedEvent {
             ProposedEvent::Tap { object_id, .. }
             | ProposedEvent::Untap { object_id, .. }
             | ProposedEvent::Destroy { object_id, .. }
-            | ProposedEvent::AddCounter { object_id, .. }
             | ProposedEvent::RemoveCounter { object_id, .. } => state
                 .objects
                 .get(object_id)
                 .map(|o| o.controller)
                 .unwrap_or(PlayerId(0)),
+            ProposedEvent::AddCounter { placement, .. } => match placement {
+                CounterPlacement::Object { object_id, .. } => state
+                    .objects
+                    .get(object_id)
+                    .map(|o| o.controller)
+                    .unwrap_or(PlayerId(0)),
+                CounterPlacement::Player { player_id, .. }
+                | CounterPlacement::Energy { player_id, .. } => *player_id,
+            },
             ProposedEvent::MoveCounter {
                 source_id,
                 destination_id,
@@ -598,10 +652,10 @@ impl ProposedEvent {
             | ProposedEvent::Tap { object_id, .. }
             | ProposedEvent::Untap { object_id, .. }
             | ProposedEvent::Destroy { object_id, .. }
-            | ProposedEvent::AddCounter { object_id, .. }
             | ProposedEvent::RemoveCounter { object_id, .. }
             | ProposedEvent::Discard { object_id, .. }
             | ProposedEvent::Sacrifice { object_id, .. } => Some(*object_id),
+            ProposedEvent::AddCounter { placement, .. } => placement.object_id(),
             ProposedEvent::MoveCounter {
                 source_id,
                 destination_id,
@@ -637,8 +691,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn proposed_event_has_21_variants() {
-        // Verify all 21 variants compile
+    fn proposed_event_variants_compile() {
+        // Verify all variants compile, including the parameterized counter
+        // placement recipients.
         let events: Vec<ProposedEvent> = vec![
             ProposedEvent::zone_change(ObjectId(1), Zone::Battlefield, Zone::Graveyard, None),
             ProposedEvent::Damage {
@@ -680,9 +735,28 @@ mod tests {
                 applied: HashSet::new(),
             },
             ProposedEvent::AddCounter {
-                actor: PlayerId(0),
-                object_id: ObjectId(1),
-                counter_type: CounterType::Plus1Plus1,
+                placement: CounterPlacement::Object {
+                    actor: PlayerId(0),
+                    object_id: ObjectId(1),
+                    counter_type: CounterType::Plus1Plus1,
+                },
+                count: 1,
+                applied: HashSet::new(),
+            },
+            ProposedEvent::AddCounter {
+                placement: CounterPlacement::Player {
+                    actor: PlayerId(0),
+                    player_id: PlayerId(0),
+                    counter_kind: PlayerCounterKind::Poison,
+                },
+                count: 1,
+                applied: HashSet::new(),
+            },
+            ProposedEvent::AddCounter {
+                placement: CounterPlacement::Energy {
+                    actor: PlayerId(0),
+                    player_id: PlayerId(0),
+                },
                 count: 1,
                 applied: HashSet::new(),
             },
@@ -764,7 +838,7 @@ mod tests {
                 applied: HashSet::new(),
             },
         ];
-        assert_eq!(events.len(), 21);
+        assert_eq!(events.len(), 23);
     }
 
     #[test]
@@ -788,6 +862,77 @@ mod tests {
         set.insert(id1);
         assert!(set.contains(&id2));
         assert!(!set.contains(&id3));
+    }
+
+    #[test]
+    fn add_counter_object_serde_keeps_legacy_flat_shape() {
+        let event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: ObjectId(1),
+                counter_type: CounterType::Plus1Plus1,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+
+        let value = serde_json::to_value(&event).unwrap();
+        let add_counter = value
+            .get("AddCounter")
+            .expect("externally tagged AddCounter variant")
+            .as_object()
+            .expect("AddCounter payload object");
+        assert!(add_counter.get("placement").is_none());
+        assert!(add_counter.get("actor").is_some());
+        assert!(add_counter.get("object_id").is_some());
+        assert!(add_counter.get("counter_type").is_some());
+
+        let roundtrip: ProposedEvent = serde_json::from_value(value).unwrap();
+        assert!(matches!(
+            roundtrip,
+            ProposedEvent::AddCounter {
+                placement: CounterPlacement::Object {
+                    actor: PlayerId(0),
+                    object_id: ObjectId(1),
+                    counter_type: CounterType::Plus1Plus1,
+                },
+                count: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn add_counter_object_serde_accepts_legacy_missing_actor() {
+        let event = ProposedEvent::AddCounter {
+            placement: CounterPlacement::Object {
+                actor: PlayerId(0),
+                object_id: ObjectId(1),
+                counter_type: CounterType::Plus1Plus1,
+            },
+            count: 1,
+            applied: HashSet::new(),
+        };
+        let mut value = serde_json::to_value(&event).unwrap();
+        value
+            .get_mut("AddCounter")
+            .and_then(|payload| payload.as_object_mut())
+            .expect("AddCounter payload object")
+            .remove("actor");
+
+        let roundtrip: ProposedEvent = serde_json::from_value(value).unwrap();
+        assert!(matches!(
+            roundtrip,
+            ProposedEvent::AddCounter {
+                placement: CounterPlacement::Object {
+                    actor: PlayerId(0),
+                    object_id: ObjectId(1),
+                    counter_type: CounterType::Plus1Plus1,
+                },
+                count: 1,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/engine/src/types/replacements.rs
+++ b/crates/engine/src/types/replacements.rs
@@ -35,7 +35,9 @@ pub enum ReplacementEvent {
     ChangeZone,
     /// CR 614.1a: Replaces an object moving zones (post-move replacement).
     Moved,
-    /// CR 614.1a: Replaces one or more counters being placed on an object.
+    /// CR 614.1a + CR 122.1: Replaces one or more counters being placed on an
+    /// object or player.
+    #[serde(alias = "AddPlayerCounter")]
     AddCounter,
     /// CR 614.1a: Replaces one or more counters being removed from an object.
     RemoveCounter,
@@ -161,7 +163,7 @@ impl FromStr for ReplacementEvent {
             "Counter" => ReplacementEvent::Counter,
             "ChangeZone" => ReplacementEvent::ChangeZone,
             "Moved" => ReplacementEvent::Moved,
-            "AddCounter" => ReplacementEvent::AddCounter,
+            "AddCounter" | "AddPlayerCounter" => ReplacementEvent::AddCounter,
             "RemoveCounter" => ReplacementEvent::RemoveCounter,
             "CreateToken" => ReplacementEvent::CreateToken,
             "Tap" => ReplacementEvent::Tap,
@@ -220,6 +222,10 @@ mod tests {
     fn parse_promoted_replacement_events() {
         assert_eq!(
             ReplacementEvent::from_str("AddCounter").unwrap(),
+            ReplacementEvent::AddCounter
+        );
+        assert_eq!(
+            ReplacementEvent::from_str("AddPlayerCounter").unwrap(),
             ReplacementEvent::AddCounter
         );
         assert_eq!(

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -1,32 +1,32 @@
 {
   "sources": [
-    "crates/engine/src/types/format.rs",
-    "crates/engine/src/types/actions.rs",
-    "crates/engine/src/types/replacements.rs",
-    "crates/engine/src/types/identifiers.rs",
-    "crates/engine/src/types/events.rs",
-    "crates/engine/src/types/proposed_event.rs",
-    "crates/engine/src/types/keywords.rs",
-    "crates/engine/src/types/statics.rs",
-    "crates/engine/src/types/triggers.rs",
-    "crates/engine/src/types/definitions.rs",
-    "crates/engine/src/types/ability.rs",
     "crates/engine/src/types/log.rs",
-    "crates/engine/src/types/game_state.rs",
-    "crates/engine/src/types/phase.rs",
-    "crates/engine/src/types/counter.rs",
+    "crates/engine/src/types/events.rs",
+    "crates/engine/src/types/statics.rs",
     "crates/engine/src/types/mod.rs",
     "crates/engine/src/types/layers.rs",
-    "crates/engine/src/types/match_config.rs",
-    "crates/engine/src/types/card.rs",
+    "crates/engine/src/types/triggers.rs",
+    "crates/engine/src/types/game_state.rs",
     "crates/engine/src/types/player.rs",
+    "crates/engine/src/types/card_type.rs",
+    "crates/engine/src/types/identifiers.rs",
+    "crates/engine/src/types/phase.rs",
+    "crates/engine/src/types/replacements.rs",
+    "crates/engine/src/types/ability.rs",
+    "crates/engine/src/types/proposed_event.rs",
     "crates/engine/src/types/mana.rs",
+    "crates/engine/src/types/actions.rs",
+    "crates/engine/src/types/match_config.rs",
     "crates/engine/src/types/zones.rs",
+    "crates/engine/src/types/definitions.rs",
+    "crates/engine/src/types/counter.rs",
+    "crates/engine/src/types/format.rs",
+    "crates/engine/src/types/card.rs",
     "crates/engine/src/types/attribution.rs",
-    "crates/engine/src/types/card_type.rs"
+    "crates/engine/src/types/keywords.rs"
   ],
-  "enum_count": 261,
-  "variant_count": 2905,
+  "enum_count": 270,
+  "variant_count": 2973,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -135,6 +135,17 @@
         "members": [
           "Goad",
           "GoadAll"
+        ],
+        "smell_score": "LOW"
+      }
+    },
+    {
+      "enum_name": "Effect",
+      "cluster": {
+        "shared_root": "Proliferate",
+        "members": [
+          "Proliferate",
+          "ProliferateTarget"
         ],
         "smell_score": "LOW"
       }
@@ -256,6 +267,17 @@
         "members": [
           "Goad",
           "GoadAll"
+        ],
+        "smell_score": "LOW"
+      }
+    },
+    {
+      "enum_name": "EffectKind",
+      "cluster": {
+        "shared_root": "Proliferate",
+        "members": [
+          "Proliferate",
+          "ProliferateTarget"
         ],
         "smell_score": "LOW"
       }
@@ -441,13 +463,13 @@
   "enums": {
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9743,
+      "line": 9852,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 9761,
+          "line": 9870,
           "kind": "struct",
           "field_names": [
             "source",
@@ -465,7 +487,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 9777,
+          "line": 9886,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -476,7 +498,7 @@
         },
         {
           "name": "AlternativeManaCostPaid",
-          "line": 9781,
+          "line": 9890,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9 + CR 608.2c: \"If the {COST} cost was paid\" on spells with an alternative *mana* cost (e.g. Baleful Mastery). Evaluates against `SpellContext.alternative_mana_cost_paid`, not `additional_cost_paid`.",
@@ -487,7 +509,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 9786,
+          "line": 9895,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -501,7 +523,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 9791,
+          "line": 9900,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -511,7 +533,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 9799,
+          "line": 9908,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -521,7 +543,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9802,
+          "line": 9911,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -533,7 +555,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 9806,
+          "line": 9915,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -546,7 +568,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 9809,
+          "line": 9918,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -559,7 +581,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 9812,
+          "line": 9921,
           "kind": "struct",
           "field_names": [
             "color",
@@ -573,7 +595,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 9822,
+          "line": 9931,
           "kind": "struct",
           "field_names": [
             "card_type",
@@ -586,7 +608,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 9830,
+          "line": 9939,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -597,7 +619,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 9833,
+          "line": 9942,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -610,7 +632,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 9838,
+          "line": 9947,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -624,7 +646,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 9842,
+          "line": 9951,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -638,7 +660,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 9851,
+          "line": 9960,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -652,7 +674,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 9856,
+          "line": 9965,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -662,7 +684,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 9858,
+          "line": 9967,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -672,7 +694,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 9861,
+          "line": 9970,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -682,7 +704,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 9865,
+          "line": 9974,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -694,7 +716,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 9870,
+          "line": 9979,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -708,7 +730,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 9878,
+          "line": 9987,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -720,7 +742,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 9883,
+          "line": 9992,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -736,7 +758,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 9895,
+          "line": 10004,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -749,7 +771,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 9899,
+          "line": 10008,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -762,7 +784,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 9903,
+          "line": 10012,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -772,7 +794,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 9911,
+          "line": 10020,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -785,7 +807,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 9916,
+          "line": 10025,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -798,7 +820,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 9921,
+          "line": 10030,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -810,7 +832,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 9927,
+          "line": 10036,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -822,7 +844,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 9931,
+          "line": 10040,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -836,7 +858,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 9934,
+          "line": 10043,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -846,7 +868,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 9943,
+          "line": 10052,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -859,7 +881,7 @@
         },
         {
           "name": "And",
-          "line": 9948,
+          "line": 10057,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -871,7 +893,7 @@
         },
         {
           "name": "Or",
-          "line": 9953,
+          "line": 10062,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -883,7 +905,7 @@
         },
         {
           "name": "Not",
-          "line": 9961,
+          "line": 10070,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -895,7 +917,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 9965,
+          "line": 10074,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -905,7 +927,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 9967,
+          "line": 10076,
           "kind": "struct",
           "field_names": [
             "state"
@@ -917,7 +939,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 9977,
+          "line": 10086,
           "kind": "struct",
           "field_names": [
             "n"
@@ -929,7 +951,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 9980,
+          "line": 10089,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -941,7 +963,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 10000,
+          "line": 10109,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -967,13 +989,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4720,
+      "line": 4739,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 4721,
+          "line": 4740,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -983,7 +1005,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 4730,
+          "line": 4749,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -996,7 +1018,7 @@
         },
         {
           "name": "Tap",
-          "line": 4733,
+          "line": 4752,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1004,7 +1026,7 @@
         },
         {
           "name": "Untap",
-          "line": 4734,
+          "line": 4753,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1012,7 +1034,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 4735,
+          "line": 4754,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1022,7 +1044,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 4738,
+          "line": 4757,
           "kind": "struct",
           "field_names": [
             "target",
@@ -1033,7 +1055,7 @@
         },
         {
           "name": "PayLife",
-          "line": 4750,
+          "line": 4769,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1045,7 +1067,7 @@
         },
         {
           "name": "Discard",
-          "line": 4753,
+          "line": 4772,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1058,7 +1080,7 @@
         },
         {
           "name": "Exile",
-          "line": 4764,
+          "line": 4783,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1070,7 +1092,7 @@
         },
         {
           "name": "ExileMaterials",
-          "line": 4778,
+          "line": 4797,
           "kind": "struct",
           "field_names": [
             "materials",
@@ -1083,7 +1105,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 4785,
+          "line": 4804,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1096,7 +1118,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 4788,
+          "line": 4807,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1107,7 +1129,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 4799,
+          "line": 4818,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1122,7 +1144,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 4805,
+          "line": 4824,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1132,7 +1154,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 4809,
+          "line": 4828,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1145,7 +1167,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 4817,
+          "line": 4836,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1159,7 +1181,7 @@
         },
         {
           "name": "Unattach",
-          "line": 4826,
+          "line": 4845,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1169,7 +1191,7 @@
         },
         {
           "name": "Mill",
-          "line": 4827,
+          "line": 4846,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1179,7 +1201,7 @@
         },
         {
           "name": "Exert",
-          "line": 4830,
+          "line": 4849,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1187,7 +1209,7 @@
         },
         {
           "name": "Blight",
-          "line": 4833,
+          "line": 4852,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1197,7 +1219,7 @@
         },
         {
           "name": "Reveal",
-          "line": 4836,
+          "line": 4855,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1208,7 +1230,7 @@
         },
         {
           "name": "Behold",
-          "line": 4844,
+          "line": 4863,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1220,7 +1242,7 @@
         },
         {
           "name": "Composite",
-          "line": 4850,
+          "line": 4869,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1230,7 +1252,7 @@
         },
         {
           "name": "OneOf",
-          "line": 4867,
+          "line": 4886,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1243,7 +1265,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 4871,
+          "line": 4890,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1253,7 +1275,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 4876,
+          "line": 4895,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1266,7 +1288,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 4883,
+          "line": 4902,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1278,7 +1300,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 4899,
+          "line": 4918,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1292,7 +1314,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 4904,
+          "line": 4923,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1305,13 +1327,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8877,
+      "line": 8974,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 8879,
+          "line": 8976,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1319,7 +1341,7 @@
         },
         {
           "name": "Activated",
-          "line": 8880,
+          "line": 8977,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1327,7 +1349,7 @@
         },
         {
           "name": "Database",
-          "line": 8881,
+          "line": 8978,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1335,7 +1357,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 8884,
+          "line": 8981,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1343,7 +1365,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 8890,
+          "line": 8987,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1356,7 +1378,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9031,
+      "line": 9128,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1364,7 +1386,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 9033,
+          "line": 9130,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1374,7 +1396,7 @@
         },
         {
           "name": "Evolve",
-          "line": 9035,
+          "line": 9132,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1384,7 +1406,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 9037,
+          "line": 9134,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1394,7 +1416,7 @@
         },
         {
           "name": "Outlast",
-          "line": 9039,
+          "line": 9136,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1404,7 +1426,7 @@
         },
         {
           "name": "Cycling",
-          "line": 9044,
+          "line": 9141,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29a + CR 702.29e: This ability originated from a Cycling (or Typecycling) keyword definition. Used so the activation pipeline can emit a `GameEvent::Cycled` (CR 702.29c) that \"When you cycle this card\" triggers match.",
@@ -1419,7 +1441,7 @@
     },
     "ActivationCadence": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 396,
+      "line": 410,
       "doc": "CR 602.5b: Activation-frequency restriction on an activated-ability-like action (e.g. Crew). `OncePerTurn` models \"Activate only once each turn\"; `Unlimited` is the default with no restriction.",
       "cr_refs": [
         "CR 602.5b"
@@ -1427,7 +1449,7 @@
       "variants": [
         {
           "name": "Unlimited",
-          "line": 398,
+          "line": 412,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1435,7 +1457,7 @@
         },
         {
           "name": "OncePerTurn",
-          "line": 399,
+          "line": 413,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1446,7 +1468,7 @@
     },
     "ActivationExemption": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 200,
+      "line": 201,
       "doc": "CR 605.1a: Exemption applied to a `CantBeActivated` prohibition.  Encodes the \"unless they're mana abilities\" suffix that appears on activation prohibitions like Pithing Needle. Modeled as a typed enum (not a bool) so the design space is self-documenting and extensible if a future card introduces a new exemption kind — do not add variants until a real card needs them.  CR 605.1a: A mana ability is an activated ability that has no target, could add mana to a player's mana pool when it resolves, and is not a loyalty ability.",
       "cr_refs": [
         "CR 605.1a"
@@ -1454,7 +1476,7 @@
       "variants": [
         {
           "name": "None",
-          "line": 203,
+          "line": 204,
           "kind": "unit",
           "field_names": [],
           "doc": "No exemption — every matching activated ability is prohibited.",
@@ -1462,7 +1484,7 @@
         },
         {
           "name": "ManaAbilities",
-          "line": 206,
+          "line": 207,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless they're mana abilities\" — activations classified as mana abilities (CR 605.1a) bypass the prohibition.",
@@ -1475,13 +1497,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9052,
+      "line": 9149,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 9053,
+          "line": 9150,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1489,7 +1511,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 9054,
+          "line": 9151,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1497,7 +1519,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 9055,
+          "line": 9152,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1505,7 +1527,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 9056,
+          "line": 9153,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1513,7 +1535,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 9057,
+          "line": 9154,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1521,7 +1543,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 9058,
+          "line": 9155,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1529,7 +1551,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 9059,
+          "line": 9156,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1537,7 +1559,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 9060,
+          "line": 9157,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1545,7 +1567,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 9061,
+          "line": 9158,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1553,7 +1575,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 9062,
+          "line": 9159,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1563,7 +1585,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 9065,
+          "line": 9162,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1573,7 +1595,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 9069,
+          "line": 9166,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1583,7 +1605,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 9071,
+          "line": 9168,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1595,7 +1617,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 9076,
+          "line": 9173,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1609,7 +1631,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 9087,
+          "line": 9184,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1623,7 +1645,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 9100,
+          "line": 9197,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1636,13 +1658,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5113,
+      "line": 5132,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 5119,
+          "line": 5138,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1653,7 +1675,7 @@
         },
         {
           "name": "Kicker",
-          "line": 5129,
+          "line": 5148,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1669,7 +1691,7 @@
         },
         {
           "name": "Choice",
-          "line": 5136,
+          "line": 5155,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1677,7 +1699,7 @@
         },
         {
           "name": "Required",
-          "line": 5138,
+          "line": 5157,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1688,7 +1710,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5147,
+      "line": 5166,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1696,7 +1718,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 5149,
+          "line": 5168,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1704,7 +1726,7 @@
         },
         {
           "name": "Kicker",
-          "line": 5150,
+          "line": 5169,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1712,7 +1734,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 5151,
+          "line": 5170,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1723,7 +1745,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3433,
+      "line": 3452,
       "doc": "CR 107.3e: Aggregate function applied over a set of objects.",
       "cr_refs": [
         "CR 107.3e"
@@ -1731,7 +1753,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 3434,
+          "line": 3453,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1739,7 +1761,7 @@
         },
         {
           "name": "Min",
-          "line": 3435,
+          "line": 3454,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1747,7 +1769,7 @@
         },
         {
           "name": "Sum",
-          "line": 3436,
+          "line": 3455,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1792,7 +1814,7 @@
     },
     "AlternativeCastKeyword": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1715,
+      "line": 1958,
       "doc": "CR 118.9: Identifies which keyword ability granted an alternative casting cost so the `WaitingFor::AlternativeCastChoice` dispatcher can route to the keyword-specific post-payment handler. The four keywords share a single player decision shape (printed cost vs. alternative cost) but diverge in post-payment semantics — this enum keeps the prompt unified while preserving CR fidelity at resolution.  Adding a new alternative-cost keyword (e.g., Madness CR 702.35a, Spectacle CR 702.137a) is a compile error at every dispatch site until handled.",
       "cr_refs": [
         "CR 118.9",
@@ -1802,7 +1824,7 @@
       "variants": [
         {
           "name": "Warp",
-          "line": 1717,
+          "line": 1960,
           "kind": "unit",
           "field_names": [],
           "doc": "Custom Warp keyword — exile-at-end-step rider; no CR section.",
@@ -1810,7 +1832,7 @@
         },
         {
           "name": "Evoke",
-          "line": 1720,
+          "line": 1963,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: ETB + sacrifice trigger fires when the resolving permanent was cast for its evoke cost (CR 702.74b).",
@@ -1820,8 +1842,38 @@
           ]
         },
         {
+          "name": "Emerge",
+          "line": 1966,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.119a-c: Emerge alternative cost requires sacrificing a creature while casting and reduces the emerge cost by that creature's mana value.",
+          "cr_refs": [
+            "CR 702.119a"
+          ]
+        },
+        {
+          "name": "Dash",
+          "line": 1969,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.109a: Cast for the dash cost — the resolving permanent gains haste and is returned to its owner's hand at the next end step.",
+          "cr_refs": [
+            "CR 702.109a"
+          ]
+        },
+        {
+          "name": "Blitz",
+          "line": 1972,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.152a: Cast for the blitz cost — the resolving permanent gains haste and a dies-draw trigger, and is sacrificed at the next end step.",
+          "cr_refs": [
+            "CR 702.152a"
+          ]
+        },
+        {
           "name": "Overload",
-          "line": 1722,
+          "line": 1974,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a: Spell's text changes \"target\" to \"each\" (CR 702.96b-c).",
@@ -1832,7 +1884,7 @@
         },
         {
           "name": "Bestow",
-          "line": 1724,
+          "line": 1976,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a: Spell becomes an Aura with enchant creature (CR 702.103b).",
@@ -1843,7 +1895,7 @@
         },
         {
           "name": "Awaken",
-          "line": 1729,
+          "line": 1981,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: \"If this spell's awaken cost was paid, put N +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.\" Paying the awaken cost adds the land target (CR 702.113b); casting normally adds no target and no rider.",
@@ -1854,7 +1906,7 @@
         },
         {
           "name": "Cleave",
-          "line": 1732,
+          "line": 1984,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Paying the cleave cost removes every square-bracketed span from the spell's text (a text-changing effect).",
@@ -1865,7 +1917,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 1734,
+          "line": 1986,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.162a: Cast converted (back face up, CR 712.14a) for the MTMTE cost.",
@@ -1876,7 +1928,7 @@
         },
         {
           "name": "Impending",
-          "line": 1738,
+          "line": 1990,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: Impending alternative cost paid from hand. On resolution the permanent enters with N time counters and isn't a creature until the last is removed. An end-step trigger removes one counter per turn.",
@@ -1886,7 +1938,7 @@
         },
         {
           "name": "Prototype",
-          "line": 1742,
+          "line": 1994,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.160a: Prototype alternative cost paid from hand. The resulting spell/permanent uses the secondary power, toughness, and mana cost characteristics while it is a creature.",
@@ -1896,7 +1948,7 @@
         },
         {
           "name": "Mutate",
-          "line": 1747,
+          "line": 1999,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.140a: Mutate alternative cost paid from hand. The spell becomes a mutating creature spell targeting a non-Human creature the caster owns (CR 702.140a); on resolution it merges with that creature (CR 730) rather than entering the battlefield, unless the target is illegal (CR 702.140b).",
@@ -1943,7 +1995,7 @@
     },
     "AttackScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3542,
+      "line": 3561,
       "doc": "CR 508.6: The time window over which \"attacked [a player]\" is measured.",
       "cr_refs": [
         "CR 508.6"
@@ -1951,7 +2003,7 @@
       "variants": [
         {
           "name": "ThisTurn",
-          "line": 3544,
+          "line": 3563,
           "kind": "unit",
           "field_names": [],
           "doc": "Across the whole turn, accumulated over every combat (CR 508.5).",
@@ -1961,7 +2013,7 @@
         },
         {
           "name": "ThisCombat",
-          "line": 3546,
+          "line": 3565,
           "kind": "unit",
           "field_names": [],
           "doc": "Within the current combat only (CR 702.121a Melee).",
@@ -1974,7 +2026,7 @@
     },
     "AttackSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3533,
+      "line": 3552,
       "doc": "CR 506.2 + CR 508.1b: Whose attacks the \"opponents attacked\" player set is measured over.",
       "cr_refs": [
         "CR 506.2",
@@ -1983,7 +2035,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 3535,
+          "line": 3554,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's controller — \"opponents you attacked\".",
@@ -1991,7 +2043,7 @@
         },
         {
           "name": "Source",
-          "line": 3537,
+          "line": 3556,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source creature — \"opponents this creature attacked\".",
@@ -2045,7 +2097,7 @@
     },
     "AttackersDeclaredCountSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3910,
+      "line": 3929,
       "doc": "CR 508.1 / CR 508.1b: Subject axis for counting members of a triggering `AttackersDeclared` event.",
       "cr_refs": [
         "CR 508.1",
@@ -2054,7 +2106,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3918,
+          "line": 3937,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -2067,7 +2119,7 @@
         },
         {
           "name": "AttackTarget",
-          "line": 3925,
+          "line": 3944,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -2081,13 +2133,13 @@
     },
     "AutoMayChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 485,
+      "line": 512,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Accept",
-          "line": 486,
+          "line": 513,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2095,7 +2147,7 @@
         },
         {
           "name": "Decline",
-          "line": 487,
+          "line": 514,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2106,13 +2158,13 @@
     },
     "AutoPassMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3611,
+      "line": 4016,
       "doc": "What the engine stores for auto-pass (includes captured state).",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3614,
+          "line": 4019,
           "kind": "struct",
           "field_names": [
             "initial_stack_len"
@@ -2122,7 +2174,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3618,
+          "line": 4023,
           "kind": "unit",
           "field_names": [],
           "doc": "Auto-pass through priority/combat stops until the flagged player's next turn starts. Interrupted by opponent stack activity (MTGA-style) or when the current phase matches the player's entry in `GameState::phase_stops`.",
@@ -2133,13 +2185,13 @@
     },
     "AutoPassRequest": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3603,
+      "line": 4008,
       "doc": "What the frontend requests for auto-pass (no internal state).  Phase stops that should interrupt `UntilEndOfTurn` are a separate per-player preference on `GameState::phase_stops`, managed via `GameAction::SetPhaseStops`. Keeping them out of the request preserves a single source of truth and lets the preference change mid-session without requiring a new auto-pass request.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 3604,
+          "line": 4009,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2147,7 +2199,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 3605,
+          "line": 4010,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2209,13 +2261,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4670,
+      "line": 4689,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 4671,
+          "line": 4690,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2223,7 +2275,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 4672,
+          "line": 4691,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2275,7 +2327,7 @@
     },
     "BlockExceptionKind": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 539,
+      "line": 548,
       "doc": "CR 509.1b: An attacker's \"can't be blocked except by ...\" restriction. Two structural shapes share this CR sub-rule:  - `Quality`: each blocker must individually match a `TargetFilter`    (e.g. \"artifact creatures\").  - `MinBlockers`: the attacker must be blocked by `min` or more creatures    total, or not at all — the generalization of Menace (CR 702.111b, min = 2).  NOTE: this enum is deliberately NOT `#[derive(Hash)]` — `TargetFilter` does not implement `Hash`. `StaticMode::hash` handles it manually (discriminant for `Quality`, `min` for `MinBlockers`), mirroring the `CantBeBlockedBy` precedent.",
       "cr_refs": [
         "CR 509.1b",
@@ -2284,7 +2336,7 @@
       "variants": [
         {
           "name": "Quality",
-          "line": 540,
+          "line": 549,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2292,7 +2344,7 @@
         },
         {
           "name": "MinBlockers",
-          "line": 541,
+          "line": 550,
           "kind": "struct",
           "field_names": [
             "min"
@@ -2305,7 +2357,7 @@
     },
     "BloodthirstValue": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 386,
+      "line": 400,
       "doc": "CR 702.54a + CR 702.54b: Bloodthirst has fixed-N and X-count forms.",
       "cr_refs": [
         "CR 702.54a",
@@ -2314,7 +2366,7 @@
       "variants": [
         {
           "name": "Fixed",
-          "line": 387,
+          "line": 401,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -2322,7 +2374,7 @@
         },
         {
           "name": "X",
-          "line": 388,
+          "line": 402,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2333,7 +2385,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5449,
+      "line": 5468,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2341,7 +2393,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 5452,
+          "line": 5471,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2349,7 +2401,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 5454,
+          "line": 5473,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2512,13 +2564,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2902,
+      "line": 2906,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 2904,
+          "line": 2908,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -2532,7 +2584,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2906,
+          "line": 2910,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -2543,7 +2595,7 @@
         },
         {
           "name": "Objects",
-          "line": 2908,
+          "line": 2912,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -2593,7 +2645,7 @@
     },
     "CastFreeOrigin": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 316,
+      "line": 317,
       "doc": "CR 601.2a + CR 903.8: Which origin zones a continuous free-cast permission may replace the mana cost from.  The axis is separate from `CastFrequency`: Omniscience/Zaffai explicitly say \"from your hand\", while Dracogenesis omits a zone qualifier and therefore also reaches command-zone roles that are already authorized by CR 903.8.",
       "cr_refs": [
         "CR 601.2a",
@@ -2602,7 +2654,7 @@
       "variants": [
         {
           "name": "Hand",
-          "line": 319,
+          "line": 320,
           "kind": "unit",
           "field_names": [],
           "doc": "Explicit \"from your hand\" permissions.",
@@ -2610,7 +2662,7 @@
         },
         {
           "name": "DefaultCastPermission",
-          "line": 323,
+          "line": 324,
           "kind": "unit",
           "field_names": [],
           "doc": "No explicit origin qualifier. This does not create a new zone permission; runtime casting still has to prove the object is in a built-in cast zone (hand, or an already-authorized command-zone role).",
@@ -2621,7 +2673,7 @@
     },
     "CastFrequency": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 261,
+      "line": 262,
       "doc": "CR 601.2a + CR 601.2b: How often a casting-permission static may be used per turn.  Replaces the older `once_per_turn: bool` flag on `GraveyardCastPermission` and parameterizes `CastFromHandFree` so every \"cast from zone X for free / via alt cost\" permission shares a single frequency axis.  - `Unlimited` — any number of casts per turn from this source (Conduit of Worlds,   Crucible of Worlds, Omniscience). - `OncePerTurn` — at most one cast per turn from this source, tracked by the   source's `ObjectId` in the corresponding per-turn used-set. CR 400.7: zone   change creates a new `ObjectId`, so the permission naturally resets when the   source leaves and returns. - `OncePerTurnPerPermanentType` — at most one cast/play per turn from this   source **for each permanent type** the consumed card has (CR 110.4 lists   the six permanent types). Tracked by the source's `ObjectId` plus the   `CoreType` slot consumed in `state.graveyard_cast_permissions_used_per_type`.   Muldrotha, the Gravetide is the canonical card: a player may play a land   and cast a permanent spell of each permanent type from their graveyard each   turn, so each permanent type acts as an independent per-turn slot.",
       "cr_refs": [
         "CR 110.4",
@@ -2632,7 +2684,7 @@
       "variants": [
         {
           "name": "Unlimited",
-          "line": 264,
+          "line": 265,
           "kind": "unit",
           "field_names": [],
           "doc": "No per-turn limit — Omniscience, Conduit of Worlds, Crucible of Worlds.",
@@ -2640,7 +2692,7 @@
         },
         {
           "name": "OncePerTurn",
-          "line": 266,
+          "line": 267,
           "kind": "unit",
           "field_names": [],
           "doc": "At most one cast per turn from this source — Lurrus, Karador, Zaffai.",
@@ -2648,7 +2700,7 @@
         },
         {
           "name": "OncePerTurnPerPermanentType",
-          "line": 271,
+          "line": 272,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.4 + CR 305.1 + CR 601.2a: Once per turn per permanent type from this source — Muldrotha, the Gravetide. Lands, creatures, artifacts, enchantments, planeswalkers, and battles each have an independent per-turn slot tracked by `(source_id, CoreType)` in `graveyard_cast_permissions_used_per_type`.",
@@ -2700,7 +2752,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2913,
+      "line": 2917,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -2708,7 +2760,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 2915,
+          "line": 2919,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -2716,7 +2768,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 2917,
+          "line": 2921,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -2727,7 +2779,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2923,
+      "line": 2927,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -2736,7 +2788,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 2925,
+          "line": 2929,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -2744,7 +2796,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 2927,
+          "line": 2931,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -2752,7 +2804,7 @@
         },
         {
           "name": "FromSource",
-          "line": 2929,
+          "line": 2933,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -2765,13 +2817,13 @@
     },
     "CastOfferKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1828,
+      "line": 2081,
       "doc": "The specific kind of cast offer being presented to the player. Parameterizes `WaitingFor::CastOffer` — all variants share `player: PlayerId` at the outer level; the kind-specific payload lives here.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Adventure",
-          "line": 1830,
+          "line": 2083,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -2785,7 +2837,7 @@
         },
         {
           "name": "Miracle",
-          "line": 1837,
+          "line": 2090,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -2798,7 +2850,7 @@
         },
         {
           "name": "Madness",
-          "line": 1842,
+          "line": 2095,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -2811,7 +2863,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 1847,
+          "line": 2100,
           "kind": "struct",
           "field_names": [
             "offers"
@@ -2823,7 +2875,7 @@
         },
         {
           "name": "Cascade",
-          "line": 1849,
+          "line": 2102,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -2837,7 +2889,7 @@
         },
         {
           "name": "Discover",
-          "line": 1855,
+          "line": 2108,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -2854,7 +2906,7 @@
     },
     "CastPaymentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 976,
+      "line": 1219,
       "doc": "CR 601.2g-h: Whether the engine may auto-pay an unambiguous spell mana cost or must pause after announcement so the player can activate mana abilities manually before committing payment.",
       "cr_refs": [
         "CR 601.2g"
@@ -2862,7 +2914,7 @@
       "variants": [
         {
           "name": "Auto",
-          "line": 978,
+          "line": 1221,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2870,7 +2922,7 @@
         },
         {
           "name": "Manual",
-          "line": 979,
+          "line": 1222,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2906,7 +2958,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4640,
+      "line": 4659,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -2915,7 +2967,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 4643,
+          "line": 4662,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -2923,7 +2975,7 @@
         },
         {
           "name": "Offering",
-          "line": 4647,
+          "line": 4666,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.48a: The spell was cast at instant speed by paying an Offering additional cost. When this permission is set, the Offering sacrifice is required (the player used the offering to unlock instant-speed timing).",
@@ -2936,7 +2988,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4597,
+      "line": 4616,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -2947,7 +2999,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4599,
+          "line": 4618,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -2958,7 +3010,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4602,
+          "line": 4621,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -2968,7 +3020,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4604,
+          "line": 4623,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -2978,7 +3030,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4606,
+          "line": 4625,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -2988,7 +3040,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4609,
+          "line": 4628,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -2998,7 +3050,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4615,
+          "line": 4634,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -3008,7 +3060,7 @@
         },
         {
           "name": "Escape",
-          "line": 4620,
+          "line": 4639,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -3019,7 +3071,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4623,
+          "line": 4642,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -3029,7 +3081,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4628,
+          "line": 4647,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -3040,7 +3092,7 @@
         },
         {
           "name": "Impending",
-          "line": 4633,
+          "line": 4652,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: The spell was cast for its impending alternative cost. The permanent entered with N time counters and is not a creature while any remain. Read by the end-step counter-removal trigger and the \"not a creature\" layer fixup.",
@@ -3172,7 +3224,7 @@
     },
     "CastingProhibitionCondition": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 77,
+      "line": 78,
       "doc": "CR 101.2: When the casting prohibition applies.  The \"pronoun-binding\" axis is encoded by the choice of `NotDuringYourTurn` vs `NotDuringAffectedPlayersTurn`. CR 109.5 binds the \"you/your\" pronoun to the static's source controller, while the distributive \"their own\" reading (from CR 102.1 plus the template structure of \"[every player] can [action] only during their own [time]\") binds the predicate per-affected caster.",
       "cr_refs": [
         "CR 101.2",
@@ -3182,7 +3234,7 @@
       "variants": [
         {
           "name": "DuringYourTurn",
-          "line": 79,
+          "line": 80,
           "kind": "unit",
           "field_names": [],
           "doc": "\"during your turn\" — prohibition active on controller's turn.",
@@ -3190,7 +3242,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 81,
+          "line": 82,
           "kind": "unit",
           "field_names": [],
           "doc": "\"during combat\" — prohibition active during any combat phase.",
@@ -3198,7 +3250,7 @@
         },
         {
           "name": "NotDuringYourTurn",
-          "line": 85,
+          "line": 86,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1a + CR 604.1: \"only during your turn\" ≡ \"can't cast when it's not your turn\" — prohibition active when it is NOT the controller's turn. E.g., Fires of Invention: \"You can cast spells only during your turn.\"",
@@ -3209,7 +3261,7 @@
         },
         {
           "name": "NotDuringAffectedPlayersTurn",
-          "line": 103,
+          "line": 104,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1 + CR 117.1a + CR 604.1: \"only during their own turn(s)\" — distributive per-affected-player binding. The prohibition is active whenever it is NOT the *affected* player's turn.  Contrasts with `NotDuringYourTurn` which binds to the static's source controller (CR 109.5 — \"your turn\" on Fires of Invention).  **Why a separate variant, not a re-use of `NotDuringYourTurn`:** `NotDuringYourTurn` says \"blocked when it is NOT the source-controller's turn\" (CR 109.5). For Dosan (\"Players can cast spells only during their own turns.\") the binding is per-affected-caster, not per-source: when Alice has Dosan on the battlefield and Bob has priority on Alice's turn, Bob is blocked because it's not *Bob's* turn — Alice's possessive doesn't reach. The CompRules don't carve out a specific pronoun-binding rule for \"their\" the way CR 109.5 governs \"you/your\"; the distributive reading follows from CR 102.1 (active player definition) + the template structure of \"[every player] can [action] only during their own [time]\".",
@@ -3222,7 +3274,7 @@
         },
         {
           "name": "NotSorcerySpeed",
-          "line": 108,
+          "line": 109,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: \"only any time they could cast a sorcery\" — prohibition active when it is not sorcery speed (main phase + active player's turn + empty stack). E.g., Teferi, Time Raveler: \"Each opponent can cast spells only any time they could cast a sorcery.\"",
@@ -3235,13 +3287,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9108,
+      "line": 9205,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 9109,
+          "line": 9206,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3249,7 +3301,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 9110,
+          "line": 9207,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3257,7 +3309,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 9111,
+          "line": 9208,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3265,7 +3317,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 9112,
+          "line": 9209,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3273,7 +3325,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 9113,
+          "line": 9210,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3281,7 +3333,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 9114,
+          "line": 9211,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3289,7 +3341,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 9115,
+          "line": 9212,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3297,7 +3349,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 9116,
+          "line": 9213,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3305,7 +3357,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 9117,
+          "line": 9214,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3313,7 +3365,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 9118,
+          "line": 9215,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3321,7 +3373,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 9119,
+          "line": 9216,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3329,7 +3381,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 9120,
+          "line": 9217,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3337,7 +3389,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 9121,
+          "line": 9218,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3345,7 +3397,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 9122,
+          "line": 9219,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3353,7 +3405,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 9123,
+          "line": 9220,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3361,7 +3413,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 9124,
+          "line": 9221,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3374,13 +3426,13 @@
     },
     "CastingVariant": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3696,
+      "line": 4101,
       "doc": "How a spell was cast — determines zone routing and post-resolution behavior. Replaces individual boolean flags (cast_as_adventure, cast_as_warp) with a single enum that captures the casting context.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Normal",
-          "line": 3699,
+          "line": 4104,
           "kind": "unit",
           "field_names": [],
           "doc": "Normal spell cast — no special resolution behavior.",
@@ -3388,7 +3440,7 @@
         },
         {
           "name": "Adventure",
-          "line": 3702,
+          "line": 4107,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.4: Cast as the Adventure half. On resolution, exiled with AdventureCreature permission and creature face restored.",
@@ -3398,7 +3450,7 @@
         },
         {
           "name": "Omen",
-          "line": 3705,
+          "line": 4110,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 720.3d / CR 720.4: Cast as the Omen half. On resolution, shuffled into its owner's library with normal characteristics restored.",
@@ -3409,7 +3461,7 @@
         },
         {
           "name": "Warp",
-          "line": 3708,
+          "line": 4113,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.185a: Cast via Warp alternative cost from hand. On resolution, creates a delayed trigger to exile at end step with WarpExile permission.",
@@ -3419,7 +3471,7 @@
         },
         {
           "name": "Escape",
-          "line": 3711,
+          "line": 4116,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138: Cast from graveyard via Escape. On resolution, goes to appropriate zone normally (unlike Flashback which exiles).",
@@ -3429,7 +3481,7 @@
         },
         {
           "name": "Retrace",
-          "line": 3714,
+          "line": 4119,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.81a: Cast from graveyard via Retrace by discarding a land card as an additional cost. Resolution uses normal spell routing.",
@@ -3439,7 +3491,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 3717,
+          "line": 4122,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled instead of going anywhere else (unlike Escape which returns to graveyard).",
@@ -3448,8 +3500,18 @@
           ]
         },
         {
+          "name": "Mayhem",
+          "line": 4127,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.187b: Cast from graveyard for mayhem cost (allowed only while the card was discarded this turn). Unlike Flashback/Harmonize, the spell is NOT exiled — it resolves normally (like Escape), so it can be discarded and recast again on a later turn.",
+          "cr_refs": [
+            "CR 702.187b"
+          ]
+        },
+        {
           "name": "Flashback",
-          "line": 3720,
+          "line": 4130,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34a: Cast from graveyard for flashback cost. On resolution (or whenever leaving the stack for any reason), exiled instead of going anywhere else.",
@@ -3459,7 +3521,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 3723,
+          "line": 4133,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Cast an aftermath half of a split card from a graveyard. If it was cast from a graveyard, exile it any time it leaves the stack.",
@@ -3469,7 +3531,7 @@
         },
         {
           "name": "Disturb",
-          "line": 3727,
+          "line": 4137,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.146a-b + CR 712.8c: Cast transformed from graveyard for disturb cost. The stack spell uses its back-face characteristics and the permanent enters the battlefield back face up on resolution.",
@@ -3480,7 +3542,7 @@
         },
         {
           "name": "GraveyardPermission",
-          "line": 3731,
+          "line": 4141,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3496,7 +3558,7 @@
         },
         {
           "name": "HandPermission",
-          "line": 3757,
+          "line": 4167,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3511,7 +3573,7 @@
         },
         {
           "name": "ExilePermission",
-          "line": 3773,
+          "line": 4183,
           "kind": "struct",
           "field_names": [
             "source",
@@ -3527,7 +3589,7 @@
         },
         {
           "name": "Sneak",
-          "line": 3790,
+          "line": 4200,
           "kind": "struct",
           "field_names": [
             "returned_creature",
@@ -3541,7 +3603,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 3799,
+          "line": 4209,
           "kind": "struct",
           "field_names": [
             "returned_creature"
@@ -3553,7 +3615,7 @@
         },
         {
           "name": "Miracle",
-          "line": 3806,
+          "line": 4216,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94a: Cast from hand via Miracle's alternative cost after revealing the card as the first card drawn this turn. The granting keyword carries the miracle mana cost, which `prepare_spell_cast_with_variant_override` substitutes for the printed mana cost. The keyword's `ManaCost` payload is read at preparation time rather than stored here because `prepare_spell_cast` already reads `obj.keywords` for analogous paths.",
@@ -3563,7 +3625,7 @@
         },
         {
           "name": "Madness",
-          "line": 3809,
+          "line": 4219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.35a: Cast from exile via Madness after the discard replacement exiled the card and its madness triggered ability resolved.",
@@ -3573,7 +3635,7 @@
         },
         {
           "name": "Evoke",
-          "line": 3813,
+          "line": 4223,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Cast from hand via Evoke's alternative cost. On resolution, the permanent enters tagged with `CastVariantPaid::Evoke`, which fires the synthesized intervening-if ETB sacrifice trigger.",
@@ -3582,8 +3644,38 @@
           ]
         },
         {
+          "name": "Emerge",
+          "line": 4229,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.119a-c: Cast from hand via Emerge's alternative cost. The printed mana cost is replaced by `Keyword::Emerge(cost)` at cast preparation; casting requires sacrificing a creature, then reduces that emerge cost by the sacrificed creature's mana value. Resolution routing matches a normal cast; Emerge has no resolution rider.",
+          "cr_refs": [
+            "CR 702.119a"
+          ]
+        },
+        {
+          "name": "Dash",
+          "line": 4233,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.109a: Cast from hand via Dash's alternative cost. On resolution, `dash::install_dash_riders` grants the permanent haste and schedules a next-end-step return to its owner's hand.",
+          "cr_refs": [
+            "CR 702.109a"
+          ]
+        },
+        {
+          "name": "Blitz",
+          "line": 4237,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.152a: Cast from hand via Blitz's alternative cost. On resolution, `blitz::install_blitz_riders` grants the permanent haste and a dies-draw trigger and schedules a next-end-step sacrifice.",
+          "cr_refs": [
+            "CR 702.152a"
+          ]
+        },
+        {
           "name": "Suspend",
-          "line": 3820,
+          "line": 4244,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast from exile via Suspend's \"play it without paying its mana cost\" trigger after the last time counter was removed. On resolution of the resulting permanent, the stack handler tags `CastVariantPaid::Suspend` and — for creature spells — installs a transient continuous \"has haste\" effect that lasts as long as the resolution-time controller still controls the permanent.",
@@ -3593,7 +3685,7 @@
         },
         {
           "name": "Plot",
-          "line": 3827,
+          "line": 4251,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.170d: Cast from exile via the Plot \"cast without paying its mana cost\" permission during the owner's main phase on a turn after the card was plotted. Detected at cast preparation when the exile-zone source has a `CastingPermission::Plotted { turn_plotted }` and the current turn is strictly greater than `turn_plotted`. Zeroes the mana cost and routes through the normal cast pipeline; no special resolution-time behavior.",
@@ -3603,7 +3695,7 @@
         },
         {
           "name": "Foretell",
-          "line": 3834,
+          "line": 4258,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a-c: Cast from exile via a foretold card's foretell cost on a turn after it was foretold. Detected at cast preparation when the exile-zone source has a `CastingPermission::Foretold { .. }`. The permission supplies the alternative mana cost; stack finalization tags the source with `CastVariantPaid::Foretell` so \"if this spell was foretold\" clauses can evaluate while the spell resolves.",
@@ -3613,7 +3705,7 @@
         },
         {
           "name": "Overload",
-          "line": 3844,
+          "line": 4268,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a-c: Cast from hand via Overload's alternative cost. The printed mana cost is replaced by `Keyword::Overload(cost)` at cast preparation (mirrors `Evoke`/`Warp`). Per CR 702.96b, every \"target\" in the spell's text is replaced by \"each\" — applied as a cast-time transformation of the spell's ability tree (`Destroy`→`DestroyAll`, `Pump`→`PumpAll`, `DealDamage`→`DamageAll`, `Tap`→`TapAll`, `Bounce`→`ChangeZoneAll`). Per CR 702.96c, the resulting spell has no targets, so target selection is naturally skipped because the transformed effects carry no `TargetRef` slots.",
@@ -3625,7 +3717,7 @@
         },
         {
           "name": "Bestow",
-          "line": 3859,
+          "line": 4283,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a-b: Cast from hand via Bestow's alternative cost. The printed mana cost is replaced by `Keyword::Bestow(cost)` at cast preparation; the spell becomes an Aura with `enchant creature` while on the stack and as the resulting permanent (until it becomes unattached, per CR 702.103f). The type-changing mutation is applied directly to the stack object (mirroring `swap_to_alternative_spell_face` for Adventure/Omen) — Layers cannot be used here because they only apply to battlefield/hand objects, not stack objects.  Per CR 702.103e: if the target is illegal at resolution, the type-changing effect ends and the spell resolves as a creature spell. Per CR 702.103f: when a bestowed Aura becomes unattached on the battlefield, the type-changing effect ends — it remains as an enchantment creature (overrides CR 704.5m for bestow Auras).",
@@ -3638,7 +3730,7 @@
         },
         {
           "name": "Awaken",
-          "line": 3870,
+          "line": 4294,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: Cast from hand via Awaken's alternative cost. The printed mana cost is replaced by `Keyword::Awaken { cost }` at cast preparation (mirrors `Overload`). A resolution rider is appended to the tail of the spell's ability tree (`effects::awaken::append_awaken_rider`): the printed effect resolves first, then \"put N +1/+1 counters on target land you control; that land becomes a 0/0 Elemental creature with haste; it's still a land.\" Per CR 702.113b, the land target only exists on the awaken variant — a normal cast appends no rider and requests no land target. CR 702.113a: the spell goes to the graveyard normally, so this variant is deliberately absent from `exiles_when_leaving_stack_for_any_reason`.",
@@ -3649,7 +3741,7 @@
         },
         {
           "name": "Cleave",
-          "line": 3881,
+          "line": 4305,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Cast from hand via Cleave's alternative cost (CR 118.9). The printed mana cost is replaced by `Keyword::Cleave(cost)` at cast preparation (mirrors `Evoke`/`Overload`). Per CR 702.148a, paying the cleave cost is a text-changing effect (CR 612) that removes every square-bracketed span from the spell's rules text. The bracket-removed ability set is parsed at build time into `CardFace::cleave_variant` and swapped onto the stack object before preparation (mirroring the Bestow object-mutation-before-prepare seam). Resolution routing matches a normal spell — there is no on-resolve special behavior, so the spell goes to its owner's graveyard like any instant/sorcery.",
@@ -3661,7 +3753,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 3888,
+          "line": 4312,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.162a + CR 712.14a: Cast from any castable zone via the More Than Meets the Eye alternative cost. The printed mana cost is replaced by the `Keyword::MoreThanMeetsTheEye(cost)` payload at cast preparation (mirrors Overload). On resolution the spell is cast CONVERTED — the resulting permanent enters the battlefield transformed (back face up) via the existing `enter_transformed` ZoneChange seed. CR 701.28 (Convert).",
@@ -3673,7 +3765,7 @@
         },
         {
           "name": "Impending",
-          "line": 3894,
+          "line": 4318,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: Cast from hand via Impending's alternative cost. The printed mana cost is replaced by `Keyword::Impending { cost, .. }` at cast preparation (mirrors Overload/Evoke). On resolution the permanent enters with N time counters (from the keyword) and is not a creature while any remain. At the beginning of your end step one time counter is removed.",
@@ -3683,7 +3775,7 @@
         },
         {
           "name": "Prototype",
-          "line": 3899,
+          "line": 4323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.160a: Cast from hand prototyped. The printed mana cost is replaced by the prototype cost during cast preparation, and the object is tagged so stack display plus layer evaluation use the secondary mana cost and P/T while it is a creature.",
@@ -3693,7 +3785,7 @@
         },
         {
           "name": "Mutate",
-          "line": 3912,
+          "line": 4336,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.140a-c: Cast from hand via Mutate's alternative cost. The printed mana cost is replaced by `Keyword::Mutate(cost)` at cast preparation (mirrors Bestow). The spell gains a single target — a non-Human creature the caster owns (CR 702.140a) — attached Bestow-style before preparation. On resolution (`stack::resolve_top`): if the target is illegal (CR 702.140b) the spell reverts to a plain creature spell and enters the battlefield normally; if legal (CR 702.140c) it does NOT enter — instead it merges with the target creature (CR 730) and the controller chooses top/bottom. Unlike Bestow this variant neither exiles on leaving the stack nor restores a front face, so it is intentionally absent from `exiles_when_leaving_stack_for_any_reason` and `restores_front_face_after_stack_exit`.",
@@ -3706,12 +3798,43 @@
         },
         {
           "name": "Freerunning",
-          "line": 3920,
+          "line": 4344,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.173a: Cast from hand via Freerunning's alternative cost. Legal only when a player was dealt combat damage this turn by an Assassin creature or a commander under the caster's control. The printed mana cost is replaced by the `Keyword::Freerunning(cost)` payload at cast preparation (mirrors `Overload` / `Foretell`). Resolution routing matches a normal cast — no on-resolve special behavior — so this is a casting-context tag, not a resolution-affecting variant.",
           "cr_refs": [
             "CR 702.173a"
+          ]
+        },
+        {
+          "name": "Prowl",
+          "line": 4352,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.76a: Cast from hand via Prowl's alternative cost. Legal only when a player was dealt combat damage this turn by a source under the caster's control that, at damage time, had any of this spell's creature types. The printed mana cost is replaced by the `Keyword::Prowl(cost)` payload at cast preparation (mirrors `Freerunning`/`Overload`). Resolution routing matches a normal cast — no on-resolve special behavior — so this is a casting-context tag, not a resolution-affecting variant.",
+          "cr_refs": [
+            "CR 702.76a"
+          ]
+        },
+        {
+          "name": "JumpStart",
+          "line": 4360,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.133a: Cast from a graveyard via Jump-start. The card is cast for its normal mana cost plus an additional cost of discarding a card (CR 601.2b/601.2f–h) — so, like `Retrace`/`Aftermath`, this is an additional cost, not an alternative cost, and is absent from `uses_alternative_cost`. Like `Flashback`, a spell cast this way is exiled instead of going anywhere else any time it would leave the stack (see `exiles_when_leaving_stack_for_any_reason`).",
+          "cr_refs": [
+            "CR 601.2b",
+            "CR 702.133a"
+          ]
+        },
+        {
+          "name": "Surge",
+          "line": 4364,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.117a: Cast from hand for the surge alternative cost, legal only if the caster has cast another spell this turn. Resolution is normal (no exile/restore), so it appears only in `uses_alternative_cost`.",
+          "cr_refs": [
+            "CR 702.117a"
           ]
         }
       ],
@@ -4218,7 +4341,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10854,
+      "line": 10963,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -4226,7 +4349,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 10855,
+          "line": 10964,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4234,7 +4357,7 @@
         },
         {
           "name": "Lost",
-          "line": 10856,
+          "line": 10965,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4245,13 +4368,13 @@
     },
     "CollectEvidenceResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1133,
+      "line": 1376,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Casting",
-          "line": 1134,
+          "line": 1377,
           "kind": "struct",
           "field_names": [
             "pending_cast"
@@ -4261,7 +4384,7 @@
         },
         {
           "name": "Effect",
-          "line": 1137,
+          "line": 1380,
           "kind": "struct",
           "field_names": [
             "pending_ability"
@@ -4274,7 +4397,7 @@
     },
     "CombatDamageAssignmentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3233,
+      "line": 3519,
       "doc": "CR 510.1c: Optional combat-damage assignment mode for attackers with text like \"you may have this creature assign its combat damage as though it weren't blocked.\"",
       "cr_refs": [
         "CR 510.1c"
@@ -4282,7 +4405,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 3235,
+          "line": 3521,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4290,7 +4413,7 @@
         },
         {
           "name": "AsThoughUnblocked",
-          "line": 3236,
+          "line": 3522,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4301,7 +4424,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11373,
+      "line": 11502,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -4309,7 +4432,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 11374,
+          "line": 11503,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4317,7 +4440,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 11375,
+          "line": 11504,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4372,7 +4495,7 @@
     },
     "CombatTaxContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1418,
+      "line": 1661,
       "doc": "CR 508.1d + CR 509.1c: Which combat step a `WaitingFor::CombatTaxPayment` belongs to.  Drives the resume branch after the tax decision — on accept, the engine submits the stored attacker / blocker declaration; on decline, the engine filters the taxed creatures out of that declaration and submits the remainder.",
       "cr_refs": [
         "CR 508.1d",
@@ -4381,7 +4504,7 @@
       "variants": [
         {
           "name": "Attacking",
-          "line": 1419,
+          "line": 1662,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4389,7 +4512,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1420,
+          "line": 1663,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4400,7 +4523,7 @@
     },
     "CombatTaxPending": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1428,
+      "line": 1671,
       "doc": "CR 508.1d + CR 509.1c: The declaration that is paused awaiting a combat-tax decision. Keyed by `CombatTaxContext` — the engine resumes the matching variant on `GameAction::PayCombatTax`.",
       "cr_refs": [
         "CR 508.1d",
@@ -4409,7 +4532,7 @@
       "variants": [
         {
           "name": "Attack",
-          "line": 1429,
+          "line": 1672,
           "kind": "struct",
           "field_names": [
             "attacks",
@@ -4420,7 +4543,7 @@
         },
         {
           "name": "Block",
-          "line": 1437,
+          "line": 1680,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -4433,7 +4556,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4025,
+      "line": 4044,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -4441,7 +4564,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 4028,
+          "line": 4047,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -4452,7 +4575,7 @@
         },
         {
           "name": "Any",
-          "line": 4032,
+          "line": 4051,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -4465,7 +4588,7 @@
     },
     "CompanionCondition": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 274,
+      "line": 288,
       "doc": "CR 702.139: Companion deckbuilding conditions. Each of the 10 companion cards has a unique condition the starting deck must satisfy.",
       "cr_refs": [
         "CR 702.139"
@@ -4473,7 +4596,7 @@
       "variants": [
         {
           "name": "EvenManaValues",
-          "line": 276,
+          "line": 290,
           "kind": "unit",
           "field_names": [],
           "doc": "Gyruda: Each nonland card in your starting deck has an even mana value.",
@@ -4481,7 +4604,7 @@
         },
         {
           "name": "NoRepeatedManaSymbols",
-          "line": 278,
+          "line": 292,
           "kind": "unit",
           "field_names": [],
           "doc": "Jegantha: No card in your starting deck has more than one of the same mana symbol in its cost.",
@@ -4489,7 +4612,7 @@
         },
         {
           "name": "CreatureTypeRestriction",
-          "line": 280,
+          "line": 294,
           "kind": "tuple",
           "field_names": [],
           "doc": "Kaheera: Each creature card in your starting deck is of one of the listed types.",
@@ -4497,7 +4620,7 @@
         },
         {
           "name": "MinManaValue",
-          "line": 282,
+          "line": 296,
           "kind": "tuple",
           "field_names": [],
           "doc": "Keruga: Each nonland card in your starting deck has mana value 3 or greater.",
@@ -4505,7 +4628,7 @@
         },
         {
           "name": "MaxPermanentManaValue",
-          "line": 284,
+          "line": 298,
           "kind": "tuple",
           "field_names": [],
           "doc": "Lurrus: Each permanent card in your starting deck has mana value 2 or less.",
@@ -4513,7 +4636,7 @@
         },
         {
           "name": "Singleton",
-          "line": 286,
+          "line": 300,
           "kind": "unit",
           "field_names": [],
           "doc": "Lutri: No nonland card in your starting deck has the same name as another.",
@@ -4521,7 +4644,7 @@
         },
         {
           "name": "OddManaValues",
-          "line": 288,
+          "line": 302,
           "kind": "unit",
           "field_names": [],
           "doc": "Obosh: Each nonland card in your starting deck has an odd mana value.",
@@ -4529,7 +4652,7 @@
         },
         {
           "name": "SharedCardType",
-          "line": 290,
+          "line": 304,
           "kind": "unit",
           "field_names": [],
           "doc": "Umori: Each nonland card in your starting deck shares a card type.",
@@ -4537,7 +4660,7 @@
         },
         {
           "name": "MinDeckSizeOver",
-          "line": 292,
+          "line": 306,
           "kind": "tuple",
           "field_names": [],
           "doc": "Yorion: Your starting deck has at least 80 cards (20 over the minimum).",
@@ -4545,7 +4668,7 @@
         },
         {
           "name": "PermanentsHaveActivatedAbilities",
-          "line": 294,
+          "line": 308,
           "kind": "unit",
           "field_names": [],
           "doc": "Zirda: Each permanent card in your starting deck has an activated ability.",
@@ -4556,13 +4679,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3871,
+      "line": 3890,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 3872,
+          "line": 3891,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4570,7 +4693,7 @@
         },
         {
           "name": "LT",
-          "line": 3873,
+          "line": 3892,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4578,7 +4701,7 @@
         },
         {
           "name": "GE",
-          "line": 3874,
+          "line": 3893,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4586,7 +4709,7 @@
         },
         {
           "name": "LE",
-          "line": 3875,
+          "line": 3894,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4594,7 +4717,7 @@
         },
         {
           "name": "EQ",
-          "line": 3876,
+          "line": 3895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4602,7 +4725,7 @@
         },
         {
           "name": "NE",
-          "line": 3877,
+          "line": 3896,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4613,13 +4736,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11793,
+      "line": 11924,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 11794,
+          "line": 11925,
           "kind": "struct",
           "field_names": [
             "values",
@@ -4630,7 +4753,7 @@
         },
         {
           "name": "SetName",
-          "line": 11809,
+          "line": 11940,
           "kind": "struct",
           "field_names": [
             "name"
@@ -4644,7 +4767,7 @@
         },
         {
           "name": "AddPower",
-          "line": 11812,
+          "line": 11943,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4654,7 +4777,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 11815,
+          "line": 11946,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4664,7 +4787,7 @@
         },
         {
           "name": "SetPower",
-          "line": 11818,
+          "line": 11949,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4674,7 +4797,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 11821,
+          "line": 11952,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4684,7 +4807,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 11824,
+          "line": 11955,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4694,7 +4817,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 11827,
+          "line": 11958,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -4704,7 +4827,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 11830,
+          "line": 11961,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4714,7 +4837,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 11837,
+          "line": 11968,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -4726,7 +4849,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 11840,
+          "line": 11971,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4734,7 +4857,7 @@
         },
         {
           "name": "AddType",
-          "line": 11841,
+          "line": 11972,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4744,7 +4867,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 11844,
+          "line": 11975,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -4754,7 +4877,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 11847,
+          "line": 11978,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4764,7 +4887,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 11850,
+          "line": 11981,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -4774,7 +4897,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 11857,
+          "line": 11988,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -4787,7 +4910,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 11863,
+          "line": 11994,
           "kind": "struct",
           "field_names": [
             "set"
@@ -4800,7 +4923,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 11867,
+          "line": 11998,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4810,7 +4933,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 11871,
+          "line": 12002,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4820,7 +4943,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 11878,
+          "line": 12009,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4832,7 +4955,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 11883,
+          "line": 12014,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4844,7 +4967,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 11887,
+          "line": 12018,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4856,7 +4979,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 11891,
+          "line": 12022,
           "kind": "struct",
           "field_names": [
             "value"
@@ -4868,7 +4991,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 11896,
+          "line": 12027,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -4881,7 +5004,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 11902,
+          "line": 12033,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -4889,7 +5012,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 11905,
+          "line": 12036,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -4900,7 +5023,7 @@
         },
         {
           "name": "AddAllLandTypes",
-          "line": 11909,
+          "line": 12040,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and their mana abilities, additive. Distinct from AddAllBasicLandTypes (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.",
@@ -4912,7 +5035,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 11912,
+          "line": 12043,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -4922,7 +5045,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 11917,
+          "line": 12048,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -4932,7 +5055,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 11924,
+          "line": 12055,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -4943,7 +5066,7 @@
         },
         {
           "name": "SetColor",
-          "line": 11925,
+          "line": 12056,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -4953,7 +5076,7 @@
         },
         {
           "name": "AddColor",
-          "line": 11928,
+          "line": 12059,
           "kind": "struct",
           "field_names": [
             "color"
@@ -4963,7 +5086,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 11933,
+          "line": 12064,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -4973,7 +5096,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 11948,
+          "line": 12079,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -4988,7 +5111,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 11952,
+          "line": 12083,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -4998,7 +5121,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 11955,
+          "line": 12086,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -5008,7 +5131,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 11957,
+          "line": 12088,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -5018,7 +5141,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 11959,
+          "line": 12090,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -5028,7 +5151,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 11962,
+          "line": 12093,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -5038,7 +5161,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 11965,
+          "line": 12096,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -5050,7 +5173,7 @@
         },
         {
           "name": "SetChosenBasicLandType",
-          "line": 11979,
+          "line": 12110,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.7 + CR 305.6: Sets a land's subtype to the basic land type CHOSEN by the granting source (e.g. Phantasmal Terrain, Convincing Mirage: \"As this Aura enters, choose a basic land type.\" + \"Enchanted land is the chosen type.\"). Mirrors `SetBasicLandType`'s replacement semantics — removes the land's old land subtypes and clears the abilities generated from its rules text — but reads the concrete subtype from the source object's `chosen_attributes` (`ChosenSubtypeKind::BasicLandType`) at layer evaluation time rather than carrying a fixed type. Unit variant: the kind is implicitly `BasicLandType`. The intrinsic mana ability for the new type is derived from the subtype in `mana_sources.rs` (CR 305.6), so no explicit mana grant is needed here.",
@@ -5061,7 +5184,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 11991,
+          "line": 12122,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -5073,7 +5196,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 11999,
+          "line": 12130,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -5088,7 +5211,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 12008,
+          "line": 12139,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -5103,7 +5226,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 12022,
+          "line": 12153,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -5118,7 +5241,7 @@
         },
         {
           "name": "RemoveManaCost",
-          "line": 12038,
+          "line": 12169,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.9 + CR 202.1b: Strip a copy's mana cost — the \"has no mana cost\" copy exception used by Embalm (CR 702.128a) and Eternalize (CR 702.129a). Like `AddCounterOnEnter`, this is consumed at copy resolution, never evaluated through the layer system, so `ContinuousModification::layer()` treats it as unreachable: `token_copy.rs` bakes it into the new token's base mana cost, and `become_copy.rs` strips it from the copied values so the continuous copy carries mana value 0.",
@@ -5297,7 +5420,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12109,
+      "line": 12240,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -5307,7 +5430,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 12112,
+          "line": 12243,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -5315,7 +5438,7 @@
         },
         {
           "name": "Finalized",
-          "line": 12114,
+          "line": 12245,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -5326,13 +5449,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5393,
+      "line": 5412,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 5394,
+          "line": 5413,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5343,7 +5466,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7597,
+      "line": 7662,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -5352,7 +5475,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 7599,
+          "line": 7664,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -5360,7 +5483,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 7601,
+          "line": 7666,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -5484,7 +5607,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4918,
+      "line": 4937,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice { .. }` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -5492,7 +5615,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 4919,
+          "line": 4938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5500,7 +5623,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 4920,
+          "line": 4939,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5508,7 +5631,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 4921,
+          "line": 4940,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5516,7 +5639,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 4922,
+          "line": 4941,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5524,7 +5647,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 4923,
+          "line": 4942,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5532,7 +5655,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 4924,
+          "line": 4943,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5540,7 +5663,7 @@
         },
         {
           "name": "Discards",
-          "line": 4925,
+          "line": 4944,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5548,7 +5671,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 4926,
+          "line": 4945,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5556,7 +5679,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 4927,
+          "line": 4946,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5564,7 +5687,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 4928,
+          "line": 4947,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5572,7 +5695,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 4929,
+          "line": 4948,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5580,7 +5703,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 4930,
+          "line": 4949,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5588,7 +5711,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 4931,
+          "line": 4950,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5596,7 +5719,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 4932,
+          "line": 4951,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5604,7 +5727,7 @@
         },
         {
           "name": "Mills",
-          "line": 4933,
+          "line": 4952,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5612,7 +5735,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 4934,
+          "line": 4953,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5620,7 +5743,7 @@
         },
         {
           "name": "Reveals",
-          "line": 4935,
+          "line": 4954,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5628,7 +5751,7 @@
         },
         {
           "name": "Exerts",
-          "line": 4936,
+          "line": 4955,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5636,7 +5759,7 @@
         },
         {
           "name": "KeywordCost",
-          "line": 4937,
+          "line": 4956,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5647,7 +5770,7 @@
     },
     "CostModifyMode": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 547,
+      "line": 556,
       "doc": "CR 601.2f: Direction/semantic axis for mana-cost modification statics. All three modes are applied in the CR 601.2f cost-locking step.",
       "cr_refs": [
         "CR 601.2f"
@@ -5655,7 +5778,7 @@
       "variants": [
         {
           "name": "Reduce",
-          "line": 549,
+          "line": 558,
           "kind": "unit",
           "field_names": [],
           "doc": "Subtractive — reduce generic mana (floor: 0).",
@@ -5663,7 +5786,7 @@
         },
         {
           "name": "Raise",
-          "line": 551,
+          "line": 560,
           "kind": "unit",
           "field_names": [],
           "doc": "Additive — increase generic mana. Thalia, Guardian of Thraben class.",
@@ -5671,7 +5794,7 @@
         },
         {
           "name": "Minimum",
-          "line": 554,
+          "line": 563,
           "kind": "unit",
           "field_names": [],
           "doc": "Floor — cost cannot fall below `amount` after all Reduce/Raise settle. CR 601.2f last-step floor. Trinisphere class.",
@@ -5684,7 +5807,7 @@
     },
     "CostObjectCount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4679,
+      "line": 4698,
       "doc": "CR 702.167a: Object-count requirement for costs whose text may ask for an exact number (\"two creatures\") or a minimum (\"one or more creatures\").",
       "cr_refs": [
         "CR 702.167a"
@@ -5692,7 +5815,7 @@
       "variants": [
         {
           "name": "Exactly",
-          "line": 4680,
+          "line": 4699,
           "kind": "struct",
           "field_names": [
             "count"
@@ -5702,7 +5825,7 @@
         },
         {
           "name": "AtLeast",
-          "line": 4681,
+          "line": 4700,
           "kind": "struct",
           "field_names": [
             "count"
@@ -5715,7 +5838,7 @@
     },
     "CostPaymentProhibition": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 227,
+      "line": 228,
       "doc": "CR 118.3 + CR 119.4b + CR 601.2h + CR 602.2b: A non-mana cost payment category prohibited by a static ability.  This is intentionally cost-scoped. `PayLife` blocks paying life as a cost without preventing damage or other life loss, unlike `CantLoseLife`. `Sacrifice` carries the object filter for the permanents that can't be sacrificed as costs, allowing \"sacrifice a permanent\" costs to remain payable with legal permanents outside the forbidden filter.",
       "cr_refs": [
         "CR 118.3",
@@ -5726,7 +5849,7 @@
       "variants": [
         {
           "name": "PayLife",
-          "line": 228,
+          "line": 229,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5734,7 +5857,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 229,
+          "line": 230,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -5747,7 +5870,7 @@
     },
     "CostResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1796,
+      "line": 2048,
       "doc": "CR 601.2b + CR 605.3b: Resumption context after a PayCost choice completes. Determines whether the engine re-enters the spell-casting pipeline or the mana-ability pipeline.",
       "cr_refs": [
         "CR 601.2b",
@@ -5756,7 +5879,7 @@
       "variants": [
         {
           "name": "Spell",
-          "line": 1797,
+          "line": 2049,
           "kind": "struct",
           "field_names": [
             "spell"
@@ -5766,7 +5889,7 @@
         },
         {
           "name": "SpellCost",
-          "line": 1801,
+          "line": 2053,
           "kind": "struct",
           "field_names": [
             "spell",
@@ -5778,7 +5901,7 @@
         },
         {
           "name": "ManaAbility",
-          "line": 1807,
+          "line": 2059,
           "kind": "struct",
           "field_names": [
             "mana_ability"
@@ -5939,6 +6062,50 @@
           "line": 30,
           "kind": "unit",
           "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "CounterPlacement": {
+      "file": "crates/engine/src/types/proposed_event.rs",
+      "line": 35,
+      "doc": "",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "Object",
+          "line": 36,
+          "kind": "struct",
+          "field_names": [
+            "actor",
+            "object_id",
+            "counter_type"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Player",
+          "line": 42,
+          "kind": "struct",
+          "field_names": [
+            "actor",
+            "player_id",
+            "counter_kind"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Energy",
+          "line": 47,
+          "kind": "struct",
+          "field_names": [
+            "actor",
+            "player_id"
+          ],
           "doc": "",
           "cr_refs": []
         }
@@ -6155,6 +6322,70 @@
       ],
       "sibling_clusters": []
     },
+    "CrewAction": {
+      "file": "crates/engine/src/types/statics.rs",
+      "line": 579,
+      "doc": "The keyword action being performed. `StaticMode::CrewContribution` stores the exact named actions it modifies. CR 702.122 / 702.171 / 702.184.",
+      "cr_refs": [
+        "CR 702.122"
+      ],
+      "variants": [
+        {
+          "name": "Crew",
+          "line": 580,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Saddle",
+          "line": 581,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Station",
+          "line": 582,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "CrewContributionKind": {
+      "file": "crates/engine/src/types/statics.rs",
+      "line": 569,
+      "doc": "CR 702.122c: How a creature's contributed power is modified when it crews a Vehicle, saddles a Mount, or stations a permanent. See [`StaticMode::CrewContribution`].",
+      "cr_refs": [
+        "CR 702.122c"
+      ],
+      "variants": [
+        {
+          "name": "PowerDelta",
+          "line": 571,
+          "kind": "struct",
+          "field_names": [
+            "delta"
+          ],
+          "doc": "\"as though its power were N greater\" — contribute `power + delta`.",
+          "cr_refs": []
+        },
+        {
+          "name": "ToughnessInsteadOfPower",
+          "line": 573,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "\"using its toughness rather than its power\" — contribute `toughness`.",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
     "CyclingCost": {
       "file": "crates/engine/src/types/keywords.rs",
       "line": 37,
@@ -6184,7 +6415,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3445,
+      "line": 3464,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -6192,7 +6423,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 3448,
+          "line": 3467,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -6244,7 +6475,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11246,
+      "line": 11375,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -6252,7 +6483,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 11248,
+          "line": 11377,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -6260,7 +6491,7 @@
         },
         {
           "name": "Triple",
-          "line": 11250,
+          "line": 11379,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -6268,7 +6499,7 @@
         },
         {
           "name": "Plus",
-          "line": 11252,
+          "line": 11381,
           "kind": "struct",
           "field_names": [
             "value"
@@ -6278,7 +6509,7 @@
         },
         {
           "name": "Minus",
-          "line": 11259,
+          "line": 11388,
           "kind": "struct",
           "field_names": [
             "value"
@@ -6291,7 +6522,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 11263,
+          "line": 11392,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -6301,7 +6532,7 @@
         },
         {
           "name": "SetTo",
-          "line": 11269,
+          "line": 11398,
           "kind": "struct",
           "field_names": [
             "value"
@@ -6313,7 +6544,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 11275,
+          "line": 11404,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -6363,7 +6594,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5374,
+      "line": 5393,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -6371,7 +6602,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 5376,
+          "line": 5395,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -6379,7 +6610,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 5379,
+          "line": 5398,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -6393,7 +6624,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11361,
+      "line": 11490,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -6401,7 +6632,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 11363,
+          "line": 11492,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -6409,7 +6640,7 @@
         },
         {
           "name": "Player",
-          "line": 11365,
+          "line": 11494,
           "kind": "struct",
           "field_names": [
             "player"
@@ -6419,7 +6650,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 11368,
+          "line": 11497,
           "kind": "struct",
           "field_names": [
             "player"
@@ -6432,7 +6663,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11345,
+      "line": 11474,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -6440,7 +6671,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 11346,
+          "line": 11475,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6448,7 +6679,7 @@
         },
         {
           "name": "Opponent",
-          "line": 11347,
+          "line": 11476,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6456,7 +6687,7 @@
         },
         {
           "name": "Controller",
-          "line": 11350,
+          "line": 11479,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -6464,7 +6695,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 11354,
+          "line": 11483,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 614.1a: Damage recipient is the player chosen for the replacement source by a linked persisted choice, or a permanent that player controls for `PlayerOrPermanentsControlledBy`.",
@@ -6475,7 +6706,7 @@
         },
         {
           "name": "Specific",
-          "line": 11355,
+          "line": 11484,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -6513,13 +6744,13 @@
     },
     "DebugAction": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 707,
+      "line": 714,
       "doc": "Direct game-state manipulation actions for debugging, testing, and remediation. Bypasses `WaitingFor` validation — fires from any game state without disrupting the current prompt. Gated on `GameState::debug_mode`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MoveToZone",
-          "line": 712,
+          "line": 719,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6532,7 +6763,7 @@
         },
         {
           "name": "CreateCard",
-          "line": 727,
+          "line": 734,
           "kind": "struct",
           "field_names": [
             "card_name",
@@ -6548,7 +6779,7 @@
         },
         {
           "name": "RemoveObject",
-          "line": 741,
+          "line": 748,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -6558,7 +6789,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 747,
+          "line": 754,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -6570,7 +6801,7 @@
         },
         {
           "name": "DrawCards",
-          "line": 750,
+          "line": 757,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6583,7 +6814,7 @@
         },
         {
           "name": "Mill",
-          "line": 752,
+          "line": 759,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6594,7 +6825,7 @@
         },
         {
           "name": "Reveal",
-          "line": 756,
+          "line": 763,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6608,7 +6839,7 @@
         },
         {
           "name": "ShuffleLibrary",
-          "line": 758,
+          "line": 765,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -6618,7 +6849,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 761,
+          "line": 768,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -6630,7 +6861,7 @@
         },
         {
           "name": "SetBasePowerToughness",
-          "line": 765,
+          "line": 772,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6642,7 +6873,7 @@
         },
         {
           "name": "ModifyCounters",
-          "line": 772,
+          "line": 779,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6654,7 +6885,7 @@
         },
         {
           "name": "SetTapped",
-          "line": 778,
+          "line": 785,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6665,7 +6896,7 @@
         },
         {
           "name": "SetPrepared",
-          "line": 784,
+          "line": 791,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6678,7 +6909,7 @@
         },
         {
           "name": "SetController",
-          "line": 786,
+          "line": 793,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6689,7 +6920,7 @@
         },
         {
           "name": "SetSummoningSickness",
-          "line": 791,
+          "line": 798,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6700,7 +6931,7 @@
         },
         {
           "name": "SetFaceState",
-          "line": 793,
+          "line": 800,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6713,7 +6944,7 @@
         },
         {
           "name": "Attach",
-          "line": 803,
+          "line": 810,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6727,7 +6958,7 @@
         },
         {
           "name": "Detach",
-          "line": 808,
+          "line": 815,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -6737,7 +6968,7 @@
         },
         {
           "name": "GrantKeyword",
-          "line": 810,
+          "line": 817,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6748,7 +6979,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 815,
+          "line": 822,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -6759,7 +6990,7 @@
         },
         {
           "name": "SetLife",
-          "line": 822,
+          "line": 829,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6770,7 +7001,7 @@
         },
         {
           "name": "ModifyPlayerCounters",
-          "line": 824,
+          "line": 831,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6782,7 +7013,7 @@
         },
         {
           "name": "ModifyEnergy",
-          "line": 830,
+          "line": 837,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6793,7 +7024,7 @@
         },
         {
           "name": "AddMana",
-          "line": 832,
+          "line": 839,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -6803,8 +7034,21 @@
           "cr_refs": []
         },
         {
+          "name": "SetInfiniteMana",
+          "line": 848,
+          "kind": "struct",
+          "field_names": [
+            "player_id",
+            "enabled"
+          ],
+          "doc": "Toggle \"infinite mana\" for a player (debug-only). While `enabled`, the engine keeps the player's mana pool topped up after every action and suppresses the end-of-step empty (CR 500.5) for that player, so any cost is payable. Setting `enabled = false` clears the toggle; the pool then empties normally on the next step transition. Off by default.",
+          "cr_refs": [
+            "CR 500.5"
+          ]
+        },
+        {
           "name": "SetPhase",
-          "line": 839,
+          "line": 852,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -6815,7 +7059,7 @@
         },
         {
           "name": "RunStateBasedActions",
-          "line": 844,
+          "line": 857,
           "kind": "unit",
           "field_names": [],
           "doc": "Explicitly run state-based actions. Use after a batch of raw mutations.",
@@ -6823,7 +7067,7 @@
         },
         {
           "name": "CreateToken",
-          "line": 862,
+          "line": 875,
           "kind": "struct",
           "field_names": [
             "request",
@@ -6838,7 +7082,7 @@
         },
         {
           "name": "CreateTokenCopy",
-          "line": 869,
+          "line": 882,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -6854,13 +7098,13 @@
     },
     "DebugTokenRequest": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 877,
+      "line": 890,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Preset",
-          "line": 878,
+          "line": 891,
           "kind": "struct",
           "field_names": [
             "preset_id",
@@ -6872,7 +7116,7 @@
         },
         {
           "name": "Custom",
-          "line": 884,
+          "line": 897,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -7087,7 +7331,7 @@
     },
     "DistributionUnit": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3252,
+      "line": 3538,
       "doc": "CR 601.2d: What is being distributed (damage, counters, life).",
       "cr_refs": [
         "CR 601.2d"
@@ -7095,7 +7339,7 @@
       "variants": [
         {
           "name": "Damage",
-          "line": 3253,
+          "line": 3539,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7103,7 +7347,7 @@
         },
         {
           "name": "EvenSplitDamage",
-          "line": 3256,
+          "line": 3542,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down). No player choice needed; bypasses `WaitingFor::DistributeAmong`.",
@@ -7113,7 +7357,7 @@
         },
         {
           "name": "Counters",
-          "line": 3257,
+          "line": 3543,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -7121,7 +7365,7 @@
         },
         {
           "name": "Life",
-          "line": 3258,
+          "line": 3544,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7313,13 +7557,13 @@
     },
     "DynamicKeywordKind": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 227,
+      "line": 241,
       "doc": "Keywords that accept a dynamic numeric parameter via \"where X is [quantity]\". Used by `ContinuousModification::AddDynamicKeyword` to construct the runtime keyword.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Annihilator",
-          "line": 228,
+          "line": 242,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7327,8 +7571,35 @@
         },
         {
           "name": "Modular",
-          "line": 229,
+          "line": 243,
           "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "EchoCost": {
+      "file": "crates/engine/src/types/keywords.rs",
+      "line": 75,
+      "doc": "CR 702.30a: Echo cost — either a mana cost (Urza-block / errata cards, e.g. Orcish Hellraiser \"Echo {R}\") or a non-mana cost (\"Echo—Discard a card\" on Rakdos Headliner, Deepcavern Imp). Mirrors `EvokeCost`/`BuybackCost`/ `CyclingCost`/`FlashbackCost` so non-mana costs compose through the existing `AbilityCost` unless-pay pipeline in `build_echo_trigger`.",
+      "cr_refs": [
+        "CR 702.30a"
+      ],
+      "variants": [
+        {
+          "name": "Mana",
+          "line": 76,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "NonMana",
+          "line": 77,
+          "kind": "tuple",
           "field_names": [],
           "doc": "",
           "cr_refs": []
@@ -7338,13 +7609,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5513,
+      "line": 5532,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 5515,
+          "line": 5534,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -7356,7 +7627,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 5521,
+          "line": 5540,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -7371,7 +7642,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 5532,
+          "line": 5551,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7383,7 +7654,7 @@
         },
         {
           "name": "Draw",
-          "line": 5552,
+          "line": 5571,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7399,7 +7670,7 @@
         },
         {
           "name": "Pump",
-          "line": 5558,
+          "line": 5577,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7411,7 +7682,7 @@
         },
         {
           "name": "PairWith",
-          "line": 5569,
+          "line": 5588,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7424,7 +7695,7 @@
         },
         {
           "name": "Destroy",
-          "line": 5572,
+          "line": 5591,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7435,7 +7706,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 5580,
+          "line": 5599,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7447,7 +7718,7 @@
         },
         {
           "name": "Counter",
-          "line": 5584,
+          "line": 5603,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7458,7 +7729,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 5605,
+          "line": 5624,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7472,7 +7743,7 @@
         },
         {
           "name": "Token",
-          "line": 5609,
+          "line": 5628,
           "kind": "struct",
           "field_names": [
             "name",
@@ -7495,7 +7766,7 @@
         },
         {
           "name": "GainLife",
-          "line": 5647,
+          "line": 5666,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7506,7 +7777,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 5658,
+          "line": 5677,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7517,7 +7788,7 @@
         },
         {
           "name": "Tap",
-          "line": 5665,
+          "line": 5684,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7527,7 +7798,7 @@
         },
         {
           "name": "Untap",
-          "line": 5669,
+          "line": 5688,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7537,7 +7808,7 @@
         },
         {
           "name": "TapAll",
-          "line": 5674,
+          "line": 5693,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7549,7 +7820,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 5679,
+          "line": 5698,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7561,7 +7832,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 5683,
+          "line": 5702,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7573,7 +7844,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5690,
+          "line": 5709,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -7585,7 +7856,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5698,
+          "line": 5717,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7597,7 +7868,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 5719,
+          "line": 5738,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7608,7 +7879,7 @@
         },
         {
           "name": "Mill",
-          "line": 5725,
+          "line": 5744,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7620,7 +7891,7 @@
         },
         {
           "name": "Scry",
-          "line": 5742,
+          "line": 5761,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7635,7 +7906,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 5748,
+          "line": 5767,
           "kind": "struct",
           "field_names": [
             "power",
@@ -7647,7 +7918,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 5762,
+          "line": 5781,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7664,7 +7935,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 5786,
+          "line": 5805,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -7677,7 +7948,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 5790,
+          "line": 5809,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7688,7 +7959,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 5797,
+          "line": 5816,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7708,7 +7979,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 5853,
+          "line": 5872,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -7723,7 +7994,7 @@
         },
         {
           "name": "Dig",
-          "line": 5876,
+          "line": 5895,
           "kind": "struct",
           "field_names": [
             "player",
@@ -7743,7 +8014,7 @@
         },
         {
           "name": "GainControl",
-          "line": 5902,
+          "line": 5921,
           "kind": "struct",
           "field_names": [
             "target"
@@ -7753,7 +8024,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 5906,
+          "line": 5925,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7764,7 +8035,7 @@
         },
         {
           "name": "Attach",
-          "line": 5912,
+          "line": 5931,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7775,7 +8046,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 5924,
+          "line": 5943,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -7788,7 +8059,7 @@
         },
         {
           "name": "Surveil",
-          "line": 5936,
+          "line": 5955,
           "kind": "struct",
           "field_names": [
             "count",
@@ -7803,7 +8074,7 @@
         },
         {
           "name": "Fight",
-          "line": 5942,
+          "line": 5961,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7814,7 +8085,7 @@
         },
         {
           "name": "Bounce",
-          "line": 5950,
+          "line": 5969,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7826,7 +8097,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 5969,
+          "line": 5988,
           "kind": "struct",
           "field_names": [
             "target",
@@ -7841,7 +8112,7 @@
         },
         {
           "name": "Explore",
-          "line": 5977,
+          "line": 5996,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7849,7 +8120,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 5981,
+          "line": 6000,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7861,7 +8132,7 @@
         },
         {
           "name": "Investigate",
-          "line": 5986,
+          "line": 6005,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Investigate — create a Clue token.",
@@ -7871,7 +8142,7 @@
         },
         {
           "name": "Tribute",
-          "line": 5993,
+          "line": 6012,
           "kind": "struct",
           "field_names": [
             "count"
@@ -7884,7 +8155,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 5999,
+          "line": 6018,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -7894,7 +8165,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 6001,
+          "line": 6020,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -7904,15 +8175,28 @@
         },
         {
           "name": "Proliferate",
-          "line": 6002,
+          "line": 6021,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
+          "name": "ProliferateTarget",
+          "line": 6028,
+          "kind": "struct",
+          "field_names": [
+            "target"
+          ],
+          "doc": "CR 701.34a (operation) + CR 122.1: \"For each kind of counter on target permanent or player, give that permanent or player another counter of that kind.\" This is the proliferate counter-add operation, but forced on a single chosen target rather than a player-chosen set — so it carries a `target` and runs without a `ProliferateChoice` prompt. Skyship Plunderer and Maulfist Revolutionary.",
+          "cr_refs": [
+            "CR 122.1",
+            "CR 701.34a"
+          ]
+        },
+        {
           "name": "Populate",
-          "line": 6004,
+          "line": 6033,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -7922,7 +8206,7 @@
         },
         {
           "name": "Clash",
-          "line": 6006,
+          "line": 6035,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -7932,7 +8216,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 6011,
+          "line": 6040,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.1: End the turn. Exile every object on the stack, check state-based actions, remove everything from combat, then skip straight to the cleanup step. Time Stop, Sundial of the Infinite, Obeka, Glorious End, Discontinuity, Day's Undoing.",
@@ -7942,7 +8226,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 6016,
+          "line": 6045,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase. Exile every object on the stack, check state-based actions, remove everything from combat, expire \"until end of combat\" effects, and skip straight to the postcombat main phase. Does nothing outside a combat phase (CR 724.2g). Mandate of Peace.",
@@ -7953,7 +8237,7 @@
         },
         {
           "name": "Vote",
-          "line": 6031,
+          "line": 6060,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -7969,7 +8253,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 6075,
+          "line": 6104,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -7989,7 +8273,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 6094,
+          "line": 6123,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8001,18 +8285,19 @@
         },
         {
           "name": "CopySpell",
-          "line": 6098,
+          "line": 6127,
           "kind": "struct",
           "field_names": [
             "target",
-            "retarget"
+            "retarget",
+            "copier"
           ],
           "doc": "",
           "cr_refs": []
         },
         {
           "name": "CastCopyOfCard",
-          "line": 6107,
+          "line": 6147,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8025,7 +8310,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 6118,
+          "line": 6158,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8045,7 +8330,7 @@
         },
         {
           "name": "Myriad",
-          "line": 6165,
+          "line": 6205,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -8054,8 +8339,42 @@
           ]
         },
         {
+          "name": "Encore",
+          "line": 6212,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.141a: Encore — for each opponent, create a token that's a copy of the (exiled) source card that must attack that opponent this turn if able. The tokens gain haste and are sacrificed at the beginning of the next end step. Resolver: `game/effects/encore.rs`. No player-selectable target (opponents and per-opponent attack binding are chosen by the effect, like `Myriad`).",
+          "cr_refs": [
+            "CR 702.141a"
+          ]
+        },
+        {
+          "name": "ExileHaunting",
+          "line": 6218,
+          "kind": "struct",
+          "field_names": [
+            "target"
+          ],
+          "doc": "CR 702.55a: Haunt — exile the source card (currently in a graveyard, put there by dying or by resolving) from the graveyard, *haunting* the target creature: it moves to exile and an `ExileLinkKind::Haunt` link records the haunted creature. Resolver: `game/haunt.rs`. The target is the haunted creature, chosen when the haunt triggered ability goes on the stack.",
+          "cr_refs": [
+            "CR 702.55a"
+          ]
+        },
+        {
+          "name": "HideawayConceal",
+          "line": 6227,
+          "kind": "struct",
+          "field_names": [
+            "target"
+          ],
+          "doc": "CR 702.75a: Hideaway conceal step — turn the just-exiled `target` card face down and link it to the source in the `exile_links` pool. Chained as a `sub_ability` after the `Effect::Dig` of a Hideaway ETB ability (`database/hideaway.rs`); `target` is `ParentTarget` (the card the Dig continuation exiled), never announced. Resolver: `game/effects/hideaway.rs`.",
+          "cr_refs": [
+            "CR 702.75a"
+          ]
+        },
+        {
           "name": "CopyTokenBlockingAttacker",
-          "line": 6174,
+          "line": 6239,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -8070,7 +8389,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 6186,
+          "line": 6251,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8086,7 +8405,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 6196,
+          "line": 6261,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -8097,7 +8416,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 6202,
+          "line": 6267,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8109,7 +8428,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 6210,
+          "line": 6275,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8123,7 +8442,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 6217,
+          "line": 6282,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8135,7 +8454,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 6225,
+          "line": 6290,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -8148,7 +8467,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 6231,
+          "line": 6296,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -8161,7 +8480,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 6239,
+          "line": 6304,
           "kind": "struct",
           "field_names": [
             "source",
@@ -8179,7 +8498,7 @@
         },
         {
           "name": "Animate",
-          "line": 6259,
+          "line": 6324,
           "kind": "struct",
           "field_names": [
             "power",
@@ -8194,7 +8513,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 6293,
+          "line": 6358,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -8218,7 +8537,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 6309,
+          "line": 6374,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -8228,7 +8547,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 6313,
+          "line": 6378,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -8240,7 +8559,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 6321,
+          "line": 6386,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -8257,7 +8576,7 @@
         },
         {
           "name": "Mana",
-          "line": 6339,
+          "line": 6404,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -8271,7 +8590,7 @@
         },
         {
           "name": "Discard",
-          "line": 6362,
+          "line": 6427,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8285,7 +8604,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 6384,
+          "line": 6449,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8295,7 +8614,7 @@
         },
         {
           "name": "Transform",
-          "line": 6388,
+          "line": 6453,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8305,7 +8624,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 6394,
+          "line": 6459,
           "kind": "struct",
           "field_names": [
             "source_zones",
@@ -8321,7 +8640,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 6451,
+          "line": 6516,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8339,7 +8658,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 6462,
+          "line": 6527,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8353,7 +8672,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 6486,
+          "line": 6551,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -8366,7 +8685,7 @@
         },
         {
           "name": "Reveal",
-          "line": 6497,
+          "line": 6562,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8379,7 +8698,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 6502,
+          "line": 6567,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8392,7 +8711,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 6511,
+          "line": 6576,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8404,7 +8723,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 6534,
+          "line": 6599,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8414,7 +8733,7 @@
         },
         {
           "name": "Choose",
-          "line": 6540,
+          "line": 6605,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -8425,7 +8744,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 6551,
+          "line": 6616,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -8438,7 +8757,7 @@
         },
         {
           "name": "Suspect",
-          "line": 6556,
+          "line": 6621,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8450,7 +8769,7 @@
         },
         {
           "name": "Connive",
-          "line": 6563,
+          "line": 6628,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8464,7 +8783,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 6571,
+          "line": 6636,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8476,7 +8795,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 6578,
+          "line": 6643,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8488,7 +8807,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 6583,
+          "line": 6648,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8500,7 +8819,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 6588,
+          "line": 6653,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8514,7 +8833,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 6597,
+          "line": 6662,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -8524,7 +8843,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 6604,
+          "line": 6669,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8536,7 +8855,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 6611,
+          "line": 6676,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8548,7 +8867,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 6616,
+          "line": 6681,
           "kind": "struct",
           "field_names": [
             "level"
@@ -8560,7 +8879,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 6621,
+          "line": 6686,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -8574,7 +8893,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 6651,
+          "line": 6716,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -8588,7 +8907,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 6657,
+          "line": 6722,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -8600,7 +8919,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 6662,
+          "line": 6727,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8613,7 +8932,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 6669,
+          "line": 6734,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -8626,7 +8945,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 6678,
+          "line": 6743,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8639,7 +8958,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 6686,
+          "line": 6751,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -8653,7 +8972,7 @@
         },
         {
           "name": "PayCost",
-          "line": 6696,
+          "line": 6761,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -8666,7 +8985,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 6707,
+          "line": 6772,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8686,7 +9005,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 6756,
+          "line": 6821,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8702,7 +9021,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 6795,
+          "line": 6860,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -8724,7 +9043,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 6836,
+          "line": 6901,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8736,7 +9055,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 6845,
+          "line": 6910,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8748,7 +9067,7 @@
         },
         {
           "name": "RollDie",
-          "line": 6858,
+          "line": 6923,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8766,7 +9085,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 6868,
+          "line": 6933,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -8779,7 +9098,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 6880,
+          "line": 6945,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8793,7 +9112,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 6889,
+          "line": 6954,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -8805,7 +9124,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 6894,
+          "line": 6959,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -8815,7 +9134,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 6897,
+          "line": 6962,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -8825,7 +9144,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 6899,
+          "line": 6964,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -8837,7 +9156,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 6904,
+          "line": 6969,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -8848,7 +9167,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 6907,
+          "line": 6972,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8860,7 +9179,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 6911,
+          "line": 6976,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.52: Roll to visit your Attractions.",
@@ -8870,7 +9189,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 6914,
+          "line": 6979,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -8880,7 +9199,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 6917,
+          "line": 6982,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -8892,7 +9211,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 6934,
+          "line": 6999,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8911,7 +9230,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 6967,
+          "line": 7032,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -8926,7 +9245,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 6980,
+          "line": 7045,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -8942,7 +9261,7 @@
         },
         {
           "name": "Exploit",
-          "line": 6995,
+          "line": 7060,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8954,7 +9273,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 7000,
+          "line": 7065,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -8966,7 +9285,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 7005,
+          "line": 7070,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -8981,7 +9300,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 7017,
+          "line": 7082,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8993,7 +9312,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 7029,
+          "line": 7094,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9009,7 +9328,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 7040,
+          "line": 7105,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9027,7 +9346,7 @@
         },
         {
           "name": "Discover",
-          "line": 7074,
+          "line": 7139,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -9039,7 +9358,7 @@
         },
         {
           "name": "Cascade",
-          "line": 7086,
+          "line": 7151,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -9049,7 +9368,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 7090,
+          "line": 7155,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -9061,7 +9380,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 7095,
+          "line": 7160,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -9073,7 +9392,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 7108,
+          "line": 7173,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9085,7 +9404,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 7117,
+          "line": 7182,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9097,7 +9416,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 7126,
+          "line": 7191,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9107,7 +9426,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 7131,
+          "line": 7196,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -9117,7 +9436,7 @@
         },
         {
           "name": "Goad",
-          "line": 7137,
+          "line": 7202,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9129,7 +9448,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 7144,
+          "line": 7209,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9141,7 +9460,7 @@
         },
         {
           "name": "Detain",
-          "line": 7151,
+          "line": 7216,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9153,7 +9472,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 7162,
+          "line": 7227,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -9167,7 +9486,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 7173,
+          "line": 7238,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9181,7 +9500,7 @@
         },
         {
           "name": "Manifest",
-          "line": 7188,
+          "line": 7253,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9194,7 +9513,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 7194,
+          "line": 7259,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -9204,7 +9523,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 7198,
+          "line": 7263,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9216,7 +9535,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 7212,
+          "line": 7277,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9229,7 +9548,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 7223,
+          "line": 7288,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9242,7 +9561,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 7233,
+          "line": 7298,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9256,7 +9575,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 7249,
+          "line": 7314,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9273,7 +9592,7 @@
         },
         {
           "name": "Double",
-          "line": 7262,
+          "line": 7327,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -9287,7 +9606,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 7270,
+          "line": 7335,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -9299,7 +9618,7 @@
         },
         {
           "name": "Incubate",
-          "line": 7276,
+          "line": 7341,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9311,7 +9630,7 @@
         },
         {
           "name": "Amass",
-          "line": 7284,
+          "line": 7349,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -9324,7 +9643,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 7292,
+          "line": 7357,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9336,7 +9655,7 @@
         },
         {
           "name": "Specialize",
-          "line": 7298,
+          "line": 7363,
           "kind": "unit",
           "field_names": [],
           "doc": "Digital-only Specialize: permanently become a color-specific face after paying the synthesized activation cost (mana + discard). Not in CR text.",
@@ -9344,7 +9663,7 @@
         },
         {
           "name": "Renown",
-          "line": 7301,
+          "line": 7366,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9356,7 +9675,7 @@
         },
         {
           "name": "Bolster",
-          "line": 7307,
+          "line": 7372,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9368,7 +9687,7 @@
         },
         {
           "name": "Adapt",
-          "line": 7313,
+          "line": 7378,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9380,7 +9699,7 @@
         },
         {
           "name": "Learn",
-          "line": 7319,
+          "line": 7384,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -9390,17 +9709,17 @@
         },
         {
           "name": "Forage",
-          "line": 7321,
+          "line": 7386,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 702.166a: Forage — exile three cards from your graveyard or sacrifice a Food.",
+          "doc": "CR 701.61a: Forage — exile three cards from your graveyard or sacrifice a Food.",
           "cr_refs": [
-            "CR 702.166a"
+            "CR 701.61a"
           ]
         },
         {
           "name": "CollectEvidence",
-          "line": 7323,
+          "line": 7388,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -9412,7 +9731,7 @@
         },
         {
           "name": "Endure",
-          "line": 7330,
+          "line": 7395,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -9425,7 +9744,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 7335,
+          "line": 7400,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9437,7 +9756,7 @@
         },
         {
           "name": "Seek",
-          "line": 7340,
+          "line": 7405,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9451,7 +9770,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 7357,
+          "line": 7422,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9464,7 +9783,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 7372,
+          "line": 7437,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9480,7 +9799,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 7379,
+          "line": 7444,
           "kind": "struct",
           "field_names": [
             "to"
@@ -9492,7 +9811,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 7384,
+          "line": 7449,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9505,7 +9824,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 7393,
+          "line": 7458,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9517,7 +9836,7 @@
         },
         {
           "name": "Conjure",
-          "line": 7400,
+          "line": 7465,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -9529,7 +9848,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 7421,
+          "line": 7486,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -9543,7 +9862,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 7432,
+          "line": 7497,
           "kind": "struct",
           "field_names": [
             "name",
@@ -9611,6 +9930,14 @@
           "smell_score": "LOW"
         },
         {
+          "shared_root": "Proliferate",
+          "members": [
+            "Proliferate",
+            "ProliferateTarget"
+          ],
+          "smell_score": "LOW"
+        },
+        {
           "shared_root": "Pump",
           "members": [
             "Pump",
@@ -9638,13 +9965,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12508,
+      "line": 12666,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 12510,
+          "line": 12668,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9652,7 +9979,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 12512,
+          "line": 12670,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9660,7 +9987,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 12514,
+          "line": 12672,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9668,7 +9995,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 12516,
+          "line": 12674,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9676,7 +10003,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 12518,
+          "line": 12676,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9684,7 +10011,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 12520,
+          "line": 12678,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -9695,13 +10022,13 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8503,
+      "line": 8592,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 8504,
+          "line": 8593,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9709,7 +10036,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 8505,
+          "line": 8594,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9717,7 +10044,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 8506,
+          "line": 8595,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9725,7 +10052,7 @@
         },
         {
           "name": "Draw",
-          "line": 8507,
+          "line": 8596,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9733,7 +10060,7 @@
         },
         {
           "name": "Pump",
-          "line": 8508,
+          "line": 8597,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9741,7 +10068,7 @@
         },
         {
           "name": "PairWith",
-          "line": 8509,
+          "line": 8598,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9749,7 +10076,7 @@
         },
         {
           "name": "Destroy",
-          "line": 8510,
+          "line": 8599,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9757,7 +10084,7 @@
         },
         {
           "name": "Counter",
-          "line": 8511,
+          "line": 8600,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9765,7 +10092,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 8512,
+          "line": 8601,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9773,7 +10100,7 @@
         },
         {
           "name": "Token",
-          "line": 8513,
+          "line": 8602,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9781,7 +10108,7 @@
         },
         {
           "name": "GainLife",
-          "line": 8514,
+          "line": 8603,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9789,7 +10116,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 8515,
+          "line": 8604,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9797,7 +10124,7 @@
         },
         {
           "name": "Tap",
-          "line": 8516,
+          "line": 8605,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9805,7 +10132,7 @@
         },
         {
           "name": "Untap",
-          "line": 8517,
+          "line": 8606,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9813,7 +10140,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 8518,
+          "line": 8607,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9821,7 +10148,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 8519,
+          "line": 8608,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9829,7 +10156,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 8520,
+          "line": 8609,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9837,7 +10164,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 8521,
+          "line": 8610,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9845,7 +10172,7 @@
         },
         {
           "name": "Mill",
-          "line": 8522,
+          "line": 8611,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9853,7 +10180,7 @@
         },
         {
           "name": "Scry",
-          "line": 8523,
+          "line": 8612,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9861,7 +10188,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 8524,
+          "line": 8613,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9869,7 +10196,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 8525,
+          "line": 8614,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9877,7 +10204,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 8526,
+          "line": 8615,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9885,7 +10212,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 8527,
+          "line": 8616,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9893,7 +10220,7 @@
         },
         {
           "name": "TapAll",
-          "line": 8528,
+          "line": 8617,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9901,7 +10228,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 8529,
+          "line": 8618,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9909,7 +10236,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 8530,
+          "line": 8619,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9917,7 +10244,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 8531,
+          "line": 8620,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9925,7 +10252,7 @@
         },
         {
           "name": "Dig",
-          "line": 8532,
+          "line": 8621,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9933,7 +10260,7 @@
         },
         {
           "name": "GainControl",
-          "line": 8533,
+          "line": 8622,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9941,7 +10268,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 8534,
+          "line": 8623,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9949,7 +10276,7 @@
         },
         {
           "name": "Attach",
-          "line": 8535,
+          "line": 8624,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9957,7 +10284,7 @@
         },
         {
           "name": "AttachAll",
-          "line": 8536,
+          "line": 8625,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9965,7 +10292,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 8537,
+          "line": 8626,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9973,7 +10300,7 @@
         },
         {
           "name": "Surveil",
-          "line": 8538,
+          "line": 8627,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9981,7 +10308,7 @@
         },
         {
           "name": "Fight",
-          "line": 8539,
+          "line": 8628,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9989,7 +10316,7 @@
         },
         {
           "name": "Bounce",
-          "line": 8540,
+          "line": 8629,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9997,7 +10324,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 8541,
+          "line": 8630,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10005,7 +10332,7 @@
         },
         {
           "name": "Explore",
-          "line": 8542,
+          "line": 8631,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10013,7 +10340,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 8543,
+          "line": 8632,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10021,7 +10348,7 @@
         },
         {
           "name": "Investigate",
-          "line": 8544,
+          "line": 8633,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10029,7 +10356,7 @@
         },
         {
           "name": "Tribute",
-          "line": 8545,
+          "line": 8634,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10037,7 +10364,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 8546,
+          "line": 8635,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10045,7 +10372,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 8547,
+          "line": 8636,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10053,7 +10380,15 @@
         },
         {
           "name": "Proliferate",
-          "line": 8548,
+          "line": 8637,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ProliferateTarget",
+          "line": 8638,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10061,7 +10396,7 @@
         },
         {
           "name": "Populate",
-          "line": 8549,
+          "line": 8639,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10069,7 +10404,7 @@
         },
         {
           "name": "Clash",
-          "line": 8550,
+          "line": 8640,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10077,7 +10412,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 8551,
+          "line": 8641,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10085,7 +10420,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 8553,
+          "line": 8643,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase — skip to the postcombat main phase.",
@@ -10095,7 +10430,7 @@
         },
         {
           "name": "Vote",
-          "line": 8555,
+          "line": 8645,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -10105,7 +10440,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 8557,
+          "line": 8647,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -10115,7 +10450,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 8558,
+          "line": 8648,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10123,7 +10458,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 8559,
+          "line": 8649,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10131,7 +10466,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 8560,
+          "line": 8650,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10139,7 +10474,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 8561,
+          "line": 8651,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10147,7 +10482,31 @@
         },
         {
           "name": "Myriad",
-          "line": 8562,
+          "line": 8652,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Encore",
+          "line": 8653,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExileHaunting",
+          "line": 8654,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "HideawayConceal",
+          "line": 8655,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10155,7 +10514,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 8563,
+          "line": 8656,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10163,7 +10522,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 8564,
+          "line": 8657,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10171,7 +10530,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 8565,
+          "line": 8658,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10179,7 +10538,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 8566,
+          "line": 8659,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10187,7 +10546,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 8567,
+          "line": 8660,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10195,7 +10554,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 8568,
+          "line": 8661,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10203,7 +10562,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 8569,
+          "line": 8662,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10211,7 +10570,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 8570,
+          "line": 8663,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10219,7 +10578,7 @@
         },
         {
           "name": "Animate",
-          "line": 8571,
+          "line": 8664,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10227,7 +10586,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 8572,
+          "line": 8665,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10235,7 +10594,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 8573,
+          "line": 8666,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10243,7 +10602,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 8574,
+          "line": 8667,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10251,7 +10610,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 8575,
+          "line": 8668,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10259,7 +10618,7 @@
         },
         {
           "name": "Mana",
-          "line": 8576,
+          "line": 8669,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10267,7 +10626,7 @@
         },
         {
           "name": "Discard",
-          "line": 8577,
+          "line": 8670,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10275,7 +10634,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 8578,
+          "line": 8671,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10283,7 +10642,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 8579,
+          "line": 8672,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10291,7 +10650,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 8580,
+          "line": 8673,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10299,7 +10658,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 8581,
+          "line": 8674,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10307,7 +10666,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 8582,
+          "line": 8675,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10315,7 +10674,7 @@
         },
         {
           "name": "Choose",
-          "line": 8583,
+          "line": 8676,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10323,7 +10682,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 8584,
+          "line": 8677,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10331,7 +10690,7 @@
         },
         {
           "name": "Suspect",
-          "line": 8585,
+          "line": 8678,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10339,7 +10698,7 @@
         },
         {
           "name": "Connive",
-          "line": 8586,
+          "line": 8679,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10347,7 +10706,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 8587,
+          "line": 8680,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10355,7 +10714,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 8588,
+          "line": 8681,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10363,7 +10722,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 8589,
+          "line": 8682,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10371,7 +10730,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 8590,
+          "line": 8683,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10379,7 +10738,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 8591,
+          "line": 8684,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10387,7 +10746,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 8593,
+          "line": 8686,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -10397,7 +10756,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 8595,
+          "line": 8688,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -10407,7 +10766,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 8596,
+          "line": 8689,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10415,7 +10774,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 8597,
+          "line": 8690,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10423,7 +10782,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 8598,
+          "line": 8691,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10431,7 +10790,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 8599,
+          "line": 8692,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10439,7 +10798,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 8600,
+          "line": 8693,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10447,7 +10806,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 8601,
+          "line": 8694,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10455,7 +10814,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 8602,
+          "line": 8695,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10463,7 +10822,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 8603,
+          "line": 8696,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10471,7 +10830,7 @@
         },
         {
           "name": "PayCost",
-          "line": 8604,
+          "line": 8697,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10479,7 +10838,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 8605,
+          "line": 8698,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10487,7 +10846,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 8606,
+          "line": 8699,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10495,7 +10854,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 8607,
+          "line": 8700,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10503,7 +10862,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 8608,
+          "line": 8701,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10511,7 +10870,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 8609,
+          "line": 8702,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10519,7 +10878,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 8610,
+          "line": 8703,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10527,7 +10886,7 @@
         },
         {
           "name": "RollDie",
-          "line": 8611,
+          "line": 8704,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10535,7 +10894,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 8612,
+          "line": 8705,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10543,7 +10902,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 8613,
+          "line": 8706,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10551,7 +10910,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 8614,
+          "line": 8707,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10559,7 +10918,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 8615,
+          "line": 8708,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10567,7 +10926,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 8616,
+          "line": 8709,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10575,7 +10934,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 8617,
+          "line": 8710,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10583,7 +10942,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 8618,
+          "line": 8711,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10591,7 +10950,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 8619,
+          "line": 8712,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10599,7 +10958,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 8620,
+          "line": 8713,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10607,7 +10966,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 8621,
+          "line": 8714,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10615,7 +10974,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 8622,
+          "line": 8715,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10623,7 +10982,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 8623,
+          "line": 8716,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10631,7 +10990,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 8624,
+          "line": 8717,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10639,7 +10998,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 8625,
+          "line": 8718,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10647,7 +11006,7 @@
         },
         {
           "name": "Exploit",
-          "line": 8626,
+          "line": 8719,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10655,7 +11014,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 8627,
+          "line": 8720,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10663,7 +11022,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 8628,
+          "line": 8721,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10671,7 +11030,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 8629,
+          "line": 8722,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10679,7 +11038,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 8630,
+          "line": 8723,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10687,7 +11046,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 8631,
+          "line": 8724,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10695,7 +11054,7 @@
         },
         {
           "name": "Discover",
-          "line": 8632,
+          "line": 8725,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10703,7 +11062,7 @@
         },
         {
           "name": "Cascade",
-          "line": 8633,
+          "line": 8726,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10711,7 +11070,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 8634,
+          "line": 8727,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10719,7 +11078,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 8635,
+          "line": 8728,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10727,7 +11086,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 8636,
+          "line": 8729,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10735,7 +11094,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 8637,
+          "line": 8730,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10743,7 +11102,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 8638,
+          "line": 8731,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10751,7 +11110,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 8639,
+          "line": 8732,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10759,7 +11118,7 @@
         },
         {
           "name": "Goad",
-          "line": 8640,
+          "line": 8733,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10767,7 +11126,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 8641,
+          "line": 8734,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10775,7 +11134,7 @@
         },
         {
           "name": "Detain",
-          "line": 8642,
+          "line": 8735,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10783,7 +11142,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 8643,
+          "line": 8736,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10791,7 +11150,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 8644,
+          "line": 8737,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10799,7 +11158,7 @@
         },
         {
           "name": "Incubate",
-          "line": 8645,
+          "line": 8738,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10807,7 +11166,7 @@
         },
         {
           "name": "Amass",
-          "line": 8646,
+          "line": 8739,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10815,7 +11174,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 8647,
+          "line": 8740,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10823,7 +11182,7 @@
         },
         {
           "name": "Specialize",
-          "line": 8648,
+          "line": 8741,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10831,7 +11190,7 @@
         },
         {
           "name": "Renown",
-          "line": 8649,
+          "line": 8742,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10839,7 +11198,7 @@
         },
         {
           "name": "Bolster",
-          "line": 8650,
+          "line": 8743,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10847,7 +11206,7 @@
         },
         {
           "name": "Adapt",
-          "line": 8651,
+          "line": 8744,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10855,7 +11214,7 @@
         },
         {
           "name": "Manifest",
-          "line": 8652,
+          "line": 8745,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10863,7 +11222,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 8653,
+          "line": 8746,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10871,7 +11230,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 8654,
+          "line": 8747,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10879,7 +11238,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 8655,
+          "line": 8748,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10887,7 +11246,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 8656,
+          "line": 8749,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10895,7 +11254,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 8657,
+          "line": 8750,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10903,7 +11262,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 8658,
+          "line": 8751,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10911,7 +11270,7 @@
         },
         {
           "name": "Double",
-          "line": 8659,
+          "line": 8752,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10919,7 +11278,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 8660,
+          "line": 8753,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10927,7 +11286,7 @@
         },
         {
           "name": "Learn",
-          "line": 8661,
+          "line": 8754,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10935,7 +11294,7 @@
         },
         {
           "name": "Forage",
-          "line": 8662,
+          "line": 8755,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10943,7 +11302,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 8663,
+          "line": 8756,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10951,7 +11310,7 @@
         },
         {
           "name": "Endure",
-          "line": 8664,
+          "line": 8757,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10959,7 +11318,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 8665,
+          "line": 8758,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10967,7 +11326,7 @@
         },
         {
           "name": "Seek",
-          "line": 8666,
+          "line": 8759,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10975,7 +11334,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 8667,
+          "line": 8760,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10983,7 +11342,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 8668,
+          "line": 8761,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10991,7 +11350,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 8669,
+          "line": 8762,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10999,7 +11358,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 8670,
+          "line": 8763,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11007,7 +11366,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 8671,
+          "line": 8764,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11015,7 +11374,7 @@
         },
         {
           "name": "Conjure",
-          "line": 8672,
+          "line": 8765,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11023,7 +11382,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 8673,
+          "line": 8766,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11031,7 +11390,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 8674,
+          "line": 8767,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11039,7 +11398,7 @@
         },
         {
           "name": "Equip",
-          "line": 8676,
+          "line": 8769,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -11047,7 +11406,7 @@
         },
         {
           "name": "Crew",
-          "line": 8678,
+          "line": 8771,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -11057,7 +11416,7 @@
         },
         {
           "name": "Station",
-          "line": 8680,
+          "line": 8773,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -11067,7 +11426,7 @@
         },
         {
           "name": "Saddle",
-          "line": 8682,
+          "line": 8775,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -11077,7 +11436,7 @@
         },
         {
           "name": "Reveal",
-          "line": 8684,
+          "line": 8777,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -11085,7 +11444,7 @@
         },
         {
           "name": "Transform",
-          "line": 8685,
+          "line": 8778,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11093,7 +11452,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 8686,
+          "line": 8779,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11101,7 +11460,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 8687,
+          "line": 8780,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11174,6 +11533,14 @@
           "smell_score": "LOW"
         },
         {
+          "shared_root": "Proliferate",
+          "members": [
+            "Proliferate",
+            "ProliferateTarget"
+          ],
+          "smell_score": "LOW"
+        },
+        {
           "shared_root": "Pump",
           "members": [
             "Pump",
@@ -11201,13 +11568,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9727,
+      "line": 9836,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 9731,
+          "line": 9840,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -11218,7 +11585,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 9734,
+          "line": 9843,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -11268,13 +11635,13 @@
     },
     "EtbTapState": {
       "file": "crates/engine/src/types/proposed_event.rs",
-      "line": 34,
+      "line": 79,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Unspecified",
-          "line": 36,
+          "line": 81,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11282,7 +11649,7 @@
         },
         {
           "name": "Tapped",
-          "line": 37,
+          "line": 82,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11290,7 +11657,7 @@
         },
         {
           "name": "Untapped",
-          "line": 38,
+          "line": 83,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11329,7 +11696,7 @@
     },
     "ExileCardPool": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 409,
+      "line": 410,
       "doc": "CR 113.6b + CR 406.6: Which exile-link pool a `StaticMode::ExileCastPermission` draws from. A typed axis (not a `bool`) so the open-ended design space — e.g. a future \"this game\" or windowed pool — slots in without a refactor.  - `ThisTurn` — the per-turn rolling list   (`GameState::cards_exiled_with_source_this_turn`). The card's reference is   scoped by the \"this turn\" suffix (Maralen, Fae Ascendant: \"...exiled with ~   *this turn*...\"). Cards exiled on a prior turn are no longer eligible. - `Persistent` — the lifetime `GameState::exile_links` pool, queried through   `linked_exile_cards_for_source` (the same source-keyed set that backs   `TargetFilter::ExiledBySource`). The card's reference has no turn bound   (\"...from among cards exiled with ~.\" — The Matrix of Time, the   Prosper/Tibalt impulse-commander class). Every card still linked to the   source remains eligible across turns.",
       "cr_refs": [
         "CR 113.6b",
@@ -11338,7 +11705,7 @@
       "variants": [
         {
           "name": "ThisTurn",
-          "line": 412,
+          "line": 413,
           "kind": "unit",
           "field_names": [],
           "doc": "Per-turn rolling pool (`cards_exiled_with_source_this_turn`).",
@@ -11346,7 +11713,7 @@
         },
         {
           "name": "Persistent",
-          "line": 414,
+          "line": 415,
           "kind": "unit",
           "field_names": [],
           "doc": "Lifetime per-source `exile_links` pool (`linked_exile_cards_for_source`).",
@@ -11357,7 +11724,7 @@
     },
     "ExileCastCost": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 364,
+      "line": 365,
       "doc": "CR 118.9 + CR 601.2a: The cost axis for `StaticMode::ExileCastPermission`.  Sibling to `CastFrequency` and `CardPlayMode` — each axis of the exile-cast permission is a typed enum rather than a `bool` so the design space stays open. `bool` fields cannot grow to accommodate future cost shapes (e.g. an alternative life cost analogous to Bolas's Citadel).  - `PayNormalCost` — cast at the spell's normal mana cost. No shipping   printing uses this shape today, but it is the natural default; if a future   card prints \"Once each turn, you may cast a spell from among cards exiled   with ~ this turn.\" (no \"without paying\" rider), this is the variant. - `WithoutPayingManaCost` — CR 118.9a: cast without paying the printed mana   cost. Maralen, Fae Ascendant (\"...without paying its mana cost.\") is the   type specimen and the only shipping printing today.",
       "cr_refs": [
         "CR 118.9",
@@ -11367,7 +11734,7 @@
       "variants": [
         {
           "name": "PayNormalCost",
-          "line": 366,
+          "line": 367,
           "kind": "unit",
           "field_names": [],
           "doc": "Cast at the spell's normal mana cost — no alternative cost applied.",
@@ -11375,7 +11742,7 @@
         },
         {
           "name": "WithoutPayingManaCost",
-          "line": 370,
+          "line": 371,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9a: Cast without paying the spell's printed mana cost (Maralen, Fae Ascendant).",
@@ -11388,7 +11755,7 @@
     },
     "ExileCastTiming": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 448,
+      "line": 449,
       "doc": "CR 117.1c + CR 305.1: When a `StaticMode::ExileCastPermission` is active. A typed axis (not a `bool`) so other timing windows (e.g. \"during combat\") extend without a refactor.  - `AnyTime` — the permission functions whenever its other gates pass   (Maralen, Fae Ascendant: the per-turn cast slot is not turn-restricted). - `YourTurnOnly` — CR 117.1c: the permission functions only while it is the   source controller's turn (\"*During your turn*, you may play lands and cast   spells from among cards exiled with ~.\" — The Matrix of Time).",
       "cr_refs": [
         "CR 117.1c",
@@ -11397,7 +11764,7 @@
       "variants": [
         {
           "name": "AnyTime",
-          "line": 451,
+          "line": 452,
           "kind": "unit",
           "field_names": [],
           "doc": "No turn restriction.",
@@ -11405,7 +11772,7 @@
         },
         {
           "name": "YourTurnOnly",
-          "line": 453,
+          "line": 454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1c: Active only during the source controller's turn.",
@@ -11448,7 +11815,7 @@
     },
     "ExileLinkKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 640,
+      "line": 667,
       "doc": "CR 607.2a + CR 406.6: Tracks the link between an exiling source and the exiled card. When the source leaves the battlefield, the exiled card returns (CR 610.3a).",
       "cr_refs": [
         "CR 406.6",
@@ -11458,7 +11825,7 @@
       "variants": [
         {
           "name": "UntilSourceLeaves",
-          "line": 642,
+          "line": 669,
           "kind": "struct",
           "field_names": [
             "return_zone"
@@ -11470,7 +11837,7 @@
         },
         {
           "name": "TrackedBySource",
-          "line": 644,
+          "line": 671,
           "kind": "unit",
           "field_names": [],
           "doc": "Track cards \"exiled with\" a source without creating an automatic return.",
@@ -11478,7 +11845,7 @@
         },
         {
           "name": "ParadigmSource",
-          "line": 653,
+          "line": 680,
           "kind": "struct",
           "field_names": [
             "player"
@@ -11493,13 +11860,34 @@
         },
         {
           "name": "Cipher",
-          "line": 662,
+          "line": 689,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99b: Cipher — the exiled card (`exiled_id`) is *encoded* on the creature (`source_id`). While the card stays in exile and the creature stays on the battlefield, the creature has \"Whenever this creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost\" (CR 702.99c). The link is pruned automatically when the card leaves exile (`zones.rs` exile-exit) or the creature leaves the battlefield (`zones.rs` battlefield-exit, since this is not an `UntilSourceLeaves` link) — exactly CR 702.99c's lifetime.",
           "cr_refs": [
             "CR 702.99b",
             "CR 702.99c"
+          ]
+        },
+        {
+          "name": "Haunt",
+          "line": 700,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.55b: Haunt — the exiled card (`exiled_id`) \"haunts\" the creature (`source_id`) targeted by its haunt ability. The link drives the card's haunt-payoff trigger, which fires from the exile zone when the haunted creature dies (CR 702.55c). Unlike `Cipher`, this link is **preserved** when the haunted creature leaves the battlefield (`zones.rs` battlefield exit) — the haunted creature's death is exactly when the payoff must read the link. The card \"haunts the creature it haunts regardless of whether or not that object is still a creature\" (CR 702.55b), so the link is pruned only when the haunting card itself leaves exile (`zones.rs` exile-exit), not when the creature changes or dies.",
+          "cr_refs": [
+            "CR 702.55b",
+            "CR 702.55c"
+          ]
+        },
+        {
+          "name": "HideawayLookable",
+          "line": 712,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.75a: Hideaway — the card (`exiled_id`) was exiled face down by the permanent (`source_id`). Like `TrackedBySource` it tracks the card so the companion \"you may play the exiled card\" ability (`TargetFilter:: ExiledBySource`, which is kind-agnostic) can later find it — but it additionally grants a *look-permission*: the player who controls the exiling permanent \"may look at this card in the exile zone\". Visibility keys the controller's face-down look-through on this kind specifically, so plain `TrackedBySource` face-down exiles that grant no such permission (Bomat Courier's \"(You can't look at it.)\", Necropotence, Asmodeus) stay redacted. Pruned on exile-exit / source-exit like `Cipher` (not an `UntilSourceLeaves` link, so no automatic return).",
+          "cr_refs": [
+            "CR 702.75a"
           ]
         }
       ],
@@ -11602,8 +11990,20 @@
           ]
         },
         {
+          "name": "HasHasteOrControlledSinceTurnBegan",
+          "line": 2051,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 302.6 + CR 702.10b + CR 702.154a: Matches creatures that either have haste or have been under their controller's control continuously since that player's most recent turn began. Used by Enlist's tap eligibility.",
+          "cr_refs": [
+            "CR 302.6",
+            "CR 702.10b",
+            "CR 702.154a"
+          ]
+        },
+        {
           "name": "WithKeyword",
-          "line": 2048,
+          "line": 2052,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11613,7 +12013,7 @@
         },
         {
           "name": "HasKeywordKind",
-          "line": 2051,
+          "line": 2055,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11623,7 +12023,7 @@
         },
         {
           "name": "WithoutKeyword",
-          "line": 2056,
+          "line": 2060,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11635,7 +12035,7 @@
         },
         {
           "name": "WithoutKeywordKind",
-          "line": 2059,
+          "line": 2063,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11645,7 +12045,7 @@
         },
         {
           "name": "CanEnchant",
-          "line": 2067,
+          "line": 2071,
           "kind": "struct",
           "field_names": [
             "target"
@@ -11658,7 +12058,7 @@
         },
         {
           "name": "Counters",
-          "line": 2077,
+          "line": 2081,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -11672,7 +12072,7 @@
         },
         {
           "name": "Cmc",
-          "line": 2087,
+          "line": 2091,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -11685,7 +12085,7 @@
         },
         {
           "name": "ManaCostIn",
-          "line": 2094,
+          "line": 2098,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -11698,7 +12098,7 @@
         },
         {
           "name": "InZone",
-          "line": 2097,
+          "line": 2101,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -11708,7 +12108,7 @@
         },
         {
           "name": "Owned",
-          "line": 2100,
+          "line": 2104,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -11718,7 +12118,7 @@
         },
         {
           "name": "Foretold",
-          "line": 2106,
+          "line": 2110,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c-d: Matches cards in exile that have the foretold designation. This is a status of the exiled card, not equivalent to having the Foretell keyword or a generic exile casting permission.",
@@ -11728,7 +12128,7 @@
         },
         {
           "name": "EnchantedBy",
-          "line": 2107,
+          "line": 2111,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11736,7 +12136,7 @@
         },
         {
           "name": "EquippedBy",
-          "line": 2108,
+          "line": 2112,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11744,7 +12144,7 @@
         },
         {
           "name": "AttachedToSource",
-          "line": 2114,
+          "line": 2118,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the matched object's `attached_to` field equals the filter source's object ID. Inverse of `EnchantedBy`/`EquippedBy`, which check whether the source has an attachment. Used for \"Aura and Equipment attached to ~\" quantity clauses (Kellan, the Fae-Blooded) and for any compound filter whose subject is \"attached to <self>\".",
@@ -11755,7 +12155,7 @@
         },
         {
           "name": "AttachedToRecipient",
-          "line": 2128,
+          "line": 2132,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4 + CR 613.4c: True when the matched object's `attached_to` field equals the *recipient* of the resolving effect (the per-object `id` in a layer's affected list). Distinct from `AttachedToSource` — for an Aura/Equipment static \"Enchanted/Equipped creature gets +N/+M for each X attached to it\", the pronoun \"it\" refers to the affected creature, not to the static's source object. The recipient is supplied through `FilterContext::recipient_id`; when recipient is unknown (no per-recipient context), this prop evaluates to false. Covers ~25 cards: Strong Back, Mantle of the Ancients, Auramancer's Guise, Champion of the Flame, Bruenor Battlehammer's \"Each creature you control gets +2/+0 for each Equipment attached to it\", and the broader \"<subject> gets +N/+M for each Aura/Equipment attached to it\" family.",
@@ -11767,7 +12167,7 @@
         },
         {
           "name": "HasAttachment",
-          "line": 2143,
+          "line": 2147,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -11782,7 +12182,7 @@
         },
         {
           "name": "HasAnyAttachmentOf",
-          "line": 2156,
+          "line": 2160,
           "kind": "struct",
           "field_names": [
             "kinds",
@@ -11796,7 +12196,7 @@
         },
         {
           "name": "Another",
-          "line": 2162,
+          "line": 2166,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches any object that is NOT the trigger source (for \"another creature\" triggers).",
@@ -11804,7 +12204,7 @@
         },
         {
           "name": "Unpaired",
-          "line": 2164,
+          "line": 2168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Matches objects that are not paired with another creature.",
@@ -11814,7 +12214,7 @@
         },
         {
           "name": "OtherThanTriggerObject",
-          "line": 2173,
+          "line": 2177,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 109.3: Matches any object that is NOT the object that caused the currently-evaluating trigger to fire (the \"triggering object\"). Distinct from `Another`, which excludes the *ability source*. Used for intervening-if count predicates like Valakut, the Molten Pinnacle's \"if you control at least five other Mountains\" — here \"other\" means \"other than the newly- entered Mountain,\" not \"other than Valakut.\" Resolves against `FilterContext::triggering_object_id`, populated at trigger-condition evaluation from the current `GameEvent`.",
@@ -11825,7 +12225,7 @@
         },
         {
           "name": "HasColor",
-          "line": 2175,
+          "line": 2179,
           "kind": "struct",
           "field_names": [
             "color"
@@ -11835,7 +12235,7 @@
         },
         {
           "name": "PtComparison",
-          "line": 2202,
+          "line": 2206,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -11853,7 +12253,7 @@
         },
         {
           "name": "PowerGTSource",
-          "line": 2211,
+          "line": 2215,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: Matches objects whose power is strictly greater than the source object's power. Used for \"creatures with greater power\" blocking restrictions (relative comparison).",
@@ -11863,7 +12263,7 @@
         },
         {
           "name": "ColorCount",
-          "line": 2215,
+          "line": 2219,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -11876,7 +12276,7 @@
         },
         {
           "name": "HasSupertype",
-          "line": 2220,
+          "line": 2224,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11886,7 +12286,7 @@
         },
         {
           "name": "IsChosenCreatureType",
-          "line": 2225,
+          "line": 2229,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose subtypes include the source object's chosen creature type. Used for \"of the chosen type\" patterns (Cavern of Souls, Metallic Mimic).",
@@ -11894,7 +12294,7 @@
         },
         {
           "name": "MostPrevalentCreatureTypeIn",
-          "line": 2238,
+          "line": 2242,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -11908,7 +12308,7 @@
         },
         {
           "name": "IsChosenColor",
-          "line": 2247,
+          "line": 2251,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose colors include the source object's chosen color. Used for \"of the chosen color\" patterns (Hall of Triumph, Runed Stalactite). Reads `ChosenAttribute::Color` from the source permanent.",
@@ -11916,7 +12316,7 @@
         },
         {
           "name": "IsChosenCardType",
-          "line": 2251,
+          "line": 2255,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose core type includes the source object's chosen card type. Used for \"spells of the chosen type\" patterns (Archon of Valor's Reach). Reads `ChosenAttribute::CardType` from the source permanent.",
@@ -11924,7 +12324,7 @@
         },
         {
           "name": "IsChosenLandOrNonlandKind",
-          "line": 2256,
+          "line": 2260,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.2 + CR 608.2c: Matches objects by the transient \"land or nonland\" choice made earlier in the same resolving instruction sequence. Used by \"of the chosen kind\" library filters, where \"Land\" means cards with the land card type and \"Nonland\" means cards without it.",
@@ -11935,7 +12335,7 @@
         },
         {
           "name": "HasSingleTarget",
-          "line": 2259,
+          "line": 2263,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.7: Matches stack entries that have exactly one target. Used for \"with a single target\" qualifiers on retarget effects.",
@@ -11945,7 +12345,7 @@
         },
         {
           "name": "NotColor",
-          "line": 2262,
+          "line": 2266,
           "kind": "struct",
           "field_names": [
             "color"
@@ -11957,7 +12357,7 @@
         },
         {
           "name": "NotSupertype",
-          "line": 2267,
+          "line": 2271,
           "kind": "struct",
           "field_names": [
             "value"
@@ -11969,7 +12369,7 @@
         },
         {
           "name": "Suspected",
-          "line": 2271,
+          "line": 2275,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.60b: Matches suspected creatures.",
@@ -11979,7 +12379,7 @@
         },
         {
           "name": "Renowned",
-          "line": 2273,
+          "line": 2277,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112b: Matches permanents with the renowned designation.",
@@ -11989,7 +12389,7 @@
         },
         {
           "name": "ToughnessGTPower",
-          "line": 2275,
+          "line": 2279,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: Matches creatures whose toughness is greater than their power.",
@@ -11999,7 +12399,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2282,
+          "line": 2286,
           "kind": "struct",
           "field_names": [
             "props"
@@ -12009,7 +12409,7 @@
         },
         {
           "name": "Modified",
-          "line": 2294,
+          "line": 2298,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.9: A permanent is modified if it has one or more counters on it (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura that is controlled by that permanent's controller (CR 303.4).  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.9 names \"modified\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Modified` for \"modified creature(s)\" subjects, analogous to how `FilterProp::Suspected` models CR 701.60b's \"suspected\" status.",
@@ -12023,7 +12423,7 @@
         },
         {
           "name": "Historic",
-          "line": 2304,
+          "line": 2308,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: An object is historic if it has the legendary supertype, the artifact card type, or the Saga subtype.  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.6 names \"historic\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Historic` for \"historic permanent\" / \"historic spell\" / \"historic card\" subjects, mirroring `FilterProp::Modified` for CR 700.9's \"modified\" predicate.",
@@ -12034,7 +12434,7 @@
         },
         {
           "name": "DifferentNameFrom",
-          "line": 2308,
+          "line": 2312,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -12044,7 +12444,7 @@
         },
         {
           "name": "InAnyZone",
-          "line": 2313,
+          "line": 2317,
           "kind": "struct",
           "field_names": [
             "zones"
@@ -12056,7 +12456,7 @@
         },
         {
           "name": "SharesQuality",
-          "line": 2319,
+          "line": 2323,
           "kind": "struct",
           "field_names": [
             "quality",
@@ -12068,7 +12468,7 @@
         },
         {
           "name": "WasDealtDamageThisTurn",
-          "line": 2328,
+          "line": 2332,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1: Object was dealt damage during this turn. Checks `damage_marked > 0` (damage persists until cleanup step).",
@@ -12078,7 +12478,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2331,
+          "line": 2335,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: Object entered the battlefield during this turn. Checks `entered_battlefield_turn == Some(current_turn)`.",
@@ -12088,7 +12488,7 @@
         },
         {
           "name": "ZoneChangedThisTurn",
-          "line": 2336,
+          "line": 2340,
           "kind": "struct",
           "field_names": [
             "from",
@@ -12102,7 +12502,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 2344,
+          "line": 2348,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Creature was declared as an attacker this turn. Checks `creatures_attacked_this_turn` tracking set on GameState.",
@@ -12112,7 +12512,7 @@
         },
         {
           "name": "BlockedThisTurn",
-          "line": 2347,
+          "line": 2351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Creature was declared as a blocker this turn. Checks `creatures_blocked_this_turn` tracking set on GameState.",
@@ -12122,7 +12522,7 @@
         },
         {
           "name": "AttackedOrBlockedThisTurn",
-          "line": 2350,
+          "line": 2354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a + CR 509.1a: Creature attacked or blocked this turn. Compound check used by \"that attacked or blocked this turn\" Oracle text.",
@@ -12133,7 +12533,7 @@
         },
         {
           "name": "FaceDown",
-          "line": 2353,
+          "line": 2357,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.2: Matches face-down objects on the battlefield. Used for \"face-down creature\" trigger subjects.",
@@ -12143,7 +12543,7 @@
         },
         {
           "name": "TargetsOnly",
-          "line": 2358,
+          "line": 2362,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -12155,7 +12555,7 @@
         },
         {
           "name": "Targets",
-          "line": 2364,
+          "line": 2368,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -12168,7 +12568,7 @@
         },
         {
           "name": "HasXInManaCost",
-          "line": 2373,
+          "line": 2377,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains an `{X}` shard. Used for \"spell with {X} in its mana cost\" qualifier on spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin Spiralmancer, Brass Infiniscope, Elementalist's Palette). Evaluated against `SpellCastRecord.has_x_in_cost` in the spell-history filter path and against `cost_has_x(&obj.mana_cost)` for live objects.",
@@ -12179,7 +12579,7 @@
         },
         {
           "name": "HasManaAbility",
-          "line": 2377,
+          "line": 2381,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1: Matches objects that have at least one ability classified as a mana ability by the engine's authoritative mana-ability classifier. Used for library filters such as \"artifact card with a mana ability\".",
@@ -12189,7 +12589,7 @@
         },
         {
           "name": "HasNoAbilities",
-          "line": 2381,
+          "line": 2385,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.1 + CR 113.3: Matches objects that currently have no abilities: no keyword, activated, triggered, replacement, or static abilities. Used for library filters such as \"creature card with no abilities\".",
@@ -12200,7 +12600,7 @@
         },
         {
           "name": "Named",
-          "line": 2385,
+          "line": 2389,
           "kind": "struct",
           "field_names": [
             "name"
@@ -12213,7 +12613,7 @@
         },
         {
           "name": "SameName",
-          "line": 2390,
+          "line": 2394,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects with the same name as a previously-referenced card. Used for \"search your library for a card with that name\" patterns.",
@@ -12221,7 +12621,7 @@
         },
         {
           "name": "SameNameAsParentTarget",
-          "line": 2403,
+          "line": 2407,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: Matches objects whose name equals the name of the resolving ability's first object target. Used by chained sub-abilities where a prior step targeted/exiled a card and the next step references \"cards with that name\" — e.g., Deadly Cover-Up's \"search ... for any number of cards with that name and exile them\" (the \"that name\" is the name of the card exiled by the immediately preceding effect, which is inherited as the first target via `TargetFilter::ParentTarget`).  Differs from `SameName` (which reads the source object's name): this reads from `ability.targets[0]` when that target is `TargetRef::Object`, looking up the name from `state.objects` (or `lki_cache` if the target has already left its zone).",
@@ -12231,7 +12631,7 @@
         },
         {
           "name": "NameMatchesAnyPermanent",
-          "line": 2410,
+          "line": 2414,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -12244,7 +12644,7 @@
         },
         {
           "name": "AttackingController",
-          "line": 2416,
+          "line": 2420,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1b: Matches attacking creatures whose defending player equals the filter's source controller (\"creatures attacking you\"). Distinct from `Attacking`, which matches any attacker regardless of defender.",
@@ -12254,7 +12654,7 @@
         },
         {
           "name": "IsCommander",
-          "line": 2423,
+          "line": 2427,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 903.3d: Matches permanents on the battlefield that are a commander. Reads `GameObject::is_commander`, set during deck construction per CR 903.3 (the legendary card designated as that deck's commander). Used for \"commander(s) you control\", \"your commander\" subject phrases and for \"target commander\" in commander-format effects (Codsworth, Falthis, Anara, Champions of Archery, etc.).",
@@ -12265,7 +12665,7 @@
         },
         {
           "name": "Other",
-          "line": 2424,
+          "line": 2428,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13042,8 +13442,21 @@
           ]
         },
         {
+          "name": "RespondToSpliceOffer",
+          "line": 433,
+          "kind": "struct",
+          "field_names": [
+            "card"
+          ],
+          "doc": "CR 702.47a–e: Respond to a `WaitingFor::SpliceOffer`. `Some(card)` splices that card from hand onto the spell being cast (re-presenting the offer for any remaining eligible cards, CR 702.47e); `None` declines/finishes splicing and proceeds to target selection.",
+          "cr_refs": [
+            "CR 702.47a",
+            "CR 702.47e"
+          ]
+        },
+        {
           "name": "DecideOptionalEffectAndRemember",
-          "line": 429,
+          "line": 436,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -13053,7 +13466,7 @@
         },
         {
           "name": "PayUnlessCost",
-          "line": 433,
+          "line": 440,
           "kind": "struct",
           "field_names": [
             "pay"
@@ -13065,7 +13478,7 @@
         },
         {
           "name": "ChooseUnlessCostBranch",
-          "line": 441,
+          "line": 448,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -13077,7 +13490,7 @@
         },
         {
           "name": "ChooseActivationCostBranch",
-          "line": 445,
+          "line": 452,
           "kind": "struct",
           "field_names": [
             "index"
@@ -13089,7 +13502,7 @@
         },
         {
           "name": "PayCombatTax",
-          "line": 453,
+          "line": 460,
           "kind": "struct",
           "field_names": [
             "accept"
@@ -13104,7 +13517,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 457,
+          "line": 464,
           "kind": "struct",
           "field_names": [
             "target"
@@ -13116,7 +13529,7 @@
         },
         {
           "name": "ChoosePair",
-          "line": 462,
+          "line": 469,
           "kind": "struct",
           "field_names": [
             "partner"
@@ -13129,7 +13542,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 466,
+          "line": 473,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -13141,7 +13554,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 470,
+          "line": 477,
           "kind": "struct",
           "field_names": [
             "room_index"
@@ -13153,7 +13566,7 @@
         },
         {
           "name": "UnlockRoomDoor",
-          "line": 474,
+          "line": 481,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13166,7 +13579,7 @@
         },
         {
           "name": "TapForConvoke",
-          "line": 480,
+          "line": 487,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -13180,7 +13593,7 @@
         },
         {
           "name": "HarmonizeTap",
-          "line": 486,
+          "line": 493,
           "kind": "struct",
           "field_names": [
             "creature_id"
@@ -13192,7 +13605,7 @@
         },
         {
           "name": "DeclareCompanion",
-          "line": 490,
+          "line": 497,
           "kind": "struct",
           "field_names": [
             "card_index"
@@ -13204,7 +13617,7 @@
         },
         {
           "name": "CompanionToHand",
-          "line": 495,
+          "line": 502,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.139a: Pay {3} to put companion into hand (special action, see rule 116.2g).",
@@ -13214,7 +13627,7 @@
         },
         {
           "name": "DiscoverChoice",
-          "line": 497,
+          "line": 504,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -13226,7 +13639,7 @@
         },
         {
           "name": "CascadeChoice",
-          "line": 501,
+          "line": 508,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -13238,7 +13651,7 @@
         },
         {
           "name": "ChooseTopOrBottom",
-          "line": 505,
+          "line": 512,
           "kind": "struct",
           "field_names": [
             "top"
@@ -13250,7 +13663,7 @@
         },
         {
           "name": "ChooseMutateMergeSide",
-          "line": 512,
+          "line": 519,
           "kind": "struct",
           "field_names": [
             "side"
@@ -13263,7 +13676,7 @@
         },
         {
           "name": "CipherEncode",
-          "line": 518,
+          "line": 525,
           "kind": "struct",
           "field_names": [
             "creature"
@@ -13275,7 +13688,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 523,
+          "line": 530,
           "kind": "struct",
           "field_names": [
             "keep"
@@ -13287,7 +13700,7 @@
         },
         {
           "name": "ChooseBattleProtector",
-          "line": 528,
+          "line": 535,
           "kind": "struct",
           "field_names": [
             "protector"
@@ -13301,7 +13714,7 @@
         },
         {
           "name": "SetAutoPass",
-          "line": 532,
+          "line": 539,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -13313,7 +13726,7 @@
         },
         {
           "name": "CancelAutoPass",
-          "line": 536,
+          "line": 543,
           "kind": "unit",
           "field_names": [],
           "doc": "Cancel any active auto-pass for the acting player.",
@@ -13321,7 +13734,7 @@
         },
         {
           "name": "SetPhaseStops",
-          "line": 541,
+          "line": 548,
           "kind": "struct",
           "field_names": [
             "stops"
@@ -13331,7 +13744,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 546,
+          "line": 553,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -13346,7 +13759,7 @@
         },
         {
           "name": "AssignBlockerDamage",
-          "line": 562,
+          "line": 569,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -13359,7 +13772,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 566,
+          "line": 573,
           "kind": "struct",
           "field_names": [
             "distribution"
@@ -13371,7 +13784,7 @@
         },
         {
           "name": "ChooseCounterMoveDistribution",
-          "line": 570,
+          "line": 577,
           "kind": "struct",
           "field_names": [
             "selections"
@@ -13384,7 +13797,7 @@
         },
         {
           "name": "SubmitPayAmount",
-          "line": 576,
+          "line": 583,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -13397,7 +13810,7 @@
         },
         {
           "name": "RetargetSpell",
-          "line": 580,
+          "line": 587,
           "kind": "struct",
           "field_names": [
             "new_targets"
@@ -13409,7 +13822,7 @@
         },
         {
           "name": "LearnDecision",
-          "line": 584,
+          "line": 591,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -13421,7 +13834,7 @@
         },
         {
           "name": "SelectCategoryPermanents",
-          "line": 590,
+          "line": 597,
           "kind": "struct",
           "field_names": [
             "choices"
@@ -13434,7 +13847,7 @@
         },
         {
           "name": "ChooseX",
-          "line": 596,
+          "line": 603,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13447,7 +13860,7 @@
         },
         {
           "name": "SubmitPhyrexianChoices",
-          "line": 602,
+          "line": 609,
           "kind": "struct",
           "field_names": [
             "choices"
@@ -13460,7 +13873,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 616,
+          "line": 623,
           "kind": "struct",
           "field_names": [
             "choice",
@@ -13475,7 +13888,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 626,
+          "line": 633,
           "kind": "struct",
           "field_names": [
             "payment"
@@ -13489,7 +13902,7 @@
         },
         {
           "name": "CastPreparedCopy",
-          "line": 635,
+          "line": 642,
           "kind": "struct",
           "field_names": [
             "source"
@@ -13501,7 +13914,7 @@
         },
         {
           "name": "ChooseSpecializeColor",
-          "line": 639,
+          "line": 646,
           "kind": "struct",
           "field_names": [
             "color"
@@ -13511,7 +13924,7 @@
         },
         {
           "name": "CastParadigmCopy",
-          "line": 646,
+          "line": 653,
           "kind": "struct",
           "field_names": [
             "source"
@@ -13523,7 +13936,7 @@
         },
         {
           "name": "PassParadigmOffer",
-          "line": 653,
+          "line": 660,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — decline the turn-based offer during `WaitingFor::CastOffer` (Paradigm). The exiled source stays in exile and may be offered again next turn. Assign when WotC publishes SOS CR update.",
@@ -13533,7 +13946,7 @@
         },
         {
           "name": "Debug",
-          "line": 657,
+          "line": 664,
           "kind": "tuple",
           "field_names": [],
           "doc": "Debug/remediation action — bypasses WaitingFor validation (like Concede). Gated on `GameState::debug_mode`. Rejected in multiplayer at both the WASM and server-core layers.",
@@ -13541,7 +13954,7 @@
         },
         {
           "name": "GrantDebugPermission",
-          "line": 663,
+          "line": 670,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13551,7 +13964,7 @@
         },
         {
           "name": "RevokeDebugPermission",
-          "line": 669,
+          "line": 676,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13561,7 +13974,7 @@
         },
         {
           "name": "Concede",
-          "line": 680,
+          "line": 687,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -13982,8 +14395,21 @@
           "cr_refs": []
         },
         {
+          "name": "ResolutionHalted",
+          "line": 343,
+          "kind": "struct",
+          "field_names": [
+            "involved"
+          ],
+          "doc": "CR 732.2: A mandatory auto-resolution sequence hit the engine's resource ceiling without settling — a net-progress loop the engine cannot shortcut (CR 732.2 resolves these by a player-declared iteration count the engine can't infer). Resolution is paused and priority returned to the active player. NOT a draw: distinct from CR 104.4b, which requires a *repeating* state (a true loop is detected separately and ends the game). `involved` carries the in-flight cascade's distinct stack-source ids for diagnostics only — never read by game logic.",
+          "cr_refs": [
+            "CR 104.4b",
+            "CR 732.2"
+          ]
+        },
+        {
           "name": "DamageDealt",
-          "line": 335,
+          "line": 346,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -13997,7 +14423,7 @@
         },
         {
           "name": "DamagePrevented",
-          "line": 346,
+          "line": 357,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -14011,7 +14437,7 @@
         },
         {
           "name": "SpellCountered",
-          "line": 351,
+          "line": 362,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14023,7 +14449,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 359,
+          "line": 370,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14035,7 +14461,7 @@
         },
         {
           "name": "Evolved",
-          "line": 366,
+          "line": 377,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14047,7 +14473,7 @@
         },
         {
           "name": "CounterRemoved",
-          "line": 369,
+          "line": 380,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14059,7 +14485,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 374,
+          "line": 385,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14070,7 +14496,7 @@
         },
         {
           "name": "ObjectConjured",
-          "line": 379,
+          "line": 390,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14081,7 +14507,7 @@
         },
         {
           "name": "CreatureDestroyed",
-          "line": 383,
+          "line": 394,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14091,7 +14517,7 @@
         },
         {
           "name": "PermanentSacrificed",
-          "line": 386,
+          "line": 397,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14102,7 +14528,7 @@
         },
         {
           "name": "EffectResolved",
-          "line": 390,
+          "line": 401,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -14113,7 +14539,7 @@
         },
         {
           "name": "Unattached",
-          "line": 396,
+          "line": 407,
           "kind": "struct",
           "field_names": [
             "attachment_id",
@@ -14126,7 +14552,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 400,
+          "line": 411,
           "kind": "struct",
           "field_names": [
             "attacker_ids",
@@ -14138,7 +14564,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 407,
+          "line": 418,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -14148,7 +14574,7 @@
         },
         {
           "name": "CombatTaxPaid",
-          "line": 412,
+          "line": 423,
           "kind": "struct",
           "field_names": [
             "player",
@@ -14162,7 +14588,7 @@
         },
         {
           "name": "CombatTaxDeclined",
-          "line": 418,
+          "line": 429,
           "kind": "struct",
           "field_names": [
             "player",
@@ -14176,7 +14602,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 422,
+          "line": 433,
           "kind": "struct",
           "field_names": [
             "target",
@@ -14187,7 +14613,7 @@
         },
         {
           "name": "VehicleCrewed",
-          "line": 428,
+          "line": 439,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -14200,7 +14626,7 @@
         },
         {
           "name": "Stationed",
-          "line": 438,
+          "line": 449,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -14214,7 +14640,7 @@
         },
         {
           "name": "Saddled",
-          "line": 448,
+          "line": 459,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -14227,7 +14653,7 @@
         },
         {
           "name": "ReplacementApplied",
-          "line": 452,
+          "line": 463,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -14238,7 +14664,7 @@
         },
         {
           "name": "Transformed",
-          "line": 456,
+          "line": 467,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14248,7 +14674,7 @@
         },
         {
           "name": "Specialized",
-          "line": 460,
+          "line": 471,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14259,7 +14685,7 @@
         },
         {
           "name": "DayNightChanged",
-          "line": 464,
+          "line": 475,
           "kind": "struct",
           "field_names": [
             "new_state"
@@ -14269,7 +14695,7 @@
         },
         {
           "name": "TurnedFaceUp",
-          "line": 467,
+          "line": 478,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14279,7 +14705,7 @@
         },
         {
           "name": "CardsRevealed",
-          "line": 470,
+          "line": 481,
           "kind": "struct",
           "field_names": [
             "player",
@@ -14291,7 +14717,7 @@
         },
         {
           "name": "CombatDamageDealtToPlayer",
-          "line": 476,
+          "line": 487,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14303,7 +14729,7 @@
         },
         {
           "name": "PlayerEliminated",
-          "line": 502,
+          "line": 513,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -14313,7 +14739,7 @@
         },
         {
           "name": "CrimeCommitted",
-          "line": 505,
+          "line": 516,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -14323,7 +14749,7 @@
         },
         {
           "name": "Cycled",
-          "line": 508,
+          "line": 519,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14334,7 +14760,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 512,
+          "line": 523,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14345,7 +14771,7 @@
         },
         {
           "name": "Regenerated",
-          "line": 517,
+          "line": 528,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14357,7 +14783,7 @@
         },
         {
           "name": "CreatureSuspected",
-          "line": 521,
+          "line": 532,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14369,7 +14795,7 @@
         },
         {
           "name": "Detained",
-          "line": 528,
+          "line": 539,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14381,7 +14807,7 @@
         },
         {
           "name": "BecamePrepared",
-          "line": 534,
+          "line": 545,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14393,7 +14819,7 @@
         },
         {
           "name": "BecameUnprepared",
-          "line": 540,
+          "line": 551,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14405,7 +14831,7 @@
         },
         {
           "name": "CaseSolved",
-          "line": 544,
+          "line": 555,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -14417,7 +14843,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 548,
+          "line": 559,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14430,7 +14856,7 @@
         },
         {
           "name": "MonarchChanged",
-          "line": 553,
+          "line": 564,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -14442,7 +14868,7 @@
         },
         {
           "name": "CityBlessingGained",
-          "line": 557,
+          "line": 568,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -14454,7 +14880,7 @@
         },
         {
           "name": "DieRolled",
-          "line": 561,
+          "line": 572,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14468,7 +14894,7 @@
         },
         {
           "name": "StartingPlayerContest",
-          "line": 574,
+          "line": 585,
           "kind": "struct",
           "field_names": [
             "rounds",
@@ -14482,7 +14908,7 @@
         },
         {
           "name": "CoinFlipped",
-          "line": 579,
+          "line": 590,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14495,7 +14921,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 584,
+          "line": 595,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -14507,7 +14933,7 @@
         },
         {
           "name": "RoomEntered",
-          "line": 588,
+          "line": 599,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14522,7 +14948,7 @@
         },
         {
           "name": "RoomDoorUnlocked",
-          "line": 595,
+          "line": 606,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14537,7 +14963,7 @@
         },
         {
           "name": "BecomesPlotted",
-          "line": 602,
+          "line": 613,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14550,7 +14976,7 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 607,
+          "line": 618,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14563,7 +14989,7 @@
         },
         {
           "name": "InitiativeTaken",
-          "line": 612,
+          "line": 623,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -14575,7 +15001,7 @@
         },
         {
           "name": "AttractionOpened",
-          "line": 616,
+          "line": 627,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14588,7 +15014,7 @@
         },
         {
           "name": "AttractionsRolledToVisit",
-          "line": 621,
+          "line": 632,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14601,7 +15027,7 @@
         },
         {
           "name": "AttractionVisited",
-          "line": 626,
+          "line": 637,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14616,7 +15042,7 @@
         },
         {
           "name": "Firebend",
-          "line": 632,
+          "line": 643,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -14627,7 +15053,7 @@
         },
         {
           "name": "Airbend",
-          "line": 637,
+          "line": 648,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -14638,7 +15064,7 @@
         },
         {
           "name": "Earthbend",
-          "line": 642,
+          "line": 653,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -14649,7 +15075,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 647,
+          "line": 658,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -14660,7 +15086,7 @@
         },
         {
           "name": "CompanionRevealed",
-          "line": 652,
+          "line": 663,
           "kind": "struct",
           "field_names": [
             "player",
@@ -14673,7 +15099,7 @@
         },
         {
           "name": "CompanionMovedToHand",
-          "line": 657,
+          "line": 668,
           "kind": "struct",
           "field_names": [
             "player",
@@ -14686,7 +15112,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 664,
+          "line": 675,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14699,7 +15125,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 674,
+          "line": 685,
           "kind": "struct",
           "field_names": [
             "ability_tag",
@@ -14716,7 +15142,7 @@
         },
         {
           "name": "CreatureExploited",
-          "line": 682,
+          "line": 693,
           "kind": "struct",
           "field_names": [
             "exploiter",
@@ -14729,7 +15155,7 @@
         },
         {
           "name": "EnergyChanged",
-          "line": 687,
+          "line": 698,
           "kind": "struct",
           "field_names": [
             "player",
@@ -14742,7 +15168,7 @@
         },
         {
           "name": "SpeedChanged",
-          "line": 692,
+          "line": 703,
           "kind": "struct",
           "field_names": [
             "player",
@@ -14756,7 +15182,7 @@
         },
         {
           "name": "PlayerCounterChanged",
-          "line": 698,
+          "line": 709,
           "kind": "struct",
           "field_names": [
             "player",
@@ -14770,7 +15196,7 @@
         },
         {
           "name": "ManaExpended",
-          "line": 704,
+          "line": 715,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14784,7 +15210,7 @@
         },
         {
           "name": "Clash",
-          "line": 710,
+          "line": 721,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -14800,7 +15226,7 @@
         },
         {
           "name": "VoteCast",
-          "line": 721,
+          "line": 732,
           "kind": "struct",
           "field_names": [
             "voter",
@@ -14814,7 +15240,7 @@
         },
         {
           "name": "VoteResolved",
-          "line": 729,
+          "line": 740,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -14827,7 +15253,7 @@
         },
         {
           "name": "PowerToughnessChanged",
-          "line": 735,
+          "line": 746,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14841,7 +15267,7 @@
         },
         {
           "name": "CascadeMissed",
-          "line": 746,
+          "line": 757,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -14855,7 +15281,7 @@
         },
         {
           "name": "DebugActionUsed",
-          "line": 754,
+          "line": 765,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -14866,7 +15292,7 @@
         },
         {
           "name": "DebugPermissionGranted",
-          "line": 760,
+          "line": 771,
           "kind": "struct",
           "field_names": [
             "host",
@@ -14877,7 +15303,7 @@
         },
         {
           "name": "DebugPermissionRevoked",
-          "line": 765,
+          "line": 776,
           "kind": "struct",
           "field_names": [
             "host",
@@ -15092,13 +15518,13 @@
     },
     "GiftKind": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 300,
+      "line": 314,
       "doc": "The type of gift promised by the Gift keyword.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Card",
-          "line": 302,
+          "line": 316,
           "kind": "unit",
           "field_names": [],
           "doc": "Opponent draws a card.",
@@ -15106,7 +15532,7 @@
         },
         {
           "name": "Treasure",
-          "line": 304,
+          "line": 318,
           "kind": "unit",
           "field_names": [],
           "doc": "Opponent creates a Treasure token.",
@@ -15114,7 +15540,7 @@
         },
         {
           "name": "Food",
-          "line": 306,
+          "line": 320,
           "kind": "unit",
           "field_names": [],
           "doc": "Opponent creates a Food token.",
@@ -15122,7 +15548,7 @@
         },
         {
           "name": "TappedFish",
-          "line": 308,
+          "line": 322,
           "kind": "unit",
           "field_names": [],
           "doc": "Opponent creates a tapped 1/1 blue Fish creature token.",
@@ -15133,7 +15559,7 @@
     },
     "HandSizeModification": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 169,
+      "line": 170,
       "doc": "CR 402.2: How a static ability modifies the maximum hand size.",
       "cr_refs": [
         "CR 402.2"
@@ -15141,7 +15567,7 @@
       "variants": [
         {
           "name": "SetTo",
-          "line": 171,
+          "line": 172,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Your maximum hand size is N.\" — overrides the base hand size.",
@@ -15149,7 +15575,7 @@
         },
         {
           "name": "AdjustedBy",
-          "line": 173,
+          "line": 174,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Your maximum hand size is increased/reduced by N.\" — adjusts the base hand size.",
@@ -15157,7 +15583,7 @@
         },
         {
           "name": "EqualTo",
-          "line": 175,
+          "line": 176,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Your maximum hand size is equal to [quantity].\" — dynamic quantity from game state.",
@@ -15168,7 +15594,7 @@
     },
     "HexproofFilter": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 315,
+      "line": 329,
       "doc": "CR 702.11d: What a hexproof-from keyword protects against. Mirrors ProtectionTarget but only applies to targeting (not DEBT).",
       "cr_refs": [
         "CR 702.11d"
@@ -15176,7 +15602,7 @@
       "variants": [
         {
           "name": "Color",
-          "line": 316,
+          "line": 330,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15184,7 +15610,7 @@
         },
         {
           "name": "CardType",
-          "line": 318,
+          "line": 332,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"hexproof from artifacts\", \"hexproof from instants\", \"hexproof from planeswalkers\"",
@@ -15192,7 +15618,7 @@
         },
         {
           "name": "Quality",
-          "line": 320,
+          "line": 334,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"hexproof from monocolored\", \"hexproof from multicolored\"",
@@ -15200,7 +15626,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 324,
+          "line": 338,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.11d + CR 105.4 + CR 609.6: \"Hexproof from that color\" / \"from the chosen color\" — resolved at runtime from the source permanent's `chosen_attributes`. Parallels `ProtectionTarget::ChosenColor`.",
@@ -15215,7 +15641,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9521,
+      "line": 9629,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -15224,7 +15650,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 9524,
+          "line": 9632,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -15235,13 +15661,13 @@
     },
     "Keyword": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 410,
+      "line": 424,
       "doc": "All MTG keywords as typed enum variants. Simple (unit) variants for keywords with no parameters. Parameterized variants carry associated data (ManaCost for costs, amounts, etc.). Unknown captures any unrecognized keyword string for forward compatibility.  Custom Deserialize: accepts both the typed externally-tagged format (new) and plain \"Name:Param\" strings (legacy card-data.json).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Flying",
-          "line": 412,
+          "line": 426,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15249,7 +15675,7 @@
         },
         {
           "name": "FirstStrike",
-          "line": 413,
+          "line": 427,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15257,7 +15683,7 @@
         },
         {
           "name": "DoubleStrike",
-          "line": 414,
+          "line": 428,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15265,7 +15691,7 @@
         },
         {
           "name": "Trample",
-          "line": 415,
+          "line": 429,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15273,7 +15699,7 @@
         },
         {
           "name": "TrampleOverPlaneswalkers",
-          "line": 417,
+          "line": 431,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.19c: Trample over planeswalkers — excess damage can spill to PW controller.",
@@ -15283,7 +15709,7 @@
         },
         {
           "name": "Deathtouch",
-          "line": 418,
+          "line": 432,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15291,7 +15717,7 @@
         },
         {
           "name": "Lifelink",
-          "line": 419,
+          "line": 433,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15299,7 +15725,7 @@
         },
         {
           "name": "Vigilance",
-          "line": 420,
+          "line": 434,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15307,7 +15733,7 @@
         },
         {
           "name": "Haste",
-          "line": 421,
+          "line": 435,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15315,7 +15741,7 @@
         },
         {
           "name": "Reach",
-          "line": 422,
+          "line": 436,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15323,7 +15749,7 @@
         },
         {
           "name": "Defender",
-          "line": 423,
+          "line": 437,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15331,7 +15757,7 @@
         },
         {
           "name": "Menace",
-          "line": 424,
+          "line": 438,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15339,7 +15765,7 @@
         },
         {
           "name": "Indestructible",
-          "line": 425,
+          "line": 439,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15347,7 +15773,7 @@
         },
         {
           "name": "Hexproof",
-          "line": 426,
+          "line": 440,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15355,7 +15781,7 @@
         },
         {
           "name": "HexproofFrom",
-          "line": 428,
+          "line": 442,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.11d: \"Hexproof from [quality]\" — prevents targeting by sources with the quality.",
@@ -15365,7 +15791,7 @@
         },
         {
           "name": "Shroud",
-          "line": 429,
+          "line": 443,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15373,7 +15799,7 @@
         },
         {
           "name": "Flash",
-          "line": 430,
+          "line": 444,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15381,7 +15807,7 @@
         },
         {
           "name": "Fear",
-          "line": 431,
+          "line": 445,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15389,7 +15815,7 @@
         },
         {
           "name": "Intimidate",
-          "line": 432,
+          "line": 446,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15397,7 +15823,7 @@
         },
         {
           "name": "Skulk",
-          "line": 433,
+          "line": 447,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15405,7 +15831,7 @@
         },
         {
           "name": "Shadow",
-          "line": 434,
+          "line": 448,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15413,7 +15839,7 @@
         },
         {
           "name": "Horsemanship",
-          "line": 435,
+          "line": 449,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15421,7 +15847,7 @@
         },
         {
           "name": "Wither",
-          "line": 438,
+          "line": 452,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15429,7 +15855,7 @@
         },
         {
           "name": "Infect",
-          "line": 439,
+          "line": 453,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15437,7 +15863,7 @@
         },
         {
           "name": "Afflict",
-          "line": 441,
+          "line": 455,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.130a: \"Afflict N\" — when blocked, defending player loses N life.",
@@ -15447,7 +15873,7 @@
         },
         {
           "name": "Prowess",
-          "line": 444,
+          "line": 458,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15455,7 +15881,7 @@
         },
         {
           "name": "Undying",
-          "line": 445,
+          "line": 459,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15463,7 +15889,7 @@
         },
         {
           "name": "Persist",
-          "line": 446,
+          "line": 460,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15471,7 +15897,7 @@
         },
         {
           "name": "Cascade",
-          "line": 447,
+          "line": 461,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15479,7 +15905,7 @@
         },
         {
           "name": "Exalted",
-          "line": 448,
+          "line": 462,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15487,7 +15913,7 @@
         },
         {
           "name": "Flanking",
-          "line": 449,
+          "line": 463,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15495,7 +15921,7 @@
         },
         {
           "name": "Evolve",
-          "line": 450,
+          "line": 464,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15503,7 +15929,7 @@
         },
         {
           "name": "Extort",
-          "line": 451,
+          "line": 465,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15511,7 +15937,7 @@
         },
         {
           "name": "Exploit",
-          "line": 452,
+          "line": 466,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15519,7 +15945,7 @@
         },
         {
           "name": "Explore",
-          "line": 453,
+          "line": 467,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15527,7 +15953,7 @@
         },
         {
           "name": "Ascend",
-          "line": 454,
+          "line": 468,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15535,7 +15961,7 @@
         },
         {
           "name": "StartYourEngines",
-          "line": 456,
+          "line": 470,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179: Grants the player a speed value via SBA and enables the inherent speed trigger.",
@@ -15545,7 +15971,7 @@
         },
         {
           "name": "Dredge",
-          "line": 457,
+          "line": 471,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15553,7 +15979,7 @@
         },
         {
           "name": "Modular",
-          "line": 458,
+          "line": 472,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15561,7 +15987,7 @@
         },
         {
           "name": "Renown",
-          "line": 459,
+          "line": 473,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15569,7 +15995,7 @@
         },
         {
           "name": "Fabricate",
-          "line": 460,
+          "line": 474,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15577,7 +16003,7 @@
         },
         {
           "name": "Annihilator",
-          "line": 461,
+          "line": 475,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15585,15 +16011,26 @@
         },
         {
           "name": "Bushido",
-          "line": 462,
+          "line": 476,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
+          "name": "Frenzy",
+          "line": 478,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 702.68a: Frenzy N — \"Whenever this creature attacks and isn't blocked, it gets +N/+0 until end of turn.\" CR 702.68b: each instance triggers separately.",
+          "cr_refs": [
+            "CR 702.68a",
+            "CR 702.68b"
+          ]
+        },
+        {
           "name": "Tribute",
-          "line": 463,
+          "line": 479,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15601,7 +16038,7 @@
         },
         {
           "name": "Soulbond",
-          "line": 464,
+          "line": 480,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15609,7 +16046,7 @@
         },
         {
           "name": "Unearth",
-          "line": 465,
+          "line": 481,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15617,78 +16054,6 @@
         },
         {
           "name": "Convoke",
-          "line": 468,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Waterbend",
-          "line": 470,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "Waterbend: tap-to-pay keyword for Avatar waterbending abilities.",
-          "cr_refs": []
-        },
-        {
-          "name": "Delve",
-          "line": 471,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Devoid",
-          "line": 472,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Changeling",
-          "line": 475,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Phasing",
-          "line": 478,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Battlecry",
-          "line": 481,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Decayed",
-          "line": 482,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Unleash",
-          "line": 483,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Riot",
           "line": 484,
           "kind": "unit",
           "field_names": [],
@@ -15696,8 +16061,80 @@
           "cr_refs": []
         },
         {
+          "name": "Waterbend",
+          "line": 486,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Waterbend: tap-to-pay keyword for Avatar waterbending abilities.",
+          "cr_refs": []
+        },
+        {
+          "name": "Delve",
+          "line": 487,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Devoid",
+          "line": 488,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Changeling",
+          "line": 491,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Phasing",
+          "line": 494,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Battlecry",
+          "line": 497,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Decayed",
+          "line": 498,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unleash",
+          "line": 499,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Riot",
+          "line": 500,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Afterlife",
-          "line": 485,
+          "line": 501,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15705,7 +16142,7 @@
         },
         {
           "name": "Enchant",
-          "line": 488,
+          "line": 504,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15713,7 +16150,7 @@
         },
         {
           "name": "EtbCounter",
-          "line": 491,
+          "line": 507,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -15724,7 +16161,7 @@
         },
         {
           "name": "Reconfigure",
-          "line": 497,
+          "line": 513,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15732,7 +16169,7 @@
         },
         {
           "name": "LivingWeapon",
-          "line": 498,
+          "line": 514,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15740,7 +16177,7 @@
         },
         {
           "name": "JobSelect",
-          "line": 501,
+          "line": 517,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.182a: Job select — \"When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this Equipment to it.\"",
@@ -15750,7 +16187,7 @@
         },
         {
           "name": "TotemArmor",
-          "line": 502,
+          "line": 518,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15758,86 +16195,6 @@
         },
         {
           "name": "Bestow",
-          "line": 503,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Embalm",
-          "line": 506,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Eternalize",
-          "line": 507,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Fading",
-          "line": 510,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Vanishing",
-          "line": 511,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Protection",
-          "line": 514,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Kicker",
-          "line": 515,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Cycling",
-          "line": 516,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Flashback",
-          "line": 517,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Ward",
-          "line": 518,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Equip",
           "line": 519,
           "kind": "tuple",
           "field_names": [],
@@ -15845,23 +16202,7 @@
           "cr_refs": []
         },
         {
-          "name": "Landwalk",
-          "line": 520,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Rampage",
-          "line": 521,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Absorb",
+          "name": "Embalm",
           "line": 522,
           "kind": "tuple",
           "field_names": [],
@@ -15869,8 +16210,104 @@
           "cr_refs": []
         },
         {
-          "name": "Crew",
+          "name": "Eternalize",
+          "line": 523,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Fading",
           "line": 526,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Vanishing",
+          "line": 527,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Protection",
+          "line": 530,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Kicker",
+          "line": 531,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Cycling",
+          "line": 532,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Flashback",
+          "line": 533,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Ward",
+          "line": 534,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 535,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Landwalk",
+          "line": 536,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Rampage",
+          "line": 537,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Absorb",
+          "line": 538,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Crew",
+          "line": 542,
           "kind": "struct",
           "field_names": [
             "power",
@@ -15884,7 +16321,7 @@
         },
         {
           "name": "Partner",
-          "line": 531,
+          "line": 547,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.124: Partner and its variant keywords for co-commander pairing.",
@@ -15894,7 +16331,7 @@
         },
         {
           "name": "Companion",
-          "line": 534,
+          "line": 550,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.139: Companion — deckbuilding restriction that allows this card to be declared as a companion from outside the game.",
@@ -15904,7 +16341,7 @@
         },
         {
           "name": "Ninjutsu",
-          "line": 535,
+          "line": 551,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15912,7 +16349,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 537,
+          "line": 553,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -15922,7 +16359,7 @@
         },
         {
           "name": "Prowl",
-          "line": 540,
+          "line": 556,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15930,7 +16367,7 @@
         },
         {
           "name": "Morph",
-          "line": 541,
+          "line": 557,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15938,7 +16375,7 @@
         },
         {
           "name": "Megamorph",
-          "line": 542,
+          "line": 558,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15946,7 +16383,7 @@
         },
         {
           "name": "Madness",
-          "line": 543,
+          "line": 559,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15954,7 +16391,7 @@
         },
         {
           "name": "Miracle",
-          "line": 552,
+          "line": 568,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.94a: Miracle {cost} — static ability linked (CR 603.11) to a triggered ability. Static: \"You may reveal this card from your hand as you draw it if it's the first card you've drawn this turn.\" Linked trigger: \"When you reveal this card this way, you may cast it by paying [cost] rather than its mana cost.\" Runtime support: draw event populates `first_card_drawn_this_turn`; on that event a `WaitingFor::MiracleReveal` prompt is offered for miracle-keyworded cards. Casting uses `CastingVariant::Miracle` with the miracle mana cost.",
@@ -15965,7 +16402,7 @@
         },
         {
           "name": "Dash",
-          "line": 553,
+          "line": 569,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -15973,15 +16410,17 @@
         },
         {
           "name": "Emerge",
-          "line": 554,
+          "line": 572,
           "kind": "tuple",
           "field_names": [],
-          "doc": "",
-          "cr_refs": []
+          "doc": "CR 702.119a-c: Emerge is an alternative cost paid by sacrificing a creature and reducing the emerge cost by that creature's mana value.",
+          "cr_refs": [
+            "CR 702.119a"
+          ]
         },
         {
           "name": "Escape",
-          "line": 557,
+          "line": 575,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -15994,7 +16433,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 563,
+          "line": 581,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.180: Harmonize {cost} — cast from graveyard for harmonize cost, tap up to one creature to reduce cost by its power, exile on resolution.",
@@ -16003,8 +16442,18 @@
           ]
         },
         {
+          "name": "Mayhem",
+          "line": 586,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 702.187b: Mayhem {cost} — \"As long as you discarded this card this turn, you may cast it from your graveyard by paying [cost] rather than paying its mana cost.\" Unlike Flashback/Harmonize, the spell is NOT exiled on resolution — it resolves normally (like Escape).",
+          "cr_refs": [
+            "CR 702.187b"
+          ]
+        },
+        {
           "name": "Evoke",
-          "line": 567,
+          "line": 590,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.74a + CR 118.9: see `EvokeCost` for the mana / non-mana split. Pure-mana evoke (Lorwyn cycle) is `EvokeCost::Mana`; MH2 Incarnations (Solitude et al.) carry `EvokeCost::NonMana(AbilityCost::Exile { .. })`.",
@@ -16015,7 +16464,7 @@
         },
         {
           "name": "Foretell",
-          "line": 568,
+          "line": 591,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16023,7 +16472,7 @@
         },
         {
           "name": "Mutate",
-          "line": 569,
+          "line": 592,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16031,7 +16480,7 @@
         },
         {
           "name": "Disturb",
-          "line": 570,
+          "line": 593,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16039,7 +16488,7 @@
         },
         {
           "name": "Disguise",
-          "line": 571,
+          "line": 594,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16047,7 +16496,7 @@
         },
         {
           "name": "Blitz",
-          "line": 572,
+          "line": 595,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16055,7 +16504,7 @@
         },
         {
           "name": "Overload",
-          "line": 573,
+          "line": 596,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16063,7 +16512,7 @@
         },
         {
           "name": "Spectacle",
-          "line": 574,
+          "line": 597,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16071,7 +16520,7 @@
         },
         {
           "name": "Surge",
-          "line": 575,
+          "line": 598,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16079,7 +16528,7 @@
         },
         {
           "name": "Encore",
-          "line": 576,
+          "line": 599,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16087,7 +16536,7 @@
         },
         {
           "name": "Buyback",
-          "line": 579,
+          "line": 602,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.27a: Buyback — optional additional cost; if paid, the spell returns to its owner's hand instead of the graveyard as it resolves.",
@@ -16097,7 +16546,7 @@
         },
         {
           "name": "Casualty",
-          "line": 582,
+          "line": 605,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.153a: Casualty N — as an additional cost, you may sacrifice a creature with power N or greater. When you do, copy this spell.",
@@ -16107,15 +16556,17 @@
         },
         {
           "name": "Echo",
-          "line": 583,
+          "line": 610,
           "kind": "tuple",
           "field_names": [],
-          "doc": "",
-          "cr_refs": []
+          "doc": "CR 702.30a: see `EchoCost` for the mana / non-mana split. Urza-block / errata cards (e.g. Orcish Hellraiser \"Echo {R}\") use `EchoCost::Mana`; \"Echo—Discard a card\" cards (Rakdos Headliner, Deepcavern Imp) carry `EchoCost::NonMana(AbilityCost::Discard { .. })`.",
+          "cr_refs": [
+            "CR 702.30a"
+          ]
         },
         {
           "name": "Entwine",
-          "line": 585,
+          "line": 612,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.42a: Entwine — pay additional cost to choose all modes of a modal spell.",
@@ -16125,7 +16576,7 @@
         },
         {
           "name": "Outlast",
-          "line": 586,
+          "line": 613,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16133,7 +16584,7 @@
         },
         {
           "name": "Scavenge",
-          "line": 587,
+          "line": 614,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16141,7 +16592,7 @@
         },
         {
           "name": "Reinforce",
-          "line": 590,
+          "line": 617,
           "kind": "struct",
           "field_names": [
             "count",
@@ -16154,7 +16605,7 @@
         },
         {
           "name": "Fortify",
-          "line": 594,
+          "line": 621,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16162,7 +16613,7 @@
         },
         {
           "name": "Prototype",
-          "line": 598,
+          "line": 625,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -16176,7 +16627,7 @@
         },
         {
           "name": "Plot",
-          "line": 605,
+          "line": 632,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16184,7 +16635,7 @@
         },
         {
           "name": "Craft",
-          "line": 613,
+          "line": 640,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -16199,7 +16650,7 @@
         },
         {
           "name": "Offspring",
-          "line": 619,
+          "line": 646,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16207,7 +16658,7 @@
         },
         {
           "name": "Impending",
-          "line": 623,
+          "line": 650,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -16220,7 +16671,7 @@
         },
         {
           "name": "LevelUp",
-          "line": 629,
+          "line": 656,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.87a: Level up is an activated ability that puts a level counter on this permanent. Activate only as a sorcery.",
@@ -16230,7 +16681,7 @@
         },
         {
           "name": "Affinity",
-          "line": 632,
+          "line": 659,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.41a: Affinity for [type] — this spell costs {1} less for each [type] you control.",
@@ -16240,7 +16691,7 @@
         },
         {
           "name": "CumulativeUpkeep",
-          "line": 639,
+          "line": 666,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.24a: cost paid per age counter on this permanent at the start of the controller's upkeep, or sacrifice. The typed `AbilityCost` lets the synthesis pipeline wire the cumulative-upkeep trigger uniformly across mana / life / sacrifice / disjunctive cost shapes.",
@@ -16250,7 +16701,7 @@
         },
         {
           "name": "Banding",
-          "line": 642,
+          "line": 669,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16258,7 +16709,7 @@
         },
         {
           "name": "Epic",
-          "line": 643,
+          "line": 670,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16266,7 +16717,7 @@
         },
         {
           "name": "Fuse",
-          "line": 644,
+          "line": 671,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16274,7 +16725,7 @@
         },
         {
           "name": "Gravestorm",
-          "line": 645,
+          "line": 672,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16282,7 +16733,7 @@
         },
         {
           "name": "Haunt",
-          "line": 646,
+          "line": 673,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16290,7 +16741,7 @@
         },
         {
           "name": "Hideaway",
-          "line": 648,
+          "line": 675,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.74a: Hideaway N — look at top N cards, exile one face down, rest on bottom.",
@@ -16300,7 +16751,7 @@
         },
         {
           "name": "Improvise",
-          "line": 649,
+          "line": 676,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16308,7 +16759,7 @@
         },
         {
           "name": "Ingest",
-          "line": 650,
+          "line": 677,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16316,7 +16767,7 @@
         },
         {
           "name": "Melee",
-          "line": 651,
+          "line": 678,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16324,7 +16775,7 @@
         },
         {
           "name": "Mentor",
-          "line": 652,
+          "line": 679,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16332,7 +16783,7 @@
         },
         {
           "name": "Myriad",
-          "line": 653,
+          "line": 680,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16340,7 +16791,7 @@
         },
         {
           "name": "Provoke",
-          "line": 658,
+          "line": 685,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.39a: Provoke — \"Whenever this creature attacks, you may have target creature defending player controls untap and block it this turn if able.\" Synthesized into an optional Attacks trigger (untap + the source-referential `Effect::ForceBlock`) in `database::synthesis`.",
@@ -16350,7 +16801,7 @@
         },
         {
           "name": "Rebound",
-          "line": 659,
+          "line": 686,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16358,7 +16809,7 @@
         },
         {
           "name": "Retrace",
-          "line": 660,
+          "line": 687,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16366,7 +16817,7 @@
         },
         {
           "name": "Ripple",
-          "line": 661,
+          "line": 688,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16374,7 +16825,7 @@
         },
         {
           "name": "SplitSecond",
-          "line": 662,
+          "line": 689,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16382,7 +16833,7 @@
         },
         {
           "name": "Storm",
-          "line": 663,
+          "line": 690,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16390,7 +16841,7 @@
         },
         {
           "name": "Suspend",
-          "line": 666,
+          "line": 693,
           "kind": "struct",
           "field_names": [
             "count",
@@ -16403,7 +16854,7 @@
         },
         {
           "name": "Totem",
-          "line": 670,
+          "line": 697,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16411,7 +16862,7 @@
         },
         {
           "name": "Warp",
-          "line": 673,
+          "line": 700,
           "kind": "tuple",
           "field_names": [],
           "doc": "Warp {cost}: alternative casting cost. Cast from hand for warp cost, exile at next end step, then may cast from exile later.",
@@ -16419,7 +16870,7 @@
         },
         {
           "name": "Sneak",
-          "line": 678,
+          "line": 705,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.190a: Sneak {cost} — alternative cost to cast this card from graveyard during the declare-blockers step by returning an unblocked attacker. CR 702.190b: the resulting permanent enters tapped and attacking the same defender.",
@@ -16430,7 +16881,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 680,
+          "line": 707,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.49 variant: Web-slinging — return a tapped creature to cast.",
@@ -16440,7 +16891,7 @@
         },
         {
           "name": "Mobilize",
-          "line": 683,
+          "line": 710,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mobilize N — when this creature attacks, create N 1/1 red Warrior tokens tapped and attacking, sacrifice them at end of combat.",
@@ -16448,7 +16899,7 @@
         },
         {
           "name": "Gift",
-          "line": 686,
+          "line": 713,
           "kind": "tuple",
           "field_names": [],
           "doc": "Gift — optional casting-time promise. If promised, opponent receives the gift at resolution before the spell's other effects.",
@@ -16456,7 +16907,7 @@
         },
         {
           "name": "Discover",
-          "line": 688,
+          "line": 715,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 701.57a: Discover N — exile from top until nonland card with MV ≤ N.",
@@ -16466,7 +16917,7 @@
         },
         {
           "name": "Spree",
-          "line": 689,
+          "line": 716,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16474,7 +16925,7 @@
         },
         {
           "name": "Ravenous",
-          "line": 690,
+          "line": 717,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16482,7 +16933,7 @@
         },
         {
           "name": "Daybound",
-          "line": 691,
+          "line": 718,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16490,7 +16941,7 @@
         },
         {
           "name": "Nightbound",
-          "line": 692,
+          "line": 719,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16498,7 +16949,7 @@
         },
         {
           "name": "Enlist",
-          "line": 693,
+          "line": 720,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16506,7 +16957,7 @@
         },
         {
           "name": "ReadAhead",
-          "line": 694,
+          "line": 721,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16514,7 +16965,7 @@
         },
         {
           "name": "Compleated",
-          "line": 695,
+          "line": 722,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16522,7 +16973,7 @@
         },
         {
           "name": "Conspire",
-          "line": 696,
+          "line": 723,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16530,7 +16981,7 @@
         },
         {
           "name": "Demonstrate",
-          "line": 697,
+          "line": 724,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16538,7 +16989,7 @@
         },
         {
           "name": "Dethrone",
-          "line": 698,
+          "line": 725,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16546,7 +16997,7 @@
         },
         {
           "name": "DoubleTeam",
-          "line": 699,
+          "line": 726,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16554,7 +17005,7 @@
         },
         {
           "name": "LivingMetal",
-          "line": 700,
+          "line": 727,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -16562,7 +17013,7 @@
         },
         {
           "name": "Poisonous",
-          "line": 701,
+          "line": 728,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16570,7 +17021,7 @@
         },
         {
           "name": "Bloodthirst",
-          "line": 702,
+          "line": 729,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16578,7 +17029,7 @@
         },
         {
           "name": "Amplify",
-          "line": 703,
+          "line": 730,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16586,7 +17037,7 @@
         },
         {
           "name": "Graft",
-          "line": 704,
+          "line": 731,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -16594,7 +17045,7 @@
         },
         {
           "name": "Devour",
-          "line": 711,
+          "line": 738,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: synthesized as-enters replacement by `database/synthesis.rs::synthesize_devour` — a `ReplacementEvent::Moved` replacement on `SelfRef` whose execute chain is a ranged `Effect::Sacrifice` over the controller's creatures + a per-sacrifice `PutCounter(+1/+1)` sub-ability. CR 702.82a: Devour N — as it enters, you may sacrifice any number of creatures; it enters with N +1/+1 counters per sacrifice.",
@@ -16604,7 +17055,7 @@
         },
         {
           "name": "Toxic",
-          "line": 715,
+          "line": 742,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.164: Toxic N — when this creature deals combat damage to a player, that player gets N poison counters.",
@@ -16614,7 +17065,7 @@
         },
         {
           "name": "Saddle",
-          "line": 717,
+          "line": 744,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.171a: Saddle N — tap creatures with total power N+ to saddle this Mount.",
@@ -16624,7 +17075,7 @@
         },
         {
           "name": "Soulshift",
-          "line": 720,
+          "line": 747,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.46: Soulshift N — when this creature dies, return target Spirit card with mana value N or less from your graveyard to your hand.",
@@ -16634,7 +17085,7 @@
         },
         {
           "name": "Backup",
-          "line": 723,
+          "line": 750,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.165: Backup N — when this creature enters, put N +1/+1 counters on target creature, which gains this creature's other abilities until EOT.",
@@ -16644,7 +17095,7 @@
         },
         {
           "name": "Squad",
-          "line": 730,
+          "line": 757,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (variable additional cost + ETB token-per-payment not wired). CR 702.157: Squad {cost} — as an additional cost to cast, you may pay {cost} any number of times; ETB creates that many tokens.",
@@ -16654,7 +17105,7 @@
         },
         {
           "name": "Typecycling",
-          "line": 734,
+          "line": 761,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -16667,7 +17118,7 @@
         },
         {
           "name": "Firebending",
-          "line": 740,
+          "line": 767,
           "kind": "tuple",
           "field_names": [],
           "doc": "Firebending N — produces N {R} when this creature attacks (Avatar crossover).",
@@ -16675,17 +17126,20 @@
         },
         {
           "name": "Splice",
-          "line": 744,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "CR 702.46a: Splice onto [type] — reveal from hand and pay splice cost while casting a spell of the specified type to add this card's effects to that spell.",
+          "line": 772,
+          "kind": "struct",
+          "field_names": [
+            "subtype",
+            "cost"
+          ],
+          "doc": "CR 702.47a: Splice onto [type] [cost] — reveal this card from hand and pay its splice cost as you cast a spell of the specified type to copy this card's text box onto that spell.",
           "cr_refs": [
-            "CR 702.46a"
+            "CR 702.47a"
           ]
         },
         {
           "name": "Bargain",
-          "line": 747,
+          "line": 778,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Bargain — you may sacrifice an artifact, enchantment, or token as an additional cost to cast this spell.",
@@ -16695,7 +17149,7 @@
         },
         {
           "name": "Sunburst",
-          "line": 754,
+          "line": 785,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.44a: Sunburst — as an object enters the battlefield as a resolving spell, it enters with a +1/+1 counter (if entering as a creature) or a charge counter (otherwise) for each color of mana spent to cast it. Wired at runtime by `synthesize_sunburst` as an ETB-counter replacement whose count is the distinct-colors-spent metric. Per CR 702.44d each instance works separately.",
@@ -16706,7 +17160,7 @@
         },
         {
           "name": "Champion",
-          "line": 759,
+          "line": 790,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.72a: Champion a [type] — exile another object of the specified type you control or sacrifice this permanent when it enters; return the exiled card when this leaves. Wired at build time by `synthesize_champion`; CR 702.72b makes the two abilities linked.",
@@ -16717,7 +17171,7 @@
         },
         {
           "name": "Training",
-          "line": 762,
+          "line": 793,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.149a: Training — whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.",
@@ -16727,7 +17181,7 @@
         },
         {
           "name": "Assist",
-          "line": 764,
+          "line": 795,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.132a: Assist — another player can help pay the generic mana cost of this spell.",
@@ -16737,7 +17191,7 @@
         },
         {
           "name": "Augment",
-          "line": 768,
+          "line": 799,
           "kind": "unit",
           "field_names": [],
           "doc": "Acorn/Un-set keyword: Augment. Runtime host-combine semantics are not implemented; the keyword identity is used for characteristic filters such as \"a card with augment\".",
@@ -16745,7 +17199,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 772,
+          "line": 803,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Aftermath allows casting this half of a split card only from a graveyard, and exiles the spell any time it leaves the stack if it was cast from a graveyard.",
@@ -16755,7 +17209,7 @@
         },
         {
           "name": "JumpStart",
-          "line": 774,
+          "line": 805,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.133a: Jump-start — cast from graveyard by discarding a card, then exile.",
@@ -16765,7 +17219,7 @@
         },
         {
           "name": "Cipher",
-          "line": 777,
+          "line": 808,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99a: Cipher — exile this spell encoded on a creature you control; whenever that creature deals combat damage to a player, cast a copy.",
@@ -16775,17 +17229,17 @@
         },
         {
           "name": "Transmute",
-          "line": 780,
+          "line": 813,
           "kind": "tuple",
           "field_names": [],
-          "doc": "CR 702.52a: Transmute {cost} — discard this card and pay {cost} to search your library for a card with the same mana value.",
+          "doc": "CR 702.53a: Transmute {cost} — \"[Cost], Discard this card: Search your library for a card with the same mana value as the discarded card, reveal it, put it into your hand, then shuffle. Activate only as a sorcery.\" Runtime: `synthesize_transmute` (database/synthesis.rs).",
           "cr_refs": [
-            "CR 702.52a"
+            "CR 702.53a"
           ]
         },
         {
           "name": "Escalate",
-          "line": 783,
+          "line": 816,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.120a: Escalate [cost] — additional cost for each mode chosen beyond the first on a modal spell.",
@@ -16795,7 +17249,7 @@
         },
         {
           "name": "Recover",
-          "line": 787,
+          "line": 820,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.59a: Recover {cost} — triggered ability: when a creature is put into your graveyard from the battlefield, you may pay {cost} to return this card from your graveyard to your hand; otherwise exile it.",
@@ -16805,7 +17259,7 @@
         },
         {
           "name": "Cleave",
-          "line": 789,
+          "line": 822,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.148a: Cleave — alternative cost that removes bracketed text from Oracle text.",
@@ -16815,7 +17269,7 @@
         },
         {
           "name": "Undaunted",
-          "line": 791,
+          "line": 824,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.125a: Undaunted — costs {1} less for each opponent.",
@@ -16825,7 +17279,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 799,
+          "line": 832,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — a keyword on instants/sorceries. Reminder: \"Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases.\" Runtime hooks in `stack.rs` (first-resolution arming) and `turns.rs` (first-main-phase offer) carry the semantics. Assign when WotC publishes SOS CR update.",
@@ -16835,7 +17289,7 @@
         },
         {
           "name": "Station",
-          "line": 807,
+          "line": 840,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Station — \"Tap another untapped creature you control: Put a number of charge counters on this permanent equal to the tapped creature's power. Activate only as a sorcery.\" The keyword is fixed (no parameter) — the full semantics come from the rule text. Runtime activation is handled via `GameAction::ActivateStation`, not through the generic activated-ability dispatch.",
@@ -16845,7 +17299,7 @@
         },
         {
           "name": "Replicate",
-          "line": 821,
+          "line": 854,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: `database::synthesis::synthesize_replicate` — repeatable optional additional cost (`AdditionalCost::Optional { repeatable: true }`) plus a `SpellCast` trigger whose execute is `replicate_copy_ability_definition()` (a `CopySpell` with `repeat_for = AdditionalCostPaymentCount`). CR 702.56a: Replicate {cost} — additional-cost-on-cast copy mechanic. \"As an additional cost to cast this spell, you may pay [cost] any number of times\" + \"When you cast this spell, if a replicate cost was paid for it, copy it for each time its replicate cost was paid. If the spell has any targets, you may choose new targets for any of the copies.\" Carries the per-copy mana cost.",
@@ -16855,7 +17309,7 @@
         },
         {
           "name": "Awaken",
-          "line": 828,
+          "line": 861,
           "kind": "struct",
           "field_names": [
             "count",
@@ -16868,7 +17322,7 @@
         },
         {
           "name": "ForMirrodin",
-          "line": 837,
+          "line": 870,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.163a: For Mirrodin! — Equipment-only triggered ability. \"When this Equipment enters, create a 2/2 red Rebel creature token, then attach this Equipment to it.\" Bare keyword; ETB trigger semantics are synthesized in `database::synthesis`.",
@@ -16878,7 +17332,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 845,
+          "line": 878,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cost cast hook not wired). CR 702.162a: More Than Meets the Eye {cost} — alternative cost (Transformers crossover). \"You may cast this card converted by paying [cost] rather than its mana cost.\" Stores the alt mana cost; the runtime alt-cost cast hook is not yet wired.",
@@ -16888,7 +17342,7 @@
         },
         {
           "name": "Freerunning",
-          "line": 856,
+          "line": 889,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cast hook + combat-damage-this-turn predicate not wired). CR 702.173a: Freerunning {cost} — alternative cost. \"You may pay [cost] rather than pay this spell's mana cost if a player was dealt combat damage this turn by a creature that, at the time it dealt that damage, was an Assassin creature or a commander under your control.\" Stores the alt mana cost; runtime alt-cast hook (combat-damage-this-turn predicate) is not yet wired.",
@@ -16898,7 +17352,7 @@
         },
         {
           "name": "Increment",
-          "line": 860,
+          "line": 893,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.191a: Increment — spell-cast trigger synthesized in `database::synthesis::synthesize_increment`.",
@@ -16908,7 +17362,7 @@
         },
         {
           "name": "Specialize",
-          "line": 873,
+          "line": 906,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (choose-color + transform hooks not wired). CR ???: Specialize {cost} — not in CR text (needs manual verification). Strixhaven student-into-mage transformation: activated alt-cast that turns the source into a colour-specific version. Stores the activation mana cost; the choose-color and transform hooks are not yet wired. mtgish encodes activation timing modifiers and from-graveyard variants separately; this keyword carries only the cost (the engine drops the activation modifier and the from-graveyard hint, mirroring how `LevelUp` drops its `Vec<Level>` payload).",
@@ -16916,7 +17370,7 @@
         },
         {
           "name": "Offering",
-          "line": 882,
+          "line": 915,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.48a: \"[Quality] offering\" — as an additional cost to cast this spell, you may sacrifice a [Quality] permanent. If you do, this spell's total cost is reduced by the sacrificed permanent's mana cost (CR 702.48c), and you may cast this spell any time you could cast an instant. Carries the canonical subtype string (e.g. \"Spirit\", \"Dragon\"). Runtime behavior is fully wired: timing unlock, sacrifice selection, and cost reduction in `casting_costs.rs`.",
@@ -16927,7 +17381,7 @@
         },
         {
           "name": "Unknown",
-          "line": 885,
+          "line": 918,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized keywords.",
@@ -16938,7 +17392,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12065,
+      "line": 12196,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -16947,7 +17401,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 12067,
+          "line": 12198,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -16960,7 +17414,7 @@
         },
         {
           "name": "Crew",
-          "line": 12073,
+          "line": 12204,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -16973,7 +17427,7 @@
         },
         {
           "name": "Saddle",
-          "line": 12079,
+          "line": 12210,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -16986,7 +17440,7 @@
         },
         {
           "name": "Station",
-          "line": 12087,
+          "line": 12218,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -17004,108 +17458,12 @@
     },
     "KeywordKind": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 71,
+      "line": 83,
       "doc": "Discriminant-level keyword identity used when the Oracle text refers to a keyword class without caring about its parameter payload.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Flying",
-          "line": 72,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FirstStrike",
-          "line": 73,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DoubleStrike",
-          "line": 74,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Trample",
-          "line": 75,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TrampleOverPlaneswalkers",
-          "line": 76,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Deathtouch",
-          "line": 77,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Lifelink",
-          "line": 78,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Vigilance",
-          "line": 79,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Haste",
-          "line": 80,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Reach",
-          "line": 81,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Defender",
-          "line": 82,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Menace",
-          "line": 83,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Indestructible",
           "line": 84,
           "kind": "unit",
           "field_names": [],
@@ -17113,7 +17471,7 @@
           "cr_refs": []
         },
         {
-          "name": "Hexproof",
+          "name": "FirstStrike",
           "line": 85,
           "kind": "unit",
           "field_names": [],
@@ -17121,7 +17479,7 @@
           "cr_refs": []
         },
         {
-          "name": "Shroud",
+          "name": "DoubleStrike",
           "line": 86,
           "kind": "unit",
           "field_names": [],
@@ -17129,7 +17487,7 @@
           "cr_refs": []
         },
         {
-          "name": "Flash",
+          "name": "Trample",
           "line": 87,
           "kind": "unit",
           "field_names": [],
@@ -17137,7 +17495,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fear",
+          "name": "TrampleOverPlaneswalkers",
           "line": 88,
           "kind": "unit",
           "field_names": [],
@@ -17145,7 +17503,7 @@
           "cr_refs": []
         },
         {
-          "name": "Intimidate",
+          "name": "Deathtouch",
           "line": 89,
           "kind": "unit",
           "field_names": [],
@@ -17153,7 +17511,7 @@
           "cr_refs": []
         },
         {
-          "name": "Skulk",
+          "name": "Lifelink",
           "line": 90,
           "kind": "unit",
           "field_names": [],
@@ -17161,7 +17519,7 @@
           "cr_refs": []
         },
         {
-          "name": "Shadow",
+          "name": "Vigilance",
           "line": 91,
           "kind": "unit",
           "field_names": [],
@@ -17169,7 +17527,7 @@
           "cr_refs": []
         },
         {
-          "name": "Horsemanship",
+          "name": "Haste",
           "line": 92,
           "kind": "unit",
           "field_names": [],
@@ -17177,7 +17535,7 @@
           "cr_refs": []
         },
         {
-          "name": "Wither",
+          "name": "Reach",
           "line": 93,
           "kind": "unit",
           "field_names": [],
@@ -17185,7 +17543,7 @@
           "cr_refs": []
         },
         {
-          "name": "Infect",
+          "name": "Defender",
           "line": 94,
           "kind": "unit",
           "field_names": [],
@@ -17193,7 +17551,7 @@
           "cr_refs": []
         },
         {
-          "name": "Afflict",
+          "name": "Menace",
           "line": 95,
           "kind": "unit",
           "field_names": [],
@@ -17201,7 +17559,7 @@
           "cr_refs": []
         },
         {
-          "name": "Prowess",
+          "name": "Indestructible",
           "line": 96,
           "kind": "unit",
           "field_names": [],
@@ -17209,7 +17567,7 @@
           "cr_refs": []
         },
         {
-          "name": "Undying",
+          "name": "Hexproof",
           "line": 97,
           "kind": "unit",
           "field_names": [],
@@ -17217,7 +17575,7 @@
           "cr_refs": []
         },
         {
-          "name": "Persist",
+          "name": "Shroud",
           "line": 98,
           "kind": "unit",
           "field_names": [],
@@ -17225,7 +17583,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cascade",
+          "name": "Flash",
           "line": 99,
           "kind": "unit",
           "field_names": [],
@@ -17233,7 +17591,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exalted",
+          "name": "Fear",
           "line": 100,
           "kind": "unit",
           "field_names": [],
@@ -17241,7 +17599,7 @@
           "cr_refs": []
         },
         {
-          "name": "Flanking",
+          "name": "Intimidate",
           "line": 101,
           "kind": "unit",
           "field_names": [],
@@ -17249,7 +17607,7 @@
           "cr_refs": []
         },
         {
-          "name": "Evolve",
+          "name": "Skulk",
           "line": 102,
           "kind": "unit",
           "field_names": [],
@@ -17257,7 +17615,7 @@
           "cr_refs": []
         },
         {
-          "name": "Extort",
+          "name": "Shadow",
           "line": 103,
           "kind": "unit",
           "field_names": [],
@@ -17265,7 +17623,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exploit",
+          "name": "Horsemanship",
           "line": 104,
           "kind": "unit",
           "field_names": [],
@@ -17273,7 +17631,7 @@
           "cr_refs": []
         },
         {
-          "name": "Explore",
+          "name": "Wither",
           "line": 105,
           "kind": "unit",
           "field_names": [],
@@ -17281,7 +17639,7 @@
           "cr_refs": []
         },
         {
-          "name": "Ascend",
+          "name": "Infect",
           "line": 106,
           "kind": "unit",
           "field_names": [],
@@ -17289,7 +17647,7 @@
           "cr_refs": []
         },
         {
-          "name": "StartYourEngines",
+          "name": "Afflict",
           "line": 107,
           "kind": "unit",
           "field_names": [],
@@ -17297,7 +17655,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dredge",
+          "name": "Prowess",
           "line": 108,
           "kind": "unit",
           "field_names": [],
@@ -17305,7 +17663,7 @@
           "cr_refs": []
         },
         {
-          "name": "Modular",
+          "name": "Undying",
           "line": 109,
           "kind": "unit",
           "field_names": [],
@@ -17313,7 +17671,7 @@
           "cr_refs": []
         },
         {
-          "name": "Renown",
+          "name": "Persist",
           "line": 110,
           "kind": "unit",
           "field_names": [],
@@ -17321,7 +17679,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fabricate",
+          "name": "Cascade",
           "line": 111,
           "kind": "unit",
           "field_names": [],
@@ -17329,8 +17687,104 @@
           "cr_refs": []
         },
         {
-          "name": "Graft",
+          "name": "Exalted",
+          "line": 112,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Flanking",
           "line": 113,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Evolve",
+          "line": 114,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Extort",
+          "line": 115,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exploit",
+          "line": 116,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Explore",
+          "line": 117,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Ascend",
+          "line": 118,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "StartYourEngines",
+          "line": 119,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Dredge",
+          "line": 120,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Modular",
+          "line": 121,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Renown",
+          "line": 122,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Fabricate",
+          "line": 123,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Graft",
+          "line": 125,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.58a: Graft N — see `Keyword::Graft`.",
@@ -17340,102 +17794,6 @@
         },
         {
           "name": "Annihilator",
-          "line": 114,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Bushido",
-          "line": 115,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Tribute",
-          "line": 116,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Soulbond",
-          "line": 117,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Unearth",
-          "line": 118,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Convoke",
-          "line": 119,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Waterbend",
-          "line": 120,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Delve",
-          "line": 121,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Devoid",
-          "line": 122,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Changeling",
-          "line": 123,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Phasing",
-          "line": 124,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Battlecry",
-          "line": 125,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Decayed",
           "line": 126,
           "kind": "unit",
           "field_names": [],
@@ -17443,7 +17801,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unleash",
+          "name": "Bushido",
           "line": 127,
           "kind": "unit",
           "field_names": [],
@@ -17451,7 +17809,7 @@
           "cr_refs": []
         },
         {
-          "name": "Riot",
+          "name": "Frenzy",
           "line": 128,
           "kind": "unit",
           "field_names": [],
@@ -17459,7 +17817,7 @@
           "cr_refs": []
         },
         {
-          "name": "Afterlife",
+          "name": "Tribute",
           "line": 129,
           "kind": "unit",
           "field_names": [],
@@ -17467,7 +17825,7 @@
           "cr_refs": []
         },
         {
-          "name": "Enchant",
+          "name": "Soulbond",
           "line": 130,
           "kind": "unit",
           "field_names": [],
@@ -17475,7 +17833,7 @@
           "cr_refs": []
         },
         {
-          "name": "EtbCounter",
+          "name": "Unearth",
           "line": 131,
           "kind": "unit",
           "field_names": [],
@@ -17483,7 +17841,7 @@
           "cr_refs": []
         },
         {
-          "name": "Reconfigure",
+          "name": "Convoke",
           "line": 132,
           "kind": "unit",
           "field_names": [],
@@ -17491,7 +17849,7 @@
           "cr_refs": []
         },
         {
-          "name": "LivingWeapon",
+          "name": "Waterbend",
           "line": 133,
           "kind": "unit",
           "field_names": [],
@@ -17499,7 +17857,7 @@
           "cr_refs": []
         },
         {
-          "name": "JobSelect",
+          "name": "Delve",
           "line": 134,
           "kind": "unit",
           "field_names": [],
@@ -17507,7 +17865,7 @@
           "cr_refs": []
         },
         {
-          "name": "TotemArmor",
+          "name": "Devoid",
           "line": 135,
           "kind": "unit",
           "field_names": [],
@@ -17515,7 +17873,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bestow",
+          "name": "Changeling",
           "line": 136,
           "kind": "unit",
           "field_names": [],
@@ -17523,7 +17881,7 @@
           "cr_refs": []
         },
         {
-          "name": "Embalm",
+          "name": "Phasing",
           "line": 137,
           "kind": "unit",
           "field_names": [],
@@ -17531,7 +17889,7 @@
           "cr_refs": []
         },
         {
-          "name": "Eternalize",
+          "name": "Battlecry",
           "line": 138,
           "kind": "unit",
           "field_names": [],
@@ -17539,7 +17897,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fading",
+          "name": "Decayed",
           "line": 139,
           "kind": "unit",
           "field_names": [],
@@ -17547,7 +17905,7 @@
           "cr_refs": []
         },
         {
-          "name": "Vanishing",
+          "name": "Unleash",
           "line": 140,
           "kind": "unit",
           "field_names": [],
@@ -17555,7 +17913,7 @@
           "cr_refs": []
         },
         {
-          "name": "Protection",
+          "name": "Riot",
           "line": 141,
           "kind": "unit",
           "field_names": [],
@@ -17563,7 +17921,7 @@
           "cr_refs": []
         },
         {
-          "name": "Kicker",
+          "name": "Afterlife",
           "line": 142,
           "kind": "unit",
           "field_names": [],
@@ -17571,7 +17929,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cycling",
+          "name": "Enchant",
           "line": 143,
           "kind": "unit",
           "field_names": [],
@@ -17579,7 +17937,7 @@
           "cr_refs": []
         },
         {
-          "name": "Flashback",
+          "name": "EtbCounter",
           "line": 144,
           "kind": "unit",
           "field_names": [],
@@ -17587,7 +17945,7 @@
           "cr_refs": []
         },
         {
-          "name": "Retrace",
+          "name": "Reconfigure",
           "line": 145,
           "kind": "unit",
           "field_names": [],
@@ -17595,7 +17953,7 @@
           "cr_refs": []
         },
         {
-          "name": "Ward",
+          "name": "LivingWeapon",
           "line": 146,
           "kind": "unit",
           "field_names": [],
@@ -17603,7 +17961,7 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "JobSelect",
           "line": 147,
           "kind": "unit",
           "field_names": [],
@@ -17611,7 +17969,7 @@
           "cr_refs": []
         },
         {
-          "name": "Landwalk",
+          "name": "TotemArmor",
           "line": 148,
           "kind": "unit",
           "field_names": [],
@@ -17619,7 +17977,7 @@
           "cr_refs": []
         },
         {
-          "name": "Rampage",
+          "name": "Bestow",
           "line": 149,
           "kind": "unit",
           "field_names": [],
@@ -17627,7 +17985,7 @@
           "cr_refs": []
         },
         {
-          "name": "Absorb",
+          "name": "Embalm",
           "line": 150,
           "kind": "unit",
           "field_names": [],
@@ -17635,7 +17993,7 @@
           "cr_refs": []
         },
         {
-          "name": "Crew",
+          "name": "Eternalize",
           "line": 151,
           "kind": "unit",
           "field_names": [],
@@ -17643,7 +18001,7 @@
           "cr_refs": []
         },
         {
-          "name": "Partner",
+          "name": "Fading",
           "line": 152,
           "kind": "unit",
           "field_names": [],
@@ -17651,7 +18009,7 @@
           "cr_refs": []
         },
         {
-          "name": "Companion",
+          "name": "Vanishing",
           "line": 153,
           "kind": "unit",
           "field_names": [],
@@ -17659,7 +18017,7 @@
           "cr_refs": []
         },
         {
-          "name": "Doctor",
+          "name": "Protection",
           "line": 154,
           "kind": "unit",
           "field_names": [],
@@ -17667,7 +18025,7 @@
           "cr_refs": []
         },
         {
-          "name": "Background",
+          "name": "Kicker",
           "line": 155,
           "kind": "unit",
           "field_names": [],
@@ -17675,7 +18033,7 @@
           "cr_refs": []
         },
         {
-          "name": "CommanderNinjutsu",
+          "name": "Cycling",
           "line": 156,
           "kind": "unit",
           "field_names": [],
@@ -17683,7 +18041,7 @@
           "cr_refs": []
         },
         {
-          "name": "Ninjutsu",
+          "name": "Flashback",
           "line": 157,
           "kind": "unit",
           "field_names": [],
@@ -17691,7 +18049,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sneak",
+          "name": "Retrace",
           "line": 158,
           "kind": "unit",
           "field_names": [],
@@ -17699,7 +18057,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mutate",
+          "name": "Ward",
           "line": 159,
           "kind": "unit",
           "field_names": [],
@@ -17707,7 +18065,7 @@
           "cr_refs": []
         },
         {
-          "name": "Escape",
+          "name": "Equip",
           "line": 160,
           "kind": "unit",
           "field_names": [],
@@ -17715,7 +18073,7 @@
           "cr_refs": []
         },
         {
-          "name": "Morph",
+          "name": "Landwalk",
           "line": 161,
           "kind": "unit",
           "field_names": [],
@@ -17723,7 +18081,7 @@
           "cr_refs": []
         },
         {
-          "name": "Megamorph",
+          "name": "Rampage",
           "line": 162,
           "kind": "unit",
           "field_names": [],
@@ -17731,7 +18089,7 @@
           "cr_refs": []
         },
         {
-          "name": "Suspend",
+          "name": "Absorb",
           "line": 163,
           "kind": "unit",
           "field_names": [],
@@ -17739,7 +18097,7 @@
           "cr_refs": []
         },
         {
-          "name": "Blitz",
+          "name": "Crew",
           "line": 164,
           "kind": "unit",
           "field_names": [],
@@ -17747,7 +18105,7 @@
           "cr_refs": []
         },
         {
-          "name": "Disturb",
+          "name": "Partner",
           "line": 165,
           "kind": "unit",
           "field_names": [],
@@ -17755,7 +18113,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnearthAlt",
+          "name": "Companion",
           "line": 166,
           "kind": "unit",
           "field_names": [],
@@ -17763,7 +18121,7 @@
           "cr_refs": []
         },
         {
-          "name": "Foretell",
+          "name": "Doctor",
           "line": 167,
           "kind": "unit",
           "field_names": [],
@@ -17771,7 +18129,7 @@
           "cr_refs": []
         },
         {
-          "name": "Plot",
+          "name": "Background",
           "line": 168,
           "kind": "unit",
           "field_names": [],
@@ -17779,7 +18137,7 @@
           "cr_refs": []
         },
         {
-          "name": "Gift",
+          "name": "CommanderNinjutsu",
           "line": 169,
           "kind": "unit",
           "field_names": [],
@@ -17787,7 +18145,7 @@
           "cr_refs": []
         },
         {
-          "name": "Outlast",
+          "name": "Ninjutsu",
           "line": 170,
           "kind": "unit",
           "field_names": [],
@@ -17795,7 +18153,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dash",
+          "name": "Sneak",
           "line": 171,
           "kind": "unit",
           "field_names": [],
@@ -17803,7 +18161,7 @@
           "cr_refs": []
         },
         {
-          "name": "Craft",
+          "name": "Mutate",
           "line": 172,
           "kind": "unit",
           "field_names": [],
@@ -17811,7 +18169,7 @@
           "cr_refs": []
         },
         {
-          "name": "Harmonize",
+          "name": "Escape",
           "line": 173,
           "kind": "unit",
           "field_names": [],
@@ -17819,7 +18177,7 @@
           "cr_refs": []
         },
         {
-          "name": "Warp",
+          "name": "Morph",
           "line": 174,
           "kind": "unit",
           "field_names": [],
@@ -17827,7 +18185,7 @@
           "cr_refs": []
         },
         {
-          "name": "Devour",
+          "name": "Megamorph",
           "line": 175,
           "kind": "unit",
           "field_names": [],
@@ -17835,7 +18193,7 @@
           "cr_refs": []
         },
         {
-          "name": "Offspring",
+          "name": "Suspend",
           "line": 176,
           "kind": "unit",
           "field_names": [],
@@ -17843,7 +18201,7 @@
           "cr_refs": []
         },
         {
-          "name": "Splice",
+          "name": "Blitz",
           "line": 177,
           "kind": "unit",
           "field_names": [],
@@ -17851,7 +18209,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bargain",
+          "name": "Disturb",
           "line": 178,
           "kind": "unit",
           "field_names": [],
@@ -17859,7 +18217,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sunburst",
+          "name": "UnearthAlt",
           "line": 179,
           "kind": "unit",
           "field_names": [],
@@ -17867,7 +18225,7 @@
           "cr_refs": []
         },
         {
-          "name": "Champion",
+          "name": "Foretell",
           "line": 180,
           "kind": "unit",
           "field_names": [],
@@ -17875,7 +18233,7 @@
           "cr_refs": []
         },
         {
-          "name": "Training",
+          "name": "Plot",
           "line": 181,
           "kind": "unit",
           "field_names": [],
@@ -17883,7 +18241,7 @@
           "cr_refs": []
         },
         {
-          "name": "Assist",
+          "name": "Gift",
           "line": 182,
           "kind": "unit",
           "field_names": [],
@@ -17891,8 +18249,120 @@
           "cr_refs": []
         },
         {
-          "name": "Augment",
+          "name": "Outlast",
+          "line": 183,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Dash",
+          "line": 184,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Craft",
           "line": 185,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Harmonize",
+          "line": 186,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mayhem",
+          "line": 187,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Warp",
+          "line": 188,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Devour",
+          "line": 189,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Offspring",
+          "line": 190,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Splice",
+          "line": 191,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Bargain",
+          "line": 192,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Sunburst",
+          "line": 193,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Champion",
+          "line": 194,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Training",
+          "line": 195,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Assist",
+          "line": 196,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Augment",
+          "line": 199,
           "kind": "unit",
           "field_names": [],
           "doc": "Acorn/Un-set keyword: Augment. Not present in the main Comprehensive Rules file, but it is still a keyword characteristic for card filters.",
@@ -17900,7 +18370,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 187,
+          "line": 201,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127: Aftermath — see `Keyword::Aftermath`.",
@@ -17910,7 +18380,7 @@
         },
         {
           "name": "JumpStart",
-          "line": 188,
+          "line": 202,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17918,7 +18388,7 @@
         },
         {
           "name": "Cipher",
-          "line": 189,
+          "line": 203,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17926,7 +18396,7 @@
         },
         {
           "name": "Transmute",
-          "line": 190,
+          "line": 204,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17934,7 +18404,7 @@
         },
         {
           "name": "Cleave",
-          "line": 191,
+          "line": 205,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17942,7 +18412,7 @@
         },
         {
           "name": "Undaunted",
-          "line": 192,
+          "line": 206,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17950,7 +18420,7 @@
         },
         {
           "name": "Station",
-          "line": 193,
+          "line": 207,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -17958,7 +18428,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 195,
+          "line": 209,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — see `Keyword::Paradigm`.",
@@ -17968,7 +18438,7 @@
         },
         {
           "name": "Miracle",
-          "line": 197,
+          "line": 211,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94: Miracle — see `Keyword::Miracle`.",
@@ -17978,7 +18448,7 @@
         },
         {
           "name": "Replicate",
-          "line": 199,
+          "line": 213,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.56: Replicate — see `Keyword::Replicate`.",
@@ -17988,7 +18458,7 @@
         },
         {
           "name": "Awaken",
-          "line": 201,
+          "line": 215,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113: Awaken — see `Keyword::Awaken`.",
@@ -17998,7 +18468,7 @@
         },
         {
           "name": "ForMirrodin",
-          "line": 203,
+          "line": 217,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.163: For Mirrodin! — see `Keyword::ForMirrodin`.",
@@ -18008,7 +18478,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 205,
+          "line": 219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.162: More Than Meets the Eye — see `Keyword::MoreThanMeetsTheEye`.",
@@ -18018,7 +18488,7 @@
         },
         {
           "name": "Freerunning",
-          "line": 207,
+          "line": 221,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.173: Freerunning — see `Keyword::Freerunning`.",
@@ -18028,7 +18498,7 @@
         },
         {
           "name": "Increment",
-          "line": 209,
+          "line": 223,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.191: Increment — see `Keyword::Increment`.",
@@ -18038,7 +18508,7 @@
         },
         {
           "name": "Firebending",
-          "line": 211,
+          "line": 225,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.189: Firebending — see `Keyword::Firebending`.",
@@ -18048,7 +18518,7 @@
         },
         {
           "name": "Specialize",
-          "line": 214,
+          "line": 228,
           "kind": "unit",
           "field_names": [],
           "doc": "CR ???: Specialize — not in CR text (needs manual verification). See `Keyword::Specialize`.",
@@ -18056,7 +18526,7 @@
         },
         {
           "name": "Offering",
-          "line": 216,
+          "line": 230,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.48: Offering — see `Keyword::Offering`.",
@@ -18066,7 +18536,7 @@
         },
         {
           "name": "Escalate",
-          "line": 218,
+          "line": 232,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.120: Escalate — see `Keyword::Escalate`.",
@@ -18076,7 +18546,7 @@
         },
         {
           "name": "Recover",
-          "line": 220,
+          "line": 234,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.59: Recover — see `Keyword::Recover`.",
@@ -18086,7 +18556,7 @@
         },
         {
           "name": "Unknown",
-          "line": 221,
+          "line": 235,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18097,7 +18567,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10107,
+      "line": 10216,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -18107,7 +18577,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 10109,
+          "line": 10218,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -18117,7 +18587,7 @@
         },
         {
           "name": "Second",
-          "line": 10112,
+          "line": 10221,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -18252,7 +18722,7 @@
     },
     "LayersDirty": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1308,
+      "line": 1551,
       "doc": "Lattice tracking which battlefield objects need layer (continuous-effect) re-evaluation. Replaces the old `bool` flag so that a token / conjure / copy entry can request an INCREMENTAL re-derive of only the entering object(s) instead of a full battlefield reset+reapply.  CR 613.1: continuous effects are evaluated in layer order over the whole board. A full evaluation is always correct; the incremental path is a performance optimization that `flush_layers` only takes when it can prove (per-entered preconditions + a board-wide escalation scan) that re-deriving just the entered objects produces a board state identical to a full pass. `mark_full()` is the conservative escalation any non-entry mutation uses.",
       "cr_refs": [
         "CR 613.1"
@@ -18260,7 +18730,7 @@
       "variants": [
         {
           "name": "Clean",
-          "line": 1311,
+          "line": 1554,
           "kind": "unit",
           "field_names": [],
           "doc": "Layers are up to date; nothing to flush.",
@@ -18268,7 +18738,7 @@
         },
         {
           "name": "EnteredObjects",
-          "line": 1315,
+          "line": 1558,
           "kind": "tuple",
           "field_names": [],
           "doc": "Only these objects entered the battlefield since the last flush and no other layer-affecting mutation occurred. Candidate for the incremental fast path.",
@@ -18276,7 +18746,7 @@
         },
         {
           "name": "Full",
-          "line": 1317,
+          "line": 1560,
           "kind": "unit",
           "field_names": [],
           "doc": "A full battlefield re-evaluation is required.",
@@ -18372,7 +18842,7 @@
     },
     "LearnOption": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 688,
+      "line": 695,
       "doc": "CR 701.48a: Learn choice — rummage a specific card, or skip entirely.",
       "cr_refs": [
         "CR 701.48a"
@@ -18380,7 +18850,7 @@
       "variants": [
         {
           "name": "Rummage",
-          "line": 690,
+          "line": 697,
           "kind": "struct",
           "field_names": [
             "card_id"
@@ -18390,7 +18860,7 @@
         },
         {
           "name": "Skip",
-          "line": 692,
+          "line": 699,
           "kind": "unit",
           "field_names": [],
           "doc": "Decline to learn (skip).",
@@ -18401,13 +18871,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5360,
+      "line": 5379,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 5361,
+          "line": 5380,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18415,7 +18885,7 @@
         },
         {
           "name": "Bottom",
-          "line": 5362,
+          "line": 5381,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18423,7 +18893,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 5364,
+          "line": 5383,
           "kind": "struct",
           "field_names": [
             "n"
@@ -18633,13 +19103,13 @@
     },
     "ManaAbilityResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1143,
+      "line": 1386,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1144,
+          "line": 1387,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18647,7 +19117,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1145,
+          "line": 1388,
           "kind": "struct",
           "field_names": [
             "convoke_mode"
@@ -18657,7 +19127,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 1149,
+          "line": 1392,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -18674,7 +19144,7 @@
     },
     "ManaChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1215,
+      "line": 1458,
       "doc": "CR 608.2d + CR 605.3b: Player's answer to a `ManaChoicePrompt`, carried by `GameAction::ChooseManaColor`. Shape mirrors the prompt variant.",
       "cr_refs": [
         "CR 605.3b",
@@ -18683,7 +19153,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1216,
+          "line": 1459,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -18691,7 +19161,7 @@
         },
         {
           "name": "Combination",
-          "line": 1217,
+          "line": 1460,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -18702,7 +19172,7 @@
     },
     "ManaChoiceContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1225,
+      "line": 1468,
       "doc": "CR 106.3 + CR 608.2d + CR 605.3b: What resumes after a mana-color choice. Mana abilities and resolving spell/ability effects share the same prompt and response action, but resume through different rules paths.",
       "cr_refs": [
         "CR 106.3",
@@ -18712,7 +19182,7 @@
       "variants": [
         {
           "name": "ManaAbility",
-          "line": 1226,
+          "line": 1469,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -18720,7 +19190,7 @@
         },
         {
           "name": "ResolvingEffect",
-          "line": 1227,
+          "line": 1470,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -18731,7 +19201,7 @@
     },
     "ManaChoicePrompt": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1198,
+      "line": 1441,
       "doc": "CR 608.2d + CR 605.3b: The shape of the prompt surfaced via `WaitingFor::ChooseManaColor`. Typed enum rather than a bool discriminator: the continuation logic is identical (validate choice → produce mana → resume), only the option set differs.",
       "cr_refs": [
         "CR 605.3b",
@@ -18740,7 +19210,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1201,
+          "line": 1444,
           "kind": "struct",
           "field_names": [
             "options"
@@ -18750,7 +19220,7 @@
         },
         {
           "name": "Combination",
-          "line": 1203,
+          "line": 1446,
           "kind": "struct",
           "field_names": [
             "options"
@@ -18760,7 +19230,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1205,
+          "line": 1448,
           "kind": "struct",
           "field_names": [
             "count",
@@ -18851,13 +19321,13 @@
     },
     "ManaCost": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 771,
+      "line": 783,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "NoCost",
-          "line": 772,
+          "line": 784,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -18865,7 +19335,7 @@
         },
         {
           "name": "Cost",
-          "line": 773,
+          "line": 785,
           "kind": "struct",
           "field_names": [
             "shards",
@@ -18876,7 +19346,7 @@
         },
         {
           "name": "SelfManaCost",
-          "line": 778,
+          "line": 790,
           "kind": "unit",
           "field_names": [],
           "doc": "The card's own mana cost (used for \"the flashback cost is equal to its mana cost\").",
@@ -18887,84 +19357,12 @@
     },
     "ManaCostShard": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 536,
+      "line": 548,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "White",
-          "line": 538,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Blue",
-          "line": 539,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Black",
-          "line": 540,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Red",
-          "line": 541,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Green",
-          "line": 542,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Colorless",
-          "line": 544,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Snow",
-          "line": 545,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "X",
-          "line": 546,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TwoOrMoreColorSource",
-          "line": 548,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "`{Z}`: one mana from a source that could produce two or more colors.",
-          "cr_refs": []
-        },
-        {
-          "name": "WhiteBlue",
           "line": 550,
           "kind": "unit",
           "field_names": [],
@@ -18972,7 +19370,7 @@
           "cr_refs": []
         },
         {
-          "name": "WhiteBlack",
+          "name": "Blue",
           "line": 551,
           "kind": "unit",
           "field_names": [],
@@ -18980,7 +19378,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlueBlack",
+          "name": "Black",
           "line": 552,
           "kind": "unit",
           "field_names": [],
@@ -18988,7 +19386,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlueRed",
+          "name": "Red",
           "line": 553,
           "kind": "unit",
           "field_names": [],
@@ -18996,7 +19394,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlackRed",
+          "name": "Green",
           "line": 554,
           "kind": "unit",
           "field_names": [],
@@ -19004,15 +19402,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlackGreen",
-          "line": 555,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RedWhite",
+          "name": "Colorless",
           "line": 556,
           "kind": "unit",
           "field_names": [],
@@ -19020,7 +19410,7 @@
           "cr_refs": []
         },
         {
-          "name": "RedGreen",
+          "name": "Snow",
           "line": 557,
           "kind": "unit",
           "field_names": [],
@@ -19028,7 +19418,7 @@
           "cr_refs": []
         },
         {
-          "name": "GreenWhite",
+          "name": "X",
           "line": 558,
           "kind": "unit",
           "field_names": [],
@@ -19036,23 +19426,15 @@
           "cr_refs": []
         },
         {
-          "name": "GreenBlue",
-          "line": 559,
+          "name": "TwoOrMoreColorSource",
+          "line": 560,
           "kind": "unit",
           "field_names": [],
-          "doc": "",
+          "doc": "`{Z}`: one mana from a source that could produce two or more colors.",
           "cr_refs": []
         },
         {
-          "name": "TwoWhite",
-          "line": 561,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TwoBlue",
+          "name": "WhiteBlue",
           "line": 562,
           "kind": "unit",
           "field_names": [],
@@ -19060,7 +19442,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoBlack",
+          "name": "WhiteBlack",
           "line": 563,
           "kind": "unit",
           "field_names": [],
@@ -19068,7 +19450,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoRed",
+          "name": "BlueBlack",
           "line": 564,
           "kind": "unit",
           "field_names": [],
@@ -19076,7 +19458,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoGreen",
+          "name": "BlueRed",
           "line": 565,
           "kind": "unit",
           "field_names": [],
@@ -19084,7 +19466,15 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhite",
+          "name": "BlackRed",
+          "line": 566,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BlackGreen",
           "line": 567,
           "kind": "unit",
           "field_names": [],
@@ -19092,7 +19482,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlue",
+          "name": "RedWhite",
           "line": 568,
           "kind": "unit",
           "field_names": [],
@@ -19100,7 +19490,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlack",
+          "name": "RedGreen",
           "line": 569,
           "kind": "unit",
           "field_names": [],
@@ -19108,7 +19498,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianRed",
+          "name": "GreenWhite",
           "line": 570,
           "kind": "unit",
           "field_names": [],
@@ -19116,7 +19506,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianGreen",
+          "name": "GreenBlue",
           "line": 571,
           "kind": "unit",
           "field_names": [],
@@ -19124,7 +19514,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhiteBlue",
+          "name": "TwoWhite",
           "line": 573,
           "kind": "unit",
           "field_names": [],
@@ -19132,7 +19522,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhiteBlack",
+          "name": "TwoBlue",
           "line": 574,
           "kind": "unit",
           "field_names": [],
@@ -19140,7 +19530,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlueBlack",
+          "name": "TwoBlack",
           "line": 575,
           "kind": "unit",
           "field_names": [],
@@ -19148,7 +19538,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlueRed",
+          "name": "TwoRed",
           "line": 576,
           "kind": "unit",
           "field_names": [],
@@ -19156,7 +19546,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlackRed",
+          "name": "TwoGreen",
           "line": 577,
           "kind": "unit",
           "field_names": [],
@@ -19164,15 +19554,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlackGreen",
-          "line": 578,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PhyrexianRedWhite",
+          "name": "PhyrexianWhite",
           "line": 579,
           "kind": "unit",
           "field_names": [],
@@ -19180,7 +19562,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianRedGreen",
+          "name": "PhyrexianBlue",
           "line": 580,
           "kind": "unit",
           "field_names": [],
@@ -19188,7 +19570,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianGreenWhite",
+          "name": "PhyrexianBlack",
           "line": 581,
           "kind": "unit",
           "field_names": [],
@@ -19196,7 +19578,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianGreenBlue",
+          "name": "PhyrexianRed",
           "line": 582,
           "kind": "unit",
           "field_names": [],
@@ -19204,15 +19586,15 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessWhite",
-          "line": 584,
+          "name": "PhyrexianGreen",
+          "line": 583,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
-          "name": "ColorlessBlue",
+          "name": "PhyrexianWhiteBlue",
           "line": 585,
           "kind": "unit",
           "field_names": [],
@@ -19220,7 +19602,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessBlack",
+          "name": "PhyrexianWhiteBlack",
           "line": 586,
           "kind": "unit",
           "field_names": [],
@@ -19228,7 +19610,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessRed",
+          "name": "PhyrexianBlueBlack",
           "line": 587,
           "kind": "unit",
           "field_names": [],
@@ -19236,8 +19618,96 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessGreen",
+          "name": "PhyrexianBlueRed",
           "line": 588,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlackRed",
+          "line": 589,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlackGreen",
+          "line": 590,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianRedWhite",
+          "line": 591,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianRedGreen",
+          "line": 592,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianGreenWhite",
+          "line": 593,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianGreenBlue",
+          "line": 594,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessWhite",
+          "line": 596,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessBlue",
+          "line": 597,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessBlack",
+          "line": 598,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessRed",
+          "line": 599,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessGreen",
+          "line": 600,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -19248,7 +19718,7 @@
     },
     "ManaExpiry": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 468,
+      "line": 480,
       "doc": "When mana expires — controls lifecycle beyond the normal CR 106.4 step/phase drain.",
       "cr_refs": [
         "CR 106.4"
@@ -19256,7 +19726,7 @@
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 471,
+          "line": 483,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana persists through normal step/phase drains until the turn reaches cleanup. Used by \"Until end of turn, you don't lose this mana as steps and phases end.\"",
@@ -19264,7 +19734,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 474,
+          "line": 486,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana persists through combat steps but drains at EndCombat → PostCombatMain. Used by Firebending and similar \"mana lasts within combat\" mechanics.",
@@ -19275,7 +19745,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11316,
+      "line": 11445,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -19284,7 +19754,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 11319,
+          "line": 11448,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -19296,7 +19766,7 @@
         },
         {
           "name": "Multiply",
-          "line": 11322,
+          "line": 11451,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -19542,7 +20012,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11328,
+      "line": 11457,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -19551,7 +20021,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 11331,
+          "line": 11460,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -19559,7 +20029,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 11333,
+          "line": 11462,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -19693,7 +20163,7 @@
     },
     "ManaSpellGrant": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 454,
+      "line": 466,
       "doc": "CR 106.6: Additional effect that the mana confers upon the spell it is spent on. E.g., \"that spell can't be countered\" (Cavern of Souls, Delighted Halfling).",
       "cr_refs": [
         "CR 106.6"
@@ -19701,7 +20171,7 @@
       "variants": [
         {
           "name": "CantBeCountered",
-          "line": 456,
+          "line": 468,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell cast with this mana can't be countered.",
@@ -19709,7 +20179,7 @@
         },
         {
           "name": "AddKeywordUntilEndOfTurn",
-          "line": 459,
+          "line": 471,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -20017,13 +20487,13 @@
     },
     "MayTriggerOrigin": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 492,
+      "line": 519,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Printed",
-          "line": 493,
+          "line": 520,
           "kind": "struct",
           "field_names": [
             "trigger_index"
@@ -20033,7 +20503,7 @@
         },
         {
           "name": "Keyword",
-          "line": 494,
+          "line": 521,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -20046,13 +20516,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8956,
+      "line": 9053,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 8958,
+          "line": 9055,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -20064,7 +20534,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 8961,
+          "line": 9058,
           "kind": "struct",
           "field_names": [
             "source",
@@ -20083,13 +20553,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8936,
+      "line": 9033,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 8937,
+          "line": 9034,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20097,7 +20567,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 8940,
+          "line": 9037,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -20112,7 +20582,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 8947,
+          "line": 9044,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -20122,7 +20592,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 8950,
+          "line": 9047,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -20175,7 +20645,7 @@
     },
     "NextSpellModifier": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 304,
+      "line": 313,
       "doc": "CR 601.2f: The kind of modification to apply to the next qualifying spell.",
       "cr_refs": [
         "CR 601.2f"
@@ -20183,7 +20653,7 @@
       "variants": [
         {
           "name": "CantBeCountered",
-          "line": 306,
+          "line": 315,
           "kind": "unit",
           "field_names": [],
           "doc": "\"The next spell you cast this turn can't be countered.\"",
@@ -20191,7 +20661,7 @@
         },
         {
           "name": "HasKeyword",
-          "line": 308,
+          "line": 317,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -20201,7 +20671,7 @@
         },
         {
           "name": "CastAsThoughFlash",
-          "line": 310,
+          "line": 319,
           "kind": "unit",
           "field_names": [],
           "doc": "\"The next spell you cast this turn can be cast as though it had flash.\"",
@@ -20209,7 +20679,7 @@
         },
         {
           "name": "WithoutPayingManaCost",
-          "line": 313,
+          "line": 322,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9a: \"The next [filter] spell you cast this turn can be cast without paying its mana cost.\" Additional costs still apply (CR 118.8).",
@@ -20223,7 +20693,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4579,
+      "line": 4598,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -20233,7 +20703,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 4581,
+          "line": 4600,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -20243,7 +20713,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 4583,
+          "line": 4602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -20256,13 +20726,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3453,
+      "line": 3472,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 3454,
+          "line": 3473,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20270,7 +20740,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3455,
+          "line": 3474,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20278,7 +20748,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 3456,
+          "line": 3475,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20289,13 +20759,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2839,
+      "line": 2843,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2845,
+          "line": 2849,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -20306,7 +20776,7 @@
         },
         {
           "name": "Target",
-          "line": 2848,
+          "line": 2852,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -20316,7 +20786,7 @@
         },
         {
           "name": "Recipient",
-          "line": 2854,
+          "line": 2858,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -20327,7 +20797,7 @@
         },
         {
           "name": "EventSource",
-          "line": 2856,
+          "line": 2860,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -20337,7 +20807,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2863,
+          "line": 2867,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -20350,7 +20820,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 2879,
+          "line": 2883,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric **pronoun** (\"it\" / \"its\") whose object referent is bound at parse time. The parser rebinds this to a concrete scope wherever the enclosing clause establishes the antecedent — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\", `EventSource` when the subject is the triggering object. The rebind ([`rebind_anaphoric_object_scope`] in `parser/oracle_effect/mod.rs`) covers every per-object characteristic (power, toughness, mana value, …) — not just power — because the pronoun refers to one object and the rebind only retargets *which* object, never *which* characteristic. When no clause subject applies (triggered-ability anaphora) `Anaphoric` survives to runtime, where it resolves identically to a demonstrative (effect-context referent first; see [`ObjectScope::Demonstrative`]). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work.",
@@ -20360,7 +20830,7 @@
         },
         {
           "name": "Demonstrative",
-          "line": 2896,
+          "line": 2900,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: A **demonstrative / definite** possessive back-reference (\"that creature's\", \"that card's\", \"that spell's\", \"the creature's\") whose antecedent is a full noun phrase naming an object introduced by an earlier instruction in the same ability — *not* the grammatical subject of the clause it appears in. Unlike [`ObjectScope::Anaphoric`] (the pronoun \"its\"), the subject-injection rewrite MUST NOT rebind this — its antecedent is fixed by the Oracle text. Steadfast Armasaur (\"its toughness\", `Anaphoric` → rebound to `Source`) and Creature Bond (\"that creature's toughness\", `Demonstrative` → never rebound) parse to the same `QuantityRef` property and differ only by this scope: collapsing them caused the LKI-toughness bug. At runtime `Demonstrative` resolves identically to `Anaphoric` — `effect_context_object` (CR 608.2c instruction-order referent) first, then the trigger source (CR 608.2k), then the cost-paid object. This is the Yuriko / Dark Confidant / Mana Drain class (issue #511): a reveal/counter/reanimate earlier in the same ability binds \"that <type>'s\" to the referenced object.",
@@ -20374,7 +20844,7 @@
     },
     "OpeningHandBottomReason": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1596,
+      "line": 1839,
       "doc": "CR 103.5 / TL:R 906.6a: Why a player is bottoming cards from an opening hand before the normal mulligan-decision step.",
       "cr_refs": [
         "CR 103.5"
@@ -20382,7 +20852,7 @@
       "variants": [
         {
           "name": "TinyLeadersMultiCommander",
-          "line": 1597,
+          "line": 1840,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20412,7 +20882,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10786,
+      "line": 10895,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -20422,7 +20892,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 10788,
+          "line": 10897,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -20430,7 +20900,7 @@
         },
         {
           "name": "Equals",
-          "line": 10790,
+          "line": 10899,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -20438,7 +20908,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 10793,
+          "line": 10902,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -20446,7 +20916,7 @@
         },
         {
           "name": "OneOf",
-          "line": 10795,
+          "line": 10904,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -20457,7 +20927,7 @@
     },
     "OutsideGameChoiceSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1546,
+      "line": 1789,
       "doc": "CR 400.11 + CR 406.3: A discriminated source for one outside-game selection. Sideboard entries (the wishboard pool) and face-up exile cards (the Karn / Coax wishboard return pool) are surfaced through one choice list so the caster picks across both pools in a single decision.  The size delta between the two variants (`Sideboard` carries a full `CardFace` so the UI can render the wishboard card without a sideboard lookup; `FaceUpExile` holds only an `ObjectId`) is intentional — `OutsideGameChoiceEntry` lists are short-lived (one entry per offered candidate while a single `WaitingFor::OutsideGameChoice` is active) and never collected by the million, so the asymmetry doesn't warrant boxing every CardFace through a heap indirection.",
       "cr_refs": [
         "CR 400.11",
@@ -20466,7 +20936,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 1548,
+          "line": 1791,
           "kind": "struct",
           "field_names": [
             "sideboard_index",
@@ -20479,7 +20949,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 1553,
+          "line": 1796,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -20588,7 +21058,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4299,
+      "line": 4318,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -20597,7 +21067,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 4300,
+          "line": 4319,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -20607,7 +21077,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 4304,
+          "line": 4323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -20617,7 +21087,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 4305,
+          "line": 4324,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20625,7 +21095,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 4307,
+          "line": 4326,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -20635,7 +21105,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 4308,
+          "line": 4327,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -20645,7 +21115,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 4311,
+          "line": 4330,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -20656,7 +21126,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 4315,
+          "line": 4334,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -20666,7 +21136,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 4319,
+          "line": 4338,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -20676,7 +21146,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 4321,
+          "line": 4340,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -20686,7 +21156,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 4322,
+          "line": 4341,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20694,7 +21164,7 @@
         },
         {
           "name": "SourceAttachedTo",
-          "line": 4326,
+          "line": 4345,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -20707,7 +21177,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 4329,
+          "line": 4348,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -20717,7 +21187,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 4332,
+          "line": 4351,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -20727,7 +21197,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 4335,
+          "line": 4354,
           "kind": "struct",
           "field_names": [
             "color"
@@ -20737,7 +21207,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 4338,
+          "line": 4357,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20745,7 +21215,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 4339,
+          "line": 4358,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20753,7 +21223,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 4340,
+          "line": 4359,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20761,7 +21231,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 4341,
+          "line": 4360,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -20772,7 +21242,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 4345,
+          "line": 4364,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -20783,7 +21253,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 4349,
+          "line": 4368,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -20795,7 +21265,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 4354,
+          "line": 4373,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20805,7 +21275,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 4357,
+          "line": 4376,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20815,7 +21285,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 4360,
+          "line": 4379,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -20825,7 +21295,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 4365,
+          "line": 4384,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -20837,7 +21307,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4374,
+          "line": 4393,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -20852,7 +21322,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 4379,
+          "line": 4398,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -20862,7 +21332,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 4382,
+          "line": 4401,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -20872,7 +21342,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 4385,
+          "line": 4404,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -20883,7 +21353,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 4389,
+          "line": 4408,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -20894,7 +21364,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 4393,
+          "line": 4412,
           "kind": "struct",
           "field_names": [
             "color",
@@ -20905,7 +21375,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 4397,
+          "line": 4416,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -20915,7 +21385,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 4400,
+          "line": 4419,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20923,7 +21393,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 4401,
+          "line": 4420,
           "kind": "struct",
           "field_names": [
             "name"
@@ -20933,7 +21403,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 4408,
+          "line": 4427,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -20946,7 +21416,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 4412,
+          "line": 4431,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -20956,7 +21426,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 4415,
+          "line": 4434,
           "kind": "struct",
           "field_names": [
             "power",
@@ -20967,7 +21437,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 4419,
+          "line": 4438,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20975,7 +21445,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 4420,
+          "line": 4439,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20985,7 +21455,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 4423,
+          "line": 4442,
           "kind": "struct",
           "field_names": [
             "count"
@@ -20995,7 +21465,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 4426,
+          "line": 4445,
           "kind": "struct",
           "field_names": [
             "count"
@@ -21005,7 +21475,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 4429,
+          "line": 4448,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21013,7 +21483,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 4430,
+          "line": 4449,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21021,7 +21491,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 4431,
+          "line": 4450,
           "kind": "struct",
           "field_names": [
             "count"
@@ -21031,7 +21501,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 4437,
+          "line": 4456,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -21039,7 +21509,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 4440,
+          "line": 4459,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21052,7 +21522,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 4444,
+          "line": 4463,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21060,7 +21530,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 4445,
+          "line": 4464,
           "kind": "struct",
           "field_names": [
             "count"
@@ -21070,7 +21540,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 4448,
+          "line": 4467,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21078,7 +21548,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 4449,
+          "line": 4468,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21086,7 +21556,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 4450,
+          "line": 4469,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21094,7 +21564,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 4451,
+          "line": 4470,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21102,7 +21572,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 4453,
+          "line": 4472,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -21112,7 +21582,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 4454,
+          "line": 4473,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21120,7 +21590,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 4455,
+          "line": 4474,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21128,7 +21598,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 4456,
+          "line": 4475,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21136,7 +21606,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4457,
+          "line": 4476,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -21147,7 +21617,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 4461,
+          "line": 4480,
           "kind": "struct",
           "field_names": [
             "count"
@@ -21157,7 +21627,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 4466,
+          "line": 4485,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -21170,7 +21640,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4471,
+          "line": 4490,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -21180,7 +21650,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 4479,
+          "line": 4498,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -21190,7 +21660,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 4492,
+          "line": 4511,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21204,7 +21674,7 @@
         },
         {
           "name": "And",
-          "line": 4500,
+          "line": 4519,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -21217,7 +21687,7 @@
         },
         {
           "name": "Or",
-          "line": 4506,
+          "line": 4525,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -21230,7 +21700,7 @@
         },
         {
           "name": "Not",
-          "line": 4513,
+          "line": 4532,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -21246,7 +21716,7 @@
     },
     "PartnerType": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 255,
+      "line": 269,
       "doc": "CR 702.124: Partner variant keywords for co-commander deckbuilding. Each variant specifies which other partner types it can legally pair with.",
       "cr_refs": [
         "CR 702.124"
@@ -21254,7 +21724,7 @@
       "variants": [
         {
           "name": "Generic",
-          "line": 257,
+          "line": 271,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124a: Generic \"Partner\" — pairs with any other generic Partner.",
@@ -21264,7 +21734,7 @@
         },
         {
           "name": "With",
-          "line": 259,
+          "line": 273,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.124c: \"Partner with [Name]\" — pairs only with the named card.",
@@ -21274,7 +21744,7 @@
         },
         {
           "name": "FriendsForever",
-          "line": 261,
+          "line": 275,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124f: \"Friends forever\" — pairs with any other Friends Forever card.",
@@ -21284,7 +21754,7 @@
         },
         {
           "name": "CharacterSelect",
-          "line": 263,
+          "line": 277,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124: \"Partner—Character select\" — pairs with any other Character Select card.",
@@ -21294,7 +21764,7 @@
         },
         {
           "name": "DoctorsCompanion",
-          "line": 265,
+          "line": 279,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124: \"Doctor's companion\" — pairs with any creature with the Doctor subtype.",
@@ -21304,7 +21774,7 @@
         },
         {
           "name": "ChooseABackground",
-          "line": 267,
+          "line": 281,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.124: \"Choose a Background\" — pairs with any enchantment with Background subtype.",
@@ -21317,7 +21787,7 @@
     },
     "PayCostKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1763,
+      "line": 2015,
       "doc": "CR 118.3 + CR 601.2b + CR 605.3b: Identifies the specific action to take on the objects a player selects while paying a cost.",
       "cr_refs": [
         "CR 118.3",
@@ -21327,7 +21797,7 @@
       "variants": [
         {
           "name": "Discard",
-          "line": 1764,
+          "line": 2016,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21335,7 +21805,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 1765,
+          "line": 2017,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21343,7 +21813,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 1766,
+          "line": 2018,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21351,7 +21821,7 @@
         },
         {
           "name": "ExileFromZone",
-          "line": 1768,
+          "line": 2020,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -21361,7 +21831,7 @@
         },
         {
           "name": "ExileMaterials",
-          "line": 1775,
+          "line": 2027,
           "kind": "struct",
           "field_names": [
             "materials"
@@ -21373,7 +21843,7 @@
         },
         {
           "name": "ExileFromManaZone",
-          "line": 1779,
+          "line": 2031,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -21383,7 +21853,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 1782,
+          "line": 2034,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -21393,7 +21863,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 1785,
+          "line": 2037,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21401,7 +21871,7 @@
         },
         {
           "name": "Behold",
-          "line": 1786,
+          "line": 2038,
           "kind": "struct",
           "field_names": [
             "action"
@@ -21414,7 +21884,7 @@
     },
     "PayableResource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3266,
+      "line": 3552,
       "doc": "CR 107.14 + CR 118.8: Resource that can be paid in a \"pay any amount of X\" prompt. Typed so the same `WaitingFor::PayAmountChoice` variant generalizes to future classes (energy, life, mana) without re-introducing boolean flags.",
       "cr_refs": [
         "CR 107.14",
@@ -21423,7 +21893,7 @@
       "variants": [
         {
           "name": "Energy",
-          "line": 3268,
+          "line": 3554,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.",
@@ -21433,7 +21903,7 @@
         },
         {
           "name": "ManaGeneric",
-          "line": 3270,
+          "line": 3556,
           "kind": "struct",
           "field_names": [
             "per_x"
@@ -21487,7 +21957,7 @@
     },
     "PaymentCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4526,
+      "line": 4545,
       "doc": "CR 118.1: A cost paid as part of an effect's resolution. Distinct from AbilityCost (which gates activation before the colon).",
       "cr_refs": [
         "CR 118.1"
@@ -21495,7 +21965,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 4527,
+          "line": 4546,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -21505,7 +21975,7 @@
         },
         {
           "name": "Life",
-          "line": 4535,
+          "line": 4554,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -21518,7 +21988,7 @@
         },
         {
           "name": "Speed",
-          "line": 4539,
+          "line": 4558,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -21531,7 +22001,7 @@
         },
         {
           "name": "Energy",
-          "line": 4544,
+          "line": 4563,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -21543,7 +22013,7 @@
         },
         {
           "name": "AbilityCost",
-          "line": 4551,
+          "line": 4570,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -21556,7 +22026,7 @@
         },
         {
           "name": "ScaledMana",
-          "line": 4561,
+          "line": 4580,
           "kind": "struct",
           "field_names": [
             "base",
@@ -21573,7 +22043,7 @@
     },
     "PendingCoinFlipKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 791,
+      "line": 841,
       "doc": "CR 705.1 + CR 614.1a: Discriminates which multi-flip resolver paused for a Krark's Thumb keep-1 choice, carrying the loop position needed to re-enter.",
       "cr_refs": [
         "CR 614.1a",
@@ -21582,7 +22052,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 793,
+          "line": 843,
           "kind": "unit",
           "field_names": [],
           "doc": "`Effect::FlipCoin` — a single logical flip.",
@@ -21590,7 +22060,7 @@
         },
         {
           "name": "FlipN",
-          "line": 796,
+          "line": 846,
           "kind": "struct",
           "field_names": [
             "remaining"
@@ -21600,12 +22070,265 @@
         },
         {
           "name": "UntilLose",
-          "line": 799,
+          "line": 849,
           "kind": "struct",
           "field_names": [
             "wins_so_far"
           ],
           "doc": "`Effect::FlipCoinUntilLose` — `wins_so_far` flips won before the one currently paused for a keep choice.",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "PendingCounterAddition": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 1170,
+      "doc": "",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "Object",
+          "line": 1171,
+          "kind": "struct",
+          "field_names": [
+            "actor",
+            "object_id",
+            "counter_type",
+            "count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Player",
+          "line": 1177,
+          "kind": "struct",
+          "field_names": [
+            "actor",
+            "player_id",
+            "counter_kind",
+            "count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Energy",
+          "line": 1183,
+          "kind": "struct",
+          "field_names": [
+            "actor",
+            "player_id",
+            "count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "PendingCounterPostAction": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 1085,
+      "doc": "",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "EmitEffectResolved",
+          "line": 1086,
+          "kind": "struct",
+          "field_names": [
+            "kind",
+            "source_id"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RecordPlayerAction",
+          "line": 1090,
+          "kind": "struct",
+          "field_names": [
+            "player_id",
+            "action"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AddSubtype",
+          "line": 1094,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "subtype"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "InjectPredefinedTokenAbilities",
+          "line": 1098,
+          "kind": "struct",
+          "field_names": [
+            "object_id"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "FinalizeTokenEntry",
+          "line": 1101,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "name",
+            "attach_to",
+            "sacrifice_at",
+            "source_id",
+            "controller"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ContinueTokenCreation",
+          "line": 1109,
+          "kind": "struct",
+          "field_names": [
+            "owner",
+            "spec",
+            "enter_tapped",
+            "remaining_count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "FinalizeCopyTokenEntry",
+          "line": 1115,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "name",
+            "enters_attacking",
+            "source_id",
+            "controller"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ContinueCopyTokenCreation",
+          "line": 1122,
+          "kind": "struct",
+          "field_names": [
+            "owner",
+            "copy",
+            "enter_tapped",
+            "enter_with_counters",
+            "remaining_count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ApplyCopyTokenModificationsAndFinalize",
+          "line": 1129,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "name",
+            "enters_attacking",
+            "source_id",
+            "controller",
+            "remaining_modifications"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ClearPendingEtbCounters",
+          "line": 1137,
+          "kind": "struct",
+          "field_names": [
+            "object_id"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ContinueZoneDeliveryTail",
+          "line": 1140,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "from",
+            "to",
+            "cause",
+            "source_id",
+            "duration",
+            "exile_tracking"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RecordStationed",
+          "line": 1149,
+          "kind": "struct",
+          "field_names": [
+            "spacecraft_id",
+            "creature_id",
+            "counters_added"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MarkMonstrous",
+          "line": 1154,
+          "kind": "struct",
+          "field_names": [
+            "object_id"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MarkRenowned",
+          "line": 1157,
+          "kind": "struct",
+          "field_names": [
+            "object_id"
+          ],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "PendingEffectResolutionEvent": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 1072,
+      "doc": "",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "Emit",
+          "line": 1074,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Suppress",
+          "line": 1075,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
           "cr_refs": []
         }
       ],
@@ -21792,7 +22515,7 @@
     },
     "PileSide": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1683,
+      "line": 1926,
       "doc": "CR 700.3: Identifies one of the two piles produced by a `SeparateIntoPiles` partition. Typed rather than `bool` so the `GameAction::ChoosePile` payload and the engine handler share a self-documenting domain and the parser/AI cannot accidentally swap pile semantics. Pile A is the partitioner's chosen subset; pile B is `eligible \\ pile_a`.",
       "cr_refs": [
         "CR 700.3"
@@ -21800,7 +22523,7 @@
       "variants": [
         {
           "name": "A",
-          "line": 1684,
+          "line": 1927,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21808,7 +22531,7 @@
         },
         {
           "name": "B",
-          "line": 1685,
+          "line": 1928,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21934,13 +22657,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3552,
+      "line": 3571,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 3556,
+          "line": 3575,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -21950,7 +22673,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3558,
+          "line": 3577,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -21958,7 +22681,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3560,
+          "line": 3579,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -21968,7 +22691,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 3562,
+          "line": 3581,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -21976,7 +22699,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 3564,
+          "line": 3583,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -21984,7 +22707,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 3574,
+          "line": 3593,
           "kind": "struct",
           "field_names": [
             "source"
@@ -21999,7 +22722,7 @@
         },
         {
           "name": "OpponentAttacked",
-          "line": 3588,
+          "line": 3607,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -22015,7 +22738,7 @@
         },
         {
           "name": "All",
-          "line": 3593,
+          "line": 3612,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -22023,7 +22746,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 3595,
+          "line": 3614,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -22033,7 +22756,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 3598,
+          "line": 3617,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -22041,7 +22764,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 3602,
+          "line": 3621,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -22055,7 +22778,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 3608,
+          "line": 3627,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -22063,7 +22786,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3612,
+          "line": 3631,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -22074,7 +22797,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 3621,
+          "line": 3640,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -22085,7 +22808,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 3632,
+          "line": 3651,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -22098,7 +22821,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3644,
+          "line": 3663,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -22109,7 +22832,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 3666,
+          "line": 3685,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -22125,7 +22848,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 3692,
+          "line": 3711,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -22155,7 +22878,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3521,
+      "line": 3540,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -22165,7 +22888,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3523,
+          "line": 3542,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -22173,7 +22896,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3525,
+          "line": 3544,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -22181,7 +22904,7 @@
         },
         {
           "name": "All",
-          "line": 3527,
+          "line": 3546,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -22192,7 +22915,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2780,
+      "line": 2784,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -22202,7 +22925,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 2782,
+          "line": 2786,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -22213,7 +22936,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2786,
+          "line": 2790,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -22224,7 +22947,7 @@
         },
         {
           "name": "Target",
-          "line": 2789,
+          "line": 2793,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -22236,7 +22959,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2793,
+          "line": 2797,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -22249,7 +22972,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2798,
+          "line": 2802,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -22262,7 +22985,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 2812,
+          "line": 2816,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -22273,7 +22996,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2818,
+          "line": 2822,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -22284,7 +23007,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 2824,
+          "line": 2828,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -22295,7 +23018,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 2831,
+          "line": 2835,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.1 + CR 109.4: The player PERSISTED on the source via `ChosenAttribute::Player` (an \"as ~ enters the battlefield, choose a player\" replacement). The player-scalar-axis analogue of `ControllerRef::SourceChosenPlayer`, read continuously from the source's `chosen_attributes` so a CDA P/T can track e.g. the chosen player's hand or graveyard size (Entropic Specter, Sewer Nemesis).",
@@ -22336,7 +23059,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11434,
+      "line": 11565,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -22345,7 +23068,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 11435,
+          "line": 11566,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -22353,7 +23076,7 @@
         },
         {
           "name": "Resolved",
-          "line": 11436,
+          "line": 11567,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -22418,7 +23141,7 @@
     },
     "ProductionOverride": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1181,
+      "line": 1424,
       "doc": "CR 605.3b + CR 106.1a: A pre-resolved choice that short-circuits the normal `ChooseManaColor` prompt. Auto-tap sets this when the cost-payment planner has already determined the exact mana to produce; manual activation leaves it `None` so the player is prompted.  Typed enum (never a bool): `SingleColor` covers the one-color-repeated variants (`AnyOneColor`, `ChoiceAmongExiledColors`), while `Combination` carries the full pre-chosen multi-mana sequence for fixed combinations (`ChoiceAmongCombinations`) and free per-slot choices (`AnyCombination`).",
       "cr_refs": [
         "CR 106.1a",
@@ -22427,7 +23150,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1185,
+          "line": 1428,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked a single color; every unit of mana the ability produces becomes this color (mirrors the pre-widening `Option<ManaType>` semantics).",
@@ -22435,7 +23158,7 @@
         },
         {
           "name": "Combination",
-          "line": 1188,
+          "line": 1431,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked one complete mana sequence; the ability produces exactly these mana types in order.",
@@ -22494,7 +23217,7 @@
     },
     "ProhibitionScope": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 26,
+      "line": 27,
       "doc": "CR 109.5 + CR 102.1: The \"who\" axis of a continuous prohibition static.  Shared across the prohibition family (casting, drawing, searching, activating). CR 109.5: The words \"you\" and \"your\" on an object refer to the object's controller. CR 102.1: \"opponent\" is defined relative to a given player's controller. Wire format (`Display` / `FromStr`) is preserved: `\"opponents\"`, `\"all_players\"`, `\"controller\"`, `\"enchanted_creature_controller\"` — do NOT change these strings, they are serialized into card-data JSON.",
       "cr_refs": [
         "CR 102.1",
@@ -22503,7 +23226,7 @@
       "variants": [
         {
           "name": "Opponents",
-          "line": 28,
+          "line": 29,
           "kind": "unit",
           "field_names": [],
           "doc": "\"your opponents\" — only the controller's opponents are prohibited.",
@@ -22511,7 +23234,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 30,
+          "line": 31,
           "kind": "unit",
           "field_names": [],
           "doc": "\"players\" / \"each player\" — all players are prohibited.",
@@ -22519,7 +23242,7 @@
         },
         {
           "name": "Controller",
-          "line": 32,
+          "line": 33,
           "kind": "unit",
           "field_names": [],
           "doc": "\"you\" — only the controller is prohibited.",
@@ -22527,7 +23250,7 @@
         },
         {
           "name": "EnchantedCreatureController",
-          "line": 35,
+          "line": 36,
           "kind": "unit",
           "field_names": [],
           "doc": "\"enchanted creature's controller\" — the controller of the creature this aura enchants. CR 303.4e: Used by auras that restrict the enchanted creature's controller.",
@@ -22540,13 +23263,13 @@
     },
     "ProposedEvent": {
       "file": "crates/engine/src/types/proposed_event.rs",
-      "line": 156,
+      "line": 201,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ZoneChange",
-          "line": 157,
+          "line": 202,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -22566,7 +23289,7 @@
         },
         {
           "name": "Damage",
-          "line": 196,
+          "line": 241,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -22580,7 +23303,7 @@
         },
         {
           "name": "Draw",
-          "line": 203,
+          "line": 248,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22592,7 +23315,7 @@
         },
         {
           "name": "Scry",
-          "line": 210,
+          "line": 255,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22607,7 +23330,7 @@
         },
         {
           "name": "Mill",
-          "line": 218,
+          "line": 263,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22623,7 +23346,7 @@
         },
         {
           "name": "CoinFlip",
-          "line": 228,
+          "line": 273,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22638,7 +23361,7 @@
         },
         {
           "name": "LifeGain",
-          "line": 233,
+          "line": 278,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22650,7 +23373,7 @@
         },
         {
           "name": "LifeLoss",
-          "line": 238,
+          "line": 283,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22662,12 +23385,10 @@
         },
         {
           "name": "AddCounter",
-          "line": 243,
+          "line": 288,
           "kind": "struct",
           "field_names": [
-            "actor",
-            "object_id",
-            "counter_type",
+            "placement",
             "count",
             "applied"
           ],
@@ -22676,7 +23397,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 251,
+          "line": 297,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -22689,7 +23410,7 @@
         },
         {
           "name": "MoveCounter",
-          "line": 260,
+          "line": 306,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -22708,7 +23429,7 @@
         },
         {
           "name": "CreateToken",
-          "line": 280,
+          "line": 326,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -22726,7 +23447,7 @@
         },
         {
           "name": "Discard",
-          "line": 299,
+          "line": 345,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22739,7 +23460,7 @@
         },
         {
           "name": "Tap",
-          "line": 306,
+          "line": 352,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -22750,7 +23471,7 @@
         },
         {
           "name": "Untap",
-          "line": 310,
+          "line": 356,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -22761,7 +23482,7 @@
         },
         {
           "name": "Destroy",
-          "line": 314,
+          "line": 360,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -22774,7 +23495,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 321,
+          "line": 367,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -22786,7 +23507,7 @@
         },
         {
           "name": "BeginTurn",
-          "line": 332,
+          "line": 378,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22803,7 +23524,7 @@
         },
         {
           "name": "BeginPhase",
-          "line": 342,
+          "line": 388,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22818,7 +23539,7 @@
         },
         {
           "name": "ProduceMana",
-          "line": 351,
+          "line": 397,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -22836,7 +23557,7 @@
         },
         {
           "name": "EmptyManaPool",
-          "line": 380,
+          "line": 426,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -22856,7 +23577,7 @@
     },
     "ProtectionTarget": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 329,
+      "line": 343,
       "doc": "What a Protection keyword protects from (CR 702.16).",
       "cr_refs": [
         "CR 702.16"
@@ -22864,7 +23585,7 @@
       "variants": [
         {
           "name": "Color",
-          "line": 330,
+          "line": 344,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -22872,7 +23593,7 @@
         },
         {
           "name": "CardType",
-          "line": 331,
+          "line": 345,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -22880,7 +23601,7 @@
         },
         {
           "name": "Quality",
-          "line": 332,
+          "line": 346,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -22888,7 +23609,7 @@
         },
         {
           "name": "Multicolored",
-          "line": 333,
+          "line": 347,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22896,7 +23617,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 336,
+          "line": 350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16: Protection from the chosen color — resolved at runtime from the source permanent's `chosen_attributes`.",
@@ -22906,7 +23627,7 @@
         },
         {
           "name": "ChosenCardType",
-          "line": 340,
+          "line": 354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16 + CR 205.2: \"Protection from the chosen card type\" — resolved at runtime from the source permanent's `chosen_attributes` (the `CardType` chosen as the permanent entered). Parallels `ChosenColor`.",
@@ -22917,7 +23638,7 @@
         },
         {
           "name": "Everything",
-          "line": 344,
+          "line": 358,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16j: \"Protection from everything\" — protection from each object regardless of that object's characteristic values. Matches every source in `source_matches_protection_target`.",
@@ -22927,7 +23648,7 @@
         },
         {
           "name": "Filter",
-          "line": 352,
+          "line": 366,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.16a: \"Protection from [quality]\" where the quality is a characteristic-value predicate expressible as a `TargetFilter`. Covers \"protection from mana value N or less/greater\" and any future filter-based protection (e.g., \"protection from power 2 or less\"). Evaluated by testing the source object's characteristics against the filter's properties — only `FilterProp` predicates that can be resolved from the object alone (without game state) are valid here.",
@@ -22937,7 +23658,7 @@
         },
         {
           "name": "FromPlayer",
-          "line": 360,
+          "line": 374,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.16k: \"Protection from [a player]\" — protection from each object controlled by the scoped player(s), relative to the protected object's controller, regardless of the source's characteristic values. Covers \"protection from each of your opponents\" (Figure of Fable's Avatar form) via `ControllerRef::Opponent`. CR 702.16i makes \"each of your opponents\" behave as protection from every opponent, which the Opponent scope captures in one variant.",
@@ -22951,7 +23672,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3936,
+      "line": 3955,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -22959,7 +23680,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 3938,
+          "line": 3957,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -22969,7 +23690,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3940,
+          "line": 3959,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -22979,7 +23700,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 3942,
+          "line": 3961,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -23025,7 +23746,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3951,
+      "line": 3970,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -23034,7 +23755,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 3954,
+          "line": 3973,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -23044,7 +23765,7 @@
         },
         {
           "name": "Base",
-          "line": 3957,
+          "line": 3976,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -23057,13 +23778,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3704,
+      "line": 3723,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 3706,
+          "line": 3725,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -23073,7 +23794,7 @@
         },
         {
           "name": "Fixed",
-          "line": 3708,
+          "line": 3727,
           "kind": "struct",
           "field_names": [
             "value"
@@ -23083,7 +23804,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 3712,
+          "line": 3731,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -23097,7 +23818,7 @@
         },
         {
           "name": "Offset",
-          "line": 3719,
+          "line": 3738,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -23110,7 +23831,7 @@
         },
         {
           "name": "ClampMin",
-          "line": 3728,
+          "line": 3747,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -23123,7 +23844,7 @@
         },
         {
           "name": "Multiply",
-          "line": 3733,
+          "line": 3752,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -23134,7 +23855,7 @@
         },
         {
           "name": "Sum",
-          "line": 3742,
+          "line": 3761,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -23144,7 +23865,7 @@
         },
         {
           "name": "UpTo",
-          "line": 3767,
+          "line": 3786,
           "kind": "struct",
           "field_names": [
             "max"
@@ -23157,7 +23878,7 @@
         },
         {
           "name": "Power",
-          "line": 3773,
+          "line": 3792,
           "kind": "struct",
           "field_names": [
             "base",
@@ -23170,7 +23891,7 @@
         },
         {
           "name": "Difference",
-          "line": 3788,
+          "line": 3807,
           "kind": "struct",
           "field_names": [
             "left",
@@ -23186,7 +23907,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11282,
+      "line": 11411,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -23194,7 +23915,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 11284,
+          "line": 11413,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -23202,7 +23923,7 @@
         },
         {
           "name": "Plus",
-          "line": 11286,
+          "line": 11415,
           "kind": "struct",
           "field_names": [
             "value"
@@ -23212,7 +23933,7 @@
         },
         {
           "name": "Minus",
-          "line": 11288,
+          "line": 11417,
           "kind": "struct",
           "field_names": [
             "value"
@@ -23222,7 +23943,7 @@
         },
         {
           "name": "Prevent",
-          "line": 11308,
+          "line": 11437,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -23239,13 +23960,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2935,
+      "line": 2939,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 2939,
+          "line": 2943,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23257,7 +23978,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 2942,
+          "line": 2946,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23269,7 +23990,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 2948,
+          "line": 2952,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23281,7 +24002,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 2951,
+          "line": 2955,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -23289,7 +24010,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 2953,
+          "line": 2957,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -23299,7 +24020,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 2956,
+          "line": 2960,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23309,7 +24030,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 2973,
+          "line": 2977,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -23323,7 +24044,7 @@
         },
         {
           "name": "ObjectCountBySharedQuality",
-          "line": 2983,
+          "line": 2987,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -23338,7 +24059,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 2990,
+          "line": 2994,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23348,7 +24069,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 3011,
+          "line": 3015,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -23361,7 +24082,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 3020,
+          "line": 3024,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -23374,7 +24095,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 3039,
+          "line": 3043,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -23391,7 +24112,7 @@
         },
         {
           "name": "Variable",
-          "line": 3044,
+          "line": 3048,
           "kind": "struct",
           "field_names": [
             "name"
@@ -23401,7 +24122,7 @@
         },
         {
           "name": "Power",
-          "line": 3051,
+          "line": 3055,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -23415,7 +24136,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3056,
+          "line": 3060,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -23429,7 +24150,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 3062,
+          "line": 3066,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -23442,7 +24163,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 3068,
+          "line": 3072,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -23455,7 +24176,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 3073,
+          "line": 3077,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -23467,8 +24188,22 @@
           ]
         },
         {
+          "name": "ObjectTypelineComponentCount",
+          "line": 3081,
+          "kind": "struct",
+          "field_names": [
+            "scope"
+          ],
+          "doc": "CR 205.4a + CR 205.2a + CR 205.3: Number of typeline components on an object (supertypes + core card types + subtypes). Embiggen: \"+1/+1 for each supertype, card type, and subtype it has.\"",
+          "cr_refs": [
+            "CR 205.2a",
+            "CR 205.3",
+            "CR 205.4a"
+          ]
+        },
+        {
           "name": "ManaSymbolsInManaCost",
-          "line": 3080,
+          "line": 3088,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -23482,7 +24217,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 3092,
+          "line": 3100,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -23494,7 +24229,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 3094,
+          "line": 3102,
           "kind": "struct",
           "field_names": [
             "function",
@@ -23508,7 +24243,7 @@
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 3111,
+          "line": 3119,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -23522,7 +24257,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 3118,
+          "line": 3126,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23532,7 +24267,7 @@
         },
         {
           "name": "Devotion",
-          "line": 3120,
+          "line": 3128,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -23544,7 +24279,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 3124,
+          "line": 3132,
           "kind": "struct",
           "field_names": [
             "source"
@@ -23556,7 +24291,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 3129,
+          "line": 3137,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -23567,7 +24302,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 3133,
+          "line": 3141,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -23581,7 +24316,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 3140,
+          "line": 3148,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -23593,7 +24328,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 3144,
+          "line": 3152,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -23603,7 +24338,7 @@
         },
         {
           "name": "FilteredTrackedSetSize",
-          "line": 3149,
+          "line": 3157,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23616,7 +24351,7 @@
         },
         {
           "name": "ExiledFromHandThisResolution",
-          "line": 3155,
+          "line": 3163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -23627,7 +24362,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 3159,
+          "line": 3167,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -23637,7 +24372,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 3174,
+          "line": 3182,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23650,7 +24385,7 @@
         },
         {
           "name": "PartySize",
-          "line": 3183,
+          "line": 3191,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23663,7 +24398,7 @@
         },
         {
           "name": "Speed",
-          "line": 3190,
+          "line": 3198,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23675,7 +24410,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 3193,
+          "line": 3201,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -23685,7 +24420,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 3201,
+          "line": 3209,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -23699,7 +24434,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 3213,
+          "line": 3221,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -23711,7 +24446,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 3216,
+          "line": 3224,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -23724,7 +24459,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 3223,
+          "line": 3231,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23734,7 +24469,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 3229,
+          "line": 3237,
           "kind": "struct",
           "field_names": [
             "player",
@@ -23747,7 +24482,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 3234,
+          "line": 3242,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -23757,7 +24492,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 3240,
+          "line": 3248,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23769,7 +24504,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 3245,
+          "line": 3253,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23781,12 +24516,13 @@
         },
         {
           "name": "LandsPlayedThisTurn",
-          "line": 3249,
+          "line": 3258,
           "kind": "struct",
           "field_names": [
-            "player"
+            "player",
+            "from_zones"
           ],
-          "doc": "CR 305.2a + CR 603.4: Count of lands played by the scoped player this turn. Backed by `Player::lands_played_this_turn`. Used for intervening-if conditions like \"if it wasn't the first land you played this turn\" (Fastbond).",
+          "doc": "CR 305.2a + CR 603.4: Count of lands played by the scoped player this turn. `from_zones: None` uses `Player::lands_played_this_turn`; `Some` reads the per-player land-play origin history for conditions like \"played a land from anywhere other than your hand.\"",
           "cr_refs": [
             "CR 305.2a",
             "CR 603.4"
@@ -23794,7 +24530,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 3252,
+          "line": 3265,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -23804,7 +24540,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 3256,
+          "line": 3269,
           "kind": "struct",
           "field_names": [
             "from",
@@ -23819,7 +24555,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 3276,
+          "line": 3289,
           "kind": "struct",
           "field_names": [
             "source",
@@ -23837,7 +24573,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 3295,
+          "line": 3308,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -23845,17 +24581,19 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 3299,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "CR 508.1a: Number of creatures the controller attacked with this turn. Used for \"if you attacked this turn\" and \"for each creature you attacked with this turn\" patterns.",
+          "line": 3315,
+          "kind": "struct",
+          "field_names": [
+            "filter"
+          ],
+          "doc": "CR 508.1a: Number of creatures the controller attacked with this turn, optionally narrowed by `filter` (e.g. \"attacked with a token / a commander / a Wolf\"). `None` counts all attacking creatures (the bare \"if you attacked this turn\" / \"for each creature you attacked with this turn\" patterns); `Some(filter)` counts only this-turn attackers matching `filter`, resolved against `state.creatures_attacked_this_turn`.",
           "cr_refs": [
             "CR 508.1a"
           ]
         },
         {
           "name": "DescendedThisTurn",
-          "line": 3301,
+          "line": 3320,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -23865,7 +24603,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 3309,
+          "line": 3328,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23879,7 +24617,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 3312,
+          "line": 3331,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -23889,7 +24627,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 3326,
+          "line": 3345,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -23903,7 +24641,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 3337,
+          "line": 3356,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -23918,7 +24656,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 3346,
+          "line": 3365,
           "kind": "struct",
           "field_names": [
             "player"
@@ -23931,7 +24669,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 3351,
+          "line": 3370,
           "kind": "struct",
           "field_names": [
             "player",
@@ -23945,7 +24683,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 3359,
+          "line": 3378,
           "kind": "struct",
           "field_names": [
             "player",
@@ -23959,7 +24697,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 3364,
+          "line": 3383,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -23969,7 +24707,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 3371,
+          "line": 3390,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -23979,7 +24717,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 3374,
+          "line": 3393,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -23990,7 +24728,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 3378,
+          "line": 3397,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -24002,7 +24740,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 3382,
+          "line": 3401,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -24012,7 +24750,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 3387,
+          "line": 3406,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -24026,7 +24764,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 3398,
+          "line": 3417,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -24037,7 +24775,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 3403,
+          "line": 3422,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -24047,7 +24785,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 3410,
+          "line": 3429,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24061,7 +24799,7 @@
         },
         {
           "name": "DistinctCounterKindsAmong",
-          "line": 3419,
+          "line": 3438,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24144,7 +24882,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9506,
+      "line": 9614,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -24153,7 +24891,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 9510,
+          "line": 9618,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -24166,13 +24904,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10570,
+      "line": 10679,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 10573,
+          "line": 10682,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24184,7 +24922,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 10579,
+          "line": 10688,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -24194,7 +24932,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 10586,
+          "line": 10695,
           "kind": "struct",
           "field_names": [
             "count",
@@ -24207,7 +24945,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 10591,
+          "line": 10700,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24219,7 +24957,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 10596,
+          "line": 10705,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -24232,7 +24970,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 10599,
+          "line": 10708,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -24244,7 +24982,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 10602,
+          "line": 10711,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -24254,7 +24992,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 10605,
+          "line": 10714,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -24265,7 +25003,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 10613,
+          "line": 10722,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -24278,7 +25016,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 10627,
+          "line": 10736,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -24291,7 +25029,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 10636,
+          "line": 10745,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -24302,7 +25040,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 10639,
+          "line": 10748,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -24312,7 +25050,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 10645,
+          "line": 10754,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -24324,7 +25062,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 10650,
+          "line": 10759,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -24336,7 +25074,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 10655,
+          "line": 10764,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -24347,7 +25085,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 10664,
+          "line": 10773,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -24359,7 +25097,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 10671,
+          "line": 10780,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -24373,7 +25111,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 10679,
+          "line": 10788,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -24383,7 +25121,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 10684,
+          "line": 10793,
           "kind": "struct",
           "field_names": [
             "source"
@@ -24397,7 +25135,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 10688,
+          "line": 10797,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -24410,7 +25148,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 10693,
+          "line": 10802,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -24421,7 +25159,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 10704,
+          "line": 10813,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -24434,7 +25172,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 10715,
+          "line": 10824,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -24446,7 +25184,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 10723,
+          "line": 10832,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -24459,7 +25197,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 10733,
+          "line": 10842,
           "kind": "struct",
           "field_names": [
             "level"
@@ -24471,7 +25209,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 10738,
+          "line": 10847,
           "kind": "struct",
           "field_names": [
             "text"
@@ -24601,17 +25339,18 @@
         },
         {
           "name": "AddCounter",
-          "line": 39,
+          "line": 41,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 614.1a: Replaces one or more counters being placed on an object.",
+          "doc": "CR 614.1a + CR 122.1: Replaces one or more counters being placed on an object or player.",
           "cr_refs": [
+            "CR 122.1",
             "CR 614.1a"
           ]
         },
         {
           "name": "RemoveCounter",
-          "line": 41,
+          "line": 43,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces one or more counters being removed from an object.",
@@ -24621,7 +25360,7 @@
         },
         {
           "name": "CreateToken",
-          "line": 43,
+          "line": 45,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces token creation with a modified event.",
@@ -24631,7 +25370,7 @@
         },
         {
           "name": "Tap",
-          "line": 45,
+          "line": 47,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces a permanent becoming tapped.",
@@ -24641,7 +25380,7 @@
         },
         {
           "name": "Untap",
-          "line": 47,
+          "line": 49,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces a permanent becoming untapped.",
@@ -24651,7 +25390,7 @@
         },
         {
           "name": "DealtDamage",
-          "line": 49,
+          "line": 51,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.2: Replaces damage being dealt to an object or player (receiver perspective).",
@@ -24661,7 +25400,7 @@
         },
         {
           "name": "Mill",
-          "line": 51,
+          "line": 53,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces milling (putting cards from library into graveyard).",
@@ -24671,7 +25410,7 @@
         },
         {
           "name": "PayLife",
-          "line": 53,
+          "line": 55,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces paying life as a cost or effect.",
@@ -24681,7 +25420,7 @@
         },
         {
           "name": "LifeReduced",
-          "line": 55,
+          "line": 57,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces a player's life total being reduced.",
@@ -24691,7 +25430,7 @@
         },
         {
           "name": "Attached",
-          "line": 57,
+          "line": 59,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces attaching an Aura, Equipment, or Fortification.",
@@ -24701,7 +25440,7 @@
         },
         {
           "name": "DrawCards",
-          "line": 61,
+          "line": 63,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.11: Replaces drawing multiple cards at once.",
@@ -24711,7 +25450,7 @@
         },
         {
           "name": "ProduceMana",
-          "line": 63,
+          "line": 65,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.6a: Replaces mana production (increases or changes mana produced).",
@@ -24721,7 +25460,7 @@
         },
         {
           "name": "Scry",
-          "line": 65,
+          "line": 67,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces a scry event.",
@@ -24731,7 +25470,7 @@
         },
         {
           "name": "CoinFlip",
-          "line": 67,
+          "line": 69,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 705.1: Replaces an individual coin flip.",
@@ -24742,7 +25481,7 @@
         },
         {
           "name": "Transform",
-          "line": 69,
+          "line": 71,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces a transform event.",
@@ -24752,7 +25491,7 @@
         },
         {
           "name": "Explore",
-          "line": 71,
+          "line": 73,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Replaces an explore event.",
@@ -24762,7 +25501,7 @@
         },
         {
           "name": "AssembleContraption",
-          "line": 74,
+          "line": 76,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24770,7 +25509,7 @@
         },
         {
           "name": "BeginPhase",
-          "line": 76,
+          "line": 78,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1b: Replaces the beginning of a phase (skip effects).",
@@ -24780,7 +25519,7 @@
         },
         {
           "name": "BeginTurn",
-          "line": 78,
+          "line": 80,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1b: Replaces the beginning of a turn (skip effects, CR 614.10).",
@@ -24791,22 +25530,6 @@
         },
         {
           "name": "Cascade",
-          "line": 79,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopySpell",
-          "line": 80,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DeclareBlocker",
           "line": 81,
           "kind": "unit",
           "field_names": [],
@@ -24814,7 +25537,7 @@
           "cr_refs": []
         },
         {
-          "name": "GameLoss",
+          "name": "CopySpell",
           "line": 82,
           "kind": "unit",
           "field_names": [],
@@ -24822,7 +25545,7 @@
           "cr_refs": []
         },
         {
-          "name": "GameWin",
+          "name": "DeclareBlocker",
           "line": 83,
           "kind": "unit",
           "field_names": [],
@@ -24830,7 +25553,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "GameLoss",
           "line": 84,
           "kind": "unit",
           "field_names": [],
@@ -24838,8 +25561,24 @@
           "cr_refs": []
         },
         {
+          "name": "GameWin",
+          "line": 85,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Learn",
+          "line": 86,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "LoseMana",
-          "line": 93,
+          "line": 95,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 703.4q + CR 614.1a + CR 614.6: Replaces the CR 703.4q \"any unspent mana in a player's mana pool empties\" event at end of each step or phase. The replacement-effect family covers two leaf actions: `Retain` (CR 614.6 — the loss event is replaced with nothing, e.g. Upwelling, Omnath Locus of Mana) and `Transform(_)` (CR 614.1a — the loss event is replaced with a recolor, e.g. Horizon Stone, Kruphix). Matched against `ProposedEvent::EmptyManaPool` via the `empty_mana_pool_matcher` registered in `build_replacement_registry`.",
@@ -24851,22 +25590,6 @@
         },
         {
           "name": "PlanarDiceResult",
-          "line": 94,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Planeswalk",
-          "line": 95,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Proliferate",
           "line": 96,
           "kind": "unit",
           "field_names": [],
@@ -24874,8 +25597,24 @@
           "cr_refs": []
         },
         {
+          "name": "Planeswalk",
+          "line": 97,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Proliferate",
+          "line": 98,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Other",
-          "line": 99,
+          "line": 101,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for truly unknown event strings.",
@@ -24886,13 +25625,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11400,
+      "line": 11531,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 11403,
+          "line": 11534,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -24900,7 +25639,7 @@
         },
         {
           "name": "Optional",
-          "line": 11405,
+          "line": 11536,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -24910,7 +25649,7 @@
         },
         {
           "name": "MayCost",
-          "line": 11412,
+          "line": 11543,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -24927,31 +25666,33 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11388,
-      "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source's controller. `valid_player: None` keeps the controller-only default; `Some(You)` is the explicit controller scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
+      "line": 11519,
+      "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source player. For permanents/spells this is the source's controller; for cards outside the battlefield/stack, CR 109.4 + CR 108.4a make this the owner. `valid_player: None` keeps the source-player default; `Some(You)` is the explicit source-player scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
+        "CR 108.4a",
+        "CR 109.4",
         "CR 614.1a"
       ],
       "variants": [
         {
           "name": "You",
-          "line": 11390,
+          "line": 11521,
           "kind": "unit",
           "field_names": [],
-          "doc": "The replacement source's controller.",
+          "doc": "The replacement source player.",
           "cr_refs": []
         },
         {
           "name": "Opponent",
-          "line": 11392,
+          "line": 11523,
           "kind": "unit",
           "field_names": [],
-          "doc": "Any opponent of the replacement source's controller.",
+          "doc": "Any opponent of the replacement source player.",
           "cr_refs": []
         },
         {
           "name": "AnyPlayer",
-          "line": 11394,
+          "line": 11525,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -25122,7 +25863,7 @@
     },
     "RetargetScope": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 3283,
+      "line": 3569,
       "doc": "CR 115.7: Scope of retargeting — single target, all targets, or forced.",
       "cr_refs": [
         "CR 115.7"
@@ -25130,7 +25871,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 3284,
+          "line": 3570,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25138,7 +25879,7 @@
         },
         {
           "name": "All",
-          "line": 3285,
+          "line": 3571,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25146,7 +25887,7 @@
         },
         {
           "name": "ForcedTo",
-          "line": 3286,
+          "line": 3572,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25157,7 +25898,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3426,
+      "line": 3445,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -25165,7 +25906,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 3427,
+          "line": 3446,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25173,7 +25914,7 @@
         },
         {
           "name": "Down",
-          "line": 3428,
+          "line": 3447,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25184,7 +25925,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4664,
+      "line": 4683,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -25192,7 +25933,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 4666,
+          "line": 4685,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -25261,7 +26002,7 @@
     },
     "SeatDirection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3508,
+      "line": 3527,
       "doc": "CR 102.1 + CR 103.1: Seating direction relative to a player. The game's default turn order proceeds clockwise (CR 103.1); the next player in turn order is seated to the active player's left (CR 101.4). Thus walking forward through `seat_order` is `Left`, and walking backward is `Right`.",
       "cr_refs": [
         "CR 101.4",
@@ -25271,7 +26012,7 @@
       "variants": [
         {
           "name": "Left",
-          "line": 3511,
+          "line": 3530,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's left — the next player in turn order (CR 101.4). Forward through `seat_order`.",
@@ -25281,7 +26022,7 @@
         },
         {
           "name": "Right",
-          "line": 3514,
+          "line": 3533,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's right — the previous player in turn order. Backward through `seat_order`.",
@@ -25292,7 +26033,7 @@
     },
     "ShardChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1466,
+      "line": 1709,
       "doc": "CR 107.4f + CR 601.2f: The caster's resolved choice for one Phyrexian shard.",
       "cr_refs": [
         "CR 107.4f",
@@ -25301,7 +26042,7 @@
       "variants": [
         {
           "name": "PayMana",
-          "line": 1468,
+          "line": 1711,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay one mana of the shard's color (or either component color for hybrid-Phyrexian).",
@@ -25309,7 +26050,7 @@
         },
         {
           "name": "PayLife",
-          "line": 1470,
+          "line": 1713,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay 2 life.",
@@ -25320,7 +26061,7 @@
     },
     "ShardOptions": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1454,
+      "line": 1697,
       "doc": "CR 107.4f + CR 601.2h: Which legal payments a single Phyrexian shard offers to the caster. Computed from the mana pool state (Phyrexian color availability) combined with the caster's life total and CantLoseLife status (CR 118.3 + CR 119.8).  The engine pauses at `WaitingFor::PhyrexianPayment` whenever any shard would deduct life — both `ManaOrLife` (player explicitly picks mana vs life) and `LifeOnly` (life is the only remaining payment route; player confirms or cancels via `CancelCast`). Only `ManaOnly` shards auto-resolve without surfacing the prompt, since they have no life consequence (issue #704: silent life deduction violated CR 601.2h's right to refuse the cast).",
       "cr_refs": [
         "CR 107.4f",
@@ -25331,7 +26072,7 @@
       "variants": [
         {
           "name": "ManaOrLife",
-          "line": 1456,
+          "line": 1699,
           "kind": "unit",
           "field_names": [],
           "doc": "Both mana and 2 life are legal payments; player must choose.",
@@ -25339,7 +26080,7 @@
         },
         {
           "name": "ManaOnly",
-          "line": 1458,
+          "line": 1701,
           "kind": "unit",
           "field_names": [],
           "doc": "Only mana is legal (insufficient life or CR 119.8 CantLoseLife lock).",
@@ -25349,7 +26090,7 @@
         },
         {
           "name": "LifeOnly",
-          "line": 1460,
+          "line": 1703,
           "kind": "unit",
           "field_names": [],
           "doc": "Only 2 life is legal (no mana of the shard's color available, given restrictions).",
@@ -25578,7 +26319,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3964,
+      "line": 3983,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -25587,7 +26328,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 3966,
+          "line": 3985,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25599,7 +26340,7 @@
         },
         {
           "name": "Text",
-          "line": 3972,
+          "line": 3991,
           "kind": "struct",
           "field_names": [
             "description"
@@ -25612,7 +26353,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5401,
+      "line": 5420,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -25620,7 +26361,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 5403,
+          "line": 5422,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -25630,7 +26371,7 @@
         },
         {
           "name": "Decrease",
-          "line": 5405,
+          "line": 5424,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -25643,13 +26384,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5210,
+      "line": 5229,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 5211,
+          "line": 5230,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25657,7 +26398,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 5212,
+          "line": 5231,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25665,7 +26406,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 5213,
+          "line": 5232,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25673,7 +26414,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 5215,
+          "line": 5234,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -25686,7 +26427,7 @@
     },
     "SpellCostSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1817,
+      "line": 2069,
       "doc": "CR 601.2h + CR 702.48c: Identifies which spell-cost component a `WaitingFor::PayCost` choice is paying when the same `AbilityCost` shape can come from different rules.",
       "cr_refs": [
         "CR 601.2h",
@@ -25695,7 +26436,7 @@
       "variants": [
         {
           "name": "Other",
-          "line": 1819,
+          "line": 2071,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25703,7 +26444,15 @@
         },
         {
           "name": "Offering",
-          "line": 1820,
+          "line": 2072,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Emerge",
+          "line": 2073,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -25714,13 +26463,13 @@
     },
     "StackEntryKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4007,
+      "line": 4467,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 4008,
+          "line": 4468,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -25733,7 +26482,7 @@
         },
         {
           "name": "ActivatedAbility",
-          "line": 4022,
+          "line": 4482,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -25744,7 +26493,7 @@
         },
         {
           "name": "TriggeredAbility",
-          "line": 4026,
+          "line": 4486,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -25761,7 +26510,7 @@
         },
         {
           "name": "KeywordAction",
-          "line": 4069,
+          "line": 4529,
           "kind": "struct",
           "field_names": [
             "action"
@@ -25777,13 +26526,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4038,
+      "line": 4057,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 4039,
+          "line": 4058,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -25794,7 +26543,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 4043,
+          "line": 4062,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25804,7 +26553,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 4049,
+          "line": 4068,
           "kind": "struct",
           "field_names": [
             "color"
@@ -25814,7 +26563,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 4058,
+          "line": 4077,
           "kind": "struct",
           "field_names": [
             "label"
@@ -25827,7 +26576,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4064,
+          "line": 4083,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -25839,7 +26588,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 4070,
+          "line": 4089,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -25849,7 +26598,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 4072,
+          "line": 4091,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -25862,7 +26611,7 @@
         },
         {
           "name": "And",
-          "line": 4076,
+          "line": 4095,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -25872,7 +26621,7 @@
         },
         {
           "name": "Or",
-          "line": 4080,
+          "line": 4099,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -25882,7 +26631,7 @@
         },
         {
           "name": "Not",
-          "line": 4086,
+          "line": 4105,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -25892,7 +26641,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 4090,
+          "line": 4109,
           "kind": "struct",
           "field_names": [
             "state"
@@ -25904,7 +26653,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 4099,
+          "line": 4118,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -25920,7 +26669,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 4109,
+          "line": 4128,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -25933,7 +26682,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 4117,
+          "line": 4136,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -25948,7 +26697,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 4125,
+          "line": 4144,
           "kind": "struct",
           "field_names": [
             "level"
@@ -25960,7 +26709,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 4132,
+          "line": 4151,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25972,7 +26721,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 4136,
+          "line": 4155,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -25982,7 +26731,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 4140,
+          "line": 4159,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -25993,7 +26742,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 4144,
+          "line": 4163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -26004,7 +26753,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 4148,
+          "line": 4167,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -26014,7 +26763,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 4150,
+          "line": 4169,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -26024,7 +26773,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 4153,
+          "line": 4172,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -26034,7 +26783,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4155,
+          "line": 4174,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -26044,7 +26793,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 4158,
+          "line": 4177,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -26054,7 +26803,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 4164,
+          "line": 4183,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26066,7 +26815,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 4172,
+          "line": 4191,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26078,7 +26827,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 4176,
+          "line": 4195,
           "kind": "struct",
           "field_names": [
             "count"
@@ -26090,7 +26839,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 4201,
+          "line": 4220,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -26108,7 +26857,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 4210,
+          "line": 4229,
           "kind": "struct",
           "field_names": [
             "text"
@@ -26118,7 +26867,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 4213,
+          "line": 4232,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26126,7 +26875,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 4216,
+          "line": 4235,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -26136,7 +26885,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 4218,
+          "line": 4237,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -26146,7 +26895,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 4220,
+          "line": 4239,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26158,7 +26907,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 4226,
+          "line": 4245,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -26172,7 +26921,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 4231,
+          "line": 4250,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -26182,7 +26931,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 4238,
+          "line": 4257,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26195,7 +26944,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 4243,
+          "line": 4262,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -26205,7 +26954,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 4247,
+          "line": 4266,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -26215,7 +26964,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 4251,
+          "line": 4270,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -26226,7 +26975,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 4255,
+          "line": 4274,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26238,7 +26987,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 4267,
+          "line": 4286,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26250,7 +26999,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 4271,
+          "line": 4290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -26260,7 +27009,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 4274,
+          "line": 4293,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -26272,7 +27021,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 4280,
+          "line": 4299,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -26283,7 +27032,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 4285,
+          "line": 4304,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ModifyCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -26294,7 +27043,7 @@
         },
         {
           "name": "None",
-          "line": 4286,
+          "line": 4305,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26305,13 +27054,13 @@
     },
     "StaticMode": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 560,
+      "line": 588,
       "doc": "All static ability modes from Forge's static ability registry. Matched case-sensitively against Forge mode strings.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Continuous",
-          "line": 561,
+          "line": 589,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26319,7 +27068,7 @@
         },
         {
           "name": "CantAttack",
-          "line": 562,
+          "line": 590,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26327,7 +27076,7 @@
         },
         {
           "name": "CantBlock",
-          "line": 563,
+          "line": 591,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26335,7 +27084,7 @@
         },
         {
           "name": "CantAttackOrBlock",
-          "line": 564,
+          "line": 592,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26343,7 +27092,7 @@
         },
         {
           "name": "MaxAttackersEachCombat",
-          "line": 567,
+          "line": 595,
           "kind": "struct",
           "field_names": [
             "max"
@@ -26355,7 +27104,7 @@
         },
         {
           "name": "MaxBlockersEachCombat",
-          "line": 572,
+          "line": 600,
           "kind": "struct",
           "field_names": [
             "max"
@@ -26367,7 +27116,7 @@
         },
         {
           "name": "CantBeTargeted",
-          "line": 575,
+          "line": 603,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26375,7 +27124,7 @@
         },
         {
           "name": "CantBeCast",
-          "line": 578,
+          "line": 606,
           "kind": "struct",
           "field_names": [
             "who"
@@ -26387,7 +27136,7 @@
         },
         {
           "name": "CantBeActivated",
-          "line": 604,
+          "line": 632,
           "kind": "struct",
           "field_names": [
             "who",
@@ -26403,7 +27152,7 @@
         },
         {
           "name": "CantSearchLibrary",
-          "line": 617,
+          "line": 645,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -26416,7 +27165,7 @@
         },
         {
           "name": "CantCauseSacrificeOrExile",
-          "line": 627,
+          "line": 655,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -26429,7 +27178,7 @@
         },
         {
           "name": "CastWithFlash",
-          "line": 630,
+          "line": 658,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26437,7 +27186,7 @@
         },
         {
           "name": "GrantsExtraVote",
-          "line": 642,
+          "line": 670,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38d: While voting, the controller of this permanent may vote an additional time. Each active source grants +1 to the controller's `Player::extra_votes_per_session` snapshot taken at vote-session start (Tivit, Seller of Secrets — \"While voting, you may vote an additional time.\").  The vote-effect resolver scans the battlefield for permanents with this static at session start (CR 701.38d: extra votes happen at the same time the player would otherwise have voted). It does *not* feed into layer 7 — there is no continuous P/T or keyword grant; the static is a pure \"session-start +1 votes\" signal.",
@@ -26447,7 +27196,7 @@
         },
         {
           "name": "CastWithKeyword",
-          "line": 646,
+          "line": 674,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -26459,12 +27208,13 @@
         },
         {
           "name": "CastWithAlternativeCost",
-          "line": 658,
+          "line": 687,
           "kind": "struct",
           "field_names": [
-            "cost"
+            "cost",
+            "timing_permission"
           ],
-          "doc": "CR 118.9 + CR 601.2f: A permanent grants its controller a wholesale alternative MANA cost for spells matching `StaticDefinition::affected` that the controller casts — they may pay `cost` rather than the spell's mana cost. Parallel to `CastWithKeyword`. Distinct from `ModifyCost { mode: Reduce, .. }` (subtractive, CR 601.2f) — this REPLACES the mana cost wholesale (CR 118.9) and is mutually exclusive with other alternative costs (CR 118.9a). Rooftop Storm ({0}, Zombie creature spells), Fist of Suns ({WUBRG}, any spell), Jodah (MV 5+).",
+          "doc": "CR 118.9 + CR 601.2f: A permanent grants its controller a wholesale alternative cost for spells matching `StaticDefinition::affected` that the controller casts — they may pay `cost` rather than the spell's mana cost. Parallel to `CastWithKeyword`. Distinct from `ModifyCost { mode: Reduce, .. }` (subtractive, CR 601.2f) — this REPLACES the mana cost wholesale (CR 118.9) and is mutually exclusive with other alternative costs (CR 118.9a). Rooftop Storm ({0}, Zombie creature spells), Fist of Suns ({WUBRG}, any spell), Jodah (MV 5+), Primal Prayers ({E}, creature MV ≤ 3, with an alternative-cost timing permission).",
           "cr_refs": [
             "CR 118.9",
             "CR 118.9a",
@@ -26473,7 +27223,7 @@
         },
         {
           "name": "ModifyCost",
-          "line": 665,
+          "line": 696,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -26488,7 +27238,7 @@
         },
         {
           "name": "ReduceAbilityCost",
-          "line": 678,
+          "line": 709,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -26503,7 +27253,7 @@
         },
         {
           "name": "ModifyActivationLimit",
-          "line": 693,
+          "line": 724,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -26516,7 +27266,7 @@
         },
         {
           "name": "ActivateAsInstant",
-          "line": 703,
+          "line": 734,
           "kind": "struct",
           "field_names": [
             "cost_category"
@@ -26529,7 +27279,7 @@
         },
         {
           "name": "CantPayCost",
-          "line": 713,
+          "line": 744,
           "kind": "struct",
           "field_names": [
             "who",
@@ -26544,7 +27294,7 @@
         },
         {
           "name": "CantGainLife",
-          "line": 717,
+          "line": 748,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26552,7 +27302,7 @@
         },
         {
           "name": "CantLoseLife",
-          "line": 718,
+          "line": 749,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26560,7 +27310,7 @@
         },
         {
           "name": "PlayerProtection",
-          "line": 727,
+          "line": 758,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.16: The scoped player(s) have protection from a quality — e.g. Serra's Emissary's \"You ... have protection from the chosen card type.\" Player scope rides on `StaticDefinition::affected` (identical to `CantGainLife`); `ProtectionTarget` is the canonical protection-quality axis. Data-carrying variant — not registry-registered (see `coverage::is_data_carrying_static`); consumed by direct pattern-match in `player_protection_from`. Only the `ChosenCardType` arm is runtime-implemented; other arms are inert.",
@@ -26570,7 +27320,7 @@
         },
         {
           "name": "MustAttack",
-          "line": 728,
+          "line": 759,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26578,7 +27328,7 @@
         },
         {
           "name": "MustAttackPlayer",
-          "line": 736,
+          "line": 767,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26590,7 +27340,7 @@
         },
         {
           "name": "MustBlock",
-          "line": 739,
+          "line": 770,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26598,7 +27348,7 @@
         },
         {
           "name": "MustBlockAttacker",
-          "line": 747,
+          "line": 778,
           "kind": "struct",
           "field_names": [
             "attacker"
@@ -26611,7 +27361,7 @@
         },
         {
           "name": "CantDraw",
-          "line": 750,
+          "line": 781,
           "kind": "struct",
           "field_names": [
             "who"
@@ -26621,7 +27371,7 @@
         },
         {
           "name": "DoubleTriggers",
-          "line": 757,
+          "line": 788,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -26633,7 +27383,7 @@
         },
         {
           "name": "IgnoreHexproof",
-          "line": 760,
+          "line": 791,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26641,7 +27391,7 @@
         },
         {
           "name": "ExtraBlockers",
-          "line": 763,
+          "line": 794,
           "kind": "struct",
           "field_names": [
             "count"
@@ -26654,7 +27404,7 @@
         },
         {
           "name": "RevealTopOfLibrary",
-          "line": 768,
+          "line": 799,
           "kind": "struct",
           "field_names": [
             "all_players"
@@ -26666,7 +27416,7 @@
         },
         {
           "name": "GraveyardCastPermission",
-          "line": 773,
+          "line": 804,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -26681,7 +27431,7 @@
         },
         {
           "name": "TopOfLibraryCastPermission",
-          "line": 803,
+          "line": 834,
           "kind": "struct",
           "field_names": [
             "play_mode",
@@ -26696,7 +27446,7 @@
         },
         {
           "name": "CastFromHandFree",
-          "line": 820,
+          "line": 851,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -26710,7 +27460,7 @@
         },
         {
           "name": "ExileCastPermission",
-          "line": 851,
+          "line": 882,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -26728,7 +27478,7 @@
         },
         {
           "name": "CantBeCountered",
-          "line": 883,
+          "line": 914,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2: This spell/permanent can't be countered.",
@@ -26738,7 +27488,7 @@
         },
         {
           "name": "CantBeCopied",
-          "line": 886,
+          "line": 917,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2 + CR 707.10: This spell can't be copied by spells or abilities. Enforced in `copy_spell::resolve` when selecting the spell to copy.",
@@ -26749,7 +27499,7 @@
         },
         {
           "name": "CantEnterBattlefieldFrom",
-          "line": 888,
+          "line": 919,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 604.3: Cards in specified zones can't enter the battlefield.",
@@ -26759,17 +27509,21 @@
         },
         {
           "name": "CantCastFrom",
-          "line": 890,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "CR 604.3: Players can't cast spells from specified zones.",
+          "line": 939,
+          "kind": "struct",
+          "field_names": [
+            "who"
+          ],
+          "doc": "CR 601.3 + CR 101.2 + CR 109.5: The scoped player(s) can't cast spells from the zones encoded in `StaticDefinition::affected` (via `FilterProp::InAnyZone`). CR 601.3: a player can cast a spell only if no effect prohibits it; CR 101.2: this \"can't\" overrides any cast-from-zone permission (escape, flashback, foretell, commander).  Two phrasings collapse onto this one variant: - Grafdigger's Cage (\"Players can't cast spells from graveyards or   libraries\"): `who = AllPlayers`, `affected = InAnyZone { [Graveyard, Library] }`. - Drannith Magistrate (\"Your opponents can't cast spells from anywhere   other than their hands\"): `who = Opponents`, `affected = InAnyZone {   [Graveyard, Library, Exile, Command] }` — every cast-capable zone except   the hand. The parser inverts \"anywhere other than [hand]\" into the   explicit prohibited-zone list so the runtime check stays a single   `InAnyZone` membership test.  `who` rides the player axis (CR 109.5); the prohibited zones ride the `affected` filter. Enforcement is in `casting.rs::is_blocked_from_casting_from_zone`.",
           "cr_refs": [
-            "CR 604.3"
+            "CR 101.2",
+            "CR 109.5",
+            "CR 601.3"
           ]
         },
         {
           "name": "CantCastDuring",
-          "line": 894,
+          "line": 945,
           "kind": "struct",
           "field_names": [
             "who",
@@ -26782,7 +27536,7 @@
         },
         {
           "name": "CantActivateDuring",
-          "line": 921,
+          "line": 972,
           "kind": "struct",
           "field_names": [
             "who",
@@ -26800,7 +27554,7 @@
         },
         {
           "name": "PerTurnCastLimit",
-          "line": 931,
+          "line": 982,
           "kind": "struct",
           "field_names": [
             "who",
@@ -26815,7 +27569,7 @@
         },
         {
           "name": "PerTurnDrawLimit",
-          "line": 939,
+          "line": 990,
           "kind": "struct",
           "field_names": [
             "who",
@@ -26828,7 +27582,7 @@
         },
         {
           "name": "SuppressTriggers",
-          "line": 966,
+          "line": 1017,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -26843,7 +27597,7 @@
         },
         {
           "name": "CantBeBlocked",
-          "line": 973,
+          "line": 1024,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: This creature can't be blocked.",
@@ -26853,7 +27607,7 @@
         },
         {
           "name": "CantBeBlockedExceptBy",
-          "line": 975,
+          "line": 1026,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -26865,7 +27619,7 @@
         },
         {
           "name": "CantBeBlockedBy",
-          "line": 980,
+          "line": 1031,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26877,7 +27631,7 @@
         },
         {
           "name": "CantBeBlockedByMoreThan",
-          "line": 988,
+          "line": 1039,
           "kind": "struct",
           "field_names": [
             "max"
@@ -26889,7 +27643,7 @@
         },
         {
           "name": "AttachmentRestriction",
-          "line": 1008,
+          "line": 1059,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26905,7 +27659,7 @@
         },
         {
           "name": "Protection",
-          "line": 1012,
+          "line": 1063,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16: Protection prevents targeting, blocking, damage, and attachment.",
@@ -26915,7 +27669,7 @@
         },
         {
           "name": "Indestructible",
-          "line": 1014,
+          "line": 1065,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.12: Indestructible — prevents destruction by lethal damage and destroy effects.",
@@ -26925,7 +27679,7 @@
         },
         {
           "name": "CantBeDestroyed",
-          "line": 1016,
+          "line": 1067,
           "kind": "unit",
           "field_names": [],
           "doc": "Permanent cannot be destroyed (distinct from Indestructible).",
@@ -26933,7 +27687,7 @@
         },
         {
           "name": "CantBeRegenerated",
-          "line": 1028,
+          "line": 1079,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.19c: \"[Permanent] can't be regenerated [this turn].\" This does not stop regeneration abilities from being activated or shields from being created; rather, it causes regeneration shields to not be applied the next time the affected permanent would be destroyed. The per-target `StaticDefinition::affected` filter carries which permanent is marked; runtime enforcement bypasses the regen shield in `replacement.rs::destroy_applier` (CR 701.19). Distinct from `CantBeDestroyed` (which prevents destruction outright) and the inline `Effect::Destroy { cant_regenerate }` (the \"Destroy X. It can't be regenerated.\" one-shot) — this is the standalone, until-end-of-turn form (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort).",
@@ -26944,7 +27698,7 @@
         },
         {
           "name": "FlashBack",
-          "line": 1030,
+          "line": 1081,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34: Flashback — allows casting from graveyard, exiled after resolution.",
@@ -26954,7 +27708,7 @@
         },
         {
           "name": "Shroud",
-          "line": 1032,
+          "line": 1083,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.18: Shroud — permanent cannot be the target of spells or abilities.",
@@ -26964,7 +27718,7 @@
         },
         {
           "name": "Hexproof",
-          "line": 1037,
+          "line": 1088,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.11: Hexproof — affected player/permanent cannot be the target of spells or abilities an opponent controls. Applied at the player scope (\"You have hexproof.\") mirroring `Shroud`; permanent-scope hexproof grants flow through `ContinuousModification::AddKeyword` instead.",
@@ -26974,7 +27728,7 @@
         },
         {
           "name": "Vigilance",
-          "line": 1039,
+          "line": 1090,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.20: Vigilance — attacking doesn't cause this creature to tap.",
@@ -26984,7 +27738,7 @@
         },
         {
           "name": "Menace",
-          "line": 1041,
+          "line": 1092,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.111: Menace — can't be blocked except by two or more creatures.",
@@ -26994,7 +27748,7 @@
         },
         {
           "name": "Reach",
-          "line": 1043,
+          "line": 1094,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.17: Reach — can block creatures with flying.",
@@ -27004,7 +27758,7 @@
         },
         {
           "name": "Flying",
-          "line": 1045,
+          "line": 1096,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.9: Flying — can't be blocked except by creatures with flying or reach.",
@@ -27014,7 +27768,7 @@
         },
         {
           "name": "Trample",
-          "line": 1047,
+          "line": 1098,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.19: Trample — excess combat damage is assigned to the defending player.",
@@ -27024,7 +27778,7 @@
         },
         {
           "name": "Deathtouch",
-          "line": 1049,
+          "line": 1100,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.2: Deathtouch — any amount of damage dealt is lethal.",
@@ -27034,7 +27788,7 @@
         },
         {
           "name": "Lifelink",
-          "line": 1051,
+          "line": 1102,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.15: Lifelink — damage dealt also causes controller to gain that much life.",
@@ -27044,7 +27798,7 @@
         },
         {
           "name": "CantTap",
-          "line": 1054,
+          "line": 1105,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27052,7 +27806,7 @@
         },
         {
           "name": "CantUntap",
-          "line": 1055,
+          "line": 1106,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27060,7 +27814,7 @@
         },
         {
           "name": "MustBeBlocked",
-          "line": 1058,
+          "line": 1109,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: This creature must be blocked if able — the defending player must assign at least one legal blocker to it.",
@@ -27070,7 +27824,7 @@
         },
         {
           "name": "MustBeBlockedByAll",
-          "line": 1064,
+          "line": 1115,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: \"All creatures able to block this creature do so\" (Lure, Prized Unicorn, Breaker of Armies, …). Unlike [`MustBeBlocked`], this places a block requirement on *every* creature able to block it: each such untapped defender must be declared as a blocker of this attacker, not merely one.",
@@ -27080,7 +27834,7 @@
         },
         {
           "name": "Goaded",
-          "line": 1068,
+          "line": 1119,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.15b: This creature is goaded for as long as the static applies. The source controller is the goading player for the \"attack another player if able\" requirement.",
@@ -27090,7 +27844,7 @@
         },
         {
           "name": "CantAttackAlone",
-          "line": 1069,
+          "line": 1120,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27098,7 +27852,7 @@
         },
         {
           "name": "CantBlockAlone",
-          "line": 1070,
+          "line": 1121,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27106,7 +27860,7 @@
         },
         {
           "name": "CantCrew",
-          "line": 1072,
+          "line": 1123,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122c: This creature can't crew Vehicles.",
@@ -27115,8 +27869,23 @@
           ]
         },
         {
+          "name": "CrewContribution",
+          "line": 1129,
+          "kind": "struct",
+          "field_names": [
+            "kind",
+            "actions"
+          ],
+          "doc": "CR 702.122c / CR 702.171a / CR 702.184a: This creature contributes to a crew/saddle/station cost as though its power were modified (Reckoner Bankbuster: \"as though its power were 2 greater\") or using its toughness instead of its power (Giant Ox). `actions` records which keyword actions the modifier applies to, since a card may name only some of them.",
+          "cr_refs": [
+            "CR 702.122c",
+            "CR 702.171a",
+            "CR 702.184a"
+          ]
+        },
+        {
           "name": "MayLookAtTopOfLibrary",
-          "line": 1073,
+          "line": 1133,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27124,7 +27893,7 @@
         },
         {
           "name": "MayChooseNotToUntap",
-          "line": 1077,
+          "line": 1137,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3: You may choose not to untap this permanent during your untap step.",
@@ -27134,7 +27903,7 @@
         },
         {
           "name": "AdditionalLandDrop",
-          "line": 1080,
+          "line": 1140,
           "kind": "struct",
           "field_names": [
             "count"
@@ -27146,7 +27915,7 @@
         },
         {
           "name": "EmblemStatic",
-          "line": 1083,
+          "line": 1143,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27154,7 +27923,7 @@
         },
         {
           "name": "BlockRestriction",
-          "line": 1084,
+          "line": 1144,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27162,7 +27931,7 @@
         },
         {
           "name": "NoMaximumHandSize",
-          "line": 1086,
+          "line": 1146,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 402.2: No maximum hand size.",
@@ -27172,7 +27941,7 @@
         },
         {
           "name": "MaximumHandSize",
-          "line": 1089,
+          "line": 1149,
           "kind": "struct",
           "field_names": [
             "modification"
@@ -27185,7 +27954,7 @@
         },
         {
           "name": "MayPlayAdditionalLand",
-          "line": 1092,
+          "line": 1152,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27193,7 +27962,7 @@
         },
         {
           "name": "CantHaveKeyword",
-          "line": 1096,
+          "line": 1156,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -27205,7 +27974,7 @@
         },
         {
           "name": "CantWinTheGame",
-          "line": 1101,
+          "line": 1161,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: This player can't win the game (Platinum Angel effect).",
@@ -27215,7 +27984,7 @@
         },
         {
           "name": "CantLoseTheGame",
-          "line": 1103,
+          "line": 1163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3b: This player can't lose the game (Platinum Angel effect).",
@@ -27225,7 +27994,7 @@
         },
         {
           "name": "LegendRuleDoesntApply",
-          "line": 1112,
+          "line": 1172,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 704.5j: The \"legend rule\" doesn't apply to the affected permanents, so they are excluded from the same-name legendary grouping in the legend-rule SBA. Scope rides on `StaticDefinition::affected`: `None` = global (Mirror Gallery, \"the legend rule doesn't apply\"); a controller-scoped filter = \"doesn't apply to [permanents/tokens/Slivers/commanders] you control\" (Sakashima of a Thousand Faces, Mirror Box, Cadric, Sliver Gravemother, Try-My-Deck Elemental, ...). Enforced per-permanent in `sba.rs` via `check_static_ability` with the candidate as the target object.",
@@ -27235,7 +28004,7 @@
         },
         {
           "name": "SpeedCanIncreaseBeyondFour",
-          "line": 1114,
+          "line": 1174,
           "kind": "unit",
           "field_names": [],
           "doc": "Speed may increase beyond 4, and 4+ still counts as max speed for that player.",
@@ -27243,7 +28012,7 @@
         },
         {
           "name": "DefilerCostReduction",
-          "line": 1118,
+          "line": 1178,
           "kind": "struct",
           "field_names": [
             "color",
@@ -27257,7 +28026,7 @@
         },
         {
           "name": "SkipStep",
-          "line": 1128,
+          "line": 1188,
           "kind": "struct",
           "field_names": [
             "step"
@@ -27270,7 +28039,7 @@
         },
         {
           "name": "SpendManaAsAnyColor",
-          "line": 1133,
+          "line": 1193,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.4b: \"You may spend mana as though it were mana of any color.\" Allows the controller to pay colored mana costs with mana of any color.",
@@ -27280,7 +28049,7 @@
         },
         {
           "name": "PayLifeAsColoredMana",
-          "line": 1145,
+          "line": 1205,
           "kind": "struct",
           "field_names": [
             "color"
@@ -27292,7 +28061,7 @@
         },
         {
           "name": "StepEndUnspentMana",
-          "line": 1159,
+          "line": 1219,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -27308,7 +28077,7 @@
         },
         {
           "name": "CanAttackWithDefender",
-          "line": 1165,
+          "line": 1225,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.3b: Allows creatures with defender to attack despite having the keyword. \"can attack as though it didn't have defender\" overrides the defender restriction.",
@@ -27318,7 +28087,7 @@
         },
         {
           "name": "IgnoreLandwalkForBlocking",
-          "line": 1182,
+          "line": 1242,
           "kind": "struct",
           "field_names": [
             "qualifier"
@@ -27333,7 +28102,7 @@
         },
         {
           "name": "CanActivateAbilitiesAsThoughHaste",
-          "line": 1190,
+          "line": 1250,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.5a: Bypasses the summoning-sickness gate on a creature's `{T}`/`{Q}` activated abilities — \"You may activate abilities of creatures you control as though those creatures had haste.\" This is NOT `AddKeyword(Haste)`: only the CR 602.5a activation restriction is lifted, combat attacker validation (CR 508.1a) is untouched. Canonical card: Tyvar, Jubilant Brawler.",
@@ -27344,7 +28113,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 1194,
+          "line": 1254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage. Used for creatures like Ornithopter of Paradise and various Walls that can attack/block but deal 0 combat damage.",
@@ -27354,7 +28123,7 @@
         },
         {
           "name": "UntapsDuringEachOtherPlayersUntapStep",
-          "line": 1203,
+          "line": 1263,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3 + CR 113.6: Continuous static that grants a second untap pass during each OTHER player's untap step. The source's controller untaps the permanents matching `StaticDefinition.affected` — NOT the active player's permanents. Canonical card: Seedborn Muse (\"Untap all permanents you control during each other player's untap step.\"). Runtime: `turns::execute_untap` runs a second pass after the active player's normal untap, scanning the battlefield for this variant on permanents whose controller != active_player.",
@@ -27365,7 +28134,7 @@
         },
         {
           "name": "EntersWithAdditionalCounters",
-          "line": 1223,
+          "line": 1283,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -27379,7 +28148,7 @@
         },
         {
           "name": "Other",
-          "line": 1228,
+          "line": 1288,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized static mode strings.",
@@ -27421,7 +28190,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5413,
+      "line": 5432,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -27430,7 +28199,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 5414,
+          "line": 5433,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27438,7 +28207,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 5415,
+          "line": 5434,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27449,7 +28218,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9471,
+      "line": 9579,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -27457,7 +28226,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 9479,
+          "line": 9587,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -27465,7 +28234,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 9484,
+          "line": 9592,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -27610,7 +28379,7 @@
     },
     "SuppressedTriggerEvent": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 148,
+      "line": 149,
       "doc": "CR 603.2g + CR 603.6a + CR 700.4: A trigger event whose triggered-ability firing can be suppressed by a `StaticMode::SuppressTriggers` effect.  Distinct from `GameEvent` (the raw engine event) — this is the narrow set of events for which the MTG rules recognize \"enters\"/\"dies\" as a bound category. Other zone-change events (leaves-battlefield, exile, bounce) are not expressed here because no printed card prohibits those specifically in this shape.",
       "cr_refs": [
         "CR 603.2g",
@@ -27620,7 +28389,7 @@
       "variants": [
         {
           "name": "EntersBattlefield",
-          "line": 152,
+          "line": 153,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6a: Enters-the-battlefield triggered abilities. Does NOT include CR 603.6d static \"enters tapped\" / \"enters with counters\" / \"as X enters\" effects — those are static, not triggered.",
@@ -27631,7 +28400,7 @@
         },
         {
           "name": "Dies",
-          "line": 155,
+          "line": 156,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: \"Dies\" means moving from the battlefield to the graveyard. Narrower than \"leaves the battlefield\" — does not catch exile or bounce.",
@@ -27644,7 +28413,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9141,
+      "line": 9238,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -27654,7 +28423,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 9143,
+          "line": 9240,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27662,7 +28431,7 @@
         },
         {
           "name": "Resolution",
-          "line": 9144,
+          "line": 9241,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27673,44 +28442,12 @@
     },
     "TargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2562,
+      "line": 2566,
       "doc": "Typed target filter replacing all Forge filter strings and TargetSpec.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 2563,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Any",
-          "line": 2564,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Player",
-          "line": 2565,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Controller",
-          "line": 2566,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SelfRef",
           "line": 2567,
           "kind": "unit",
           "field_names": [],
@@ -27718,8 +28455,40 @@
           "cr_refs": []
         },
         {
-          "name": "SourceOrPaired",
+          "name": "Any",
+          "line": 2568,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Player",
+          "line": 2569,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Controller",
           "line": 2570,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SelfRef",
+          "line": 2571,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SourceOrPaired",
+          "line": 2574,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Resolves to the source object and the creature it is paired with. If the source is not paired, this matches no objects.",
@@ -27729,7 +28498,7 @@
         },
         {
           "name": "Typed",
-          "line": 2571,
+          "line": 2575,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27737,7 +28506,7 @@
         },
         {
           "name": "Not",
-          "line": 2572,
+          "line": 2576,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27747,7 +28516,7 @@
         },
         {
           "name": "Or",
-          "line": 2575,
+          "line": 2579,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -27757,7 +28526,7 @@
         },
         {
           "name": "And",
-          "line": 2578,
+          "line": 2582,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -27767,7 +28536,7 @@
         },
         {
           "name": "StackAbility",
-          "line": 2583,
+          "line": 2587,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -27777,7 +28546,7 @@
         },
         {
           "name": "StackSpell",
-          "line": 2589,
+          "line": 2593,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches spells on the stack (not activated/triggered abilities). CR 115.1a: Used by \"becomes the target of a spell\" triggers to filter source type.",
@@ -27787,7 +28556,7 @@
         },
         {
           "name": "SpecificObject",
-          "line": 2593,
+          "line": 2597,
           "kind": "struct",
           "field_names": [
             "id"
@@ -27797,7 +28566,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 2601,
+          "line": 2605,
           "kind": "struct",
           "field_names": [
             "id"
@@ -27810,7 +28579,7 @@
         },
         {
           "name": "Neighbor",
-          "line": 2609,
+          "line": 2613,
           "kind": "struct",
           "field_names": [
             "direction"
@@ -27823,7 +28592,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2615,
+          "line": 2619,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -27834,7 +28603,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 2618,
+          "line": 2622,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -27842,7 +28611,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 2621,
+          "line": 2625,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -27850,7 +28619,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 2625,
+          "line": 2629,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -27861,7 +28630,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 2628,
+          "line": 2632,
           "kind": "struct",
           "field_names": [
             "id"
@@ -27873,7 +28642,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 2643,
+          "line": 2647,
           "kind": "struct",
           "field_names": [
             "id",
@@ -27887,7 +28656,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 2649,
+          "line": 2653,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 610.3: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
@@ -27897,7 +28666,7 @@
         },
         {
           "name": "TriggeringSpellController",
-          "line": 2651,
+          "line": 2655,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -27907,7 +28676,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 2653,
+          "line": 2657,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -27917,7 +28686,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2655,
+          "line": 2659,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -27927,7 +28696,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 2657,
+          "line": 2661,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -27937,7 +28706,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2662,
+          "line": 2666,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -27945,7 +28714,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 2667,
+          "line": 2671,
           "kind": "struct",
           "field_names": [
             "index"
@@ -27957,7 +28726,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2673,
+          "line": 2677,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -27967,7 +28736,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 2684,
+          "line": 2688,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -27979,7 +28748,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 2689,
+          "line": 2693,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 608.2c: Resolves to the player chosen for the source by a linked persisted choice (\"the chosen player\"). This is not a target slot and is distinct from `ControllerRef::ChosenPlayer`, which is resolution-scoped to the current ability chain.",
@@ -27990,7 +28759,7 @@
         },
         {
           "name": "OriginalController",
-          "line": 2710,
+          "line": 2714,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -28002,7 +28771,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 2729,
+          "line": 2733,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -28013,7 +28782,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 2734,
+          "line": 2738,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -28023,7 +28792,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2738,
+          "line": 2742,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -28034,7 +28803,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 2741,
+          "line": 2745,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -28042,7 +28811,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 2745,
+          "line": 2749,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -28052,7 +28821,7 @@
         },
         {
           "name": "Named",
-          "line": 2748,
+          "line": 2752,
           "kind": "struct",
           "field_names": [
             "name"
@@ -28062,7 +28831,7 @@
         },
         {
           "name": "Owner",
-          "line": 2756,
+          "line": 2760,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -28072,7 +28841,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 2763,
+          "line": 2767,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -28103,13 +28872,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12047,
+      "line": 12178,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 12048,
+          "line": 12179,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -28117,7 +28886,7 @@
         },
         {
           "name": "Player",
-          "line": 12049,
+          "line": 12180,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -28128,13 +28897,13 @@
     },
     "TargetSelectionConstraint": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1394,
+      "line": 1637,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 1395,
+          "line": 1638,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28142,7 +28911,7 @@
         },
         {
           "name": "DifferentObjectControllers",
-          "line": 1397,
+          "line": 1640,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2c: Object targets must be controlled by different players.",
@@ -28153,7 +28922,7 @@
         },
         {
           "name": "TotalManaValue",
-          "line": 1405,
+          "line": 1648,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -28172,7 +28941,7 @@
     },
     "TargetSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2541,
+      "line": 2545,
       "doc": "CR 115.1 + CR 701.9b: How a target slot's referent is selected.  CR 115.1: Default — the spell/ability's controller chooses each target. CR 701.9b: Some effects override the controller-choice default by requiring the game to make the selection (analogous to \"random discard\" — the affected player does not choose). Magic Oracle text expresses this with the modifier \"random target [predicate]\" appearing immediately before the target word (Mana Clash, Goblin Lyre, Pixie Queen, Vexing Sphinx, Maddening Hex, etc.).  Categorical-boundary check (per CLAUDE.md \"Parameterize, don't proliferate\"): this enum is the *selection-mode* axis — one level above the predicate (`TargetFilter`) and orthogonal to slot count (`MultiTargetSpec`). It does not belong on `TargetFilter` (which captures *what* matches), nor on `MultiTargetSpec` (which captures *how many*). It captures *who selects*.",
       "cr_refs": [
         "CR 115.1",
@@ -28181,7 +28950,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2544,
+          "line": 2548,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The spell or ability's controller chooses each target.",
@@ -28191,13 +28960,40 @@
         },
         {
           "name": "Random",
-          "line": 2547,
+          "line": 2551,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9b (analogous): The game selects each target uniformly at random from the legal-target set. The controller does not choose.",
           "cr_refs": [
             "CR 701.9b"
           ]
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "TimeTravelPhase": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 2124,
+      "doc": "CR 701.56a: Which half of a time-travel choice is currently being presented. Typed instead of boolean so serialized engine state says whether the player is adding or removing counters.",
+      "cr_refs": [
+        "CR 701.56a"
+      ],
+      "variants": [
+        {
+          "name": "Remove",
+          "line": 2125,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Add",
+          "line": 2126,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
         }
       ],
       "sibling_clusters": []
@@ -28236,7 +29032,7 @@
     },
     "TriggerCause": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 489,
+      "line": 490,
       "doc": "CR 603.2d: The cause-predicate axis for trigger-doubling static abilities.  \"An effect that states a triggered ability of an object triggers additional times\" may be restricted to triggers caused by specific events (Panharmonicon: artifact/creature entering the battlefield; Isshin: creature attacking). A wildcard `Any` cause covers hypothetical unrestricted doublers.  This is a typed enum rather than a boolean because the design space is open-ended: new cards routinely introduce novel cause predicates, and `bool` fields cannot grow to accommodate them.",
       "cr_refs": [
         "CR 603.2d"
@@ -28244,7 +29040,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 491,
+          "line": 492,
           "kind": "unit",
           "field_names": [],
           "doc": "Unrestricted doubler — matches any trigger cause.",
@@ -28252,7 +29048,7 @@
         },
         {
           "name": "EntersBattlefield",
-          "line": 497,
+          "line": 498,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -28264,7 +29060,7 @@
         },
         {
           "name": "CreatureAttacking",
-          "line": 504,
+          "line": 505,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1 + CR 308.1: Trigger was caused by a creature attacking (Isshin-class). Matches `GameEvent::AttackersDeclared` regardless of attack target (player, planeswalker, or battle).",
@@ -28275,7 +29071,7 @@
         },
         {
           "name": "CreatureDying",
-          "line": 510,
+          "line": 511,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6c + CR 700.4: Trigger was caused by a creature dying — a creature moving from the battlefield to the graveyard (Drivnod-class). Matches `GameEvent::ZoneChanged` from `Battlefield` to `Graveyard` for an object whose snapshot included `Creature` in its core types.",
@@ -28283,19 +29079,30 @@
             "CR 603.6c",
             "CR 700.4"
           ]
+        },
+        {
+          "name": "ControlledCreatureDealtDamage",
+          "line": 516,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 603.2d + CR 120.3: Trigger was caused by a creature you control being dealt damage (Wayta, Trainer Prodigy-class). Matches `GameEvent::DamageDealt` whose target is a creature controlled by the doubler's controller.",
+          "cr_refs": [
+            "CR 120.3",
+            "CR 603.2d"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10244,
+      "line": 10353,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 10247,
+          "line": 10356,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -28305,7 +29112,7 @@
         },
         {
           "name": "LostLife",
-          "line": 10249,
+          "line": 10358,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -28313,7 +29120,7 @@
         },
         {
           "name": "Descended",
-          "line": 10251,
+          "line": 10360,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -28321,7 +29128,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 10253,
+          "line": 10362,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28331,7 +29138,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 10255,
+          "line": 10364,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -28341,7 +29148,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 10257,
+          "line": 10366,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -28351,7 +29158,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 10267,
+          "line": 10376,
           "kind": "struct",
           "field_names": [
             "player"
@@ -28364,7 +29171,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 10270,
+          "line": 10379,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -28375,7 +29182,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 10273,
+          "line": 10382,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -28385,7 +29192,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 10286,
+          "line": 10395,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -28399,7 +29206,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 10293,
+          "line": 10402,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -28409,7 +29216,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 10296,
+          "line": 10405,
           "kind": "struct",
           "field_names": [
             "level"
@@ -28421,7 +29228,7 @@
         },
         {
           "name": "AttractionVisitRoll",
-          "line": 10299,
+          "line": 10408,
           "kind": "struct",
           "field_names": [
             "min",
@@ -28435,7 +29242,7 @@
         },
         {
           "name": "WasCast",
-          "line": 10302,
+          "line": 10411,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -28448,7 +29255,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 10309,
+          "line": 10418,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -28459,7 +29266,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 10314,
+          "line": 10423,
           "kind": "struct",
           "field_names": [
             "source",
@@ -28475,7 +29282,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 10330,
+          "line": 10439,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -28485,7 +29292,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 10336,
+          "line": 10445,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28500,7 +29307,7 @@
         },
         {
           "name": "CastVariantPaidPersistent",
-          "line": 10341,
+          "line": 10450,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28513,7 +29320,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 10345,
+          "line": 10454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -28524,7 +29331,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 10349,
+          "line": 10458,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -28535,7 +29342,7 @@
         },
         {
           "name": "WasType",
-          "line": 10354,
+          "line": 10463,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -28548,7 +29355,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 10357,
+          "line": 10466,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -28560,7 +29367,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 10361,
+          "line": 10470,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -28573,7 +29380,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 10365,
+          "line": 10474,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28585,7 +29392,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 10369,
+          "line": 10478,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -28595,7 +29402,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 10372,
+          "line": 10481,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -28607,7 +29414,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 10376,
+          "line": 10485,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28619,7 +29426,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 10379,
+          "line": 10488,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -28631,7 +29438,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 10385,
+          "line": 10494,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -28641,7 +29448,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 10388,
+          "line": 10497,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -28651,7 +29458,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 10391,
+          "line": 10500,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -28661,7 +29468,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 10398,
+          "line": 10507,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -28673,7 +29480,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 10403,
+          "line": 10512,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28685,7 +29492,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 10407,
+          "line": 10516,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -28695,7 +29502,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 10412,
+          "line": 10521,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -28707,7 +29514,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 10418,
+          "line": 10527,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -28717,7 +29524,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 10423,
+          "line": 10532,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -28727,7 +29534,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 10426,
+          "line": 10535,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -28737,7 +29544,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 10429,
+          "line": 10538,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -28747,7 +29554,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 10431,
+          "line": 10540,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -28759,7 +29566,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 10434,
+          "line": 10543,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -28769,7 +29576,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 10438,
+          "line": 10547,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -28779,7 +29586,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 10442,
+          "line": 10551,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28792,7 +29599,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 10445,
+          "line": 10554,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -28802,7 +29609,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 10449,
+          "line": 10558,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -28815,7 +29622,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 10452,
+          "line": 10561,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -28828,7 +29635,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 10454,
+          "line": 10563,
           "kind": "struct",
           "field_names": [
             "color",
@@ -28841,7 +29648,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 10456,
+          "line": 10565,
           "kind": "struct",
           "field_names": [
             "text"
@@ -28853,7 +29660,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 10458,
+          "line": 10567,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -28865,7 +29672,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 10462,
+          "line": 10571,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -28879,7 +29686,7 @@
         },
         {
           "name": "SourceIsRenowned",
-          "line": 10464,
+          "line": 10573,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112a: \"if ~ is renowned\" — true when the source has been made renowned.",
@@ -28889,7 +29696,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 10469,
+          "line": 10578,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -28904,7 +29711,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 10480,
+          "line": 10589,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -28920,7 +29727,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 10495,
+          "line": 10604,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -28932,7 +29739,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 10498,
+          "line": 10607,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28945,7 +29752,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 10508,
+          "line": 10617,
           "kind": "struct",
           "field_names": [
             "label"
@@ -28959,7 +29766,7 @@
         },
         {
           "name": "AttackersDeclaredCount",
-          "line": 10522,
+          "line": 10631,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -28976,7 +29783,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 10536,
+          "line": 10645,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -28988,7 +29795,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 10547,
+          "line": 10656,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -29000,7 +29807,7 @@
         },
         {
           "name": "And",
-          "line": 10551,
+          "line": 10660,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -29010,7 +29817,7 @@
         },
         {
           "name": "Or",
-          "line": 10553,
+          "line": 10662,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -29020,7 +29827,7 @@
         },
         {
           "name": "Not",
-          "line": 10563,
+          "line": 10672,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -29036,13 +29843,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10744,
+      "line": 10853,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 10746,
+          "line": 10855,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -29050,7 +29857,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 10748,
+          "line": 10857,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -29058,7 +29865,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 10750,
+          "line": 10859,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -29066,7 +29873,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 10755,
+          "line": 10864,
           "kind": "struct",
           "field_names": [
             "n",
@@ -29077,7 +29884,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 10762,
+          "line": 10871,
           "kind": "struct",
           "field_names": [
             "n"
@@ -29087,7 +29894,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 10764,
+          "line": 10873,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -29095,7 +29902,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 10768,
+          "line": 10877,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -29105,7 +29912,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 10770,
+          "line": 10879,
           "kind": "struct",
           "field_names": [
             "level"
@@ -29117,7 +29924,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 10773,
+          "line": 10882,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29129,7 +29936,7 @@
         },
         {
           "name": "OncePerOpponentPerTurn",
-          "line": 10777,
+          "line": 10886,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: \"for the first time during each of their turns\" — fires once per opponent per turn. Used by Valgavoth, Harrower of Souls: \"Whenever an opponent loses life for the first time during each of their turns, ...\"",
@@ -31206,8 +32013,18 @@
           "cr_refs": []
         },
         {
+          "name": "HauntedCreatureDies",
+          "line": 532,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.55c: Haunt payoff — \"When the creature this card haunts dies, …\". A dynamic, per-card trigger that fires while the card is in the exile zone (`trigger_zones = [Exile]`): it matches a creature's death only when that creature is the one the source card haunts, resolved through the `ExileLinkKind::Haunt` link. Matched by `game::haunt::match_haunted_creature_dies`.",
+          "cr_refs": [
+            "CR 702.55c"
+          ]
+        },
+        {
           "name": "Unknown",
-          "line": 527,
+          "line": 535,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized trigger mode strings.",
@@ -31471,7 +32288,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3991,
+      "line": 4010,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -31480,7 +32297,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 3993,
+          "line": 4012,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31488,7 +32305,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 3994,
+          "line": 4013,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31496,7 +32313,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 3995,
+          "line": 4014,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -31506,7 +32323,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 3998,
+          "line": 4017,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -31516,7 +32333,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 4010,
+          "line": 4029,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -31532,7 +32349,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3478,
+      "line": 3497,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -31545,7 +32362,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 3482,
+          "line": 3501,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31558,7 +32375,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 3486,
+          "line": 3505,
           "kind": "struct",
           "field_names": [
             "property",
@@ -31576,7 +32393,7 @@
     },
     "VoteActor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1658,
+      "line": 1901,
       "doc": "CR 101.4 + CR 608.2 (Battlebond friend-or-foe keyword action — no explicit CR section): The \"who acts\" semantic for a `WaitingFor::VoteChoice` step.  * `SubjectActs` — the player named by `player` casts the vote for   themselves. Classic Council's-dilemma (CR 701.38) is exclusively this   case: each voter acts on their own behalf and APNAP iteration changes   both subject and actor together. * `Delegated(actor)` — a fixed `actor` casts every vote on behalf of the   cycling subjects. The Battlebond friend-or-foe spell controller pins   themselves here so `player` cycles through every player in APNAP order   while authorization stays with the controller.  Stored on `WaitingFor::VoteChoice` instead of `Option<PlayerId>` so the \"is this delegated?\" discriminator is a named sum type with a meaningful pair of variant names, not a boolean-flavored optional. Callers route through [`VoteActor::resolve`] to get the authorized submitter without branching at every call site.",
       "cr_refs": [
         "CR 101.4",
@@ -31586,7 +32403,7 @@
       "variants": [
         {
           "name": "SubjectActs",
-          "line": 1659,
+          "line": 1902,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31594,7 +32411,7 @@
         },
         {
           "name": "Delegated",
-          "line": 1660,
+          "line": 1903,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -31605,7 +32422,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7814,
+      "line": 7885,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -31614,7 +32431,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 7817,
+          "line": 7888,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -31624,7 +32441,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 7821,
+          "line": 7892,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -31634,7 +32451,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 7829,
+          "line": 7900,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -31648,13 +32465,13 @@
     },
     "WaitingFor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1869,
+      "line": 2131,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1870,
+          "line": 2132,
           "kind": "struct",
           "field_names": [
             "player"
@@ -31664,7 +32481,7 @@
         },
         {
           "name": "MulliganDecision",
-          "line": 1886,
+          "line": 2148,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -31679,7 +32496,7 @@
         },
         {
           "name": "MulliganBottomCards",
-          "line": 1899,
+          "line": 2161,
           "kind": "struct",
           "field_names": [
             "pending"
@@ -31691,7 +32508,7 @@
         },
         {
           "name": "OpeningHandBottomCards",
-          "line": 1905,
+          "line": 2167,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -31702,7 +32519,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1909,
+          "line": 2171,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31713,7 +32530,7 @@
         },
         {
           "name": "ChooseXValue",
-          "line": 1927,
+          "line": 2189,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31730,7 +32547,7 @@
         },
         {
           "name": "TargetSelection",
-          "line": 1936,
+          "line": 2198,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31744,7 +32561,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 1952,
+          "line": 2214,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31756,7 +32573,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 1958,
+          "line": 2220,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31769,7 +32586,7 @@
         },
         {
           "name": "UntapChoice",
-          "line": 1974,
+          "line": 2236,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31783,7 +32600,7 @@
         },
         {
           "name": "ExertChoice",
-          "line": 1986,
+          "line": 2248,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31798,7 +32615,7 @@
         },
         {
           "name": "GameOver",
-          "line": 1992,
+          "line": 2254,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -31808,7 +32625,7 @@
         },
         {
           "name": "ReplacementChoice",
-          "line": 1995,
+          "line": 2257,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31820,7 +32637,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 2008,
+          "line": 2270,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31835,7 +32652,7 @@
         },
         {
           "name": "CopyTargetChoice",
-          "line": 2014,
+          "line": 2276,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31850,7 +32667,7 @@
         },
         {
           "name": "ExploreChoice",
-          "line": 2024,
+          "line": 2286,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31866,7 +32683,7 @@
         },
         {
           "name": "ReturnAsAuraTarget",
-          "line": 2046,
+          "line": 2308,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31889,7 +32706,7 @@
         },
         {
           "name": "EquipTarget",
-          "line": 2063,
+          "line": 2325,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31901,7 +32718,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 2069,
+          "line": 2331,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31916,7 +32733,7 @@
         },
         {
           "name": "StationTarget",
-          "line": 2080,
+          "line": 2342,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31930,7 +32747,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 2088,
+          "line": 2350,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31945,7 +32762,7 @@
         },
         {
           "name": "ScryChoice",
-          "line": 2096,
+          "line": 2358,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31956,7 +32773,7 @@
         },
         {
           "name": "CoinFlipKeepChoice",
-          "line": 2103,
+          "line": 2365,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31972,7 +32789,7 @@
         },
         {
           "name": "DigChoice",
-          "line": 2109,
+          "line": 2371,
           "kind": "struct",
           "field_names": [
             "player",
@@ -31992,7 +32809,7 @@
         },
         {
           "name": "SurveilChoice",
-          "line": 2133,
+          "line": 2395,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32003,7 +32820,7 @@
         },
         {
           "name": "RevealChoice",
-          "line": 2137,
+          "line": 2399,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32017,7 +32834,7 @@
         },
         {
           "name": "SearchChoice",
-          "line": 2156,
+          "line": 2418,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32033,7 +32850,7 @@
         },
         {
           "name": "SearchPartitionChoice",
-          "line": 2190,
+          "line": 2452,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32052,7 +32869,7 @@
         },
         {
           "name": "OutsideGameChoice",
-          "line": 2203,
+          "line": 2465,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32071,7 +32888,7 @@
         },
         {
           "name": "ChooseFromZoneChoice",
-          "line": 2217,
+          "line": 2479,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32088,7 +32905,7 @@
         },
         {
           "name": "ChooseOneOfBranch",
-          "line": 2229,
+          "line": 2491,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32107,7 +32924,7 @@
         },
         {
           "name": "ConniveDiscard",
-          "line": 2247,
+          "line": 2509,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32123,7 +32940,7 @@
         },
         {
           "name": "DiscardChoice",
-          "line": 2256,
+          "line": 2518,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32141,7 +32958,7 @@
         },
         {
           "name": "EffectZoneChoice",
-          "line": 2272,
+          "line": 2534,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32168,7 +32985,7 @@
         },
         {
           "name": "DrawnThisTurnTopdeckChoice",
-          "line": 2325,
+          "line": 2587,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32183,7 +33000,7 @@
         },
         {
           "name": "LearnChoice",
-          "line": 2335,
+          "line": 2597,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32196,7 +33013,7 @@
         },
         {
           "name": "ManifestDreadChoice",
-          "line": 2341,
+          "line": 2603,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32209,7 +33026,7 @@
         },
         {
           "name": "TriggerTargetSelection",
-          "line": 2345,
+          "line": 2607,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32225,7 +33042,7 @@
         },
         {
           "name": "BetweenGamesSideboard",
-          "line": 2365,
+          "line": 2627,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32237,7 +33054,7 @@
         },
         {
           "name": "BetweenGamesChoosePlayDraw",
-          "line": 2370,
+          "line": 2632,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32249,7 +33066,7 @@
         },
         {
           "name": "NamedChoice",
-          "line": 2376,
+          "line": 2638,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32262,7 +33079,7 @@
         },
         {
           "name": "DamageSourceChoice",
-          "line": 2386,
+          "line": 2648,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32276,7 +33093,7 @@
         },
         {
           "name": "ModeChoice",
-          "line": 2392,
+          "line": 2654,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32288,7 +33105,7 @@
         },
         {
           "name": "DiscardToHandSize",
-          "line": 2398,
+          "line": 2660,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32300,7 +33117,7 @@
         },
         {
           "name": "OptionalCostChoice",
-          "line": 2406,
+          "line": 2668,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32312,8 +33129,22 @@
           "cr_refs": []
         },
         {
+          "name": "SpliceOffer",
+          "line": 2684,
+          "kind": "struct",
+          "field_names": [
+            "player",
+            "pending_cast",
+            "eligible"
+          ],
+          "doc": "CR 702.47a–e: As an Arcane (or other matching-subtype) spell is cast, its controller may reveal a \"Splice onto [subtype]\" card from hand to copy its text box onto the spell and pay its splice cost as an additional cost. `eligible` are the hand cards still available to splice; the prompt is re-presented after each acceptance until the caster declines (`card: None`) or `eligible` is exhausted.",
+          "cr_refs": [
+            "CR 702.47a"
+          ]
+        },
+        {
           "name": "DefilerPayment",
-          "line": 2418,
+          "line": 2691,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32328,7 +33159,7 @@
         },
         {
           "name": "CastOffer",
-          "line": 2428,
+          "line": 2701,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32346,7 +33177,7 @@
         },
         {
           "name": "ModalFaceChoice",
-          "line": 2442,
+          "line": 2715,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32362,7 +33193,7 @@
         },
         {
           "name": "AlternativeCastChoice",
-          "line": 2465,
+          "line": 2738,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32388,7 +33219,7 @@
         },
         {
           "name": "MutateMergeChoice",
-          "line": 2504,
+          "line": 2777,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32405,7 +33236,7 @@
         },
         {
           "name": "CipherEncodeChoice",
-          "line": 2514,
+          "line": 2787,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32419,7 +33250,7 @@
         },
         {
           "name": "CastingVariantChoice",
-          "line": 2521,
+          "line": 2794,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32435,7 +33266,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 2533,
+          "line": 2806,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32452,7 +33283,7 @@
         },
         {
           "name": "MultiTargetSelection",
-          "line": 2544,
+          "line": 2817,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32468,7 +33299,7 @@
         },
         {
           "name": "AbilityModeChoice",
-          "line": 2555,
+          "line": 2828,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32485,7 +33316,7 @@
         },
         {
           "name": "OptionalEffectChoice",
-          "line": 2578,
+          "line": 2851,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32500,7 +33331,7 @@
         },
         {
           "name": "PairChoice",
-          "line": 2589,
+          "line": 2862,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32515,7 +33346,7 @@
         },
         {
           "name": "TributeChoice",
-          "line": 2600,
+          "line": 2873,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32530,7 +33361,7 @@
         },
         {
           "name": "MiracleReveal",
-          "line": 2612,
+          "line": 2885,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32545,7 +33376,7 @@
         },
         {
           "name": "OpponentMayChoice",
-          "line": 2619,
+          "line": 2892,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32561,7 +33392,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 2632,
+          "line": 2905,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32579,7 +33410,7 @@
         },
         {
           "name": "UnlessPaymentChooseCost",
-          "line": 2666,
+          "line": 2939,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32597,7 +33428,7 @@
         },
         {
           "name": "WardDiscardChoice",
-          "line": 2696,
+          "line": 2969,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32611,7 +33442,7 @@
         },
         {
           "name": "WardSacrificeChoice",
-          "line": 2704,
+          "line": 2977,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32626,7 +33457,7 @@
         },
         {
           "name": "UnlessBounceChoice",
-          "line": 2715,
+          "line": 2988,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32641,7 +33472,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 2723,
+          "line": 2996,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32654,7 +33485,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 2728,
+          "line": 3001,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32667,7 +33498,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 2733,
+          "line": 3006,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32682,7 +33513,7 @@
         },
         {
           "name": "SpecializeColor",
-          "line": 2740,
+          "line": 3013,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32694,7 +33525,7 @@
         },
         {
           "name": "PayCost",
-          "line": 2751,
+          "line": 3024,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32713,7 +33544,7 @@
         },
         {
           "name": "ActivationCostOneOfChoice",
-          "line": 2765,
+          "line": 3038,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32727,7 +33558,7 @@
         },
         {
           "name": "BlightChoice",
-          "line": 2771,
+          "line": 3044,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32740,7 +33571,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 2789,
+          "line": 3062,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32756,7 +33587,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 2799,
+          "line": 3072,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32772,7 +33603,7 @@
         },
         {
           "name": "CollectEvidenceChoice",
-          "line": 2806,
+          "line": 3079,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32788,7 +33619,7 @@
         },
         {
           "name": "HarmonizeTapChoice",
-          "line": 2815,
+          "line": 3088,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32805,7 +33636,7 @@
         },
         {
           "name": "RevealUntilKeptChoice",
-          "line": 2827,
+          "line": 3100,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32826,7 +33657,7 @@
         },
         {
           "name": "RepeatDecision",
-          "line": 2848,
+          "line": 3121,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32840,7 +33671,7 @@
         },
         {
           "name": "TopOrBottomChoice",
-          "line": 2855,
+          "line": 3128,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32853,7 +33684,7 @@
         },
         {
           "name": "PopulateChoice",
-          "line": 2860,
+          "line": 3133,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32867,7 +33698,7 @@
         },
         {
           "name": "ClashChooseOpponent",
-          "line": 2870,
+          "line": 3143,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32881,7 +33712,7 @@
         },
         {
           "name": "ClashCardPlacement",
-          "line": 2878,
+          "line": 3151,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32895,7 +33726,7 @@
         },
         {
           "name": "VoteChoice",
-          "line": 2889,
+          "line": 3162,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32917,7 +33748,7 @@
         },
         {
           "name": "SeparatePilesPartition",
-          "line": 2948,
+          "line": 3221,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32938,7 +33769,7 @@
         },
         {
           "name": "SeparatePilesChoice",
-          "line": 2978,
+          "line": 3251,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32955,7 +33786,7 @@
         },
         {
           "name": "CompanionReveal",
-          "line": 2993,
+          "line": 3266,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32968,7 +33799,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 3000,
+          "line": 3273,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32982,7 +33813,7 @@
         },
         {
           "name": "CommanderZoneChoice",
-          "line": 3009,
+          "line": 3282,
           "kind": "struct",
           "field_names": [
             "player",
@@ -32996,7 +33827,7 @@
         },
         {
           "name": "BattleProtectorChoice",
-          "line": 3020,
+          "line": 3293,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33012,7 +33843,7 @@
         },
         {
           "name": "ProliferateChoice",
-          "line": 3027,
+          "line": 3300,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33024,8 +33855,22 @@
           ]
         },
         {
+          "name": "TimeTravelChoice",
+          "line": 3313,
+          "kind": "struct",
+          "field_names": [
+            "player",
+            "eligible",
+            "phase"
+          ],
+          "doc": "CR 701.56a: Time travel — the player chooses any number of eligible objects (permanents they control with a time counter and/or suspended cards they own in exile with a time counter) and, for each, puts or removes a time counter. Modeled in two phases over `GameAction::SelectTargets`: `TimeTravelPhase::Remove` first selects objects to remove a time counter from; then `TimeTravelPhase::Add` selects (from the still-eligible remainder) objects to add a time counter to.",
+          "cr_refs": [
+            "CR 701.56a"
+          ]
+        },
+        {
           "name": "ChooseObjectsSelection",
-          "line": 3037,
+          "line": 3323,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33039,7 +33884,7 @@
         },
         {
           "name": "CategoryChoice",
-          "line": 3050,
+          "line": 3336,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33063,7 +33908,7 @@
         },
         {
           "name": "CopyRetarget",
-          "line": 3087,
+          "line": 3373,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33078,7 +33923,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 3097,
+          "line": 3383,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33100,7 +33945,7 @@
         },
         {
           "name": "AssignBlockerDamage",
-          "line": 3124,
+          "line": 3410,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33116,7 +33961,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 3134,
+          "line": 3420,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33131,7 +33976,7 @@
         },
         {
           "name": "MoveCountersDistribution",
-          "line": 3142,
+          "line": 3428,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33149,7 +33994,7 @@
         },
         {
           "name": "PayAmountChoice",
-          "line": 3156,
+          "line": 3442,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33167,7 +34012,7 @@
         },
         {
           "name": "RetargetChoice",
-          "line": 3169,
+          "line": 3455,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33183,7 +34028,7 @@
         },
         {
           "name": "CombatTaxPayment",
-          "line": 3191,
+          "line": 3477,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33203,7 +34048,7 @@
         },
         {
           "name": "PhyrexianPayment",
-          "line": 3209,
+          "line": 3495,
           "kind": "struct",
           "field_names": [
             "player",
@@ -33222,7 +34067,7 @@
     },
     "WardCost": {
       "file": "crates/engine/src/types/keywords.rs",
-      "line": 366,
+      "line": 380,
       "doc": "CR 702.21a: Ward cost — what the targeting player must pay.",
       "cr_refs": [
         "CR 702.21a"
@@ -33230,7 +34075,7 @@
       "variants": [
         {
           "name": "Mana",
-          "line": 367,
+          "line": 381,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -33238,7 +34083,7 @@
         },
         {
           "name": "PayLife",
-          "line": 368,
+          "line": 382,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -33246,7 +34091,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 369,
+          "line": 383,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33254,7 +34099,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 371,
+          "line": 385,
           "kind": "struct",
           "field_names": [
             "count",
@@ -33267,7 +34112,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 377,
+          "line": 391,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.21a: Ward cost paid via waterbend — tap artifacts/creatures to help pay. Distinct from Mana because waterbend has unique payment semantics (CR 701.67).",
@@ -33278,7 +34123,7 @@
         },
         {
           "name": "Compound",
-          "line": 380,
+          "line": 394,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.21a: Compound ward cost — multiple costs that must all be paid. Used for \"Ward—{2}, Pay 2 life\" where comma-separated sub-costs are conjoined.",
@@ -33360,6 +34205,31 @@
           "cr_refs": [
             "CR 408"
           ]
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "ZoneDeliveryExileTracking": {
+      "file": "crates/engine/src/types/game_state.rs",
+      "line": 1163,
+      "doc": "",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "None",
+          "line": 1165,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TrackBySource",
+          "line": 1166,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
         }
       ],
       "sibling_clusters": []


### PR DESCRIPTION
## Summary
Adds engine support for **Solemnity**.

## Files changed
- crates/engine/src/game/casting.rs
- crates/engine/src/game/casting_costs.rs
- crates/engine/src/game/effects/adapt.rs
- crates/engine/src/game/effects/amass.rs
- crates/engine/src/game/effects/become_copy.rs
- crates/engine/src/game/effects/bolster.rs
- crates/engine/src/game/effects/change_zone.rs
- crates/engine/src/game/effects/connive.rs
- crates/engine/src/game/effects/counters.rs
- crates/engine/src/game/effects/double.rs
- crates/engine/src/game/effects/energy.rs
- crates/engine/src/game/effects/explore.rs
- crates/engine/src/game/effects/incubate.rs
- crates/engine/src/game/effects/mod.rs
- crates/engine/src/game/effects/monstrosity.rs
- crates/engine/src/game/effects/player_counter.rs
- crates/engine/src/game/effects/proliferate.rs
- crates/engine/src/game/effects/renown.rs
- crates/engine/src/game/effects/token.rs
- crates/engine/src/game/effects/token_copy.rs
- crates/engine/src/game/effects/tribute.rs
- crates/engine/src/game/engine.rs
- crates/engine/src/game/engine_payment_choices.rs
- crates/engine/src/game/engine_replacement.rs
- crates/engine/src/game/engine_resolution_choices.rs
- crates/engine/src/game/replacement.rs
- crates/engine/src/game/stack.rs
- crates/engine/src/game/turns.rs
- crates/engine/src/parser/oracle_classifier.rs
- crates/engine/src/parser/oracle_replacement.rs
- crates/engine/src/types/game_state.rs
- crates/engine/src/types/proposed_event.rs
- crates/engine/src/types/replacements.rs
- data/engine-inventory.json

## CR references
- CR 111.1
- CR 111.10
- CR 122.1
- CR 122.6a
- CR 400.7
- CR 508.4
- CR 603.6a
- CR 603.7
- CR 614.1
- CR 614.1a
- CR 614.1c
- CR 614.17
- CR 616.1
- CR 616.1e
- CR 701.24a
- CR 701.37a
- CR 707.2
- CR 707.9

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Gate A
`./scripts/check-parser-combinators.sh`:
```text
(no output; exit 0)
```

## Anchored on
- crates/engine/src/parser/oracle_classifier.rs:550 — existing classifier pattern using `nom_primitives::scan_at_word_boundaries` with nom `tag()` combinators.
- crates/engine/src/game/engine_replacement.rs:399 — existing replacement-choice resume ordering that drains pending counter additions before downstream continuations.
- crates/engine/src/game/engine_replacement.rs:408 — existing replacement-choice resume ordering that drains pending copy-token resolution after counter continuations.

## Verification
- `cargo fmt --all` — clean
- `cargo fmt --all -- --check` — clean
- `git diff --check` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p engine` — 10261 lib passed / 0 failed / 4 ignored; 662 integration passed; doctests 7 ignored
- `cargo engine-inventory` — clean
- `./scripts/gen-card-data.sh` — Solemnity supported with `gap_count: 0`
- `cargo coverage` — 29267/34771 faces supported, 84.2%; Solemnity supported with `gap_count: 0`
- `cargo semantic-audit` — completed; Solemnity has no flagged entry

## Scope Expansion
Introduces generalized `AddCounter` replacement plumbing for object, player, and energy counters, plus resumable counter-replacement continuations for token, copy-token, and zone-change flows so Solemnity uses reusable engine primitives rather than card-specific handling.

## Validation Failures
None.

## CI Failures
None.
