### PR TITLE
Fix Planar Genesis dig and Broken Bond land drop (#2405)

### DIFF
--- a/crates/engine/src/database/hideaway.rs
+++ b/crates/engine/src/database/hideaway.rs
@@ -85,6 +85,7 @@ fn hideaway_trigger(n: u32) -> TriggerDefinition {
             rest_destination: Some(Zone::Library),
             // CR 701.20e: the cards are looked at privately, not revealed.
             reveal: false,
+            enter_tapped: false,
         },
     )
     // CR 608.2c: continuation — conceal the just-exiled card (ParentTarget).

--- a/crates/engine/src/game/effects/choose_card.rs
+++ b/crates/engine/src/game/effects/choose_card.rs
@@ -86,6 +86,7 @@ pub fn resolve(
         kept_destination: None,
         rest_destination: None,
         source_id: Some(ability.source_id),
+        enter_tapped: false,
     };
 
     events.push(GameEvent::EffectResolved {

--- a/crates/engine/src/game/effects/dig.rs
+++ b/crates/engine/src/game/effects/dig.rs
@@ -21,6 +21,7 @@ pub fn resolve(
         kept_dest,
         rest_dest,
         is_reveal,
+        enter_tapped,
     ) = match &ability.effect {
         Effect::Dig {
             player,
@@ -31,6 +32,7 @@ pub fn resolve(
             destination,
             rest_destination,
             reveal,
+            enter_tapped,
         } => {
             let resolved_count =
                 resolve_quantity_with_targets(state, count, ability).max(0) as usize;
@@ -50,6 +52,7 @@ pub fn resolve(
                 *destination,
                 *rest_destination,
                 *reveal,
+                *enter_tapped,
             )
         }
         _ => (
@@ -60,6 +63,7 @@ pub fn resolve(
             TargetFilter::Any,
             None,
             None,
+            false,
             false,
         ),
     };
@@ -149,6 +153,7 @@ pub fn resolve(
         kept_destination: kept_dest,
         rest_destination: rest_dest,
         source_id: Some(ability.source_id),
+        enter_tapped,
     };
 
     events.push(GameEvent::EffectResolved {
@@ -184,6 +189,7 @@ mod tests {
                 filter: TargetFilter::Any,
                 rest_destination: None,
                 reveal: false,
+                enter_tapped: false,
             },
             vec![],
             ObjectId(100),
@@ -264,6 +270,7 @@ mod tests {
                 filter: TargetFilter::Any,
                 rest_destination: None,
                 reveal: false,
+                enter_tapped: false,
             },
             vec![crate::types::ability::TargetRef::Player(PlayerId(1))],
             ObjectId(100),
@@ -314,6 +321,7 @@ mod tests {
                 filter: TargetFilter::Any,
                 rest_destination: None,
                 reveal: false,
+                enter_tapped: false,
             },
             vec![],
             ObjectId(100),
@@ -364,6 +372,7 @@ mod tests {
                 filter: TargetFilter::Any,
                 rest_destination: Some(Zone::Library),
                 reveal: false,
+                enter_tapped: false,
             },
             vec![],
             ObjectId(100),
@@ -432,6 +441,7 @@ mod tests {
             kept_destination: None,
             rest_destination: Some(Zone::Library),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
         let action = GameAction::SelectCards {
             cards: kept.clone(),
@@ -502,6 +512,7 @@ mod tests {
             kept_destination: Some(Zone::Library),
             rest_destination: Some(Zone::Library),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
         state.pending_continuation =
             Some(PendingContinuation::new(Box::new(ResolvedAbility::new(
@@ -570,6 +581,7 @@ mod tests {
             kept_destination: Some(Zone::Library),
             rest_destination: Some(Zone::Library),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
 
         let mut events = Vec::new();
@@ -632,6 +644,7 @@ mod tests {
             kept_destination: Some(Zone::Hand),
             rest_destination: Some(Zone::Graveyard),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
 
         let mut events = Vec::new();
@@ -691,6 +704,7 @@ mod tests {
             kept_destination: Some(Zone::Hand),
             rest_destination: Some(Zone::Graveyard),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
 
         let mut events = Vec::new();
@@ -759,6 +773,7 @@ mod tests {
             kept_destination: Some(Zone::Hand),
             rest_destination: Some(Zone::Library),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
@@ -829,6 +844,7 @@ mod tests {
             kept_destination: Some(Zone::Hand),
             rest_destination: Some(Zone::Library),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
@@ -894,6 +910,7 @@ mod tests {
             kept_destination: Some(Zone::Hand),
             rest_destination: Some(Zone::Library),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
         let mut gain_life = ResolvedAbility::new(
             Effect::GainLife {
@@ -969,6 +986,7 @@ mod tests {
                 filter,
                 rest_destination: None,
                 reveal: false,
+                enter_tapped: false,
             },
             vec![],
             ObjectId(100),
@@ -1162,6 +1180,7 @@ mod tests {
                 filter: filter.clone(),
                 rest_destination: Some(Zone::Library),
                 reveal: false,
+                enter_tapped: false,
             },
             vec![],
             ObjectId(200),
@@ -1215,6 +1234,7 @@ mod tests {
                 filter: filter_you,
                 rest_destination: Some(Zone::Library),
                 reveal: false,
+                enter_tapped: false,
             },
             vec![],
             ObjectId(201),
@@ -1280,6 +1300,7 @@ mod tests {
             kept_destination: Some(Zone::Battlefield),
             rest_destination: Some(Zone::Library),
             source_id: Some(ObjectId(100)),
+            enter_tapped: false,
         };
         let action = GameAction::SelectCards {
             cards: kept.clone(),

--- a/crates/engine/src/game/effects/explore.rs
+++ b/crates/engine/src/game/effects/explore.rs
@@ -306,6 +306,7 @@ pub fn resolve(
             kept_destination: Some(crate::types::zones::Zone::Library),
             rest_destination: Some(crate::types::zones::Zone::Graveyard),
             source_id: Some(ability.source_id),
+            enter_tapped: false,
         };
 
         events.push(GameEvent::EffectResolved {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -15361,4 +15361,52 @@ mod tests {
             None
         );
     }
+
+    /// Issue #2405: Broken Bond — optional hand→battlefield land put must not
+    /// consume the land-drop counter (CR 305.4).
+    #[test]
+    fn issue_2405_broken_bond_land_put_does_not_consume_land_drop() {
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "Destroy target artifact or enchantment. You may put a land card from your hand onto the battlefield.",
+            AbilityKind::Spell,
+        );
+        let sub = def.sub_ability.as_ref().expect("land put sub");
+
+        let mut state = GameState::new_two_player(42);
+        state.lands_played_this_turn = 1;
+        state.players[0].lands_played_this_turn = 1;
+        let _played_land = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        let hand_land = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Island".to_string(),
+            Zone::Hand,
+        );
+        for id in [_played_land, hand_land] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types = vec![CoreType::Land];
+        }
+        let mut ability =
+            crate::game::ability_utils::build_resolved_from_def(sub, ObjectId(999), PlayerId(0));
+        ability.optional = false;
+        ability.context.optional_effect_performed = true;
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        assert_eq!(
+            state.lands_played_this_turn, 1,
+            "effect-driven land put must not consume land drop"
+        );
+        assert!(
+            state.battlefield.contains(&hand_land),
+            "land must reach battlefield, waiting_for={:?}",
+            state.waiting_for
+        );
+    }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1053,6 +1053,7 @@ pub(super) fn handle_resolution_choice(
                 selectable_cards,
                 kept_destination,
                 rest_destination,
+                enter_tapped,
                 ..
             },
             GameAction::SelectCards { cards: kept },
@@ -1119,6 +1120,11 @@ pub(super) fn handle_resolution_choice(
             }
             for &obj_id in &kept {
                 zones::move_to_zone(state, obj_id, kept_zone, events);
+                if enter_tapped && kept_zone == Zone::Battlefield {
+                    if let Some(obj) = state.objects.get_mut(&obj_id) {
+                        obj.tapped = true;
+                    }
+                }
             }
             // CR 701.33 + CR 701.18: Publish the kept (revealed) cards as a
             // tracked set so downstream sub_abilities can route them by type

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -252,6 +252,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         kept_destination,
         rest_destination,
         source_id,
+        enter_tapped,
     } = state.waiting_for
     {
         if !can_view_private_for_player(player) {
@@ -265,6 +266,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
                 kept_destination,
                 rest_destination,
                 source_id,
+                enter_tapped,
             };
         }
     }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1896,6 +1896,7 @@ pub(super) fn try_parse_dig_instead_alternative(
         filter: _,
         rest_destination: prev_rest,
         reveal: prev_reveal,
+        enter_tapped: prev_enter_tapped,
     } = &*prev.effect
     else {
         return None;
@@ -1950,6 +1951,7 @@ pub(super) fn try_parse_dig_instead_alternative(
         filter: alt_filter,
         destination: alt_destination,
         rest_destination: alt_rest,
+        enter_tapped: alt_enter_tapped,
         ..
     } = alt_continuation
     else {
@@ -1982,6 +1984,7 @@ pub(super) fn try_parse_dig_instead_alternative(
         filter: alt_filter,
         rest_destination: alt_rest.or(*prev_rest),
         reveal: *prev_reveal,
+        enter_tapped: alt_enter_tapped || *prev_enter_tapped,
     };
 
     let mut result = AbilityDefinition::new(kind, alt_effect);

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1896,7 +1896,7 @@ pub(super) fn try_parse_dig_instead_alternative(
         filter: _,
         rest_destination: prev_rest,
         reveal: prev_reveal,
-        enter_tapped: prev_enter_tapped,
+        enter_tapped: _,
     } = &*prev.effect
     else {
         return None;
@@ -1984,7 +1984,7 @@ pub(super) fn try_parse_dig_instead_alternative(
         filter: alt_filter,
         rest_destination: alt_rest.or(*prev_rest),
         reveal: *prev_reveal,
-        enter_tapped: alt_enter_tapped || *prev_enter_tapped,
+        enter_tapped: alt_enter_tapped,
     };
 
     let mut result = AbilityDefinition::new(kind, alt_effect);

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2080,6 +2080,7 @@ pub(super) fn lower_search_and_creation_ast(ast: SearchCreationImperativeAst) ->
             filter: TargetFilter::Any,
             rest_destination: None,
             reveal,
+            enter_tapped: false,
         },
         SearchCreationImperativeAst::CopyTokenOf {
             target,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -43978,3 +43978,45 @@ mod snapshot_tests {
         ));
     }
 }
+
+#[test]
+fn issue_2405_broken_bond_optional_land_from_hand() {
+    let def = parse_effect_chain(
+        "Destroy target artifact or enchantment. You may put a land card from your hand onto the battlefield.",
+        AbilityKind::Spell,
+    );
+    let sub = def.sub_ability.as_ref().expect("land put sub");
+    assert!(sub.optional);
+    let Effect::ChangeZone {
+        origin: Some(Zone::Hand),
+        destination: Zone::Battlefield,
+        ..
+    } = sub.effect.as_ref()
+    else {
+        panic!(
+            "expected optional hand->battlefield ChangeZone, got {:?}",
+            sub.effect
+        );
+    };
+}
+
+#[test]
+fn issue_2405_planar_genesis_dig_land_enters_tapped() {
+    let def = parse_effect_chain(
+        "Look at the top four cards of your library. You may put a land card from among them onto the battlefield tapped. If you don't, put those cards into your hand. Put the rest on the bottom of your library in a random order.",
+        AbilityKind::Spell,
+    );
+    let Effect::Dig {
+        destination: Some(Zone::Battlefield),
+        enter_tapped: true,
+        filter,
+        ..
+    } = def.effect.as_ref()
+    else {
+        panic!("expected tapped battlefield Dig, got {:?}", def.effect);
+    };
+    let TargetFilter::Typed(typed) = filter else {
+        panic!("expected land filter");
+    };
+    assert_eq!(typed.type_filters, vec![TypeFilter::Land]);
+}

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2799,17 +2799,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
     // Experiment): "reveal up to N <filter> cards from among them, then put the
     // rest on the bottom" — the kept cards are NOT auto-routed; subsequent
     // sub_abilities route them by type via `TargetFilter::TrackedSetFiltered`.
-    let destination = if nom_primitives::scan_contains(lower, "onto the battlefield") {
-        Some(Zone::Battlefield)
-    } else if nom_primitives::scan_contains(lower, "into your hand")
-        || nom_primitives::scan_contains(lower, "into their hand")
-        || nom_primitives::scan_contains(lower, "to your hand")
-        || nom_primitives::scan_contains(lower, "to their hand")
-    {
-        Some(Zone::Hand)
-    } else {
-        None
-    };
+    let (destination, enter_tapped) = parse_dig_kept_destination(lower);
 
     // "put N of them into your hand [and the rest on the bottom]" — no filter, count explicit.
     // Must be checked BEFORE the "from among" path since "of them" appears in both forms.
@@ -2849,7 +2839,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
             rest_destination,
             enters_under: None,
             face_down_profile: None,
-            enter_tapped: false,
+            enter_tapped,
         });
     }
 
@@ -2970,7 +2960,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
             rest_destination: None,
             enters_under,
             face_down_profile,
-            enter_tapped: false,
+            enter_tapped,
         });
     }
 
@@ -3051,7 +3041,6 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
     } else {
         None
     };
-    let enter_tapped = nom_primitives::scan_contains(lower, "battlefield tapped");
 
     Some(ContinuationAst::DigFromAmong {
         quantity,
@@ -3062,6 +3051,85 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
         face_down_profile,
         enter_tapped,
     })
+}
+
+fn parse_dig_kept_destination(lower: &str) -> (Option<Zone>, bool) {
+    if let Some(parsed) = parse_dig_from_among_destination(lower) {
+        return parsed;
+    }
+
+    let destination = if nom_primitives::scan_contains(lower, "onto the battlefield") {
+        Some(Zone::Battlefield)
+    } else if nom_primitives::scan_contains(lower, "into your hand")
+        || nom_primitives::scan_contains(lower, "into their hand")
+        || nom_primitives::scan_contains(lower, "to your hand")
+        || nom_primitives::scan_contains(lower, "to their hand")
+    {
+        Some(Zone::Hand)
+    } else {
+        None
+    };
+    (destination, false)
+}
+
+fn parse_dig_from_among_destination(lower: &str) -> Option<(Option<Zone>, bool)> {
+    let (tail, _) = preceded(
+        take_until::<_, _, OracleError<'_>>("from among"),
+        (
+            tag::<_, _, OracleError<'_>>("from among "),
+            alt((tag("them"), tag("those cards"), tag("those"))),
+        ),
+    )
+    .parse(lower)
+    .ok()?;
+    parse_dig_destination_tail(tail)
+}
+
+fn parse_dig_destination_tail(input: &str) -> Option<(Option<Zone>, bool)> {
+    let input = input.trim_start();
+    let (input, _) = opt(alt((tag::<_, _, OracleError<'_>>("and "), tag("then "))))
+        .parse(input)
+        .ok()?;
+    let input = input.trim_start();
+    let (input, _) = opt(alt((
+        tag::<_, _, OracleError<'_>>("put it "),
+        tag("put them "),
+        tag("put that card "),
+        tag("put those cards "),
+        tag("put the card "),
+        tag("return it "),
+        tag("return them "),
+        tag("return that card "),
+    )))
+    .parse(input)
+    .ok()?;
+    let input = input.trim_start();
+
+    if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>("onto the battlefield"),
+        tag("to the battlefield"),
+    ))
+    .parse(input)
+    {
+        let (_, tapped) = opt(tag::<_, _, OracleError<'_>>(" tapped"))
+            .parse(rest)
+            .ok()?;
+        return Some((Some(Zone::Battlefield), tapped.is_some()));
+    }
+
+    if alt((
+        tag::<_, _, OracleError<'_>>("into your hand"),
+        tag("into their hand"),
+        tag("to your hand"),
+        tag("to their hand"),
+    ))
+    .parse(input)
+    .is_ok()
+    {
+        return Some((Some(Zone::Hand), false));
+    }
+
+    None
 }
 
 /// CR 708.2a + CR 205.1a: Parse a "They're N/M [types] [subtypes] creatures."
@@ -5199,6 +5267,22 @@ mod tests {
                 face_down_profile: None,
                 enter_tapped: false,
             })
+        );
+    }
+
+    #[test]
+    fn from_among_enter_tapped_is_local_to_kept_destination() {
+        assert_eq!(
+            parse_dig_kept_destination(
+                "put a land card from among them onto the battlefield tapped. put the rest on the bottom of your library.",
+            ),
+            (Some(Zone::Battlefield), true)
+        );
+        assert_eq!(
+            parse_dig_kept_destination(
+                "put a land card from among them onto the battlefield. put the rest onto the battlefield tapped.",
+            ),
+            (Some(Zone::Battlefield), false)
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2056,6 +2056,7 @@ pub(super) fn apply_clause_continuation(
             rest_destination: rest_dest,
             enters_under,
             face_down_profile,
+            enter_tapped,
         } => {
             // CR 608.2c: the "from among those cards" continuation patches the
             // earlier "look at the top N" instruction. When a transparent
@@ -2076,6 +2077,7 @@ pub(super) fn apply_clause_continuation(
                 destination,
                 rest_destination,
                 reveal,
+                enter_tapped: dig_enter_tapped,
                 ..
             } = &mut *previous.effect
             {
@@ -2127,6 +2129,7 @@ pub(super) fn apply_clause_continuation(
                 if let Some(rd) = rest_dest {
                     *rest_destination = Some(rd);
                 }
+                *dig_enter_tapped = enter_tapped;
             } else if let Effect::Mill {
                 destination: mill_destination,
                 ..
@@ -2846,6 +2849,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
             rest_destination,
             enters_under: None,
             face_down_profile: None,
+            enter_tapped: false,
         });
     }
 
@@ -2966,6 +2970,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
             rest_destination: None,
             enters_under,
             face_down_profile,
+            enter_tapped: false,
         });
     }
 
@@ -3046,6 +3051,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
     } else {
         None
     };
+    let enter_tapped = nom_primitives::scan_contains(lower, "battlefield tapped");
 
     Some(ContinuationAst::DigFromAmong {
         quantity,
@@ -3054,6 +3060,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
         rest_destination: None, // rest_destination handled by subsequent PutRest continuation
         enters_under,
         face_down_profile,
+        enter_tapped,
     })
 }
 
@@ -3508,6 +3515,7 @@ pub(super) fn parse_followup_continuation_ast(
                 rest_destination: None,
                 enters_under: None,
                 face_down_profile: None,
+                enter_tapped: false,
             })
         }
         // "You may put one of those cards back on top of your library" after
@@ -3521,6 +3529,7 @@ pub(super) fn parse_followup_continuation_ast(
                 rest_destination: None,
                 enters_under: None,
                 face_down_profile: None,
+                enter_tapped: false,
             })
         }
         // "put them back in any order" after Dig means all looked-at cards
@@ -4972,6 +4981,7 @@ mod tests {
             filter: TargetFilter::Any,
             rest_destination: None,
             reveal: false,
+            enter_tapped: false,
         }
     }
 
@@ -5114,6 +5124,7 @@ mod tests {
                 rest_destination: Some(Zone::Library),
                 enters_under: None,
                 face_down_profile: None,
+                enter_tapped: false,
             })
         );
     }
