### PR TITLE
Fix Doubling Chant per-creature search loop (#2400)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -6766,6 +6766,39 @@ mod tests {
         }
     }
 
+    #[test]
+    fn build_target_slots_surfaces_player_slot_for_search_target_player_library() {
+        let state = GameState::new_two_player(42);
+        let ability = ResolvedAbility::new(
+            Effect::SearchLibrary {
+                filter: TargetFilter::Any,
+                count: QuantityExpr::Fixed { value: 1 },
+                reveal: false,
+                target_player: Some(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent),
+                )),
+                selection_constraint: SearchSelectionConstraint::None,
+                split: None,
+                source_zones: vec![Zone::Library],
+            },
+            vec![],
+            ObjectId(900),
+            PlayerId(0),
+        );
+
+        let slots = build_target_slots(&state, &ability).expect("should build");
+        assert_eq!(slots.len(), 1);
+        assert!(slots[0]
+            .legal_targets
+            .contains(&TargetRef::Player(PlayerId(1))));
+        assert!(
+            !slots[0]
+                .legal_targets
+                .contains(&TargetRef::Player(PlayerId(0))),
+            "target opponent library search must not allow targeting yourself"
+        );
+    }
+
     /// Issue #933: mass filters can declare a target only through a dynamic
     /// threshold ("power greater than target creature's power"). The target
     /// lives inside `FilterProp::PtComparison.value`, so `DestroyAll` must

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2578,10 +2578,32 @@ fn effect_parent_ref_slots(effect: &Effect) -> Vec<&TargetFilter> {
 /// True if any object-target slot of the effect references the per-iteration
 /// object via a parent context ref. Member-driven `repeat_for: ObjectCount`
 /// loops use this to decide whether to rebind the parent target each iteration.
+fn filter_refs_same_name_as_parent_target(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::SameNameAsParentTarget)),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(filter_refs_same_name_as_parent_target)
+        }
+        TargetFilter::Not { filter } => filter_refs_same_name_as_parent_target(filter),
+        _ => false,
+    }
+}
+
 fn effect_iterates_over_parent_target(effect: &Effect) -> bool {
-    effect_parent_ref_slots(effect)
+    if effect_parent_ref_slots(effect)
         .iter()
         .any(|f| filter_refs_parent_target(f))
+    {
+        return true;
+    }
+    // CR 608.2c: Doubling Chant — `repeat_for: ObjectCount` over creatures you
+    // control with a `SearchLibrary` filter using `SameNameAsParentTarget` must
+    // rebind the parent target each iteration even though the parent-ref lives on
+    // the search filter, not a `TargetFilter::ParentTarget` slot.
+    matches!(effect, Effect::SearchLibrary { filter, .. } if filter_refs_same_name_as_parent_target(filter))
 }
 
 /// Recurse into compound filters so a wrapped `ParentTargetController` is
@@ -2640,6 +2662,20 @@ fn has_kind_driven_repeat(ability: &ResolvedAbility) -> bool {
             qty: QuantityRef::DistinctCounterKindsAmong { .. },
         })
     )
