### PR TITLE
Fix Semblance Anvil imprint type cost reduction (#2414)

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -2121,6 +2121,8 @@ fn spell_object_matches_property(
             ctx.spell_object_id
                 .is_some_and(|spell_id| spell_id != ctx.source_id)
         }),
+        // CR 601.2f: Spell cost modifiers may require the spell share a quality
+        // (e.g., card type) with a reference object such as an imprinted card.
         FilterProp::SharesQuality {
             quality,
             reference,
@@ -2135,44 +2137,15 @@ fn spell_object_matches_property(
             let Some(spell_obj) = context.state.objects.get(&spell_id) else {
                 return false;
             };
-            let source_obj = context.state.objects.get(&context.source_id);
-            let source = SourceContext {
-                id: context.source_id,
-                controller: Some(context.source_controller),
-                attached_to: source_obj.and_then(|o| o.attached_to.clone()),
-                source_is_aura: source_obj
-                    .is_some_and(|o| o.card_types.subtypes.iter().any(|s| s == "Aura")),
-                source_is_equipment: source_obj
-                    .is_some_and(|o| o.card_types.subtypes.iter().any(|s| s == "Equipment")),
-                chosen_creature_type: source_obj.and_then(|o| o.chosen_creature_type()),
-                chosen_attributes: source_obj
-                    .map(|o| o.chosen_attributes.as_slice())
-                    .unwrap_or(&[]),
-                ability: None,
-                recipient_id: None,
-            };
-            let shares = reference.as_ref().is_none_or(|reference_filter| {
-                object_shares_quality_with_reference_filter(
-                    context.state,
-                    spell_obj,
-                    quality,
-                    reference_filter,
-                    &source,
-                )
-            });
-            match relation {
-                SharedQualityRelation::Shares => shares,
-                SharedQualityRelation::DoesNotShare => {
-                    !shares
-                        && (!matches!(quality, SharedQuality::Name)
-                            || !object_shared_quality_values(
-                                spell_obj,
-                                quality,
-                                &context.state.all_creature_types,
-                            )
-                            .is_empty())
-                }
-            }
+            let source = source_context_from_spell_filter(context);
+            evaluate_shares_quality(
+                context.state,
+                spell_obj,
+                quality,
+                reference,
+                relation,
+                &source,
+            )
         }
         _ => spell_record_matches_property(record, prop),
     }
@@ -3055,30 +3028,7 @@ fn matches_filter_prop(
             quality,
             reference,
             relation,
-        } => {
-            let shares = reference.as_ref().is_none_or(|reference_filter| {
-                object_shares_quality_with_reference_filter(
-                    state,
-                    obj,
-                    quality,
-                    reference_filter,
-                    source,
-                )
-            });
-            match relation {
-                SharedQualityRelation::Shares => shares,
-                SharedQualityRelation::DoesNotShare => {
-                    !shares
-                        && (!matches!(quality, SharedQuality::Name)
-                            || !object_shared_quality_values(
-                                obj,
-                                quality,
-                                &state.all_creature_types,
-                            )
-                            .is_empty())
-                }
-            }
-        }
+        } => evaluate_shares_quality(state, obj, quality, reference, relation, source),
         // CR 120.6 + CR 120.9: "Was dealt damage this turn" is a historical fact,
         // not a query against current marked damage. CR 120.6 removes marked damage
         // when a permanent regenerates and during the cleanup step, so reading
@@ -3707,6 +3657,47 @@ fn parent_target_shared_quality_values(
                     lki_shared_quality_values(&snapshot.lki, quality, &state.all_creature_types)
                 })
         })
+}
+
+fn evaluate_shares_quality(
+    state: &GameState,
+    obj: &GameObject,
+    quality: &SharedQuality,
+    reference: &Option<Box<TargetFilter>>,
+    relation: &SharedQualityRelation,
+    source: &SourceContext<'_>,
+) -> bool {
+    let shares = reference.as_ref().is_none_or(|reference_filter| {
+        object_shares_quality_with_reference_filter(state, obj, quality, reference_filter, source)
+    });
+    match relation {
+        SharedQualityRelation::Shares => shares,
+        SharedQualityRelation::DoesNotShare => {
+            !shares
+                && (!matches!(quality, SharedQuality::Name)
+                    || !object_shared_quality_values(obj, quality, &state.all_creature_types)
+                        .is_empty())
+        }
+    }
+}
+
+fn source_context_from_spell_filter(context: SpellFilterContext<'_>) -> SourceContext<'_> {
+    let source_obj = context.state.objects.get(&context.source_id);
+    SourceContext {
+        id: context.source_id,
+        controller: Some(context.source_controller),
+        attached_to: source_obj.and_then(|o| o.attached_to),
+        source_is_aura: source_obj
+            .is_some_and(|o| o.card_types.subtypes.iter().any(|s| s == "Aura")),
+        source_is_equipment: source_obj
+            .is_some_and(|o| o.card_types.subtypes.iter().any(|s| s == "Equipment")),
+        chosen_creature_type: source_obj.and_then(|o| o.chosen_creature_type()),
+        chosen_attributes: source_obj
+            .map(|o| o.chosen_attributes.as_slice())
+            .unwrap_or(&[]),
+        ability: None,
+        recipient_id: None,
+    }
 }
 
 fn object_shares_quality_with_reference_filter(

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -2121,6 +2121,59 @@ fn spell_object_matches_property(
             ctx.spell_object_id
                 .is_some_and(|spell_id| spell_id != ctx.source_id)
         }),
+        FilterProp::SharesQuality {
+            quality,
+            reference,
+            relation,
+        } => {
+            let Some(context) = context else {
+                return false;
+            };
+            let Some(spell_id) = context.spell_object_id else {
+                return false;
+            };
+            let Some(spell_obj) = context.state.objects.get(&spell_id) else {
+                return false;
+            };
+            let source_obj = context.state.objects.get(&context.source_id);
+            let source = SourceContext {
+                id: context.source_id,
+                controller: Some(context.source_controller),
+                attached_to: source_obj.and_then(|o| o.attached_to.clone()),
+                source_is_aura: source_obj
+                    .is_some_and(|o| o.card_types.subtypes.iter().any(|s| s == "Aura")),
+                source_is_equipment: source_obj
+                    .is_some_and(|o| o.card_types.subtypes.iter().any(|s| s == "Equipment")),
+                chosen_creature_type: source_obj.and_then(|o| o.chosen_creature_type()),
+                chosen_attributes: source_obj
+                    .map(|o| o.chosen_attributes.as_slice())
+                    .unwrap_or(&[]),
+                ability: None,
+                recipient_id: None,
+            };
+            let shares = reference.as_ref().is_none_or(|reference_filter| {
+                object_shares_quality_with_reference_filter(
+                    context.state,
+                    spell_obj,
+                    quality,
+                    reference_filter,
+                    &source,
+                )
+            });
+            match relation {
+                SharedQualityRelation::Shares => shares,
+                SharedQualityRelation::DoesNotShare => {
+                    !shares
+                        && (!matches!(quality, SharedQuality::Name)
+                            || !object_shared_quality_values(
+                                spell_obj,
+                                quality,
+                                &context.state.all_creature_types,
+                            )
+                            .is_empty())
+                }
+            }
+        }
         _ => spell_record_matches_property(record, prop),
     }
 }

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -44,8 +44,9 @@ mod prelude {
         AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ActivationRestriction,
         AttachmentKind, BasicLandType, CardPlayMode, ChosenSubtypeKind, Comparator,
         ContinuousModification, ControllerRef, CostCategory, CountScope, FilterProp, ObjectScope,
-        ParsedCondition, PtStat, PtValueScope, QuantityExpr, QuantityRef, StaticCondition,
-        StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+        ParsedCondition, PtStat, PtValueScope, QuantityExpr, QuantityRef, SharedQuality,
+        SharedQualityRelation, StaticCondition, StaticDefinition, TargetFilter, TypeFilter,
+        TypedFilter,
     };
     pub(super) use crate::types::card_type::{
         noncreature_subtype_set, CoreType, SubtypeSet, Supertype,

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -105,9 +105,9 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
     filter.map(remap_cost_mod_imprint_exile_reference)
 }
 