@@ -5136,6 +5147,7 @@ mod tests {
                 rest_destination: Some(Zone::Library),
                 enters_under: None,
                 face_down_profile: None,
+                enter_tapped: false,
             })
         );
     }
@@ -5163,6 +5175,7 @@ mod tests {
                 rest_destination: Some(Zone::Library),
                 enters_under: None,
                 face_down_profile: None,
+                enter_tapped: false,
             })
         );
     }
@@ -5184,6 +5197,7 @@ mod tests {
                 rest_destination: Some(Zone::Graveyard),
                 enters_under: None,
                 face_down_profile: None,
+                enter_tapped: false,
             })
         );
     }
@@ -5322,6 +5336,7 @@ mod tests {
                 rest_destination: None,
                 enters_under: None,
                 face_down_profile: None,
+                enter_tapped: false,
             },
             AbilityKind::Spell,
         );
@@ -5863,6 +5878,7 @@ mod tests {
                 rest_destination: None,
                 enters_under: None,
                 face_down_profile: None,
+                enter_tapped: false,
             })
         );
     }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -302,7 +302,8 @@ pub(crate) enum ContinuationAst {
         /// Cyberman artifact creatures."). `None` = normal face-up entry.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         face_down_profile: Option<FaceDownProfile>,
-        /// CR 508.4: "onto the battlefield tapped" on the from-among put-step.
+        /// CR 614.1 / CR 110.5b: "onto the battlefield tapped" on the
+        /// from-among put-step.
         #[serde(default)]
         enter_tapped: bool,
     },

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -302,6 +302,9 @@ pub(crate) enum ContinuationAst {
         /// Cyberman artifact creatures."). `None` = normal face-up entry.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         face_down_profile: Option<FaceDownProfile>,
+        /// CR 508.4: "onto the battlefield tapped" on the from-among put-step.
+        #[serde(default)]
+        enter_tapped: bool,
     },
     /// CR 708.2a + CR 205.1a: "They're N/M [types] [subtypes] creatures." after a
     /// put-face-down clause — refines the preceding face-down move's profile.

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_ir.snap
@@ -23,7 +23,8 @@ expression: "&ir"
             "type": "Any"
           },
           "rest_destination": null,
