### PR TITLE
fix(engine): support top-library exile cumulative upkeep

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -9982,14 +9982,14 @@ mod tests {
 
     #[test]
     fn unsupported_cumulative_upkeep_cost_counts_as_keyword_gap() {
-        // CR 702.24a: Exile-base cumulative upkeep is still unsupported by the
-        // unless-payment pipeline (Discard became supported once the per-counter
-        // discard payment chain landed), so it remains a coverage gap.
+        // CR 702.24a: arbitrary exile-base cumulative upkeep still needs
+        // interactive object selection before it can enter the unless-payment
+        // pipeline. Thought Lash-style top-library exile is covered separately.
         let mut face = make_face();
         face.keywords
             .push(Keyword::CumulativeUpkeep(AbilityCost::Exile {
                 count: 1,
-                zone: None,
+                zone: Some(Zone::Graveyard),
                 filter: None,
             }));
 
@@ -10004,6 +10004,26 @@ mod tests {
             .find(|item| item.category == ParseCategory::Keyword)
             .expect("keyword parse item");
         assert!(!keyword.supported);
+    }
+
+    #[test]
+    fn top_library_exile_cumulative_upkeep_has_no_keyword_gap() {
+        let mut face = make_face();
+        face.keywords
+            .push(Keyword::CumulativeUpkeep(AbilityCost::Exile {
+                count: 1,
+                zone: Some(Zone::Library),
+                filter: None,
+            }));
+
+        assert!(card_face_gaps(&face).is_empty());
+
+        let parse_details = build_parse_details_for_face(&face);
+        let keyword = parse_details
+            .iter()
+            .find(|item| item.category == ParseCategory::Keyword)
+            .expect("keyword parse item");
+        assert!(keyword.supported);
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -19,6 +19,7 @@ use crate::types::game_state::{
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::mana::ManaCost;
 use crate::types::player::{Player, PlayerId};
+use crate::types::zones::Zone;
 
 pub mod adapt;
 pub mod add_restriction;

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5624,6 +5624,17 @@ fn expand_per_counter(base: &AbilityCost, n: u32) -> AbilityCost {
             random: *random,
             self_ref: *self_ref,
         },
+        // CR 702.24a: Thought Lash-style cumulative upkeep scales the number
+        // of top-library cards exiled by the number of age counters.
+        AbilityCost::Exile {
+            count,
+            zone: Some(Zone::Library),
+            filter: None,
+        } => AbilityCost::Exile {
+            count: count.saturating_mul(n),
+            zone: Some(Zone::Library),
+            filter: None,
+        },
         // YAGNI fallback: no current cumulative-upkeep card uses these
         // base variants. If a future mechanic does, the
         // Composite-of-N-copies expansion is semantically correct for
@@ -6820,6 +6831,26 @@ mod tests {
         assert_eq!(filter, Some(TargetFilter::SelfRef));
         assert!(!random);
         assert!(self_ref);
+    }
+
+    #[test]
+    fn expand_per_counter_top_library_exile_scales_count() {
+        let base = AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Library),
+            filter: None,
+        };
+
+        let expanded = expand_per_counter(&base, 3);
+
+        assert_eq!(
+            expanded,
+            AbilityCost::Exile {
+                count: 3,
+                zone: Some(Zone::Library),
+                filter: None,
+            }
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -18934,6 +18934,127 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
     // sourced (synthesized by Keyword::CumulativeUpkeep, not parsed) and in
     // the `PerCounter` expansion that lives in the sub-ability's unless-cost.
 
+    fn cumulative_upkeep_exile_top_trigger() -> TriggerDefinition {
+        crate::database::synthesis::build_cumulative_upkeep_trigger(AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Library),
+            filter: None,
+        })
+    }
+
+    fn setup_thought_lash_upkeep_state(
+        preloaded_age_counters: u32,
+        library_count: u32,
+    ) -> (GameState, ObjectId, Vec<ObjectId>) {
+        let mut state = new_game(42);
+        state.turn_number = 2;
+        state.phase = Phase::Untap;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        let mut library_cards = Vec::new();
+        for index in 0..library_count {
+            library_cards.push(create_object(
+                &mut state,
+                CardId(8000 + index),
+                PlayerId(0),
+                format!("Library Card {}", index + 1),
+                Zone::Library,
+            ));
+        }
+
+        let thought_lash = create_object(
+            &mut state,
+            CardId(70240),
+            PlayerId(0),
+            "Thought Lash".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&thought_lash).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.trigger_definitions
+                .push(cumulative_upkeep_exile_top_trigger());
+            if preloaded_age_counters > 0 {
+                obj.counters.insert(
+                    crate::types::counter::CounterType::Age,
+                    preloaded_age_counters,
+                );
+            }
+        }
+
+        (state, thought_lash, library_cards)
+    }
+
+    #[test]
+    fn thought_lash_cumulative_upkeep_exiles_top_cards_and_keeps_permanent() {
+        let (mut state, thought_lash, library_cards) = setup_thought_lash_upkeep_state(1, 3);
+
+        advance_to_unless_payment_prompt(&mut state);
+
+        match &state.waiting_for {
+            WaitingFor::UnlessPayment { player, cost, .. } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(
+                    cost,
+                    &AbilityCost::Exile {
+                        count: 2,
+                        zone: Some(Zone::Library),
+                        filter: None,
+                    },
+                    "one preloaded age counter plus the upkeep tick should require exiling two top cards"
+                );
+            }
+            other => panic!("expected UnlessPayment for top-library exile, got {other:?}"),
+        }
+
+        apply_as_current(&mut state, GameAction::PayUnlessCost { pay: true })
+            .expect("top-library exile cumulative-upkeep cost should be payable");
+
+        assert_eq!(state.objects[&thought_lash].zone, Zone::Battlefield);
+        assert_eq!(state.objects[&library_cards[0]].zone, Zone::Exile);
+        assert_eq!(state.objects[&library_cards[1]].zone, Zone::Exile);
+        assert_eq!(state.objects[&library_cards[2]].zone, Zone::Library);
+        assert_eq!(
+            state.players[0].library.front().copied(),
+            Some(library_cards[2]),
+            "the third card should become the new library top after paying"
+        );
+    }
+
+    #[test]
+    fn thought_lash_cumulative_upkeep_sacrifices_when_library_payment_unpayable() {
+        let (mut state, thought_lash, library_cards) = setup_thought_lash_upkeep_state(1, 1);
+
+        advance_to_unless_payment_prompt(&mut state);
+
+        match &state.waiting_for {
+            WaitingFor::UnlessPayment { cost, .. } => assert_eq!(
+                cost,
+                &AbilityCost::Exile {
+                    count: 2,
+                    zone: Some(Zone::Library),
+                    filter: None,
+                }
+            ),
+            other => panic!("expected UnlessPayment for top-library exile, got {other:?}"),
+        }
+
+        apply_as_current(&mut state, GameAction::PayUnlessCost { pay: true })
+            .expect("unpayable top-library exile cost should fall through to sacrifice");
+
+        assert_eq!(
+            state.objects[&thought_lash].zone,
+            Zone::Graveyard,
+            "partial cumulative-upkeep payments are not allowed; too few library cards sacrifices the permanent"
+        );
+        assert_eq!(
+            state.objects[&library_cards[0]].zone,
+            Zone::Library,
+            "failed payment must not partially exile the available top card"
+        );
+    }
+
     /// Build the synthesized cumulative-upkeep trigger for "Cumulative upkeep
     /// {N}" (mana base cost) by delegating to the production synthesizer.
     /// Binding the end-to-end tests to the real builder ensures any regression

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -14973,9 +14973,9 @@ mod phase_trigger_regression_tests {
     use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::{
         AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, Effect,
-        FilterProp, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef, ResolvedAbility,
-        TargetFilter, TargetRef, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
-        UnlessPayModifier,
+        FilterProp, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition,
+        ReplacementMode, ResolvedAbility, TargetFilter, TargetRef, TriggerConstraint,
+        TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
     };
     use crate::types::card::CardFace;
     use crate::types::card_type::CoreType;
@@ -14984,6 +14984,7 @@ mod phase_trigger_regression_tests {
     use crate::types::keywords::Keyword;
     use crate::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
     use crate::types::player::PlayerId;
+    use crate::types::replacements::ReplacementEvent;
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
 
@@ -18968,7 +18969,7 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
         })
     }
 
