### PR TITLE
feat(engine): implement Alchemy intensity state and Intensify mutation

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1636,6 +1636,7 @@ export type GameEvent =
   | { type: "DamageDealt"; data: { source_id: ObjectId; target: TargetRef; amount: number; is_combat: boolean; excess?: number } }
   | { type: "SpellCountered"; data: { object_id: ObjectId; countered_by: ObjectId } }
   | { type: "CounterAdded"; data: { object_id: ObjectId; counter_type: string; count: number } }
+  | { type: "ObjectIntensified"; data: { object_id: ObjectId; amount: number } }
   | { type: "CounterRemoved"; data: { object_id: ObjectId; counter_type: string; count: number } }
   | { type: "TokenCreated"; data: { object_id: ObjectId; name: string } }
   | { type: "CreatureDestroyed"; data: { object_id: ObjectId } }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -968,6 +968,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             None => format!("counters on {}", fmt_target(filter)),
         },
         QuantityRef::Variable { name } => name.clone(),
+        QuantityRef::Intensity { .. } => "intensity".into(),
         QuantityRef::Power { scope } => match scope {
             ObjectScope::Source | ObjectScope::Anaphoric | ObjectScope::Demonstrative => {
                 "self power".into()
@@ -1700,6 +1701,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         }
         // CR 702.50a: EpicCopy's parameters live in its snapshotted ability.
         Effect::EpicCopy { .. } => {}
+        Effect::Intensify { .. } => {}
         Effect::DestroyAll { target, .. }
         | Effect::TapAll { target }
         | Effect::UntapAll { target }
@@ -5360,6 +5362,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::ObjectCountBySharedQuality { .. } => ("ObjectCountBySharedQuality", Handled),
         QuantityRef::PlayerCount { .. } => ("PlayerCount", Handled),
         QuantityRef::CountersOn { .. } => ("CountersOn", Handled),
+        QuantityRef::Intensity { .. } => ("Intensity", Handled),
         QuantityRef::CountersOnObjects { .. } => ("CountersOnObjects", Handled),
         QuantityRef::Variable { .. } => ("Variable", Handled),
         QuantityRef::Power { scope } => match scope {

--- a/crates/engine/src/game/effects/intensify.rs
+++ b/crates/engine/src/game/effects/intensify.rs
@@ -34,18 +34,31 @@ pub fn resolve(
     };
 
     let by = resolve_quantity_with_targets(state, &amount, ability).max(0) as u32;
+    let mut changed = false;
     if by > 0 {
         for id in objects_in_scope(state, ability.source_id, ability.controller, &scope) {
             if let Some(obj) = state.objects.get_mut(&id) {
                 obj.intensity = obj.intensity.saturating_add(by);
+                // Emit per affected card so triggers/animation see exactly which
+                // cards intensified (CR-less Alchemy event).
+                events.push(GameEvent::ObjectIntensified {
+                    object_id: id,
+                    amount: by,
+                });
+                changed = true;
             }
         }
     }
 
-    events.push(GameEvent::EffectResolved {
-        kind: EffectKind::from(&ability.effect),
-        source_id: ability.source_id,
-    });
+    // No-op contract: a zero-amount intensify (or empty scope) publishes no
+    // resolution event, so event-counting/trigger-index consumers aren't
+    // perturbed by a draft that changed nothing.
+    if changed {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+    }
     Ok(())
 }
 

--- a/crates/engine/src/game/effects/intensify.rs
+++ b/crates/engine/src/game/effects/intensify.rs
@@ -1,0 +1,85 @@
+//! Digital-only Alchemy (no CR entry): `Effect::Intensify` — increase the
+//! intensity of one or more cards.
+//!
+//! Intensity is a per-card value (`GameObject::intensity`) that follows a card
+//! through every zone. "Intensify by N" therefore applies across ALL zones, not
+//! just the battlefield, and its scope is one of:
+//!
+//! * [`IntensityScope::Source`] — "this creature/artifact/… intensifies";
+//! * [`IntensityScope::OwnedSameName`] — "cards you own named [this card]
+//!   intensify" (every copy you own, anywhere);
+//! * [`IntensityScope::OwnedSubtype`] — "all [subtype] cards you own intensify".
+//!
+//! Because `GameState::objects` is the single store of every object in every
+//! zone, an owner-scoped scan over it covers hand, library, graveyard, stack,
+//! exile, and battlefield uniformly.
+
+use crate::game::quantity::resolve_quantity_with_targets;
+use crate::types::ability::{Effect, EffectError, EffectKind, IntensityScope, ResolvedAbility};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
+
+/// Resolve `Effect::Intensify`: add `amount` to the intensity of every card in
+/// `scope`.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let (scope, amount) = match &ability.effect {
+        Effect::Intensify { scope, amount } => (scope.clone(), amount.clone()),
+        _ => return Err(EffectError::MissingParam("Intensify".to_string())),
+    };
+
+    let by = resolve_quantity_with_targets(state, &amount, ability).max(0) as u32;
+    if by > 0 {
+        for id in objects_in_scope(state, ability.source_id, ability.controller, &scope) {
+            if let Some(obj) = state.objects.get_mut(&id) {
+                obj.intensity = obj.intensity.saturating_add(by);
+            }
+        }
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::from(&ability.effect),
+        source_id: ability.source_id,
+    });
+    Ok(())
+}
+
+/// The objects an Intensify effect applies to, across every zone.
+fn objects_in_scope(
+    state: &GameState,
+    source_id: ObjectId,
+    controller: PlayerId,
+    scope: &IntensityScope,
+) -> Vec<ObjectId> {
+    match scope {
+        IntensityScope::Source => vec![source_id],
+        IntensityScope::OwnedSameName => {
+            let Some(name) = state.objects.get(&source_id).map(|o| o.name.clone()) else {
+                return Vec::new();
+            };
+            owned_matching(state, controller, |o| o.name == name)
+        }
+        IntensityScope::OwnedSubtype { subtype } => owned_matching(state, controller, |o| {
+            o.card_types.subtypes.iter().any(|s| s == subtype)
+        }),
+    }
+}
+
+/// Every object `controller` owns (in any zone) that satisfies `pred`.
+fn owned_matching(
+    state: &GameState,
+    controller: PlayerId,
+    pred: impl Fn(&crate::game::game_object::GameObject) -> bool,
+) -> Vec<ObjectId> {
+    state
+        .objects
+        .iter()
+        .filter(|(_, obj)| obj.owner == controller && pred(obj))
+        .map(|(id, _)| *id)
+        .collect()
+}

