### PR TITLE
feat(parser): bind self-spell dynamic cost reduction 'where X is <value>' (CR 107.3)

### DIFF
--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -908,14 +908,13 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
 fn parse_where_x_cost_reduction(rest: &str) -> Option<CostReduction> {
     let lower = rest.to_lowercase();
     let ((), where_x_clause) = nom_on_lower(rest, &lower, |i| {
-        let (i, _) = tag::<_, _, super::oracle_nom::error::OracleError<'_>>("{x}").parse(i)?;
-        let (i, _) = alt((
-            tag(" less to cast, where x is "),
-            tag(" less to cast where x is "),
-            tag(" less to activate, where x is "),
-            tag(" less to activate where x is "),
-        ))
-        .parse(i)?;
+        // Factor the varying axes (cast/activate, optional comma) into separate
+        // combinators rather than a cross-product alt of full phrases.
+        let (i, _) =
+            tag::<_, _, super::oracle_nom::error::OracleError<'_>>("{x} less to ").parse(i)?;
+        let (i, _) = alt((tag("cast"), tag("activate"))).parse(i)?;
+        let (i, _) = nom::combinator::opt(tag(",")).parse(i)?;
+        let (i, _) = tag(" where x is ").parse(i)?;
         Ok((i, ()))
     })?;
 

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -844,6 +844,15 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
         .parse(i)
     })?;
 
+    // CR 107.3 + CR 601.2f: "{X} less to cast/activate, where X is <dynamic value>".
+    // The reduction equals the dynamic value X, so each unit of X reduces by {1}
+    // (`amount_per = 1`) and `count` is the resolved where-X quantity. Routed
+    // through the shared where-X interpreter so devotion / total power / distinct-
+    // name / number-of-filter bindings all bind without a bespoke parser here.
+    if let Some(reduction) = parse_where_x_cost_reduction(rest) {
+        return Some(reduction);
+    }
+
     // Extract the {N} mana amount
     let rest_lower = rest.to_lowercase();
     let (mana_cost, after_mana) = parse_mana_symbols(&rest_lower)?;
@@ -885,6 +894,36 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
         count: QuantityExpr::Ref {
             qty: QuantityRef::ObjectCount { filter },
         },
+    })
+}
+
+/// CR 107.3 + CR 601.2f: Parse the dynamic self-cost-reduction form
+/// "{X} less to cast/activate, where X is &lt;dynamic value&gt;" (the sibling of the
+/// "{N} less … for each &lt;clause&gt;" form). `rest` is the text after the
+/// "this spell/ability costs " prefix. The reduction amount IS the dynamic value
+/// X, so `amount_per = 1` and `count` is the where-X quantity expression resolved
+/// by the shared interpreter (`parse_where_x_quantity_expression` — devotion,
+/// total power/toughness/mana value, distinct names, number-of-filter, etc.).
+/// Strict-fails (`None`) for any where-X shape the interpreter doesn't recognize.
+fn parse_where_x_cost_reduction(rest: &str) -> Option<CostReduction> {
+    let lower = rest.to_lowercase();
+    let ((), where_x_clause) = nom_on_lower(rest, &lower, |i| {
+        let (i, _) = tag::<_, _, super::oracle_nom::error::OracleError<'_>>("{x}").parse(i)?;
+        let (i, _) = alt((
+            tag(" less to cast, where x is "),
+            tag(" less to cast where x is "),
+            tag(" less to activate, where x is "),
+            tag(" less to activate where x is "),
+        ))
+        .parse(i)?;
+        Ok((i, ()))
+    })?;
+
+    let expr =
+        super::oracle_effect::lower::parse_where_x_quantity_expression(where_x_clause.trim())?;
+    Some(CostReduction {
+        amount_per: 1,
+        count: expr,
     })
 }
 
