### PR TITLE
Implement bands with other combat runtime

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1655,6 +1655,81 @@ pub fn has_banding(state: &GameState, object_id: ObjectId) -> bool {
         .is_some_and(|obj| obj.has_keyword(&Keyword::Banding))
 }
 
+fn bands_with_other_qualities(state: &GameState, object_id: ObjectId) -> Vec<&str> {
+    state
+        .objects
+        .get(&object_id)
+        .map(|obj| {
+            obj.keywords
+                .iter()
+                .filter_map(|keyword| match keyword {
+                    Keyword::BandsWithOther(quality) => Some(quality.as_str()),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn object_matches_bands_with_other_quality(
+    state: &GameState,
+    object_id: ObjectId,
+    quality: &str,
+) -> bool {
+    let Some(obj) = state.objects.get(&object_id) else {
+        return false;
+    };
+    if quality.eq_ignore_ascii_case("legend") {
+        return obj.card_types.supertypes.contains(&Supertype::Legendary);
+    }
+    obj.card_types
+        .subtypes
+        .iter()
+        .any(|subtype| subtype.eq_ignore_ascii_case(quality))
+}
+
+fn shared_bands_with_other_quality(state: &GameState, a: ObjectId, b: ObjectId) -> Option<&str> {
+    bands_with_other_qualities(state, a)
+        .into_iter()
+        .find(|quality| {
+            object_matches_bands_with_other_quality(state, a, quality)
+                && object_matches_bands_with_other_quality(state, b, quality)
+                && bands_with_other_qualities(state, b)
+                    .into_iter()
+                    .any(|other| other.eq_ignore_ascii_case(quality))
+        })
+}
+
+/// CR 702.22j/k: Damage-assignment control also applies to "bands with other"
+/// when the relevant creatures share the keyword's quality.
+pub fn has_banding_damage_assignment_relation(
+    state: &GameState,
+    source: ObjectId,
+    paired: ObjectId,
+) -> bool {
+    has_banding(state, source) || shared_bands_with_other_quality(state, source, paired).is_some()
+}
+
+fn validate_bands_with_other_declaration(
+    state: &GameState,
+    members: &[ObjectId],
+) -> Result<(), String> {
+    let Some(&first) = members.first() else {
+        return Err("empty bands-with-other declaration".to_string());
+    };
+    for quality in bands_with_other_qualities(state, first) {
+        if members.iter().all(|&member| {
+            object_matches_bands_with_other_quality(state, member, quality)
+                && bands_with_other_qualities(state, member)
+                    .into_iter()
+                    .any(|other| other.eq_ignore_ascii_case(quality))
+        }) {
+            return Ok(());
+        }
+    }
+    Err("band must satisfy ordinary banding or a shared bands-with-other quality".to_string())
+}
+
 /// CR 702.22: Attackers sharing a `band_id` (declaration order preserved).
 pub fn band_members(combat: &CombatState, band_id: u32) -> Vec<&AttackerInfo> {
     combat
@@ -1667,7 +1742,8 @@ pub fn band_members(combat: &CombatState, band_id: u32) -> Vec<&AttackerInfo> {
 /// CR 702.22c/d: Validate explicit band declarations at declare attackers.
 /// Each band must contain only declared attackers (702.22c), share one attack
 /// target (702.22d), include at least one banding creature, and at most one
-/// non-banding creature (702.22c).
+/// non-banding creature (702.22c), or satisfy a "bands with other [quality]"
+/// declaration over a shared quality.
 pub fn validate_attack_band_declarations(
     state: &GameState,
     attacks: &[(ObjectId, AttackTarget)],
@@ -1713,12 +1789,15 @@ pub fn validate_attack_band_declarations(
             }
         }
 
-        if banding_count == 0 {
-            return Err(format!(
-                "band {band_index} must include at least one banding creature"
-            ));
-        }
-        if non_banding_count > 1 {
+        if banding_count == 0 || non_banding_count > 1 {
+            if validate_bands_with_other_declaration(state, members).is_ok() {
+                continue;
+            }
+            if banding_count == 0 {
+                return Err(format!(
+                    "band {band_index} must include at least one banding creature"
+                ));
+            }
             return Err(format!(
                 "band {band_index} has {non_banding_count} non-banding creatures (max 1)"
             ));
@@ -3492,6 +3571,62 @@ mod tests {
         assert_eq!(combat.attackers[0].band_id, Some(1));
     }
 
+    fn grant_bands_with_other_wolves(state: &mut GameState, id: ObjectId) {
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.subtypes.push("Wolf".to_string());
+        obj.keywords
+            .push(Keyword::BandsWithOther("Wolf".to_string()));
+    }
+
+    #[test]
+    fn bands_with_other_declaration_assigns_shared_band_id() {
+        let mut state = setup();
+        let wolf_a = create_creature(&mut state, PlayerId(0), "Wolf A", 2, 2);
+        let wolf_b = create_creature(&mut state, PlayerId(0), "Wolf B", 2, 2);
+        grant_bands_with_other_wolves(&mut state, wolf_a);
+        grant_bands_with_other_wolves(&mut state, wolf_b);
+
+        let target = AttackTarget::Player(PlayerId(1));
+        declare_attackers_with_bands(
+            &mut state,
+            &[(wolf_a, target), (wolf_b, target)],
+            &[vec![wolf_a, wolf_b]],
+            &mut Vec::new(),
+        )
+        .unwrap();
+
+        let combat = state.combat.as_ref().unwrap();
+        assert_eq!(combat.attackers[0].band_id, Some(1));
+        assert_eq!(combat.attackers[1].band_id, Some(1));
+    }
+
+    #[test]
+    fn bands_with_other_declaration_rejects_mixed_quality() {
+        let mut state = setup();
+        let wolf = create_creature(&mut state, PlayerId(0), "Wolf", 2, 2);
+        let bear = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        grant_bands_with_other_wolves(&mut state, wolf);
+        state
+            .objects
+            .get_mut(&bear)
+            .unwrap()
+            .keywords
+            .push(Keyword::BandsWithOther("Wolf".to_string()));
+
+        let target = AttackTarget::Player(PlayerId(1));
+        let err = declare_attackers_with_bands(
+            &mut state,
+            &[(wolf, target), (bear, target)],
+            &[vec![wolf, bear]],
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("banding creature"),
+            "expected mixed-quality bands-with-other declaration to fail, got: {err}"
+        );
+    }
+
     #[test]
     fn band_declaration_rejects_two_non_banding_members() {
         let mut state = setup();
@@ -3555,6 +3690,33 @@ mod tests {
                 .get(&blocker)
                 .is_some_and(|attackers| attackers.contains(&hero) && attackers.contains(&pegasus)),
             "blocker_to_attacker must list every propagated band member"
+        );
+    }
+
+    #[test]
+    fn bands_with_other_block_propagates_to_all_members() {
+        let mut state = setup();
+        let wolf_a = create_creature(&mut state, PlayerId(0), "Wolf A", 2, 2);
+        let wolf_b = create_creature(&mut state, PlayerId(0), "Wolf B", 2, 2);
+        let blocker = create_creature(&mut state, PlayerId(1), "Soldier", 1, 1);
+        grant_bands_with_other_wolves(&mut state, wolf_a);
+        grant_bands_with_other_wolves(&mut state, wolf_b);
+
+        let target = AttackTarget::Player(PlayerId(1));
+        declare_attackers_with_bands(
+            &mut state,
+            &[(wolf_a, target), (wolf_b, target)],
+            &[vec![wolf_a, wolf_b]],
+            &mut Vec::new(),
+        )
+        .unwrap();
+        declare_blockers(&mut state, &[(blocker, wolf_a)], &mut Vec::new()).unwrap();
+
+        let combat = state.combat.as_ref().unwrap();
+        assert!(combat.attackers.iter().all(|a| a.blocked));
+        assert_eq!(
+            combat.blocker_assignments.get(&wolf_b),
+            combat.blocker_assignments.get(&wolf_a)
         );
     }
 

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1688,43 +1688,49 @@ fn object_matches_bands_with_other_quality(
         .any(|subtype| subtype.eq_ignore_ascii_case(quality))
 }
 
-fn shared_bands_with_other_quality(state: &GameState, a: ObjectId, b: ObjectId) -> Option<&str> {
-    bands_with_other_qualities(state, a)
+fn has_bands_with_other_quality(state: &GameState, object_id: ObjectId, quality: &str) -> bool {
+    bands_with_other_qualities(state, object_id)
         .into_iter()
-        .find(|quality| {
-            object_matches_bands_with_other_quality(state, a, quality)
-                && object_matches_bands_with_other_quality(state, b, quality)
-                && bands_with_other_qualities(state, b)
-                    .into_iter()
-                    .any(|other| other.eq_ignore_ascii_case(quality))
-        })
+        .any(|other| other.eq_ignore_ascii_case(quality))
 }
 
 /// CR 702.22j/k: Damage-assignment control also applies to "bands with other"
-/// when the relevant creatures share the keyword's quality.
-pub fn has_banding_damage_assignment_relation(
+/// when the relevant blocker/attacker set contains a qualifying keyword-holder
+/// and another creature of the same quality.
+pub fn has_bands_with_other_damage_assignment_group(
     state: &GameState,
-    source: ObjectId,
-    paired: ObjectId,
+    creatures: &[ObjectId],
 ) -> bool {
-    has_banding(state, source) || shared_bands_with_other_quality(state, source, paired).is_some()
+    creatures.iter().any(|&holder| {
+        bands_with_other_qualities(state, holder)
+            .into_iter()
+            .any(|quality| {
+                object_matches_bands_with_other_quality(state, holder, quality)
+                    && creatures.iter().any(|&other| {
+                        other != holder
+                            && object_matches_bands_with_other_quality(state, other, quality)
+                    })
+            })
+    })
 }
 
 fn validate_bands_with_other_declaration(
     state: &GameState,
     members: &[ObjectId],
 ) -> Result<(), String> {
-    let Some(&first) = members.first() else {
+    if members.is_empty() {
         return Err("empty bands-with-other declaration".to_string());
-    };
-    for quality in bands_with_other_qualities(state, first) {
-        if members.iter().all(|&member| {
-            object_matches_bands_with_other_quality(state, member, quality)
-                && bands_with_other_qualities(state, member)
-                    .into_iter()
-                    .any(|other| other.eq_ignore_ascii_case(quality))
-        }) {
-            return Ok(());
+    }
+    for &holder in members {
+        for quality in bands_with_other_qualities(state, holder) {
+            if object_matches_bands_with_other_quality(state, holder, quality)
+                && has_bands_with_other_quality(state, holder, quality)
+                && members
+                    .iter()
+                    .all(|&member| object_matches_bands_with_other_quality(state, member, quality))
+            {
+                return Ok(());
+            }
         }
     }
     Err("band must satisfy ordinary banding or a shared bands-with-other quality".to_string())
@@ -3571,10 +3577,23 @@ mod tests {
         assert_eq!(combat.attackers[0].band_id, Some(1));
     }
 
+    fn add_wolf_subtype(state: &mut GameState, id: ObjectId) {
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Wolf".to_string());
+    }
+
     fn grant_bands_with_other_wolves(state: &mut GameState, id: ObjectId) {
-        let obj = state.objects.get_mut(&id).unwrap();
-        obj.card_types.subtypes.push("Wolf".to_string());
-        obj.keywords
+        add_wolf_subtype(state, id);
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .keywords
             .push(Keyword::BandsWithOther("Wolf".to_string()));
     }
 
@@ -3584,7 +3603,7 @@ mod tests {
         let wolf_a = create_creature(&mut state, PlayerId(0), "Wolf A", 2, 2);
         let wolf_b = create_creature(&mut state, PlayerId(0), "Wolf B", 2, 2);
         grant_bands_with_other_wolves(&mut state, wolf_a);
-        grant_bands_with_other_wolves(&mut state, wolf_b);
+        add_wolf_subtype(&mut state, wolf_b);
 
         let target = AttackTarget::Player(PlayerId(1));
         declare_attackers_with_bands(

--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -296,13 +296,11 @@ fn collect_damage_assignments(state: &mut GameState, sub_step: SubStep) -> Optio
                 .get(&attacker_info.object_id)
                 .into_iter()
                 .flatten()
-                .any(|&bid| {
-                    crate::game::combat::has_banding_damage_assignment_relation(
-                        state,
-                        bid,
-                        attacker_info.object_id,
-                    )
-                });
+                .any(|&bid| crate::game::combat::has_banding(state, bid))
+                || crate::game::combat::has_bands_with_other_damage_assignment_group(
+                    state,
+                    &blocker_ids,
+                );
             if blocked_by_banding {
                 controller = attacker_info.defending_player;
             }
@@ -421,15 +419,13 @@ fn collect_damage_assignments(state: &mut GameState, sub_step: SubStep) -> Optio
         // how the blocking creature's damage is divided among the attackers it's
         // blocking. This only matters when the blocker is blocking 2+ attackers.
         let active_player_divides = attacker_ids.len() >= 2
-            && attacker_ids.iter().any(|&aid| {
-                crate::game::combat::has_banding(state, aid)
-                    || attacker_ids.iter().any(|&other| {
-                        other != aid
-                            && crate::game::combat::has_banding_damage_assignment_relation(
-                                state, aid, other,
-                            )
-                    })
-            });
+            && (attacker_ids
+                .iter()
+                .any(|&aid| crate::game::combat::has_banding(state, aid))
+                || crate::game::combat::has_bands_with_other_damage_assignment_group(
+                    state,
+                    attacker_ids,
+                ));
 
         if active_player_divides {
             return Some(WaitingFor::AssignBlockerDamage {
@@ -1117,10 +1113,23 @@ mod tests {
         state.combat = Some(combat);
     }
 
+    fn add_wolf_subtype(state: &mut GameState, id: ObjectId) {
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Wolf".to_string());
+    }
+
     fn grant_bands_with_other_wolves(state: &mut GameState, id: ObjectId) {
-        let obj = state.objects.get_mut(&id).unwrap();
-        obj.card_types.subtypes.push("Wolf".to_string());
-        obj.keywords
+        add_wolf_subtype(state, id);
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .keywords
             .push(Keyword::BandsWithOther("Wolf".to_string()));
     }
 
@@ -1705,11 +1714,11 @@ mod tests {
     #[test]
     fn bands_with_other_blocker_reroutes_attacker_damage_assignment() {
         let mut state = setup();
-        let attacker = create_creature(&mut state, PlayerId(0), "Wolf Attacker", 5, 5);
+        let attacker = create_creature(&mut state, PlayerId(0), "Attacker", 5, 5);
         let blocker1 = create_creature(&mut state, PlayerId(1), "Wolf Blocker", 2, 2);
-        let blocker2 = create_creature(&mut state, PlayerId(1), "Bear Blocker", 2, 2);
-        grant_bands_with_other_wolves(&mut state, attacker);
+        let blocker2 = create_creature(&mut state, PlayerId(1), "Plain Wolf Blocker", 2, 2);
         grant_bands_with_other_wolves(&mut state, blocker1);
+        add_wolf_subtype(&mut state, blocker2);
         setup_combat(
             &mut state,
             vec![attacker],
@@ -1737,7 +1746,7 @@ mod tests {
         let attacker2 = create_creature(&mut state, PlayerId(0), "Wolf B", 2, 2);
         let blocker = create_creature(&mut state, PlayerId(1), "Guard", 3, 3);
         grant_bands_with_other_wolves(&mut state, attacker1);
-        grant_bands_with_other_wolves(&mut state, attacker2);
+        add_wolf_subtype(&mut state, attacker2);
         setup_combat(
             &mut state,
             vec![attacker1, attacker2],

--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -285,21 +285,24 @@ fn collect_damage_assignments(state: &mut GameState, sub_step: SubStep) -> Optio
                 .unwrap_or(state.active_player);
 
             // CR 702.22j: During the combat damage step, if an attacking creature
-            // is being blocked by a creature with banding, the DEFENDING player
-            // (rather than the active player) chooses how the attacking
-            // creature's damage is assigned. We reach this branch whenever an
-            // interactive assignment is required — both the multi-blocker case
-            // (2+ blockers, a genuine division per CR 510.1c) and the single
-            // banded-blocker-with-trample case (the attacker must still choose
-            // how much excess tramples through past the blocker). Keyed on LIVE
-            // banding at damage time (CR 702.22a static ability).
-            // CR 702.22j: bands-with-other arm deferred (no Keyword::BandsWithOther).
+            // is being blocked by a creature with banding or a qualifying "bands
+            // with other" relation, the DEFENDING player (rather than the active
+            // player) chooses how the attacking creature's damage is assigned.
+            // We reach this branch whenever an interactive assignment is required
+            // — both the multi-blocker case and the single banded-blocker-with-
+            // trample case.
             let blocked_by_banding = combat
                 .blocker_assignments
                 .get(&attacker_info.object_id)
                 .into_iter()
                 .flatten()
-                .any(|&bid| crate::game::combat::has_banding(state, bid));
+                .any(|&bid| {
+                    crate::game::combat::has_banding_damage_assignment_relation(
+                        state,
+                        bid,
+                        attacker_info.object_id,
+                    )
+                });
             if blocked_by_banding {
                 controller = attacker_info.defending_player;
             }
@@ -413,17 +416,20 @@ fn collect_damage_assignments(state: &mut GameState, sub_step: SubStep) -> Optio
         }
 
         // CR 702.22k: During the combat damage step, if a blocking creature is
-        // blocking a creature with banding, the ACTIVE player (rather than the
-        // defending player) chooses how the blocking creature's damage is
-        // divided among the attackers it's blocking. This only matters when the
-        // blocker is blocking 2+ attackers (a sole blocked attacker leaves no
-        // choice — CR 510.1d). Keyed on the ATTACKER's LIVE banding, NOT the
-        // blocker's own banding.
-        // CR 702.22k: bands-with-other arm deferred (no Keyword::BandsWithOther).
+        // blocking a creature with banding or a qualifying "bands with other"
+        // relation, the ACTIVE player (rather than the defending player) chooses
+        // how the blocking creature's damage is divided among the attackers it's
+        // blocking. This only matters when the blocker is blocking 2+ attackers.
         let active_player_divides = attacker_ids.len() >= 2
-            && attacker_ids
-                .iter()
-                .any(|&aid| crate::game::combat::has_banding(state, aid));
+            && attacker_ids.iter().any(|&aid| {
+                crate::game::combat::has_banding(state, aid)
+                    || attacker_ids.iter().any(|&other| {
+                        other != aid
+                            && crate::game::combat::has_banding_damage_assignment_relation(
+                                state, aid, other,
+                            )
+                    })
+            });
 
         if active_player_divides {
             return Some(WaitingFor::AssignBlockerDamage {
@@ -1111,6 +1117,13 @@ mod tests {
         state.combat = Some(combat);
     }
 
+    fn grant_bands_with_other_wolves(state: &mut GameState, id: ObjectId) {
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.subtypes.push("Wolf".to_string());
+        obj.keywords
+            .push(Keyword::BandsWithOther("Wolf".to_string()));
+    }
+
     /// Drive `resolve_combat_damage` and, whenever it pauses on an
     /// `AssignCombatDamage` prompt (now reachable for single-blocker trample with
     /// excess per CR 702.19b, as well as the existing 2+ blocker case), submit the
@@ -1687,6 +1700,62 @@ mod tests {
         assert_eq!(state.objects[&blocker2].damage_marked, 0);
         // No damage to player
         assert_eq!(state.players[1].life, 20);
+    }
+
+    #[test]
+    fn bands_with_other_blocker_reroutes_attacker_damage_assignment() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Wolf Attacker", 5, 5);
+        let blocker1 = create_creature(&mut state, PlayerId(1), "Wolf Blocker", 2, 2);
+        let blocker2 = create_creature(&mut state, PlayerId(1), "Bear Blocker", 2, 2);
+        grant_bands_with_other_wolves(&mut state, attacker);
+        grant_bands_with_other_wolves(&mut state, blocker1);
+        setup_combat(
+            &mut state,
+            vec![attacker],
+            vec![(attacker, vec![blocker1, blocker2])],
+        );
+
+        let mut events = Vec::new();
+        let waiting = resolve_combat_damage(&mut state, &mut events);
+        match waiting {
+            Some(WaitingFor::AssignCombatDamage { player, .. }) => {
+                assert_eq!(
+                    player,
+                    PlayerId(1),
+                    "CR 702.22j: defending player assigns attacker damage"
+                );
+            }
+            other => panic!("expected AssignCombatDamage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bands_with_other_attackers_reroute_blocker_damage_assignment() {
+        let mut state = setup();
+        let attacker1 = create_creature(&mut state, PlayerId(0), "Wolf A", 2, 2);
+        let attacker2 = create_creature(&mut state, PlayerId(0), "Wolf B", 2, 2);
+        let blocker = create_creature(&mut state, PlayerId(1), "Guard", 3, 3);
+        grant_bands_with_other_wolves(&mut state, attacker1);
+        grant_bands_with_other_wolves(&mut state, attacker2);
+        setup_combat(
+            &mut state,
+            vec![attacker1, attacker2],
+            vec![(attacker1, vec![blocker]), (attacker2, vec![blocker])],
+        );
+
+        let mut events = Vec::new();
+        let waiting = resolve_combat_damage(&mut state, &mut events);
+        match waiting {
+            Some(WaitingFor::AssignBlockerDamage { player, .. }) => {
+                assert_eq!(
+                    player,
+                    PlayerId(0),
+                    "CR 702.22k: active player assigns blocker damage"
+                );
+            }
+            other => panic!("expected AssignBlockerDamage, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -19,7 +19,8 @@ use crate::types::ability::{
     TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::keywords::{
-    BloodthirstValue, BuybackCost, CyclingCost, FlashbackCost, Keyword, WardCost,
+    normalize_bands_with_other_quality, BloodthirstValue, BuybackCost, CyclingCost, FlashbackCost,
+    Keyword, WardCost,
 };
 use crate::types::mana::{ManaCost, ManaCostShard};
 use crate::types::zones::Zone;
@@ -384,6 +385,9 @@ fn parse_mtgjson_missing_standalone_keyword_line(line: &str) -> Option<Vec<Keywo
         // standalone keyword line MTGJSON does not surface in its `keywords` array,
         // so it must be recovered from the Oracle line here.
         Keyword::TotemArmor => Some(vec![keyword]),
+        // CR 702.22: "Bands with other [quality]" carries the quality in Oracle
+        // text; MTGJSON's keyword list has no typed payload to preserve it.
+        Keyword::BandsWithOther(_) => Some(vec![keyword]),
         _ => None,
     }
 }
@@ -1301,6 +1305,13 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
         return Some(Keyword::TotemArmor);
     }
 
+    if let Ok((quality, _)) = tag::<_, _, OracleError<'_>>("bands with other ").parse(text) {
+        let normalized = normalize_bands_with_other_quality(quality);
+        if !normalized.is_empty() {
+            return Some(Keyword::BandsWithOther(normalized));
+        }
+    }
+
     // For parameterized keywords, find the first space to split name from parameter.
     // Oracle format: "protection from multicolored" → name="protection", rest="from multicolored"
     // Oracle format: "ward {2}" → name="ward", rest="{2}"
@@ -1390,6 +1401,7 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::StartYourEngines => "start your engines!".to_string(),
         Keyword::Soulbond => "soulbond".to_string(),
         Keyword::Banding => "banding".to_string(),
+        Keyword::BandsWithOther(quality) => format!("bands with other {}", quality.to_lowercase()),
         // CR 702.24a: Cumulative upkeep's display includes its base cost so
         // tooltips and AI hint text show the actual payment ("cumulative upkeep
         // — {1}", "cumulative upkeep — Pay 2 life", etc.) instead of a bare
@@ -1969,6 +1981,25 @@ mod tests {
             "ripple 2 — N is captured"
         );
         assert_eq!(parse_keyword_from_oracle("ripple 4 extra"), None);
+    }
+
+    #[test]
+    fn parse_keyword_from_oracle_bands_with_other_quality() {
+        assert_eq!(
+            parse_keyword_from_oracle("bands with other wolves"),
+            Some(Keyword::BandsWithOther("Wolf".to_string()))
+        );
+        assert_eq!(
+            parse_keyword_from_oracle("bands with other legends"),
+            Some(Keyword::BandsWithOther("Legend".to_string()))
+        );
+    }
+
+    #[test]
+    fn extract_keyword_line_bands_with_other_quality() {
+        let result = extract_keyword_line("Bands with other Wolves", &[])
+            .expect("bands with other should parse from Oracle keyword line");
+        assert_eq!(result, vec![Keyword::BandsWithOther("Wolf".to_string())]);
     }
 
     /// CR 702.48a: Offering — the Oracle line "<Subtype> offering (...)" carries

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -236,6 +236,8 @@ pub enum KeywordKind {
     Recover,
     /// CR 702.102: Fuse — see `Keyword::Fuse`.
     Fuse,
+    /// CR 702.22: Bands with other [quality] — see `Keyword::BandsWithOther`.
+    BandsWithOther,
     Unknown,
 }
 
@@ -671,6 +673,10 @@ pub enum Keyword {
 
     // Simple keywords (no params)
     Banding,
+    /// CR 702.22: "Bands with other [quality]". The payload is the normalized
+    /// quality text, currently used for subtype qualities such as "Wolf" and
+    /// the historical "Legend" / "Legends" shape.
+    BandsWithOther(String),
     Epic,
     Fuse,
     Gravestorm,
@@ -1006,6 +1012,7 @@ impl Keyword {
             Keyword::Frenzy(_) => KeywordKind::Frenzy,
             Keyword::Tribute(_) => KeywordKind::Tribute,
             Keyword::Soulbond => KeywordKind::Soulbond,
+            Keyword::BandsWithOther(_) => KeywordKind::BandsWithOther,
             Keyword::Unearth(_) => KeywordKind::Unearth,
             Keyword::Convoke => KeywordKind::Convoke,
             Keyword::Waterbend => KeywordKind::Waterbend,
@@ -2017,6 +2024,18 @@ impl FromStr for Keyword {
             "friendsforever" => Ok(Keyword::Partner(PartnerType::FriendsForever)),
             "characterselect" => Ok(Keyword::Partner(PartnerType::CharacterSelect)),
             "banding" => Ok(Keyword::Banding),
+            s if s.starts_with("bandswithother:") => {
+                let quality = &s["bandswithother:".len()..];
+                Ok(Keyword::BandsWithOther(normalize_bands_with_other_quality(
+                    quality,
+                )))
+            }
+            s if s.starts_with("bandswithother") && s.len() > "bandswithother".len() => {
+                let quality = &s["bandswithother".len()..];
+                Ok(Keyword::BandsWithOther(normalize_bands_with_other_quality(
+                    quality,
+                )))
+            }
             "epic" => Ok(Keyword::Epic),
             "fuse" => Ok(Keyword::Fuse),
             "gravestorm" => Ok(Keyword::Gravestorm),
@@ -2097,6 +2116,44 @@ impl FromStr for Keyword {
             _ => Ok(Keyword::Unknown(s.to_string())),
         }
     }
+}
+
+pub fn normalize_bands_with_other_quality(raw: &str) -> String {
+    let trimmed = raw
+        .trim()
+        .trim_matches('.')
+        .trim_start_matches("other ")
+        .trim();
+    let words: Vec<String> = trimmed
+        .split_whitespace()
+        .map(|word| {
+            word.trim_matches(|c: char| !c.is_alphanumeric())
+                .to_string()
+        })
+        .filter(|word| !word.is_empty())
+        .collect();
+    let joined = words.join(" ");
+    let singular = match joined.to_ascii_lowercase().as_str() {
+        "legends" | "legendary creatures" | "legendary creature" => "Legend".to_string(),
+        "wolves" => "Wolf".to_string(),
+        "walls" => "Wall".to_string(),
+        other if other.ends_with("ies") && other.len() > 3 => {
+            format!("{}y", &joined[..joined.len() - 3])
+        }
+        other if other.ends_with('s') && other.len() > 1 => joined[..joined.len() - 1].to_string(),
+        _ => joined,
+    };
+    singular
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// CR 702.11d: Parse the quality after "hexproof from " into a HexproofFilter.
@@ -2293,6 +2350,11 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "StartYourEngines" => Ok(Keyword::StartYourEngines),
         "Soulbond" => Ok(Keyword::Soulbond),
         "Banding" => Ok(Keyword::Banding),
+        "BandsWithOther" => Ok(Keyword::BandsWithOther(
+            data.as_str()
+                .map(normalize_bands_with_other_quality)
+                .unwrap_or_default(),
+        )),
         "Epic" => Ok(Keyword::Epic),
         "Fuse" => Ok(Keyword::Fuse),
         "Gravestorm" => Ok(Keyword::Gravestorm),

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1610,6 +1610,7 @@ impl fmt::Display for Keyword {
             Keyword::Fear => write!(f, "Fear"),
             Keyword::Horsemanship => write!(f, "Horsemanship"),
             Keyword::Infect => write!(f, "Infect"),
+            Keyword::BandsWithOther(quality) => write!(f, "Bands with other {quality}"),
             // Debug-fallback for variants that don't have an explicit
             // user-facing label yet. Unambiguous (no two `Keyword`
             // variants share Debug output) but not necessarily pretty —
@@ -2892,6 +2893,14 @@ mod tests {
         assert_eq!(
             Keyword::Landwalk("Artifact".to_string()).to_string(),
             "Artifact Landwalk"
+        );
+    }
+
+    #[test]
+    fn display_bands_with_other_uses_oracle_spelling() {
+        assert_eq!(
+            Keyword::BandsWithOther("Wolf".to_string()).to_string(),
+            "Bands with other Wolf"
         );
     }
 


### PR DESCRIPTION
## Summary
- Adds `BandsWithOther` keyword support, including oracle parsing, string/tagged deserialization, display naming, and normalized quality matching.
- Allows legal attack band declarations when all members share a matching `bands with other` quality, including `Legend` and subtype-based qualities.
- Extends combat damage assignment hooks so CR 702.22j/k use the matching `bands with other` relationship alongside ordinary banding.

## Issue
Closes #2662

## Tests
- `cargo fmt --all --check`
- `cargo +nightly-2026-04-19-x86_64-pc-windows-gnu check -p engine`

## Notes
Focused `cargo test` coverage was added for parser, attack declaration, block propagation, and combat damage assignment behavior. Full focused test execution may require the Windows GNU `dlltool.exe` dependency to be available in the environment.