### PR TITLE
Fix Eladamri hand reveal RevealChoice (#1970)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2276,28 +2276,57 @@ pub(super) fn parse_hand_reveal_ast(
 }
 
 fn parse_hand_reveal_card_filter(after_reveal_lower: &str) -> TargetFilter {
-    let Ok((after_all, _)) = tag::<_, _, OracleError<'_>>("all ").parse(after_reveal_lower) else {
+    if let Ok((after_all, _)) = tag::<_, _, OracleError<'_>>("all ").parse(after_reveal_lower) {
+        let Ok((rest, descriptor)) = take_until::<_, _, OracleError<'_>>(" cards").parse(after_all)
+        else {
+            return TargetFilter::None;
+        };
+        if alt((
+            tag::<_, _, OracleError<'_>>(" cards in "),
+            tag(" cards from "),
+        ))
+        .parse(rest)
+        .is_err()
+        {
+            return TargetFilter::None;
+        }
+        if descriptor.trim().is_empty() {
+            return TargetFilter::Any;
+        }
+        let singular = format!("{} card", descriptor.trim());
+        let (filter, rem) = parse_type_phrase(&singular);
+        if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_)) {
+            return filter;
+        }
         return TargetFilter::None;
-    };
-    let Ok((rest, descriptor)) = take_until::<_, _, OracleError<'_>>(" cards").parse(after_all)
+    }
+
+    // CR 701.20a: "reveal a card from your hand" / "reveal an [type] card from ..."
+    let Ok((after_article, _)) =
+        alt((tag::<_, _, OracleError<'_>>("a "), tag("an "))).parse(after_reveal_lower)
     else {
         return TargetFilter::None;
     };
-    if alt((
-        tag::<_, _, OracleError<'_>>(" cards in "),
-        tag(" cards from "),
-    ))
-    .parse(rest)
-    .is_err()
+    if tag::<_, _, OracleError<'_>>("card from ")
+        .parse(after_article)
+        .is_ok()
+    {
+        return TargetFilter::Any;
+    }
+    let Ok((rest, descriptor)) =
+        take_until::<_, _, OracleError<'_>>(" card from ").parse(after_article)
+    else {
+        return TargetFilter::None;
+    };
+    if tag::<_, _, OracleError<'_>>(" card from ")
+        .parse(rest)
+        .is_err()
     {
         return TargetFilter::None;
     }
-    if descriptor.trim().is_empty() {
-        return TargetFilter::Any;
-    }
     let singular = format!("{} card", descriptor.trim());
     let (filter, rem) = parse_type_phrase(&singular);
-    if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_)) {
+    if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_) | TargetFilter::Any) {
         filter
     } else {
         TargetFilter::None

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2267,63 +2267,72 @@ pub(super) fn parse_hand_reveal_ast(
     // This function only handles hand-related reveals.
 
     if nom_primitives::scan_contains(lower, "hand") {
+        let (target, card_filter) = parse_hand_reveal_target_and_card_filter(after_reveal_lower);
         return Some(HandRevealImperativeAst::RevealAll {
-            card_filter: parse_hand_reveal_card_filter(after_reveal_lower),
+            target,
+            card_filter,
         });
     }
 
     None
 }
 
-fn parse_hand_reveal_card_filter(after_reveal_lower: &str) -> TargetFilter {
+fn parse_hand_reveal_target_and_card_filter(
+    after_reveal_lower: &str,
+) -> (TargetFilter, TargetFilter) {
     if let Ok((after_all, _)) = tag::<_, _, OracleError<'_>>("all ").parse(after_reveal_lower) {
-        let Ok((rest, descriptor)) = take_until::<_, _, OracleError<'_>>(" cards").parse(after_all)
-        else {
-            return TargetFilter::None;
+        let Ok((hand_phrase, descriptor)) = terminated(
+            take_until::<_, _, OracleError<'_>>(" cards"),
+            alt((
+                tag::<_, _, OracleError<'_>>(" cards in "),
+                tag(" cards from "),
+            )),
+        )
+        .parse(after_all) else {
+            return (TargetFilter::Any, TargetFilter::None);
         };
-        if alt((
-            tag::<_, _, OracleError<'_>>(" cards in "),
-            tag(" cards from "),
-        ))
-        .parse(rest)
-        .is_err()
-        {
-            return TargetFilter::None;
-        }
+        let target = parse_hand_possessive_target(hand_phrase)
+            .map(|(_, target)| target)
+            .unwrap_or(TargetFilter::Any);
         if descriptor.trim().is_empty() {
-            return TargetFilter::Any;
+            return (target, TargetFilter::Any);
         }
         let singular = format!("{} card", descriptor.trim());
         let (filter, rem) = parse_type_phrase(&singular);
         if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_)) {
-            return filter;
+            return (target, filter);
         }
-        return TargetFilter::None;
+        return (target, TargetFilter::None);
     }
 
     // CR 701.20a: "reveal a card from your hand" / "reveal an [type] card from ..."
     let Ok((after_article, _)) =
         alt((tag::<_, _, OracleError<'_>>("a "), tag("an "))).parse(after_reveal_lower)
     else {
-        return TargetFilter::None;
+        return (TargetFilter::Any, TargetFilter::None);
     };
-    if tag::<_, _, OracleError<'_>>("card from ")
-        .parse(after_article)
-        .is_ok()
-    {
-        return TargetFilter::Any;
+    if let Ok((hand_phrase, _)) = tag::<_, _, OracleError<'_>>("card from ").parse(after_article) {
+        let target = parse_hand_possessive_target(hand_phrase)
+            .map(|(_, target)| target)
+            .unwrap_or(TargetFilter::Any);
+        return (target, TargetFilter::Any);
     }
-    let Ok((_, descriptor)) =
-        take_until::<_, _, OracleError<'_>>(" card from ").parse(after_article)
-    else {
-        return TargetFilter::None;
+    let Ok((hand_phrase, descriptor)) = terminated(
+        take_until::<_, _, OracleError<'_>>(" card from "),
+        tag(" card from "),
+    )
+    .parse(after_article) else {
+        return (TargetFilter::Any, TargetFilter::None);
     };
+    let target = parse_hand_possessive_target(hand_phrase)
+        .map(|(_, target)| target)
+        .unwrap_or(TargetFilter::Any);
     let singular = format!("{} card", descriptor.trim());
     let (filter, rem) = parse_type_phrase(&singular);
     if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_)) {
-        filter
+        (target, filter)
     } else {
-        TargetFilter::None
+        (target, TargetFilter::None)
     }
 }
 
@@ -2340,8 +2349,11 @@ pub(super) fn lower_hand_reveal_ast(ast: HandRevealImperativeAst) -> Effect {
             random,
             choice_optional: false,
         },
-        HandRevealImperativeAst::RevealAll { card_filter } => Effect::RevealHand {
-            target: TargetFilter::Any,
+        HandRevealImperativeAst::RevealAll {
+            target,
+            card_filter,
+        } => Effect::RevealHand {
+            target,
             card_filter,
             count: None,
             random: false,

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2318,12 +2318,6 @@ fn parse_hand_reveal_card_filter(after_reveal_lower: &str) -> TargetFilter {
     else {
         return TargetFilter::None;
     };
-    if tag::<_, _, OracleError<'_>>(" card from ")
-        .parse(rest)
-        .is_err()
-    {
-        return TargetFilter::None;
-    }
     let singular = format!("{} card", descriptor.trim());
     let (filter, rem) = parse_type_phrase(&singular);
     if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_) | TargetFilter::Any) {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2313,14 +2313,14 @@ fn parse_hand_reveal_card_filter(after_reveal_lower: &str) -> TargetFilter {
     {
         return TargetFilter::Any;
     }
-    let Ok((rest, descriptor)) =
+    let Ok((_, descriptor)) =
         take_until::<_, _, OracleError<'_>>(" card from ").parse(after_article)
     else {
         return TargetFilter::None;
     };
     let singular = format!("{} card", descriptor.trim());
     let (filter, rem) = parse_type_phrase(&singular);
-    if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_) | TargetFilter::Any) {
+    if rem.trim().is_empty() && matches!(filter, TargetFilter::Typed(_)) {
         filter
     } else {
         TargetFilter::None

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -30004,14 +30004,43 @@ mod tests {
     fn parse_reveal_a_card_from_your_hand_sets_any_card_filter() {
         let def = parse_effect_chain("Reveal a card from your hand.", AbilityKind::Spell);
 
-        let Effect::RevealHand { card_filter, .. } = &*def.effect else {
+        let Effect::RevealHand {
+            target,
+            card_filter,
+            ..
+        } = &*def.effect
+        else {
             panic!("Expected RevealHand, got {:?}", def.effect);
         };
+        assert_eq!(*target, TargetFilter::Controller);
         assert_eq!(
             *card_filter,
             TargetFilter::Any,
             "singular hand reveal must let the player choose any hand card"
         );
+    }
+
+    #[test]
+    fn parse_reveal_a_card_from_target_opponents_hand_preserves_hand_owner() {
+        let def = parse_effect_chain(
+            "Reveal a card from target opponent's hand.",
+            AbilityKind::Spell,
+        );
+
+        let Effect::RevealHand {
+            target,
+            card_filter,
+            ..
+        } = &*def.effect
+        else {
+            panic!("Expected RevealHand, got {:?}", def.effect);
+        };
+        assert!(matches!(
+            target,
+            TargetFilter::Typed(tf)
+                if tf.controller == Some(crate::types::ability::ControllerRef::Opponent)
+        ));
+        assert_eq!(*card_filter, TargetFilter::Any);
     }
 
     #[test]
@@ -30021,9 +30050,15 @@ mod tests {
             AbilityKind::Activated,
         );
 
-        let Effect::RevealHand { card_filter, .. } = &*def.effect else {
+        let Effect::RevealHand {
+            target,
+            card_filter,
+            ..
+        } = &*def.effect
+        else {
             panic!("Expected RevealHand, got {:?}", def.effect);
         };
+        assert_eq!(*target, TargetFilter::Controller);
         assert_eq!(*card_filter, TargetFilter::Any);
     }
 
@@ -30031,9 +30066,15 @@ mod tests {
     fn parse_reveal_creature_card_from_your_hand_sets_creature_filter() {
         let def = parse_effect_chain("Reveal a creature card from your hand.", AbilityKind::Spell);
 
-        let Effect::RevealHand { card_filter, .. } = &*def.effect else {
+        let Effect::RevealHand {
+            target,
+            card_filter,
+            ..
+        } = &*def.effect
+        else {
             panic!("Expected RevealHand, got {:?}", def.effect);
         };
+        assert_eq!(*target, TargetFilter::Controller);
         assert!(
             matches!(
                 card_filter,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -29637,6 +29637,49 @@ mod tests {
     }
 
     #[test]
+    fn parse_reveal_a_card_from_your_hand_sets_any_card_filter() {
+        let def = parse_effect_chain("Reveal a card from your hand.", AbilityKind::Spell);
+
+        let Effect::RevealHand { card_filter, .. } = &*def.effect else {
+            panic!("Expected RevealHand, got {:?}", def.effect);
+        };
+        assert_eq!(
+            *card_filter,
+            TargetFilter::Any,
+            "singular hand reveal must let the player choose any hand card"
+        );
+    }
+
+    #[test]
+    fn parse_eladamri_hand_mode_reveal_sets_any_card_filter() {
+        let def = parse_effect_chain(
+            "Reveal a card from your hand. If it's a creature card, you may put it onto the battlefield.",
+            AbilityKind::Activated,
+        );
+
+        let Effect::RevealHand { card_filter, .. } = &*def.effect else {
+            panic!("Expected RevealHand, got {:?}", def.effect);
+        };
+        assert_eq!(*card_filter, TargetFilter::Any);
+    }
+
+    #[test]
+    fn parse_reveal_creature_card_from_your_hand_sets_creature_filter() {
+        let def = parse_effect_chain("Reveal a creature card from your hand.", AbilityKind::Spell);
+
+        let Effect::RevealHand { card_filter, .. } = &*def.effect else {
+            panic!("Expected RevealHand, got {:?}", def.effect);
+        };
+        assert!(
+            matches!(
+                card_filter,
+                TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature)
+            ),
+            "typed singular hand reveal must preserve the card filter, got {card_filter:?}"
+        );
+    }
+
+    #[test]
     fn reveal_hand_all_nonland_then_choose_one_preserves_reveal_filter() {
         let def = parse_effect_chain(
             "Target opponent reveals all nonland cards in their hand. You may choose one of those cards. If you do, that player exiles it.",

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -908,6 +908,7 @@ pub(crate) enum HandRevealImperativeAst {
         random: bool,
     },
     RevealAll {
+        target: TargetFilter,
         card_filter: TargetFilter,
     },
     /// "reveals a number of cards from their hand equal to X" (CR 701.20a).

--- a/crates/engine/tests/integration/issue_1970_eladamri.rs
+++ b/crates/engine/tests/integration/issue_1970_eladamri.rs
@@ -26,9 +26,19 @@ fn hand_creature(state: &mut GameState, card_id: u64, owner: PlayerId, name: &st
 #[test]
 fn eladamri_hand_mode_offers_reveal_choice_for_controller_hand() {
     let def = parse_effect_chain(ELADAMRI_HAND_MODE, AbilityKind::Activated);
-    let Effect::RevealHand { card_filter, .. } = def.effect.as_ref() else {
+    let Effect::RevealHand {
+        target,
+        card_filter,
+        ..
+    } = def.effect.as_ref()
+    else {
         panic!("parsed shape: {:?}", def.effect);
     };
+    assert_eq!(
+        *target,
+        TargetFilter::Controller,
+        "hand mode should reveal from the controller's hand"
+    );
     assert_eq!(
         *card_filter,
         TargetFilter::Any,

--- a/crates/engine/tests/integration/issue_1970_eladamri.rs
+++ b/crates/engine/tests/integration/issue_1970_eladamri.rs
@@ -1,0 +1,86 @@
+//! Issue #1970 — Eladamri, Korvecdal's hand mode must pause on RevealChoice so
+//! the activator can pick a card from their hand.
+
+use engine::game::ability_utils::build_resolved_from_def_with_targets;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, TargetFilter, TargetRef};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const ELADAMRI_HAND_MODE: &str = "\
+Reveal a card from your hand. If it's a creature card, you may put it onto the battlefield.";
+
+fn hand_creature(state: &mut GameState, card_id: u64, owner: PlayerId, name: &str) -> ObjectId {
+    let oid = create_object(state, CardId(card_id), owner, name.to_string(), Zone::Hand);
+    let obj = state.objects.get_mut(&oid).expect("just created");
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.base_card_types = obj.card_types.clone();
+    oid
+}
+
+#[test]
+fn eladamri_hand_mode_offers_reveal_choice_for_controller_hand() {
+    let def = parse_effect_chain(ELADAMRI_HAND_MODE, AbilityKind::Activated);
+    let Effect::RevealHand { card_filter, .. } = def.effect.as_ref() else {
+        panic!("parsed shape: {:?}", def.effect);
+    };
+    assert_eq!(
+        *card_filter,
+        TargetFilter::Any,
+        "hand mode must expose every hand card for selection, got {card_filter:?}"
+    );
+
+    let mut state = GameState::new_two_player(1970);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Eladamri, Korvecdal".to_string(),
+        Zone::Battlefield,
+    );
+    let creature_in_hand = hand_creature(&mut state, 10, PlayerId(0), "Grizzly Bears");
+    let _land_in_hand = create_object(
+        &mut state,
+        CardId(11),
+        PlayerId(0),
+        "Forest".to_string(),
+        Zone::Hand,
+    );
+
+    let ability = build_resolved_from_def_with_targets(
+        &def,
+        source,
+        PlayerId(0),
+        vec![TargetRef::Player(PlayerId(0))],
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0)
+        .expect("Eladamri hand mode resolves through reveal");
+
+    match &state.waiting_for {
+        WaitingFor::RevealChoice {
+            player,
+            cards,
+            filter,
+            ..
+        } => {
+            assert_eq!(*player, PlayerId(0));
+            assert_eq!(*filter, TargetFilter::Any);
+            assert!(
+                cards.contains(&creature_in_hand),
+                "creature in hand must be eligible: {cards:?}"
+            );
+            assert_eq!(
+                cards.len(),
+                2,
+                "both hand cards are eligible with Any filter"
+            );
+        }
+        other => panic!("hand reveal must pause on RevealChoice, not stall or skip: {other:?}"),
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -83,6 +83,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod issue_1509_sorcery_main_phase_cast;
+mod issue_1970_eladamri;
 mod issue_1971_enduring_tenacity;
 mod issue_1973_rise_of_dark_realms;
 mod issue_1985_dfc_command_zone_cast;


### PR DESCRIPTION
## Summary
- Parse singular hand reveal phrases (`a card from your hand`, `a creature card from your hand`) into `TargetFilter::Any` or a typed filter instead of `TargetFilter::None`.
- Eladamri, Korvecdal's hand mode now pauses on `WaitingFor::RevealChoice` so the activator can pick a card from their hand.

## Test plan
- [x] `cargo test -p engine eladamri`
- [x] `cargo test -p engine parse_reveal`
- [x] `cargo clippy -p engine -- -D warnings`
- [x] `./scripts/check-parser-combinators.sh`

Fixes #1970