-          "reveal": false
+          "reveal": false,
+          "enter_tapped": false
         },
         "cost": {
           "type": "Loyalty",

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_lowered.snap
@@ -22,7 +22,8 @@ expression: "&lowered"
           "type": "Any"
         },
         "rest_destination": null,
-        "reveal": false
+        "reveal": false,
+        "enter_tapped": false
       },
       "cost": {
         "type": "Loyalty",

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5974,6 +5974,10 @@ pub enum Effect {
         /// CR 701.20a vs CR 701.16a: True = cards are revealed (public), false = looked at (private).
         #[serde(default)]
         reveal: bool,
+        /// CR 508.4: Kept cards routed to the battlefield enter tapped when true
+        /// (Planar Genesis — "onto the battlefield tapped").
+        #[serde(default)]
+        enter_tapped: bool,
     },
     GainControl {
         #[serde(default = "default_target_filter_any")]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5974,8 +5974,8 @@ pub enum Effect {
         /// CR 701.20a vs CR 701.16a: True = cards are revealed (public), false = looked at (private).
         #[serde(default)]
         reveal: bool,
-        /// CR 508.4: Kept cards routed to the battlefield enter tapped when true
-        /// (Planar Genesis — "onto the battlefield tapped").
+        /// CR 614.1 / CR 110.5b: Kept cards routed to the battlefield enter
+        /// tapped when true (Planar Genesis — "onto the battlefield tapped").
         #[serde(default)]
         enter_tapped: bool,
     },

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2461,6 +2461,9 @@ pub enum WaitingFor {
         /// Source ability's object ID for filter context.
         #[serde(default)]
         source_id: Option<ObjectId>,
+        /// CR 508.4: Kept cards entering the battlefield via this dig are tapped.
+        #[serde(default)]
+        enter_tapped: bool,
     },
     SurveilChoice {
         player: PlayerId,
@@ -6933,6 +6936,7 @@ mod tests {
             kept_destination: None,
             rest_destination: None,
             source_id: None,
+            enter_tapped: false,
         }
         .accepts_freeform_card_selection());
 
@@ -7196,6 +7200,7 @@ mod tests {
             kept_destination: None,
             rest_destination: None,
             source_id: None,
+            enter_tapped: false,
         }));
         variants.push(Box::new(WaitingFor::SurveilChoice {
             player: PlayerId(0),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2461,7 +2461,8 @@ pub enum WaitingFor {
         /// Source ability's object ID for filter context.
         #[serde(default)]
         source_id: Option<ObjectId>,
-        /// CR 508.4: Kept cards entering the battlefield via this dig are tapped.
+        /// CR 614.1 / CR 110.5b: Kept cards entering the battlefield via this
+        /// dig are tapped.
         #[serde(default)]
         enter_tapped: bool,
     },

--- a/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_jace_the_mind_sculptor.snap
+++ b/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_jace_the_mind_sculptor.snap
@@ -22,7 +22,8 @@ expression: result
           "type": "Any"
         },
         "rest_destination": null,
-        "reveal": false
+        "reveal": false,
+        "enter_tapped": false
       },
       "cost": {
         "type": "Loyalty",

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -2217,6 +2217,7 @@ mod tests {
                     kept_destination: None,
                     rest_destination: None,
                     source_id: None,
+                    enter_tapped: false,
                 },
             ),
             (

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -2771,6 +2771,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
             filter: TargetFilter::Any,
             rest_destination: None,
             reveal: false,
+            enter_tapped: false,
         },
 
         // CR 701.20e + CR 608.2c: "Look at the top N cards of your library.
@@ -4367,6 +4368,7 @@ fn convert_look_at_top(
             filter: TargetFilter::Any,
             rest_destination: None,
             reveal: false,
+            enter_tapped: false,
         }),
 
         // Brainstorm-style "put one into your hand and the rest on the
