### PR TITLE
test(engine): modal DFC commander back-face cast from command zone (#1985)

### DIFF
--- a/crates/engine/tests/integration/issue_1985_dfc_command_zone_cast.rs
+++ b/crates/engine/tests/integration/issue_1985_dfc_command_zone_cast.rs
@@ -1,0 +1,83 @@
+//! Regression (issue #1985): Modal DFC commanders must offer a cast-time face
+//! choice when cast from the command zone (CR 712.11b + CR 903.8).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::actions::GameAction;
+use engine::types::card::LayoutKind;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use crate::support::shared_card_db as load_db;
+
+#[test]
+fn issue_1985_peter_parker_commander_offers_modal_face_choice_from_command_zone() {
+    let Some(db) = load_db() else { return };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let card = scenario.add_real_card(P0, "Peter Parker", Zone::Hand, db);
+    scenario.with_commander(card);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::White, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    runner.state_mut().format_config.command_zone = true;
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    let back = runner
+        .state()
+        .objects
+        .get(&card)
+        .and_then(|o| o.back_face.clone())
+        .expect("command-zone commander must hydrate modal back face");
+    assert_eq!(back.name, "Amazing Spider-Man");
+    assert_eq!(back.layout_kind, Some(LayoutKind::Modal));
+
+    let cast_actions = engine::ai_support::legal_actions(runner.state())
+        .iter()
+        .filter(|a| matches!(a, GameAction::CastSpell { object_id, .. } if *object_id == card))
+        .count();
+    assert_eq!(
+        cast_actions, 1,
+        "commander must be offered as castable from the command zone before casting"
+    );
+
+    let card_id = runner.state().objects[&card].card_id;
+    let result = runner
+        .act(GameAction::CastSpell {
+            object_id: card,
+            card_id,
+            targets: vec![],
+        })
+        .expect("CastSpell on commander from command zone accepted");
+    assert!(
+        matches!(result.waiting_for, WaitingFor::ModalFaceChoice { .. }),
+        "commander modal DFC must enter ModalFaceChoice from command zone; got {:?}",
+        result.waiting_for
+    );
+
+    runner
+        .act(GameAction::ChooseModalFace { back_face: true })
+        .expect("ChooseModalFace{back} from command zone accepted");
+    runner.advance_until_stack_empty();
+
+    assert!(
+        runner
+            .battlefield_names()
+            .iter()
+            .any(|n| n == "Amazing Spider-Man"),
+        "back face must resolve from command-zone commander cast; battlefield = {:?}",
+        runner.battlefield_names()
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -83,6 +83,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod issue_1509_sorcery_main_phase_cast;
+mod issue_1985_dfc_command_zone_cast;
 mod issue_2011_eldrazi_temple_kozilek_cast;
 mod issue_2345_lavinia_no_mana_spent;
 mod issue_2360_the_rack;


### PR DESCRIPTION
## Summary
- Add end-to-end integration regression for casting Peter Parker // Amazing Spider-Man's back face from the command zone as a commander.
- Confirms `ModalFaceChoice` is offered and the back face resolves onto the battlefield (CR 712.11b + CR 903.8).

## Test plan
- [x] `cargo test -p engine --test integration issue_1985`

Fixes #1985

Made with [Cursor](https://cursor.com)