-/// CR 603.10a: Cost-mod lines such as Semblance Anvil reference "the exiled
-/// card" as the imprinted card exiled by the source permanent. The shared-
-/// quality nom parser emits `TrackedSet` for that phrase; remap to
+/// CR 607.2a + CR 607.3: Cost-mod lines such as Semblance Anvil reference
+/// "the exiled card" as the imprinted card exiled by the source permanent. The
+/// shared-quality nom parser emits `TrackedSet` for that phrase; remap to
 /// `ExiledBySource` so live `exile_links` resolve the reference at cast time.
 fn remap_cost_mod_imprint_exile_reference(filter: TargetFilter) -> TargetFilter {
     match filter {

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -36,6 +36,10 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
             take_until(" that are "),
             recognize((tag::<_, _, OracleError<'_>>(" that are "), rest)),
         ),
+        (
+            take_until(" that "),
+            recognize((tag::<_, _, OracleError<'_>>(" that "), rest)),
+        ),
     )))
     .parse(base);
 
@@ -82,7 +86,7 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
         }
     };
 
-    match (typed_filter, qual_props.is_empty()) {
+    let filter = match (typed_filter, qual_props.is_empty()) {
         (filter, true) => filter,
         (Some(TargetFilter::Typed(mut tf)), false) => {
             tf.properties.extend(qual_props);
@@ -97,6 +101,37 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
         (None, false) => Some(TargetFilter::Typed(
             TypedFilter::card().properties(qual_props),
         )),
+    };
+    filter.map(remap_cost_mod_imprint_exile_reference)
+}
+
+/// CR 603.10a: Cost-mod lines such as Semblance Anvil reference "the exiled
+/// card" as the imprinted card exiled by the source permanent. The shared-
+/// quality nom parser emits `TrackedSet` for that phrase; remap to
+/// `ExiledBySource` so live `exile_links` resolve the reference at cast time.
+fn remap_cost_mod_imprint_exile_reference(filter: TargetFilter) -> TargetFilter {
+    match filter {
+        TargetFilter::Typed(mut tf) => {
+            for prop in &mut tf.properties {
+                remap_shares_quality_imprint_reference(prop);
+            }
+            TargetFilter::Typed(tf)
+        }
+        TargetFilter::And { filters } => TargetFilter::And {
+            filters: filters
+                .into_iter()
+                .map(remap_cost_mod_imprint_exile_reference)
+                .collect(),
+        },
+        other => other,
+    }
+}
+
+fn remap_shares_quality_imprint_reference(prop: &mut FilterProp) {
+    if let FilterProp::SharesQuality { reference, .. } = prop {
+        if matches!(reference.as_deref(), Some(TargetFilter::TrackedSet { .. })) {
+            *reference = Some(Box::new(TargetFilter::ExiledBySource));
+        }
     }
 }
 
@@ -216,121 +251,109 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
 
     // Extract spell type filter from the text before "cost"
     // E.g., "Creature spells you cast" → Creature, "Instant and sorcery spells" → AnyOf(Instant, Sorcery)
-    let spell_filter =
-        if nom_primitives::scan_contains(lower, "share a card type with the exiled card")
-            || nom_primitives::scan_contains(lower, "shares a card type with the exiled card")
-        {
-            // CR 601.2f: Semblance Anvil — imprinted card type gates the reduction.
-            Some(TargetFilter::Typed(TypedFilter::card().properties(vec![
-                FilterProp::SharesQuality {
-                    quality: SharedQuality::CardType,
-                    reference: Some(Box::new(TargetFilter::ExiledBySource)),
-                    relation: SharedQualityRelation::Shares,
-                },
-            ])))
-        } else if is_self_spell {
-            parse_self_spell_target_cost_filter(lower)
-        } else if let Some(filter) = first_qualified_spell_filter.clone() {
-            Some(filter)
+    let spell_filter = if is_self_spell {
+        parse_self_spell_target_cost_filter(lower)
+    } else if let Some(filter) = first_qualified_spell_filter.clone() {
+        Some(filter)
+    // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+    } else if let Some(cost_idx) = lower.find(" cost") {
         // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-        } else if let Some(cost_idx) = lower.find(" cost") {
+        let prefix = &lower[..cost_idx];
+        let prefix = strip_cost_modifier_target_clause(prefix);
+        // Strip "from [zones]" clause (only if zones were detected), player scope, then "spells"
+        let without_from = if !cast_from_zones.is_empty() {
             // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-            let prefix = &lower[..cost_idx];
-            let prefix = strip_cost_modifier_target_clause(prefix);
-            // Strip "from [zones]" clause (only if zones were detected), player scope, then "spells"
-            let without_from = if !cast_from_zones.is_empty() {
+            if let Some(from_idx) = prefix.find(" from ") {
                 // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-                if let Some(from_idx) = prefix.find(" from ") {
-                    // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-                    &prefix[..from_idx]
-                } else {
-                    prefix
-                }
+                &prefix[..from_idx]
             } else {
                 prefix
-            };
-            // CR 201.3 / CR 113.6: Strip the trailing "with the chosen name" qualifier
-            // (Disruptor Flute: "Spells with the chosen name cost {3} more to cast.")
-            // before the standard suffix-trim chain runs. Track it so the spell filter is
-            // composed with `HasChosenName` after type parsing — same convention used by
-            // `parse_continuous_subject_filter` for object-class chosen-name phrases.
-            let (without_chosen, has_chosen_name) =
-                match nom_primitives::split_once_on(without_from, " with the chosen name") {
-                    Ok((_, (before, _))) => (before, true),
-                    Err(_) => (without_from, false),
-                };
-            // CR 205.2a + CR 601.2f: Strip the "of the chosen type" / "of that type"
-            // qualifier (Cloud Key, Umori, Stenn, Herald's Horn: "Spells you cast of
-            // the chosen type cost {1} less"). A "you cast" infix sits between the
-            // type word and this qualifier, so the trim chain below can't reach the
-            // type word and `parse_type_phrase` never extracts the chosen-type
-            // discriminator. Strip it here and re-attach IsChosenCardType /
-            // IsChosenCreatureType after the base type is parsed — mirrors the
-            // "with the chosen name" handling above.
-            let (without_chosen, has_chosen_type) = if let Ok((_, (before, _))) =
-                nom_primitives::split_once_on(without_chosen, " of the chosen type")
-            {
-                (before, true)
-            } else if let Ok((_, (before, _))) =
-                nom_primitives::split_once_on(without_chosen, " of that type")
-            {
-                (before, true)
-            } else {
-                (without_chosen, false)
-            };
-            let type_desc = without_chosen
-                .trim_end_matches(" you cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-                .trim_end_matches(" your opponents cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-                .trim_end_matches(" opponents cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-                .trim_end_matches(" spells") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-                .trim_end_matches(" spell") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-                .trim();
-            // "spells" alone means no type restriction (bare "Spells you cast cost...")
-            let typed_filter =
-                if type_desc.is_empty() || type_desc == "spells" || type_desc == "spell" {
-                    None
-                } else {
-                    parse_cost_mod_spell_type_prefix(type_desc)
-                };
-            // CR 205.2a: Re-attach the chosen-type discriminator stripped above. A
-            // creature-typed base ("Creature spells ... of the chosen type",
-            // Herald's Horn) pairs with a chosen CREATURE type; a bare-spells base
-            // ("Spells ... of the chosen type", Cloud Key / Umori / Stenn) pairs
-            // with a chosen CARD type. Resolved at cast time against the source
-            // permanent's `ChosenAttribute` (CR 601.2f).
-            let typed_filter = if has_chosen_type {
-                match typed_filter {
-                    Some(TargetFilter::Typed(mut tf))
-                        if tf.type_filters.contains(&TypeFilter::Creature) =>
-                    {
-                        tf.properties.push(FilterProp::IsChosenCreatureType);
-                        Some(TargetFilter::Typed(tf))
-                    }
-                    Some(TargetFilter::Typed(mut tf)) => {
-                        tf.properties.push(FilterProp::IsChosenCardType);
-                        Some(TargetFilter::Typed(tf))
-                    }
-                    None => Some(TargetFilter::Typed(
-                        TypedFilter::card().properties(vec![FilterProp::IsChosenCardType]),
-                    )),
-                    other => other,
-                }
-            } else {
-                typed_filter
-            };
-            // Compose chosen-name constraint with the typed prefix (if any). Bare
-            // "Spells with the chosen name" → `HasChosenName` alone; typed
-            // "<Type> spells with the chosen name" → `And{Typed, HasChosenName}`.
-            match (typed_filter, has_chosen_name) {
-                (Some(tf), true) => Some(TargetFilter::And {
-                    filters: vec![tf, TargetFilter::HasChosenName],
-                }),
-                (None, true) => Some(TargetFilter::HasChosenName),
-                (tf, false) => tf,
             }
         } else {
-            None
+            prefix
         };
+        // CR 201.3 / CR 113.6: Strip the trailing "with the chosen name" qualifier
+        // (Disruptor Flute: "Spells with the chosen name cost {3} more to cast.")
+        // before the standard suffix-trim chain runs. Track it so the spell filter is
+        // composed with `HasChosenName` after type parsing — same convention used by
+        // `parse_continuous_subject_filter` for object-class chosen-name phrases.
+        let (without_chosen, has_chosen_name) =
+            match nom_primitives::split_once_on(without_from, " with the chosen name") {
+                Ok((_, (before, _))) => (before, true),
+                Err(_) => (without_from, false),
+            };
+        // CR 205.2a + CR 601.2f: Strip the "of the chosen type" / "of that type"
+        // qualifier (Cloud Key, Umori, Stenn, Herald's Horn: "Spells you cast of
+        // the chosen type cost {1} less"). A "you cast" infix sits between the
+        // type word and this qualifier, so the trim chain below can't reach the
+        // type word and `parse_type_phrase` never extracts the chosen-type
+        // discriminator. Strip it here and re-attach IsChosenCardType /
+        // IsChosenCreatureType after the base type is parsed — mirrors the
+        // "with the chosen name" handling above.
+        let (without_chosen, has_chosen_type) = if let Ok((_, (before, _))) =
+            nom_primitives::split_once_on(without_chosen, " of the chosen type")
+        {
+            (before, true)
+        } else if let Ok((_, (before, _))) =
+            nom_primitives::split_once_on(without_chosen, " of that type")
+        {
+            (before, true)
+        } else {
+            (without_chosen, false)
+        };
+        let type_desc = without_chosen
+            .trim_end_matches(" you cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+            .trim_end_matches(" your opponents cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+            .trim_end_matches(" opponents cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+            .trim_end_matches(" spells") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+            .trim_end_matches(" spell") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+            .trim();
+        // "spells" alone means no type restriction (bare "Spells you cast cost...")
+        let typed_filter = if type_desc.is_empty() || type_desc == "spells" || type_desc == "spell"
+        {
+            None
+        } else {
+            parse_cost_mod_spell_type_prefix(type_desc)
+        };
+        // CR 205.2a: Re-attach the chosen-type discriminator stripped above. A
+        // creature-typed base ("Creature spells ... of the chosen type",
+        // Herald's Horn) pairs with a chosen CREATURE type; a bare-spells base
+        // ("Spells ... of the chosen type", Cloud Key / Umori / Stenn) pairs
+        // with a chosen CARD type. Resolved at cast time against the source
+        // permanent's `ChosenAttribute` (CR 601.2f).
+        let typed_filter = if has_chosen_type {
+            match typed_filter {
+                Some(TargetFilter::Typed(mut tf))
+                    if tf.type_filters.contains(&TypeFilter::Creature) =>
+                {
+                    tf.properties.push(FilterProp::IsChosenCreatureType);
+                    Some(TargetFilter::Typed(tf))
+                }
+                Some(TargetFilter::Typed(mut tf)) => {
+                    tf.properties.push(FilterProp::IsChosenCardType);
+                    Some(TargetFilter::Typed(tf))
+                }
+                None => Some(TargetFilter::Typed(
+                    TypedFilter::card().properties(vec![FilterProp::IsChosenCardType]),
+                )),
+                other => other,
+            }
+        } else {
+            typed_filter
+        };
+        // Compose chosen-name constraint with the typed prefix (if any). Bare
+        // "Spells with the chosen name" → `HasChosenName` alone; typed
+        // "<Type> spells with the chosen name" → `And{Typed, HasChosenName}`.
+        match (typed_filter, has_chosen_name) {
+            (Some(tf), true) => Some(TargetFilter::And {
+                filters: vec![tf, TargetFilter::HasChosenName],
+            }),
+            (None, true) => Some(TargetFilter::HasChosenName),
+            (tf, false) => tf,
+        }
+    } else {
+        None
+    };
 
     let spell_filter = merge_cost_modifier_target_filter(spell_filter, target_cost_filter);
 

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -216,109 +216,121 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
 
     // Extract spell type filter from the text before "cost"
     // E.g., "Creature spells you cast" → Creature, "Instant and sorcery spells" → AnyOf(Instant, Sorcery)
-    let spell_filter = if is_self_spell {
-        parse_self_spell_target_cost_filter(lower)
-    } else if let Some(filter) = first_qualified_spell_filter.clone() {
-        Some(filter)
-    // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-    } else if let Some(cost_idx) = lower.find(" cost") {
+    let spell_filter =
+        if nom_primitives::scan_contains(lower, "share a card type with the exiled card")
+            || nom_primitives::scan_contains(lower, "shares a card type with the exiled card")
+        {
+            // CR 601.2f: Semblance Anvil — imprinted card type gates the reduction.
+            Some(TargetFilter::Typed(TypedFilter::card().properties(vec![
+                FilterProp::SharesQuality {
+                    quality: SharedQuality::CardType,
+                    reference: Some(Box::new(TargetFilter::ExiledBySource)),
+                    relation: SharedQualityRelation::Shares,
+                },
+            ])))
+        } else if is_self_spell {
+            parse_self_spell_target_cost_filter(lower)
+        } else if let Some(filter) = first_qualified_spell_filter.clone() {
+            Some(filter)
         // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-        let prefix = &lower[..cost_idx];
-        let prefix = strip_cost_modifier_target_clause(prefix);
-        // Strip "from [zones]" clause (only if zones were detected), player scope, then "spells"
-        let without_from = if !cast_from_zones.is_empty() {
+        } else if let Some(cost_idx) = lower.find(" cost") {
             // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-            if let Some(from_idx) = prefix.find(" from ") {
+            let prefix = &lower[..cost_idx];
+            let prefix = strip_cost_modifier_target_clause(prefix);
+            // Strip "from [zones]" clause (only if zones were detected), player scope, then "spells"
+            let without_from = if !cast_from_zones.is_empty() {
                 // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-                &prefix[..from_idx]
+                if let Some(from_idx) = prefix.find(" from ") {
+                    // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+                    &prefix[..from_idx]
+                } else {
+                    prefix
+                }
             } else {
                 prefix
-            }
-        } else {
-            prefix
-        };
-        // CR 201.3 / CR 113.6: Strip the trailing "with the chosen name" qualifier
-        // (Disruptor Flute: "Spells with the chosen name cost {3} more to cast.")
-        // before the standard suffix-trim chain runs. Track it so the spell filter is
-        // composed with `HasChosenName` after type parsing — same convention used by
-        // `parse_continuous_subject_filter` for object-class chosen-name phrases.
-        let (without_chosen, has_chosen_name) =
-            match nom_primitives::split_once_on(without_from, " with the chosen name") {
-                Ok((_, (before, _))) => (before, true),
-                Err(_) => (without_from, false),
             };
-        // CR 205.2a + CR 601.2f: Strip the "of the chosen type" / "of that type"
-        // qualifier (Cloud Key, Umori, Stenn, Herald's Horn: "Spells you cast of
-        // the chosen type cost {1} less"). A "you cast" infix sits between the
-        // type word and this qualifier, so the trim chain below can't reach the
-        // type word and `parse_type_phrase` never extracts the chosen-type
-        // discriminator. Strip it here and re-attach IsChosenCardType /
-        // IsChosenCreatureType after the base type is parsed — mirrors the
-        // "with the chosen name" handling above.
-        let (without_chosen, has_chosen_type) = if let Ok((_, (before, _))) =
-            nom_primitives::split_once_on(without_chosen, " of the chosen type")
-        {
-            (before, true)
-        } else if let Ok((_, (before, _))) =
-            nom_primitives::split_once_on(without_chosen, " of that type")
-        {
-            (before, true)
-        } else {
-            (without_chosen, false)
-        };
-        let type_desc = without_chosen
-            .trim_end_matches(" you cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-            .trim_end_matches(" your opponents cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-            .trim_end_matches(" opponents cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-            .trim_end_matches(" spells") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-            .trim_end_matches(" spell") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
-            .trim();
-        // "spells" alone means no type restriction (bare "Spells you cast cost...")
-        let typed_filter = if type_desc.is_empty() || type_desc == "spells" || type_desc == "spell"
-        {
-            None
-        } else {
-            parse_cost_mod_spell_type_prefix(type_desc)
-        };
-        // CR 205.2a: Re-attach the chosen-type discriminator stripped above. A
-        // creature-typed base ("Creature spells ... of the chosen type",
-        // Herald's Horn) pairs with a chosen CREATURE type; a bare-spells base
-        // ("Spells ... of the chosen type", Cloud Key / Umori / Stenn) pairs
-        // with a chosen CARD type. Resolved at cast time against the source
-        // permanent's `ChosenAttribute` (CR 601.2f).
-        let typed_filter = if has_chosen_type {
-            match typed_filter {
-                Some(TargetFilter::Typed(mut tf))
-                    if tf.type_filters.contains(&TypeFilter::Creature) =>
-                {
-                    tf.properties.push(FilterProp::IsChosenCreatureType);
-                    Some(TargetFilter::Typed(tf))
+            // CR 201.3 / CR 113.6: Strip the trailing "with the chosen name" qualifier
+            // (Disruptor Flute: "Spells with the chosen name cost {3} more to cast.")
+            // before the standard suffix-trim chain runs. Track it so the spell filter is
+            // composed with `HasChosenName` after type parsing — same convention used by
+            // `parse_continuous_subject_filter` for object-class chosen-name phrases.
+            let (without_chosen, has_chosen_name) =
+                match nom_primitives::split_once_on(without_from, " with the chosen name") {
+                    Ok((_, (before, _))) => (before, true),
+                    Err(_) => (without_from, false),
+                };
+            // CR 205.2a + CR 601.2f: Strip the "of the chosen type" / "of that type"
+            // qualifier (Cloud Key, Umori, Stenn, Herald's Horn: "Spells you cast of
+            // the chosen type cost {1} less"). A "you cast" infix sits between the
+            // type word and this qualifier, so the trim chain below can't reach the
+            // type word and `parse_type_phrase` never extracts the chosen-type
+            // discriminator. Strip it here and re-attach IsChosenCardType /
+            // IsChosenCreatureType after the base type is parsed — mirrors the
+            // "with the chosen name" handling above.
+            let (without_chosen, has_chosen_type) = if let Ok((_, (before, _))) =
+                nom_primitives::split_once_on(without_chosen, " of the chosen type")
+            {
+                (before, true)
+            } else if let Ok((_, (before, _))) =
+                nom_primitives::split_once_on(without_chosen, " of that type")
+            {
+                (before, true)
+            } else {
+                (without_chosen, false)
+            };
+            let type_desc = without_chosen
+                .trim_end_matches(" you cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+                .trim_end_matches(" your opponents cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+                .trim_end_matches(" opponents cast") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+                .trim_end_matches(" spells") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+                .trim_end_matches(" spell") // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
+                .trim();
+            // "spells" alone means no type restriction (bare "Spells you cast cost...")
+            let typed_filter =
+                if type_desc.is_empty() || type_desc == "spells" || type_desc == "spell" {
+                    None
+                } else {
+                    parse_cost_mod_spell_type_prefix(type_desc)
+                };
+            // CR 205.2a: Re-attach the chosen-type discriminator stripped above. A
+            // creature-typed base ("Creature spells ... of the chosen type",
+            // Herald's Horn) pairs with a chosen CREATURE type; a bare-spells base
+            // ("Spells ... of the chosen type", Cloud Key / Umori / Stenn) pairs
+            // with a chosen CARD type. Resolved at cast time against the source
+            // permanent's `ChosenAttribute` (CR 601.2f).
+            let typed_filter = if has_chosen_type {
+                match typed_filter {
+                    Some(TargetFilter::Typed(mut tf))
+                        if tf.type_filters.contains(&TypeFilter::Creature) =>
+                    {
+                        tf.properties.push(FilterProp::IsChosenCreatureType);
+                        Some(TargetFilter::Typed(tf))
+                    }
+                    Some(TargetFilter::Typed(mut tf)) => {
+                        tf.properties.push(FilterProp::IsChosenCardType);
+                        Some(TargetFilter::Typed(tf))
+                    }
+                    None => Some(TargetFilter::Typed(
+                        TypedFilter::card().properties(vec![FilterProp::IsChosenCardType]),
+                    )),
+                    other => other,
                 }
-                Some(TargetFilter::Typed(mut tf)) => {
-                    tf.properties.push(FilterProp::IsChosenCardType);
-                    Some(TargetFilter::Typed(tf))
-                }
-                None => Some(TargetFilter::Typed(
-                    TypedFilter::card().properties(vec![FilterProp::IsChosenCardType]),
-                )),
-                other => other,
+            } else {
+                typed_filter
+            };
+            // Compose chosen-name constraint with the typed prefix (if any). Bare
+            // "Spells with the chosen name" → `HasChosenName` alone; typed
+            // "<Type> spells with the chosen name" → `And{Typed, HasChosenName}`.
+            match (typed_filter, has_chosen_name) {
+                (Some(tf), true) => Some(TargetFilter::And {
+                    filters: vec![tf, TargetFilter::HasChosenName],
+                }),
+                (None, true) => Some(TargetFilter::HasChosenName),
+                (tf, false) => tf,
             }
         } else {
-            typed_filter
+            None
         };
-        // Compose chosen-name constraint with the typed prefix (if any). Bare
-        // "Spells with the chosen name" → `HasChosenName` alone; typed
-        // "<Type> spells with the chosen name" → `And{Typed, HasChosenName}`.
-        match (typed_filter, has_chosen_name) {
-            (Some(tf), true) => Some(TargetFilter::And {
-                filters: vec![tf, TargetFilter::HasChosenName],
-            }),
-            (None, true) => Some(TargetFilter::HasChosenName),
-            (tf, false) => tf,
-        }
-    } else {
-        None
-    };
 
     let spell_filter = merge_cost_modifier_target_filter(spell_filter, target_cost_filter);
 

--- a/crates/engine/tests/integration/issue_2414_semblance_anvil.rs
+++ b/crates/engine/tests/integration/issue_2414_semblance_anvil.rs
@@ -1,0 +1,111 @@
+//! Regression for issue #2414: Semblance Anvil must reduce costs only for
+//! spells sharing a card type with the imprinted card.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_static::parse_static_line;
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::CardId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+#[test]
+fn semblance_anvil_reduces_only_matching_card_type() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+    let state = runner.state_mut();
+
+    let anvil = create_object(
+        state,
+        CardId(1),
+        P0,
+        "Semblance Anvil".to_string(),
+        Zone::Battlefield,
+    );
+    let reduction = parse_static_line(
+        "Spells you cast that share a card type with the exiled card cost {2} less to cast.",
+    )
+    .expect("Semblance Anvil cost-reduction static should parse");
+    state
+        .objects
+        .get_mut(&anvil)
+        .unwrap()
+        .static_definitions
+        .push(reduction);
+
+    let exiled_creature = create_object(
+        state,
+        CardId(2),
+        P0,
+        "Imprinted Creature".to_string(),
+        Zone::Exile,
+    );
+    {
+        let obj = state.objects.get_mut(&exiled_creature).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+    }
+    state
+        .exile_links
+        .push(engine::types::game_state::ExileLink {
+            source_id: anvil,
+            exiled_id: exiled_creature,
+            kind: engine::types::game_state::ExileLinkKind::TrackedBySource,
+        });
+
+    let matching_creature = create_object(
+        state,
+        CardId(3),
+        P0,
+        "Matching Creature Spell".to_string(),
+        Zone::Hand,
+    );
+    {
+        let obj = state.objects.get_mut(&matching_creature).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.mana_cost = ManaCost::generic(4);
+    }
+
+    let nonmatching_artifact = create_object(
+        state,
+        CardId(4),
+        P0,
+        "Nonmatching Artifact".to_string(),
+        Zone::Hand,
+    );
+    {
+        let obj = state.objects.get_mut(&nonmatching_artifact).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.mana_cost = ManaCost::generic(4);
+    }
+
+    let matching_cost =
+        engine::game::casting::display_spell_cost(state, P0, matching_creature).unwrap();
+    let nonmatching_cost =
+        engine::game::casting::display_spell_cost(state, P0, nonmatching_artifact).unwrap();
+
+    let ManaCost::Cost {
+        generic: matching_generic,
+        ..
+    } = matching_cost
+    else {
+        panic!("expected cost for matching spell");
+    };
+    let ManaCost::Cost {
+        generic: nonmatching_generic,
+        ..
+    } = nonmatching_cost
+    else {
+        panic!("expected cost for nonmatching spell");
+    };
+
+    assert_eq!(
+        matching_generic, 2,
+        "creature spell sharing imprinted creature type should be reduced by 2"
+    );
+    assert_eq!(
+        nonmatching_generic, 4,
+        "artifact spell must not receive Semblance Anvil's reduction"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -90,6 +90,7 @@ mod issue_2371_triskaidekaphile;
 mod issue_2372_nourishing_shoal_alt_cost;
 mod issue_2374_fblthp_library_origin;
 mod issue_2376_pyromancers_ascension;
+mod issue_2414_semblance_anvil;
 mod issue_2415_rottenmouth_viper_sacrifice_cost;
 mod issue_2417_satoru_intervening_if;
 mod issue_2422_demanding_dragon;

--- a/crates/mtgish-import/src/convert/filter.rs
+++ b/crates/mtgish-import/src/convert/filter.rs
@@ -7,7 +7,7 @@
 
 use engine::types::ability::{
     ChoiceType, Comparator, ControllerRef, FilterProp, PtStat, PtValueScope, QuantityExpr,
-    TargetFilter, TypeFilter, TypedFilter,
+    SharedQuality, SharedQualityRelation, TargetFilter, TypeFilter, TypedFilter,
 };
 use engine::types::counter::CounterMatch;
 use engine::types::keywords::{Keyword, KeywordKind};
@@ -892,221 +892,231 @@ fn damage_sources_variant_tag(s: &DamageSources) -> String {
 /// so the report tracks the work queue.
 pub(crate) fn spells_to_filter(s: &crate::schema::types::Spells) -> ConvResult<TargetFilter> {
     use crate::schema::types::Spells as S;
-    let filter =
-        match s {
-            S::AnySpell => TargetFilter::Typed(TypedFilter::default()),
-            S::IsCardtype(ct) => TargetFilter::Typed(TypedFilter::new(card_type(ct))),
-            S::IsNonCardtype(ct) => {
-                TargetFilter::Typed(TypedFilter::new(TypeFilter::Non(Box::new(card_type(ct)))))
-            }
-            S::IsCreatureType(ct) => TargetFilter::Typed(
-                TypedFilter::new(TypeFilter::Creature)
-                    .with_type(TypeFilter::Subtype(creature_type_name(ct))),
-            ),
-            S::IsNonCreatureType(ct) => {
-                TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature).with_type(
-                    TypeFilter::Non(Box::new(TypeFilter::Subtype(creature_type_name(ct)))),
-                ))
-            }
-            S::IsNonSupertype(st) => TargetFilter::Typed(TypedFilter::default().properties(vec![
-                FilterProp::NotSupertype {
+    let filter = match s {
+        S::AnySpell => TargetFilter::Typed(TypedFilter::default()),
+        S::IsCardtype(ct) => TargetFilter::Typed(TypedFilter::new(card_type(ct))),
+        S::IsNonCardtype(ct) => {
+            TargetFilter::Typed(TypedFilter::new(TypeFilter::Non(Box::new(card_type(ct)))))
+        }
+        S::IsCreatureType(ct) => TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Creature)
+                .with_type(TypeFilter::Subtype(creature_type_name(ct))),
+        ),
+        S::IsNonCreatureType(ct) => TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Creature).with_type(TypeFilter::Non(Box::new(
+                TypeFilter::Subtype(creature_type_name(ct)),
+            ))),
+        ),
+        S::IsNonSupertype(st) => {
+            TargetFilter::Typed(
+                TypedFilter::default().properties(vec![FilterProp::NotSupertype {
                     value: supertype_to_engine(st),
-                },
-            ])),
-            S::IsNonEnchantmentType(et) => TargetFilter::Typed(
-                TypedFilter::default()
-                    .with_type(TypeFilter::Enchantment)
-                    .with_type(TypeFilter::Non(Box::new(TypeFilter::Subtype(
-                        enchantment_type_name(et),
-                    )))),
-            ),
+                }]),
+            )
+        }
+        S::IsNonEnchantmentType(et) => TargetFilter::Typed(
+            TypedFilter::default()
+                .with_type(TypeFilter::Enchantment)
+                .with_type(TypeFilter::Non(Box::new(TypeFilter::Subtype(
+                    enchantment_type_name(et),
+                )))),
+        ),
 
-            // CR 205.3: Subtype predicates on spells (cards on the stack still
-            // carry their printed subtypes, so the typed-filter shape mirrors the
-            // Permanents arms).
-            S::IsArtifactType(at) => TargetFilter::Typed(
-                TypedFilter::default()
-                    .with_type(TypeFilter::Artifact)
-                    .with_type(TypeFilter::Subtype(artifact_type_name(at))),
-            ),
-            S::IsEnchantmentType(et) => TargetFilter::Typed(
-                TypedFilter::default()
-                    .with_type(TypeFilter::Enchantment)
-                    .with_type(TypeFilter::Subtype(enchantment_type_name(et))),
-            ),
-            S::IsPlaneswalkerType(pt) => TargetFilter::Typed(
-                TypedFilter::default()
-                    .with_type(TypeFilter::Planeswalker)
-                    .with_type(TypeFilter::Subtype(planeswalker_type_name(pt))),
-            ),
-            // CR 205.4a: nonbasic / nonlegendary / etc.
-            S::IsSupertype(st) => TargetFilter::Typed(TypedFilter::default().properties(vec![
-                FilterProp::HasSupertype {
+        // CR 205.3: Subtype predicates on spells (cards on the stack still
+        // carry their printed subtypes, so the typed-filter shape mirrors the
+        // Permanents arms).
+        S::IsArtifactType(at) => TargetFilter::Typed(
+            TypedFilter::default()
+                .with_type(TypeFilter::Artifact)
+                .with_type(TypeFilter::Subtype(artifact_type_name(at))),
+        ),
+        S::IsEnchantmentType(et) => TargetFilter::Typed(
+            TypedFilter::default()
+                .with_type(TypeFilter::Enchantment)
+                .with_type(TypeFilter::Subtype(enchantment_type_name(et))),
+        ),
+        S::IsPlaneswalkerType(pt) => TargetFilter::Typed(
+            TypedFilter::default()
+                .with_type(TypeFilter::Planeswalker)
+                .with_type(TypeFilter::Subtype(planeswalker_type_name(pt))),
+        ),
+        // CR 205.4a: nonbasic / nonlegendary / etc.
+        S::IsSupertype(st) => {
+            TargetFilter::Typed(
+                TypedFilter::default().properties(vec![FilterProp::HasSupertype {
                     value: supertype_to_engine(st),
-                },
-            ])),
-            // CR 110.1: spells that resolve to permanents (artifact/creature/
-            // enchantment/land/planeswalker/battle). Engine TypedFilter has no
-            // boolean "permanent" axis on a card-on-stack scope, so we inherit
-            // the Permanents-side `permanent()` typed filter — the type set is
-            // the same.
-            S::IsPermanent => TargetFilter::Typed(TypedFilter::permanent()),
+                }]),
+            )
+        }
+        // CR 110.1: spells that resolve to permanents (artifact/creature/
+        // enchantment/land/planeswalker/battle). Engine TypedFilter has no
+        // boolean "permanent" axis on a card-on-stack scope, so we inherit
+        // the Permanents-side `permanent()` typed filter — the type set is
+        // the same.
+        S::IsPermanent => TargetFilter::Typed(TypedFilter::permanent()),
 
-            // CR 105.1 / CR 105.2c: Color predicates over spells. Non-concrete
-            // colors strict-fail (chosen-color requires runtime binding).
-            S::IsColor(c) => match concrete_color(c) {
-                Some(color) => TargetFilter::Typed(
-                    TypedFilter::default().properties(vec![FilterProp::HasColor { color }]),
-                ),
-                None => {
-                    return Err(ConversionGap::MalformedIdiom {
-                        idiom: "Spells/IsColor",
-                        path: String::new(),
-                        detail: format!("non-concrete color: {c:?}"),
-                    });
-                }
-            },
-            S::IsNonColor(c) => match concrete_color(c) {
-                Some(color) => TargetFilter::Not {
-                    filter: Box::new(TargetFilter::Typed(
-                        TypedFilter::default().properties(vec![FilterProp::HasColor { color }]),
-                    )),
-                },
-                None => {
-                    return Err(ConversionGap::MalformedIdiom {
-                        idiom: "Spells/IsNonColor",
-                        path: String::new(),
-                        detail: format!("non-concrete color: {c:?}"),
-                    });
-                }
-            },
-            S::IsColorless => {
-                TargetFilter::Typed(TypedFilter::default().properties(vec![colorless_prop()]))
-            }
-            S::IsMulticolored => {
-                TargetFilter::Typed(TypedFilter::default().properties(vec![multicolored_prop()]))
-            }
-            // CR 700.6: "historic" — legendary, artifact, or Saga.
-            S::IsHistoric => {
-                TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Historic]))
-            }
-
-            // CR 202.3 / CR 208: Numeric comparisons on the cast spell. Reuse
-            // the same comparison helpers Permanents uses; they emit
-            // FilterProp::Cmc / FilterProp::PtComparison which evaluate against
-            // the card's printed/current values regardless of zone.
-            S::ManaValueIs(cmp) => cmc_comparison_filter(cmp)?,
-            S::PowerIs(cmp) => power_comparison_filter(cmp)?,
-            S::ToughnessIs(cmp) => toughness_comparison_filter(cmp)?,
-            // CR 107.3 + CR 202.1: spell with {X} in its mana cost.
-            S::HasXInManaCost => TargetFilter::Typed(
-                TypedFilter::default().properties(vec![FilterProp::HasXInManaCost]),
+        // CR 105.1 / CR 105.2c: Color predicates over spells. Non-concrete
+        // colors strict-fail (chosen-color requires runtime binding).
+        S::IsColor(c) => match concrete_color(c) {
+            Some(color) => TargetFilter::Typed(
+                TypedFilter::default().properties(vec![FilterProp::HasColor { color }]),
             ),
-
-            // CR 201.2: name predicate. Reuses the shared NameFilter helper,
-            // which strict-fails for non-static name shapes.
-            S::IsNamed(nf) => name_filter_to_filter(nf)?,
-
-            // CR 702: Keyword presence / absence on a spell. Reuses the same
-            // CheckHasable helper as Permanents — composite shapes strict-fail.
-            S::HasAbility(check) => has_ability_filter(check)?,
-            S::DoesntHaveAbility(check) => TargetFilter::Not {
-                filter: Box::new(has_ability_filter(check)?),
-            },
-
-            // CR 903.3: "your commander" — controller-scoped commander predicate.
-            S::IsYourCommander => TargetFilter::Typed(
-                TypedFilter::default()
-                    .controller(ControllerRef::You)
-                    .properties(vec![FilterProp::IsCommander]),
-            ),
-            // CR 903.3: "a commander" — any commander on the stack.
-            S::IsACommander => TargetFilter::Typed(
-                TypedFilter::default().properties(vec![FilterProp::IsCommander]),
-            ),
-
-            // CR 601.2 / CR 109.4: caster / owner / controller axis. The engine
-            // tracks the stack-object controller via ControllerRef; "cast by
-            // player X" maps directly. Compound `Players` (multi-player sets)
-            // strict-fail through `players_to_controller`.
-            S::CastByAPlayer(players) => {
-                let ctrl = players_to_controller(players)?;
-                TargetFilter::Typed(TypedFilter::default().controller(ctrl))
-            }
-            S::CastByPlayer(player) => {
-                let ctrl = player_to_controller(player)?;
-                TargetFilter::Typed(TypedFilter::default().controller(ctrl))
-            }
-            S::ControlledByAPlayer(players) => {
-                let ctrl = players_to_controller(players)?;
-                TargetFilter::Typed(TypedFilter::default().controller(ctrl))
-            }
-            S::OwnedByAPlayer(players) => {
-                let ctrl = players_to_controller(players)?;
-                TargetFilter::Typed(
-                    TypedFilter::default().properties(vec![FilterProp::Owned { controller: ctrl }]),
-                )
-            }
-
-            // CR 115.9c: "spell that targets only ~" — the inner Permanent /
-            // Permanents filter constrains every target of the spell.
-            S::TargetsOnlySinglePermanent(inner) => {
-                TargetFilter::Typed(TypedFilter::default().properties(vec![
-                    FilterProp::TargetsOnly {
-                        filter: Box::new(convert_permanent(inner)?),
-                    },
-                ]))
-            }
-            S::CanTargetOnly(inner) => {
-                TargetFilter::Typed(TypedFilter::default().properties(vec![
-                    FilterProp::TargetsOnly {
-                        filter: Box::new(convert(inner)?),
-                    },
-                ]))
-            }
-            // CR 115.9b: "spell that targets ~" (ANY target satisfies the inner
-            // filter). `TargetsAPermanent` carries a `Permanents`; `TargetsPermanent`
-            // carries a singular `Permanent`. Both reduce to FilterProp::Targets.
-            S::TargetsAPermanent(inner) => {
-                TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Targets {
-                    filter: Box::new(convert(inner)?),
-                }]))
-            }
-            S::TargetsPermanent(inner) => {
-                TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Targets {
-                    filter: Box::new(convert_permanent(inner)?),
-                }]))
-            }
-            // CR 115.7: spell with exactly one target.
-            S::HasASingleTarget => TargetFilter::Typed(
-                TypedFilter::default().properties(vec![FilterProp::HasSingleTarget]),
-            ),
-
-            S::And(parts) => {
-                let mut filters = Vec::with_capacity(parts.len());
-                for part in parts {
-                    filters.push(spells_to_filter(part)?);
-                }
-                TargetFilter::And { filters }
-            }
-            S::Or(parts) => {
-                let mut filters = Vec::with_capacity(parts.len());
-                for part in parts {
-                    filters.push(spells_to_filter(part)?);
-                }
-                TargetFilter::Or { filters }
-            }
-            S::Not(inner) => TargetFilter::Not {
-                filter: Box::new(spells_to_filter(inner)?),
-            },
-
-            other => {
-                return Err(ConversionGap::EnginePrerequisiteMissing {
-                    engine_type: "TargetFilter",
-                    needed_variant: format!("Spells::{}", spells_variant_tag(other)),
+            None => {
+                return Err(ConversionGap::MalformedIdiom {
+                    idiom: "Spells/IsColor",
+                    path: String::new(),
+                    detail: format!("non-concrete color: {c:?}"),
                 });
             }
-        };
+        },
+        S::IsNonColor(c) => match concrete_color(c) {
+            Some(color) => TargetFilter::Not {
+                filter: Box::new(TargetFilter::Typed(
+                    TypedFilter::default().properties(vec![FilterProp::HasColor { color }]),
+                )),
+            },
+            None => {
+                return Err(ConversionGap::MalformedIdiom {
+                    idiom: "Spells/IsNonColor",
+                    path: String::new(),
+                    detail: format!("non-concrete color: {c:?}"),
+                });
+            }
+        },
+        S::IsColorless => {
+            TargetFilter::Typed(TypedFilter::default().properties(vec![colorless_prop()]))
+        }
+        S::IsMulticolored => {
+            TargetFilter::Typed(TypedFilter::default().properties(vec![multicolored_prop()]))
+        }
+        // CR 700.6: "historic" — legendary, artifact, or Saga.
+        S::IsHistoric => {
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Historic]))
+        }
+
+        // CR 202.3 / CR 208: Numeric comparisons on the cast spell. Reuse
+        // the same comparison helpers Permanents uses; they emit
+        // FilterProp::Cmc / FilterProp::PtComparison which evaluate against
+        // the card's printed/current values regardless of zone.
+        S::ManaValueIs(cmp) => cmc_comparison_filter(cmp)?,
+        S::PowerIs(cmp) => power_comparison_filter(cmp)?,
+        S::ToughnessIs(cmp) => toughness_comparison_filter(cmp)?,
+        // CR 107.3 + CR 202.1: spell with {X} in its mana cost.
+        S::HasXInManaCost => {
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::HasXInManaCost]))
+        }
+
+        // CR 201.2: name predicate. Reuses the shared NameFilter helper,
+        // which strict-fails for non-static name shapes.
+        S::IsNamed(nf) => name_filter_to_filter(nf)?,
+
+        // CR 702: Keyword presence / absence on a spell. Reuses the same
+        // CheckHasable helper as Permanents — composite shapes strict-fail.
+        S::HasAbility(check) => has_ability_filter(check)?,
+        S::DoesntHaveAbility(check) => TargetFilter::Not {
+            filter: Box::new(has_ability_filter(check)?),
+        },
+
+        // CR 903.3: "your commander" — controller-scoped commander predicate.
+        S::IsYourCommander => TargetFilter::Typed(
+            TypedFilter::default()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::IsCommander]),
+        ),
+        // CR 903.3: "a commander" — any commander on the stack.
+        S::IsACommander => {
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::IsCommander]))
+        }
+
+        // CR 601.2 / CR 109.4: caster / owner / controller axis. The engine
+        // tracks the stack-object controller via ControllerRef; "cast by
+        // player X" maps directly. Compound `Players` (multi-player sets)
+        // strict-fail through `players_to_controller`.
+        S::CastByAPlayer(players) => {
+            let ctrl = players_to_controller(players)?;
+            TargetFilter::Typed(TypedFilter::default().controller(ctrl))
+        }
+        S::CastByPlayer(player) => {
+            let ctrl = player_to_controller(player)?;
+            TargetFilter::Typed(TypedFilter::default().controller(ctrl))
+        }
+        S::ControlledByAPlayer(players) => {
+            let ctrl = players_to_controller(players)?;
+            TargetFilter::Typed(TypedFilter::default().controller(ctrl))
+        }
+        S::OwnedByAPlayer(players) => {
+            let ctrl = players_to_controller(players)?;
+            TargetFilter::Typed(
+                TypedFilter::default().properties(vec![FilterProp::Owned { controller: ctrl }]),
+            )
+        }
+
+        // CR 115.9c: "spell that targets only ~" — the inner Permanent /
+        // Permanents filter constrains every target of the spell.
+        S::TargetsOnlySinglePermanent(inner) => TargetFilter::Typed(
+            TypedFilter::default().properties(vec![FilterProp::TargetsOnly {
+                filter: Box::new(convert_permanent(inner)?),
+            }]),
+        ),
+        S::CanTargetOnly(inner) => {
+            TargetFilter::Typed(
+                TypedFilter::default().properties(vec![FilterProp::TargetsOnly {
+                    filter: Box::new(convert(inner)?),
+                }]),
+            )
+        }
+        // CR 115.9b: "spell that targets ~" (ANY target satisfies the inner
+        // filter). `TargetsAPermanent` carries a `Permanents`; `TargetsPermanent`
+        // carries a singular `Permanent`. Both reduce to FilterProp::Targets.
+        S::TargetsAPermanent(inner) => {
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Targets {
+                filter: Box::new(convert(inner)?),
+            }]))
+        }
+        S::TargetsPermanent(inner) => {
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Targets {
+                filter: Box::new(convert_permanent(inner)?),
+            }]))
+        }
+        // CR 115.7: spell with exactly one target.
+        S::HasASingleTarget => TargetFilter::Typed(
+            TypedFilter::default().properties(vec![FilterProp::HasSingleTarget]),
+        ),
+
+        S::And(parts) => {
+            let mut filters = Vec::with_capacity(parts.len());
+            for part in parts {
+                filters.push(spells_to_filter(part)?);
+            }
+            TargetFilter::And { filters }
+        }
+        S::Or(parts) => {
+            let mut filters = Vec::with_capacity(parts.len());
+            for part in parts {
+                filters.push(spells_to_filter(part)?);
+            }
+            TargetFilter::Or { filters }
+        }
+        S::Not(inner) => TargetFilter::Not {
+            filter: Box::new(spells_to_filter(inner)?),
+        },
+        // CR 601.2f: Semblance Anvil — spells sharing a card type with the
+        // imprinted (exiled-by-source) card cost less to cast.
+        S::SharesACardtypeWithExiledCard(_) => TargetFilter::Typed(TypedFilter::card().properties(
+            vec![FilterProp::SharesQuality {
+                quality: SharedQuality::CardType,
+                reference: Some(Box::new(TargetFilter::ExiledBySource)),
+                relation: SharedQualityRelation::Shares,
+            }],
+        )),
+
+        other => {
+            return Err(ConversionGap::EnginePrerequisiteMissing {
+                engine_type: "TargetFilter",
+                needed_variant: format!("Spells::{}", spells_variant_tag(other)),
+            });
+        }
+    };
     Ok(filter.normalized())
 }
 