@@ -4384,6 +4386,7 @@ fn convert_look_at_top(
                 filter: TargetFilter::Any,
                 rest_destination: Some(Zone::Library),
                 reveal: false,
+                enter_tapped: false,
             })
         }
 
@@ -4400,6 +4403,7 @@ fn convert_look_at_top(
                 filter: TargetFilter::Any,
                 rest_destination: None,
                 reveal: false,
+                enter_tapped: false,
             })
         }
 
@@ -4419,6 +4423,7 @@ fn convert_look_at_top(
                 filter: filter_mod::cards_to_filter(cards)?,
                 rest_destination: Some(Zone::Library),
                 reveal: true,
+                enter_tapped: false,
             })
         }
 
@@ -4434,6 +4439,7 @@ fn convert_look_at_top(
                 filter: filter_mod::cards_to_filter(cards)?,
                 rest_destination: Some(Zone::Graveyard),
                 reveal: true,
+                enter_tapped: false,
             })
         }
 
@@ -4492,6 +4498,7 @@ fn convert_reveal_top_dig(
                 filter: filter_mod::cards_to_filter(cards)?,
                 rest_destination: None,
                 reveal: true,
+                enter_tapped: false,
             })
         }
         [RevealTheTopNumberCardsOfLibraryAction::PutACardOfTypeIntoHand(cards), RevealTheTopNumberCardsOfLibraryAction::PutTheRemainingCardsIntoGraveyard] => {
@@ -4504,6 +4511,7 @@ fn convert_reveal_top_dig(
                 filter: filter_mod::cards_to_filter(cards)?,
                 rest_destination: None,
                 reveal: true,
+                enter_tapped: false,
             })
         }
         [RevealTheTopNumberCardsOfLibraryAction::PutAGenericCardIntoHand, RevealTheTopNumberCardsOfLibraryAction::PutTheRemainingCardsIntoGraveyard] => {
@@ -4516,6 +4524,7 @@ fn convert_reveal_top_dig(
                 filter: TargetFilter::Any,
                 rest_destination: None,
                 reveal: true,
+                enter_tapped: false,
             })
         }
         [RevealTheTopNumberCardsOfLibraryAction::MayPutACardOfTypeIntoHand(cards), RevealTheTopNumberCardsOfLibraryAction::PutTheRemainingCardsOnTheBottomOfLibraryInAnyOrder]
