### PR TITLE
feat(p2p): raise online multiplayer cap from 4 to 6 players

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -236,7 +236,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     vi.useRealTimers();
   });
 
-  it("rejects construction with playerCount outside 2-4", () => {
+  it("rejects construction with playerCount outside 2-6", () => {
     const { peer, onGuestConnected } = createFakePeer();
     const hostDeck = {
       player: { main_deck: [], sideboard: [] },
@@ -245,10 +245,10 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     };
     expect(
       () => new P2PHostAdapter(hostDeck, peer as unknown as Peer, onGuestConnected, 1),
-    ).toThrow("P2P supports 2-4 players");
+    ).toThrow("P2P supports 2-6 players");
     expect(
-      () => new P2PHostAdapter(hostDeck, peer as unknown as Peer, onGuestConnected, 5),
-    ).toThrow("P2P supports 2-4 players");
+      () => new P2PHostAdapter(hostDeck, peer as unknown as Peer, onGuestConnected, 7),
+    ).toThrow("P2P supports 2-6 players");
   });
 
   it("enables multiplayer-mode enforcement on the engine at init time", async () => {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -346,10 +346,10 @@ export class P2PHostAdapter implements EngineAdapter {
       resumeData?: { state: GameState; session: PersistedP2PHostSession };
     },
   ) {
-    if (playerCount < 2 || playerCount > 4) {
+    if (playerCount < 2 || playerCount > 6) {
       throw new AdapterError(
         "P2P_PLAYER_COUNT",
-        `P2P supports 2-4 players; got ${playerCount}`,
+        `P2P supports 2-6 players; got ${playerCount}`,
         false,
       );
     }

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -47,11 +47,11 @@ const GROUP_ORDER: Record<FormatGroup, number> = {
 const DIFFICULTY_OPTIONS = ["VeryEasy", "Easy", "Medium", "Hard", "VeryHard"];
 const FFA_DECK_SIZE_OPTIONS = [60, 40] as const;
 
-/** P2P's WebRTC mesh supports 2-4 peers (see `p2p-adapter.ts:165`). The
- * HostSetup UI clamps format player counts to this ceiling so multi-seat
- * formats like Commander can still be hosted while 6-player FreeForAll
- * can't advertise an unreachable configuration. */
-const P2P_MAX_PEERS = 4;
+/** P2P uses a hub-and-spoke topology (see `p2p-adapter.ts` `P2PHostAdapter`):
+ * the host holds one connection per guest and fans out filtered state, which
+ * scales linearly. The ceiling here matches the engine's Free-for-All maximum
+ * (`format.rs` `free_for_all`, max_players 6) rather than a transport limit. */
+const P2P_MAX_PEERS = 6;
 
 /** Uppercase field label + optional hint wrapper (mirrors the design mockup's
  *  Host-setup `Field`). Pure presentation. */
@@ -344,10 +344,10 @@ export function HostSetup({
     }
   };
 
-  // Filter formats: P2P supports 2-4 peers via WebRTC mesh, so any format
-  // whose minimum is reachable from that ceiling is listable. Multi-seat
-  // formats that need more than 4 players (e.g. 6-player FreeForAll) are
-  // hidden here to avoid advertising a configuration we can't actually host.
+  // Filter formats: P2P supports 2-6 players (hub-and-spoke, see P2P_MAX_PEERS),
+  // so any format whose minimum is reachable from that ceiling is listable.
+  // Formats requiring more seats than the ceiling are hidden here to avoid
+  // advertising a configuration we can't actually host.
   const availableFormats = isP2P
     ? FORMAT_OPTIONS.filter(
         (f) => FORMAT_DEFAULTS[f.format].min_players <= P2P_MAX_PEERS,


### PR DESCRIPTION
The P2P host adapter rejected playerCount > 4, and the lobby UI clamped
format player counts to the same ceiling, hiding 6-player Free-for-All
from P2P hosts. Play-vs-AI had no such cap because it drives the same
WASM engine directly (engine Free-for-All max_players is 6).

The 4 was a conservative transport policy, not a hard limit: P2P uses a
hub-and-spoke topology where the host holds one connection per guest and
fans out per-seat filtered state, which scales linearly (not the
quadratic growth of a full mesh). Raise the ceiling to match the
engine's 6-player Free-for-All maximum. The lobby broker (max 8) and
full-server mode (max 6) already allowed it, so this is a client-only
change.
