### PR TITLE
feat(engine): implement Epic keyword runtime

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2695,6 +2695,12 @@ fn prepare_spell_cast_with_variant_override_inner(
     variant_override: Option<CastingVariant>,
     mode: CastingMode,
 ) -> Result<PreparedSpellCast, EngineError> {
+    if super::epic::player_is_epic_locked(state, player) {
+        return Err(EngineError::ActionNotAllowed(
+            "Player can't cast spells due to Epic".to_string(),
+        ));
+    }
+
     let obj = state
         .objects
         .get(&object_id)
@@ -8580,6 +8586,9 @@ pub fn can_cast_object_now(state: &GameState, player: PlayerId, object_id: Objec
     // CR 702.61a: While a spell with split second is on the stack, players can't
     // cast spells (mana abilities are exempt per CR 702.61b, but spells are not).
     if super::keywords::stack_has_split_second(state) {
+        return false;
+    }
+    if super::epic::player_is_epic_locked(state, player) {
         return false;
     }
     let Ok(prepared) = prepare_spell_cast(state, player, object_id) else {

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -57,6 +57,9 @@ pub fn resolve(
         copy_obj.additional_cost_payment_count = 0;
         copy_obj.kickers_paid.clear();
         state.objects.insert(copy_id, copy_obj);
+        if super::super::epic::epic_source_entry(state, top_entry.id).is_some() {
+            super::super::epic::remove_epic_keyword_from_copy(state, copy_id);
+        }
     }
 
     // CR 707.10: The copy has the same characteristics as the original, but its
@@ -370,6 +373,9 @@ fn copy_source_entry(state: &GameState, ability: &ResolvedAbility) -> Option<Sta
             if entry.id == ability.source_id {
                 return Some(entry.clone());
             }
+        }
+        if let Some(entry) = super::super::epic::epic_source_entry(state, ability.source_id) {
+            return Some(entry);
         }
         return None;
     }

--- a/crates/engine/src/game/epic.rs
+++ b/crates/engine/src/game/epic.rs
@@ -1,0 +1,120 @@
+use crate::game::triggers::{PendingTrigger, PendingTriggerContext};
+use crate::types::ability::{CopyRetargetPermission, Effect, ResolvedAbility, TargetFilter};
+use crate::types::events::GameEvent;
+use crate::types::game_state::{EpicEffect, GameState, StackEntry, StackEntryKind};
+use crate::types::identifiers::ObjectId;
+use crate::types::keywords::Keyword;
+use crate::types::phase::Phase;
+use crate::types::player::PlayerId;
+
+pub fn player_is_epic_locked(state: &GameState, player: PlayerId) -> bool {
+    state
+        .epic_effects
+        .iter()
+        .any(|effect| effect.controller == player)
+}
+
+pub fn epic_source_entry(state: &GameState, source_id: ObjectId) -> Option<StackEntry> {
+    state
+        .epic_effects
+        .iter()
+        .find(|effect| effect.source_entry.id == source_id)
+        .map(|effect| effect.source_entry.clone())
+}
+
+pub fn register_epic_effect(state: &mut GameState, entry: &StackEntry) {
+    if !entry_has_epic_spell_keyword(state, entry) {
+        return;
+    }
+
+    let source_name = state
+        .objects
+        .get(&entry.id)
+        .map(|object| object.name.clone())
+        .unwrap_or_default();
+    let timestamp = state.next_timestamp() as u32;
+
+    state.epic_effects.push(EpicEffect {
+        controller: entry.controller,
+        source_entry: entry.clone(),
+        source_name,
+        timestamp,
+    });
+}
+
+pub fn collect_upkeep_triggers(
+    state: &GameState,
+    events: &[GameEvent],
+    pending: &mut Vec<PendingTriggerContext>,
+) {
+    for event in events {
+        if !matches!(
+            event,
+            GameEvent::PhaseChanged {
+                phase: Phase::Upkeep
+            }
+        ) {
+            continue;
+        }
+
+        let active = state.active_player;
+        for effect in state
+            .epic_effects
+            .iter()
+            .filter(|effect| effect.controller == active)
+        {
+            let ability = ResolvedAbility::new(
+                Effect::CopySpell {
+                    target: TargetFilter::SelfRef,
+                    retarget: CopyRetargetPermission::MayChooseNewTargets,
+                    copier: None,
+                },
+                Vec::new(),
+                effect.source_entry.id,
+                effect.controller,
+            );
+
+            pending.push(PendingTriggerContext {
+                trigger_events: vec![event.clone()],
+                pending: PendingTrigger {
+                    source_id: effect.source_entry.id,
+                    controller: effect.controller,
+                    condition: None,
+                    ability,
+                    timestamp: effect.timestamp,
+                    target_constraints: Vec::new(),
+                    distribute: None,
+                    trigger_event: Some(event.clone()),
+                    modal: None,
+                    mode_abilities: Vec::new(),
+                    description: Some(format!("Epic - {}", effect.source_name)),
+                    may_trigger_origin: None,
+                    subject_match_count: None,
+                    die_result: None,
+                },
+            });
+        }
+    }
+}
+
+pub fn remove_epic_keyword_from_copy(state: &mut GameState, object_id: ObjectId) {
+    if let Some(object) = state.objects.get_mut(&object_id) {
+        object
+            .keywords
+            .retain(|keyword| !matches!(keyword, Keyword::Epic));
+        object
+            .base_keywords
+            .retain(|keyword| !matches!(keyword, Keyword::Epic));
+    }
+}
+
+fn entry_has_epic_spell_keyword(state: &GameState, entry: &StackEntry) -> bool {
+    matches!(&entry.kind, StackEntryKind::Spell { .. })
+        && state.objects.get(&entry.id).is_some_and(|object| {
+            !object.is_token
+                && object
+                    .keywords
+                    .iter()
+                    .any(|keyword| matches!(keyword, Keyword::Epic))
+        })
+}

--- a/crates/engine/src/game/epic_tests.rs
+++ b/crates/engine/src/game/epic_tests.rs
@@ -1,0 +1,142 @@
+use crate::game::game_object::GameObject;
+use crate::game::{casting, epic, stack, triggers};
+use crate::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+use crate::types::card_type::CoreType;
+use crate::types::events::GameEvent;
+use crate::types::game_state::{CastingVariant, GameState, StackEntry, StackEntryKind};
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::keywords::Keyword;
+use crate::types::mana::ManaCost;
+use crate::types::phase::Phase;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+fn blank_ability(source_id: ObjectId) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 0 },
+            target: TargetFilter::Controller,
+        },
+        Vec::new(),
+        source_id,
+        PlayerId(0),
+    )
+}
+
+fn make_spell_object(
+    state: &mut GameState,
+    id: ObjectId,
+    card_id: CardId,
+    zone: Zone,
+    keywords: Vec<Keyword>,
+) {
+    let mut object = GameObject::new(id, card_id, PlayerId(0), "Endless Swarm".to_string(), zone);
+    object.card_types.core_types.push(CoreType::Instant);
+    object.mana_cost = ManaCost::zero();
+    object.keywords = keywords.clone();
+    object.base_keywords = keywords;
+    object.sync_missing_base_characteristics();
+    state.objects.insert(id, object);
+    if state.next_object_id <= id.0 {
+        state.next_object_id = id.0 + 1;
+    }
+}
+
+fn push_epic_spell(state: &mut GameState, spell_id: ObjectId) {
+    let card_id = CardId(100);
+    make_spell_object(state, spell_id, card_id, Zone::Stack, vec![Keyword::Epic]);
+    state.stack.push_back(StackEntry {
+        id: spell_id,
+        source_id: spell_id,
+        controller: PlayerId(0),
+        kind: StackEntryKind::Spell {
+            card_id,
+            ability: Some(blank_ability(spell_id)),
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+}
+
+#[test]
+fn resolving_epic_spell_registers_rest_of_game_effect_and_locks_casting() {
+    let mut state = GameState::new_two_player(1);
+    push_epic_spell(&mut state, ObjectId(10));
+
+    let mut events = Vec::new();
+    stack::resolve_top(&mut state, &mut events);
+
+    assert_eq!(state.epic_effects.len(), 1);
+    assert!(epic::player_is_epic_locked(&state, PlayerId(0)));
+    assert!(matches!(
+        state.objects.get(&ObjectId(10)).map(|object| object.zone),
+        Some(Zone::Graveyard)
+    ));
+
+    make_spell_object(
+        &mut state,
+        ObjectId(20),
+        CardId(200),
+        Zone::Hand,
+        Vec::new(),
+    );
+
+    assert!(!casting::can_cast_object_now(
+        &state,
+        PlayerId(0),
+        ObjectId(20)
+    ));
+    assert!(casting::handle_cast_spell(
+        &mut state,
+        PlayerId(0),
+        ObjectId(20),
+        CardId(200),
+        &mut Vec::new(),
+    )
+    .is_err());
+}
+
+#[test]
+fn epic_upkeep_trigger_copies_spell_without_casting_or_rearming_epic() {
+    let mut state = GameState::new_two_player(2);
+    push_epic_spell(&mut state, ObjectId(10));
+
+    let mut events = Vec::new();
+    stack::resolve_top(&mut state, &mut events);
+    assert_eq!(state.epic_effects.len(), 1);
+
+    state.active_player = PlayerId(0);
+    triggers::process_triggers(
+        &mut state,
+        &[GameEvent::PhaseChanged {
+            phase: Phase::Upkeep,
+        }],
+    );
+    assert_eq!(state.stack.len(), 1);
+
+    events.clear();
+    stack::resolve_top(&mut state, &mut events);
+    assert_eq!(state.stack.len(), 1);
+    assert!(events.iter().any(|event| matches!(
+        event,
+        GameEvent::SpellCopied {
+            original_id: ObjectId(10),
+            ..
+        }
+    )));
+
+    let copy_id = state.stack.back().expect("Epic copy on stack").id;
+    let copy = state.objects.get(&copy_id).expect("Epic copy object");
+    assert!(copy.is_token);
+    assert!(!copy
+        .keywords
+        .iter()
+        .any(|keyword| matches!(keyword, Keyword::Epic)));
+
+    events.clear();
+    stack::resolve_top(&mut state, &mut events);
+    assert_eq!(state.epic_effects.len(), 1);
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, GameEvent::SpellCast { .. })));
+}

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -47,6 +47,10 @@ pub(crate) mod engine_priority;
 pub(crate) mod engine_replacement;
 pub(crate) mod engine_resolution_choices;
 pub(crate) mod engine_stack;