@@ -4529,6 +4538,7 @@ fn convert_reveal_top_dig(
                 filter: filter_mod::cards_to_filter(cards)?,
                 rest_destination: Some(Zone::Library),
                 reveal: true,
+                enter_tapped: false,
             })
         }
         [RevealTheTopNumberCardsOfLibraryAction::PutACardOfTypeIntoHand(cards), RevealTheTopNumberCardsOfLibraryAction::PutTheRemainingCardsOnTheBottomOfLibraryInAnyOrder]
@@ -4542,6 +4552,7 @@ fn convert_reveal_top_dig(
                 filter: filter_mod::cards_to_filter(cards)?,
                 rest_destination: Some(Zone::Library),
                 reveal: true,
+                enter_tapped: false,
             })
         }
         _ => Err(prereq(format!(

--- a/crates/phase-ai/src/features/control.rs
+++ b/crates/phase-ai/src/features/control.rs
@@ -513,6 +513,7 @@ mod tests {
                 filter: TargetFilter::Any,
                 rest_destination: None,
                 reveal: false,
+                enter_tapped: false,
             },
         ));
         let deck = vec![entry(face, 4)];
@@ -538,6 +539,7 @@ mod tests {
                 filter: TargetFilter::Any,
                 rest_destination: None,
                 reveal: false,
+                enter_tapped: false,
             },
         ));
         let deck = vec![entry(face, 4)];