-    fn setup_thought_lash_upkeep_state(
+    fn setup_top_library_exile_upkeep_state(
         preloaded_age_counters: u32,
         library_count: u32,
     ) -> (GameState, ObjectId, Vec<ObjectId>) {
@@ -18989,15 +18990,15 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
             ));
         }
 
-        let thought_lash = create_object(
+        let source = create_object(
             &mut state,
             CardId(70240),
             PlayerId(0),
-            "Thought Lash".to_string(),
+            "Top-Library Exile Upkeep".to_string(),
             Zone::Battlefield,
         );
         {
-            let obj = state.objects.get_mut(&thought_lash).unwrap();
+            let obj = state.objects.get_mut(&source).unwrap();
             obj.card_types.core_types.push(CoreType::Enchantment);
             obj.trigger_definitions
                 .push(cumulative_upkeep_exile_top_trigger());
@@ -19009,12 +19010,30 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
             }
         }
 
-        (state, thought_lash, library_cards)
+        (state, source, library_cards)
+    }
+
+    fn install_optional_exile_move_replacement(state: &mut GameState, card_id: ObjectId) {
+        let replacement_source = create_object(
+            state,
+            CardId(70241),
+            PlayerId(0),
+            "Optional Exile Move Replacement".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&replacement_source).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.replacement_definitions.push(
+            ReplacementDefinition::new(ReplacementEvent::Moved)
+                .mode(ReplacementMode::Optional { decline: None })
+                .valid_card(TargetFilter::SpecificObject { id: card_id })
+                .destination_zone(Zone::Exile),
+        );
     }
 
     #[test]
