### PR TITLE
fix(keyword): cumulative upkeep with non-mana Discard cost (CR 702.24)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1157,7 +1157,7 @@ export type WaitingFor =
   // to pay (or declines all). Drives Tergrid's Lantern and the broader
   // "unless they X or Y" punisher class.
   | { type: "UnlessPaymentChooseCost"; data: { player: PlayerId; costs: UnlessCost[]; pending_effect: unknown; trigger_event?: unknown; effect_description?: string } }
-  | { type: "WardDiscardChoice"; data: { player: PlayerId; cards: ObjectId[]; pending_effect: unknown } }
+  | { type: "WardDiscardChoice"; data: { player: PlayerId; cards: ObjectId[]; pending_effect: unknown; remaining: number; filter?: unknown } }
   | { type: "WardSacrificeChoice"; data: { player: PlayerId; permanents: ObjectId[]; pending_effect: unknown; remaining: number } }
   | { type: "UnlessBounceChoice"; data: { player: PlayerId; permanents: ObjectId[]; pending_effect: unknown; remaining: number } }
   | { type: "ChooseRingBearer"; data: { player: PlayerId; candidates: ObjectId[] } }

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -14719,22 +14719,11 @@ mod cumulative_upkeep_synthesis_tests {
     /// silent-no-op state until per-shape support lands.
     #[test]
     fn cumulative_upkeep_synthesizer_skips_unsupported_base_shapes() {
-        // Discard base — no current cumulative-upkeep card resolves through
-        // `AbilityCost::Discard` because the unless-payment pipeline can't pay
-        // it. Synthesizer must refuse to install.
-        let discard_kw = Keyword::CumulativeUpkeep(AbilityCost::Discard {
-            count: QuantityExpr::Fixed { value: 1 },
-            filter: None,
-            random: false,
-            self_ref: false,
-        });
-        assert_eq!(
-            KeywordTriggerInstaller::triggers_for(&discard_kw).len(),
-            0,
-            "Discard base must not install a cumulative-upkeep trigger"
-        );
-
-        // Exile base — same reasoning as Discard.
+        // Exile base — no current cumulative-upkeep card resolves through
+        // `AbilityCost::Exile` because the unless-payment pipeline can't pay
+        // it. Synthesizer must refuse to install. (Discard became supported
+        // once the per-counter discard payment chain landed — CR 702.24a — so
+        // Exile is now the canonical still-unsupported non-mana base shape.)
         let exile_kw = Keyword::CumulativeUpkeep(AbilityCost::Exile {
             count: 1,
             zone: None,
@@ -14747,17 +14736,16 @@ mod cumulative_upkeep_synthesis_tests {
         );
 
         // Composite of mixed shapes — Composite-of-Mana is supported, but
-        // Composite containing Discard/Exile is not.
+        // Composite containing an unsupported shape (Exile) is not.
         let mixed_composite_kw = Keyword::CumulativeUpkeep(AbilityCost::Composite {
             costs: vec![
                 AbilityCost::Mana {
                     cost: ManaCost::generic(1),
                 },
-                AbilityCost::Discard {
-                    count: QuantityExpr::Fixed { value: 1 },
+                AbilityCost::Exile {
+                    count: 1,
+                    zone: None,
                     filter: None,
-                    random: false,
-                    self_ref: false,
                 },
             ],
         });
@@ -14771,16 +14759,15 @@ mod cumulative_upkeep_synthesis_tests {
         // PayCumulativeUpkeep trigger after synthesis runs.
         let mut face = CardFace::default();
         face.keywords
-            .push(Keyword::CumulativeUpkeep(AbilityCost::Discard {
-                count: QuantityExpr::Fixed { value: 1 },
+            .push(Keyword::CumulativeUpkeep(AbilityCost::Exile {
+                count: 1,
+                zone: None,
                 filter: None,
-                random: false,
-                self_ref: false,
             }));
         synthesize_cumulative_upkeep(&mut face);
         assert!(
             face.triggers.is_empty(),
-            "synthesize_cumulative_upkeep on a Discard base must install no triggers"
+            "synthesize_cumulative_upkeep on an Exile base must install no triggers"
         );
     }
 
@@ -14816,6 +14803,21 @@ mod cumulative_upkeep_synthesis_tests {
             KeywordTriggerInstaller::triggers_for(&sacrifice_kw).len(),
             1,
             "Sacrifice base must install exactly one cumulative-upkeep trigger"
+        );
+
+        // CR 702.24a: Discard base — Vexing Sphinx-shape. Supported once the
+        // per-counter discard payment chain (scaled_by + remaining re-prompt)
+        // landed; must install exactly one trigger.
+        let discard_kw = Keyword::CumulativeUpkeep(AbilityCost::Discard {
+            count: QuantityExpr::Fixed { value: 1 },
+            filter: None,
+            random: false,
+            self_ref: false,
+        });
+        assert_eq!(
+            KeywordTriggerInstaller::triggers_for(&discard_kw).len(),
+            1,
+            "Discard base must install exactly one cumulative-upkeep trigger"
         );
 
         // OneOf-of-Mana — Jötun Owl Keeper-shape disjunction of mana costs.

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -9979,13 +9979,15 @@ mod tests {
 
     #[test]
     fn unsupported_cumulative_upkeep_cost_counts_as_keyword_gap() {
+        // CR 702.24a: Exile-base cumulative upkeep is still unsupported by the
+        // unless-payment pipeline (Discard became supported once the per-counter
+        // discard payment chain landed), so it remains a coverage gap.
         let mut face = make_face();
         face.keywords
-            .push(Keyword::CumulativeUpkeep(AbilityCost::Discard {
-                count: QuantityExpr::Fixed { value: 1 },
+            .push(Keyword::CumulativeUpkeep(AbilityCost::Exile {
+                count: 1,
+                zone: None,
                 filter: None,
-                random: false,
-                self_ref: false,
             }));
 
         let gaps = card_face_gaps(&face);

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5528,6 +5528,21 @@ fn expand_per_counter(base: &AbilityCost, n: u32) -> AbilityCost {
         AbilityCost::Composite { costs } => AbilityCost::Composite {
             costs: costs.iter().map(|c| expand_per_counter(c, n)).collect(),
         },
+        // CR 702.24a: "If [cost] has choices … each choice is made separately for
+        // each age counter." Scale the discard count by the age-counter multiplier
+        // so N age counters demand N discards; filter/random/self_ref are unchanged
+        // per-counter axes.
+        AbilityCost::Discard {
+            count,
+            filter,
+            random,
+            self_ref,
+        } => AbilityCost::Discard {
+            count: count.scaled_by(n),
+            filter: filter.clone(),
+            random: *random,
+            self_ref: *self_ref,
+        },
         // YAGNI fallback: no current cumulative-upkeep card uses these
         // base variants. If a future mechanic does, the
         // Composite-of-N-copies expansion is semantically correct for
@@ -6698,6 +6713,32 @@ mod tests {
             panic!("expected Sacrifice");
         };
         assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn expand_per_counter_discard_scales_count() {
+        // CR 702.24a: N age counters demand N discards; filter/random/self_ref
+        // are unchanged per-counter axes.
+        let base = AbilityCost::Discard {
+            count: QuantityExpr::Fixed { value: 1 },
+            filter: Some(TargetFilter::SelfRef),
+            random: false,
+            self_ref: true,
+        };
+        let expanded = expand_per_counter(&base, 3);
+        let AbilityCost::Discard {
+            count,
+            filter,
+            random,
+            self_ref,
+        } = expanded
+        else {
+            panic!("expected Discard");
+        };
+        assert_eq!(count, QuantityExpr::Fixed { value: 3 });
+        assert_eq!(filter, Some(TargetFilter::SelfRef));
+        assert!(!random);
+        assert!(self_ref);
     }
 
     #[test]

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -433,32 +433,42 @@ pub(super) fn handle_unless_payment(
                     });
                 }
             }
-            // CR 118.12 + CR 701.9: Unless-discard. Defers to the unified
-            // `WardDiscardChoice` waiting state (the name predates the fold
-            // and now covers both ward and counter unless-discard cases).
-            // `count`/`random`/`self_ref` axes from the unified `Discard`
-            // shape are not yet consumed at this site — extending them is
-            // future work tracked alongside the `Balduvian Horde` random-
-            // discard fidelity gap.
+            // CR 118.12a + CR 701.9 + CR 702.24a: Unless-discard. Resolve the
+            // per-counter-scaled count, gate on eligible hand size, and seed the
+            // `remaining` re-prompt loop (one card per round-trip). Defers to the
+            // unified `WardDiscardChoice` waiting state (the name predates the
+            // fold and now covers both ward and counter unless-discard cases).
             AbilityCost::Discard {
-                count: _,
+                count,
                 filter,
                 random: _,
                 self_ref: _,
             } => {
+                let resolved = crate::game::quantity::resolve_quantity_with_targets(
+                    state,
+                    &count,
+                    pending_effect.as_ref(),
+                );
+                let count = u32::try_from(resolved.max(0)).unwrap_or(0);
+
                 let hand_cards = crate::game::casting::find_eligible_discard_targets(
                     state,
                     player,
                     pending_effect.source_id,
                     filter.as_ref(),
                 );
-                if hand_cards.is_empty() {
+                // CR 702.24a: partial payments aren't allowed — if the controller
+                // can't produce the full count, the unless cost is unpayable and
+                // the effect happens.
+                if (hand_cards.len() as u32) < count {
                     payment_failed = true;
                 } else {
                     state.waiting_for = WaitingFor::WardDiscardChoice {
                         player,
                         cards: hand_cards,
                         pending_effect: pending_effect.clone(),
+                        remaining: count,
+                        filter: filter.clone(),
                     };
                     return Ok(action_result(events, state.waiting_for.clone()));
                 }
@@ -908,6 +918,8 @@ pub(super) fn handle_ward_discard_choice(
         player,
         cards: legal_cards,
         pending_effect,
+        remaining,
+        filter,
     } = waiting_for
     else {
         return Err(EngineError::InvalidAction(
@@ -922,6 +934,27 @@ pub(super) fn handle_ward_discard_choice(
     }
 
     effects::discard::complete_discard_to_graveyard(state, chosen[0], player, events);
+
+    // CR 702.24a: more discards remain — re-derive hand eligibility (the
+    // just-discarded card still keys `state.objects` in the graveyard, so
+    // re-derive from hand rather than filtering by `contains_key`).
+    if remaining > 1 {
+        let hand_cards = crate::game::casting::find_eligible_discard_targets(
+            state,
+            player,
+            pending_effect.source_id,
+            filter.as_ref(),
+        );
+        state.waiting_for = WaitingFor::WardDiscardChoice {
+            player,
+            cards: hand_cards,
+            pending_effect,
+            remaining: remaining - 1,
+            filter,
+        };
+        return Ok(state.waiting_for.clone());
+    }
+
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::from(&pending_effect.effect),
         source_id: pending_effect.source_id,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4999,7 +4999,11 @@ impl AbilityCost {
         match self {
             AbilityCost::Mana { .. }
             | AbilityCost::PayLife { .. }
-            | AbilityCost::Sacrifice { .. } => true,
+            | AbilityCost::Sacrifice { .. }
+            // CR 702.24a + CR 118.12: Discard's per-counter-scaled count is
+            // folded by `expand_per_counter` and paid by the `remaining`
+            // re-prompt loop in `handle_unless_payment` end-to-end.
+            | AbilityCost::Discard { .. } => true,
             // CR 118.12a: OneOf at the base must be a disjunction of mana
             // costs; mixed-shape disjunctions are not yet expanded into a
             // payable per-counter form.
@@ -13025,7 +13029,7 @@ mod tests {
             ],
         }
         .supports_cumulative_upkeep_payment());
-        assert!(!AbilityCost::Discard {
+        assert!(AbilityCost::Discard {
             count: QuantityExpr::Fixed { value: 1 },
             filter: None,
             random: false,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2972,6 +2972,14 @@ pub enum WaitingFor {
         cards: Vec<ObjectId>,
         /// The counter effect to prevent if the discard succeeds.
         pending_effect: Box<ResolvedAbility>,
+        /// CR 702.24a: cards remaining to discard (per-age-counter scaling). One card per round-trip.
+        #[serde(default = "default_remaining_one")]
+        remaining: u32,
+        /// CR 701.9b: eligibility filter, threaded so the re-prompt branch can re-derive hand
+        /// eligibility after each discard (the just-discarded card is moved to graveyard but STILL
+        /// EXISTS in state.objects, so a contains_key filter would be wrong).
+        #[serde(default)]
+        filter: Option<TargetFilter>,
     },
     /// CR 702.21a: Player must choose a permanent to sacrifice as ward cost payment.
     WardSacrificeChoice {

--- a/crates/engine/tests/cumulative_upkeep_discard.rs
+++ b/crates/engine/tests/cumulative_upkeep_discard.rs
@@ -1,0 +1,274 @@
+//! Regression coverage for the **Cumulative upkeep—Discard a card** class
+//! (Vexing Sphinx, Phyrexian Soulgorger-adjacent discard variants).
+//!
+//! ROOT CAUSE under test: `AbilityCost::supports_cumulative_upkeep_payment()`
+//! previously hit `_ => false` for `Discard`, so the production synthesizer
+//! (`database::synthesis::build`, gated at synthesis.rs:211) emitted **no**
+//! cumulative-upkeep trigger for Vexing Sphinx — the permanent sat on the
+//! battlefield free, never demanding the discard. The fix makes the Discard
+//! runtime payment chain functional (per-counter `scaled_by` expansion +
+//! a `remaining` re-prompt loop) and then flips the support gate.
+//!
+//! These tests drive the REAL pipeline: a Vexing Sphinx built from its
+//! authoritative Oracle text through `GameScenario::add_creature_from_oracle`
+//! (which runs `synthesize_all`, including `synthesize_cumulative_upkeep`),
+//! then advanced through the upkeep step so the synthesized trigger fires,
+//! adds an age counter, and surfaces the `UnlessPayment` discard prompt.
+//!
+//! CR ANCHORS:
+//!   * CR 702.24a — "pay [cost] for each age counter on it … If [cost] has
+//!     choices … each choice is made separately for each age counter …
+//!     Partial payments aren't allowed."
+//!   * CR 701.9 / 701.9a — Discard keyword action (hand → graveyard).
+//!   * CR 118.12 / 118.12a — unless-payment semantics (decline ≡ unpayable).
+//!
+//! CARD TEXT (verified from this engine's card-data for Vexing Sphinx):
+//!   "Flying\nCumulative upkeep—Discard a card. (At the beginning of your
+//!    upkeep, put an age counter on this permanent, then sacrifice it unless
+//!    you pay its upkeep cost for each age counter on it.)\nWhen this creature
+//!    dies, draw a card for each age counter on it."
+
+use engine::game::scenario::GameScenario;
+use engine::types::ability::{AbilityCost, QuantityExpr};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+const VEXING_SPHINX_ORACLE: &str = "Flying\nCumulative upkeep—Discard a card. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)\nWhen this creature dies, draw a card for each age counter on it.";
+
+/// Build a Vexing Sphinx on PlayerId(0)'s battlefield with `preloaded_age`
+/// age counters and `hand_card_count` generic discardable cards in hand, then
+/// advance to the controller's upkeep and resolve the cumulative-upkeep trigger
+/// so the engine is paused at the `UnlessPayment` prompt.
+///
+/// Returns `(runner, sphinx_id)` paused at `WaitingFor::UnlessPayment`.
+fn setup_at_unless_prompt(
+    preloaded_age: u32,
+    hand_card_count: usize,
+) -> (engine::game::scenario::GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    // Start at Untap so a single `auto_advance` (driven by `advance_to_upkeep`)
+    // ticks into Upkeep and fires the synthesized cumulative-upkeep trigger
+    // onto the stack (CR 503.1a).
+    scenario.at_phase(Phase::Untap);
+
+    let sphinx = scenario
+        .add_creature_from_oracle(P0, "Vexing Sphinx", 4, 4, VEXING_SPHINX_ORACLE)
+        .id();
+
+    if preloaded_age > 0 {
+        scenario.with_counter(sphinx, CounterType::Age, preloaded_age);
+    }
+
+    let hand_names: Vec<String> = (0..hand_card_count)
+        .map(|i| format!("Filler Card {i}"))
+        .collect();
+    let hand_refs: Vec<&str> = hand_names.iter().map(String::as_str).collect();
+    scenario.with_cards_in_hand(P0, &hand_refs);
+
+    let mut runner = scenario.build();
+    // `advance_to_upkeep` runs `auto_advance` (Untap → Upkeep), landing the
+    // cumulative-upkeep trigger on the stack; `resolve_top` then resolves it,
+    // adding the age counter and surfacing the per-counter discard prompt.
+    runner.advance_to_upkeep();
+    runner.resolve_top();
+
+    (runner, sphinx)
+}
+
+/// CR 702.24a + CR 701.9 + CR 118.12a: with one pre-loaded age counter, the
+/// first resolved upkeep ticks the counter to TWO, so `expand_per_counter`
+/// scales `Discard { Fixed(1) }` to `Discard { Fixed(2) }` and the controller
+/// must discard exactly two cards (one per round-trip) to keep the Sphinx.
+#[test]
+fn vexing_sphinx_cumulative_upkeep_demands_discard_per_age_counter() {
+    let (mut runner, sphinx) = setup_at_unless_prompt(1, 3);
+
+    // CR 702.24a: the age counter ticked from 1 (pre-loaded) to 2 before the
+    // per-counter unless-cost is computed.
+    assert_eq!(
+        runner.state().objects[&sphinx]
+            .counters
+            .get(&CounterType::Age)
+            .copied(),
+        Some(2),
+        "age counter must tick from 1 (pre-loaded) to 2 on this upkeep"
+    );
+
+    // CR 702.24a + CR 701.9: the synthesized trigger surfaced an UnlessPayment
+    // prompt whose cost is the per-counter-scaled Discard (Fixed(1) × 2 = 2).
+    // THIS is the discrimination point: on origin/main the support gate is
+    // `false` for Discard, so no trigger synthesizes and `waiting_for` never
+    // becomes `UnlessPayment` here.
+    match &runner.state().waiting_for {
+        WaitingFor::UnlessPayment { player, cost, .. } => {
+            assert_eq!(*player, P0, "controller is the unless-payer");
+            match cost {
+                AbilityCost::Discard { count, .. } => {
+                    assert_eq!(
+                        *count,
+                        QuantityExpr::Fixed { value: 2 },
+                        "2 age counters × base count 1 = 2 (scaled_by)"
+                    );
+                }
+                other => panic!("expected Discard unless-cost, got {other:?}"),
+            }
+        }
+        other => panic!("expected UnlessPayment prompt, got {other:?}"),
+    }
+
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
+
+    // CR 118.12: pay → engine seeds the `remaining` discard loop and surfaces
+    // `WardDiscardChoice { remaining: 2 }`.
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("paying the discard cost must be accepted");
+
+    let (first_choice, second_remaining_cards) = match &runner.state().waiting_for {
+        WaitingFor::WardDiscardChoice {
+            player,
+            cards,
+            remaining,
+            ..
+        } => {
+            assert_eq!(*player, P0, "controller picks which card to discard");
+            assert_eq!(*remaining, 2, "two discards required for two age counters");
+            assert!(
+                cards.len() >= 2,
+                "at least two eligible hand cards to discard"
+            );
+            (cards[0], cards.clone())
+        }
+        other => panic!("expected WardDiscardChoice prompt, got {other:?}"),
+    };
+
+    // CR 701.9a: discard the first card (hand → graveyard).
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![first_choice],
+        })
+        .expect("first discard selection must be accepted");
+
+    // CR 702.24a: one discard remains — the prompt re-derives hand eligibility
+    // and the just-discarded card is NO LONGER offered (proves re-derivation
+    // excludes the graveyard card rather than filtering by `contains_key`).
+    let second_choice = match &runner.state().waiting_for {
+        WaitingFor::WardDiscardChoice {
+            player,
+            cards,
+            remaining,
+            ..
+        } => {
+            assert_eq!(*player, P0);
+            assert_eq!(*remaining, 1, "one discard remaining after the first");
+            assert!(
+                !cards.contains(&first_choice),
+                "just-discarded card must not be re-offered on the second prompt"
+            );
+            assert!(
+                second_remaining_cards.contains(&cards[0]) || !cards.is_empty(),
+                "a distinct eligible card must remain"
+            );
+            cards[0]
+        }
+        other => panic!("expected second WardDiscardChoice prompt, got {other:?}"),
+    };
+    assert_ne!(
+        first_choice, second_choice,
+        "the two discards must be distinct cards (CR 702.24a per-counter)"
+    );
+
+    // CR 701.9a: discard the second card — completing the per-counter payment.
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![second_choice],
+        })
+        .expect("second discard selection must be accepted");
+
+    // CR 702.24a: paying the full cost keeps the permanent on the battlefield.
+    assert_eq!(
+        runner.state().objects[&sphinx].zone,
+        Zone::Battlefield,
+        "paying the cumulative-upkeep discard cost must NOT sacrifice the Sphinx"
+    );
+    // Hand decreased by exactly two; both discarded cards are in the graveyard.
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        hand_before - 2,
+        "exactly two cards discarded"
+    );
+    assert_eq!(
+        runner.state().objects[&first_choice].zone,
+        Zone::Graveyard,
+        "first discarded card must be in the graveyard"
+    );
+    assert_eq!(
+        runner.state().objects[&second_choice].zone,
+        Zone::Graveyard,
+        "second discarded card must be in the graveyard"
+    );
+}
+
+/// CR 702.24a + CR 118.12a: declining the discard (explicit `pay: false`) or
+/// being unable to produce the full per-counter count both make the unless
+/// effect happen — the Sphinx is sacrificed. Partial payments aren't allowed.
+#[test]
+fn vexing_sphinx_declining_discard_sacrifices() {
+    // Sub-case (a): explicit decline. Two age counters demanded; hand has
+    // enough cards to pay, but the controller chooses not to.
+    {
+        let (mut runner, sphinx) = setup_at_unless_prompt(1, 3);
+        assert!(
+            matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+            "must be paused at the discard unless-prompt"
+        );
+
+        runner
+            .act(GameAction::PayUnlessCost { pay: false })
+            .expect("declining the unless cost must be accepted");
+
+        // CR 118.12a: declining ≡ the effect (sacrifice) happens.
+        assert_eq!(
+            runner.state().objects[&sphinx].zone,
+            Zone::Graveyard,
+            "declining the cumulative-upkeep discard must sacrifice the Sphinx"
+        );
+    }
+
+    // Sub-case (b): under-payable hand. Two age counters demanded (counter
+    // ticks 1 → 2) but only ONE eligible card in hand — fewer than the
+    // required two, so the cost is unpayable even on `pay: true`, and the
+    // effect happens (CR 702.24a: partial payments aren't allowed).
+    {
+        let (mut runner, sphinx) = setup_at_unless_prompt(1, 1);
+        assert!(
+            matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+            "must be paused at the discard unless-prompt"
+        );
+
+        runner
+            .act(GameAction::PayUnlessCost { pay: true })
+            .expect("attempting to pay an unpayable cost must be accepted");
+
+        // CR 702.24a: the controller can't produce two discards, so the cost
+        // is unpayable and the Sphinx is sacrificed — it must NOT consume the
+        // single card as a partial payment.
+        assert_eq!(
+            runner.state().objects[&sphinx].zone,
+            Zone::Graveyard,
+            "an under-payable discard cost must sacrifice the Sphinx (no partial payment)"
+        );
+        assert_eq!(
+            runner.state().players[P0.0 as usize].hand.len(),
+            1,
+            "the lone hand card must NOT be discarded as a partial payment"
+        );
+    }
+}


### PR DESCRIPTION
Vexing Sphinx ("Cumulative upkeep—Discard a card") was non-functional:
supports_cumulative_upkeep_payment() returned false for Discard, so
synthesis emitted no cumulative-upkeep trigger and the permanent sat on
the battlefield free instead of demanding a discard per age counter.

Unlock the Discard runtime payment chain, then flip the synthesis gate:
- expand_per_counter scales the discard count by the age-counter
  multiplier (QuantityExpr::scaled_by) so N age counters demand N discards
  (CR 702.24a "pay [cost] for each age counter").
- handle_unless_payment Discard arm now resolves the QuantityExpr count
  and gates on eligible hand size (CR 702.24a partial payments not
  allowed); WardDiscardChoice carries remaining + filter, and
  handle_ward_discard_choice re-prompts one card per round-trip,
  re-deriving hand eligibility via find_eligible_discard_targets (the
  discarded card moves to the graveyard but stays in state.objects, so a
  contains_key re-filter would wrongly re-offer it).
- supports_cumulative_upkeep_payment gates Discard => true.

Also fixes a latent defect: the prior unless-discard arm ignored count
and only ever prompted one discard, under-paying any multi-card
'discard N unless' cost.

Scope is Discard only; other non-mana cumulative-upkeep costs
(Draw/Exile/counter/life-gain/mixed-Composite) remain deferred.

CR 702.24a (per-counter cost), CR 701.9 (Discard keyword action),
CR 118.12 (unless-payment).
