### PR TITLE
fix(keyword): Devour respects simultaneous co-entry exclusion (CR 702.82 / 614.13a)

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -213,7 +213,7 @@ pub(crate) fn apply_zone_delivery_tail(
     duration: Option<&Duration>,
     exile_tracking: ZoneDeliveryExileTracking,
     events: &mut Vec<GameEvent>,
-) {
+) -> ZoneDeliveryResult {
     // CR 701.24a: To shuffle a library, randomize the cards within it so that
     // no player knows their order.
     if to == Zone::Library {
@@ -233,7 +233,7 @@ pub(crate) fn apply_zone_delivery_tail(
                 _ if matches!(exile_tracking, ZoneDeliveryExileTracking::TrackBySource) => {
                     ExileLinkKind::TrackedBySource
                 }
-                _ => return,
+                _ => return ZoneDeliveryResult::Done,
             };
             state.exile_links.push(ExileLink {
                 exiled_id: object_id,
@@ -247,15 +247,25 @@ pub(crate) fn apply_zone_delivery_tail(
     // (`ChangeZone`) in the same way stack resolution and land play already
     // do, so as-enters work such as "enters prepared" or persisted choices
     // applies before triggers and priority.
+    //
+    // CR 614.12a: A Devour as-enters sacrifice surfaces its own interactive
+    // `EffectZoneChoice` here. Surface that pause to the caller via
+    // `NeedsChoice` so the mass/single zone-change loop stashes the remaining
+    // co-entering members and resumes after the choice (instead of dropping
+    // them, issue #535 class).
     if state.post_replacement_continuation.is_some() {
-        let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
+        let waiting_for = crate::game::engine_replacement::apply_pending_post_replacement_effect(
             state,
             Some(object_id),
             None,
             Some(crate::types::replacements::ReplacementEvent::Moved),
             events,
         );
+        if matches!(waiting_for, Some(WaitingFor::EffectZoneChoice { .. })) {
+            return replacement_pause_delivery_result(state);
+        }
     }
+    ZoneDeliveryResult::Done
 }
 
 fn aura_enchant_filter(state: &GameState, object_id: ObjectId) -> Option<TargetFilter> {
@@ -368,6 +378,16 @@ pub(crate) fn deliver_replaced_zone_change(
         } else {
             Vec::new()
         };
+
+        // CR 614.12a + CR 614.13a: snapshot the pre-entry eligible pool the instant
+        // before the FIRST co-entering devourer enters; persisted (is_none gate) so all
+        // co-entering devourers share it. Excludes self + every co-arriver.
+        if to == Zone::Battlefield
+            && state.devour_eligible_snapshot.is_none()
+            && crate::game::engine_replacement::object_has_devour_replacement(state, object_id)
+        {
+            state.devour_eligible_snapshot = Some(state.battlefield.iter().copied().collect());
+        }
 
         zones::move_to_zone(state, object_id, to, events);
         if to == Zone::Battlefield || from == Zone::Battlefield {
@@ -530,7 +550,7 @@ pub(crate) fn deliver_replaced_zone_change(
                 );
             }
         }
-        apply_zone_delivery_tail(
+        return apply_zone_delivery_tail(
             state,
             object_id,
             from,
@@ -546,10 +566,13 @@ pub(crate) fn deliver_replaced_zone_change(
 }
 
 fn replacement_pause_delivery_result(state: &GameState) -> ZoneDeliveryResult {
-    if let WaitingFor::ReplacementChoice { player, .. } = &state.waiting_for {
-        ZoneDeliveryResult::NeedsChoice(*player)
-    } else {
-        ZoneDeliveryResult::NeedsChoice(state.active_player)
+    match &state.waiting_for {
+        WaitingFor::ReplacementChoice { player, .. } => ZoneDeliveryResult::NeedsChoice(*player),
+        // CR 614.12a: a Devour as-enters sacrifice surfaced its own
+        // `EffectZoneChoice`; carry its chooser so the caller's `park_waiting_for`
+        // doesn't clobber the already-surfaced prompt.
+        WaitingFor::EffectZoneChoice { player, .. } => ZoneDeliveryResult::NeedsChoice(*player),
+        _ => ZoneDeliveryResult::NeedsChoice(state.active_player),
     }
 }
 
@@ -1037,18 +1060,28 @@ pub fn resolve(
                     }
                 }
                 ZoneMoveResult::NeedsChoice(player) => {
+                    // CR 614.12a: single-pick branch (Random single / single-eligible)
+                    // has NO stash/drain, so KEEP the counter-pause EffectResolved
+                    // append — it is the ONLY resume-path EffectResolved emit (the
+                    // synchronous Done-branch emit below does NOT run on the pause
+                    // path). Only the wait-state setter changes to `park_waiting_for`
+                    // so a Devour as-enters sacrifice `EffectZoneChoice` already
+                    // surfaced by the move isn't clobbered.
                     append_effect_resolved_after_counter_pause(
                         state,
                         EffectKind::from(&ability.effect),
                         ability.source_id,
                     );
-                    state.waiting_for =
-                        crate::game::replacement::replacement_choice_waiting_for(player, state);
+                    crate::game::replacement::park_waiting_for(state, player);
                     return Ok(());
                 }
                 ZoneMoveResult::NeedsAuraAttachmentChoice => return Ok(()),
             }
 
+            // CR 614.13a: single-pick entry completed (Done branch) — clear the
+            // pre-entry Devour snapshot (its lifetime = this entry event). The
+            // pause arm above returned before reaching here.
+            let _ = state.devour_eligible_snapshot.take();
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::from(&ability.effect),
                 source_id: ability.source_id,
@@ -1091,18 +1124,28 @@ pub fn resolve(
                     }
                 }
                 ZoneMoveResult::NeedsChoice(player) => {
+                    // CR 614.12a: single-pick branch (Random single / single-eligible)
+                    // has NO stash/drain, so KEEP the counter-pause EffectResolved
+                    // append — it is the ONLY resume-path EffectResolved emit (the
+                    // synchronous Done-branch emit below does NOT run on the pause
+                    // path). Only the wait-state setter changes to `park_waiting_for`
+                    // so a Devour as-enters sacrifice `EffectZoneChoice` already
+                    // surfaced by the move isn't clobbered.
                     append_effect_resolved_after_counter_pause(
                         state,
                         EffectKind::from(&ability.effect),
                         ability.source_id,
                     );
-                    state.waiting_for =
-                        crate::game::replacement::replacement_choice_waiting_for(player, state);
+                    crate::game::replacement::park_waiting_for(state, player);
                     return Ok(());
                 }
                 ZoneMoveResult::NeedsAuraAttachmentChoice => return Ok(()),
             }
 
+            // CR 614.13a: single-pick entry completed (Done branch) — clear the
+            // pre-entry Devour snapshot (its lifetime = this entry event). The
+            // pause arm above returned before reaching here.
+            let _ = state.devour_eligible_snapshot.take();
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::from(&ability.effect),
                 source_id: ability.source_id,
@@ -1147,6 +1190,19 @@ pub fn resolve(
         track_exiled_by_source,
     };
     let _ = owner_library; // routing handled by move_to_zone (CR 400.7)
+
+    // CR 614.12a + CR 614.13a: same pre-loop snapshot as the mass path, for a
+    // targeted multi-`ChangeZone` co-entry that brings in one or more devourers.
+    // Captured before any member enters so every co-arriver (and the devourers
+    // themselves) is excluded regardless of iteration order.
+    if dest_zone == Zone::Battlefield
+        && state.devour_eligible_snapshot.is_none()
+        && targeted_objects
+            .iter()
+            .any(|id| crate::game::engine_replacement::object_has_devour_replacement(state, *id))
+    {
+        state.devour_eligible_snapshot = Some(state.battlefield.iter().copied().collect());
+    }
 
     for (i, obj_id) in targeted_objects.iter().enumerate() {
         if dest_zone == Zone::Exile {
@@ -1208,14 +1264,19 @@ pub fn resolve(
                         track_exiled_by_source: ctx.track_exiled_by_source,
                         effect_kind: EffectKind::from(&ability.effect),
                     });
-                state.waiting_for =
-                    crate::game::replacement::replacement_choice_waiting_for(player, state);
+                // CR 614.12a: park (don't clobber) — a Devour as-enters sacrifice
+                // may already have surfaced its own `EffectZoneChoice`.
+                crate::game::replacement::park_waiting_for(state, player);
                 // EffectResolved is emitted by the drain after the loop completes —
                 // do NOT emit here.
                 return Ok(());
             }
         }
     }
+
+    // CR 614.13a: targeted multi-ChangeZone co-entry completed without pausing —
+    // clear the pre-entry Devour snapshot (its lifetime = this entry event).
+    let _ = state.devour_eligible_snapshot.take();
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::from(&ability.effect),
@@ -1496,9 +1557,27 @@ pub fn resolve_all(
         state.tracked_object_sets.remove(id);
     }
 
+    // CR 614.12a + CR 614.13a: when a mass entry brings in one or more devourers
+    // simultaneously, snapshot the eligible pool BEFORE any co-entering member
+    // enters — `state.objects` is unordered, so an ordinary co-arriver may be
+    // processed before the devourer; capturing at devourer-entry time would then
+    // wrongly include that already-entered co-arriver. Capture pre-loop (when the
+    // battlefield is still the pre-entry set) so every co-arriver is excluded.
+    // `is_none`-gated so a nested/resumed pass doesn't re-capture; cleared on the
+    // event-completion paths below.
+    if dest_zone == Zone::Battlefield
+        && state.devour_eligible_snapshot.is_none()
+        && matching
+            .iter()
+            .any(|id| crate::game::engine_replacement::object_has_devour_replacement(state, *id))
+    {
+        state.devour_eligible_snapshot = Some(state.battlefield.iter().copied().collect());
+    }
+
     let mut moved_count: i32 = 0;
     let mut departed: Vec<ObjectId> = Vec::new();
-    for obj_id in matching {
+    for (i, obj_id) in matching.iter().enumerate() {
+        let obj_id = *obj_id;
         // CR 400.3: Each object's actual current zone is the source zone for the
         // move. Single-zone callers pass `origin_zones = [zone]`; multi-zone
         // callers (e.g. "search graveyard, hand, and library") let each object's
@@ -1555,18 +1634,55 @@ pub fn resolve_all(
                 }
             }
             ZoneMoveResult::NeedsChoice(player) => {
-                append_effect_resolved_after_counter_pause(
-                    state,
-                    EffectKind::from(&ability.effect),
-                    ability.source_id,
-                );
-                state.waiting_for =
-                    crate::game::replacement::replacement_choice_waiting_for(player, state);
+                // CR 614.12a + CR 614.13: a Devour as-enters sacrifice surfaced its
+                // own `EffectZoneChoice` (or a counter-pause replacement choice).
+                // Stash the unprocessed co-entering members so
+                // `drain_pending_change_zone_iteration` resumes the mass move after
+                // the player resolves this choice — without the stash, every member
+                // after the first NeedsChoice would be silently dropped (issue #535
+                // class). The drain owns the single trailing EffectResolved, so we do
+                // NOT emit it here (mirrors the targeted loop's contract).
+                //
+                // NOTE (pre-existing face_down residual, extended not regressed):
+                // `process_one_zone_move` (the drain's mover) hardcodes
+                // `face_down=None`, while this mass loop passes
+                // `face_down_profile.as_ref()`. Resumed members of a face-down mass
+                // entry (the Cyber-Controller class) therefore lose their face-down
+                // profile. This carrier gap predates this change.
+                state.pending_change_zone_iteration =
+                    Some(crate::types::game_state::PendingChangeZoneIteration {
+                        remaining: matching[i + 1..].to_vec(),
+                        source_id: ability.source_id,
+                        controller: ability.controller,
+                        origin: None,
+                        destination: dest_zone,
+                        enter_transformed: false,
+                        enter_tapped,
+                        enters_under_player,
+                        enters_attacking: false,
+                        enter_with_counters: vec![],
+                        duration: ability.duration.clone(),
+                        track_exiled_by_source,
+                        effect_kind: EffectKind::from(&ability.effect),
+                    });
+                crate::game::replacement::park_waiting_for(state, player);
                 return Ok(());
             }
-            ZoneMoveResult::NeedsAuraAttachmentChoice => return Ok(()),
+            ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                // CR 614.13a: this terminal early-exit ends the mass-entry event
+                // (no stash/resume), so the pre-entry Devour snapshot's lifetime is
+                // over — clear it so it can't leak into a later sacrifice.
+                let _ = state.devour_eligible_snapshot.take();
+                return Ok(());
+            }
         }
     }
