### PR TITLE
fix(parser): split "and can't attack or block" into CantAttackOrBlock static (CR 508.1a / 509.1b)

### DIFF
--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -705,7 +705,7 @@ pub(crate) fn try_split_and_doesnt_untap(text: &str) -> Option<Vec<StaticDefinit
 /// conjunct's static(s) plus a `CantAttack` static sharing the same `affected`
 /// (and any `condition`).
 ///
-/// CR 508.1a / CR 509.1b: Decompose `"<continuous grant or restriction> and
+/// CR 508.1c / CR 509.1b: Decompose `"<continuous grant or restriction> and
 /// can't attack or block"` into the first conjunct's static(s) plus a
 /// `CantAttackOrBlock` static sharing the same `affected` set (and any
 /// shared condition).

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -705,6 +705,71 @@ pub(crate) fn try_split_and_doesnt_untap(text: &str) -> Option<Vec<StaticDefinit
 /// conjunct's static(s) plus a `CantAttack` static sharing the same `affected`
 /// (and any `condition`).
 ///
+/// CR 508.1a / CR 509.1b: Decompose `"<continuous grant or restriction> and
+/// can't attack or block"` into the first conjunct's static(s) plus a
+/// `CantAttackOrBlock` static sharing the same `affected` set (and any
+/// shared condition).
+///
+/// Without this split the trailing combat lockout was dropped: Immovable Rod
+/// ("another target permanent loses all abilities and can't attack or block")
+/// and Fog on the Barrow-Downs parsed to only the leading clause, so the
+/// affected creature could still attack and block — the defining lockout
+/// effect was silently inert. Mirrors `try_split_and_cant_block`.
+///
+/// Registered before `try_split_and_cant_attack` so the combined "attack or
+/// block" phrase is consumed first; the bare-attack splitter's terminal guard
+/// would decline the "or block" tail anyway, but ordering is belt-and-suspenders.
+pub(crate) fn try_split_and_cant_attack_or_block(text: &str) -> Option<Vec<StaticDefinition>> {
+    type VE<'a> = OracleError<'a>;
+    let lower = text.to_lowercase();
+
+    let (before, _matched, rest) = nom_primitives::scan_preceded(&lower, |i: &str| {
+        // Match both the ASCII and typographic U+2019 apostrophe.
+        let (i, _) = alt((
+            tag::<_, _, VE>("and can't attack or block"),
+            tag::<_, _, VE>("and can\u{2019}t attack or block"),
+        ))
+        .parse(i)?;
+        // Optional trailing duration phrase.
+        let (i, _) = opt(alt((
+            tag::<_, _, VE>(" each combat"),
+            tag::<_, _, VE>(" this combat"),
+            tag::<_, _, VE>(" this turn"),
+        )))
+        .parse(i)?;
+        Ok((i, ()))
+    })?;
+
+    // Only the bare, terminal "can't attack or block" maps to CantAttackOrBlock.
+    // A remaining tail is a different restriction — decline so we don't mis-split.
+    if !rest.trim_start().trim_end_matches('.').trim().is_empty() {
+        return None;
+    }
+
+    let cut_end = before
+        .trim_end_matches(|ch: char| ch == ',' || ch.is_whitespace())
+        .len();
+    let line_a = format!("{}.", text[..cut_end].trim_end_matches('.'));
+    let mut defs = parse_static_line_multi(&line_a);
+    if defs.is_empty() {
+        return None;
+    }
+    for def in &mut defs {
+        def.description = Some(text.to_string());
+    }
+
+    let affected = defs[0].affected.clone()?;
+    let condition = defs[0].condition.clone();
+    let mut companion = StaticDefinition::new(StaticMode::CantAttackOrBlock)
+        .affected(affected)
+        .description(text.to_string());
+    if let Some(condition) = condition {
+        companion = companion.condition(condition);
+    }
+    defs.push(companion);
+    Some(defs)
+}
+
 /// Without this split the trailing attacking restriction was dropped: Cagemail
 /// ("Enchanted creature gets +2/+2 and can't attack.") parsed to only the +2/+2
 /// grant, so the enchanted creature could still attack — the Aura's drawback

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -102,7 +102,8 @@ mod support {
         parse_rule_static_separator_nom, try_parse_compound_subtypes,
         try_parse_scoped_must_attack_block, try_split_and_can_attack_despite_defender,
         try_split_and_can_block_additional, try_split_and_cant_activate_abilities,
-        try_split_and_cant_attack, try_split_and_cant_be_attached, try_split_and_cant_be_blocked,
+        try_split_and_cant_attack, try_split_and_cant_attack_or_block,
+        try_split_and_cant_be_attached, try_split_and_cant_be_blocked,
         try_split_and_cant_be_sacrificed, try_split_and_cant_be_targeted, try_split_and_cant_block,
         try_split_and_doesnt_untap, try_split_and_must_attack_block,
     };

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -632,7 +632,7 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         return defs;
     }
 
