### PR TITLE
fix(engine): scope Dromoka's Command prevention to chosen spell; stop modal-sibling fusion

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -3,8 +3,8 @@ use crate::types::ability::{
     CombatRelationSubject, ControllerRef, CounterMoveSelection, Effect, FilterProp,
     GameRestriction, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
     MultiTargetSpec, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef, ResolvedAbility,
-    RestrictionPlayerScope, SpellContext, TargetChoiceTiming, TargetFilter, TargetRef, TypeFilter,
-    TypedFilter,
+    RestrictionPlayerScope, SpellContext, SubAbilityLink, TargetChoiceTiming, TargetFilter,
+    TargetRef, TypeFilter, TypedFilter,
 };
 #[cfg(test)]
 use crate::types::counter::CounterType;
@@ -222,7 +222,14 @@ pub fn build_chained_resolved(
         // CR 700.2d: When chaining multiple modes, append subsequent modes after
         // the current mode's own sub_ability chain (e.g., Cathartic Pyre mode 2's
         // "discard, then draw that many" must preserve the draw sub_ability).
-        if let Some(next_mode) = result {
+        if let Some(mut next_mode) = result {
+            // CR 700.2d + CR 700.2f + CR 608.2c: chained modes are independent
+            // instructions, not continuations. Tag the appended mode root as a
+            // `SequentialSibling` so resolution treats it as its own instruction
+            // (e.g. Dromoka's Command mode 3's `PutCounter` must resolve on its
+            // own target, NOT as a rider of mode 1's prevention shield). Within a
+            // single mode, then/comma sub-steps remain `ContinuationStep`.
+            next_mode.sub_link = SubAbilityLink::SequentialSibling;
             append_to_sub_chain(&mut resolved, next_mode);
         }
         result = Some(resolved);
@@ -1106,6 +1113,14 @@ pub fn validate_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -
                 legal.into_iter().next()
             })
             .collect()
