### PR TITLE
Fix Hazel copy-of-token resolution (#2402)

### DIFF
--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -664,6 +664,7 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
             if has_attrs {
                 obj.power = ch.power;
                 obj.toughness = ch.toughness;
+                obj.base_name = ch.display_name.clone();
                 obj.base_power = ch.power;
                 obj.base_toughness = ch.toughness;
                 obj.card_types = CardType {

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -980,7 +980,7 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityDefinition, AbilityKind, ContinuousModification, ControllerRef,
-        CostPaidObjectSnapshot, Effect, FilterProp, ObjectScope, QuantityExpr,
+        CostPaidObjectSnapshot, Effect, FilterProp, ObjectScope, PtValue, QuantityExpr,
         QuantityModification, QuantityRef, ReplacementDefinition, RoundingMode, TargetFilter,
         TargetRef, TypeFilter, TypedFilter,
     };
@@ -1724,31 +1724,12 @@ mod tests {
         assert!(token.is_token);
     }
 
-    /// Issue #2402: Hazel of the Rootbloom — copy a token target whose live
-    /// characteristics were never mirrored into `base_*` fields.
+    /// Issue #2402: Hazel of the Rootbloom — copy a non-Squirrel token target
+    /// whose live characteristics must be mirrored into `base_*` fields by the
+    /// real token creation path before copy-token resolution reads copiable values.
     #[test]
     fn issue_2402_copy_token_of_token_target_creates_copy() {
         let mut state = GameState::new_two_player(42);
-
-        let squirrel = create_object(
-            &mut state,
-            CardId(0),
-            PlayerId(0),
-            "Squirrel".to_string(),
-            Zone::Battlefield,
-        );
-        {
-            let token = state.objects.get_mut(&squirrel).unwrap();
-            token.is_token = true;
-            token.power = Some(1);
-            token.toughness = Some(1);
-            token.card_types = CardType {
-                supertypes: vec![],
-                core_types: vec![CoreType::Creature],
-                subtypes: vec!["Squirrel".to_string()],
-            };
-        }
-
         let source_id = create_object(
             &mut state,
             CardId(2),
@@ -1756,6 +1737,39 @@ mod tests {
             "Hazel".to_string(),
             Zone::Battlefield,
         );
+        let create_food = ResolvedAbility::new(
+            Effect::Token {
+                name: "Food".to_string(),
+                power: PtValue::Fixed(0),
+                toughness: PtValue::Fixed(0),
+                types: vec!["Artifact".to_string(), "Food".to_string()],
+                colors: vec![],
+                keywords: vec![],
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                owner: TargetFilter::Controller,
+                attach_to: None,
+                enters_attacking: false,
+                supertypes: vec![],
+                static_abilities: vec![],
+                enter_with_counters: vec![],
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        crate::game::effects::token::resolve(&mut state, &create_food, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(&mut state);
+        let food = state.last_created_token_ids[0];
+        let food_token = state.objects.get(&food).unwrap();
+        assert!(food_token.base_characteristics_initialized);
+        assert_eq!(food_token.base_name, "Food");
+        assert_eq!(
+            food_token.base_card_types.core_types,
+            vec![CoreType::Artifact]
+        );
+        assert_eq!(food_token.base_card_types.subtypes, vec!["Food"]);
 
         let ability = ResolvedAbility::new(
             Effect::CopyTokenOf {
@@ -1768,19 +1782,18 @@ mod tests {
                 extra_keywords: vec![],
                 additional_modifications: vec![],
             },
-            vec![TargetRef::Object(squirrel)],
+            vec![TargetRef::Object(food)],
             source_id,
             PlayerId(0),
         );
-        let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
         let copy_id = ObjectId(state.next_object_id - 1);
         let copy = state.objects.get(&copy_id).unwrap();
         assert!(copy.is_token);
-        assert_eq!(copy.name, "Squirrel");
-        assert_eq!(copy.power, Some(1));
-        assert_eq!(copy.toughness, Some(1));
+        assert_eq!(copy.name, "Food");
+        assert_eq!(copy.card_types.core_types, vec![CoreType::Artifact]);
+        assert_eq!(copy.card_types.subtypes, vec!["Food"]);
     }
 
     /// CR 109.4 + CR 111.2: "target opponent creates a token that's a copy of

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1724,6 +1724,65 @@ mod tests {
         assert!(token.is_token);
     }
 
+    /// Issue #2402: Hazel of the Rootbloom — copy a token target whose live
+    /// characteristics were never mirrored into `base_*` fields.
+    #[test]
+    fn issue_2402_copy_token_of_token_target_creates_copy() {
+        let mut state = GameState::new_two_player(42);
+
+        let squirrel = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Squirrel".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let token = state.objects.get_mut(&squirrel).unwrap();
+            token.is_token = true;
+            token.power = Some(1);
+            token.toughness = Some(1);
+            token.card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec!["Squirrel".to_string()],
+            };
+        }
+
+        let source_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Hazel".to_string(),
+            Zone::Battlefield,
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::Any,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            },
+            vec![TargetRef::Object(squirrel)],
+            source_id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let copy_id = ObjectId(state.next_object_id - 1);
+        let copy = state.objects.get(&copy_id).unwrap();
+        assert!(copy.is_token);
+        assert_eq!(copy.name, "Squirrel");
+        assert_eq!(copy.power, Some(1));
+        assert_eq!(copy.toughness, Some(1));
+    }
+
     /// CR 109.4 + CR 111.2: "target opponent creates a token that's a copy of
     /// it" — the copy token must enter under the chosen opponent's control,
     /// not the trigger controller's. Pins the new `owner` channel at the

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -906,6 +906,9 @@ impl GameObject {
         if self.base_loyalty.is_none() && self.loyalty.is_some() {
             self.base_loyalty = self.loyalty;
         }
+        if self.base_name.is_empty() && !self.name.is_empty() {
+            self.base_name = self.name.clone();
+        }
         if self.base_card_types == CardType::default() && self.card_types != CardType::default() {
             self.base_card_types = self.card_types.clone();
         }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -316,15 +316,49 @@ pub fn intrinsic_etb_counters(obj: &GameObject) -> Vec<(CounterType, u32)> {
 }
 
 pub fn intrinsic_copiable_values(obj: &GameObject) -> CopiableValues {
+    // CR 707.2: Tokens created by `Effect::Token` seed live characteristics
+    // (`name`, `power`, …) but often leave the parallel `base_*` fields empty.
+    // Copy-token resolution reads copiable values through this helper, so fall
+    // back to the live fields when the base snapshot was never initialized
+    // (Hazel of the Rootbloom — copy target token you control).
+    let use_live = obj.is_token && !obj.base_characteristics_initialized;
     CopiableValues {
-        name: obj.base_name.clone(),
-        mana_cost: obj.base_mana_cost.clone(),
-        color: obj.base_color.clone(),
-        card_types: obj.base_card_types.clone(),
-        power: obj.base_power,
-        toughness: obj.base_toughness,
-        loyalty: obj.base_loyalty,
-        keywords: obj.base_keywords.clone(),
+        name: if use_live {
+            obj.name.clone()
+        } else {
+            obj.base_name.clone()
+        },
+        mana_cost: if use_live {
+            obj.mana_cost.clone()
+        } else {
+            obj.base_mana_cost.clone()
+        },
+        color: if use_live {
+            obj.color.clone()
+        } else {
+            obj.base_color.clone()
+        },
+        card_types: if use_live {
+            obj.card_types.clone()
+        } else {
+            obj.base_card_types.clone()
+        },
+        power: if use_live { obj.power } else { obj.base_power },
+        toughness: if use_live {
+            obj.toughness
+        } else {
+            obj.base_toughness
+        },
+        loyalty: if use_live {
+            obj.loyalty
+        } else {
+            obj.base_loyalty
+        },
+        keywords: if use_live {
+            obj.keywords.clone()
+        } else {
+            obj.base_keywords.clone()
+        },
         // CopiableValues now shares `Arc<Vec<_>>` with the source object —
         // a copy-effect never mutates the ability set, so refcount sharing
         // is both correct and zero-allocation.

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -330,49 +330,15 @@ pub fn intrinsic_etb_counters(obj: &GameObject) -> Vec<(CounterType, u32)> {
 }
 
 pub fn intrinsic_copiable_values(obj: &GameObject) -> CopiableValues {
-    // CR 707.2: Tokens created by `Effect::Token` seed live characteristics
-    // (`name`, `power`, …) but often leave the parallel `base_*` fields empty.
-    // Copy-token resolution reads copiable values through this helper, so fall
-    // back to the live fields when the base snapshot was never initialized
-    // (Hazel of the Rootbloom — copy target token you control).
-    let use_live = obj.is_token && !obj.base_characteristics_initialized;
     CopiableValues {
-        name: if use_live {
-            obj.name.clone()
-        } else {
-            obj.base_name.clone()
-        },
-        mana_cost: if use_live {
-            obj.mana_cost.clone()
-        } else {
-            obj.base_mana_cost.clone()
-        },
-        color: if use_live {
-            obj.color.clone()
-        } else {
-            obj.base_color.clone()
-        },
-        card_types: if use_live {
-            obj.card_types.clone()
-        } else {
-            obj.base_card_types.clone()
-        },
-        power: if use_live { obj.power } else { obj.base_power },
-        toughness: if use_live {
-            obj.toughness
-        } else {
-            obj.base_toughness
-        },
-        loyalty: if use_live {
-            obj.loyalty
-        } else {
-            obj.base_loyalty
-        },
-        keywords: if use_live {
-            obj.keywords.clone()
-        } else {
-            obj.base_keywords.clone()
-        },
+        name: obj.base_name.clone(),
+        mana_cost: obj.base_mana_cost.clone(),
+        color: obj.base_color.clone(),
+        card_types: obj.base_card_types.clone(),
+        power: obj.base_power,
+        toughness: obj.base_toughness,
+        loyalty: obj.base_loyalty,
+        keywords: obj.base_keywords.clone(),
         // CopiableValues now shares `Arc<Vec<_>>` with the source object —
         // a copy-effect never mutates the ability set, so refcount sharing
         // is both correct and zero-allocation.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -43808,3 +43808,27 @@ mod snapshot_tests {
         ));
     }
 }
+
+#[test]
+fn issue_2402_hazel_copy_target_token_trigger_parses() {
+    use crate::parser::oracle_trigger::parse_trigger_line;
+    let def = parse_trigger_line(
+        "At the beginning of your end step, create a token that's a copy of target token you control. If that token is a Squirrel, instead create two tokens that are copies of it.",
+        "Hazel of the Rootbloom",
+    );
+    let execute = def.execute.as_ref().expect("trigger execute");
+    let Effect::CopyTokenOf { target, .. } = execute.effect.as_ref() else {
+        panic!(
+            "expected CopyTokenOf trigger effect, got {:?}",
+            execute.effect
+        );
+    };
+    let TargetFilter::Typed(tf) = target else {
+        panic!("expected typed target token filter, got {target:?}");
+    };
+    assert_eq!(tf.controller, Some(ControllerRef::You));
+    assert!(tf
+        .properties
+        .iter()
+        .any(|prop| matches!(prop, FilterProp::Token)));
+}

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -55,6 +55,8 @@ pub(crate) use self::token::parse_token_description;
 use std::str::FromStr;
 
 use crate::parser::oracle_nom::error::OracleError;
+#[cfg(test)]
+use crate::parser::oracle_trigger::parse_trigger_line;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{anychar, multispace1};
@@ -43981,7 +43983,6 @@ mod snapshot_tests {
 
 #[test]
 fn issue_2402_hazel_copy_target_token_trigger_parses() {
-    use crate::parser::oracle_trigger::parse_trigger_line;
     let def = parse_trigger_line(
         "At the beginning of your end step, create a token that's a copy of target token you control. If that token is a Squirrel, instead create two tokens that are copies of it.",
         "Hazel of the Rootbloom",


### PR DESCRIPTION
## Summary

- Fall back to live token characteristics in `intrinsic_copiable_values` when copying a token target that has no base snapshot.

## Test plan

- [x] `cargo test -p engine --lib issue_2402`
- [x] `./scripts/check-parser-combinators.sh`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #2402