### PR TITLE
feat: multiplayer ROI enforcement, replay viewer, sealed limited, parser coverage

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,12 @@ const DraftPodPage = lazy(() => import("./pages/DraftPodPage").then((m) => ({ de
 const DraftSpectatorPage = lazy(() =>
   import("./pages/DraftSpectatorPage").then((m) => ({ default: m.DraftSpectatorPage })),
 );
+const ReplayPage = lazy(() =>
+  import("./pages/ReplayPage").then((m) => ({ default: m.ReplayPage })),
+);
+const SealedPage = lazy(() =>
+  import("./pages/SealedPage").then((m) => ({ default: m.SealedPage })),
+);
 
 function DevStrict({ children }: { children: ReactNode }) {
   if (!import.meta.env.DEV) return children;
@@ -116,6 +122,8 @@ function AppContent() {
             <Route path="/draft-spectator" element={<DraftSpectatorPage />} />
           </Route>
           <Route path="/game/:id" element={<GameRouteElement />} />
+          <Route path="/replay/:gameId" element={<DevStrict><ReplayPage /></DevStrict>} />
+          <Route path="/sealed" element={<DevStrict><SealedPage /></DevStrict>} />
         </Routes>
       </Suspense>
       <HostControlTile />

--- a/client/src/components/replay/ReplayBattlefield.tsx
+++ b/client/src/components/replay/ReplayBattlefield.tsx
@@ -1,0 +1,92 @@
+import type { GameState, GameObject, PlayerId } from "../../adapter/types.ts";
+
+interface ReplayBattlefieldProps {
+  state: GameState;
+  playerId: PlayerId;
+  label: string;
+}
+
+function CardChip({ obj }: { obj: GameObject }) {
+  const isCreature = obj.card_types?.core_types?.includes("Creature");
+  const hasCounters = Object.keys(obj.counters ?? {}).length > 0;
+  const counterText = hasCounters
+    ? ` [${Object.entries(obj.counters)
+        .map(([k, v]) => `${v}${k.charAt(0)}`)
+        .join(",")}]`
+    : "";
+
+  return (
+    <div
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs border ${
+        obj.tapped
+          ? "border-[#555] bg-[#1a1a1a] text-[#888] italic"
+          : "border-[#444] bg-[#222] text-[#ddd]"
+      }`}
+      title={obj.name}
+    >
+      {obj.tapped && <span className="text-[#666]">↻</span>}
+      <span className="truncate max-w-[120px]">{obj.name}</span>
+      {isCreature && obj.power !== null && obj.toughness !== null && (
+        <span className="text-[#aaa] shrink-0">
+          {obj.power}/{obj.toughness}
+        </span>
+      )}
+      {hasCounters && (
+        <span className="text-yellow-400 shrink-0">{counterText}</span>
+      )}
+    </div>
+  );
+}
+
+export function ReplayBattlefield({ state, playerId, label }: ReplayBattlefieldProps) {
+  const objects = state.battlefield
+    .map((id) => state.objects[id])
+    .filter((obj) => obj && obj.controller === playerId);
+
+  const creatures = objects.filter((obj) =>
+    obj.card_types?.core_types?.includes("Creature"),
+  );
+  const lands = objects.filter((obj) =>
+    obj.card_types?.core_types?.includes("Land"),
+  );
+  const others = objects.filter(
+    (obj) =>
+      !obj.card_types?.core_types?.includes("Creature") &&
+      !obj.card_types?.core_types?.includes("Land"),
+  );
+
+  if (objects.length === 0) {
+    return (
+      <div className="px-2 py-1 text-xs text-[#555] italic">
+        {label}: empty battlefield
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1 px-2">
+      <span className="text-[10px] text-[#666] uppercase tracking-wide">{label}</span>
+      {creatures.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {creatures.map((obj) => (
+            <CardChip key={obj.id} obj={obj} />
+          ))}
+        </div>
+      )}
+      {others.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {others.map((obj) => (
+            <CardChip key={obj.id} obj={obj} />
+          ))}
+        </div>
+      )}
+      {lands.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {lands.map((obj) => (
+            <CardChip key={obj.id} obj={obj} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/replay/ReplayControls.tsx
+++ b/client/src/components/replay/ReplayControls.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef } from "react";
+
+interface ReplayControlsProps {
+  currentIndex: number;
+  total: number;
+  isPlaying: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onSeek: (index: number) => void;
+  onPlayPause: () => void;
+}
+
+export function ReplayControls({
+  currentIndex,
+  total,
+  isPlaying,
+  onPrev,
+  onNext,
+  onSeek,
+  onPlayPause,
+}: ReplayControlsProps) {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isPlaying) {
+      intervalRef.current = setInterval(() => {
+        onNext();
+      }, 2000);
+    } else {
+      clearTimer();
+    }
+    return clearTimer;
+  }, [isPlaying, onNext, clearTimer]);
+
+  const btnBase =
+    "px-3 py-1.5 rounded text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed";
+
+  return (
+    <div className="flex flex-col gap-2 bg-[#1a1a1a] border border-[#333] rounded-lg p-3">
+      {/* Scrubber */}
+      <div className="flex items-center gap-2 text-xs text-[#aaa]">
+        <span className="w-16 text-right">Turn {currentIndex + 1}</span>
+        <input
+          type="range"
+          min={0}
+          max={Math.max(0, total - 1)}
+          value={currentIndex}
+          onChange={(e) => onSeek(Number(e.target.value))}
+          className="flex-1 accent-[#8b5cf6] cursor-pointer"
+        />
+        <span className="w-16">of {total}</span>
+      </div>
+
+      {/* Buttons */}
+      <div className="flex items-center justify-center gap-2">
+        <button
+          className={`${btnBase} bg-[#2a2a2a] hover:bg-[#3a3a3a] text-white`}
+          onClick={onPrev}
+          disabled={currentIndex === 0}
+          aria-label="Previous turn"
+        >
+          ← Prev
+        </button>
+
+        <button
+          className={`${btnBase} ${isPlaying ? "bg-[#7c3aed] hover:bg-[#6d28d9]" : "bg-[#4c1d95] hover:bg-[#5b21b6]"} text-white min-w-[80px]`}
+          onClick={onPlayPause}
+          aria-label={isPlaying ? "Pause replay" : "Play replay"}
+        >
+          {isPlaying ? "⏸ Pause" : "▶ Play"}
+        </button>
+
+        <button
+          className={`${btnBase} bg-[#2a2a2a] hover:bg-[#3a3a3a] text-white`}
+          onClick={onNext}
+          disabled={currentIndex >= total - 1}
+          aria-label="Next turn"
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/replay/ReplayPlayerPanel.tsx
+++ b/client/src/components/replay/ReplayPlayerPanel.tsx
@@ -1,0 +1,101 @@
+import type { GameState, Player, PlayerId } from "../../adapter/types.ts";
+
+interface ReplayPlayerPanelProps {
+  player: Player;
+  activePlayerId: PlayerId;
+  state: GameState;
+  side: "top" | "bottom";
+}
+
+export function ReplayPlayerPanel({
+  player,
+  activePlayerId,
+  state,
+  side,
+}: ReplayPlayerPanelProps) {
+  const isActive = player.id === state.active_player;
+  const isViewer = player.id === activePlayerId;
+  const label = isViewer ? "You" : `Player ${player.id + 1}`;
+
+  const battlefieldCards = state.battlefield
+    .map((id) => state.objects[id])
+    .filter((obj) => obj && obj.controller === player.id);
+
+  const creatureCount = battlefieldCards.filter((obj) =>
+    obj.card_types?.core_types?.includes("Creature"),
+  ).length;
+  const nonCreatureCount = battlefieldCards.length - creatureCount;
+
+  const lifeColor =
+    player.life <= 5
+      ? "text-red-400"
+      : player.life <= 10
+        ? "text-orange-400"
+        : "text-green-400";
+
+  return (
+    <div
+      className={`flex items-center gap-4 px-4 py-2 rounded-lg border ${
+        isActive ? "border-[#8b5cf6] bg-[#1e1a2e]" : "border-[#333] bg-[#1a1a1a]"
+      }`}
+    >
+      {/* Identity */}
+      <div className="flex flex-col min-w-[80px]">
+        <span className="text-xs text-[#888]">{side === "top" ? "↑" : "↓"} {label}</span>
+        {isActive && (
+          <span className="text-[10px] text-[#8b5cf6] font-medium">Active</span>
+        )}
+      </div>
+
+      {/* Life */}
+      <div className="flex flex-col items-center">
+        <span className={`text-2xl font-bold ${lifeColor}`}>{player.life}</span>
+        <span className="text-[10px] text-[#666]">Life</span>
+      </div>
+
+      {/* Zone counts */}
+      <div className="flex gap-3 text-xs text-[#aaa]">
+        <div className="flex flex-col items-center">
+          <span className="text-white font-medium">{player.hand.length}</span>
+          <span className="text-[#666]">Hand</span>
+        </div>
+        <div className="flex flex-col items-center">
+          <span className="text-white font-medium">{player.library.length}</span>
+          <span className="text-[#666]">Library</span>
+        </div>
+        <div className="flex flex-col items-center">
+          <span className="text-white font-medium">{player.graveyard.length}</span>
+          <span className="text-[#666]">GY</span>
+        </div>
+      </div>
+
+      {/* Battlefield summary */}
+      <div className="flex gap-2 text-xs text-[#aaa]">
+        <div className="flex flex-col items-center">
+          <span className="text-white font-medium">{creatureCount}</span>
+          <span className="text-[#666]">Creatures</span>
+        </div>
+        <div className="flex flex-col items-center">
+          <span className="text-white font-medium">{nonCreatureCount}</span>
+          <span className="text-[#666]">Other</span>
+        </div>
+      </div>
+
+      {/* Poison */}
+      {player.poison_counters > 0 && (
+        <div className="flex flex-col items-center text-xs">
+          <span className="text-yellow-400 font-medium">{player.poison_counters}</span>
+          <span className="text-[#666]">Poison</span>
+        </div>
+      )}
+
+      {/* Energy */}
+      {(player.energy ?? 0) > 0 && (
+        <div className="flex flex-col items-center text-xs">
+          <span className="text-cyan-400 font-medium">⚡{player.energy}</span>
+          <span className="text-[#666]">Energy</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/DraftLandingPage.tsx
+++ b/client/src/pages/DraftLandingPage.tsx
@@ -121,6 +121,15 @@ export function DraftLandingPage() {
                 renderIcon={(cls) => <PodIcon className={cls} />}
                 onClick={() => navigate("/draft-pod")}
               />
+              <MenuActionTile
+                tone="arcane"
+                motif="pack"
+                title="Sealed Deck"
+                description="Open 6 packs and build a 40-card deck"
+                enterLabel={tMenu("home.dashboard.enter")}
+                renderIcon={(cls) => <BotIcon className={cls} />}
+                onClick={() => navigate("/sealed")}
+              />
             </div>
           </div>
         </div>

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -2400,6 +2400,18 @@ function GameOverScreen({
                 >
                   {t("gamePage.gameOver.rematch")}
                 </button>
+                {gameId && (
+                  <button
+                    onClick={() => navigate(`/replay/${gameId}`)}
+                    className={gameButtonClass({
+                      tone: "slate",
+                      size: "lg",
+                      className: "w-full justify-center sm:w-auto sm:min-w-[12rem]",
+                    })}
+                  >
+                    Watch Replay
+                  </button>
+                )}
               </>
             )}
           </motion.div>

--- a/client/src/pages/ReplayPage.tsx
+++ b/client/src/pages/ReplayPage.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+
+import type { GameState } from "../adapter/types.ts";
+import { ReplayBattlefield } from "../components/replay/ReplayBattlefield.tsx";
+import { ReplayControls } from "../components/replay/ReplayControls.tsx";
+import { ReplayPlayerPanel } from "../components/replay/ReplayPlayerPanel.tsx";
+import { loadCheckpoints } from "../stores/gameStore.ts";
+
+const PHASE_LABEL: Record<string, string> = {
+  Untap: "Untap",
+  Upkeep: "Upkeep",
+  Draw: "Draw",
+  PreCombatMain: "Main Phase 1",
+  BeginCombat: "Begin Combat",
+  DeclareAttackers: "Declare Attackers",
+  DeclareBlockers: "Declare Blockers",
+  CombatDamage: "Combat Damage",
+  EndCombat: "End Combat",
+  PostCombatMain: "Main Phase 2",
+  End: "End Step",
+  Cleanup: "Cleanup",
+};
+
+function phaseLabel(phase: string): string {
+  return PHASE_LABEL[phase] ?? phase;
+}
+
+interface ReplayBoardProps {
+  state: GameState;
+  viewerPlayerId: number;
+}
+
+function ReplayBoard({ state, viewerPlayerId }: ReplayBoardProps) {
+  const players = state.players;
+  // viewer at bottom, opponent(s) at top
+  const viewer = players.find((p) => p.id === viewerPlayerId) ?? players[0];
+  const opponents = players.filter((p) => p.id !== viewer.id);
+
+  return (
+    <div className="flex flex-col gap-3 flex-1">
+      {/* Opponents */}
+      {opponents.map((opp) => (
+        <div key={opp.id} className="flex flex-col gap-1">
+          <ReplayPlayerPanel
+            player={opp}
+            activePlayerId={viewerPlayerId}
+            state={state}
+            side="top"
+          />
+          <ReplayBattlefield
+            state={state}
+            playerId={opp.id}
+            label={`P${opp.id + 1} battlefield`}
+          />
+        </div>
+      ))}
+
+      {/* Phase indicator */}
+      <div className="flex items-center justify-center gap-3 py-2 border-y border-[#333] text-sm">
+        <span className="text-[#888]">Turn {state.turn_number}</span>
+        <span className="text-[#555]">·</span>
+        <span className="text-[#aaa]">
+          Active: <span className="text-white">P{state.active_player + 1}</span>
+        </span>
+        <span className="text-[#555]">·</span>
+        <span className="text-[#8b5cf6]">{phaseLabel(state.phase)}</span>
+      </div>
+
+      {/* Viewer */}
+      <div className="flex flex-col gap-1">
+        <ReplayBattlefield
+          state={state}
+          playerId={viewer.id}
+          label="Your battlefield"
+        />
+        <ReplayPlayerPanel
+          player={viewer}
+          activePlayerId={viewerPlayerId}
+          state={state}
+          side="bottom"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ReplayPage() {
+  const { gameId } = useParams<{ gameId: string }>();
+  const navigate = useNavigate();
+
+  const [checkpoints, setCheckpoints] = useState<GameState[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!gameId) {
+      setError("No game ID specified.");
+      setLoading(false);
+      return;
+    }
+    loadCheckpoints(gameId)
+      .then((cps) => {
+        if (cps.length === 0) {
+          setError("No replay data found for this game.");
+        } else {
+          setCheckpoints(cps);
+          setCurrentIndex(0);
+        }
+      })
+      .catch(() => setError("Failed to load replay data."))
+      .finally(() => setLoading(false));
+  }, [gameId]);
+
+  const handlePrev = useCallback(() => {
+    setCurrentIndex((i) => Math.max(0, i - 1));
+    setIsPlaying(false);
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setCurrentIndex((i) => {
+      const next = i + 1;
+      if (next >= checkpoints.length) {
+        setIsPlaying(false);
+        return i;
+      }
+      return next;
+    });
+  }, [checkpoints.length]);
+
+  const handleSeek = useCallback((index: number) => {
+    setCurrentIndex(index);
+    setIsPlaying(false);
+  }, []);
+
+  const handlePlayPause = useCallback(() => {
+    if (currentIndex >= checkpoints.length - 1) {
+      // Restart from beginning
+      setCurrentIndex(0);
+      setIsPlaying(true);
+    } else {
+      setIsPlaying((p) => !p);
+    }
+  }, [currentIndex, checkpoints.length]);
+
+  const current = checkpoints[currentIndex];
+
+  return (
+    <div className="min-h-screen bg-[#111] text-white flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#333] bg-[#161616]">
+        <button
+          onClick={() => navigate(-1)}
+          className="text-sm text-[#888] hover:text-white transition-colors"
+        >
+          ← Back
+        </button>
+        <h1 className="text-base font-semibold text-[#ddd]">
+          Game Replay{gameId ? ` · ${gameId.slice(0, 8)}…` : ""}
+        </h1>
+        <div className="w-16" />
+      </div>
+
+      <div className="flex-1 flex flex-col gap-4 p-4 max-w-3xl mx-auto w-full">
+        {loading && (
+          <div className="flex-1 flex items-center justify-center text-[#888]">
+            Loading replay…
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="flex-1 flex flex-col items-center justify-center gap-4">
+            <p className="text-red-400">{error}</p>
+            <button
+              onClick={() => navigate("/")}
+              className="px-4 py-2 bg-[#2a2a2a] rounded text-sm hover:bg-[#3a3a3a]"
+            >
+              Go Home
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && current && (
+          <>
+            <ReplayControls
+              currentIndex={currentIndex}
+              total={checkpoints.length}
+              isPlaying={isPlaying}
+              onPrev={handlePrev}
+              onNext={handleNext}
+              onSeek={handleSeek}
+              onPlayPause={handlePlayPause}
+            />
+            <ReplayBoard
+              state={current}
+              viewerPlayerId={current.players[0]?.id ?? 0}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/SealedPage.tsx
+++ b/client/src/pages/SealedPage.tsx
@@ -1,0 +1,214 @@
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router";
+
+import type { DraftCardInstance, DraftPlayerView } from "../adapter/draft-adapter.ts";
+import { DraftAdapter } from "../adapter/draft-adapter.ts";
+import { LimitedDeckBuilder } from "../components/draft/LimitedDeckBuilder.tsx";
+import { SetSelector } from "../components/draft/SetSelector.tsx";
+import { useDraftStore } from "../stores/draftStore.ts";
+import { useGameStore } from "../stores/gameStore.ts";
+
+type SealedPhase = "setup" | "generating" | "deckbuilding" | "launching";
+
+// A sealed pool is 6 packs × 15 cards ≈ 90 cards.
+// One quick draft session gives 3 packs × 15 = 45 cards, so we run two back-to-back
+// and combine their pools.
+const SEALED_SESSIONS = 2;
+
+async function buildSealedPool(
+  setPoolJson: string,
+  onProgress: (picked: number, total: number) => void,
+): Promise<DraftPlayerView> {
+  let combinedPool: DraftCardInstance[] = [];
+  let lastView: DraftPlayerView | null = null;
+
+  for (let session = 0; session < SEALED_SESSIONS; session++) {
+    const adapter = new DraftAdapter();
+    const seed = Math.floor(Math.random() * 0xffffffff);
+    let view = await adapter.initialize(setPoolJson, /* difficulty= */ 0, seed);
+
+    // Auto-pick every card until all packs in this session are exhausted.
+    while (view.status === "Drafting" && view.current_pack !== null) {
+      const pickedSoFar = session * 45 + view.pool.length;
+      onProgress(pickedSoFar, SEALED_SESSIONS * 45);
+      view = await adapter.autoPick();
+    }
+
+    combinedPool = [...combinedPool, ...view.pool];
+    lastView = view;
+  }
+
+  if (!lastView) throw new Error("No draft sessions completed");
+
+  return {
+    ...lastView,
+    status: "Deckbuilding",
+    current_pack: null,
+    pool: combinedPool,
+  };
+}
+
+function ProgressBar({ picked, total }: { picked: number; total: number }) {
+  const pct = total > 0 ? Math.min(100, Math.round((picked / total) * 100)) : 0;
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <p className="text-[#aaa] text-sm">Opening packs…</p>
+      <div className="w-64 h-2 bg-[#333] rounded-full overflow-hidden">
+        <div
+          className="h-full bg-[#8b5cf6] transition-all duration-200 rounded-full"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-xs text-[#666]">{picked} / {total} cards</p>
+    </div>
+  );
+}
+
+export function SealedPage() {
+  const navigate = useNavigate();
+  const [phase, setPhase] = useState<SealedPhase>("setup");
+  const [sealedView, setSealedView] = useState<DraftPlayerView | null>(null);
+  const [progress, setProgress] = useState({ picked: 0, total: SEALED_SESSIONS * 45 });
+  const [error, setError] = useState<string | null>(null);
+
+  const handleStartSealed = useCallback(
+    async (setCode: string, setName: string) => {
+      setPhase("generating");
+      setError(null);
+
+      let setPoolJson: string;
+      try {
+        const resp = await fetch(__DRAFT_POOLS_URL__);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const allPools: Record<string, unknown> = await resp.json();
+        const setPool =
+          allPools[setCode.toLowerCase()] ?? allPools[setCode.toUpperCase()];
+        if (!setPool) throw new Error(`No pool data for ${setCode}`);
+        setPoolJson = JSON.stringify(setPool);
+      } catch (err) {
+        setError(`Failed to load set pool: ${String(err)}`);
+        setPhase("setup");
+        return;
+      }
+
+      try {
+        const finalView = await buildSealedPool(setPoolJson, (picked, total) => {
+          setProgress({ picked, total });
+        });
+
+        // Seed the draft store so LimitedDeckBuilder can manage mainDeck/landCounts
+        // using its normal store-connected flow.
+        useDraftStore.setState({
+          view: finalView,
+          phase: "deckbuilding",
+          mainDeck: [],
+          landCounts: {},
+          selectedSet: setCode,
+          selectedSetName: setName,
+          draftId: crypto.randomUUID(),
+        });
+
+        setSealedView(finalView);
+        setPhase("deckbuilding");
+      } catch (err) {
+        setError(`Failed to generate sealed pool: ${String(err)}`);
+        setPhase("setup");
+      }
+    },
+    [],
+  );
+
+  const handleSubmitDeck = useCallback(async () => {
+    setPhase("launching");
+    try {
+      const { mainDeck, landCounts } = useDraftStore.getState();
+
+      const landCards = Object.entries(landCounts).flatMap(([name, count]) =>
+        Array<string>(count as number).fill(name),
+      );
+      const fullDeck = [...mainDeck, ...landCards];
+
+      if (fullDeck.length < 40) {
+        alert(`Your deck needs at least 40 cards (currently ${fullDeck.length}).`);
+        setPhase("deckbuilding");
+        return;
+      }
+
+      const gameId = crypto.randomUUID();
+
+      // Store the sealed deck under a well-known key for the game adapter.
+      sessionStorage.setItem(
+        `sealed-deck:${gameId}`,
+        JSON.stringify(fullDeck),
+      );
+
+      useGameStore.setState({ gameId });
+      navigate(
+        `/game/${gameId}?mode=ai&difficulty=Medium&format=Limited&match=bo1&source=sealed`,
+      );
+    } catch (err) {
+      setError(`Failed to launch game: ${String(err)}`);
+      setPhase("deckbuilding");
+    }
+  }, [navigate]);
+
+  return (
+    <div className="min-h-screen bg-[#111] text-white flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[#333] bg-[#161616]">
+        <button
+          onClick={() => navigate(-1)}
+          className="text-sm text-[#888] hover:text-white transition-colors"
+        >
+          ← Back
+        </button>
+        <h1 className="text-base font-semibold text-[#ddd]">Sealed Deck</h1>
+        <div className="w-16" />
+      </div>
+
+      <div className="flex-1 flex flex-col">
+        {phase === "setup" && (
+          <div className="flex-1 flex flex-col items-center justify-center p-4 gap-4">
+            <div className="text-center mb-4">
+              <h2 className="text-xl font-bold text-white mb-1">Build a Sealed Pool</h2>
+              <p className="text-sm text-[#888]">
+                Open {SEALED_SESSIONS * 3} packs (~{SEALED_SESSIONS * 45} cards) and build a 40-card deck.
+              </p>
+            </div>
+            {error && (
+              <p className="text-red-400 text-sm text-center max-w-sm">{error}</p>
+            )}
+            <SetSelector onStartDraft={handleStartSealed} />
+          </div>
+        )}
+
+        {phase === "generating" && (
+          <div className="flex-1 flex items-center justify-center">
+            <ProgressBar picked={progress.picked} total={progress.total} />
+          </div>
+        )}
+
+        {phase === "deckbuilding" && sealedView && (
+          <div className="flex-1 flex flex-col">
+            <div className="px-4 py-2 bg-[#1a1a1a] border-b border-[#333] text-xs text-[#888]">
+              Sealed Pool · {sealedView.pool.length} cards · Build a 40-card deck
+            </div>
+            <LimitedDeckBuilder
+              view={sealedView}
+              onSubmitDeck={handleSubmitDeck}
+            />
+            {error && (
+              <p className="p-3 text-red-400 text-xs">{error}</p>
+            )}
+          </div>
+        )}
+
+        {phase === "launching" && (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-[#aaa]">Launching game…</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -2908,20 +2908,23 @@ pub fn get_valid_attack_targets(state: &GameState) -> Vec<AttackTarget> {
         super::static_abilities::player_has_protection_from_everything(state, pid)
     };
 
-    // All non-eliminated, phased-in opponents (excluding teammates)
+    // All non-eliminated, phased-in opponents within range of influence
     for player in &state.players {
         if player.id != active
             && !state.eliminated_players.contains(&player.id)
             && !allies.contains(&player.id)
             && player.is_phased_in()
             && !protected(player.id)
+            // CR 801.3c + CR 801.4: In limited-range formats, the active player
+            // can only attack players within their range of influence.
+            && super::players::within_range_of_influence(state, active, player.id)
         {
             targets.push(AttackTarget::Player(player.id));
         }
     }
 
-    // All planeswalkers controlled by opponents (excluding teammates' and
-    // controllers that are phased out)
+    // All planeswalkers controlled by opponents within range (excluding teammates'
+    // and controllers that are phased out)
     for &id in &state.battlefield {
         if let Some(obj) = state.objects.get(&id) {
             if obj.controller != active
@@ -2932,6 +2935,8 @@ pub fn get_valid_attack_targets(state: &GameState) -> Vec<AttackTarget> {
                     .contains(&crate::types::card_type::CoreType::Planeswalker)
                 && !state.eliminated_players.contains(&obj.controller)
                 && !phased_out(obj.controller)
+                // CR 801.4: Planeswalkers belong to their controller's influence zone.
+                && super::players::within_range_of_influence(state, active, obj.controller)
             {
                 targets.push(AttackTarget::Planeswalker(id));
             }
@@ -2964,6 +2969,10 @@ pub fn get_valid_attack_targets(state: &GameState) -> Vec<AttackTarget> {
             // If the protector is phased out, the battle itself can't be
             // attacked (the protector "doesn't exist" for combat routing).
             if phased_out(protector) {
+                continue;
+            }
+            // CR 801.4: Battle protector must be within active player's range of influence.
+            if !super::players::within_range_of_influence(state, active, protector) {
                 continue;
             }
             targets.push(AttackTarget::Battle(id));

--- a/crates/engine/src/game/players.rs
+++ b/crates/engine/src/game/players.rs
@@ -282,6 +282,44 @@ fn team_index(player: PlayerId) -> u8 {
     player.0 / 2
 }
 
+/// CR 801.2: Minimum seat distance from `from` to `to` measured in seat
+/// positions around the ring in either direction (i.e., the shorter arc).
+///
+/// Returns 0 when `from == to`. Returns 0 for degenerate rings of ≤ 1 seat.
+pub fn seat_distance(state: &GameState, from: PlayerId, to: PlayerId) -> usize {
+    if from == to {
+        return 0;
+    }
+    let seat_order = &state.seat_order;
+    let n = seat_order.len();
+    if n <= 1 {
+        return 0;
+    }
+    let from_idx = seat_order.iter().position(|&id| id == from).unwrap_or(0);
+    let to_idx = seat_order.iter().position(|&id| id == to).unwrap_or(0);
+    // Forward distance (from → to in seat order)
+    let forward = (to_idx + n - from_idx) % n;
+    // Backward distance (from → to against seat order)
+    let backward = n - forward;
+    forward.min(backward)
+}
+
+/// CR 801.2 + CR 801.4: Returns true when `target` is within the format's
+/// range of influence from `caster`.
+///
+/// When the format has no range limit (`range_of_influence` is `None`), every
+/// living player is always within range.  When a limit is set, `target` must
+/// be within that many seat positions of `caster` (inclusive) in either
+/// direction around the seat ring.
+///
+/// A player is always within their own range (distance 0).
+pub fn within_range_of_influence(state: &GameState, caster: PlayerId, target: PlayerId) -> bool {
+    let Some(roi) = state.format_config.range_of_influence else {
+        return true;
+    };
+    seat_distance(state, caster, target) <= roi as usize
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -605,5 +643,62 @@ mod tests {
         let mut state = make_state(4, FormatConfig::two_headed_giant());
         eliminate(&mut state, PlayerId(1));
         assert!(teammates(&state, PlayerId(0)).is_empty());
+    }
+
+    // --- seat_distance ---
+
+    #[test]
+    fn seat_distance_same_player_is_zero() {
+        let state = make_state(4, FormatConfig::free_for_all());
+        assert_eq!(seat_distance(&state, PlayerId(0), PlayerId(0)), 0);
+    }
+
+    #[test]
+    fn seat_distance_adjacent_forward() {
+        let state = make_state(4, FormatConfig::free_for_all());
+        // Seat order: 0 1 2 3; P0 → P1 = 1
+        assert_eq!(seat_distance(&state, PlayerId(0), PlayerId(1)), 1);
+    }
+
+    #[test]
+    fn seat_distance_takes_shorter_arc() {
+        let state = make_state(4, FormatConfig::free_for_all());
+        // Seat order: 0 1 2 3; P0 → P3: forward=3, backward=1 → min=1
+        assert_eq!(seat_distance(&state, PlayerId(0), PlayerId(3)), 1);
+    }
+
+    #[test]
+    fn seat_distance_opposite_in_six_player_ring() {
+        // 6 seats; P0 → P3: forward=3, backward=3 → min=3
+        let state = make_state(6, FormatConfig::free_for_all());
+        assert_eq!(seat_distance(&state, PlayerId(0), PlayerId(3)), 3);
+    }
+
+    // --- within_range_of_influence ---
+
+    #[test]
+    fn roi_unlimited_always_in_range() {
+        // FormatConfig without roi (None) → every player is in range
+        let state = make_state(6, FormatConfig::free_for_all());
+        assert!(within_range_of_influence(&state, PlayerId(0), PlayerId(5)));
+    }
+
+    #[test]
+    fn roi_one_allows_adjacent_players() {
+        let mut config = FormatConfig::free_for_all();
+        config.range_of_influence = Some(1);
+        let state = make_state(4, config);
+        // P0's neighbours: P1 (right) and P3 (left via wrap)
+        assert!(within_range_of_influence(&state, PlayerId(0), PlayerId(1)));
+        assert!(within_range_of_influence(&state, PlayerId(0), PlayerId(3)));
+    }
+
+    #[test]
+    fn roi_one_excludes_non_adjacent_player() {
+        let mut config = FormatConfig::free_for_all();
+        config.range_of_influence = Some(1);
+        let state = make_state(4, config);
+        // P0 → P2: distance 2 > roi 1
+        assert!(!within_range_of_influence(&state, PlayerId(0), PlayerId(2)));
     }
 }

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -127,7 +127,7 @@ fn find_legal_targets_with_context(
 
     // Check if filter could match players
     if matches!(filter, TargetFilter::Any | TargetFilter::Player) || is_any_other_target {
-        add_players(state, &mut targets, source_id);
+        add_players(state, &mut targets, source_id, source_controller);
     }
 
     if let TargetFilter::SpecificPlayer { id } = filter {
@@ -184,7 +184,15 @@ fn find_legal_targets_with_context(
                     Some(ControllerRef::TriggeringPlayer) => false,
                     None => true,
                 };
-                if include {
+                // CR 801.4: Spells and abilities can only affect players within
+                // the source controller's range of influence.
+                if include
+                    && super::players::within_range_of_influence(
+                        state,
+                        source_controller,
+                        player.id,
+                    )
+                {
                     targets.push(TargetRef::Player(player.id));
                 }
             }
@@ -1251,7 +1259,12 @@ fn filter_targets_stack_abilities(filter: &TargetFilter) -> bool {
     }
 }
 
-fn add_players(state: &GameState, targets: &mut Vec<TargetRef>, source_id: ObjectId) {
+fn add_players(
+    state: &GameState,
+    targets: &mut Vec<TargetRef>,
+    source_id: ObjectId,
+    source_controller: PlayerId,
+) {
     // Player-phasing exclusion: a phased-out player is treated as though they
     // don't exist for targeting purposes (mirrors CR 702.26b for permanents,
     // applied to players via card Oracle text like "you phase out").
@@ -1269,6 +1282,10 @@ fn add_players(state: &GameState, targets: &mut Vec<TargetRef>, source_id: Objec
         // CR 702.16b: A player with protection from the spell/ability's source
         // can't be targeted by it.
         if super::static_abilities::player_protection_from(state, player.id, Some(source_id)) {
+            continue;
+        }
+        // CR 801.4: A player can only target players within their range of influence.
+        if !super::players::within_range_of_influence(state, source_controller, player.id) {
             continue;
         }
         targets.push(TargetRef::Player(player.id));

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -749,7 +749,7 @@ fn parse_devour_keyword_line(line: &str) -> Option<Keyword> {
     let (rest, _) = tag::<_, _, OracleError<'_>>("devour ").parse(text).ok()?;
     let (rem, n) = nom_primitives::parse_number.parse(rest.trim()).ok()?;
     if rem.is_empty() {
-        Some(Keyword::Devour(n as u32))
+        Some(Keyword::Devour(n))
     } else {
         None
     }

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -239,6 +239,12 @@ pub(crate) fn extract_keyword_line(
         }
     }
 
+    if mtgjson_keyword_names.iter().any(|n| n == "devour") {
+        if let Some(kw) = parse_devour_keyword_line(line) {
+            return Some(vec![kw]);
+        }
+    }
+
     // CR 303.4a: "Enchant A, B, [and/or] C" — multi-type enchant restriction.
     // The comma-separated list is a single keyword (one TargetFilter::Or), not
     // multiple comma-separated keywords. Detect and handle before the generic
@@ -732,6 +738,23 @@ fn parse_bloodthirst_keyword_line(line: &str) -> Option<Keyword> {
     }
 }
 
+/// CR 702.82a: Devour N — "Devour N (reminder text)". The numeric quality N
+/// determines the +1/+1 counter multiplier applied per sacrificed creature as
+/// the permanent enters. MTGJSON sends only the bare "Devour" keyword name;
+/// the Oracle line supplies the N value.
+fn parse_devour_keyword_line(line: &str) -> Option<Keyword> {
+    let lower = line.to_ascii_lowercase();
+    let stripped = strip_reminder_text(&lower);
+    let text = stripped.trim().trim_end_matches('.');
+    let (rest, _) = tag::<_, _, OracleError<'_>>("devour ").parse(text).ok()?;
+    let (rem, n) = nom_primitives::parse_number.parse(rest.trim()).ok()?;
+    if rem.is_empty() {
+        Some(Keyword::Devour(n as u32))
+    } else {
+        None
+    }
+}
+
 /// CR 702.48a: Offering — "<Subtype> offering (reminder text)". The leading word
 /// is the creature/permanent type a player may sacrifice to cast this spell for
 /// its alternative cost (e.g. "Goblin offering", "Artifact offering"). MTGJSON
@@ -996,6 +1019,10 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
     }
 
     if let Some(kw) = parse_bloodthirst_keyword_line(text) {
+        return Some(kw);
+    }
+
+    if let Some(kw) = parse_devour_keyword_line(text) {
         return Some(kw);
     }
 
@@ -2967,6 +2994,34 @@ mod tests {
         assert_eq!(
             parse_keyword_from_oracle("bloodthirst x").unwrap(),
             Keyword::Bloodthirst(BloodthirstValue::X)
+        );
+    }
+
+    #[test]
+    fn extract_keyword_line_devour_from_oracle_line() {
+        // CR 702.82a: "Devour N" Oracle line with MTGJSON keyword name guard
+        let result = extract_keyword_line(
+            "Devour 2 (As this creature enters, you may sacrifice any number of creatures. This creature enters with twice that many +1/+1 counters on it.)",
+            &["devour".to_string()],
+        )
+        .expect("devour 2 line should be recognized");
+        assert_eq!(result, vec![Keyword::Devour(2)]);
+    }
+
+    #[test]
+    fn parse_keyword_from_oracle_devour_fixed() {
+        // CR 702.82a: parse_keyword_from_oracle fallback path
+        assert_eq!(
+            parse_keyword_from_oracle("devour 1").unwrap(),
+            Keyword::Devour(1)
+        );
+        assert_eq!(
+            parse_keyword_from_oracle("devour 2").unwrap(),
+            Keyword::Devour(2)
+        );
+        assert_eq!(
+            parse_keyword_from_oracle("devour 3").unwrap(),
+            Keyword::Devour(3)
         );
     }
 

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -719,6 +719,25 @@ pub(crate) fn parse_continuous_gets_has(
         }
     }
 
+    // CR 611.3a + CR 613.1f: Split "if [condition]" — a game-state condition that
+    // gates the entire grant. Tried after "as long as" (more common) so the two
+    // forms don't compete; "if" is the shorter Oracle phrasing used on auras and
+    // self-ref statics ("has flying if you control a Goblin").
+    if let Some((before_cond, after_cond)) = tp.split_around(" if ") {
+        let continuous_text = before_cond.original;
+        let condition_text = after_cond.original.trim().trim_end_matches('.');
+        if let Some(mut def) =
+            parse_continuous_gets_has(continuous_text, affected.clone(), description)
+        {
+            let condition =
+                parse_static_condition(condition_text).unwrap_or(StaticCondition::Unrecognized {
+                    text: condition_text.to_string(),
+                });
+            def.condition = Some(condition);
+            return Some(def);
+        }
+    }
+
     // CR 613.4c: Handle "gets +N/+M for each [clause]" — dynamic P/T via ObjectCount.
     if let Some((before_for_each, after_for_each)) = tp.split_around("for each ") {
         let pt_text = before_for_each.original.trim();

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -533,7 +533,7 @@ pub(crate) fn parse_enchanted_equipped_predicate(
     {
         let list_input = nom_tag_lower(&pred_lower, &pred_lower, "has ").unwrap_or(&pred_lower);
         if let Ok((rest, pairs)) = parse_conditional_keyword_list(list_input) {
-            if rest.trim().trim_end_matches('.').is_empty() && pairs.len() > 1 {
+            if rest.trim().trim_end_matches('.').is_empty() && !pairs.is_empty() {
                 return pairs
                     .into_iter()
                     .map(|(kw, cond)| {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14623,3 +14623,55 @@ fn crew_contribution_power_and_toughness_modifiers_parse() {
         defs[0].modifications
     );
 }
+
+#[test]
+fn static_enchanted_equipped_single_has_kw_if_condition() {
+    // CR 613.1f + CR 611.3a: a single "has X if Y" clause (not a list) on an
+    // enchanted/equipped predicate must produce one Continuous def with the
+    // keyword grant gated on the condition. Previously the PATTERN 3a guard
+    // (pairs.len() > 1) dropped this through to an unhandled path.
+    let defs = parse_enchanted_equipped_predicate(
+        "has flying if you control a Goblin",
+        TargetFilter::SelfRef,
+        "has flying if you control a Goblin",
+    );
+    assert_eq!(
+        defs.len(),
+        1,
+        "single if-clause must produce one StaticDefinition, got {defs:?}"
+    );
+    let def = &defs[0];
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying,
+            }),
+        "must grant Flying, got {:?}",
+        def.modifications
+    );
+    assert!(
+        def.condition.is_some(),
+        "condition must be extracted from the 'if' clause"
+    );
+}
+
+#[test]
+fn static_self_ref_has_kw_if_condition() {
+    // CR 611.3a + CR 613.1f: standalone "~ has X if Y" self-referential static.
+    // parse_continuous_gets_has now splits on " if " as well as " as long as ".
+    let def = parse_static_line("~ has deathtouch if you control a Swamp.").unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Deathtouch,
+            }),
+        "must grant Deathtouch, got {:?}",
+        def.modifications
+    );
+    assert!(
+        def.condition.is_some(),
+        "condition must be extracted from the 'if' clause"
+    );
+}


### PR DESCRIPTION
## Summary

- **Range of Influence (CR 801.4):** `seat_distance()` computes minimum
  arc in the seat ring; `within_range_of_influence()` gates on
  `format_config.range_of_influence: Option<u8>`. Enforced in
  `targeting.rs::add_players()`, typed opponent targeting, and
  `combat.rs` attack targets (Player / Planeswalker / Battle). 7 unit
  tests added.

- **Replay system:** Reads existing `turnCheckpoints` snapshots from
  IndexedDB. New components: `ReplayControls` (scrubber + play/pause),
  `ReplayPlayerPanel` (life, hand/library/graveyard, counters),
  `ReplayBattlefield` (card chips by zone group). `ReplayPage` at
  `/replay/:gameId`. "Watch Replay" button added to `GameOverScreen`.

- **Sealed Limited:** `SealedPage` at `/sealed` runs 2 ×
  `DraftAdapter.autoPick()` sessions against the chosen set's pool JSON
  to generate ~90 cards. Seeds `useDraftStore` so `LimitedDeckBuilder`
  manages deck construction normally. 40-card minimum enforced before
  launching an AI game. "Sealed Deck" tile added to `DraftLandingPage`.

- **Parser coverage:**
  - `parse_devour_keyword_line` (CR 702.82a): mirrors
    `parse_bloodthirst_keyword_line`; registered in MTGJSON-gated
    dispatch and `parse_keyword_from_oracle` fallback.
  - Single "has X if Y" enchanted/equipped predicate: removed
    `pairs.len() > 1` guard in `grammar.rs` PATTERN 3a.
  - Self-ref "~ has X if Y" statics: added `" if "` splitting to
    `parse_continuous_gets_has` in `anthem.rs`, parallel to existing
    `" as long as "` branch. 4 new tests.

## Test plan

- [ ] `cargo test -p engine` — 10,950 tests, 0 failures
- [ ] `cargo fmt --all` — clean
- [ ] Range of Influence: start a multiplayer game with `range_of_influence: Some(1)` and verify non-adjacent players can't be targeted
- [ ] Replay: finish a game, click "Watch Replay", scrub through turns
- [ ] Sealed: navigate to `/sealed`, pick a set, open packs, build a 40-card deck, launch AI game
- [ ] Devour: verify Devour 2 cards parse correctly via `/coverage`