+    } else if let Some(src_leaf) = prevent_damage_source_slot_filter(&validated.effect).cloned() {
+        // CR 608.2b + CR 609.7a: A source-scoped `PreventDamage` carries its
+        // chosen source spell in `targets[0]`. `extract_target_filter_from_effect`
+        // returns `None` for its `Any` recipient, so the generic `None` arm below
+        // would fizzle-filter the spell to battlefield presence and drop it
+        // (the spell lives on the STACK). Re-validate against the source leaf
+        // (`InZone Stack`-aware) instead, preserving the spell target.
+        targeting::validate_targets_for_ability(state, &validated.targets, &src_leaf, &validated)
     } else {
         match triggers::extract_target_filter_from_effect(&validated.effect) {
             Some(filter) if matches!(validated.effect, Effect::PairWith { .. }) => {
@@ -1169,6 +1184,41 @@ pub fn validate_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -
     validated
 }
 
+/// CR 609.7 + CR 601.2c: For a source-scoped `PreventDamage`
+/// ("prevent all damage target instant or sorcery spell would deal this turn"),
+/// surface the choosable source object as a target slot.
+///
+/// The effect's `damage_source_filter` is an `And` pairing a
+/// `ParentTargetSlot { index }` sentinel (which captures the chosen object at
+/// resolution, CR 609.7a) with the choosable `Typed`/stack-spell leaf. The
+/// sentinel cannot be enumerated by `find_legal_targets`, so we return the
+/// SIBLING leaf — the actual "instant or sorcery spell" filter that
+/// `targeting.rs::filter_targets_stack_spells` can enumerate on the stack.
+///
+/// Returns `None` for recipient-scoped or `ChosenDamageSource`/`IsChosenColor`
+/// ("by …" Arachnogenesis) prevents, so those are NOT diverted into a source
+/// target slot.
+fn prevent_damage_source_slot_filter(effect: &Effect) -> Option<&TargetFilter> {
+    let Effect::PreventDamage {
+        damage_source_filter: Some(TargetFilter::And { filters }),
+        ..
+    } = effect
+    else {
+        return None;
+    };
+    // Only an `And` that carries the `ParentTargetSlot` sentinel is a
+    // source-scoped capture; return the sibling choosable leaf.
+    if !filters
+        .iter()
+        .any(|f| matches!(f, TargetFilter::ParentTargetSlot { .. }))
+    {
+        return None;
+    }
+    filters
+        .iter()
+        .find(|f| !matches!(f, TargetFilter::ParentTargetSlot { .. }))
+}
+
 fn collect_target_slots(
     state: &GameState,
     ability: &ResolvedAbility,
@@ -1183,6 +1233,30 @@ fn collect_target_slots(
         if ability.context.additional_cost_paid {
             collect_target_slots(state, sub_ability, acc)?;
             return Ok(());
+        }
+    }
+
+    // CR 609.7 + CR 601.2c: A source-scoped `PreventDamage` ("prevent all damage
+    // target instant or sorcery spell would deal this turn") surfaces the
+    // choosable source spell as a target slot. Declared FIRST (CR 601.2c
+    // declaration order). The generic path below cannot reach it —
+    // `target_filter()` returns the `Any` recipient and short-circuits to `None`
+    // — so we surface it here, mirroring the `CreateDamageReplacement` arm. We
+    // do NOT `return`: the generic recipient logic still runs, but for the
+    // source-scoped form `target == Any` so it adds nothing.
+    if ability.target_choice_timing == TargetChoiceTiming::Stack {
+        if let Some(src_leaf) = prevent_damage_source_slot_filter(&ability.effect) {
+            let legal_targets =
+                legal_targets_for_ability_filter(state, ability, src_leaf, &acc.slots);
+            if legal_targets.is_empty() && !ability.optional_targeting {
+                return Err(EngineError::ActionNotAllowed(
+                    "No legal targets available".to_string(),
+                ));
+            }
+            acc.push(TargetSelectionSlot {
+                legal_targets,
+                optional: ability.optional_targeting,
+            });
         }
     }
 
@@ -2072,6 +2146,21 @@ fn collect_target_slot_specs(
         if ability.context.additional_cost_paid {
             collect_target_slot_specs(state, sub_ability, specs, next_instance);
             return;
+        }
+    }
+
+    // CR 609.7 + CR 601.2c: Mirror the source-scoped `PreventDamage` slot from
+    // `collect_target_slots` one-for-one so per-slot specs line up with the
+    // surfaced TargetSelectionSlots (the choosable source spell, declared first).
+    if ability.target_choice_timing == TargetChoiceTiming::Stack {
+        if let Some(src_leaf) = prevent_damage_source_slot_filter(&ability.effect) {
+            let id = TargetInstanceId(*next_instance);
+            *next_instance += 1;
+            specs.push(TargetSlotSpec {
+                filter: src_leaf.clone(),
+                optional: ability.optional_targeting,
+                instance: id,
+            });
         }
     }
 
@@ -3503,6 +3592,24 @@ fn assign_targets_recursive(
         return Ok(());
     }
 
+    // CR 609.7 + CR 601.2c: Mirror the source-scoped `PreventDamage` slot pushed
+    // by `collect_target_slots`. The chosen source spell is consumed into THIS
+    // node's `targets` (the PreventDamage HEAD node) BEFORE descending into the
+    // sub-chain, so the modal sub (mode 3's PutCounter) consumes its own target
+    // next. Slot order matches `collect_target_slots`: source slot first.
+    if ability.target_choice_timing == TargetChoiceTiming::Stack
+        && prevent_damage_source_slot_filter(&ability.effect).is_some()
+    {
+        if let Some(target) = targets.get(*next_target) {
+            ability.targets.push(target.clone());
+            *next_target += 1;
+        } else if !ability.optional_targeting {
+            return Err(EngineError::InvalidAction(
+                "Missing required target".to_string(),
+            ));
+        }
+    }
+
     // CR 109.4 + CR 115.1: Mirror the companion-player slot pushed by
     // `collect_target_slots` for effects whose filters reference
     // `ControllerRef::TargetPlayer` (DamageAll, PutCounterAll, etc.). The
@@ -3701,6 +3808,30 @@ fn assign_selected_slots_recursive(
             assign_selected_slots_recursive(state, sub_ability, selected_slots, next_slot)?;
         }
         return Ok(());
+    }
+
+    // CR 609.7 + CR 601.2c: Mirror the source-scoped `PreventDamage` slot — the
+    // modal cast pipeline drives the slots path, so the chosen source spell must
+    // be consumed into THIS node's `targets` here too, BEFORE descending into the
+    // (modal) sub-chain. Slot order matches `collect_target_slots`: source first.
+    if ability.target_choice_timing == TargetChoiceTiming::Stack
+        && prevent_damage_source_slot_filter(&ability.effect).is_some()
+    {
+        let Some(selected_slot) = selected_slots.get(*next_slot) else {
+            return Err(EngineError::InvalidAction(
+                "Missing target selection".to_string(),
+            ));
+        };
+        match selected_slot {
+            Some(target) => ability.targets.push(target.clone()),
+            None if ability.optional_targeting => {}
+            None => {
+                return Err(EngineError::InvalidAction(
+                    "Missing required target".to_string(),
+                ));
+            }
+        }
+        *next_slot += 1;
     }
 
     // CR 109.4 + CR 115.1: Mirror the companion-player slot pushed by
@@ -3996,6 +4127,16 @@ fn chain_has_target_sink(ability: &ResolvedAbility) -> bool {
         {
             return true;
         }
+    }
+
+    // CR 609.7 + CR 601.2c: A source-scoped `PreventDamage` head node consumes
+    // the chosen source spell into its own `targets[0]` — `collect_target_slots`
+    // pushes a source slot for it, and `assign_targets_recursive` consumes one
+    // target into this node BEFORE descending into the (modal) sub-chain.
+    if ability.target_choice_timing == TargetChoiceTiming::Stack
+        && prevent_damage_source_slot_filter(&ability.effect).is_some()
+    {
+        return true;
     }
 
     // CR 109.4 + CR 115.1: A node also acts as a target sink when its filter
@@ -8490,6 +8631,112 @@ mod tests {
             )
             .is_err(),
             "DifferentObjectControllers must still reject two P0-controlled objects"
+        );
+    }
+
+    /// CR 609.7 + CR 601.2c: A source-scoped `PreventDamage` ("prevent all
+    /// damage target instant or sorcery spell would deal this turn") surfaces
+    /// exactly one target slot whose legal targets are the spell(s) on the
+    /// stack. Drives the real targeting pipeline — deleting the
+    /// `prevent_damage_source_slot_filter` arm in `collect_target_slots` makes
+    /// this fail.
+    #[test]
+    fn build_target_slots_surfaces_source_scoped_spell_slot() {
+        use crate::types::ability::{PreventionAmount, PreventionScope};
+        use crate::types::game_state::CastingVariant;
+        let mut state = GameState::new_two_player(42);
+        let dromoka = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Dromoka's Command".into(),
+            Zone::Stack,
+        );
+        // An instant spell on the stack — the choosable source.
+        let spell = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Lightning Bolt".into(),
+            Zone::Stack,
+        );
+        state.stack.push_back(crate::types::game_state::StackEntry {
+            id: spell,
+            source_id: spell,
+            controller: PlayerId(1),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(2),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        state.objects.get_mut(&spell).unwrap().card_types.core_types = vec![CoreType::Instant];
+
+        let source_filter = TargetFilter::And {
+            filters: vec![
+                TargetFilter::ParentTargetSlot { index: 0 },
+                TargetFilter::And {
+                    filters: vec![
+                        TargetFilter::StackSpell,
+                        TargetFilter::Typed(TypedFilter::default().with_type(TypeFilter::Instant)),
+                    ],
+                },
+            ],
+        };
+        let ability = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Any,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: Some(source_filter),
+            },
+            vec![],
+            dromoka,
+            PlayerId(0),
+        );
+
+        let slots = build_target_slots(&state, &ability).expect("source slot must build");
+        assert_eq!(slots.len(), 1, "exactly one source-scope slot");
+        assert!(
+            slots[0].legal_targets.contains(&TargetRef::Object(spell)),
+            "the stack spell must be a legal source target, got {:?}",
+            slots[0].legal_targets
+        );
+    }
+
+    /// CR 700.2d + CR 608.2c: Chaining two modes via `build_chained_resolved`
+    /// appends the later mode as the earlier mode's `sub_ability` with
+    /// `sub_link == SequentialSibling` — chained modes are independent
+    /// instructions, not continuations.
+    #[test]
+    fn build_chained_resolved_tags_appended_mode_sequential_sibling() {
+        let mode_a = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        let mode_b = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Controller,
+            },
+        );
+        let abilities = vec![mode_a, mode_b];
+        let chained =
+            build_chained_resolved(&abilities, &[0, 1], ObjectId(1), PlayerId(0)).unwrap();
+        let sub = chained
+            .sub_ability
+            .as_deref()
+            .expect("second mode appended as sub");
+        assert_eq!(
+            sub.sub_link,
+            SubAbilityLink::SequentialSibling,
+            "appended mode root must be tagged SequentialSibling"
         );
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4386,16 +4386,26 @@ fn resolve_chain_body(
         return Ok(());
     }
 