+
+    // CR 614.13a: the whole co-entry event completed without pausing — clear the
+    // pre-entry Devour snapshot (its lifetime = this one ChangeZone-to-battlefield
+    // event). NOT cleared on the NeedsChoice pause above (the paused devourer's
+    // sacrifice + remaining co-entering members still need it).
+    let _ = state.devour_eligible_snapshot.take();
 
     // CR 603.10a + CR 608.2f: Every battlefield-origin object that left did so as
     // part of the same mass zone-change event, so leaves-the-battlefield observers

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -555,7 +555,12 @@ fn apply_pending_counter_post_action(
             duration,
             exile_tracking,
         } => {
-            super::change_zone::apply_zone_delivery_tail(
+            // CR 614.12a: the delivery tail may surface a Devour as-enters
+            // sacrifice `EffectZoneChoice`. On that pause, return `false` so the
+            // drain stashes the remaining post-actions and pauses; the tail's
+            // post-effect already fired (it surfaced the choice), so the resume
+            // path continues from the EffectZoneChoice resolution.
+            match super::change_zone::apply_zone_delivery_tail(
                 state,
                 object_id,
                 from,
@@ -565,8 +570,10 @@ fn apply_pending_counter_post_action(
                 duration.as_ref(),
                 exile_tracking,
                 events,
-            );
-            true
+            ) {
+                super::change_zone::ZoneDeliveryResult::Done => true,
+                super::change_zone::ZoneDeliveryResult::NeedsChoice(_) => false,
+            }
         }
         PendingCounterPostAction::RecordStationed {
             spacecraft_id,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -586,8 +586,10 @@ fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<G
                             track_exiled_by_source: ctx.track_exiled_by_source,
                             effect_kind,
                         });