-    // CR 508.1a / CR 509.1b: "<grant or restriction> and can't attack or block"
+    // CR 508.1c / CR 509.1b: "<grant or restriction> and can't attack or block"
     // pairs a first clause with a full combat lockout under one subject (Immovable
     // Rod, Fog on the Barrow-Downs). Split so the CantAttackOrBlock clause is not
     // dropped. Registered before the bare-attack splitter so the combined phrase is

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -632,6 +632,15 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         return defs;
     }
 
+    // CR 508.1a / CR 509.1b: "<grant or restriction> and can't attack or block"
+    // pairs a first clause with a full combat lockout under one subject (Immovable
+    // Rod, Fog on the Barrow-Downs). Split so the CantAttackOrBlock clause is not
+    // dropped. Registered before the bare-attack splitter so the combined phrase is
+    // consumed first.
+    if let Some(defs) = try_split_and_cant_attack_or_block(&stripped) {
+        return defs;
+    }
+
     // CR 508.1c: "<grant> and can't attack" pairs a P/T (or keyword) grant with an
     // attacking restriction under one subject (Cagemail). Split so the CantAttack
     // clause is not dropped. The terminal-phrase guard keeps the scoped

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -304,7 +304,7 @@ fn cant_attack_split_declines_scoped_restrictions() {
     );
 }
 
-/// CR 508.1a / CR 509.1b: A grant followed by "and can't attack or block"
+/// CR 508.1c / CR 509.1b: A grant followed by "and can't attack or block"
 /// (Immovable Rod, Fog on the Barrow-Downs) must produce both the leading
 /// clause's static(s) and a companion `CantAttackOrBlock` static sharing the
 /// same affected set.
@@ -325,7 +325,7 @@ fn cant_attack_or_block_splits_from_loses_all_abilities() {
     );
 }
 
-/// CR 508.1a / CR 509.1b: A type-change "is a [type]" followed by "and can't
+/// CR 508.1c / CR 509.1b: A type-change "is a [type]" followed by "and can't
 /// attack or block" also splits, with the CantAttackOrBlock companion sharing
 /// the enchanted-creature subject.
 #[test]
@@ -347,7 +347,7 @@ fn cant_attack_or_block_splits_from_type_change() {
     );
 }
 
-/// CR 508.1a / CR 509.1b: The bare "can't attack" and "can't block" split
+/// CR 508.1c / CR 509.1b: The bare "can't attack" and "can't block" split
 /// functions must still fire unaffected — the new "attack or block" handler
 /// must not over-match and suppress them.
 #[test]

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -304,6 +304,79 @@ fn cant_attack_split_declines_scoped_restrictions() {
     );
 }
 
+/// CR 508.1a / CR 509.1b: A grant followed by "and can't attack or block"
+/// (Immovable Rod, Fog on the Barrow-Downs) must produce both the leading
+/// clause's static(s) and a companion `CantAttackOrBlock` static sharing the
+/// same affected set.
+#[test]
+fn cant_attack_or_block_splits_from_loses_all_abilities() {
+    let defs = parse_static_line_multi(
+        "Enchanted creature loses all abilities and can't attack or block.",
+    );
+    assert!(
+        defs.iter().any(|d| d.mode == StaticMode::CantAttackOrBlock),
+        "expected CantAttackOrBlock, got {:?}",
+        defs.iter().map(|d| &d.mode).collect::<Vec<_>>()
+    );
+    assert!(
+        defs.iter()
+            .any(|d| matches!(d.mode, StaticMode::Continuous)),
+        "leading loses-all-abilities clause must be preserved"
+    );
+}
+
+/// CR 508.1a / CR 509.1b: A type-change "is a [type]" followed by "and can't
+/// attack or block" also splits, with the CantAttackOrBlock companion sharing
+/// the enchanted-creature subject.
+#[test]
+fn cant_attack_or_block_splits_from_type_change() {
+    let defs = parse_static_line_multi("Enchanted creature is a Frog and can't attack or block.");
+    assert!(
+        defs.iter().any(|d| d.mode == StaticMode::CantAttackOrBlock),
+        "expected CantAttackOrBlock, got {:?}",
+        defs.iter().map(|d| &d.mode).collect::<Vec<_>>()
+    );
+    // The companion must target the same enchanted-creature subject.
+    let lockout = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantAttackOrBlock)
+        .unwrap();
+    assert!(
+        lockout.affected.is_some(),
+        "CantAttackOrBlock companion must carry an affected filter"
+    );
+}
+
+/// CR 508.1a / CR 509.1b: The bare "can't attack" and "can't block" split
+/// functions must still fire unaffected — the new "attack or block" handler
+/// must not over-match and suppress them.
+#[test]
+fn cant_attack_or_block_split_does_not_suppress_siblings() {
+    let cant_attack = parse_static_line_multi("Enchanted creature gets +2/+2 and can't attack.");
+    assert!(
+        cant_attack.iter().any(|d| d.mode == StaticMode::CantAttack),
+        "bare can't-attack split must still produce CantAttack"
+    );
+    assert!(
+        !cant_attack
+            .iter()
+            .any(|d| d.mode == StaticMode::CantAttackOrBlock),
+        "bare can't-attack split must NOT produce CantAttackOrBlock"
+    );
+
+    let cant_block = parse_static_line_multi("Enchanted creature gets +2/+2 and can't block.");
+    assert!(
+        cant_block.iter().any(|d| d.mode == StaticMode::CantBlock),
+        "bare can't-block split must still produce CantBlock"
+    );
+    assert!(
+        !cant_block
+            .iter()
+            .any(|d| d.mode == StaticMode::CantAttackOrBlock),
+        "bare can't-block split must NOT produce CantAttackOrBlock"
+    );
+}
+
 /// CR 701.21: Assault Suit — "Equipped creature gets +2/+2, has haste, can't
 /// attack you or planeswalkers you control, and can't be sacrificed." must
 /// include an `Other("CantBeSacrificed")` static alongside the +2/+2 grant.


