### PR TITLE
fix(ai): emit legal mixed-target attacks under goad/must-attack (CR 508.1d)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3278,6 +3278,13 @@ fn attacker_actions(
     // so a must-attacker that also can't attack the chosen target could still
     // yield an illegal forced candidate. That over-constraint axis is a
     // pre-existing gap (independent of goad) and is not addressed here.
+    // Likewise, a *requirements conflict* — a creature with MustAttackPlayer{P}
+    // that is also goaded by P — has no legal declaration at all: the CR 508.1b
+    // gate demands attacking P while the CR 701.15b redirect forbids it (a
+    // non-goading target exists). The engine validator enforces both
+    // requirements independently rather than obeying the CR 508.1d maximum, so
+    // no target this builder picks can survive filtering. Fixing that is a
+    // validator concern (CR 508.1d max-satisfaction), not a generator one.
     let forced: Vec<(ObjectId, AttackTarget)> = valid_attacker_ids
         .iter()
         .copied()

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -678,7 +678,7 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             player,
             valid_attacker_ids,
             valid_attack_targets,
-        } => attacker_actions(*player, valid_attacker_ids, valid_attack_targets),
+        } => attacker_actions(state, *player, valid_attacker_ids, valid_attack_targets),
         WaitingFor::DeclareBlockers {
             player,
             valid_blocker_ids,
@@ -3191,11 +3191,15 @@ fn target_step_actions(
 }
 
 fn attacker_actions(
+    state: &GameState,
     player: PlayerId,
     valid_attacker_ids: &[crate::types::identifiers::ObjectId],
     valid_attack_targets: &[AttackTarget],
 ) -> Vec<CandidateAction> {
-    let default_target = valid_attack_targets.first().cloned();
+    // CR 508.1a: declaring no attackers is a structurally legal submission. The
+    // engine's combat-requirement check rejects it at apply time only when a
+    // creature *must* attack (goad, CR 701.15b), and the simulation filter then
+    // drops it — so it is always safe to offer here.
     let mut actions = vec![candidate(
         GameAction::DeclareAttackers {
             attacks: Vec::new(),
@@ -3206,29 +3210,107 @@ fn attacker_actions(
         Some(player),
     )];
 
-    let Some(target) = default_target else {
+    if valid_attack_targets.is_empty() {
         return actions;
-    };
-
-    for &id in valid_attacker_ids {
-        actions.push(candidate(
-            GameAction::DeclareAttackers {
-                attacks: vec![(id, target)],
-                bands: vec![],
-            },
-            TacticalClass::Attack,
-            Some(player),
-        ));
     }
 
+    // CR 508.1: each attacker independently chooses any one defending player,
+    // planeswalker, or battle. Enumerate every (attacker, target) pairing rather
+    // than only the first target — a goaded creature (CR 701.15b) must attack a
+    // player *other than* the goader if able, so pairing solely against the
+    // first target makes the only non-empty candidate illegal whenever that
+    // target is the goader, collapsing the legal-action set to empty and
+    // hanging the game.
+    for &id in valid_attacker_ids {
+        for &target in valid_attack_targets {
+            actions.push(candidate(
+                GameAction::DeclareAttackers {
+                    attacks: vec![(id, target)],
+                    bands: vec![],
+                },
+                TacticalClass::Attack,
+                Some(player),
+            ));
+        }
+    }
+
+    // Alpha-strike: all eligible attackers swing at a single shared target.
+    // Offer one per target so goad on a lone attacker doesn't make the only
+    // all-in candidate illegal.
     if valid_attacker_ids.len() > 1 {
+        for &target in valid_attack_targets {
+            actions.push(candidate(
+                GameAction::DeclareAttackers {
+                    attacks: valid_attacker_ids
+                        .iter()
+                        .copied()
+                        .map(|id| (id, target))
+                        .collect(),
+                    bands: vec![],
+                },
+                TacticalClass::Attack,
+                Some(player),
+            ));
+        }
+    }
+
+    // CR 508.1d: a declaration must include *every* creature that must attack
+    // (goad CR 701.15b, MustAttack/MustAttackPlayer statics CR 508.1b). When
+    // those per-creature requirements force different targets — two creatures
+    // goaded by *different* players, or a MustAttackPlayer creature alongside a
+    // goaded one — the only legal declaration assigns them to *different* targets,
+    // a mixed-target combination none of the candidates above ever emit (singles
+    // omit the other must-attacker; alpha-strike forces one shared target that is
+    // illegal for whichever creature is goaded by / not directed at it). Add one
+    // greedy forced-legal assignment so a legal candidate survives filtering.
+    // Each must-attack requirement is per-creature and independent (creatures may
+    // share a defender), so choosing each creature's target independently yields a
+    // jointly legal declaration. Target priority mirrors the validator's
+    // enforcement order: CR 508.1b MustAttackPlayer (strict — attack the directed
+    // player when attackable) first, then CR 701.15b goad redirect (avoid this
+    // creature's goader if able), then any valid target ("if able"). Reuses the
+    // engine's single authorities (`creature_must_attack`,
+    // `must_attack_players_for_creature`, `goading_players_for_creature`). Only
+    // needed for 2+ must-attack creatures — the single case is covered above.
+    // Scope: this steers by must-attack *requirements* (CR 508.1d) only. It does
+    // not consult scoped CR 508.1c can't-attack *restrictions*
+    // (CantAttack/CantAttackOrBlock with an attack_target scope, e.g. Eriette),
+    // so a must-attacker that also can't attack the chosen target could still
+    // yield an illegal forced candidate. That over-constraint axis is a
+    // pre-existing gap (independent of goad) and is not addressed here.
+    let forced: Vec<(ObjectId, AttackTarget)> = valid_attacker_ids
+        .iter()
+        .copied()
+        .filter(|&id| crate::game::combat::creature_must_attack(state, id))
+        .filter_map(|id| {
+            let obj = state.objects.get(&id)?;
+            let must_attack_players =
+                crate::game::combat::must_attack_players_for_creature(state, obj);
+            let goaders = crate::game::combat::goading_players_for_creature(state, id);
+            valid_attack_targets
+                .iter()
+                .copied()
+                // CR 508.1b: honor a directed MustAttackPlayer requirement first.
+                .find(|target| {
+                    matches!(target, AttackTarget::Player(pid) if must_attack_players.contains(pid))
+                })
+                // CR 701.15b "if able": otherwise steer away from this creature's
+                // goader.
+                .or_else(|| {
+                    valid_attack_targets.iter().copied().find(|target| match target {
+                        AttackTarget::Player(pid) => !goaders.contains(pid),
+                        _ => true,
+                    })
+                })
+                // Fall back to any valid target when no constraint can be honored.
+                .or_else(|| valid_attack_targets.first().copied())
+                .map(|target| (id, target))
+        })
+        .collect();
+    if forced.len() > 1 {
         actions.push(candidate(
             GameAction::DeclareAttackers {
-                attacks: valid_attacker_ids
-                    .iter()
-                    .copied()
-                    .map(|id| (id, target))
-                    .collect(),
+                attacks: forced,
                 bands: vec![],
             },
             TacticalClass::Attack,
@@ -4303,6 +4385,188 @@ mod tests {
         let actions = candidate_actions(&state);
         assert!(actions.iter().any(|a| matches!(a.action, GameAction::DeclareAttackers { ref attacks, .. } if attacks.is_empty())));
         assert!(actions.iter().any(|a| matches!(a.action, GameAction::DeclareAttackers { ref attacks, .. } if attacks.len() == 2)));
+    }
+
+    /// Regression (hung game — turn 20, 4-player Commander): a goaded creature
+    /// (CR 701.15b) must attack a player *other than* the goader if able. The
+    /// attacker generator previously paired every attacker with only
+    /// `valid_attack_targets.first()`. When that first target is the goading
+    /// player, the sole non-empty candidate (attack the goader) is illegal and
+    /// the empty "no attackers" candidate is illegal (a goaded creature must
+    /// attack) — so the simulation filter dropped every candidate, `legal_actions`
+    /// returned empty, and the AI's combat step hung. The generator must offer
+    /// each attacker against *every* valid target so a legal redirect onto a
+    /// non-goading opponent always survives filtering.
+    #[test]
+    fn declare_attackers_offers_every_target_for_each_attacker() {
+        let attacker = crate::types::identifiers::ObjectId(1);
+        let goader = AttackTarget::Player(PlayerId(1));
+        let other_a = AttackTarget::Player(PlayerId(2));
+        let other_b = AttackTarget::Player(PlayerId(3));
+        let state = GameState {
+            waiting_for: WaitingFor::DeclareAttackers {
+                player: PlayerId(0),
+                valid_attacker_ids: vec![attacker],
+                // The goading player is deliberately first: the pre-fix generator
+                // would only ever offer this single (illegal-under-goad) pairing.
+                valid_attack_targets: vec![goader, other_a, other_b],
+            },
+            ..GameState::new_two_player(42)
+        };
+
+        let actions = candidate_actions(&state);
+        let attacks_against = |t: AttackTarget| {
+            actions.iter().any(|a| {
+                matches!(
+                    &a.action,
+                    GameAction::DeclareAttackers { attacks, .. }
+                        if attacks.len() == 1 && attacks[0] == (attacker, t)
+                )
+            })
+        };
+        // Every target must be offered for the attacker — including the
+        // non-goading opponents a goaded creature is actually allowed to attack.
+        assert!(
+            attacks_against(goader),
+            "goader target must still be offered"
+        );
+        assert!(
+            attacks_against(other_a) && attacks_against(other_b),
+            "non-goading opponents must be offered so goad has a legal redirect"
+        );
+    }
+
+    /// Regression (multi-goad residual): two creatures goaded by *different*
+    /// players force a mixed-target declaration (CR 508.1d requires every
+    /// must-attack creature be declared; CR 701.15b forbids each from attacking
+    /// its own goader). Neither the per-target singles (each omits the other
+    /// must-attacker) nor the shared-target alpha-strikes ever emit that mixed
+    /// assignment, so without the greedy forced-legal candidate the generator
+    /// again produces zero legal declarations and the game hangs. Verify the
+    /// generator now offers the legal mixed assignment.
+    #[test]
+    fn declare_attackers_offers_legal_mixed_assignment_for_multi_goad() {
+        let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 3, 42);
+        state.active_player = PlayerId(0);
+        state.phase = Phase::DeclareAttackers;
+
+        // Two creatures controlled by the active player, each goaded by a
+        // different opponent.
+        let make_goaded = |state: &mut GameState, card: u64, goader: PlayerId| -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(card),
+                PlayerId(0),
+                format!("Goaded {card}"),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.summoning_sick = false;
+            obj.goaded_by.insert(goader);
+            id
+        };
+        let a = make_goaded(&mut state, 1, PlayerId(1));
+        let b = make_goaded(&mut state, 2, PlayerId(2));
+
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![a, b],
+            valid_attack_targets: vec![
+                AttackTarget::Player(PlayerId(1)),
+                AttackTarget::Player(PlayerId(2)),
+            ],
+        };
+
+        let actions = candidate_actions(&state);
+        // The only legal declaration: A avoids its goader P1 (attacks P2), B
+        // avoids its goader P2 (attacks P1). It must be offered.
+        let has_legal_mixed = actions.iter().any(|act| {
+            matches!(&act.action, GameAction::DeclareAttackers { attacks, .. }
+                if attacks.len() == 2
+                    && attacks.contains(&(a, AttackTarget::Player(PlayerId(2))))
+                    && attacks.contains(&(b, AttackTarget::Player(PlayerId(1)))))
+        });
+        assert!(
+            has_legal_mixed,
+            "generator must offer the legal mixed-target assignment for multi-goad"
+        );
+    }
+
+    /// Regression (multi-requirement residual): a creature directed by
+    /// `MustAttackPlayer` (CR 508.1b) alongside a goaded creature (CR 701.15b)
+    /// also forces a mixed-target declaration. The greedy forced-legal candidate
+    /// must steer the directed creature onto its *required* player regardless of
+    /// `valid_attack_targets` ordering. A goad-only target pick would land the
+    /// directed creature on the first non-goading target instead, making the
+    /// forced candidate illegal (filtered) and re-stranding the game. Targets are
+    /// ordered with the required player LAST to catch exactly that ordering bug.
+    #[test]
+    fn declare_attackers_forced_assignment_respects_must_attack_player() {
+        let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 3, 42);
+        state.active_player = PlayerId(0);
+        state.phase = Phase::DeclareAttackers;
+
+        let make_creature = |state: &mut GameState, card: u64| -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(card),
+                PlayerId(0),
+                format!("Creature {card}"),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.summoning_sick = false;
+            id
+        };
+
+        // A is directed to attack P1; B is goaded by P1 (must avoid P1).
+        let directed = make_creature(&mut state, 1);
+        state
+            .objects
+            .get_mut(&directed)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(
+                crate::types::statics::StaticMode::MustAttackPlayer {
+                    player: PlayerId(1),
+                },
+            ));
+        let goaded = make_creature(&mut state, 2);
+        state
+            .objects
+            .get_mut(&goaded)
+            .unwrap()
+            .goaded_by
+            .insert(PlayerId(1));
+
+        // Required/goading player P1 deliberately ordered LAST.
+        state.waiting_for = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![directed, goaded],
+            valid_attack_targets: vec![
+                AttackTarget::Player(PlayerId(2)),
+                AttackTarget::Player(PlayerId(1)),
+            ],
+        };
+
+        let actions = candidate_actions(&state);
+        // Legal declaration: directed -> P1 (required), goaded -> P2 (avoids goader).
+        let has_legal = actions.iter().any(|act| {
+            matches!(&act.action, GameAction::DeclareAttackers { attacks, .. }
+                if attacks.len() == 2
+                    && attacks.contains(&(directed, AttackTarget::Player(PlayerId(1))))
+                    && attacks.contains(&(goaded, AttackTarget::Player(PlayerId(2)))))
+        });
+        assert!(
+            has_legal,
+            "forced assignment must direct the MustAttackPlayer creature to its required player"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1574,7 +1574,15 @@ fn attackable_player_targets(state: &GameState) -> Vec<PlayerId> {
         .collect()
 }
 
-fn must_attack_players_for_creature(state: &GameState, obj: &GameObject) -> Vec<PlayerId> {
+/// CR 508.1b: The players this creature is required to attack directly via a
+/// `StaticMode::MustAttackPlayer` static ("attacks ~ each combat if able"
+/// directed at a specific player). Single authority for the requirement; the
+/// declare-attackers validator enforces it and the AI candidate generator reuses
+/// it to steer a forced-legal assignment toward the required player.
+pub(crate) fn must_attack_players_for_creature(
+    state: &GameState,
+    obj: &GameObject,
+) -> Vec<PlayerId> {
     super::functioning_abilities::active_static_definitions(state, obj)
         .filter_map(|sd| match sd.mode {
             StaticMode::MustAttackPlayer { player } => Some(player),
@@ -2108,7 +2116,15 @@ pub fn declare_attackers(
     declare_attackers_with_bands(state, attacks, &[], events)
 }
 
-fn goading_players_for_creature(state: &GameState, creature_id: ObjectId) -> HashSet<PlayerId> {
+/// CR 701.15b: The set of players that have goaded `creature_id` — both the
+/// per-object `goaded_by` designations and any active `StaticMode::Goaded`
+/// effects affecting it. This is the single authority for "who goaded this
+/// creature"; the AI candidate generator reuses it to build a legal forced
+/// attack assignment that avoids each goaded creature's goader.
+pub(crate) fn goading_players_for_creature(
+    state: &GameState,
+    creature_id: ObjectId,
+) -> HashSet<PlayerId> {
     let mut players = state
         .objects
         .get(&creature_id)


### PR DESCRIPTION
## Problem

A 4-player Commander game hung at turn 20 (reported from a saved game-state). Every `DeclareAttackers` candidate the AI generated was rejected by the simulation-oracle legal filter, leaving an **empty legal-action set** → the game could not advance.

## Root cause

The candidate generator never emits a **mixed-target** attack declaration. When 2+ creatures are goaded by *different* players (or a `MustAttackPlayer` creature sits alongside a goaded one), **CR 508.1d** requires every must-attack creature to be declared, but each must attack a *different* legal target:

- **Singles** omit the other must-attacker → illegal (508.1d).
- **Alpha-strike** forces one *shared* target → illegal for whichever creature is goaded by / directed away from it (CR 701.15b / 508.1b).

With no legal candidate surviving the filter, the action set is empty and the engine hangs.

## Fix

Same bug class, three layers — all reusing the engine's existing combat authorities (no logic reimplemented in `ai_support`):

1. **Single goader** — singles and alpha-strike now enumerate *every* `(attacker, target)` pair instead of one default target.
2. **Multi-goader** — a greedy forced-legal candidate assigns each must-attacker its own legal target. Per-creature requirements are independent (creatures may share a defender), so greedy per-creature picks are provably *jointly* legal — no enumeration needed.
3. **MustAttackPlayer co-occurrence** — target-pick priority mirrors the apply-time validator's enforcement order: **CR 508.1b** directed-attack (strict) → **CR 701.15b** goad redirect → any valid target.

`creature_must_attack`, `must_attack_players_for_creature`, and `goading_players_for_creature` are reused (widened to `pub(crate)`).

## Scope / residual

Scoped **CR 508.1c** can't-attack *restrictions* (Eriette-style "can't attack you") remain a pre-existing over-constraint gap, documented inline. Independent of goad; not addressed here.

## Tests

Three new regression tests:
- single-goader target coverage (every target offered per attacker)
- multi-goad mixed assignment (`{a→P2, b→P1}` offered)
- `MustAttackPlayer` + goad co-occurrence with the required player ordered last (the exact ordering that defeated a goad-only heuristic)

## Verification

Root cause was proven against the real engine via a repro binary (empty legal-action set reproduced from the saved game-state, then closed). Per-CR citations grep-verified against `docs/MagicCompRules.txt`. Static-reviewed across two rounds (APPROVE-WITH-NITS). Full build/test deferred to CI.