--- a/crates/phase-ai/src/features/spellslinger_prowess.rs
+++ b/crates/phase-ai/src/features/spellslinger_prowess.rs
@@ -625,6 +625,7 @@ mod tests {
             filter: TargetFilter::Any,
             rest_destination: None,
             reveal: false,
+            enter_tapped: false,
         }));
         let f = detect(&[entry(c, 4)]);
         assert_eq!(f.cantrip_count, 4);
@@ -645,6 +646,7 @@ mod tests {
             filter: TargetFilter::Any,
             rest_destination: None,
             reveal: false,
+            enter_tapped: false,
         }));
         let f = detect(&[entry(c, 4)]);
         // impulse-dig should NOT count as cantrip

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -2109,6 +2109,7 @@ mod tests {
             kept_destination: Some(Zone::Library),
             rest_destination: Some(Zone::Library),
             source_id: None,
+            enter_tapped: false,
         };
 
         // Non-canonical permutation [c, a, b] — not an enumerated candidate.


### PR DESCRIPTION
## Summary

- Add `enter_tapped` support on Dig keep-to-battlefield for Planar Genesis land branch.
- Confirm spell-resolution hand-to-battlefield land puts do not consume the land drop.

## Test plan

- [x] `cargo test -p engine --lib issue_2405`
- [x] `./scripts/check-parser-combinators.sh`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #2405