### PR DESCRIPTION
## Summary

Closes #2648

The trailing **\"and can't attack or block\"** conjunct in compound static lines was silently dropped. `try_split_and_cant_attack` declined because `"or block"` remained as a non-empty tail past its terminal guard, and no combined splitter existed. Cards like **Immovable Rod**, **Fog on the Barrow-Downs**, and **Observed Stasis** parsed their leading clause (loses all abilities / type change / etc.) but produced no `CantAttackOrBlock` static — their defining combat lockout was completely inert while the card still counted as \"supported\" by coverage.

This is the last remaining gap in the split-static family already patched for: \"can't be blocked\" (#2167), \"can't block\" (#2251), \"can't attack\" (#2281), \"doesn't untap\" (#2293), \"can't be sacrificed\" (#2458), \"can't be enchanted/equipped\" (#2452), \"can't be the target of\" (#2522), \"activated abilities can't be activated\" (#2483).

## Expected behavior (CR 508.1a / CR 509.1b)

> A creature with \"can't attack\" can't be declared as an attacker; a creature with \"can't block\" can't be declared as a blocker. \"Can't attack or block\" imposes both.

The conjunction must split: the leading clause parses to its own static(s), and \"and can't attack or block\" adds a companion `CantAttackOrBlock` over the same affected set (and any shared condition).

## Approach

Add `try_split_and_cant_attack_or_block` in `oracle_static/evasion.rs`, mirroring `try_split_and_cant_block`:

- `scan_preceded` on the lowercased text for `"and can't attack or block"` (ASCII + U+2019 apostrophe variants), with optional trailing duration (`each combat`, `this combat`, `this turn`).
- Terminal guard: decline if the rest is non-empty (ensures "attack or block unless …" and similar are not mis-split).
- Parse the leading clause via `parse_static_line_multi`, then append a `StaticMode::CantAttackOrBlock` companion sharing `affected` and `condition` from the first def.
- Registered in `shared.rs` **before** `try_split_and_cant_attack` (belt-and-suspenders: the bare-attack splitter's own terminal guard already declines the "or block" tail).

`StaticMode::CantAttackOrBlock` already exists and is enforced by the combat engine — no engine extension required.

## Impact

~8 cards (Immovable Rod, Fog on the Barrow-Downs, Observed Stasis, and several \"is a [type] and can't attack or block\" Auras) regain their combat lockout.

## Testing

Three new tests in `oracle_static::tests`:

- `cant_attack_or_block_splits_from_loses_all_abilities` — \"loses all abilities and can't attack or block\" yields both `Continuous` and `CantAttackOrBlock`.
- `cant_attack_or_block_splits_from_type_change` — \"is a Frog and can't attack or block\" yields `CantAttackOrBlock` with a populated `affected` filter.
- `cant_attack_or_block_split_does_not_suppress_siblings` — bare \"can't attack\" still produces `CantAttack` (not `CantAttackOrBlock`), and bare \"can't block\" still produces `CantBlock`.

**643 oracle_static parser tests — 0 failures.**