### PR TITLE
fix(engine): enforce CR 111.8 — a token that left the battlefield can't return

### DIFF
--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1244,7 +1244,7 @@ fn check_token_cease_to_exist(state: &mut GameState, any_performed: &mut bool) {
     )> = state
         .objects
         .iter()
-        .filter(|(_, obj)| obj.is_token && obj.zone != Zone::Battlefield && obj.zone != Zone::Stack)
+        .filter(|(_, obj)| zones::token_is_outside_battlefield_and_stack(obj))
         .map(|(id, obj)| (*id, obj.zone, obj.owner))
         .collect();
 

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -317,6 +317,19 @@ pub fn move_to_zone(
     mut to: Zone,
     events: &mut Vec<GameEvent>,
 ) {
+    // CR 111.8: A token that has left the battlefield can't move to another zone
+    // or come back onto the battlefield — "if such a token would change zones, it
+    // remains in its current zone instead." It ceases to exist at the next SBA
+    // (CR 111.7, enforced in sba.rs). Without this guard a single-resolution
+    // flicker ("exile target permanent, then return it") on a token would return
+    // it before the cease-to-exist SBA runs. The Stack carve-out matches the
+    // CR 111.7 SBA so a copy of a spell still resolves off the stack normally.
+    if let Some(obj) = state.objects.get(&object_id) {
+        if obj.is_token && obj.zone != Zone::Battlefield && obj.zone != Zone::Stack {
+            return;
+        }
+    }
+
     // CR 903.9a: A fresh zone change resets the "declined zone return" flag
     // so the owner gets a new choice opportunity if the commander moves again.
     state.commander_declined_zone_return.remove(&object_id);
@@ -948,6 +961,44 @@ mod tests {
             Zone::Battlefield,
         );
         assert!(state.battlefield.contains(&id));
+    }
+
+    /// CR 111.8: A token that has left the battlefield can't move to another zone
+    /// or come back onto the battlefield; it remains in its current zone and
+    /// ceases to exist at the next SBA (CR 111.7). A single-resolution flicker
+    /// ("exile target permanent, then return it") on a token therefore must NOT
+    /// bring it back — modeled here as the two zone changes such an effect makes,
+    /// battlefield -> exile then exile -> battlefield, with no SBA in between.
+    #[test]
+    fn token_that_left_battlefield_cannot_return() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Cat".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().is_token = true;
+
+        let mut events = Vec::new();
+        // Flicker step 1: the token leaves the battlefield (exiled).
+        move_to_zone(&mut state, id, Zone::Exile, &mut events);
+        assert_eq!(state.objects[&id].zone, Zone::Exile);
+
+        // Flicker step 2 (same resolution, no SBA between): attempt to return it.
+        move_to_zone(&mut state, id, Zone::Battlefield, &mut events);
+
+        // CR 111.8: it stays in exile; it must not re-enter the battlefield.
+        assert_eq!(
+            state.objects[&id].zone,
+            Zone::Exile,
+            "CR 111.8: a token that left the battlefield can't return"
+        );
+        assert!(
+            !state.battlefield.contains(&id),
+            "returned token must not be on the battlefield"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -11,6 +11,13 @@ use crate::types::zones::Zone;
 use super::game_object::GameObject;
 use super::printed_cards::{apply_back_face_to_object, snapshot_object_face};
 
+/// CR 111.7 / CR 111.8: A token outside the battlefield ceases to exist at
+/// the next SBA, and can't change zones before then. Stack tokens are excluded
+/// so spell copies can finish resolving before the next SBA check.
+pub(super) fn token_is_outside_battlefield_and_stack(obj: &GameObject) -> bool {
+    obj.is_token && obj.zone != Zone::Battlefield && obj.zone != Zone::Stack
+}
+
 /// CR 603.10a + CR 603.6e: Capture a snapshot of every attachment on `obj` at the
 /// moment of the zone change. The snapshot records each attachment's current
 /// controller and kind (Aura/Equipment) so that look-back triggers of the form
@@ -324,10 +331,12 @@ pub fn move_to_zone(
     // flicker ("exile target permanent, then return it") on a token would return
     // it before the cease-to-exist SBA runs. The Stack carve-out matches the
     // CR 111.7 SBA so a copy of a spell still resolves off the stack normally.
-    if let Some(obj) = state.objects.get(&object_id) {
-        if obj.is_token && obj.zone != Zone::Battlefield && obj.zone != Zone::Stack {
-            return;
-        }
+    if state
+        .objects
+        .get(&object_id)
+        .is_some_and(token_is_outside_battlefield_and_stack)
+    {
+        return;
     }
 
     // CR 903.9a: A fresh zone change resets the "declined zone return" flag
@@ -692,6 +701,15 @@ pub fn move_to_library_at_index(
     index: Option<usize>,
     events: &mut Vec<GameEvent>,
 ) {
+    // CR 111.8: A token that has left the battlefield can't move to another zone.
+    if state
+        .objects
+        .get(&object_id)
+        .is_some_and(token_is_outside_battlefield_and_stack)
+    {
+        return;
+    }
+
     // CR 903.9a: A fresh zone change resets the "declined zone return" flag.
     state.commander_declined_zone_return.remove(&object_id);
 
@@ -998,6 +1016,35 @@ mod tests {
         assert!(
             !state.battlefield.contains(&id),
             "returned token must not be on the battlefield"
+        );
+    }
+
+    /// CR 111.8: A token that has left the battlefield can't move into a
+    /// library before the next SBA removes it.
+    #[test]
+    fn token_that_left_battlefield_cannot_move_to_library_position() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Cat".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().is_token = true;
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, id, Zone::Exile, &mut events);
+        move_to_library_position(&mut state, id, true, &mut events);
+
+        assert_eq!(
+            state.objects[&id].zone,
+            Zone::Exile,
+            "CR 111.8: a token that left the battlefield can't move into a library"
+        );
+        assert!(
+            !state.players[0].library.contains(&id),
+            "token must not be inserted into its owner's library"
         );
     }
 


### PR DESCRIPTION
## Summary

`move_to_zone` enforces CR 111.7 (a token in a zone other than the battlefield ceases to exist — an SBA in `sba.rs`) but **not CR 111.8** (a token that has left the battlefield can't move to another zone or come back). The only guards before a permanent re-enters the battlefield are Grafdigger's-Cage statics and the instant/sorcery check — nothing checks `is_token`.

Because SBAs are not checked mid-resolution (**CR 704.3**), a single effect that resolves "exile target permanent, then return it" performs two zone changes on the token in one resolution with no SBA between. The CR 111.7 cease-to-exist SBA never runs between the exile and the return, the token object is still present (`zone == Exile`), and the unguarded `move_to_zone` puts it back on the battlefield.

## Reproduction

```rust
// a token on the battlefield (is_token = true)
move_to_zone(&mut state, id, Zone::Exile, &mut events);        // leaves the battlefield
move_to_zone(&mut state, id, Zone::Battlefield, &mut events);  // attempt return
// CR 111.8: must stay in Exile -- currently returns to Battlefield
```

## Fix

Guard at the top of `move_to_zone`: if the object is a token whose current zone is neither the battlefield nor the stack, leave it in place (no move, no event); the CR 111.7 SBA then removes it.

```rust
if let Some(obj) = state.objects.get(&object_id) {
    if obj.is_token && obj.zone != Zone::Battlefield && obj.zone != Zone::Stack {
        return;
    }
}
```

The `Zone::Stack` carve-out (a copy of a spell resolving off the stack) mirrors the existing CR 111.7 SBA filter in `sba.rs`. Token creation is unaffected — tokens are created directly via `create_object(.., Zone::Battlefield)`, never moved onto the battlefield from another zone.

## Impact

Every "exile, then return" / flicker effect applied to a token — Felidar Guardian, Cloudshift, Ephemerate, Restoration Angel, Eldrazi Displacer, Otherworldly Journey, etc. Per CR 111.8 a flickered token must vanish; the engine instead kept it and re-triggered its ETBs.

## Testing

- New `token_that_left_battlefield_cannot_return`: fails on `main` (token returns to the battlefield), passes after the fix.
- **Full `engine` lib suite: 10,819 passed, 0 failed** — no regression from this central `move_to_zone` change.
- CR 111.7 / 111.8 / 704.3 verified against `docs/MagicCompRules.txt`.

Fixes #2619
