### PR TITLE
fix(engine): Bucknard's Everfull Purse treasure + control transfer (#1987)

### DIFF
--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -84,18 +84,7 @@ pub fn resolve_give(
         unique_recipient_from_filter(state, recipient, ability.controller)?
     };
 
-    // CR 608.2c: Resolve the permanent target from the effect's `target`
-    // filter — `SelfRef` ("this artifact") must bind to `ability.source_id`
-    // even when `ability.targets` is empty, so chained GiveControl sub-
-    // abilities (Bucknard's Everfull Purse) transfer the source object.
-    let object_ids: Vec<ObjectId> =
-        crate::game::targeting::resolved_targets(ability, target, state)
-            .into_iter()
-            .filter_map(|t| match t {
-                TargetRef::Object(id) => Some(id),
-                TargetRef::Player(_) => None,
-            })
-            .collect();
+    let object_ids = give_control_object_targets(state, ability, target);
 
     for obj_id in object_ids {
         if !state.objects.contains_key(&obj_id) {
@@ -121,6 +110,32 @@ pub fn resolve_give(
     });
 
     Ok(())
+}
+
+fn give_control_object_targets(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    filter: &TargetFilter,
+) -> Vec<ObjectId> {
+    // CR 608.2c: `SelfRef` ("this artifact") binds to the ability source even
+    // when target propagation has populated `ability.targets`.
+    if matches!(filter, TargetFilter::SelfRef) {
+        return vec![ability.source_id];
+    }
+
+    let chosen_objects = super::effect_object_targets(filter, &ability.targets);
+
+    if !chosen_objects.is_empty() {
+        return chosen_objects;
+    }
+
+    crate::game::targeting::resolved_targets(ability, filter, state)
+        .into_iter()
+        .filter_map(|target| match target {
+            TargetRef::Object(id) => Some(id),
+            TargetRef::Player(_) => None,
+        })
+        .collect()
 }
 
 fn unique_recipient_from_filter(
@@ -368,6 +383,66 @@ mod tests {
         assert_eq!(
             state.objects.get(&target_id).unwrap().controller,
             PlayerId(1)
+        );
+    }
+
+    /// CR 601.2c + CR 608.2c: explicit GiveControl object targets are the
+    /// selected spell/ability targets. A live trigger event may also make
+    /// `ParentTarget` resolvable, but that event context must not override the
+    /// chosen target when `ability.targets` already carries one.
+    #[test]
+    fn give_control_prefers_chosen_object_over_live_event_context() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Blocking Source".to_string(),
+            Zone::Battlefield,
+        );
+        let chosen_target = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Chosen Gift".to_string(),
+            Zone::Battlefield,
+        );
+        let event_context_target = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Blocked Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        state.current_trigger_event = Some(GameEvent::BlockersDeclared {
+            assignments: vec![(source, event_context_target)],
+        });
+        let ability = ResolvedAbility::new(
+            Effect::GiveControl {
+                target: TargetFilter::ParentTarget,
+                recipient: TargetFilter::Any,
+            },
+            vec![
+                TargetRef::Object(chosen_target),
+                TargetRef::Player(PlayerId(1)),
+            ],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_give(&mut state, &ability, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(
+            state.objects.get(&chosen_target).unwrap().controller,
+            PlayerId(1),
+            "the explicitly chosen object must be transferred"
+        );
+        assert_eq!(
+            state.objects.get(&event_context_target).unwrap().controller,
+            PlayerId(0),
+            "live event context must not replace the chosen object target"
         );
     }
 

--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -61,6 +61,10 @@ pub fn resolve_give(
 ) -> Result<(), EffectError> {
     let duration = ability.duration.clone().unwrap_or(Duration::Permanent);
 
+    let Effect::GiveControl { target, recipient } = &ability.effect else {
+        return Err(EffectError::MissingParam("GiveControl".to_string()));
+    };
+
     // CR 110.2 + CR 613.3: The recipient is the player target when one is
     // explicitly in ability.targets (normal targeting path). When no player
     // target is present — e.g. a post-replacement continuation whose target
@@ -76,30 +80,39 @@ pub fn resolve_give(
         }
     }) {
         pid
-    } else if let Effect::GiveControl { recipient, .. } = &ability.effect {
-        unique_recipient_from_filter(state, recipient, ability.controller)?
     } else {
-        ability.controller
+        unique_recipient_from_filter(state, recipient, ability.controller)?
     };
 