+}
+
+/// CR 608.2c + CR 608.2d: Doubling Chant — `repeat_for: ObjectCount` with a
+/// per-iteration parent ref (`SameNameAsParentTarget` on `SearchLibrary`) makes
+/// its "you may" apply per iterated creature, not once up front. Suppress the
+/// single optional gate in `resolve_chain_body` and fire optionality inside the
+/// `repeat_for` loop instead (mirrors `has_kind_driven_repeat`).
+fn has_member_driven_repeat(ability: &ResolvedAbility) -> bool {
+    matches!(
+        ability.repeat_for,
+        Some(QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { .. },
+        })
+    ) && effect_iterates_over_parent_target(&ability.effect)
 }
 
 fn rebind_iterated_counter_kind(
@@ -3790,7 +3826,7 @@ fn resolve_chain_body(
     // accept another. Suppress the single up-front gate here; the `repeat_for`
     // loop below fires its own per-iteration `OptionalEffectChoice` for each
     // counter kind (see the `kind_driven` optional path in the loop).
-    if ability.optional && !has_kind_driven_repeat(ability) {
+    if ability.optional && !has_kind_driven_repeat(ability) && !has_member_driven_repeat(ability) {
         let description = ability.description.clone();
         let prompt_player = optional_prompt_player(state, ability);
         let may_trigger_key = ability
@@ -4180,17 +4216,14 @@ fn resolve_chain_body(
                                 &mut iter_ability,
                                 iterated_counter_kinds[iteration].clone(),
                             );
-                            // CR 608.2c + CR 608.2d: when the per-kind action is
-                            // optional (Bribe Taker's "you may"), this iteration
-                            // must route through `resolve_ability_chain` so the
-                            // up-front optional gate fires its OWN
-                            // `OptionalEffectChoice` for THIS kind (decline →
-                            // place nothing for this kind and advance; accept →
-                            // the `ChooseOneOf` branch prompt). The loop owns
-                            // iteration, so clear `repeat_for` on the clone to
-                            // prevent re-entering this loop (the up-front gate at
-                            // the top of `resolve_chain_body` is suppressed for
-                            // kind-driven loops via `has_kind_driven_repeat`).
+                        }
+                        // CR 608.2c + CR 608.2d: per-iteration optional actions
+                        // (Bribe Taker per counter kind; Doubling Chant per
+                        // creature search) route through `resolve_ability_chain`
+                        // so each iteration fires its own `OptionalEffectChoice`.
+                        // Clear `repeat_for` on the clone so the inner chain does
+                        // not re-enter this outer loop.
+                        if kind_driven || (member_driven && iter_ability.optional) {
                             iter_ability.repeat_for = None;
                         }
                         if let (true, Effect::CopySpell { retarget, .. }) =
@@ -4202,13 +4235,13 @@ fn resolve_chain_body(
                     } else {
                         effective
                     };
-                // CR 608.2d: A kind-driven iteration whose action is optional
-                // fires its per-kind "you may" gate (and any accepted
-                // `ChooseOneOf` branch prompt) through the full chain. All other
-                // iterations resolve the effect directly — `resolve_effect` does
-                // not check `optional`, which is correct because non-kind loops
-                // apply their `optional` once up front in `resolve_chain_body`.
-                if kind_driven && iter_effective.optional {
+                // CR 608.2d: A kind-driven or member-driven iteration whose action
+                // is optional fires its per-iteration "you may" gate through the
+                // full chain. All other iterations resolve the effect directly —
+                // `resolve_effect` does not check `optional`, which is correct
+                // because non-per-iteration loops apply their `optional` once up
+                // front in `resolve_chain_body`.
+                if (kind_driven || member_driven) && iter_effective.optional {
                     // CR 608.2c: pass a non-zero depth so the depth==0 prelude
                     // (chain-local state clearing, resolution counter) does not
                     // re-run mid-loop — this iteration continues the current
@@ -15360,5 +15393,61 @@ mod tests {
             ),
             None
         );
+    }
+
+    /// Issue #2400: Doubling Chant — `repeat_for: ObjectCount` over controlled
+    /// creatures must drive the `SearchLibrary` loop when the search filter uses
+    /// `SameNameAsParentTarget`, not silently produce zero iterations.
+    #[test]
+    fn issue_2400_doubling_chant_member_driven_search_iterations() {
+        let mut state = GameState::new_two_player(42);
+
+        for (card_id, name) in [(CardId(1), "Bear"), (CardId(2), "Elephant")] {
+            let id = create_object(
+                &mut state,
+                card_id,
+                PlayerId(0),
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types = vec![CoreType::Creature];
+        }
+
+        let source = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Doubling Chant".to_string(),
+            Zone::Stack,
+        );
+
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "For each creature you control, you may search your library for a creature card with the same name as that creature. Put those cards onto the battlefield, then shuffle.",
+            AbilityKind::Spell,
+        );
+        let ability =
+            crate::game::ability_utils::build_resolved_from_def(&def, source, PlayerId(0));
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        assert!(
+            state.pending_repeat_iteration.is_some()
+                || matches!(
+                    state.waiting_for,
+                    WaitingFor::SearchChoice { .. } | WaitingFor::OptionalEffectChoice { .. }
+                ),
+            "member-driven search must enter the repeat loop, got waiting_for={:?} pending={:?}",
+            state.waiting_for,
+            state.pending_repeat_iteration
+        );
+        if let Some(pending) = state.pending_repeat_iteration.as_ref() {
+            assert_eq!(
+                pending.total_iterations, 2,
+                "two controlled creatures ⇒ two search iterations"
+            );
+            assert_eq!(pending.tracked_members.len(), 2);
+        }
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2678,6 +2678,10 @@ fn has_member_driven_repeat(ability: &ResolvedAbility) -> bool {
     ) && effect_iterates_over_parent_target(&ability.effect)
 }
 
+fn has_member_driven_repeat_after_hydration(state: &GameState, ability: &ResolvedAbility) -> bool {
+    has_member_driven_repeat(&ability_with_event_context_targets(state, ability))
+}
+
 fn rebind_iterated_counter_kind(
     ability: &mut ResolvedAbility,
     kind: crate::types::counter::CounterType,
@@ -3826,7 +3830,10 @@ fn resolve_chain_body(
     // accept another. Suppress the single up-front gate here; the `repeat_for`
     // loop below fires its own per-iteration `OptionalEffectChoice` for each
     // counter kind (see the `kind_driven` optional path in the loop).
-    if ability.optional && !has_kind_driven_repeat(ability) && !has_member_driven_repeat(ability) {
+    if ability.optional
+        && !has_kind_driven_repeat(ability)
+        && !has_member_driven_repeat_after_hydration(state, ability)
+    {
         let description = ability.description.clone();
         let prompt_player = optional_prompt_player(state, ability);
         let may_trigger_key = ability
@@ -15413,6 +15420,39 @@ mod tests {
             let obj = state.objects.get_mut(&id).unwrap();
             obj.card_types.core_types = vec![CoreType::Creature];
         }
+        let library_bear = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Library,
+        );
+        state
+            .objects
+            .get_mut(&library_bear)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Creature];
+        let library_elephant = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Elephant".to_string(),
+            Zone::Library,
+        );
+        state
+            .objects
+            .get_mut(&library_elephant)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Creature];
+        let library_bear_noncreature = create_object(
+            &mut state,
+            CardId(5),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Library,
+        );
 
         let source = create_object(
             &mut state,
@@ -15432,22 +15472,134 @@ mod tests {
         let mut events = Vec::new();
         resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
 
-        assert!(
-            state.pending_repeat_iteration.is_some()
-                || matches!(
-                    state.waiting_for,
-                    WaitingFor::SearchChoice { .. } | WaitingFor::OptionalEffectChoice { .. }
-                ),
-            "member-driven search must enter the repeat loop, got waiting_for={:?} pending={:?}",
+        assert!(matches!(
             state.waiting_for,
-            state.pending_repeat_iteration
+            WaitingFor::OptionalEffectChoice { .. }
+        ));
+        let pending = state
+            .pending_repeat_iteration
+            .as_ref()
+            .expect("first optional prompt must stash the remaining iteration");
+        assert_eq!(
+            pending.total_iterations, 2,
+            "two controlled creatures imply two search iterations"
         );
-        if let Some(pending) = state.pending_repeat_iteration.as_ref() {
-            assert_eq!(
-                pending.total_iterations, 2,
-                "two controlled creatures ⇒ two search iterations"
+        assert_eq!(pending.next_iteration, 1);
+        assert_eq!(pending.tracked_members.len(), 2);
+
+        let first_member = pending.tracked_members[0];
+        let first_name = state.objects.get(&first_member).unwrap().name.clone();
+        let expected_first_card = match first_name.as_str() {
+            "Bear" => library_bear,
+            "Elephant" => library_elephant,
+            other => panic!("unexpected iterated creature {other}"),
+        };
+        let other_card = if expected_first_card == library_bear {
+            library_elephant
+        } else {
+            library_bear
+        };
+
+        crate::game::engine::apply_as_current(
+            &mut state,
+            GameAction::DecideOptionalEffect { accept: true },
+        )
+        .unwrap();
+
+        let WaitingFor::SearchChoice { cards, count, .. } = &state.waiting_for else {
+            panic!(
+                "accepting first per-creature optional search must enter SearchChoice, got {:?}",
+                state.waiting_for
             );
-            assert_eq!(pending.tracked_members.len(), 2);
+        };
+        assert_eq!(*count, 1);
+        assert!(
+            cards.contains(&expected_first_card),
+            "SearchChoice must offer same-named creature card {expected_first_card:?} for {first_name}"
+        );
+        assert!(
+            !cards.contains(&other_card),
+            "SearchChoice must not offer a creature with the other iterated name"
+        );
+        assert!(
+            !cards.contains(&library_bear_noncreature),
+            "SearchChoice must still require a creature card"
+        );
+    }
+
+    #[test]
+    fn dichotomancy_member_driven_search_uses_target_players_library() {
+        let mut state = GameState::new_two_player(42);
+
+        let battlefield_relic = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Relic".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&battlefield_relic).unwrap();
+            obj.controller = PlayerId(1);
+            obj.tapped = true;
+            obj.card_types.core_types = vec![crate::types::card_type::CoreType::Artifact];
         }
+
+        let caster_library_relic = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Relic".to_string(),
+            Zone::Library,
+        );
+        let opponent_library_relic = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Relic".to_string(),
+            Zone::Library,
+        );
+
+        let source = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Dichotomancy".to_string(),
+            Zone::Stack,
+        );
+
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "For each tapped nonland permanent target opponent controls, search that player's library for a card with the same name as that permanent and put it onto the battlefield under your control. Then that player shuffles.",
+            AbilityKind::Spell,
+        );
+        let mut ability =
+            crate::game::ability_utils::build_resolved_from_def(&def, source, PlayerId(0));
+        ability.targets = vec![TargetRef::Player(PlayerId(1))];
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        let WaitingFor::SearchChoice {
+            player,
+            cards,
+            count,
+            ..
+        } = &state.waiting_for
+        else {
+            panic!(
+                "Dichotomancy must enter a search choice for the target player's library, got {:?}",
+                state.waiting_for
+            );
+        };
+        assert_eq!(*player, PlayerId(0), "the caster searches that library");
+        assert_eq!(*count, 1);
+        assert!(
+            cards.contains(&opponent_library_relic),
+            "search must offer same-named card from the target opponent's library"
+        );
+        assert!(
+            !cards.contains(&caster_library_relic),
+            "search must not offer same-named card from the caster's library"
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6543,18 +6543,22 @@ fn for_each_clause_target_controller_filter(for_each_clause: &str) -> Option<Tar
                 TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
                 tag("target opponent controls"),
             ),
-            value(TargetFilter::Player, tag("target player controls")),
+            value(
+                TargetFilter::Typed(TypedFilter::default()),
+                tag("target player controls"),
+            ),
         ))
         .parse(input)
     })
 }
 
 fn parsed_for_each_quantity_effect(
-    effect: Effect,
+    mut effect: Effect,
     duration: Option<Duration>,
     reference_target: Option<TargetFilter>,
 ) -> ParsedEffectClause {
     if let Some(target) = reference_target {
+        bind_search_library_for_each_antecedent(&mut effect, &target, "");
         if matches!(
             effect,
             Effect::Draw {
@@ -6587,6 +6591,32 @@ fn parsed_for_each_quantity_effect(
         optional: false,
         unless_pay: None,
     }
+}
+
+fn bind_search_library_for_each_antecedent(
+    effect: &mut Effect,
+    target: &TargetFilter,
+    text_lower: &str,
+) {
+    if let Effect::SearchLibrary { target_player, .. } = effect {
+        if target_player
+            .as_ref()
+            .is_some_and(search_library_target_player_is_for_each_antecedent)
+            || (target_player.is_none()
+                && nom_primitives::scan_contains(text_lower, "search that player's "))
+        {
+            *target_player = Some(target.clone());
+        }
+    }
+}
+
+fn search_library_target_player_is_for_each_antecedent(target: &TargetFilter) -> bool {
+    let TargetFilter::Typed(typed) = target else {
+        return false;
+    };
+    typed.type_filters.is_empty()
+        && typed.properties.is_empty()
+        && typed.controller == Some(ControllerRef::TargetPlayer)
 }
 
 fn try_parse_gain_energy(tp: TextPair<'_>, ctx: &mut ParseContext) -> Option<ParsedEffectClause> {
@@ -15006,11 +15036,15 @@ pub(crate) fn parse_effect_chain_ir(
         // `parse_effect_clause` claims it. The generic `for each` strip would
         // otherwise lift the counter-kind iteration into `repeat_for` and drop
         // the target, leaving an Unimplemented "give … counter" body.
-        let (repeat_for, text) = if try_parse_proliferate_target(&text).is_some() {
-            (None, text)
-        } else {
-            strip_for_each_prefix(&text)
-        };
+        let (repeat_for, text, for_each_reference_target) =
+            if try_parse_proliferate_target(&text).is_some() {
+                (None, text, None)
+            } else {
+                let reference_target = for_each_clause_target_controller_filter(&text);
+                let (repeat_for, text) = strip_for_each_prefix(&text);
+                let reference_target = repeat_for.as_ref().and(reference_target);
+                (repeat_for, text, reference_target)
+            };
         let (text_without_where_x, local_where_x_expression) = {
             let text_where_x_lower = text.to_lowercase();
             let (without_where_x, where_x_expression) =
@@ -15540,6 +15574,9 @@ pub(crate) fn parse_effect_chain_ir(
         // carries the caster default (Controller). Per D-04, this is parse-time
         // pronoun resolution that belongs in IR production.
         let mut clause = clause;
+        if let Some(target) = &for_each_reference_target {
+            bind_search_library_for_each_antecedent(&mut clause.effect, target, &text_no_qty_lower);
+        }
         // CR 608.2: `parse_exile_ast` uses `ScopedPlayer` as the structural
         // marker for "each player's library". Lower it into the same
         // player_scope-driven shape used by Evelyn/Jeleva-class effects:
@@ -44004,4 +44041,60 @@ fn issue_2400_doubling_chant_repeat_for_member_driven_search() {
             .contains(&FilterProp::SameNameAsParentTarget),
         "search must bind same name as per-iteration creature"
     );
+}
+
+#[test]
+fn dichotomancy_searches_target_players_library_per_iterated_permanent() {
+    let def = parse_effect_chain(
+        "For each tapped nonland permanent target opponent controls, search that player's library for a card with the same name as that permanent and put it onto the battlefield under your control. Then that player shuffles.",
+        AbilityKind::Spell,
+    );
+    assert!(matches!(&*def.effect, Effect::SearchLibrary { .. }));
+    let Some(QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount { filter },
+    }) = &def.repeat_for
+    else {
+        panic!("expected ObjectCount repeat_for, got {:?}", def.repeat_for);
+    };
+    let TargetFilter::Typed(repeat_filter) = filter else {
+        panic!("expected typed repeat filter, got {filter:?}");
+    };
+    assert_eq!(repeat_filter.controller, Some(ControllerRef::TargetPlayer));
+
+    let Effect::SearchLibrary {
+        filter,
+        target_player,
+        ..
+    } = def.effect.as_ref()
+    else {
+        panic!("expected SearchLibrary");
+    };
+    let Some(TargetFilter::Typed(target_player)) = target_player else {
+        panic!("expected target-player scoped library owner");
+    };
+    assert_eq!(target_player.controller, Some(ControllerRef::Opponent));
+    let TargetFilter::Typed(search_filter) = filter else {
+        panic!("expected typed search filter, got {filter:?}");
+    };
+    assert!(
+        search_filter
+            .properties
+            .contains(&FilterProp::SameNameAsParentTarget),
+        "search must bind same name as per-iteration permanent"
+    );
+}
+
+#[test]
+fn for_each_target_player_controls_search_that_players_library_keeps_caster_searcher_shape() {
+    let def = parse_effect_chain(
+        "For each tapped nonland permanent target player controls, search that player's library for a card with the same name as that permanent and put it onto the battlefield under your control.",
+        AbilityKind::Spell,
+    );
+    let Effect::SearchLibrary { target_player, .. } = def.effect.as_ref() else {
+        panic!("expected SearchLibrary");
+    };
+    let Some(TargetFilter::Typed(target_player)) = target_player else {
+        panic!("expected typed target-player library owner, got {target_player:?}");
+    };
+    assert_eq!(target_player.controller, None);
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -43978,3 +43978,30 @@ mod snapshot_tests {
         ));
     }
 }
+
+#[test]
+fn issue_2400_doubling_chant_repeat_for_member_driven_search() {
+    let def = parse_effect_chain(
+        "For each creature you control, you may search your library for a creature card with the same name as that creature. Put those cards onto the battlefield, then shuffle.",
+        AbilityKind::Spell,
+    );
+    assert!(matches!(&*def.effect, Effect::SearchLibrary { .. }));
+    assert!(matches!(
+        def.repeat_for,
+        Some(QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { .. }
+        })
+    ));
+    let Effect::SearchLibrary { filter, .. } = def.effect.as_ref() else {
+        panic!("expected SearchLibrary");
+    };
+    let TargetFilter::Typed(typed) = filter else {
+        panic!("expected typed search filter, got {filter:?}");
+    };
+    assert!(
+        typed
+            .properties
+            .contains(&FilterProp::SameNameAsParentTarget),
+        "search must bind same name as per-iteration creature"
+    );
+}

--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -625,7 +625,10 @@ fn parse_search_target_player(lower: &str) -> Option<TargetFilter> {
                     TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
                     tag("target opponent's "),
                 ),
-                value(TargetFilter::Player, tag("target player's ")),
+                value(
+                    TargetFilter::Typed(TypedFilter::default()),
+                    tag("target player's "),
+                ),
                 value(
                     TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
                     tag("an opponent's "),
@@ -2810,7 +2813,10 @@ mod tests {
             &mut ParseContext::default(),
         );
         assert!(details.target_player.is_some());
-        assert_eq!(details.target_player.unwrap(), TargetFilter::Player);
+        let TargetFilter::Typed(target_player) = details.target_player.unwrap() else {
+            panic!("expected typed target-player library owner");
+        };
+        assert_eq!(target_player.controller, None);
     }
 
     #[test]
@@ -2822,6 +2828,15 @@ mod tests {
         );
         assert!(details.target_player.is_some());
         assert_eq!(details.count, QuantityExpr::Fixed { value: 3 });
+    }
+
+    #[test]
+    fn search_that_players_library_without_context_does_not_surface_player_target() {
+        let details = parse_search_library_details(
+            "search that player's library for a card with the same name as that permanent",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(details.target_player, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Treat `SearchLibrary` filters using `SameNameAsParentTarget` as member-driven `repeat_for: ObjectCount` iterations so Doubling Chant's optional library search runs once per creature you control.

## Test plan

- [x] `cargo test -p engine --lib issue_2400`
- [x] `./scripts/check-parser-combinators.sh`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #2400