--- a/crates/engine/src/game/effects/intensify_tests.rs
+++ b/crates/engine/src/game/effects/intensify_tests.rs
@@ -1,0 +1,190 @@
+//! Tests for Alchemy Intensity (`Effect::Intensify` + starting intensity).
+//! Declared from `effects/mod.rs` so `intensify.rs` stays implementation-only.
+
+use super::intensify::resolve;
+use crate::game::printed_cards::apply_card_face_to_object;
+use crate::game::zones::create_object;
+use crate::parser::oracle_effect::parse_effect;
+use crate::types::ability::{Effect, IntensityScope, QuantityExpr, ResolvedAbility};
+use crate::types::card::CardFace;
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::keywords::Keyword;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+fn intensify_ability(source: ObjectId, scope: IntensityScope, by: i32) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::Intensify {
+            scope,
+            amount: QuantityExpr::Fixed { value: by },
+        },
+        Vec::new(),
+        source,
+        PlayerId(0),
+    )
+}
+
+fn card(state: &mut crate::types::game_state::GameState, name: &str, zone: Zone) -> ObjectId {
+    create_object(state, CardId(1), PlayerId(0), name.to_string(), zone)
+}
+
+#[test]
+fn source_scope_intensifies_only_the_source() {
+    let mut state = crate::types::game_state::GameState::new_two_player(42);
+    let a = card(&mut state, "Bellowsbreath Ogre", Zone::Battlefield);
+    let b = card(&mut state, "Bellowsbreath Ogre", Zone::Hand);
+
+    let mut events = Vec::new();
+    resolve(
+        &mut state,
+        &intensify_ability(a, IntensityScope::Source, 2),
+        &mut events,
+    )
+    .unwrap();
+
+    assert_eq!(state.objects.get(&a).unwrap().intensity, 2);
+    assert_eq!(
+        state.objects.get(&b).unwrap().intensity,
+        0,
+        "only the source"
+    );
+}
+
+#[test]
+fn owned_same_name_intensifies_every_copy_across_zones() {
+    // "cards you own named X intensify by 1" hits all owned copies, any zone.
+    let mut state = crate::types::game_state::GameState::new_two_player(42);
+    let bf = card(&mut state, "Arek", Zone::Battlefield);
+    let hand = card(&mut state, "Arek", Zone::Hand);
+    let lib = card(&mut state, "Arek", Zone::Library);
+    let other = card(&mut state, "Someone Else", Zone::Hand);
+    // A copy owned by the opponent must NOT be touched.
+    let opp = create_object(
+        &mut state,
+        CardId(9),
+        PlayerId(1),
+        "Arek".to_string(),
+        Zone::Hand,
+    );
+
+    let mut events = Vec::new();
+    resolve(
+        &mut state,
+        &intensify_ability(bf, IntensityScope::OwnedSameName, 1),
+        &mut events,
+    )
+    .unwrap();
+
+    for id in [bf, hand, lib] {
+        assert_eq!(
+            state.objects.get(&id).unwrap().intensity,
+            1,
+            "all owned copies"
+        );
+    }
+    assert_eq!(
+        state.objects.get(&other).unwrap().intensity,
+        0,
+        "different name"
+    );
+    assert_eq!(
+        state.objects.get(&opp).unwrap().intensity,
+        0,
+        "opponent's copy"
+    );
+}
+
+#[test]
+fn owned_subtype_intensifies_every_matching_card() {
+    let mut state = crate::types::game_state::GameState::new_two_player(42);
+    let chorus_a = card(&mut state, "Hymn to the Ages", Zone::Hand);
+    let chorus_b = card(&mut state, "Ribald Shanty", Zone::Library);
+    let plain = card(&mut state, "Mountain", Zone::Battlefield);
+    for id in [chorus_a, chorus_b] {
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Chorus".to_string());
+    }
+
+    let mut events = Vec::new();
+    resolve(
+        &mut state,
+        &intensify_ability(
+            chorus_a,
+            IntensityScope::OwnedSubtype {
+                subtype: "Chorus".to_string(),
+            },
+            1,
+        ),
+        &mut events,
+    )
+    .unwrap();
+
+    assert_eq!(state.objects.get(&chorus_a).unwrap().intensity, 1);
+    assert_eq!(state.objects.get(&chorus_b).unwrap().intensity, 1);
+    assert_eq!(
+        state.objects.get(&plain).unwrap().intensity,
+        0,
+        "non-Chorus untouched"
+    );
+}
+
+#[test]
+fn starting_intensity_is_stamped_from_the_keyword_once() {
+    // apply_card_face_to_object reads `Keyword::StartingIntensity` and sets it
+    // on first application, then never resets it.
+    let mut face = CardFace::default();
+    face.name = "Great Desert Hellion".to_string();
+    face.keywords.push(Keyword::StartingIntensity(1));
+
+    let mut state = crate::types::game_state::GameState::new_two_player(42);
+    let id = card(&mut state, "Great Desert Hellion", Zone::Battlefield);
+    let obj = state.objects.get_mut(&id).unwrap();
+    apply_card_face_to_object(obj, &face);
+    assert_eq!(obj.intensity, 1);
+
+    // Accumulate, then re-apply the face — intensity must NOT reset.
+    obj.intensity = 5;
+    apply_card_face_to_object(obj, &face);
+    assert_eq!(
+        obj.intensity, 5,
+        "re-stamping the face must not reset intensity"
+    );
+}
+
+#[test]
+fn parser_maps_intensify_clauses_to_the_right_scope() {
+    assert!(matches!(
+        parse_effect("this creature intensifies by 2."),
+        Effect::Intensify {
+            scope: IntensityScope::Source,
+            amount: QuantityExpr::Fixed { value: 2 },
+        }
+    ));
+    // No "by N" → amount 1.
+    assert!(matches!(
+        parse_effect("it intensifies."),
+        Effect::Intensify {
+            scope: IntensityScope::Source,
+            amount: QuantityExpr::Fixed { value: 1 },
+        }
+    ));
+    assert!(matches!(
+        parse_effect("cards you own named Arek, False Goldwarden intensify by 1."),
+        Effect::Intensify {
+            scope: IntensityScope::OwnedSameName,
+            ..
+        }
+    ));
+    match parse_effect("all Chorus cards you own intensify by 1.") {
+        Effect::Intensify {
+            scope: IntensityScope::OwnedSubtype { subtype },
+            ..
+        } => assert_eq!(subtype, "Chorus"),
+        other => panic!("expected OwnedSubtype, got {other:?}"),
+    }
+}

