### PR TITLE
docs(pipeline): add author-side gates from contribution retrospective

### DIFF
--- a/.claude/agents/engine-implementation-executor.md
+++ b/.claude/agents/engine-implementation-executor.md
@@ -125,12 +125,12 @@ If any modified file is under `crates/engine/src/parser/`, inspect added lines f
 ```bash
 git diff --name-only | grep 'crates/engine/src/parser/' | while read f; do
   git diff "$f" | grep '^+' | grep -v '^+++' | grep -vE '^\+\s*//' \
-    | grep -E '\.(contains|starts_with|ends_with|find)\(' \
+    | grep -E '\.(contains|starts_with|ends_with|find|rfind|split|splitn|rsplit|split_once)\(' \
     | grep -v '#\[test\]' | grep -v '#\[cfg(test)\]'
 done
 ```
 
-Any output is a hard failure unless it is a test, comment, explicitly annotated non-dispatch structural use, or `oracle_util.rs` dual-string `TextPair` helper work.
+The `rfind`/`split`/`split_once`/`rsplit` arms are deliberate: `scripts/check-parser-combinators.sh` does not catch them, so a green gate is not proof of combinator compliance — this inline grep covers that blind spot. Any output is a hard failure unless it is a test, comment, explicitly annotated non-dispatch structural use, or `oracle_util.rs` dual-string `TextPair` helper work.
 
 For parser changes always run additionally:
 