-    // CR 615.5: `PreventDamage` with a chained sub-ability installs the sub
-    // as the shield's `runtime_execute` continuation — it runs once per fired
-    // damage prevention event (Gatta and Luzzu's "prevent that damage and put
-    // that many +1/+1 counters on it"). The outer chain walker must NOT also
-    // resolve the sub-ability inline, or the rider would fire twice (once
-    // immediately when the shield is installed, and again from each
-    // post-replacement continuation). The shield is the single authority for
-    // the rider's execution lifecycle.
-    if matches!(ability.effect, Effect::PreventDamage { .. }) && ability.sub_ability.is_some() {
-        return Ok(());
+    // CR 615.5: `PreventDamage` with a chained `ContinuationStep` sub-ability
+    // installs the sub as the shield's `runtime_execute` continuation — it runs
+    // once per fired damage prevention event (Gatta and Luzzu's "prevent that
+    // damage and put that many +1/+1 counters on it"). The outer chain walker
+    // must NOT also resolve such a sub inline, or the rider would fire twice
+    // (once immediately when the shield is installed, and again from each
+    // post-replacement continuation). The shield is the single authority for the
+    // rider's execution lifecycle.
+    //
+    // CR 700.2d: A `SequentialSibling` sub is an INDEPENDENT instruction (a
+    // separate chosen mode of a modal spell — Dromoka's Command mode 3's
+    // `PutCounter`), not a rider. It is NOT installed as the shield's
+    // `runtime_execute`, so the chain walker must fall through to the generic
+    // sub resolution tail below and resolve it on its own target.
+    if matches!(ability.effect, Effect::PreventDamage { .. }) {
+        if let Some(sub) = ability.sub_ability.as_deref() {
+            if sub.sub_link == SubAbilityLink::ContinuationStep {
+                return Ok(());
+            }
+        }
     }
 
     // Extract moved objects for result forwarding when forward_result is set.

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -2,7 +2,7 @@ use crate::game::quantity::resolve_quantity;
 use crate::types::ability::{
     CombatDamageScope, DamageTargetFilter, DamageTargetPlayerScope, Effect, EffectError,
     EffectKind, FilterProp, PreventionAmount, PreventionScope, ReplacementDefinition,
-    ResolvedAbility, TargetFilter, TargetRef,
+    ResolvedAbility, SubAbilityLink, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
@@ -11,14 +11,46 @@ use crate::types::player::PlayerId;
 use crate::types::replacements::ReplacementEvent;
 use crate::types::zones::Zone;
 
+/// Resolve each child of an `And`/`Or` source filter and drop `StackSpell`
+/// legs (which `resolve_source_filter` maps to `TargetFilter::Any`). A leg that
+/// resolves to a bare `Any` carries no damage-time constraint, so it is pruned
+/// from the conjunction/disjunction — keeping only the `SpecificObject` identity
+/// pin and the typed (instant/sorcery) recheck. See `resolve_source_filter`'s
+/// `StackSpell` arm (CR 609.7a).
+fn resolve_and_prune_stack_spell_legs(
+    filters: &[TargetFilter],
+    state: &GameState,
+    source_id: ObjectId,
+    ability_targets: &[TargetRef],
+) -> Vec<TargetFilter> {
+    filters
+        .iter()
+        .map(|inner| resolve_source_filter(inner, state, source_id, ability_targets))
+        .filter(|f| !matches!(f, TargetFilter::Any))
+        .collect()
+}
+
 /// CR 614.1a: Resolve a damage source filter, replacing dynamic references
-/// (e.g., `IsChosenColor`) with concrete values from the source object's state.
+/// (e.g., `IsChosenColor`, `ParentTargetSlot`) with concrete values from the
+/// source object's state and the ability's chosen targets.
 fn resolve_source_filter(
     filter: &TargetFilter,
     state: &GameState,
     source_id: ObjectId,
+    ability_targets: &[TargetRef],
 ) -> TargetFilter {
     match filter {
+        // CR 609.7a: a cast-time-chosen source object ("target instant or
+        // sorcery spell") is captured into a SpecificObject shield so it
+        // persists after the spell leaves the stack.
+        TargetFilter::ParentTargetSlot { index } => ability_targets
+            .get(*index)
+            .and_then(|t| match t {
+                TargetRef::Object(id) => Some(*id),
+                _ => None,
+            })
+            .map(|id| TargetFilter::SpecificObject { id })
+            .unwrap_or(TargetFilter::None),
         TargetFilter::ChosenDamageSource => state
             .last_chosen_damage_source
             .as_ref()
@@ -27,25 +59,41 @@ fn resolve_source_filter(
                     TargetFilter::SpecificObject {
                         id: choice.source_id,
                     },
-                    resolve_source_filter(&choice.source_filter, state, source_id),
+                    resolve_source_filter(&choice.source_filter, state, source_id, ability_targets),
                 ],
             })
             .unwrap_or(TargetFilter::None),
         TargetFilter::Not { filter: inner } => TargetFilter::Not {
-            filter: Box::new(resolve_source_filter(inner, state, source_id)),
+            filter: Box::new(resolve_source_filter(
+                inner,
+                state,
+                source_id,
+                ability_targets,
+            )),
         },
+        // CR 609.7a: A `StackSpell` leg ("instant or sorcery SPELL") is a
+        // targeting-enumeration predicate (zone presence on the stack), not a
+        // damage-time property recheck. Once the chosen source is pinned by its
+        // `SpecificObject` identity, CR 609.7a applies the shield "even if that
+        // object is no longer in the zone it used to be in" — and the resolving
+        // spell deals its damage while leaving the stack. `matches_target_filter`
+        // never matches `StackSpell` at damage time (it is handled only at
+        // targeting call sites), so the leg is dropped here, leaving the typed
+        // (instant/sorcery) recheck (CR 609.7b) intact.
+        TargetFilter::StackSpell => TargetFilter::Any,
         TargetFilter::Or { filters } => TargetFilter::Or {
-            filters: filters
-                .iter()
-                .map(|inner| resolve_source_filter(inner, state, source_id))
-                .collect(),
+            filters: resolve_and_prune_stack_spell_legs(filters, state, source_id, ability_targets),
         },
-        TargetFilter::And { filters } => TargetFilter::And {
-            filters: filters
-                .iter()
-                .map(|inner| resolve_source_filter(inner, state, source_id))
-                .collect(),
-        },
+        TargetFilter::And { filters } => {
+            let pruned =
+                resolve_and_prune_stack_spell_legs(filters, state, source_id, ability_targets);
+            // An `And` reduced to a single non-trivial leg collapses to that leg.
+            match pruned.len() {
+                0 => TargetFilter::Any,
+                1 => pruned.into_iter().next().unwrap(),
+                _ => TargetFilter::And { filters: pruned },
+            }
+        }
         TargetFilter::Typed(tf) => {
             let has_chosen_ref = tf
                 .properties
@@ -165,6 +213,20 @@ pub fn resolve(
         }
     };
 
+    // CR 609.7 + CR 609.7a: A source-scoped prevent ("prevent all damage target
+    // instant or sorcery spell would deal this turn") carries its chosen source
+    // object in `ability.targets[0]` via a `ParentTargetSlot` sentinel in the
+    // source filter. Those targets are the damage SOURCE, not a recipient — so
+    // the shield must NOT be hosted on them as a recipient object. It routes to
+    // the untargeted branch (pending registry) scoped via `damage_source_filter`.
+    let source_scoped_prevent = matches!(
+        &effect_source_filter,
+        Some(TargetFilter::And { filters })
+            if filters
+                .iter()
+                .any(|f| matches!(f, TargetFilter::ParentTargetSlot { .. }))
+    );
+
     // CR 615.11: A dynamic prevention amount is resolved to a concrete depletion
     // count at effect-resolution time; the Next(n) shield itself is always static.
     let amount = match amount_dynamic {
@@ -186,7 +248,8 @@ pub fn resolve(
     // Filters using IsChosenColor need the chosen color resolved from the source object
     // and converted to a concrete HasColor filter for the shield.
     if let Some(src_filter) = effect_source_filter {
-        let resolved_filter = resolve_source_filter(&src_filter, state, ability.source_id);
+        let resolved_filter =
+            resolve_source_filter(&src_filter, state, ability.source_id, &ability.targets);
         shield = shield.damage_source_filter(resolved_filter);
     }
 
@@ -215,8 +278,16 @@ pub fn resolve(
         }
     }
 
+    // CR 615.5: A `ContinuationStep` rider ("prevent that damage and put that
+    // many +1/+1 counters on it" — Gatta and Luzzu) fires per prevented event,
+    // so it installs as the shield's `runtime_execute`. A `SequentialSibling`
+    // sub is an independent instruction (CR 700.2d — a separate chosen mode of a
+    // modal spell, e.g. Dromoka's Command mode 3), NOT a rider; it is resolved
+    // on its own by the chain walker and must not become the shield rider.
     if let Some(sub_ability) = &ability.sub_ability {
-        shield = shield.runtime_execute(sub_ability.as_ref().clone());
+        if sub_ability.sub_link == SubAbilityLink::ContinuationStep {
+            shield = shield.runtime_execute(sub_ability.as_ref().clone());
+        }
     }
 
     // CR 615: For targeted prevention ("prevent the next N damage to target creature"),
@@ -235,7 +306,8 @@ pub fn resolve(
     // The shield host is the chosen creature in that case, so the targeted
     // branch must also accept `ParentTarget` when `ability.targets` carries the
     // inherited parent targets.
-    let host_on_targets = !ability.targets.is_empty()
+    let host_on_targets = !source_scoped_prevent
+        && !ability.targets.is_empty()
         && (!target.is_context_ref() || matches!(target, TargetFilter::ParentTarget));
     if host_on_targets {
         for selected_target in &ability.targets {
@@ -1123,5 +1195,259 @@ mod tests {
             "shield must NOT land on the source — got {:?}",
             source_obj.replacement_definitions
         );
+    }
+
+    /// CR 609.7a: A source-scoped prevent's `ParentTargetSlot { 0 }` sentinel is
+    /// concretized into a `SpecificObject` shield from the ability's chosen
+    /// target, so the prevention persists after the spell leaves the stack. The
+    /// sibling `Typed` leg survives for the CR 609.7b damage-time recheck.
+    /// Mirrors `chosen_damage_source_resolves_to_specific_source_and_rechecked_filter`.
+    #[test]
+    fn parent_target_slot_resolves_to_specific_chosen_spell() {
+        use crate::types::ability::TypeFilter;
+        let mut state = GameState::new_two_player(42);
+        let spell = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Lightning Bolt".to_string(),
+            Zone::Stack,
+        );
+        let typed_leg =
+            TargetFilter::Typed(TypedFilter::default().with_type(TypeFilter::AnyOf(vec![
+                TypeFilter::Instant,
+                TypeFilter::Sorcery,
+            ])));
+        let source_filter = TargetFilter::And {
+            filters: vec![
+                TargetFilter::ParentTargetSlot { index: 0 },
+                typed_leg.clone(),
+            ],
+        };
+        let resolved = resolve_source_filter(
+            &source_filter,
+            &state,
+            ObjectId(99),
+            &[TargetRef::Object(spell)],
+        );
+        assert_eq!(
+            resolved,
+            TargetFilter::And {
+                filters: vec![TargetFilter::SpecificObject { id: spell }, typed_leg],
+            },
+            "ParentTargetSlot must resolve to the chosen spell's SpecificObject, keeping the Typed leg"
+        );
+    }
+
+    /// CR 609.7 + CR 609.7b: A source-scoped prevent shield is restricted to the
+    /// ONE chosen spell — damage from a different source (a creature trigger, as
+    /// in Shalai and Hallar's "+1/+1 counter → deal damage to opponent") is NOT
+    /// prevented, while damage from the chosen spell IS. This is the
+    /// discriminating regression for the Dromoka's Command infinite loop.
+    #[test]
+    fn source_scoped_shield_only_prevents_chosen_spell_not_other_sources() {
+        use crate::types::ability::TypeFilter;
+        let mut state = GameState::new_two_player(42);
+        // The Dromoka's Command spell on the stack chooses a spell as its source.
+        let dromoka = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Dromoka's Command".to_string(),
+            Zone::Stack,
+        );
+        let chosen_spell = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Banefire".to_string(),
+            Zone::Stack,
+        );
+        state
+            .objects
+            .get_mut(&chosen_spell)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Sorcery);
+        // An unrelated creature source (Shalai) that must NOT be shielded.
+        let creature = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Shalai and Hallar".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let ability = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::Any,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: Some(TargetFilter::And {
+                    filters: vec![
+                        TargetFilter::ParentTargetSlot { index: 0 },
+                        TargetFilter::Typed(TypedFilter::default().with_type(TypeFilter::AnyOf(
+                            vec![TypeFilter::Instant, TypeFilter::Sorcery],
+                        ))),
+                    ],
+                }),
+            },
+            vec![TargetRef::Object(chosen_spell)],
+            dromoka,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // The shield must be a global pending shield (the source instant leaves
+        // the stack), scoped to the chosen spell — NOT hosted on the chosen
+        // spell as a recipient.
+        assert_eq!(
+            state.pending_damage_replacements.len(),
+            1,
+            "source-scoped shield must go to the pending registry"
+        );
+        assert!(
+            state
+                .objects
+                .get(&chosen_spell)
+                .unwrap()
+                .replacement_definitions
+                .is_empty(),
+            "shield must NOT be hosted on the chosen spell as a recipient"
+        );
+        let shield = &state.pending_damage_replacements[0];
+        assert_eq!(
+            shield.damage_source_filter,
+            Some(TargetFilter::And {
+                filters: vec![
+                    TargetFilter::SpecificObject { id: chosen_spell },
+                    TargetFilter::Typed(TypedFilter::default().with_type(TypeFilter::AnyOf(vec![
+                        TypeFilter::Instant,
+                        TypeFilter::Sorcery,
+                    ]))),
+                ],
+            })
+        );
+
+        // Damage from the chosen spell IS prevented.
+        let spell_ctx = deal_damage::DamageContext::from_source(&state, chosen_spell).unwrap();
+        let spell_result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &spell_ctx,
+            TargetRef::Player(PlayerId(0)),
+            5,
+            false,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(spell_result, deal_damage::DamageResult::Applied(0)),
+            "damage from the chosen spell must be prevented"
+        );
+        assert_eq!(state.players[0].life, 20);
+
+        // Damage from the unrelated creature is NOT prevented (no loop).
+        let creature_ctx = deal_damage::DamageContext::from_source(&state, creature).unwrap();
+        let creature_result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &creature_ctx,
+            TargetRef::Player(PlayerId(0)),
+            3,
+            false,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(creature_result, deal_damage::DamageResult::Applied(3)),
+            "damage from a non-chosen source must NOT be prevented"
+        );
+        assert_eq!(state.players[0].life, 17);
+    }
+
+    /// CR 615.5 + CR 700.2d: A `ContinuationStep` rider (Gatta and Luzzu) is
+    /// installed as the shield's `runtime_execute`, but a `SequentialSibling`
+    /// sub (Dromoka's Command mode 3's independent `PutCounter`) is NOT — it is
+    /// an independent instruction resolved by the chain walker, not a rider.
+    #[test]
+    fn sequential_sibling_sub_is_not_installed_as_shield_rider() {
+        use crate::types::ability::QuantityExpr;
+        use crate::types::counter::CounterType;
+
+        fn put_counter_sub(source: ObjectId, link: SubAbilityLink) -> ResolvedAbility {
+            let mut sub = ResolvedAbility::new(
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            );
+            sub.sub_link = link;
+            sub
+        }
+
+        // ContinuationStep rider → installed.
+        {
+            let mut state = GameState::new_two_player(42);
+            let source = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Gatta and Luzzu".into(),
+                Zone::Battlefield,
+            );
+            let ability = make_prevent_ability(
+                source,
+                PreventionAmount::All,
+                PreventionScope::AllDamage,
+                vec![],
+            )
+            .sub_ability(put_counter_sub(source, SubAbilityLink::ContinuationStep));
+            let mut events = Vec::new();
+            resolve(&mut state, &ability, &mut events).unwrap();
+            let shield = &state.objects.get(&source).unwrap().replacement_definitions[0];
+            assert!(
+                shield.runtime_execute.is_some(),
+                "a ContinuationStep rider must install as runtime_execute"
+            );
+        }
+
+        // SequentialSibling sub → NOT installed.
+        {
+            let mut state = GameState::new_two_player(42);
+            let source = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Dromoka's Command".into(),
+                Zone::Battlefield,
+            );
+            let ability = make_prevent_ability(
+                source,
+                PreventionAmount::All,
+                PreventionScope::AllDamage,
+                vec![],
+            )
+            .sub_ability(put_counter_sub(source, SubAbilityLink::SequentialSibling));
+            let mut events = Vec::new();
+            resolve(&mut state, &ability, &mut events).unwrap();
+            let shield = &state.objects.get(&source).unwrap().replacement_definitions[0];
+            assert!(
+                shield.runtime_execute.is_none(),
+                "a SequentialSibling sub must NOT install as runtime_execute"
+            );
+        }
     }
 }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