-    for target in &ability.targets {
-        if let TargetRef::Object(obj_id) = target {
-            if !state.objects.contains_key(obj_id) {
-                return Err(EffectError::ObjectNotFound(*obj_id));
-            }
+    // CR 608.2c: Resolve the permanent target from the effect's `target`
+    // filter — `SelfRef` ("this artifact") must bind to `ability.source_id`
+    // even when `ability.targets` is empty, so chained GiveControl sub-
+    // abilities (Bucknard's Everfull Purse) transfer the source object.
+    let object_ids: Vec<ObjectId> =
+        crate::game::targeting::resolved_targets(ability, target, state)
+            .into_iter()
+            .filter_map(|t| match t {
+                TargetRef::Object(id) => Some(id),
+                TargetRef::Player(_) => None,
+            })
+            .collect();
 
-            // CR 613.3: Create a transient continuous effect at Layer 2 (Control)
-            // with the recipient as the new controller.
-            state.add_transient_continuous_effect(
-                ability.source_id,
-                recipient_id,
-                duration.clone(),
-                TargetFilter::SpecificObject { id: *obj_id },
-                vec![ContinuousModification::ChangeController],
-                None,
-            );
-            mark_echo_due_for_new_controller(state, *obj_id);
+    for obj_id in object_ids {
+        if !state.objects.contains_key(&obj_id) {
+            return Err(EffectError::ObjectNotFound(obj_id));
         }
+
+        // CR 613.3: Create a transient continuous effect at Layer 2 (Control)
+        // with the recipient as the new controller.
+        state.add_transient_continuous_effect(
+            ability.source_id,
+            recipient_id,
+            duration.clone(),
+            TargetFilter::SpecificObject { id: obj_id },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+        mark_echo_due_for_new_controller(state, obj_id);
     }
 
     events.push(GameEvent::EffectResolved {
@@ -741,5 +754,94 @@ mod tests {
 
         let result = resolve(&mut state, &ability, &mut events);
         assert!(result.is_err());
+    }
+
+    /// Issue #1987: chained GiveControl with `target: SelfRef` and empty
+    /// `ability.targets` must still transfer the source permanent.
+    #[test]
+    fn issue_1987_give_control_self_ref_with_empty_targets_transfers_source() {
+        use crate::types::ability::SeatDirection;
+
+        let mut state = GameState::new(FormatConfig::free_for_all(), 3, 42);
+        let artifact = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bucknard's Everfull Purse".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::GiveControl {
+                target: TargetFilter::SelfRef,
+                recipient: TargetFilter::Neighbor {
+                    direction: SeatDirection::Right,
+                },
+            },
+            vec![],
+            artifact,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_give(&mut state, &ability, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(
+            state.objects.get(&artifact).unwrap().controller,
+            PlayerId(2),
+            "SelfRef GiveControl must transfer the source with empty targets"
+        );
+    }
+
+    /// Issue #1987: parsed activated ability must chain
+    /// RollDie → Token(EventContextAmount) → GiveControl(Neighbor Right).
+    #[test]
+    fn issue_1987_bucknards_parsed_ability_chain_shape() {
+        use crate::parser::parse_oracle_text;
+        use crate::types::ability::{QuantityExpr, QuantityRef, SeatDirection};
+
+        let parsed = parse_oracle_text(
+            "{1}, {T}: Roll a d4 and create a number of Treasure tokens equal to the result. The player to your right gains control of this artifact.",
+            "Bucknard's Everfull Purse",
+            &[],
+            &["Artifact".to_string()],
+            &[],
+        );
+        assert_eq!(parsed.abilities.len(), 1, "parsed: {parsed:#?}");
+        let ability = &parsed.abilities[0];
+
+        let Effect::RollDie { sides, .. } = ability.effect.as_ref() else {
+            panic!("head must be RollDie, got {:?}", ability.effect);
+        };
+        assert_eq!(*sides, 4);
+
+        let token_ability = ability.sub_ability.as_ref().expect("RollDie sub = Token");
+        let Effect::Token { count, .. } = token_ability.effect.as_ref() else {
+            panic!("RollDie sub must be Token, got {:?}", token_ability.effect);
+        };
+        assert_eq!(
+            count,
+            &QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount
+            }
+        );
+
+        let give_ability = token_ability
+            .sub_ability
+            .as_ref()
+            .expect("Token sub = GiveControl");
+        let Effect::GiveControl { target, recipient } = give_ability.effect.as_ref() else {
+            panic!(
+                "Token sub must be GiveControl, got {:?}",
+                give_ability.effect
+            );
+        };
+        assert_eq!(target, &TargetFilter::SelfRef);
+        assert_eq!(
+            recipient,
+            &TargetFilter::Neighbor {
+                direction: SeatDirection::Right
+            }
+        );
     }
 }

--- a/crates/engine/tests/integration/issue_1987_bucknards_everfull_purse.rs
+++ b/crates/engine/tests/integration/issue_1987_bucknards_everfull_purse.rs
@@ -1,0 +1,99 @@
+//! Regression (issue #1987): Bucknard's Everfull Purse activated ability must
+//! roll a d4, create that many Treasure tokens, and pass control to the player
+//! on the controller's right.
+//!
+//! CR 706.2: "create a number of Treasure tokens equal to the result."
+//! CR 102.1 + CR 103.1: "the player to your right" is seating-relative.
+
+use engine::game::players::previous_player;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{Effect, SeatDirection, TargetFilter};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::PlayerId;
+
+const P2: PlayerId = PlayerId(2);
+
+const BUCKNARDS_ORACLE: &str = "{1}, {T}: Roll a d4 and create a number of Treasure tokens equal to the result. The player to your right gains control of this artifact.";
+
+fn floating_colorless(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn treasure_count_for_controller(state: &GameState, controller: PlayerId) -> usize {
+    state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|o| {
+            o.card_types.subtypes.contains(&"Treasure".to_string()) && o.controller == controller
+        })
+        .count()
+}
+
+#[test]
+fn issue_1987_bucknards_parsed_oracle_creates_treasures_and_passes_right() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let purse_id = scenario
+        .add_creature(P0, "Bucknard's Everfull Purse", 0, 0)
+        .as_artifact()
+        .from_oracle_text(BUCKNARDS_ORACLE)
+        .id();
+
+    scenario.with_mana_pool(P0, floating_colorless(1));
+
+    let mut runner = scenario.build();
+    let ability = &runner.state().objects.get(&purse_id).unwrap().abilities[0];
+    let Effect::RollDie { .. } = ability.effect.as_ref() else {
+        panic!("head must be RollDie, got {:?}", ability.effect);
+    };
+    let token = ability.sub_ability.as_ref().expect("RollDie sub = Token");
+    let give = token.sub_ability.as_ref().expect("Token sub = GiveControl");
+    let Effect::GiveControl { target, recipient } = give.effect.as_ref() else {
+        panic!("Token sub must be GiveControl, got {:?}", give.effect);
+    };
+    assert_eq!(target, &TargetFilter::SelfRef);
+    assert_eq!(
+        recipient,
+        &TargetFilter::Neighbor {
+            direction: SeatDirection::Right
+        }
+    );
+
+    let outcome = runner.activate(purse_id, 0).resolve();
+    let state = outcome.state();
+
+    let treasures = treasure_count_for_controller(state, P0);
+    assert!(
+        (1..=4).contains(&treasures),
+        "must create between 1 and 4 Treasure tokens (d4 roll), got {treasures}; waiting_for={:?}",
+        state.waiting_for
+    );
+
+    assert_eq!(
+        previous_player(state, P0),
+        P2,
+        "right neighbor of P0 in a 3-player seat is P2"
+    );
+    assert_eq!(
+        state.objects.get(&purse_id).unwrap().controller,
+        P2,
+        "Purse must transfer to the player on the controller's right"
+    );
+    assert!(
+        state
+            .battlefield
+            .iter()
+            .filter_map(|id| state.objects.get(id))
+            .filter(|o| o.card_types.subtypes.contains(&"Treasure".to_string()))
+            .all(|o| o.card_types.core_types.contains(&CoreType::Artifact) && o.color.is_empty()),
+        "Treasure tokens must be colorless artifacts"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -83,6 +83,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod issue_1509_sorcery_main_phase_cast;
+mod issue_1987_bucknards_everfull_purse;
 mod issue_2011_eldrazi_temple_kozilek_cast;
 mod issue_2345_lavinia_no_mana_spent;
 mod issue_2360_the_rack;


### PR DESCRIPTION
## Summary
- Fix `GiveControl` with `target: SelfRef` to resolve the source permanent via `resolved_targets` when `ability.targets` is empty.
- Bucknard's Everfull Purse activated ability now creates Treasure tokens from the d4 roll and passes control to the player on the controller's right.

## Test plan
- [x] `cargo test -p engine --lib issue_1987`
- [x] `cargo test -p engine --test integration issue_1987`
- [x] `cargo clippy -p engine --all-targets -- -D warnings`

Fixes #1987

Made with [Cursor](https://cursor.com)