-    fn thought_lash_cumulative_upkeep_exiles_top_cards_and_keeps_permanent() {
-        let (mut state, thought_lash, library_cards) = setup_thought_lash_upkeep_state(1, 3);
+    fn top_library_exile_cumulative_upkeep_exiles_top_cards_and_keeps_permanent() {
+        let (mut state, source, library_cards) = setup_top_library_exile_upkeep_state(1, 3);
 
         advance_to_unless_payment_prompt(&mut state);
 
@@ -19037,7 +19056,7 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
         apply_as_current(&mut state, GameAction::PayUnlessCost { pay: true })
             .expect("top-library exile cumulative-upkeep cost should be payable");
 
-        assert_eq!(state.objects[&thought_lash].zone, Zone::Battlefield);
+        assert_eq!(state.objects[&source].zone, Zone::Battlefield);
         assert_eq!(state.objects[&library_cards[0]].zone, Zone::Exile);
         assert_eq!(state.objects[&library_cards[1]].zone, Zone::Exile);
         assert_eq!(state.objects[&library_cards[2]].zone, Zone::Library);
@@ -19049,8 +19068,8 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
     }
 
     #[test]
-    fn thought_lash_cumulative_upkeep_sacrifices_when_library_payment_unpayable() {
-        let (mut state, thought_lash, library_cards) = setup_thought_lash_upkeep_state(1, 1);
+    fn top_library_exile_cumulative_upkeep_sacrifices_when_library_payment_unpayable() {
+        let (mut state, source, library_cards) = setup_top_library_exile_upkeep_state(1, 1);
 
         advance_to_unless_payment_prompt(&mut state);
 
@@ -19070,7 +19089,7 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
             .expect("unpayable top-library exile cost should fall through to sacrifice");
 
         assert_eq!(
-            state.objects[&thought_lash].zone,
+            state.objects[&source].zone,
             Zone::Graveyard,
             "partial cumulative-upkeep payments are not allowed; too few library cards sacrifices the permanent"
         );
@@ -19078,6 +19097,42 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
             state.objects[&library_cards[0]].zone,
             Zone::Library,
             "failed payment must not partially exile the available top card"
+        );
+    }
+
+    #[test]
+    fn top_library_exile_cumulative_upkeep_replacement_choice_is_atomic() {
+        let (mut state, source, library_cards) = setup_top_library_exile_upkeep_state(1, 3);
+        install_optional_exile_move_replacement(&mut state, library_cards[1]);
+
+        advance_to_unless_payment_prompt(&mut state);
+
+        apply_as_current(&mut state, GameAction::PayUnlessCost { pay: true })
+            .expect("choice-based top-library exile cost should fall through to sacrifice");
+
+        assert_eq!(
+            state.objects[&source].zone,
+            Zone::Graveyard,
+            "a choice-based replacement makes the deterministic cumulative-upkeep payment fail"
+        );
+        assert_eq!(
+            state.objects[&library_cards[0]].zone,
+            Zone::Library,
+            "failed payment must not partially exile the first top card"
+        );
+        assert_eq!(
+            state.objects[&library_cards[1]].zone,
+            Zone::Library,
+            "failed payment must not partially exile later top cards"
+        );
+        assert_eq!(
+            state.players[0].library.front().copied(),
+            Some(library_cards[0]),
+            "choice-based payment failure leaves library order untouched"
+        );
+        assert!(
+            state.pending_replacement.is_none(),
+            "abandoned deterministic payment must not leave a replacement choice pending"
         );
     }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -18956,7 +18956,7 @@ Echo—Discard a card. (At the beginning of your upkeep, if this came under your
         for index in 0..library_count {
             library_cards.push(create_object(
                 &mut state,
-                CardId(8000 + index),
+                CardId(8000 + u64::from(index)),
                 PlayerId(0),
                 format!("Library Card {}", index + 1),
                 Zone::Library,

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -360,27 +360,39 @@ fn pay_top_library_exile_cost(
         return Ok(false);
     }
 
-    for _ in 0..count {
-        let Some(card_id) = state
-            .players
-            .iter()
-            .find(|p| p.id == player)
-            .and_then(|p| p.library.front().copied())
-        else {
-            return Ok(false);
-        };
+    let top_cards = state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| {
+            p.library
+                .iter()
+                .copied()
+                .take(count as usize)
+                .collect::<Vec<_>>()
+        })
+        .ok_or_else(|| EngineError::InvalidAction("Player not found".to_string()))?;
+    let mut zone_changes = Vec::with_capacity(top_cards.len());
+
+    for card_id in top_cards {
         let proposed =
             ProposedEvent::zone_change(card_id, Zone::Library, Zone::Exile, Some(source_id));
         match replacement::replace_event(state, proposed, events) {
             ReplacementResult::Execute(ProposedEvent::ZoneChange { object_id, to, .. }) => {
-                zones::move_to_zone(state, object_id, to, events);
+                zone_changes.push((object_id, to));
             }
-            ReplacementResult::Execute(_)
-            | ReplacementResult::Prevented
-            | ReplacementResult::NeedsChoice(_) => {
+            ReplacementResult::Execute(_) | ReplacementResult::Prevented => {
+                return Ok(false);
+            }
+            ReplacementResult::NeedsChoice(_) => {
+                state.pending_replacement = None;
                 return Ok(false);
             }
         }
+    }
+
+    for (object_id, to) in zone_changes {
+        zones::move_to_zone(state, object_id, to, events);
     }
 
     Ok(true)

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -1,4 +1,5 @@
 use crate::game::filter;
+use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, Effect, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
 };
@@ -9,6 +10,8 @@ use crate::types::game_state::{
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
+use crate::types::player::PlayerId;
+use crate::types::proposed_event::ProposedEvent;
 use crate::types::zones::Zone;
 
 use super::casting;
@@ -340,6 +343,49 @@ pub(super) fn handle_unless_payment_choose_cost(
     }
 }
 
+fn pay_top_library_exile_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    count: u32,
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> Result<bool, EngineError> {
+    let library_len = state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.library.len())
+        .ok_or_else(|| EngineError::InvalidAction("Player not found".to_string()))?;
+    if library_len < count as usize {
+        return Ok(false);
+    }
+
+    for _ in 0..count {
+        let Some(card_id) = state
+            .players
+            .iter()
+            .find(|p| p.id == player)
+            .and_then(|p| p.library.front().copied())
+        else {
+            return Ok(false);
+        };
+        let proposed =
+            ProposedEvent::zone_change(card_id, Zone::Library, Zone::Exile, Some(source_id));
+        match replacement::replace_event(state, proposed, events) {
+            ReplacementResult::Execute(ProposedEvent::ZoneChange { object_id, to, .. }) => {
+                zones::move_to_zone(state, object_id, to, events);
+            }
+            ReplacementResult::Execute(_)
+            | ReplacementResult::Prevented
+            | ReplacementResult::NeedsChoice(_) => {
+                return Ok(false);
+            }
+        }
+    }
+
+    Ok(true)
+}
+
 pub(super) fn handle_unless_payment(
     state: &mut GameState,
     waiting_for: WaitingFor,
@@ -523,27 +569,14 @@ pub(super) fn handle_unless_payment(
                 zone: Some(Zone::Library),
                 filter: None,
             } => {
-                let library_len = state
-                    .players
-                    .iter()
-                    .find(|p| p.id == player)
-                    .map(|p| p.library.len())
-                    .ok_or_else(|| EngineError::InvalidAction("Player not found".to_string()))?;
-                if library_len < count as usize {
+                if !pay_top_library_exile_cost(
+                    state,
+                    player,
+                    count,
+                    pending_effect.source_id,
+                    events,
+                )? {
                     payment_failed = true;
-                } else {
-                    for _ in 0..count {
-                        let Some(card_id) = state
-                            .players
-                            .iter()
-                            .find(|p| p.id == player)
-                            .and_then(|p| p.library.front().copied())
-                        else {
-                            payment_failed = true;
-                            break;
-                        };
-                        zones::move_to_zone(state, card_id, Zone::Exile, events);
-                    }
                 }
             }
             // CR 118.12: Return-to-hand unless cost. `from_zone` defaults to

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -513,6 +513,39 @@ pub(super) fn handle_unless_payment(
                     return Ok(action_result(events, state.waiting_for.clone()));
                 }
             }
+            // CR 702.24a + CR 701.13: Thought Lash-style cumulative upkeep
+            // pays by exiling the top N cards of the payer's library. This is
+            // deterministic, so it does not need an object-selection prompt.
+            // Partial payments are not allowed; if the library has too few
+            // cards, the unless cost is unpayable and the sacrifice happens.
+            AbilityCost::Exile {
+                count,
+                zone: Some(Zone::Library),
+                filter: None,
+            } => {
+                let library_len = state
+                    .players
+                    .iter()
+                    .find(|p| p.id == player)
+                    .map(|p| p.library.len())
+                    .ok_or_else(|| EngineError::InvalidAction("Player not found".to_string()))?;
+                if library_len < count as usize {
+                    payment_failed = true;
+                } else {
+                    for _ in 0..count {
+                        let Some(card_id) = state
+                            .players
+                            .iter()
+                            .find(|p| p.id == player)
+                            .and_then(|p| p.library.front().copied())
+                        else {
+                            payment_failed = true;
+                            break;
+                        };
+                        zones::move_to_zone(state, card_id, Zone::Exile, events);
+                    }
+                }
+            }
             // CR 118.12: Return-to-hand unless cost. `from_zone` defaults to
             // battlefield (the standard shape); `Some(Zone::Graveyard)` is
             // used by Harvest Wurm and similar.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5031,6 +5031,15 @@ impl AbilityCost {
             // folded by `expand_per_counter` and paid by the `remaining`
             // re-prompt loop in `handle_unless_payment` end-to-end.
             | AbilityCost::Discard { .. } => true,
+            // CR 702.24a: Thought Lash-style "exile the top card of your
+            // library" is payable as a deterministic top-library cost. Other
+            // exile costs still need interactive object selection and stay
+            // outside the cumulative-upkeep support boundary.
+            AbilityCost::Exile {
+                zone: Some(Zone::Library),
+                filter: None,
+                ..
+            } => true,
             // CR 118.12a: OneOf at the base must be a disjunction of mana
             // costs; mixed-shape disjunctions are not yet expanded into a
             // payable per-counter form.
@@ -13082,6 +13091,18 @@ mod tests {
             filter: None,
             random: false,
             self_ref: false,
+        }
+        .supports_cumulative_upkeep_payment());
+        assert!(AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Library),
+            filter: None,
+        }
+        .supports_cumulative_upkeep_payment());
+        assert!(!AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Graveyard),
+            filter: None,
         }
         .supports_cumulative_upkeep_payment());
     }


### PR DESCRIPTION
Fixes #2690

## Summary
- support Thought Lash-style cumulative upkeep costs that exile the top card of the controller's library
- scale top-library exile costs through the existing PerCounter cumulative-upkeep expansion
- pay deterministic top-library exile unless-costs without an object-selection prompt, while preserving unsupported coverage for arbitrary exile costs
- add support, expansion, coverage, and runtime tests for payable and unpayable library-exile cumulative upkeep

## Tests
- cargo fmt --all
- git diff --check
- cargo test -p engine thought_lash_cumulative_upkeep --lib (blocked locally: MSVC link.exe not installed)