-use crate::parser::oracle_nom::bridge::{nom_on_lower, nom_parse_lower};
+use crate::parser::oracle_nom::bridge::{nom_on_lower, nom_parse_lower, split_once_on_lower};
 use crate::parser::oracle_nom::primitives as nom_primitives;
 use crate::parser::oracle_static::{
     parse_continuous_modifications, parse_quoted_ability_modifications,
@@ -3341,6 +3341,28 @@ fn parse_prevent_effect(text: &str) -> Effect {
         PreventionAmount::Next(n)
     };
 
+    // CR 609.7 + CR 615.2: prevention scoped to a chosen source (a targeted
+    // spell). "Prevent all damage target instant or sorcery spell would deal
+    // this turn" (Dromoka's Command) restricts the shield to a SINGLE chosen
+    // source object, not a blanket recipient-scoped prevent-all. When this
+    // matches, the recipient `target` collapses to `Any` and the source scope
+    // is carried as the `damage_source_filter`.
+    if let Some(source_filter) = parse_prevent_source_scope(text, &lower) {
+        // CR 609.7a: the source is chosen when the effect is created and applies
+        // even after the spell leaves the stack. The chosen spell lands in
+        // `ability.targets[0]` (the recipient `Any` surfaces no slot), so the
+        // shield captures it via `ParentTargetSlot { index: 0 }`.
+        return Effect::PreventDamage {
+            amount,
+            amount_dynamic: None,
+            target: TargetFilter::Any,
+            scope,
+            damage_source_filter: Some(TargetFilter::And {
+                filters: vec![TargetFilter::ParentTargetSlot { index: 0 }, source_filter],
+            }),
+        };
+    }
+
     // Determine target
     let target = if nom_primitives::scan_contains(rest, "any target") {
         TargetFilter::Any
@@ -3398,6 +3420,65 @@ fn parse_prevent_damage_source_filter(text: &str, lower: &str) -> Option<TargetF
         Some(filter)
     } else {
         None
+    }
+}
+
+/// CR 609.7 + CR 615.2: Detect the source-scoped prevent form — "prevent
+/// [all/the next N] damage **target `<source>`** would deal this turn"
+/// (Dromoka's Command: "Prevent all damage target instant or sorcery spell
+/// would deal this turn").
+///
+/// This is distinct from the recipient form ("...damage **to** target
+/// creature"), which the caller already handles. The disambiguator is the
+/// trailing `" would deal"` clause: a source-scoped prevent names what the
+/// chosen object *deals*, whereas the recipient form names what is dealt *to*
+/// the target. We isolate the region before `" would deal"`, take the source
+/// descriptor after `"target "` (both via the `split_once_on_lower` combinator
+/// bridge — `take_until`+`tag`, never ad-hoc string dispatch), and run
+/// `parse_target` on it. We accept ONLY when the parsed filter resolves to a
+/// choosable stack source (a spell on the stack) — `parse_target` is the
+/// detector.
+///
+/// Returns the parsed `<source>` filter (e.g. an `Or`/`And` of stack-spell
+/// `Typed` legs) on match, or `None` to fall through to the recipient/by-source
+/// logic.
+fn parse_prevent_source_scope(text: &str, lower: &str) -> Option<TargetFilter> {
+    // Isolate the slice that precedes " would deal" (the source phrase region).
+    // `split_once_on_lower` composes `take_until`+`tag` internally and returns
+    // original-case slices, so the borrowed remainder escapes cleanly.
+    let (before_would_deal, _) = split_once_on_lower(text, lower, " would deal")?;
+    // Within that region, the source descriptor follows the "target " keyword.
+    let region_lower = before_would_deal.to_lowercase();
+    let (_, source_descriptor) = split_once_on_lower(before_would_deal, &region_lower, "target ")?;
+    let (source_filter, rem) = parse_target(source_descriptor);
+    // The candidate must consume the entire source descriptor and resolve to a
+    // choosable spell on the stack — otherwise this is not the source-scoped
+    // form (e.g. "target creature" recipient).
+    if rem.trim().is_empty() && filter_is_choosable_stack_source(&source_filter) {
+        Some(source_filter)
+    } else {
+        None
+    }
+}
+
+/// CR 609.7a: A source-scope prevent's chosen source must be a choosable object
+/// on the stack — a spell (`StackSpell`, or a `Typed` filter scoped `InZone
+/// Stack`), possibly wrapped in `And`/`Or`/`Not` (e.g. "instant or sorcery
+/// spell" → `Or` of two stack-spell legs). Mirrors `targeting.rs`'s
+/// `filter_targets_stack_spells`, kept local so the parser stays dependency-free
+/// of the runtime targeting module.
+fn filter_is_choosable_stack_source(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::StackSpell => true,
+        TargetFilter::Typed(tf) => tf
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::InZone { zone } if *zone == Zone::Stack)),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_is_choosable_stack_source)
+        }
+        TargetFilter::Not { filter } => filter_is_choosable_stack_source(filter),
+        _ => false,
     }
 }
 