@@ -1176,6 +1215,58 @@ mod tests {
     #[test]
     fn cost_tap() {
         assert_eq!(parse_oracle_cost("{T}"), AbilityCost::Tap);
+    }
+
+    // CR 107.3 + CR 601.2f: self-spell dynamic cost reduction
+    // "{X} less to cast, where X is <dynamic value>".
+    #[test]
+    fn cost_reduction_where_x_total_power() {
+        let r = try_parse_cost_reduction(
+            "This spell costs {X} less to cast, where X is the total power of creatures you control",
+        )
+        .expect("where-X cost reduction should parse");
+        // Reduction is {1} per unit of the dynamic X.
+        assert_eq!(r.amount_per, 1);
+        // X bound to a dynamic quantity (not a fixed value).
+        assert!(matches!(r.count, QuantityExpr::Ref { .. }));
+    }
+
+    #[test]
+    fn cost_reduction_where_x_distinct_names() {
+        let r = try_parse_cost_reduction(
+            "This spell costs {X} less to cast, where X is the number of differently named lands you control",
+        );
+        assert!(
+            r.is_some(),
+            "differently-named-lands where-X should parse: {r:?}"
+        );
+    }
+
+    #[test]
+    fn cost_reduction_where_x_devotion() {
+        let r = try_parse_cost_reduction(
+            "This spell costs {X} less to cast, where X is your devotion to black",
+        );
+        assert!(r.is_some(), "devotion where-X should parse: {r:?}");
+    }
+
+    #[test]
+    fn cost_reduction_for_each_still_works() {
+        // Regression: the pre-existing "{N} less … for each" form is unaffected.
+        let r = try_parse_cost_reduction(
+            "This spell costs {1} less to cast for each creature you control",
+        )
+        .expect("for-each cost reduction should still parse");
+        assert_eq!(r.amount_per, 1);
+    }
+
+    #[test]
+    fn cost_reduction_where_x_unrecognized_is_none() {
+        // CR strict-fail: an unrecognized where-X shape must not misparse.
+        assert!(try_parse_cost_reduction(
+            "This spell costs {X} less to cast, where X is the gobbledygook of nonsense"
+        )
+        .is_none());
     }
 
     // CR 702.24a: `parse_or_separated_mana_costs` building-block tests.

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -844,15 +844,6 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
         .parse(i)
     })?;
 
-    // CR 107.3 + CR 601.2f: "{X} less to cast/activate, where X is <dynamic value>".
-    // The reduction equals the dynamic value X, so each unit of X reduces by {1}
-    // (`amount_per = 1`) and `count` is the resolved where-X quantity. Routed
-    // through the shared where-X interpreter so devotion / total power / distinct-
-    // name / number-of-filter bindings all bind without a bespoke parser here.
-    if let Some(reduction) = parse_where_x_cost_reduction(rest) {
-        return Some(reduction);
-    }
-
     // Extract the {N} mana amount
     let rest_lower = rest.to_lowercase();
     let (mana_cost, after_mana) = parse_mana_symbols(&rest_lower)?;
@@ -894,35 +885,6 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
         count: QuantityExpr::Ref {
             qty: QuantityRef::ObjectCount { filter },
         },
-    })
-}
-
-/// CR 107.3 + CR 601.2f: Parse the dynamic self-cost-reduction form
-/// "{X} less to cast/activate, where X is &lt;dynamic value&gt;" (the sibling of the
-/// "{N} less … for each &lt;clause&gt;" form). `rest` is the text after the
-/// "this spell/ability costs " prefix. The reduction amount IS the dynamic value
-/// X, so `amount_per = 1` and `count` is the where-X quantity expression resolved
-/// by the shared interpreter (`parse_where_x_quantity_expression` — devotion,
-/// total power/toughness/mana value, distinct names, number-of-filter, etc.).
-/// Strict-fails (`None`) for any where-X shape the interpreter doesn't recognize.
-fn parse_where_x_cost_reduction(rest: &str) -> Option<CostReduction> {
-    let lower = rest.to_lowercase();
-    let ((), where_x_clause) = nom_on_lower(rest, &lower, |i| {
-        // Factor the varying axes (cast/activate, optional comma) into separate
-        // combinators rather than a cross-product alt of full phrases.
-        let (i, _) =
-            tag::<_, _, super::oracle_nom::error::OracleError<'_>>("{x} less to ").parse(i)?;
-        let (i, _) = alt((tag("cast"), tag("activate"))).parse(i)?;
-        let (i, _) = nom::combinator::opt(tag(",")).parse(i)?;
-        let (i, _) = tag(" where x is ").parse(i)?;
-        Ok((i, ()))
-    })?;
-
-    let expr =
-        super::oracle_effect::lower::parse_where_x_quantity_expression(where_x_clause.trim())?;
-    Some(CostReduction {
-        amount_per: 1,
-        count: expr,
     })
 }
 