+pub mod epic;
+#[cfg(test)]
+#[path = "epic_tests.rs"]
+mod epic_tests;
 pub(crate) mod exile_links;
 pub mod filter;
 pub mod functioning_abilities;

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -410,6 +410,10 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // to Exile. Copies (`is_token`) never arm Paradigm because their card
     // name is derived but they are not "the" spell per the reminder. Assign
     // when WotC publishes SOS CR update.
+    if is_spell {
+        super::epic::register_epic_effect(state, &entry);
+    }
+
     let paradigm_armed = if is_spell {
         let obj = state.objects.get(&entry.id);
         let has_paradigm = obj.is_some_and(|o| {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -830,6 +830,7 @@ fn collect_pending_triggers(
     // continuous effects before this pass scans for matching triggers.
     super::layers::flush_layers(state);
     let mut pending: Vec<PendingTriggerContext> = Vec::new();
+    super::epic::collect_upkeep_triggers(state, events, &mut pending);
     // CR 603.2c: Track which batched triggers (source_id, trig_idx) have already
     // fired in this pass so "one or more" triggers fire at most once per batch.
     let mut batched_this_pass: HashSet<(ObjectId, usize)> = HashSet::new();

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4156,6 +4156,17 @@ impl StackEntry {
     }
 }
 
+/// CR 702.50a: Persistent "for the rest of the game" Epic record created when
+/// an Epic spell resolves. The stored stack entry is a copyable snapshot of the
+/// resolved spell; upkeep triggers use it to create non-cast spell copies.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EpicEffect {
+    pub controller: PlayerId,
+    pub source_entry: StackEntry,
+    pub source_name: String,
+    pub timestamp: u32,
+}
+
 /// CR 702.94a + CR 603.11: A pending miracle reveal offer queued during the
 /// resolution of an action that caused `player` to draw `object_id` as their
 /// first card of the turn. `cost` is the miracle mana cost taken from the
@@ -5041,6 +5052,11 @@ pub struct GameState {
     /// publishes SOS CR update.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub paradigm_primed: Vec<ParadigmPrime>,
+
+    /// CR 702.50a: Epic creates a persistent "for the rest of the game"
+    /// effect that copies the resolved spell at the beginning of each upkeep.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub epic_effects: Vec<EpicEffect>,
 
     /// CR 603.7: Delayed triggered abilities waiting to fire.
     #[serde(default)]
@@ -6258,6 +6274,7 @@ impl GameState {
             pending_trigger_order: None,
             exile_links: Vec::new(),
             paradigm_primed: Vec::new(),
+            epic_effects: Vec::new(),
             delayed_triggers: Vec::new(),
             tracked_object_sets: HashMap::new(),
             next_tracked_set_id: 1,
@@ -6671,6 +6688,7 @@ impl PartialEq for GameState {
             && self.pending_trigger_order == other.pending_trigger_order
             && self.exile_links == other.exile_links
             && self.paradigm_primed == other.paradigm_primed
+            && self.epic_effects == other.epic_effects
             && self.delayed_triggers == other.delayed_triggers
             && self.tracked_object_sets == other.tracked_object_sets
             && self.next_tracked_set_id == other.next_tracked_set_id


### PR DESCRIPTION
Fixies #2688

## Summary
- add persistent Epic effects to GameState
- register resolved non-token Epic spells and lock their controller out of future spell casts
- create upkeep copy triggers that use the existing copy-spell path without firing SpellCast or rearming Epic

## Tests
- cargo fmt --all
- git diff --check
- cargo test -p engine epic --lib (blocked locally: MSVC link.exe not installed)