@@ -140,6 +140,28 @@ cargo coverage
 cargo semantic-audit
 ```
 
+### Discriminating-test gate
+
+Every behavioral change MUST ship at least one test that drives the real pipeline (`apply()` / the scenario runner / the cast-pipeline harness) and **would fail if the fix were reverted**. A test that only asserts the parsed AST shape — an `assert_eq!` on a parsed `AbilityDefinition` / `Effect` / `StaticMode` without resolving it through the engine — does NOT satisfy this gate. It is a shape test, not a regression test.
+
+Confirm discrimination concretely before returning:
+
+- For the primary fix, name the assertion that flips when the fix is reverted. If you cannot name one, the test does not discriminate — add one that does.
+- Trace each test fixture through the fix's first input-shape dispatches (`is_none()` / `is_empty()` / variant `match` / "has-X" guards). If every fixture is degenerate in the same way (no ability, no targets, empty or single-element collection, all-generic cost), the test likely takes a different internal branch than production inputs and silently passes — reach the real arm instead. (Precedent: an Emerge cost-reduction test whose all-generic sacrifice made the wrong reduction coincide with the right one; an Undaunted test that called a function the reduction never runs in, so the positive case could not pass.)
+
+This is the single most common defect the `/review-impl` loop catches (shape-only tests on keyword and parser PRs). Catch it here, before review.
+
+### CR-annotation diff gate
+
+Before returning, grep every CR number you added or changed **in the diff** against `docs/MagicCompRules.txt` — not just the ones you remember writing:
+
+```bash
+git diff | grep -E '^\+' | grep -oE 'CR [0-9]{3}(\.[0-9]+[a-z]?)?' | sed 's/^CR //' | sort -u \
+  | while read -r n; do grep -qE "^${n}([^0-9]|$)" docs/MagicCompRules.txt || echo "UNVERIFIED: CR ${n}"; done
+```
+
+Any `UNVERIFIED:` line is a hard stop — the rule number does not exist in the rules text (a hallucinated subpart, e.g. the recurring `702.808` / wrong-keyword-subpart class) or is malformed. Re-derive the correct rule or flag it explicitly; never ship an unverified CR annotation. A clean grep is necessary but not sufficient: also confirm the cited rule actually *describes* the annotated code, not merely that the number exists.
+
 ## Output
 
 Return a structured report to the orchestrator:
@@ -147,10 +169,12 @@ Return a structured report to the orchestrator:
 1. **Diff summary** — files touched, grouped by subsystem, with a one-line purpose per file.
 2. **Verification results** — which Tilt resources are green; any failures with `tilt logs` excerpts (own vs unrelated).
 3. **Parser diff gate** — pass/fail with offending lines if any.
-4. **Judgement calls** — any place you had to choose between two readings of the plan, with the reasoning.
-5. **Stop-and-return items** — any places you stopped rather than improvise.
-6. **CR annotations added/changed** — each one with the grep command that verified it.
-7. **Deviations from the plan** — what changed vs. the plan and why.
-8. **Risks** — anything the orchestrator's `/review-impl` loop should pay extra attention to.
+4. **Discriminating-test gate** — for the primary fix, the assertion that flips when the fix is reverted, and confirmation no production-reachable arm is left covered only by a degenerate fixture. State if any test is shape-only.
+5. **CR-annotation diff gate** — the grep result; list any `UNVERIFIED:` rule, or confirm zero.
+6. **Judgement calls** — any place you had to choose between two readings of the plan, with the reasoning.
+7. **Stop-and-return items** — any places you stopped rather than improvise.
+8. **CR annotations added/changed** — each one with the grep command that verified it.
+9. **Deviations from the plan** — what changed vs. the plan and why.
+10. **Risks** — anything the orchestrator's `/review-impl` loop should pay extra attention to.
 
 Do NOT commit. Do NOT push. The orchestrator decides what to stage and when.

--- a/.claude/skills/engine-implementer/SKILL.md
+++ b/.claude/skills/engine-implementer/SKILL.md
@@ -77,6 +77,8 @@ cargo fmt --all
 
 After a non-zero `tilt-wait.sh`, fetch details with `tilt logs <resource> --tail 50 --since 2m`. Distinguish your diff's errors from concurrent-agent errors per CLAUDE.md's "Defer to other active agents" guidance.
 
+Confirm the executor's two pre-commit gates came back clean (items 4 and 5 of its report): the **discriminating-test gate** (at least one test drives the real pipeline and would fail if the fix were reverted — AST-shape-only coverage does not count) and the **CR-annotation diff gate** (every added/changed `CR <n>` resolves in `docs/MagicCompRules.txt`). If the executor shipped only shape tests, or any CR annotation came back `UNVERIFIED`, loop back to Step 3 with that as a fix constraint — do not commit shape-only coverage or an unverified CR number.
+
 ### Step 5 — Review implementation until clean (unbounded loop)
 
 Spawn a `general-purpose` agent and instruct it to invoke `/review-impl` against the implementation diff. The reviewer MUST also verify the originally reported bug or requirement is actually fixed via a discriminating runtime test — not just that the code looks clean (`feedback_review_impl_verify_bug_fixed`).

--- a/.claude/skills/pr-contribution-handler/SKILL.md
+++ b/.claude/skills/pr-contribution-handler/SKILL.md
@@ -100,6 +100,30 @@ These are the recurring accidental-damage patterns. Fix inline as part of your n
 
 Run these checks BEFORE prioritization. A PR with hard-stop issues is removed from the queue entirely; a PR with auto-fix issues stays in the queue and gets handled.
 
+## Duplicate-PR and Scope-Contamination Check (per PR — at intake)
+
+Two recurring, expensive intake problems that are neither security hard-stops nor mechanical auto-fixes. Surface them as evidence **before** investing review effort.
+
+**Duplicate PR.** Confirm no other open PR implements the same card, issue, or mechanic. Collisions waste reviewer/CI effort and one will lose the merge-queue race (precedent: #2530 and #2531 both added `StaticMode::CrewContribution` for #2529; #2520's prevention half duplicated open #2495).
+
+```bash
+gh pr view <N> --json closingIssuesReferences,title --jq '{title, closes: [.closingIssuesReferences[].number]}'
+gh pr list --repo phase-rs/phase --state open --json number,title --jq '.[] | select(.number != <N>)'   # scan for the same issue / card / mechanic
+```
+
+If a duplicate exists, do not handle both: hand-trace each, keep the more rules-correct base, report the other for close/supersede, and note it in the Final Report. Two PRs for one issue are never both enqueued.
+
+**Scope contamination / stale branch.** Diff the PR against current `origin/main` and confirm the change set matches the PR's stated scope.
+
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus --jq '{mergeable, mergeStateStatus}'
+git diff --stat origin/main...HEAD
+```
+
+- `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY` / branch far behind → needs a rebase before review. If the diff would revert other agents' landed work (token data, deploy config, concurrent integration tests), that is **BLOCK-pending-rebase**, not an inline fix (precedent: #2519 was 53 commits behind and its diff would have reverted ~5,800 unrelated lines; #2520 was 40 behind and bundled two features).
+- Diff touches generated registries (`known-tokens.toml`), stray gitlinks/submodules (`new file mode 160000`), or subsystems unrelated to the stated scope → handle via the Security/Sanity auto-fix classes (strip/revert); if the contamination is load-bearing to the PR's logic, reduce the PR to its real change before review.
+- A PR body claiming "Scope Expansion: None" whose diff is large and cross-cutting is a contradiction to verify, not to trust.
+
 ## Prioritize (multi-PR runs and Standard-tier quality gauge)
 
 When given multiple PRs, fetch each PR body before checkout and read its `Tier:` line:
@@ -176,6 +200,13 @@ Resolve conflicts in the same architectural style as the surrounding code. Do no
 If `origin/main` is already an ancestor and there are no conflicts, skip the merge — repeatedly bringing-current adds noise to the PR history without changing mergeability under the queue.
 
 ## Review Comment Resolution
+
+**Operational — posting and fetching.** Post every PR comment, review body, and final report through a temp file (`gh pr comment <N> --body-file /tmp/body.md`, `gh pr review <N> --body-file /tmp/review.md`), **never** an inline `--body "…"` string. Inline bodies are mangled by the shell — zsh strips backticked identifiers and code spans, which has silently corrupted the technical claims of a *blocking* review. Write the body to a file, then pass `--body-file`. When handling many PRs, fetch comments in one batched repo-wide sweep rather than looping per-PR `gh` calls — the per-PR pattern drains the 5,000/hr GitHub core rate limit at fleet scale:
+
+```bash
+gh api --paginate 'repos/phase-rs/phase/pulls/comments?since=<ISO8601>&per_page=100'
+gh api --paginate 'repos/phase-rs/phase/issues/comments?since=<ISO8601>&per_page=100'
+```
 
 Apply `.claude/agents/pr-review-comment-resolver.md` directly:
 
@@ -365,6 +396,7 @@ Every item must be satisfied before running `gh pr merge`. Failing any item mean
 
 - [ ] **Security pre-check clean.** No hard-stop issues fired (prompt injection, CI/build hijacking, secrets/network surface changes, skill/agent/instruction tampering, unexplained binaries). Auto-fix issues are OK if they were actually reverted/stripped in this invocation.
 - [ ] **No workflow or instruction edits in the final diff.** Re-grep the post-fix diff for any path under `.github/workflows/`, `.github/actions/`, `.claude/`, `CLAUDE.md`, `AGENTS.md`, `docs/AI-CONTRIBUTOR.md`, or this skill itself. Even legitimate-looking edits in these paths require maintainer review — the blast radius is the whole agent fleet, not just the PR.