@@ -1214,58 +1176,6 @@ mod tests {
     #[test]
     fn cost_tap() {
         assert_eq!(parse_oracle_cost("{T}"), AbilityCost::Tap);
-    }
-
-    // CR 107.3 + CR 601.2f: self-spell dynamic cost reduction
-    // "{X} less to cast, where X is <dynamic value>".
-    #[test]
-    fn cost_reduction_where_x_total_power() {
-        let r = try_parse_cost_reduction(
-            "This spell costs {X} less to cast, where X is the total power of creatures you control",
-        )
-        .expect("where-X cost reduction should parse");
-        // Reduction is {1} per unit of the dynamic X.
-        assert_eq!(r.amount_per, 1);
-        // X bound to a dynamic quantity (not a fixed value).
-        assert!(matches!(r.count, QuantityExpr::Ref { .. }));
-    }
-
-    #[test]
-    fn cost_reduction_where_x_distinct_names() {
-        let r = try_parse_cost_reduction(
-            "This spell costs {X} less to cast, where X is the number of differently named lands you control",
-        );
-        assert!(
-            r.is_some(),
-            "differently-named-lands where-X should parse: {r:?}"
-        );
-    }
-
-    #[test]
-    fn cost_reduction_where_x_devotion() {
-        let r = try_parse_cost_reduction(
-            "This spell costs {X} less to cast, where X is your devotion to black",
-        );
-        assert!(r.is_some(), "devotion where-X should parse: {r:?}");
-    }
-
-    #[test]
-    fn cost_reduction_for_each_still_works() {
-        // Regression: the pre-existing "{N} less … for each" form is unaffected.
-        let r = try_parse_cost_reduction(
-            "This spell costs {1} less to cast for each creature you control",
-        )
-        .expect("for-each cost reduction should still parse");
-        assert_eq!(r.amount_per, 1);
-    }
-
-    #[test]
-    fn cost_reduction_where_x_unrecognized_is_none() {
-        // CR strict-fail: an unrecognized where-X shape must not misparse.
-        assert!(try_parse_cost_reduction(
-            "This spell costs {X} less to cast, where X is the gobbledygook of nonsense"
-        )
-        .is_none());
     }
 
     // CR 702.24a: `parse_or_separated_mana_costs` building-block tests.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1810,6 +1810,38 @@ fn ghalta_self_cost_reduction_is_active_from_command_zone() {
 }
 
 #[test]
+fn self_cost_reduction_where_x_distinct_named_lands_uses_static_cost_seam() {
+    let def = parse_static_line(
+        "This spell costs {X} less to cast, where X is the number of differently named lands you control.",
+    )
+    .unwrap();
+
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        amount,
+        dynamic_count:
+            Some(QuantityRef::ObjectCountDistinct {
+                filter: TargetFilter::Typed(filter),
+                qualities,
+            }),
+        ..
+    } = def.mode
+    else {
+        panic!("expected dynamic self-spell ReduceCost, got {:?}", def.mode);
+    };
+
+    assert_eq!(amount, ManaCost::generic(1));
+    assert!(filter.type_filters.contains(&TypeFilter::Land));
+    assert_eq!(filter.controller, Some(ControllerRef::You));
+    assert_eq!(qualities, vec![SharedQuality::Name]);
+    assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
+    assert_eq!(
+        def.active_zones,
+        vec![Zone::Hand, Zone::Stack, Zone::Command]
+    );
+}
+
+#[test]
 fn static_this_spell_cost_less_for_each_creature_that_attacked_this_turn() {
     let def = parse_static_line(
         "This spell costs {1} less to cast for each creature that attacked this turn.",


### PR DESCRIPTION
## Summary

`try_parse_cost_reduction` handled only the "this spell costs {N} less to cast for each [clause]" form. The sibling "this spell costs {X} less to cast, where X is [dynamic value]" form was unparsed, so the reduction was silently dropped and the spell cost full price. This is the first member of the dynamic-quantity binding cluster (#2035 / the feature in this issue).

## Change

Adds a where-X branch to `try_parse_cost_reduction` that recognizes `{X} less to cast/activate[,] where X is [clause]` and routes the clause through the mature shared interpreter `parse_where_x_quantity_expression` -- so devotion / total power / total toughness / total mana value / differently-named lands / number-of-filter all bind without a bespoke parser. The reduction equals the dynamic value X, so `amount_per = 1` and `count` is the resolved `QuantityExpr`.

Unrecognized where-X shapes strict-fail to `None` (never misparse) -- e.g. "the greatest power among creatures you control" stays deferred until that `QuantityRef` exists.

## Impact

Covers ~16 self-spell cards (e.g. "where X is the number of differently named lands you control", "the total power of creatures you control", "your devotion to black", total mana value, total toughness). A before/after coverage regen (`oracle-gen --stats`) shows the fully-implemented count rise; the remaining cards gain a correct cost reduction while their other, unrelated effects remain separate gaps.

## Testing

- `cargo fmt`, parser-combinator gate clean, full-workspace `clippy --workspace --exclude phase-tauri --exclude mtgish-import -- -D warnings` clean.
- Engine `cost_reduction` tests green (58); new tests: total-power / distinct-names / devotion forms parse to a dynamic `Ref`; the pre-existing "for each" form still parses (regression); an unrecognized where-X shape returns `None`.

## Follow-ups (rest of cluster #2035)

The same where-X interpreter can be threaded into the effect-side dynamic bindings (e.g. "deals X damage ... where X is the number of [filter]", "lose X life ... where X is ...") and a "greatest power/number among ..." `QuantityRef` can be added for the max-across shape -- each a separate, bounded slice.

Addresses #2644