### PR TITLE
Fix Vesuva copy identity persisting in graveyard (#2413)

### DIFF
--- a/crates/engine/src/game/effects/become_copy.rs
+++ b/crates/engine/src/game/effects/become_copy.rs
@@ -442,7 +442,12 @@ mod tests {
         evaluate_layers(&mut state);
         assert_eq!(state.objects[&source_id].name, "Target Bear");
 
-        move_to_zone(&mut state, source_id, Zone::Exile, &mut events);
+        move_to_zone(&mut state, source_id, Zone::Graveyard, &mut events);
+        assert_eq!(
+            state.objects[&source_id].name, "Copy Source",
+            "copy identity must not persist in graveyard after leaving the battlefield"
+        );
+
         move_to_zone(&mut state, source_id, Zone::Battlefield, &mut events);
         evaluate_layers(&mut state);
         assert_eq!(state.objects[&source_id].name, "Copy Source");

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1181,6 +1181,8 @@ impl GameObject {
         self.power = self.base_power;
         self.toughness = self.base_toughness;
         self.loyalty = self.base_loyalty;
+        // CR 310.4a + CR 400.7: Battle defense reverts to printed baseline off the battlefield.
+        self.defense = self.base_defense;
         self.card_types = self.base_card_types.clone();
         self.mana_cost = self.base_mana_cost.clone();
         self.keywords = self.base_keywords.clone();

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1170,6 +1170,32 @@ impl GameObject {
         }
     }
 
+    /// CR 613.1 + CR 400.7: Revert layer-derived characteristics to the object's
+    /// printed baseline. Mirrors the per-object reset in `evaluate_layers` Step 1
+    /// (layers.rs) but runs at zone-exit time so off-battlefield objects — e.g. a
+    /// Vesuva copy sacrificed to the legend rule — do not retain copied name, types,
+    /// or abilities in the graveyard after copy effects are pruned.
+    pub fn revert_layered_characteristics_to_base(&mut self) {
+        self.sync_missing_base_characteristics();
+        self.name = self.base_name.clone();
+        self.power = self.base_power;
+        self.toughness = self.base_toughness;
+        self.loyalty = self.base_loyalty;
+        self.card_types = self.base_card_types.clone();
+        self.mana_cost = self.base_mana_cost.clone();
+        self.keywords = self.base_keywords.clone();
+        self.abilities = Arc::clone(&self.base_abilities);
+        self.trigger_definitions = Arc::clone(&self.base_trigger_definitions).into();
+        self.replacement_definitions = Arc::clone(&self.base_replacement_definitions).into();
+        self.static_definitions = Arc::clone(&self.base_static_definitions).into();
+        self.color = self.base_color.clone();
+        self.printed_ref = self.base_printed_ref.clone();
+        self.controller = self.base_controller.unwrap_or(self.owner);
+        self.assigns_damage_from_toughness = false;
+        self.assigns_damage_as_though_unblocked = false;
+        self.assigns_no_combat_damage = false;
+    }
+
     /// CR 400.7: Clear battlefield-only designations when a permanent leaves the battlefield.
     /// Separate from entry reset because some state (counters, transform) is already handled
     /// by `apply_zone_exit_cleanup` in zones.rs.

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -253,6 +253,13 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
         crate::game::layers::mark_layers_full(state);
         super::layers::prune_host_left_effects(state, object_id);
         super::layers::prune_affected_object_left_effects(state, object_id);
+        // CR 613.1 + CR 400.7: Copy effects are pruned above, but layer-derived
+        // characteristics (name, types, abilities) persist on the object until
+        // explicitly reset. Revert to printed baseline so graveyard/exile objects
+        // do not retain copied identity (Vesuva legend-rule sacrifice).
+        if let Some(obj) = state.objects.get_mut(&object_id) {
+            obj.revert_layered_characteristics_to_base();
+        }
         for tapped in state.lands_tapped_for_mana.values_mut() {
             tapped.retain(|&id| id != object_id);
         }


### PR DESCRIPTION
## Summary
- Revert layered characteristics to printed baseline when a permanent leaves the battlefield, after copy effects are pruned
- Ensures graveyard/exile objects do not retain copied names and types (Vesuva legend-rule sacrifice)

## Test plan
- [x] `cargo test -p engine --lib permanent_become_copy_is_pruned`
- [x] Extended test asserts graveyard name reverts without re-entering the battlefield

Fixes #2413