+- [ ] **No duplicate open PR, and no scope contamination.** Per the intake "Duplicate-PR and Scope-Contamination Check": no other open PR implements the same issue/card/mechanic (if one does, the more rules-correct base was chosen and the other reported for close — two PRs for one issue are never both enqueued), the diff matches the PR's stated scope, and any generated-registry/stray-gitlink contamination was stripped.
 - [ ] **Change is at the architecturally correct LOCATION (the right seam) — highest-priority gate.** The fix lives in the layer/module/function the codebase's design says owns this responsibility, not a symptom-patch at the wrong seam that merely makes the test green. A wrong-location change is technical debt even with green CI; **velocity never justifies merging debt** — a wrong-seam fix that ships is worse than no fix because it looks done while leaving the real seam broken and obscured. If the correct seam is elsewhere, the verdict is BLOCK or full re-implementation, never an inline patch of the wrong place. A failure here is disqualifying no matter how clean the code or how green the checks.
 - [ ] **Change at the seam is the MOST IDIOMATIC possible — paired second gate.** Given the right location, the implementation reuses the established building block, parameterizes an existing typed enum rather than adding a `bool`/sibling variant, and composes combinators rather than string-dispatching — the change a principal engineer steeped in this repo would write. A correct-but-unidiomatic change was brought to the idiom before enqueue (author's branch improved per Quality Bar rule 1), not merged as-is.
 - [ ] **PR is valuable — behaviorally AND architecturally.** It does real work (implements/fixes a mechanic, lands a card, fixes a bug, improves coverage) AND leaves the codebase cleaner. Reject pure renaming/reformatting/restructuring with no behavioral change, and unrequested "improvements." Any new machinery has earned its keep (serves a real card *class*, not one card; does not duplicate existing infra).

--- a/.claude/skills/review-impl/SKILL.md
+++ b/.claude/skills/review-impl/SKILL.md
@@ -41,6 +41,7 @@ Two gates lead every review; apply them before the rest.
 ### Engine Logic
 
 - Verify every new or moved `// CR <rule>` by checking `docs/MagicCompRules.txt`; the cited rule must actually describe the code.
+- Compound CR annotations are the project's documented convention, **not** format violations: `CR X + CR Y` for interacting rules, `CR X / CR Y` for alternatives, and range/subpart forms like `CR 702.45a/b` (see CLAUDE.md "MTG Comprehensive Rules Annotations"). Do not flag the `+` / `/` / range forms as malformed or as regex violations — Gemini routinely raises these and they should be refuted, not echoed. Only flag a CR citation whose base number does not resolve in `docs/MagicCompRules.txt`, or one that does not describe the annotated code.
 - Check reuse of building blocks in `parser/oracle_nom/`, `parser/oracle_util.rs`, `game/filter.rs`, `game/quantity.rs`, `game/ability_utils.rs`, `game/keywords.rs`, `game/zones.rs`, and `game/targeting.rs`.
 - Keep game logic in the engine. If player-visible state was added, verify multiplayer filtering.
 - For non-battlefield zones, player-scoped queries usually use `owner`, not `controller`.

--- a/docs/AI-CONTRIBUTOR.md
+++ b/docs/AI-CONTRIBUTOR.md
@@ -160,13 +160,26 @@ From the JSON, select a card where:
 
 Record the chosen card name. It will appear in the branch name, commit message, and PR title.
 
+### 3.1. Confirm the work isn't already in flight
+
+Before implementing, confirm no open PR already covers the selected card **or its core mechanic**. Duplicate PRs for the same issue waste reviewer and CI effort and one will lose the merge-queue race (recurring: two PRs adding the same crew/saddle contribution static, two adding the same prevention-recipient scope). Scan by card name *and* by mechanic — the keyword you would add may already be in flight under a different card:
+
+```bash
+gh pr list --repo phase-rs/phase --state open --search "<Card Name>" --json number,title,headRefName
+gh pr list --repo phase-rs/phase --state open --search "<keyword-or-mechanic>" --json number,title
+```
+
+If an open PR already implements the card or the core mechanic, **stop and report it to the human** rather than opening a duplicate — offer to review or extend the existing PR instead.
+
 ---
 
 ## 4. Implement with `$engine-implementer`
 
-Create a branch (with a collision guard so re-runs on the same fork don't fail):
+Base your branch on the **current upstream `main`**, not your fork's (possibly stale) `main`. A branch cut from a stale base shows spurious diffs against `origin/main`, risks textual merge-queue conflicts, and can revert other contributors' landed work. Fetch upstream first, then create the branch (with a collision guard so re-runs on the same fork don't fail):
 
 ```bash
+git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://github.com/phase-rs/phase.git
+git fetch upstream main
 slug="card/<slug-of-card-name>"
 n=2
 while git rev-parse --verify "refs/heads/$slug" >/dev/null 2>&1 \
@@ -174,8 +187,10 @@ while git rev-parse --verify "refs/heads/$slug" >/dev/null 2>&1 \
   slug="card/<slug-of-card-name>-$n"
   n=$((n + 1))
 done
-git checkout -b "$slug"
+git checkout -b "$slug" upstream/main   # cut from current upstream, not a stale fork main
 ```
+
+If your work spans more than a few minutes and upstream `main` advances, keep current with `git fetch upstream main && git merge --no-edit upstream/main` so the final diff contains only your change.
 
 Then invoke the `$engine-implementer` skill with this prompt, substituting `<NAME>`:
 
@@ -197,7 +212,7 @@ Apply **all three** checks:
 
 1. **Review section exists with concrete findings.** The final report must contain an explicit `$review-impl` section enumerating findings with file:line references, or a clear clean-review result that states an implementation review ran against the full diff.
 2. **Findings were addressed with code.** For every finding classified as a defect, gap, or missing case, there must be a corresponding change in `git diff HEAD~ HEAD` (or the working tree if not yet committed). An acknowledgement without a diff is a failure.
-3. **Clean-review cross-check (fresh context).** If the report claims zero findings, run an independent pass when your environment supports it; otherwise note the limitation in the PR body. Hand the reviewer ONLY the unified diff (`git diff HEAD~ HEAD`), `CLAUDE.md`, and the relevant skills under `.claude/skills/`. No prior conversation. The reviewer must explicitly check: (a) **correct seam / location** — is the change at the layer/module/function the design says owns this responsibility, or a symptom-patch at the wrong seam that merely makes a test pass? A wrong-location fix is debt even when green; flag it as disqualifying and name the correct seam; (b) **most idiomatic change at the seam** — given the right location, is this the implementation a principal engineer steeped in this repo would write (established building-block reuse over re-implementation, combinator composition over string dispatch, enum parameterization over a new bool/sibling)? A correct-but-unidiomatic change is a finding, not a nit; (c) **nom-mandate compliance** — flag any `match` over a stringified parser-text variable with string-literal arms, any chained `if let Ok(..) = tag(..)` blocks, and any string-method dispatch (`.contains("…")`, `.find("…")`, `.split_once`, etc.); (d) **CR-citation completeness** — for each cited rule, did the implementation also cite the *authorizing* rule, not just the *layering* rule? (e) **pattern coverage** — does this work for ≥10 cards or just one? (f) **logic placement** — engine vs frontend per `CLAUDE.md`; (g) **building-block reuse** — did the implementation duplicate logic an existing helper already handles? Re-implementing what `oracle_util.rs`, `oracle_quantity.rs`, `game/filter.rs`, `game/zones.rs`, etc. already provide is a defect even if the new code works; (h) **bool-flag avoidance** — any new `bool` field/parameter where a typed enum (`ControllerRef`, `Comparator`, `Option<T>`, etc.) would express the design space better is a defect. If the cross-check produces findings, feed them back into `$engine-implementer` and loop.
+3. **Clean-review cross-check (fresh context).** If the report claims zero findings, run an independent pass when your environment supports it; otherwise note the limitation in the PR body. Hand the reviewer ONLY the unified diff (`git diff HEAD~ HEAD`), `CLAUDE.md`, and the relevant skills under `.claude/skills/`. No prior conversation. The reviewer must explicitly check: (a) **correct seam / location** — is the change at the layer/module/function the design says owns this responsibility, or a symptom-patch at the wrong seam that merely makes a test pass? A wrong-location fix is debt even when green; flag it as disqualifying and name the correct seam; (b) **most idiomatic change at the seam** — given the right location, is this the implementation a principal engineer steeped in this repo would write (established building-block reuse over re-implementation, combinator composition over string dispatch, enum parameterization over a new bool/sibling)? A correct-but-unidiomatic change is a finding, not a nit; (c) **nom-mandate compliance** — flag any `match` over a stringified parser-text variable with string-literal arms, any chained `if let Ok(..) = tag(..)` blocks, and any string-method dispatch (`.contains("…")`, `.find("…")`, `.rfind("…")`, `.split(`, `.split_once`, `.splitn`, etc. — `.rfind`/`.split` are not caught by `check-parser-combinators.sh`, so grep the diff for them by hand); (d) **CR-citation completeness** — for each cited rule, did the implementation also cite the *authorizing* rule, not just the *layering* rule? (e) **pattern coverage** — does this work for ≥10 cards or just one? (f) **logic placement** — engine vs frontend per `CLAUDE.md`; (g) **building-block reuse** — did the implementation duplicate logic an existing helper already handles? Re-implementing what `oracle_util.rs`, `oracle_quantity.rs`, `game/filter.rs`, `game/zones.rs`, etc. already provide is a defect even if the new code works; (h) **bool-flag avoidance** — any new `bool` field/parameter where a typed enum (`ControllerRef`, `Comparator`, `Option<T>`, etc.) would express the design space better is a defect; (i) **test discrimination** — does at least one test drive the real pipeline (`apply()` / scenario runner / cast harness) and FAIL if the fix were reverted? A test that only asserts parsed AST shape — an `assert_eq!` on a parsed `Effect` / `StaticMode` / `AbilityDefinition` without resolving it — is a shape test, not a regression test, and is the single most common gap on keyword and parser PRs; name it as a defect and require a discriminating runtime test before the PR opens. If the cross-check produces findings, feed them back into `$engine-implementer` and loop.
 
 **If any check fails:** rerun `$engine-implementer` or continue the same skill workflow with explicit instructions to execute `$review-impl` and address every finding with code changes. Do **not** proceed to Step 6 until validation passes. Retry at most 2 times; on a third failure, abort the run and record the gap in the PR body under a "Validation Failures" heading so the maintainer can triage.
 


### PR DESCRIPTION
Derived from a week-long retrospective of the AI-contribution pipeline
(Gemini, /review-impl, /pr-contribution-handler) over ~2,000 PR comments.
Stops the most-flagged author-side defects at the source.

- engine-implementation-executor: blocking discriminating-test gate (the #1
  finding across every reviewer was AST-shape-only tests that pass when the
  fix is reverted) and CR-annotation diff gate (catches hallucinated subparts
  like CR 702.808); extend the parser-diff-gate regex to rfind/split/split_once
  (check-parser-combinators.sh blind spots).
- engine-implementer: Step 4 confirms both new gates before commit.
- pr-contribution-handler: duplicate-PR + scope-contamination intake gate and
  enqueue item; post comments via --body-file (shell backtick mangling) and
  batch comment-fetch (rate-limit).
- review-impl: codify CR +// compound-annotation convention so Gemini's format
  pedantry is refuted, not echoed.
- AI-CONTRIBUTOR: contributor-side duplicate-PR check (3.1), branch off current
  upstream/main (4), and test-discrimination + rfind/split in the 5 cross-check.