@@ -11621,6 +11702,79 @@ mod tests {
                 }
             ),
             "expected ScopedPlayer ExileTop, got {each:?}"
+        );
+    }
+
+    /// CR 609.7 + CR 615.2: A source-scoped prevent ("prevent all damage target
+    /// instant or sorcery spell would deal this turn" — Dromoka's Command)
+    /// collapses the recipient `target` to `Any` and carries the chosen source
+    /// as `damage_source_filter = And[ParentTargetSlot{0}, <stack-spell leaf>]`.
+    #[test]
+    fn prevent_source_scoped_spell_yields_parent_target_slot_filter() {
+        let effect = parse_prevent_effect(
+            "Prevent all damage target instant or sorcery spell would deal this turn.",
+        );
+        let Effect::PreventDamage {
+            amount,
+            target,
+            scope,
+            damage_source_filter,
+            ..
+        } = effect
+        else {
+            panic!("expected PreventDamage, got {effect:?}");
+        };
+        assert_eq!(amount, PreventionAmount::All);
+        assert_eq!(target, TargetFilter::Any);
+        assert_eq!(scope, PreventionScope::AllDamage);
+        let Some(TargetFilter::And { filters }) = damage_source_filter else {
+            panic!("expected And source filter, got {damage_source_filter:?}");
+        };
+        // First leg: the cast-time-chosen-source sentinel at slot 0.
+        assert!(
+            filters
+                .iter()
+                .any(|f| matches!(f, TargetFilter::ParentTargetSlot { index: 0 })),
+            "expected ParentTargetSlot {{ index: 0 }} leg, got {filters:?}"
+        );
+        // Sibling leg: the choosable instant-or-sorcery stack-spell filter.
+        let source_leaf = filters
+            .iter()
+            .find(|f| !matches!(f, TargetFilter::ParentTargetSlot { .. }))
+            .expect("source leaf present");
+        assert!(
+            is_stack_spell_leg(source_leaf)
+                || matches!(source_leaf, TargetFilter::Or { filters } if filters.iter().any(is_stack_spell_leg)),
+            "source leaf must scope to a stack spell, got {source_leaf:?}"
+        );
+    }
+
+    /// NEGATIVE: a recipient-scoped prevent ("prevent the next 3 damage to
+    /// target creature") must stay recipient-targeted — `target: Typed(creature)`
+    /// and `damage_source_filter: None` — proving the source-scope branch does
+    /// not divert the recipient form.
+    #[test]
+    fn prevent_recipient_scoped_creature_not_diverted_to_source() {
+        let effect = parse_prevent_effect(
+            "Prevent the next 3 damage that would be dealt to target creature this turn.",
+        );
+        let Effect::PreventDamage {
+            amount,
+            target,
+            damage_source_filter,
+            ..
+        } = effect
+        else {
+            panic!("expected PreventDamage, got {effect:?}");
+        };
+        assert_eq!(amount, PreventionAmount::Next(3));
+        assert!(
+            typed_leg(&target).is_some_and(|tf| has_type(tf, TypeFilter::Creature)),
+            "recipient target must stay Typed(creature), got {target:?}"
+        );
+        assert_eq!(
+            damage_source_filter, None,
+            "recipient prevent must not carry a source filter"
         );
     }
 }