--- a/crates/mtgish-import/src/convert/filter.rs
+++ b/crates/mtgish-import/src/convert/filter.rs
@@ -16,9 +16,9 @@ use engine::types::mana::ManaColor;
 use crate::convert::quantity::convert as convert_quantity;
 use crate::convert::result::{ConvResult, ConversionGap};
 use crate::schema::types::{
-    ArtifactType, CardType, CardtypeVariable, CheckHasable, ChoosableColor, Color, Comparison,
-    CounterType, CreatureType, CreatureTypeVariable, DamageSources, EnchantmentType, LandType,
-    NameFilter, Permanent, Permanents, PlaneswalkerType, Player, Players, SuperType,
+    ArtifactType, CardInExile, CardType, CardtypeVariable, CheckHasable, ChoosableColor, Color,
+    Comparison, CounterType, CreatureType, CreatureTypeVariable, DamageSources, EnchantmentType,
+    LandType, NameFilter, Permanent, Permanents, PlaneswalkerType, Player, Players, SuperType,
 };
 
 fn color_count_prop(comparator: Comparator, count: u8) -> FilterProp {
@@ -1100,15 +1100,23 @@ pub(crate) fn spells_to_filter(s: &crate::schema::types::Spells) -> ConvResult<T
         S::Not(inner) => TargetFilter::Not {
             filter: Box::new(spells_to_filter(inner)?),
         },
-        // CR 601.2f: Semblance Anvil — spells sharing a card type with the
-        // imprinted (exiled-by-source) card cost less to cast.
-        S::SharesACardtypeWithExiledCard(_) => TargetFilter::Typed(TypedFilter::card().properties(
-            vec![FilterProp::SharesQuality {
-                quality: SharedQuality::CardType,
-                reference: Some(Box::new(TargetFilter::ExiledBySource)),
-                relation: SharedQualityRelation::Shares,
-            }],
-        )),
+        // CR 601.2f + CR 607.2a + CR 607.3: Semblance Anvil-style spell cost
+        // reduction compares against "the exiled card" linked to the source.
+        S::SharesACardtypeWithExiledCard(card) => {
+            if !matches!(card.as_ref(), CardInExile::TheExiledCard) {
+                return Err(ConversionGap::EnginePrerequisiteMissing {
+                    engine_type: "TargetFilter",
+                    needed_variant: format!("SharesACardtypeWithExiledCard/{:?}", card.as_ref()),
+                });
+            }
+            TargetFilter::Typed(
+                TypedFilter::card().properties(vec![FilterProp::SharesQuality {
+                    quality: SharedQuality::CardType,
+                    reference: Some(Box::new(TargetFilter::ExiledBySource)),
+                    relation: SharedQualityRelation::Shares,
+                }]),
+            )
+        }
 
         other => {
             return Err(ConversionGap::EnginePrerequisiteMissing {


### PR DESCRIPTION
## Summary
- Parse "share a card type with the exiled card" on spell cost-reduction statics
- Convert mtgish `SharesACardtypeWithExiledCard` to `SharesQuality` + `ExiledBySource`
- Evaluate `SharesQuality` in live spell cost filtering so only matching types are reduced

## Test plan
- [x] `cargo test --test integration semblance_anvil`

Fixes #2414 