-                    state.waiting_for =
-                        crate::game::replacement::replacement_choice_waiting_for(player, state);
+                    // CR 614.12a: park (don't clobber) — a Devour as-enters sacrifice
+                    // may already have surfaced its own `EffectZoneChoice` during the
+                    // resumed member's entry.
+                    crate::game::replacement::park_waiting_for(state, player);
                     paused = true;
                     break;
                 }
@@ -620,6 +622,11 @@ fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<G
             state,
             &mut events[events_before_drain..],
         );
+        // CR 614.13a: the resumed mass/targeted co-entry finished without pausing —
+        // the whole ChangeZone entry event is complete, so clear the pre-entry
+        // Devour snapshot. NOT cleared on the `paused` break above (a further
+        // devourer's sacrifice and the remaining members still need it).
+        let _ = state.devour_eligible_snapshot.take();
         events.push(GameEvent::EffectResolved {
             kind: effect_kind,
             source_id: ctx.source_id,

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -188,17 +188,25 @@ pub fn resolve(
             .iter()
             .copied()
             .filter(|id| {
-                state.objects.get(id).is_some_and(|obj| {
-                    obj.controller == chooser
-                        && !obj.is_emblem
-                        && crate::game::filter::matches_target_filter(state, *id, filter, &ctx)
-                        && !crate::game::static_abilities::triggered_cause_sacrifice_or_exile_muzzled(
-                            state,
-                            ability,
-                            *id,
-                            chooser,
-                        )
-                })
+                // CR 614.13a/b: restrict to objects present before the devourer co-entry
+                // began; vacuous when None. (Pool is built from LIVE battlefield, so an
+                // object an earlier co-entering devourer already sacrificed is excluded by
+                // the live basis, and the devourers themselves by the snapshot.)
+                state
+                    .devour_eligible_snapshot
+                    .as_ref()
+                    .is_none_or(|s| s.contains(id))
+                    && state.objects.get(id).is_some_and(|obj| {
+                        obj.controller == chooser
+                            && !obj.is_emblem
+                            && crate::game::filter::matches_target_filter(state, *id, filter, &ctx)
+                            && !crate::game::static_abilities::triggered_cause_sacrifice_or_exile_muzzled(
+                                state,
+                                ability,
+                                *id,
+                                chooser,
+                            )
+                    })
             })
             .collect();
 

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -637,14 +637,23 @@ pub fn route_debug_create_to_battlefield(
     let mut waiting_for = state.waiting_for.clone();
     match replacement::replace_event(state, proposed, &mut events) {
         ReplacementResult::Execute(event) => {
-            super::effects::change_zone::deliver_replaced_zone_change(
+            // CR 614.12a: a Devour as-enters sacrifice may surface its own
+            // `EffectZoneChoice`; park on it so the debug-place flow keeps the
+            // pending sacrifice prompt instead of overwriting it.
+            match super::effects::change_zone::deliver_replaced_zone_change(
                 state,
                 event,
                 None,
                 None,
                 false,
                 &mut events,
-            );
+            ) {
+                super::effects::change_zone::ZoneDeliveryResult::Done => {}
+                super::effects::change_zone::ZoneDeliveryResult::NeedsChoice(player) => {
+                    replacement::park_waiting_for(state, player);
+                    waiting_for = state.waiting_for.clone();
+                }
+            }
             super::triggers::process_triggers(state, &events); // CR 603: Process triggers
             super::sba::check_state_based_actions(state, &mut events); // CR 704: Check SBAs
         }

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -26,6 +26,43 @@ use super::engine::EngineError;
 use super::sacrifice::apply_sacrifice_after_replacement;
 use super::zones;
 
+/// CR 614.13a + CR 702.82a/c: matches the broad as-enters shape of a Devour
+/// sacrifice replacement — a `Moved` (ETB-style) event whose post-effect is a
+/// `Sacrifice` over a `Typed`/`Any` scope filter (the chooser-driven "sacrifice
+/// any number of creatures/permanents" pool). This is a structural shape match,
+/// NOT a Devour-specific one: other `Moved + Sacrifice{Typed|Any}` replacements
+/// share it. Used both to suppress the source-as-pre-selected target injection
+/// and as the capture gate for the pre-entry eligible snapshot.
+/// (`ReplacementEvent` is Clone-not-Copy, so we borrow it.)
+pub(crate) fn is_as_enters_sacrifice_scope_replacement(
+    event: Option<&ReplacementEvent>,
+    effect: &Effect,
+) -> bool {
+    matches!(event, Some(ReplacementEvent::Moved))
+        && matches!(
+            effect,
+            Effect::Sacrifice {
+                target: TargetFilter::Typed(_) | TargetFilter::Any,
+                ..
+            }
+        )
+}
+
+/// CR 614.13a + CR 702.82a/c: true if `id`'s self-referential replacement
+/// definitions carry an as-enters Devour-shape sacrifice (see
+/// [`is_as_enters_sacrifice_scope_replacement`]). Capture gate for the
+/// pre-entry eligible snapshot in `deliver_replaced_zone_change`.
+pub(crate) fn object_has_devour_replacement(state: &GameState, id: ObjectId) -> bool {
+    state.objects.get(&id).is_some_and(|obj| {
+        obj.replacement_definitions.iter_all().any(|def| {
+            def.valid_card == Some(TargetFilter::SelfRef)
+                && def.execute.as_ref().is_some_and(|e| {
+                    is_as_enters_sacrifice_scope_replacement(Some(&def.event), &e.effect)
+                })
+        })
+    })
+}
+
 pub(super) fn handle_replacement_choice(
     state: &mut GameState,
     index: usize,
@@ -708,14 +745,7 @@ pub(super) fn apply_post_replacement_effect(
     // "sacrifice that many permanents") and Outfitted Jouster (DamageDone:
     // "sacrifice an Equipment") — keep the pre-Devour injection path so their
     // target-as-pre-selected resolution is unchanged.
-    let sacrifice_typed_scope = matches!(event, Some(ReplacementEvent::Moved))
-        && matches!(
-            &*real_work.effect,
-            Effect::Sacrifice {
-                target: TargetFilter::Typed(_) | TargetFilter::Any,
-                ..
-            }
-        );
+    let sacrifice_typed_scope = is_as_enters_sacrifice_scope_replacement(event, &real_work.effect);
     let targets = if sacrifice_typed_scope {
         Vec::new()
     } else {

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2006,6 +2006,27 @@ pub(super) fn handle_resolution_choice(
                 }
             }
 
+            // CR 614.13a (snapshot lifetime): a *single-pick* `ChangeZone` devour
+            // entry paused on its as-enters sacrifice WITHOUT stashing a
+            // `pending_change_zone_iteration` (only the mass/targeted loop stashes
+            // one). So when this sacrifice resolves and no iteration is pending,
+            // the single-pick entry's event is over and the pre-entry Devour
+            // snapshot's lifetime ends here — mirroring the synchronous Done-branch
+            // `take()` in `change_zone::resolve`. The snapshot only gated the
+            // (already-built, already-chosen) eligible pool, so clearing it now
+            // cannot unconstrain this devourer's own pool. When an iteration IS
+            // pending (mass/targeted co-entry, or a nested move during a mass
+            // pause), the snapshot is still needed by the remaining members and is
+            // cleared by `drain_pending_change_zone_iteration` instead — so this
+            // never over-clears a live mass snapshot. No-op when no Devour is in
+            // flight (`snapshot == None`).
+            if matches!(effect_kind, EffectKind::Sacrifice)
+                && state.devour_eligible_snapshot.is_some()
+                && state.pending_change_zone_iteration.is_none()
+            {
+                let _ = state.devour_eligible_snapshot.take();
+            }
+
             if chosen.is_empty() {
                 // Issue #423 audit: no cards chosen — this branch moves no
                 // objects and emits no battlefield-exit events, so no

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -366,6 +366,16 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
     }
 }
 
+/// CR 614.12a: Park on the replacement choice for `player`, unless a downstream
+/// effect (a Devour as-enters Sacrifice `EffectZoneChoice`) already surfaced its
+/// own interactive prompt — then leave it so the pending choice isn't clobbered.
+pub fn park_waiting_for(state: &mut GameState, player: PlayerId) {
+    if matches!(state.waiting_for, WaitingFor::EffectZoneChoice { .. }) {
+        return;
+    }
+    state.waiting_for = replacement_choice_waiting_for(player, state);
+}
+
 /// CR 614.12a: Human-readable accept-label for a `MayCost` replacement prompt.
 /// Returns a complete imperative phrase (the caller no longer prepends "Pay ")
 /// so non-mana costs read naturally. Exhaustive — a new `AbilityCost` variant

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5538,6 +5538,25 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_change_zone_iteration: Option<PendingChangeZoneIteration>,
 
+    /// CR 614.12a + CR 614.13a/b: Battlefield objects eligible to be chosen by an
+    /// as-enters Devour sacrifice (CR 702.82a/c), captured the instant BEFORE the
+    /// FIRST co-entering devourer enters and PERSISTED for the whole simultaneous
+    /// entry. Because CR 614.12a makes every co-entering permanent's as-enters
+    /// choice happen before ANY of them enter, the engine (which serializes entry)
+    /// reuses this one pre-entry snapshot for every co-entering devourer — so a
+    /// second devourer cannot devour the first (it entered "at the same time",
+    /// CR 614.13a), and the eligible pool (live battlefield ∩ snapshot) also
+    /// excludes anything an earlier devourer already sacrificed (it left the
+    /// battlefield) and the devourers themselves (absent from the pre-entry set).
+    /// `None` outside a Devour co-entry; cleared when the whole ChangeZone entry
+    /// event completes (all co-entering members resolved), NOT per-sacrifice.
+    ///
+    /// WARNING — save/resume: the serde attr MUST stay `skip_serializing_if =
+    /// "Option::is_none"` (skips only `None`; a live `Some` is serialized so a
+    /// mid-prompt save keeps the constraint). Never broaden to skip `Some`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devour_eligible_snapshot: Option<HashSet<ObjectId>>,
+
     /// CR 707.2 + CR 614.1a + CR 616.1: Pending `CopyTokenOf` source loop
     /// paused by an interactive token-creation replacement. Drained by
     /// `token_copy::drain_pending_copy_token_resolution` after the current
@@ -6324,6 +6343,7 @@ impl GameState {
             pending_continuation: None,
             pending_repeat_iteration: None,
             pending_change_zone_iteration: None,
+            devour_eligible_snapshot: None,
             pending_copy_token_resolution: None,
             pending_coin_flip: None,
             pending_repeat_until: None,
@@ -6740,6 +6760,21 @@ impl PartialEq for GameState {
             && self.pending_continuation == other.pending_continuation
             && self.pending_repeat_iteration == other.pending_repeat_iteration
             && self.pending_change_zone_iteration == other.pending_change_zone_iteration
+            // `devour_eligible_snapshot` is INTENTIONALLY excluded from PartialEq.
+            // It is a TRANSIENT mid-resolution carrier (CR 614.12a/13a): `Some`
+            // only while a Devour co-entry is in flight, `None` everywhere else.
+            // It is NOT necessarily recoverable from the other compared fields
+            // during its Some-window — at the as-enters sacrifice prompt the
+            // Devour PutCounter sub-ability has not run, so for a vanilla devourer
+            // `pending_etb_counters` does not contain the entering ObjectId; the
+            // snapshot can be live across this boundary. Exclusion is safe anyway:
+            // PartialEq is used for AI-search position dedup, and the only effect
+            // of ignoring this field is that two otherwise-identical transient
+            // mid-resolution states may dedup together — an AI-search collapse,
+            // never a game-rule error (the rule-bearing constraint is the live
+            // snapshot itself, which IS preserved on serde round-trip: the field
+            // is serialized whenever `Some` — see `skip_serializing_if` above —
+            // so a mid-prompt save/resume keeps the constraint intact).
             && self.pending_copy_token_resolution == other.pending_copy_token_resolution
             && self.pending_coin_flip == other.pending_coin_flip
             && self.pending_repeat_until == other.pending_repeat_until

--- a/crates/engine/tests/integration/devour_co_entry_regression.rs
+++ b/crates/engine/tests/integration/devour_co_entry_regression.rs
@@ -1,0 +1,389 @@
+//! Regression for Devour co-entry (CR 702.82 / CR 614.12a / CR 614.13a-b):
+//! when one or more Devour creatures enter the battlefield simultaneously with
+//! other permanents (via a single `Effect::ChangeZoneAll`), the as-enters Devour
+//! sacrifice MUST NOT be able to sacrifice:
+//!   * the devourer itself (CR 614.13a — the permanent that's entering),
+//!   * any other object entering at the same time (CR 614.13a),
+//!   * a co-entering second devourer (CR 614.12a + CR 614.13a — both choices are
+//!     made before either devourer "enters", so neither can devour the other).
+//!
+//! Both tests drive the REAL production `change_zone::resolve_all` path (the same
+//! path a "put all creature cards exiled this way onto the battlefield" /
+//! reanimation-style `ChangeZoneAll` flows through) with synthetic objects, so
+//! they need no card-data and exercise the engine end-to-end. The Devour
+//! replacement is constructed to match `database::synthesis::synthesize_devour`.
+
+use engine::game::effects::change_zone::{resolve, resolve_all};
+use engine::game::effects::sacrifice;
+use engine::game::engine::apply_as_current;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, ControllerRef, Effect, QuantityExpr, QuantityRef,
+    ReplacementDefinition, ResolvedAbility, TargetFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::Zone;
+
+/// Build the Devour-N as-enters replacement, mirroring
+/// `database::synthesis::synthesize_devour`: a `Moved` replacement valid on
+/// SelfRef whose `execute` is a ranged (up-to, min 0) `Sacrifice` over
+/// "creatures you control", chained to a self-targeted `PutCounter`.
+fn devour_replacement(n: i32) -> ReplacementDefinition {
+    // Mirror `synthesize_devour` exactly: for n == 1 the per-creature counter
+    // count is a bare `Ref` (no Multiply); only n > 1 wraps it in `Multiply`.
+    let counter_count = if n == 1 {
+        QuantityExpr::Ref {
+            qty: QuantityRef::EventContextAmount,
+        }
+    } else {
+        QuantityExpr::Multiply {
+            factor: n,
+            inner: Box::new(QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            }),
+        }
+    };
+    let put_counters = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PutCounter {
+            counter_type: CounterType::Plus1Plus1,
+            count: counter_count,
+            target: TargetFilter::SelfRef,
+        },
+    );
+    let sacrifice = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Sacrifice {
+            target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            count: QuantityExpr::up_to(QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(
+                        TypedFilter::creature().controller(ControllerRef::You),
+                    ),
+                },
+            }),
+            min_count: 0,
+        },
+    )
+    .sub_ability(put_counters);
+
+    ReplacementDefinition {
+        event: ReplacementEvent::Moved,
+        execute: Some(Box::new(sacrifice)),
+        valid_card: Some(TargetFilter::SelfRef),
+        ..ReplacementDefinition::new(ReplacementEvent::Moved)
+    }
+}
+
+/// Create a creature in `zone` controlled/owned by P0.
+fn make_creature(state: &mut GameState, id: u64, name: &str, zone: Zone) -> ObjectId {
+    let oid = create_object(state, CardId(id), PlayerId(0), name.to_string(), zone);
+    state
+        .objects
+        .get_mut(&oid)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+    oid
+}
+
+/// Create a Devour-N creature in Exile (so a `ChangeZoneAll { Exile -> Battlefield }`
+/// co-entry brings it in alongside the other Exile members).
+fn make_devourer_in_exile(state: &mut GameState, id: u64, name: &str, n: i32) -> ObjectId {
+    let oid = make_creature(state, id, name, Zone::Exile);
+    state.objects.get_mut(&oid).unwrap().replacement_definitions =
+        vec![devour_replacement(n)].into();
+    oid
+}
+
+/// CR 614.13a: a Devour creature entering simultaneously with an ordinary
+/// creature (one `ChangeZoneAll`) cannot devour that co-arriver, nor itself; a
+/// pre-existing battlefield creature IS eligible. The co-arriver survives.
+///
+/// MUST FAIL on origin/main: without the pre-entry snapshot the devourer's
+/// eligible pool would include itself (a creature it controls).
+#[test]
+fn devour_cannot_eat_simultaneous_co_arrival() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+
+    // A creature already on the battlefield — the only legal devour victim.
+    let preexisting = make_creature(&mut state, 10, "Pre-Existing Bear", Zone::Battlefield);
+
+    // The devourer and an ordinary creature both wait in Exile and co-enter via
+    // one ChangeZoneAll. The pre-entry snapshot is captured before EITHER enters
+    // (= {preexisting}), so the co-arriver is excluded regardless of the
+    // (unordered) entry order.
+    let devourer = make_devourer_in_exile(&mut state, 20, "Devourer", 1);
+    let co_arriver = make_creature(&mut state, 30, "Co-Arriver", Zone::Exile);
+
+    let ability = ResolvedAbility::new(
+        Effect::ChangeZoneAll {
+            origin: Some(Zone::Exile),
+            destination: Zone::Battlefield,
+            target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            enters_under: None,
+            enter_tapped: false,
+            face_down_profile: None,
+        },
+        vec![],
+        ObjectId(100),
+        PlayerId(0),
+    );
+
+    let mut events = Vec::new();
+    resolve_all(&mut state, &ability, &mut events).unwrap();
+
+    // The devourer's as-enters sacrifice must surface its eligible-pool prompt.
+    let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for else {
+        panic!(
+            "expected Devour sacrifice EffectZoneChoice, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&preexisting),
+        "pre-existing battlefield creature must be a legal devour victim; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&devourer),
+        "CR 614.13a: a devourer cannot sacrifice itself; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&co_arriver),
+        "CR 614.13a: a co-entering creature cannot be devoured; pool={cards:?}"
+    );
+
+    // Decline the sacrifice (min 0) — the co-arriver must still enter and survive.
+    apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] })
+        .expect("decline devour sacrifice");
+
+    assert_eq!(
+        state.objects[&co_arriver].zone,
+        Zone::Battlefield,
+        "the co-arriver must finish entering the battlefield"
+    );
+    assert_eq!(
+        state.objects[&devourer].zone,
+        Zone::Battlefield,
+        "the devourer entered the battlefield"
+    );
+}
+
+/// CR 614.12a + CR 614.13a (the strict case): two Devour creatures co-entering
+/// via one `ChangeZoneAll` cannot devour each other — both as-enters choices are
+/// made before either is considered "entered". After devourer A eats one
+/// pre-existing creature, devourer B's prompt must appear (park/resume works,
+/// no clobber/deadlock) and B's pool must EXCLUDE devourer A entirely (not just
+/// the creature A ate) and exclude B itself.
+///
+/// MUST FAIL on origin/main: with no persisted pre-entry snapshot, B's pool
+/// would include devourer A. This is specifically a persist-snapshot test — a
+/// single-clear design (clearing the snapshot in `sacrifice.rs`) would let B
+/// re-capture a fresh pool that includes A, and this test would fail.
+#[test]
+fn two_devourers_cannot_eat_each_other() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+
+    // Two pre-existing creatures: A eats one, leaving the other as B's only
+    // legal victim — so B's prompt is non-empty and its pool is inspectable.
+    let pre_x = make_creature(&mut state, 11, "Pre-X", Zone::Battlefield);
+    let pre_y = make_creature(&mut state, 12, "Pre-Y", Zone::Battlefield);
+
+    let devourer_a = make_devourer_in_exile(&mut state, 21, "Devourer A", 1);
+    let devourer_b = make_devourer_in_exile(&mut state, 22, "Devourer B", 1);
+
+    let ability = ResolvedAbility::new(
+        Effect::ChangeZoneAll {
+            origin: Some(Zone::Exile),
+            destination: Zone::Battlefield,
+            target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            enters_under: None,
+            enter_tapped: false,
+            face_down_profile: None,
+        },
+        vec![],
+        ObjectId(100),
+        PlayerId(0),
+    );
+
+    let mut events = Vec::new();
+    resolve_all(&mut state, &ability, &mut events).unwrap();
+
+    // Devourer A's prompt appears first.
+    let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for else {
+        panic!(
+            "expected devourer A's sacrifice EffectZoneChoice, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&pre_x) && cards.contains(&pre_y),
+        "A's pool must include both pre-existing creatures; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&devourer_a) && !cards.contains(&devourer_b),
+        "CR 614.13a: A cannot devour itself or co-entering B; pool={cards:?}"
+    );
+
+    // A eats Pre-X.
+    apply_as_current(&mut state, GameAction::SelectCards { cards: vec![pre_x] })
+        .expect("A devours Pre-X");
+
+    assert_eq!(
+        state.objects[&pre_x].zone,
+        Zone::Graveyard,
+        "Pre-X was sacrificed by devourer A"
+    );
+
+    // Devourer B's prompt must now appear (resume works, no clobber/deadlock).
+    let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for else {
+        panic!(
+            "expected devourer B's sacrifice EffectZoneChoice after A resolves, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&pre_y),
+        "B's pool must still include the surviving pre-existing creature; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&devourer_a),
+        "CR 614.12a/614.13a: devourer B cannot devour co-entering devourer A; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&devourer_b),
+        "CR 614.13a: devourer B cannot devour itself; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&pre_x),
+        "Pre-X already left the battlefield (eaten by A); pool={cards:?}"
+    );
+
+    // B declines; both devourers survive on the battlefield.
+    apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] })
+        .expect("B declines its sacrifice");
+
+    assert_eq!(state.objects[&devourer_a].zone, Zone::Battlefield);
+    assert_eq!(state.objects[&devourer_b].zone, Zone::Battlefield);
+}
+
+/// CR 614.13a (snapshot lifetime): the pre-entry Devour snapshot must not leak
+/// past the entry event that captured it. A *single-target* `Effect::ChangeZone`
+/// of ONE devourer flows through the single-pick branch in `change_zone::resolve`
+/// (not the mass loop), pausing on its as-enters Devour sacrifice and resuming
+/// via the deferred counter-pause `EffectResolved`. If the snapshot isn't cleared
+/// on that resume, it stays `Some` and wrongly shrinks the eligible pool of the
+/// NEXT, unrelated `Effect::Sacrifice` in the same resolution chain.
+///
+/// MUST FAIL without the single-pick resume clear: the later sacrifice's pool
+/// collapses to the stale snapshot `{preexisting}` (count 1 ≤ pool 1 → the
+/// mandatory-all fast-path silently sacrifices the pre-existing creature with no
+/// prompt, excluding the devourer and the freshly-created creature entirely).
+/// PASSES with the clear: the snapshot is `None`, so the later sacrifice sees the
+/// FULL controller pool and surfaces a prompt over all of it.
+#[test]
+fn single_pick_devour_does_not_leak_snapshot_to_later_sacrifice() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+
+    // One pre-existing creature on the battlefield — the devourer's only legal
+    // victim and (if the snapshot leaks) the only survivor of the later pool.
+    let preexisting = make_creature(&mut state, 10, "Pre-Existing Bear", Zone::Battlefield);
+
+    // A single devourer waiting in Exile; nothing else is in Exile, so the
+    // untargeted `ChangeZone { Exile -> Battlefield, creature you control }`
+    // scan resolves to exactly ONE eligible object and takes the single-pick
+    // (single-eligible) branch in `change_zone::resolve`.
+    let devourer = make_devourer_in_exile(&mut state, 20, "Devourer", 1);
+
+    let change_zone = ResolvedAbility::new(
+        Effect::ChangeZone {
+            origin: Some(Zone::Exile),
+            destination: Zone::Battlefield,
+            target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: false,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            face_down_profile: None,
+        },
+        vec![],
+        ObjectId(100),
+        PlayerId(0),
+    );
+
+    let mut events = Vec::new();
+    resolve(&mut state, &change_zone, &mut events).unwrap();
+
+    // The single-pick entry paused on the devourer's as-enters sacrifice prompt;
+    // its pool is the snapshot-constrained pre-entry pool {preexisting}.
+    let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for else {
+        panic!(
+            "expected the devourer's single-pick as-enters sacrifice EffectZoneChoice, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&preexisting) && !cards.contains(&devourer),
+        "devourer's own pool = pre-entry snapshot (excludes itself); pool={cards:?}"
+    );
+
+    // Decline the as-enters sacrifice (min 0). The deferred counter-pause
+    // `EffectResolved` drains on this resume — and, with the fix, the snapshot
+    // clear drains alongside it.
+    apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] })
+        .expect("decline the devour sacrifice");
+    assert_eq!(
+        state.objects[&devourer].zone,
+        Zone::Battlefield,
+        "the devourer finished entering the battlefield"
+    );
+
+    // Now create a fresh creature and run an UNRELATED sacrifice in a fresh
+    // resolution. With the snapshot cleared, the eligible pool is the controller's
+    // FULL creature set; if it leaked, the pool would be the stale {preexisting}.
+    let fresh = make_creature(&mut state, 30, "Fresh Beast", Zone::Battlefield);
+
+    let unrelated_sacrifice = ResolvedAbility::new(
+        Effect::Sacrifice {
+            target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            count: QuantityExpr::Fixed { value: 1 },
+            min_count: 1,
+        },
+        vec![],
+        ObjectId(101),
+        PlayerId(0),
+    );
+
+    let mut events2 = Vec::new();
+    sacrifice::resolve(&mut state, &unrelated_sacrifice, &mut events2).unwrap();
+
+    // count 1 < 3 eligible → the sacrifice surfaces a choice over the FULL pool.
+    let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for else {
+        panic!(
+            "snapshot leaked: the unrelated sacrifice auto-resolved over a shrunk \
+             pool instead of prompting over the full pool; got {:?}",
+            state.waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&devourer) && cards.contains(&preexisting) && cards.contains(&fresh),
+        "CR 614.13a: a stale Devour snapshot must not constrain a later, unrelated \
+         sacrifice — pool must be the FULL controller creature set; pool={cards:?}"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -41,6 +41,7 @@ mod crossway_troublemakers_attacking_keywords;
 mod cultivate_split_destination;
 mod dalkovan_encampment_attack_trigger;
 mod dark_confidant_upkeep;
+mod devour_co_entry_regression;
 mod devour_intellect_treasure_rider;
 mod doran_attack_block_pump;
 mod double_strike_first_strike_trigger_removes_attacker;


### PR DESCRIPTION
A devouring permanent could sacrifice creatures entering the battlefield
simultaneously with it, and two devourers entering together could both
devour the same creature (or each other). CR 614.12a makes every
co-entering permanent's as-enters choice happen before any of them enter,
so CR 614.13a forbids choosing the devourer itself or any object entering
at the same time, and CR 614.13b forbids choosing the same object twice.

Fix: capture a pre-entry battlefield snapshot the instant before the first
co-entering devourer enters, persist it across the whole ChangeZone entry
event, and intersect it into the Devour sacrifice's eligible pool. Because
the pool is built from the live battlefield, an object an earlier
co-entering devourer already sacrificed is excluded by the live basis and
the devourers themselves by the snapshot. The snapshot is captured
pre-loop (state.objects is unordered, so a co-arriver may be processed
before the devourer) and cleared only when the entry event fully completes:
the drain owns the clear for mass/targeted co-entry, and the EffectZoneChoice
handler clears it for the single-pick path (gated on
pending_change_zone_iteration.is_none() to avoid clearing a still-active
mass snapshot).

To resolve co-entering devourers sequentially without clobbering each
other's sacrifice prompts, apply_zone_delivery_tail now propagates a pending
EffectZoneChoice as ZoneDeliveryResult::NeedsChoice, the mass loop parks via
a PendingChangeZoneIteration stash, and park_waiting_for preserves an
already-surfaced EffectZoneChoice over a ReplacementChoice.

Tests: devour_co_entry_regression.rs drives real ChangeZoneAll Exile->
Battlefield co-entry — a devourer cannot eat a co-arriver, two devourers
cannot eat each other, and a single-pick devour does not leak its snapshot
into a later unrelated sacrifice. All fail without the fix.