--- a/crates/engine/tests/atarkas_command_sequential_mode_after_decline.rs
+++ b/crates/engine/tests/atarkas_command_sequential_mode_after_decline.rs
@@ -1,0 +1,55 @@
+//! Gap-4 regression: a later chosen modal mode must resolve even when an
+//! EARLIER chosen mode is an optional ("you may") effect that is DECLINED.
+//!
+//! Atarka's Command "Choose two —" with mode 3 ("You may put a land card from
+//! your hand onto the battlefield") and mode 4 ("Creatures you control get
+//! +1/+1 and gain reach until end of turn"). Declining mode 3 must NOT skip
+//! mode 4 — chained modes are independent instructions (CR 700.2d), so the
+//! appended mode root is tagged `SubAbilityLink::SequentialSibling` and the
+//! optional-decline handler resolves it regardless of the decline.
+//!
+//! Before the modal-chaining fix, the appended mode was a `ContinuationStep`
+//! (the default), so a declined optional parent would swallow the following
+//! mode and the pump would never apply.
+//!
+//! CR 700.2d + CR 608.2c + CR 609.3.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const ATARKAS_COMMAND: &str = "Choose two —\n\
+    • Your opponents can't gain life this turn.\n\
+    • Atarka's Command deals 3 damage to each opponent.\n\
+    • You may put a land card from your hand onto the battlefield.\n\
+    • Creatures you control get +1/+1 and gain reach until end of turn.";
+
+#[test]
+fn atarkas_command_pump_mode_resolves_after_declined_optional_land_mode() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0's creature that mode 4 must pump (+1/+1).
+    let creature = scenario.add_creature(P0, "Wild Bear", 2, 2).id();
+    // A land in hand so mode 3's optional put has a legal action to decline.
+    scenario.add_land_to_hand(P0, "Forest");
+
+    let command = scenario
+        .add_spell_to_hand_from_oracle(P0, "Atarka's Command", true, ATARKAS_COMMAND)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Choose modes 3 (optional land — 0-indexed 2) and 4 (pump — 0-indexed 3).
+    // The default ResolutionPolicy declines the optional land put.
+    let outcome = runner.cast(command).modes(&[2, 3]).resolve();
+
+    // DISCRIMINATOR: mode 4 STILL resolves — the creature is pumped to 3/3 —
+    // even though mode 3 (the optional land put) was declined.
+    assert_eq!(
+        outcome.power_toughness(creature),
+        (3, 3),
+        "mode 4 pump (+1/+1) must apply after the declined optional mode 3"
+    );
+}