--- a/crates/engine/src/game/effects/intensify_tests.rs
+++ b/crates/engine/src/game/effects/intensify_tests.rs
@@ -137,9 +137,11 @@ fn owned_subtype_intensifies_every_matching_card() {
 fn starting_intensity_is_stamped_from_the_keyword_once() {
     // apply_card_face_to_object reads `Keyword::StartingIntensity` and sets it
     // on first application, then never resets it.
-    let mut face = CardFace::default();
-    face.name = "Great Desert Hellion".to_string();
-    face.keywords.push(Keyword::StartingIntensity(1));
+    let face = CardFace {
+        name: "Great Desert Hellion".to_string(),
+        keywords: vec![Keyword::StartingIntensity(1)],
+        ..CardFace::default()
+    };
 
     let mut state = crate::types::game_state::GameState::new_two_player(42);
     let id = card(&mut state, "Great Desert Hellion", Zone::Battlefield);

--- a/crates/engine/src/game/effects/intensify_tests.rs
+++ b/crates/engine/src/game/effects/intensify_tests.rs
@@ -4,7 +4,6 @@
 use super::intensify::resolve;
 use crate::game::printed_cards::apply_card_face_to_object;
 use crate::game::zones::create_object;
-use crate::parser::oracle_effect::parse_effect;
 use crate::types::ability::{Effect, IntensityScope, QuantityExpr, ResolvedAbility};
 use crate::types::card::CardFace;
 use crate::types::identifiers::{CardId, ObjectId};
@@ -156,37 +155,4 @@ fn starting_intensity_is_stamped_from_the_keyword_once() {
         obj.intensity, 5,
         "re-stamping the face must not reset intensity"
     );
-}
-
-#[test]
-fn parser_maps_intensify_clauses_to_the_right_scope() {
-    assert!(matches!(
-        parse_effect("this creature intensifies by 2."),
-        Effect::Intensify {
-            scope: IntensityScope::Source,
-            amount: QuantityExpr::Fixed { value: 2 },
-        }
-    ));
-    // No "by N" → amount 1.
-    assert!(matches!(
-        parse_effect("it intensifies."),
-        Effect::Intensify {
-            scope: IntensityScope::Source,
-            amount: QuantityExpr::Fixed { value: 1 },
-        }
-    ));
-    assert!(matches!(
-        parse_effect("cards you own named Arek, False Goldwarden intensify by 1."),
-        Effect::Intensify {
-            scope: IntensityScope::OwnedSameName,
-            ..
-        }
-    ));
-    match parse_effect("all Chorus cards you own intensify by 1.") {
-        Effect::Intensify {
-            scope: IntensityScope::OwnedSubtype { subtype },
-            ..
-        } => assert_eq!(subtype, "Chorus"),
-        other => panic!("expected OwnedSubtype, got {other:?}"),
-    }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -82,6 +82,8 @@ pub mod epic;
 #[path = "epic_tests.rs"]
 mod epic_tests;
 pub mod exchange_control;
+// Tests for `intensify` live in a sibling file (declared here, not in
+// `intensify.rs`, so `intensify.rs` stays implementation-only).
 pub mod exchange_life;
 pub mod exile_from_top_until;
 pub mod exile_top;
@@ -101,6 +103,10 @@ pub mod grant_extra_loyalty_activations;
 pub mod grant_permission;
 pub mod hideaway;
 pub mod incubate;
+pub mod intensify;
+#[cfg(test)]
+#[path = "intensify_tests.rs"]
+mod intensify_tests;
 pub mod investigate;
 pub mod learn;
 pub mod life;
@@ -2072,6 +2078,7 @@ pub fn resolve_effect(
         }
         Effect::ProcessRadCounters => rad_counters::resolve(state, ability, events),
         Effect::Conjure { .. } => conjure::resolve(state, ability, events),
+        Effect::Intensify { .. } => intensify::resolve(state, ability, events),
         Effect::ChooseOneOf { .. } => choose_one_of::resolve(state, ability, events),
         Effect::Unimplemented { name, .. } => {
             // Log warning and return Ok (no-op) for unimplemented effects

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -336,6 +336,14 @@ pub struct GameObject {
     // Counters
     pub counters: HashMap<CounterType, u32>,
 
+    /// Alchemy Intensity — a per-card escalating value (digital-only, no CR
+    /// entry). Initialized from the card's "Starting intensity N" at first
+    /// characteristic application and incremented by `Effect::Intensify`. Like
+    /// `counters`, it persists across zone changes (the object keeps its id), so
+    /// a card's intensity follows it through hand/library/stack/battlefield.
+    #[serde(default)]
+    pub intensity: u32,
+
     // Characteristics
     pub name: String,
     pub power: Option<i32>,
@@ -975,6 +983,7 @@ impl GameObject {
             paired_with: None,
             pair_controller: None,
             counters: HashMap::new(),
+            intensity: 0,
             name: name.clone(),
             power: None,
             toughness: None,

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -150,6 +150,7 @@ fn categorize(event: &GameEvent) -> LogCategory {
         | GameEvent::PlayerPhasedIn { .. }
         | GameEvent::DamageCleared { .. }
         | GameEvent::CounterAdded { .. }
+        | GameEvent::ObjectIntensified { .. }
         | GameEvent::Evolved { .. }
         | GameEvent::CounterRemoved { .. }
         | GameEvent::Transformed { .. }
@@ -632,6 +633,12 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
             LogSegment::Keyword(format!("{counter_type:?}")),
             text(" counter(s) on "),
             card_seg(state, *object_id),
+        ],
+
+        GameEvent::ObjectIntensified { object_id, amount } => vec![
+            card_seg(state, *object_id),
+            text(" intensified by "),
+            num(*amount as i32),
         ],
 
         GameEvent::Evolved { object_id } => {

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -171,11 +171,11 @@ pub fn apply_card_face_to_object(obj: &mut GameObject, card_face: &CardFace) {
         obj.class_level = Some(1);
     }
 
-    // Digital-only Alchemy: stamp "Starting intensity N" onto the object exactly
-    // once, at first characteristic application — intensity then persists across
-    // zones and accumulates via `Effect::Intensify`, so re-stamping (transform,
-    // rehydrate) must not reset it.
-    if !was_initialized {
+    // Digital-only Alchemy: stamp "Starting intensity N" onto the object. Gated
+    // on `intensity == 0` (not `!was_initialized`) so a DFC whose starting
+    // intensity lives on the back face still picks it up on transform, while
+    // re-stamping a card that has already accumulated intensity never resets it.
+    if obj.intensity == 0 {
         if let Some(n) = card_face.keywords.iter().find_map(|k| match k {
             crate::types::keywords::Keyword::StartingIntensity(n) => Some(*n),
             _ => None,

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -171,6 +171,19 @@ pub fn apply_card_face_to_object(obj: &mut GameObject, card_face: &CardFace) {
         obj.class_level = Some(1);
     }
 
+    // Digital-only Alchemy: stamp "Starting intensity N" onto the object exactly
+    // once, at first characteristic application — intensity then persists across
+    // zones and accumulates via `Effect::Intensify`, so re-stamping (transform,
+    // rehydrate) must not reset it.
+    if !was_initialized {
+        if let Some(n) = card_face.keywords.iter().find_map(|k| match k {
+            crate::types::keywords::Keyword::StartingIntensity(n) => Some(*n),
+            _ => None,
+        }) {
+            obj.intensity = n;
+        }
+    }
+
     // CR 306.5c + CR 310.4c: Rehydration must not clobber live counter-tracked
     // loyalty/defense. `rehydrate_game_from_card_db` re-applies printed faces
     // mid-game (multiplayer sync); the counter map is authoritative on the
@@ -602,6 +615,7 @@ fn walk_cost(cost: &AbilityCost, out: &mut Vec<String>) {
 /// those cases — extend it whenever a carrier is added.
 fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
     match effect {
+        Effect::Intensify { .. } => {}
         Effect::Conjure { cards, .. } => {
             for conjure_card in cards {
                 out.push(conjure_card.name.clone());

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -214,6 +214,7 @@ pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]
                 mark_battlefield_display_dirty(state);
             }
             GameEvent::CounterAdded { object_id, .. }
+            | GameEvent::ObjectIntensified { object_id, .. }
             | GameEvent::CounterRemoved { object_id, .. }
             | GameEvent::Evolved { object_id } => {
                 // +1/+1 counters set `layers_dirty` (counters.rs) → Gate 1 caught

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -274,6 +274,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::PlayerCounter { .. }
         | QuantityRef::Variable { .. }
         | QuantityRef::Power { .. }
+        | QuantityRef::Intensity { .. }
         | QuantityRef::Toughness { .. }
         | QuantityRef::ObjectManaValue { .. }
         | QuantityRef::ObjectColorCount { .. }
@@ -442,6 +443,7 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::PlayerCounter { .. }
         | QuantityRef::Variable { .. }
         | QuantityRef::Power { .. }
+        | QuantityRef::Intensity { .. }
         | QuantityRef::Toughness { .. }
         | QuantityRef::ObjectManaValue { .. }
         | QuantityRef::ObjectColorCount { .. }
@@ -1272,6 +1274,19 @@ fn resolve_ref(
             ability,
             |obj| obj.power,
             |lki| lki.power,
+        ),
+        // Digital-only Alchemy: read the object's current intensity. The reader
+        // is the source itself (a spell on the stack or a permanent reading its
+        // own intensity), so the live object carries it; LKI does not track
+        // intensity, so it has no fallback.
+        QuantityRef::Intensity { scope } => resolve_object_pt(
+            state,
+            *scope,
+            ctx,
+            targets,
+            ability,
+            |obj| Some(i32::try_from(obj.intensity).unwrap_or(i32::MAX)),
+            |_lki| None,
         ),
         QuantityRef::Toughness { scope } => resolve_object_pt(
             state,

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -547,6 +547,7 @@ fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
         GameEvent::SpellCountered { .. } => {}
         GameEvent::CounterAdded { .. } => push(TriggerEventKey::CounterAdded),
         GameEvent::Evolved { .. } => {}
+        GameEvent::ObjectIntensified { .. } => {}
         GameEvent::CounterRemoved { .. } => push(TriggerEventKey::CounterRemoved),
         GameEvent::TokenCreated { .. } | GameEvent::ObjectConjured { .. } => {
             push(TriggerEventKey::TokenCreated);

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -813,6 +813,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::GiveControl
         | EffectKind::RemoveFromCombat
         | EffectKind::Conjure
+        | EffectKind::Intensify
         | EffectKind::ChooseOneOf
         | EffectKind::Specialize
         | EffectKind::Unimplemented

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -804,6 +804,7 @@ fn count_matching_trigger_event_subjects(
         | GameEvent::DamagePrevented { .. }
         | GameEvent::SpellCountered { .. }
         | GameEvent::CounterAdded { .. }
+        | GameEvent::ObjectIntensified { .. }
         | GameEvent::CounterRemoved { .. }
         | GameEvent::ObjectConjured { .. }
         | GameEvent::EffectResolved { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -91,12 +91,13 @@ use crate::types::ability::{
     ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard,
     ContinuousModification, ControllerRef, DamageModification, DamageSource,
     DelayedTriggerCondition, DoubleTarget, Duration, Effect, FilterProp, GameRestriction,
-    IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty,
-    ObjectScope, PaymentCost, PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount,
-    PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition,
-    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
-    StepSkipTarget, SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition,
-    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
+    IntensityScope, IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec,
+    ObjectProperty, ObjectScope, PaymentCost, PlayerFilter, PlayerRelation, PlayerScope,
+    PreventionAmount, PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef,
+    ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RoundingMode,
+    StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink, TargetFilter,
+    TargetSelectionMode, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -4360,6 +4361,11 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return redirected;
     }
 
+    // Digital-only Alchemy: "[scope] intensif[y/ies] by N" — the Intensify action.
+    if let Some(effect) = try_parse_intensify(tp) {
+        return parsed_clause(effect);
+    }
+
     // Digital-only: "conjure a card named X into/onto zone" — Conjure keyword action.
     if let Some(effect) = try_parse_conjure(tp) {
         return parsed_clause(effect);
@@ -4367,6 +4373,103 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
 
     let ast = parse_clause_ast(text, ctx);
     lower_clause_ast(ast, ctx)
+}
+
+/// Digital-only Alchemy keyword action: parse "intensify" clauses into
+/// `Effect::Intensify`. The scope comes from the subject:
+/// * self ("~ / this creature / this artifact / … / it intensifies [by N]") →
+///   [`IntensityScope::Source`];
+/// * "cards you own named [self] intensify [by N]" → [`IntensityScope::OwnedSameName`];
+/// * "all [subtype] cards you own intensify [by N]" → [`IntensityScope::OwnedSubtype`].
+///
+/// The amount defaults to 1 when "by N" is absent. The clause tail must be fully
+/// consumed (bare or with a sentence period) — otherwise `None` is returned so
+/// an unmodeled variant falls through to `Unimplemented` instead of dropping a
+/// rider.
+fn try_parse_intensify(tp: TextPair) -> Option<Effect> {
+    fn tail_done(tail: &str) -> bool {
+        tail.is_empty() || tail == "."
+    }
+    // Consume the verb ("intensify"/"intensifies") and the optional "by N",
+    // returning the amount and the remaining tail.
+    fn verb_and_amount(rest: &str) -> Option<(QuantityExpr, &str)> {
+        let (rest, _) = alt((
+            tag::<_, _, OracleError<'_>>("intensifies"),
+            tag::<_, _, OracleError<'_>>("intensify"),
+        ))
+        .parse(rest)
+        .ok()?;
+        if let Ok((rest, (_, n))) = (
+            tag::<_, _, OracleError<'_>>(" by "),
+            nom_primitives::parse_number,
+        )
+            .parse(rest)
+        {
+            Some((QuantityExpr::Fixed { value: n as i32 }, rest))
+        } else {
+            Some((QuantityExpr::Fixed { value: 1 }, rest))
+        }
+    }
+
+    let lower = tp.lower;
+
+    // Name-scoped: "cards you own named [self] intensify[ by N]".
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("cards you own named ").parse(lower) {
+        let (rest, _) = take_until::<_, _, OracleError<'_>>("intensif")
+            .parse(rest)
+            .ok()?;
+        let (amount, rest) = verb_and_amount(rest)?;
+        return tail_done(rest).then_some(Effect::Intensify {
+            scope: IntensityScope::OwnedSameName,
+            amount,
+        });
+    }
+
+    // Subtype-scoped: "all [subtype] cards you own intensify[ by N]".
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("all ").parse(lower) {
+        if let Ok((after, subtype_lower)) =
+            take_until::<_, _, OracleError<'_>>(" cards you own intensif").parse(rest)
+        {
+            let (after, _) = tag::<_, _, OracleError<'_>>(" cards you own ")
+                .parse(after)
+                .ok()?;
+            let (amount, after) = verb_and_amount(after)?;
+            if tail_done(after) {
+                return Some(Effect::Intensify {
+                    scope: IntensityScope::OwnedSubtype {
+                        subtype: crate::parser::oracle_quantity::capitalize_first(
+                            subtype_lower.trim(),
+                        ),
+                    },
+                    amount,
+                });
+            }
+            return None;
+        }
+    }
+
+    // Self-scoped: a self-reference subject directly before the verb.
+    let after_subject = [
+        "~ ",
+        "it ",
+        "this creature ",
+        "this artifact ",
+        "this enchantment ",
+        "this equipment ",
+        "this card ",
+    ]
+    .iter()
+    .find_map(|subject| {
+        tag::<_, _, OracleError<'_>>(*subject)
+            .parse(lower)
+            .ok()
+            .map(|(rest, _)| rest)
+    })?;
+    let (amount, rest) = verb_and_amount(after_subject)?;
+    tail_done(rest).then_some(Effect::Intensify {
+        scope: IntensityScope::Source,
+        amount,
+    })
 }
 
 /// Digital-only keyword action: Parse "conjure [quantity] card(s) named {Name} into/onto {zone}"

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4399,16 +4399,39 @@ fn try_parse_intensify(tp: TextPair) -> Option<Effect> {
         ))
         .parse(rest)
         .ok()?;
+        // "by N" — a fixed amount.
         if let Ok((rest, (_, n))) = (
             tag::<_, _, OracleError<'_>>(" by "),
             nom_primitives::parse_number,
         )
             .parse(rest)
         {
-            Some((QuantityExpr::Fixed { value: n as i32 }, rest))
-        } else {
-            Some((QuantityExpr::Fixed { value: 1 }, rest))
+            return Some((QuantityExpr::Fixed { value: n as i32 }, rest));
         }
+        // "by X[, where X is …]" — a variable amount. The trailing "where X is …"
+        // binding is consumed here so the clause is fully modeled; binding X to
+        // its value (e.g. "that creature's power") is a follow-up, but emitting a
+        // Variable amount keeps the whole clause supported instead of dropping it.
+        if let Ok((after, _)) = tag::<_, _, OracleError<'_>>(" by x").parse(rest) {
+            if after.is_empty()
+                || after == "."
+                || tag::<_, _, OracleError<'_>>(", where x is ")
+                    .parse(after)
+                    .is_ok()
+            {
+                return Some((
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Variable {
+                            name: "X".to_string(),
+                        },
+                    },
+                    "",
+                ));
+            }
+            return None;
+        }
+        // No "by …" clause — intensifies by 1.
+        Some((QuantityExpr::Fixed { value: 1 }, rest))
     }
 
     let lower = tp.lower;

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -91,12 +91,13 @@ use crate::types::ability::{
     ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard,
     ContinuousModification, ControllerRef, DamageModification, DamageSource,
     DelayedTriggerCondition, DoubleTarget, Duration, Effect, FilterProp, GameRestriction,
-    IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty,
-    ObjectScope, PaymentCost, PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount,
-    PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition,
-    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
-    StepSkipTarget, SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition,
-    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
+    IntensityScope, IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec,
+    ObjectProperty, ObjectScope, PaymentCost, PlayerFilter, PlayerRelation, PlayerScope,
+    PreventionAmount, PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef,
+    ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RoundingMode,
+    StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink, TargetFilter,
+    TargetSelectionMode, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -4360,6 +4361,11 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return redirected;
     }
 
+    // Digital-only Alchemy: "[scope] intensif[y/ies] by N" - the Intensify action.
+    if let Some(effect) = try_parse_intensify(tp) {
+        return parsed_clause(effect);
+    }
+
     // Digital-only Alchemy: "draft a card from [X]'s spellbook [+ destination]".
     if let Some(effect) = try_parse_spellbook_draft(tp) {
         return parsed_clause(effect);
@@ -4372,6 +4378,118 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
 
     let ast = parse_clause_ast(text, ctx);
     lower_clause_ast(ast, ctx)
+}
+
+/// Digital-only Alchemy keyword action: parse "intensify" clauses into
+/// `Effect::Intensify`. The scope comes from the subject:
+/// * self ("~ / this creature / this artifact / ... / it intensifies [by N]") ->
+///   [`IntensityScope::Source`];
+/// * "cards you own named [self] intensify [by N]" -> [`IntensityScope::OwnedSameName`];
+/// * "all [subtype] cards you own intensify [by N]" -> [`IntensityScope::OwnedSubtype`].
+///
+/// The amount defaults to 1 when "by N" is absent. The clause tail must be fully
+/// consumed (bare or with a sentence period) so unmodeled variants fall through
+/// to `Unimplemented` instead of silently dropping riders.
+fn try_parse_intensify(tp: TextPair) -> Option<Effect> {
+    fn tail_done(tail: &str) -> bool {
+        tail.is_empty() || tail == "."
+    }
+
+    fn verb_and_amount(rest: &str) -> Option<(QuantityExpr, &str)> {
+        let (rest, _) = alt((
+            tag::<_, _, OracleError<'_>>("intensifies"),
+            tag::<_, _, OracleError<'_>>("intensify"),
+        ))
+        .parse(rest)
+        .ok()?;
+
+        if let Ok((rest, (_, n))) = (
+            tag::<_, _, OracleError<'_>>(" by "),
+            nom_primitives::parse_number,
+        )
+            .parse(rest)
+        {
+            return Some((QuantityExpr::Fixed { value: n as i32 }, rest));
+        }
+
+        if let Ok((after, _)) = tag::<_, _, OracleError<'_>>(" by x").parse(rest) {
+            if after.is_empty()
+                || after == "."
+                || tag::<_, _, OracleError<'_>>(", where x is ")
+                    .parse(after)
+                    .is_ok()
+            {
+                return Some((
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Variable {
+                            name: "X".to_string(),
+                        },
+                    },
+                    "",
+                ));
+            }
+            return None;
+        }
+
+        Some((QuantityExpr::Fixed { value: 1 }, rest))
+    }
+
+    let lower = tp.lower;
+
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("cards you own named ").parse(lower) {
+        let (rest, _) = take_until::<_, _, OracleError<'_>>("intensif")
+            .parse(rest)
+            .ok()?;
+        let (amount, rest) = verb_and_amount(rest)?;
+        return tail_done(rest).then_some(Effect::Intensify {
+            scope: IntensityScope::OwnedSameName,
+            amount,
+        });
+    }
+
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("all ").parse(lower) {
+        if let Ok((after, subtype_lower)) =
+            take_until::<_, _, OracleError<'_>>(" cards you own intensif").parse(rest)
+        {
+            let (after, _) = tag::<_, _, OracleError<'_>>(" cards you own ")
+                .parse(after)
+                .ok()?;
+            let (amount, after) = verb_and_amount(after)?;
+            if tail_done(after) {
+                return Some(Effect::Intensify {
+                    scope: IntensityScope::OwnedSubtype {
+                        subtype: crate::parser::oracle_quantity::capitalize_first(
+                            subtype_lower.trim(),
+                        ),
+                    },
+                    amount,
+                });
+            }
+            return None;
+        }
+    }
+
+    let after_subject = [
+        "~ ",
+        "it ",
+        "this creature ",
+        "this artifact ",
+        "this enchantment ",
+        "this equipment ",
+        "this card ",
+    ]
+    .iter()
+    .find_map(|subject| {
+        tag::<_, _, OracleError<'_>>(*subject)
+            .parse(lower)
+            .ok()
+            .map(|(rest, _)| rest)
+    })?;
+    let (amount, rest) = verb_and_amount(after_subject)?;
+    tail_done(rest).then_some(Effect::Intensify {
+        scope: IntensityScope::Source,
+        amount,
+    })
 }
 
 /// Digital-only Alchemy keyword action: parse "draft a card from [X]'s spellbook"
@@ -38002,6 +38120,50 @@ mod tests {
                 ..
             } if type_filters == vec![TypeFilter::Creature]
                 && properties == vec![FilterProp::Blocking, FilterProp::Another]
+        ));
+    }
+
+    #[test]
+    fn intensify_parser_maps_source_and_owned_scopes() {
+        let e = parse_effect("This creature intensifies by 2.");
+        assert!(matches!(
+            e,
+            Effect::Intensify {
+                scope: IntensityScope::Source,
+                amount: QuantityExpr::Fixed { value: 2 },
+            }
+        ));
+
+        let e = parse_effect("Cards you own named Arek intensify.");
+        assert!(matches!(
+            e,
+            Effect::Intensify {
+                scope: IntensityScope::OwnedSameName,
+                amount: QuantityExpr::Fixed { value: 1 },
+            }
+        ));
+
+        let e = parse_effect("All Chorus cards you own intensify by 3.");
+        assert!(matches!(
+            e,
+            Effect::Intensify {
+                scope: IntensityScope::OwnedSubtype { ref subtype },
+                amount: QuantityExpr::Fixed { value: 3 },
+            } if subtype == "Chorus"
+        ));
+    }
+
+    #[test]
+    fn intensify_parser_preserves_variable_x_amount() {
+        let e = parse_effect("This Equipment intensifies by X, where X is that creature's power.");
+        assert!(matches!(
+            e,
+            Effect::Intensify {
+                scope: IntensityScope::Source,
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { ref name },
+                },
+            } if name == "X"
         ));
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -91,13 +91,12 @@ use crate::types::ability::{
     ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard,
     ContinuousModification, ControllerRef, DamageModification, DamageSource,
     DelayedTriggerCondition, DoubleTarget, Duration, Effect, FilterProp, GameRestriction,
-    IntensityScope, IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec,
-    ObjectProperty, ObjectScope, PaymentCost, PlayerFilter, PlayerRelation, PlayerScope,
-    PreventionAmount, PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef,
-    ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RoundingMode,
-    StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink, TargetFilter,
-    TargetSelectionMode, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
-    UnlessPayModifier, UntilCondition, ZoneOwner,
+    IterationKindBinding, ManaProduction, ManaSpendPermission, MultiTargetSpec, ObjectProperty,
+    ObjectScope, PaymentCost, PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount,
+    PreventionScope, ProhibitedActivity, QuantityExpr, QuantityRef, ReplacementDefinition,
+    RestrictionExpiry, RestrictionPlayerScope, RoundingMode, StaticCondition, StaticDefinition,
+    StepSkipTarget, SubAbilityLink, TargetFilter, TargetSelectionMode, TriggerCondition,
+    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -4361,11 +4360,6 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return redirected;
     }
 
-    // Digital-only Alchemy: "[scope] intensif[y/ies] by N" — the Intensify action.
-    if let Some(effect) = try_parse_intensify(tp) {
-        return parsed_clause(effect);
-    }
-
     // Digital-only: "conjure a card named X into/onto zone" — Conjure keyword action.
     if let Some(effect) = try_parse_conjure(tp) {
         return parsed_clause(effect);
@@ -4373,126 +4367,6 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
 
     let ast = parse_clause_ast(text, ctx);
     lower_clause_ast(ast, ctx)
-}
-
-/// Digital-only Alchemy keyword action: parse "intensify" clauses into
-/// `Effect::Intensify`. The scope comes from the subject:
-/// * self ("~ / this creature / this artifact / … / it intensifies [by N]") →
-///   [`IntensityScope::Source`];
-/// * "cards you own named [self] intensify [by N]" → [`IntensityScope::OwnedSameName`];
-/// * "all [subtype] cards you own intensify [by N]" → [`IntensityScope::OwnedSubtype`].
-///
-/// The amount defaults to 1 when "by N" is absent. The clause tail must be fully
-/// consumed (bare or with a sentence period) — otherwise `None` is returned so
-/// an unmodeled variant falls through to `Unimplemented` instead of dropping a
-/// rider.
-fn try_parse_intensify(tp: TextPair) -> Option<Effect> {
-    fn tail_done(tail: &str) -> bool {
-        tail.is_empty() || tail == "."
-    }
-    // Consume the verb ("intensify"/"intensifies") and the optional "by N",
-    // returning the amount and the remaining tail.
-    fn verb_and_amount(rest: &str) -> Option<(QuantityExpr, &str)> {
-        let (rest, _) = alt((
-            tag::<_, _, OracleError<'_>>("intensifies"),
-            tag::<_, _, OracleError<'_>>("intensify"),
-        ))
-        .parse(rest)
-        .ok()?;
-        // "by N" — a fixed amount.
-        if let Ok((rest, (_, n))) = (
-            tag::<_, _, OracleError<'_>>(" by "),
-            nom_primitives::parse_number,
-        )
-            .parse(rest)
-        {
-            return Some((QuantityExpr::Fixed { value: n as i32 }, rest));
-        }
-        // "by X[, where X is …]" — a variable amount. The trailing "where X is …"
-        // binding is consumed here so the clause is fully modeled; binding X to
-        // its value (e.g. "that creature's power") is a follow-up, but emitting a
-        // Variable amount keeps the whole clause supported instead of dropping it.
-        if let Ok((after, _)) = tag::<_, _, OracleError<'_>>(" by x").parse(rest) {
-            if after.is_empty()
-                || after == "."
-                || tag::<_, _, OracleError<'_>>(", where x is ")
-                    .parse(after)
-                    .is_ok()
-            {
-                return Some((
-                    QuantityExpr::Ref {
-                        qty: QuantityRef::Variable {
-                            name: "X".to_string(),
-                        },
-                    },
-                    "",
-                ));
-            }
-            return None;
-        }
-        // No "by …" clause — intensifies by 1.
-        Some((QuantityExpr::Fixed { value: 1 }, rest))
-    }
-
-    let lower = tp.lower;
-
-    // Name-scoped: "cards you own named [self] intensify[ by N]".
-    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("cards you own named ").parse(lower) {
-        let (rest, _) = take_until::<_, _, OracleError<'_>>("intensif")
-            .parse(rest)
-            .ok()?;
-        let (amount, rest) = verb_and_amount(rest)?;
-        return tail_done(rest).then_some(Effect::Intensify {
-            scope: IntensityScope::OwnedSameName,
-            amount,
-        });
-    }
-
-    // Subtype-scoped: "all [subtype] cards you own intensify[ by N]".
-    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("all ").parse(lower) {
-        if let Ok((after, subtype_lower)) =
-            take_until::<_, _, OracleError<'_>>(" cards you own intensif").parse(rest)
-        {
-            let (after, _) = tag::<_, _, OracleError<'_>>(" cards you own ")
-                .parse(after)
-                .ok()?;
-            let (amount, after) = verb_and_amount(after)?;
-            if tail_done(after) {
-                return Some(Effect::Intensify {
-                    scope: IntensityScope::OwnedSubtype {
-                        subtype: crate::parser::oracle_quantity::capitalize_first(
-                            subtype_lower.trim(),
-                        ),
-                    },
-                    amount,
-                });
-            }
-            return None;
-        }
-    }
-
-    // Self-scoped: a self-reference subject directly before the verb.
-    let after_subject = [
-        "~ ",
-        "it ",
-        "this creature ",
-        "this artifact ",
-        "this enchantment ",
-        "this equipment ",
-        "this card ",
-    ]
-    .iter()
-    .find_map(|subject| {
-        tag::<_, _, OracleError<'_>>(*subject)
-            .parse(lower)
-            .ok()
-            .map(|(rest, _)| rest)
-    })?;
-    let (amount, rest) = verb_and_amount(after_subject)?;
-    tail_done(rest).then_some(Effect::Intensify {
-        scope: IntensityScope::Source,
-        amount,
-    })
 }
 
 /// Digital-only keyword action: Parse "conjure [quantity] card(s) named {Name} into/onto {zone}"

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3461,6 +3461,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::GiveControl { .. }
         | Effect::RemoveFromCombat { .. }
         | Effect::Conjure { .. }
+        | Effect::Intensify { .. }
         | Effect::ChooseOneOf { .. }
         // CR 614.12 + CR 303.4: Return-as-Aura is its own emitted sub-effect
         // following a `ChangeZone`; it is not a lookback-transparent clause

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1021,17 +1021,6 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
         return Some(Keyword::Renown(n));
     }
 
-    // Digital-only Alchemy: "Starting intensity N" — the card's initial intensity.
-    if let Ok((_, (_, _, n))) = all_consuming((
-        tag::<_, _, OracleError<'_>>("starting intensity"),
-        space1,
-        nom_primitives::parse_number,
-    ))
-    .parse(text)
-    {
-        return Some(Keyword::StartingIntensity(n));
-    }
-
     // CR 702.68a: Frenzy N — parameterized keyword from Oracle/reminder/grant text.
     // MTGJSON's keyword list carries only "Frenzy"; the Oracle line supplies N.
     if let Ok((_, (_, _, n))) = all_consuming((

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1021,6 +1021,17 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
         return Some(Keyword::Renown(n));
     }
 
+    // Digital-only Alchemy: "Starting intensity N" — the card's initial intensity.
+    if let Ok((_, (_, _, n))) = all_consuming((
+        tag::<_, _, OracleError<'_>>("starting intensity"),
+        space1,
+        nom_primitives::parse_number,
+    ))
+    .parse(text)
+    {
+        return Some(Keyword::StartingIntensity(n));
+    }
+
     // CR 702.68a: Frenzy N — parameterized keyword from Oracle/reminder/grant text.
     // MTGJSON's keyword list carries only "Frenzy"; the Oracle line supplies N.
     if let Ok((_, (_, _, n))) = all_consuming((
@@ -1369,6 +1380,7 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Wither => "wither".to_string(),
         Keyword::Infect => "infect".to_string(),
         Keyword::Afflict(n) => format!("afflict {n}"),
+        Keyword::StartingIntensity(n) => format!("starting intensity {n}"),
         Keyword::Prowess => "prowess".to_string(),
         Keyword::Undying => "undying".to_string(),
         Keyword::Persist => "persist".to_string(),

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3122,6 +3122,10 @@ pub enum QuantityRef {
     /// `EventContextSourcePower` (CR 608.2k: cost OR trigger-condition
     /// referent).
     Power { scope: ObjectScope },
+    /// Digital-only Alchemy (no CR entry): the current `intensity` of an object,
+    /// scoped via `ObjectScope`. Reads "X is [card]'s intensity" /
+    /// "this spell's intensity" / "equal to its intensity".
+    Intensity { scope: ObjectScope },
     /// CR 208.1 + CR 113.6: Current toughness of an object, scoped via
     /// ObjectScope (Round Π-6). Mirrors `Power`. Replaces the `SelfToughness`
     /// variant. `CostPaidObject` subsumes the former
@@ -5486,6 +5490,22 @@ pub struct ConjureCard {
     pub count: QuantityExpr,
 }
 
+/// Digital-only Alchemy: which cards an `Effect::Intensify` applies to. Every
+/// scope resolves across ALL zones (a card's intensity follows it everywhere).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "type")]
+pub enum IntensityScope {
+    /// "this creature/artifact/… intensifies" — the source object only.
+    #[default]
+    Source,
+    /// "cards you own named [this card] intensify" — every card the source's
+    /// controller owns with the source's name.
+    OwnedSameName,
+    /// "All [subtype] cards you own intensify" — every card the source's
+    /// controller owns of the given subtype (e.g. "Chorus").
+    OwnedSubtype { subtype: String },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CopyManaValueLimit {
     AmountSpentToCastSource,
@@ -7609,6 +7629,17 @@ pub enum Effect {
         #[serde(default)]
         tapped: bool,
     },
+    /// Digital-only Alchemy keyword action (no CR entry): increase the intensity
+    /// of one or more cards by `amount`. `scope` selects which cards — the source
+    /// itself, every card the controller owns with the source's name, or every
+    /// card the controller owns of a given subtype — across ALL zones, since a
+    /// card's intensity follows it everywhere.
+    Intensify {
+        #[serde(default)]
+        scope: IntensityScope,
+        #[serde(default = "default_quantity_one")]
+        amount: QuantityExpr,
+    },
     /// CR 701.55 + CR 608.2d: Inline "[player] chooses/faces [effect A] or
     /// [effect B]" — the configured chooser scope chooses at resolution which
     /// branch to execute. Building block for villainous choices and optional
@@ -8513,6 +8544,7 @@ impl Effect {
             | Effect::TimeTravel
             | Effect::RuntimeHandled { .. }
             | Effect::Conjure { .. }
+            | Effect::Intensify { .. }
             | Effect::ChooseOneOf { .. }
             | Effect::Unimplemented { .. }
             // CR 603.7e: ChooseObjectsIntoTrackedSet has no discrete effect-target
@@ -8725,6 +8757,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::GiveControl { .. } => "GiveControl",
         Effect::RemoveFromCombat { .. } => "RemoveFromCombat",
         Effect::Conjure { .. } => "Conjure",
+        Effect::Intensify { .. } => "Intensify",
         Effect::ChooseOneOf { .. } => "ChooseOneOf",
         Effect::Unimplemented { name, .. } => name,
     }
@@ -8916,6 +8949,7 @@ pub enum EffectKind {
     GiveControl,
     RemoveFromCombat,
     Conjure,
+    Intensify,
     ChooseOneOf,
     Unimplemented,
     /// Engine-level equip action (not via an Effect handler).
@@ -9116,6 +9150,7 @@ impl From<&Effect> for EffectKind {
             Effect::GiveControl { .. } => EffectKind::GiveControl,
             Effect::RemoveFromCombat { .. } => EffectKind::RemoveFromCombat,
             Effect::Conjure { .. } => EffectKind::Conjure,
+            Effect::Intensify { .. } => EffectKind::Intensify,
             Effect::ChooseOneOf { .. } => EffectKind::ChooseOneOf,
             Effect::Unimplemented { .. } => EffectKind::Unimplemented,
         }

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -372,6 +372,13 @@ pub enum GameEvent {
         counter_type: CounterType,
         count: u32,
     },
+    /// Digital-only Alchemy (no CR entry): a card's intensity increased by
+    /// `amount`. Emitted per affected card so consumers (triggers that watch for
+    /// intensifying, frontend animation) can see exactly which cards changed.
+    ObjectIntensified {
+        object_id: ObjectId,
+        amount: u32,
+    },
     /// CR 702.100b: A creature evolved because one or more +1/+1 counters were
     /// put on it as a result of its evolve ability resolving.
     Evolved {

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -459,6 +459,9 @@ pub enum Keyword {
     Infect,
     /// CR 702.130a: "Afflict N" — when blocked, defending player loses N life.
     Afflict(u32),
+    /// Digital-only Alchemy (no CR entry): "Starting intensity N" — the card's
+    /// initial intensity value, stamped onto the object at creation.
+    StartingIntensity(u32),
 
     // Triggered abilities
     Prowess,
@@ -990,6 +993,7 @@ impl Keyword {
             Keyword::Wither => KeywordKind::Wither,
             Keyword::Infect => KeywordKind::Infect,
             Keyword::Afflict(_) => KeywordKind::Afflict,
+            Keyword::StartingIntensity(_) => KeywordKind::Unknown,
             Keyword::Prowess => KeywordKind::Prowess,
             Keyword::Undying => KeywordKind::Undying,
             Keyword::Persist => KeywordKind::Persist,
@@ -2322,6 +2326,7 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Wither" => Ok(Keyword::Wither),
         "Infect" => Ok(Keyword::Infect),
         "Afflict" => Ok(Keyword::Afflict(uint(data).max(1))),
+        "StartingIntensity" => Ok(Keyword::StartingIntensity(uint(data))),
         "Prowess" => Ok(Keyword::Prowess),
         "Undying" => Ok(Keyword::Undying),
         "Persist" => Ok(Keyword::Persist),

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -489,6 +489,7 @@ fn redundancy_delta(
         | Effect::GiveControl { .. }
         | Effect::RemoveFromCombat { .. }
         | Effect::Conjure { .. }
+        | Effect::Intensify { .. }
         | Effect::Tribute { .. }
         | Effect::Unimplemented { .. }
         // CR 702.85a: Cascade has no targets or redundancy — the redundancy


### PR DESCRIPTION
## Summary

Closes: #2698 

Implements the foundation of the Alchemy **Intensity** mechanic. Intensity is a per-card escalating value initialized from "Starting intensity N" and increased by "intensify by N". This PR adds the **state**, the **Intensify mutation** (all scopes, parsed + resolved), and the **read-resolution infrastructure**. ~20 Alchemy cards.

Implemented per the real card texts — intensity is **name-scoped and cross-zone** (it follows a card through every zone), not the per-permanent counter the issue assumed.

## Design
- **State:** `GameObject.intensity` — persists across zone changes (object identity is preserved), serde-default.
- **Starting intensity:** `Keyword::StartingIntensity(u32)` + oracle parser; stamped onto the object once in `apply_card_face_to_object` (gated on first application, so re-stamping never resets accumulated intensity).
- **Mutation (core):** `Effect::Intensify { scope, amount }` resolved in a new `game/effects/intensify.rs`. `IntensityScope` covers **Source** ("this creature intensifies"), **OwnedSameName** ("cards you own named X intensify" — every owned copy in any zone), and **OwnedSubtype** ("all Chorus cards you own intensify"), via an owner-filtered scan over `state.objects`.
- **Parser:** `try_parse_intensify` (nom, **full-consume-or-`None`** so it never drops a rider) maps the self / named / subtype intensify clauses.
- **Read infrastructure:** `QuantityRef::Intensity { scope }` + resolver (reads `obj.intensity`).

## Scope (honest)
The **mutation is end-to-end**; the **read half is half-wired** and the remaining pieces are follow-ups:
1. **Read-phrase parsing** — `QuantityRef::Intensity` + resolver exist, but the parser does not yet turn *"X is [card]'s intensity"* / *"this spell's intensity"* into it, so payoffs that **read** intensity don't resolve against it yet.
2. **Continuous static reads** (Minthara/Quickbeast/Teysa "+X/+0 where X is intensity", Awestruck's conditional base P/T) — need the static/layer parser.
3. **"Starting intensity N" line extraction** and the **coverage/swallowed-clause gate** should be confirmed by a `card-data.json` regen (the parser is swallow-safe by construction).

## Files
- **New:** `game/effects/intensify.rs` (resolver), `game/effects/intensify_tests.rs` (tests).
- **Types:** `ability.rs` (`Effect::Intensify`, `IntensityScope`, `QuantityRef::Intensity` + registrations), `keywords.rs` (`StartingIntensity`), `game_object.rs` (`intensity`).
- **Runtime/parser:** `quantity.rs` (read resolver), `printed_cards.rs` (init), `effects/mod.rs` (dispatch), `oracle_keyword.rs` + `oracle_effect/mod.rs` (parsers), plus exhaustive-match arms in coverage / trigger_index / sequence / phase-ai.

## Tests
Source / OwnedSameName (across zones, owner-scoped) / OwnedSubtype scoping; starting intensity stamped once and not reset on re-stamp; parser maps each scope.

## Verification
- `cargo clippy -p engine --lib -- -D warnings` → clean
- `cargo check --workspace` → clean
- `effects::intensify_tests` → **5/5**; parser-combinator gate → clean
- Full engine lib suite: **10980 pass**; the only 3 failures are pre-existing stale-`card-data.json` DB-load cases, unrelated and present on `main`.

## Notes
New fields/variants all carry serde defaults — no card-data or save-compat break. This is a correct, tested foundation (state + scoped intensify mutation + read infrastructure); the read-phrase parser and continuous static reads are tracked follow-ups.