--- a/crates/engine/tests/dromokas_command_spell_prevention.rs
+++ b/crates/engine/tests/dromokas_command_spell_prevention.rs
@@ -1,0 +1,192 @@
+//! Pipeline regression for **Dromoka's Command** mode 1 + mode 3 — the
+//! source-scoped prevention + independent modal `PutCounter` interaction that
+//! produced an infinite loop (Shalai and Hallar's "+1/+1 counter → deal damage
+//! to opponent" trigger looping when Dromoka's mode-1 prevention shield was
+//! fused as a blanket prevent-all whose rider was mode 3's `PutCounter`).
+//!
+//! Defect A (parser): "Prevent all damage target instant or sorcery spell would
+//! deal this turn" dropped the source scope, producing a blanket prevent-all
+//! shield (`target: Any`, no `damage_source_filter`).
+//!
+//! Defect B (resolver/chaining): mode 3's `PutCounter` was fused as mode 1's
+//! prevention-shield `runtime_execute`, so the shield intercepted every
+//! `DamageDone` event and re-fired the +1/+1 counter — an infinite loop.
+//!
+//! This test drives the REAL cast pipeline: P0 (the active player) casts a
+//! damage instant at itself, holds it on the stack, then casts Dromoka's
+//! Command in response — choosing mode 1 (target the instant) and mode 3 (put a
+//! +1/+1 counter on P0's creature). It asserts:
+//!   * the shield's `damage_source_filter` is `And[SpecificObject, Typed]`
+//!     (source-scoped, not blanket);
+//!   * the +1/+1 counter lands EXACTLY ONCE on the chosen creature (no loop);
+//!   * the prevented spell deals no damage to P0.
+//!
+//! The wrong-source discrimination (a non-chosen source's damage is NOT
+//! prevented) is covered at the resolver level by
+//! `source_scoped_shield_only_prevents_chosen_spell_not_other_sources` in
+//! `prevent_damage.rs`, which can drive the in-crate damage primitive directly.
+//!
+//! CR 609.7 + CR 609.7a + CR 615.2 + CR 700.2d.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::TargetFilter;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DROMOKAS_COMMAND: &str = "Choose two —\n\
+    • Prevent all damage target instant or sorcery spell would deal this turn.\n\
+    • Target player sacrifices an enchantment.\n\
+    • Put a +1/+1 counter on target creature.\n\
+    • Target creature you control fights target creature you don't control.";
+
+/// A simple damage instant: deals 3 damage to a target player. Cast by P0 at
+/// itself; it stays on the stack while Dromoka (cast in response) resolves on
+/// top, so Dromoka's mode 1 can target it as the prevention source.
+const DAMAGE_INSTANT: &str = "This spell deals 3 damage to target player.";
+
+#[test]
+fn dromokas_command_mode_one_source_scoped_prevent_puts_counter_once_no_loop() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0's creature that receives the +1/+1 counter (mode 3).
+    let my_creature = scenario.add_creature(P0, "Shalai and Hallar", 3, 4).id();
+
+    // P0's damage instant aimed at P0 — the prevention source for mode 1.
+    let bolt = scenario
+        .add_spell_to_hand_from_oracle(P0, "Searing Spell", true, DAMAGE_INSTANT)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    // P0's Dromoka's Command.
+    let command = scenario
+        .add_spell_to_hand_from_oracle(P0, "Dromoka's Command", true, DROMOKAS_COMMAND)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+
+    // P0 casts the damage instant at itself and holds it on the stack (P0 is the
+    // active player and retains priority after casting — it then casts Dromoka
+    // in response).
+    let bolt_card = runner.state().objects[&bolt].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: bolt,
+            card_id: bolt_card,
+            targets: vec![],
+        })
+        .expect("casting the damage instant must succeed");
+    // Answer the bolt's single player-target slot, then leave it on the stack.
+    drive_target_then_stop(&mut runner, &[], &[P0]);
+    assert!(
+        runner.state().stack.iter().any(|e| e.id == bolt),
+        "the damage instant must be on the stack as Dromoka's prevention source"
+    );
+
+    // P0 casts Dromoka's Command in response, choosing mode 1 (target the
+    // instant) and mode 3 (put a +1/+1 counter on P0's creature). The
+    // SpellCast driver walks the modal slots in written order: mode-1 source
+    // slot first (the stack spell), then mode-3 creature slot.
+    let outcome = runner
+        .cast(command)
+        .modes(&[0, 2])
+        .target_objects(&[bolt, my_creature])
+        .resolve();
+
+    // The +1/+1 counter must land EXACTLY ONCE — no loop.
+    assert_eq!(
+        outcome.state().objects[&my_creature]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(1),
+        "mode 3 must place exactly one +1/+1 counter (no infinite loop); counters: {:?}",
+        outcome.state().objects[&my_creature].counters
+    );
+
+    // The shield must be source-scoped: `And[SpecificObject, Typed]`, NOT a
+    // blanket prevent-all.
+    let source_scoped = outcome
+        .state()
+        .pending_damage_replacements
+        .iter()
+        .chain(
+            outcome.state().objects[&my_creature]
+                .replacement_definitions
+                .as_slice()
+                .iter(),
+        )
+        .filter_map(|r| r.damage_source_filter.as_ref())
+        .any(|f| {
+            matches!(
+                f,
+                TargetFilter::And { filters }
+                    if filters.iter().any(|x| matches!(x, TargetFilter::SpecificObject { .. }))
+            )
+        });
+    assert!(
+        source_scoped,
+        "the prevention shield must carry an And[SpecificObject, Typed] source filter; \
+         pending: {:?}",
+        outcome.state().pending_damage_replacements
+    );
+
+    // The prevented spell dealt no damage to P0.
+    assert_eq!(
+        outcome.life_delta(P0),
+        0,
+        "the chosen spell's damage to P0 must be fully prevented"
+    );
+
+    // Sanity: the prevented spell left the stack to the graveyard.
+    assert_eq!(outcome.zone_of(bolt), Zone::Graveyard);
+}
+
+/// Drive a just-cast spell through its target-selection slots (answering with
+/// the declared object/player intent), then STOP at the post-cast priority
+/// window, leaving the spell on the stack.
+fn drive_target_then_stop(
+    runner: &mut engine::game::scenario::GameRunner,
+    objects: &[engine::types::identifiers::ObjectId],
+    players: &[engine::types::player::PlayerId],
+) {
+    let mut remaining: Vec<engine::types::identifiers::ObjectId> = objects.to_vec();
+    for _ in 0..32 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let slot = &target_slots[selection.current_slot];
+                let choice = remaining
+                    .iter()
+                    .position(|&o| {
+                        slot.legal_targets
+                            .contains(&engine::types::ability::TargetRef::Object(o))
+                    })
+                    .map(|pos| engine::types::ability::TargetRef::Object(remaining.remove(pos)))
+                    .or_else(|| {
+                        players
+                            .iter()
+                            .find(|&&p| {
+                                slot.legal_targets
+                                    .contains(&engine::types::ability::TargetRef::Player(p))
+                            })
+                            .map(|&p| engine::types::ability::TargetRef::Player(p))
+                    });
+                runner
+                    .act(GameAction::ChooseTarget { target: choice })
+                    .expect("ChooseTarget must be accepted");
+            }
+            WaitingFor::Priority { .. } => return,
+            other => panic!("unexpected waiting state while committing spell: {other:?}"),
+        }
+    }
+    panic!("spell did not commit to the stack after 32 iterations");
+}


### PR DESCRIPTION
Two defects let Shalai and Hallar's '+1/+1 counter -> deal damage to target
opponent' trigger loop forever (each chosen target added a +1/+1 to Shalai
instead of damaging the opponent):

A. Parser dropped the 'instant or sorcery spell' source-scope on Dromoka's
   Command mode 1 ('Prevent all damage target instant or sorcery spell would
   deal this turn'), producing a blanket prevent-ALL-damage shield that
   intercepted every DamageDone event (CR 609.7 / 615.2). Now parsed as a
   source-scoped shield: target=Any + damage_source_filter=And[ParentTargetSlot,
   <chosen stack spell>], resolved to And[SpecificObject{id}, Typed] so it only
   prevents the chosen spell's damage and persists after it leaves the stack
   (CR 609.7a/b).

B. Modal-chain fusion wired mode 3's PutCounter as mode 1's prevention-shield
   runtime_execute, so the blanket shield put a +1/+1 on Shalai on every
   intercept. Chained modal modes are now tagged SubAbilityLink::SequentialSibling
   (CR 700.2d/700.2f/608.2c); the PreventDamage rider carve-outs only fire for a
   genuine ContinuationStep sub (CR 615.5), so independent modes resolve on their
   own and a declined optional earlier mode no longer skips a later chosen mode.

Adds discriminating pipeline tests (Dromoka loop-fix, Atarka optional-decline).
