### PR TITLE
fix(engine): expose runtime-granted typecycling

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -4129,9 +4129,11 @@ mod tests {
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, BasicLandType,
         ChoiceType, ChosenAttribute, ChosenSubtypeKind, ContinuousModification, Effect, EffectKind,
-        ManaContribution, ManaProduction, QuantityExpr, StaticDefinition, TargetFilter, TargetRef,
+        FilterProp, ManaContribution, ManaProduction, QuantityExpr, StaticDefinition, TargetFilter,
+        TargetRef, TypedFilter,
     };
     use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::keywords::{Keyword, KeywordKind};
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::zones::Zone;
 
@@ -4380,6 +4382,78 @@ mod tests {
                 door: RoomDoor::Left,
             } if *object_id == room
         )));
+    }
+
+    #[test]
+    fn priority_actions_offer_runtime_granted_typecycling_from_homing_sliver() {
+        let mut state = GameState::new_two_player(42);
+        let p0 = PlayerId(0);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = p0;
+        state.priority_player = p0;
+        state.waiting_for = WaitingFor::Priority { player: p0 };
+
+        let homing_sliver = create_object(
+            &mut state,
+            CardId(100),
+            p0,
+            "Homing Sliver".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&homing_sliver)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::card()
+                            .subtype("Sliver".to_string())
+                            .properties(vec![FilterProp::InZone { zone: Zone::Hand }]),
+                    ))
+                    .modifications(vec![ContinuousModification::AddKeyword {
+                        keyword: Keyword::Typecycling {
+                            cost: ManaCost::NoCost,
+                            subtype: "Sliver".to_string(),
+                        },
+                    }]),
+            );
+
+        let hand_sliver = create_object(
+            &mut state,
+            CardId(101),
+            p0,
+            "Striking Sliver".to_string(),
+            Zone::Hand,
+        );
+        let printed_len = {
+            let obj = state.objects.get_mut(&hand_sliver).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Sliver".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.abilities.len()
+        };
+
+        assert!(
+            crate::game::off_zone_characteristics::off_zone_has_keyword_kind(
+                &state,
+                hand_sliver,
+                KeywordKind::Typecycling,
+            ),
+            "Homing Sliver static should grant Typecycling to the Sliver card in hand"
+        );
+
+        let actions = priority_actions(&state, p0);
+        assert!(actions.iter().any(|candidate| {
+            matches!(
+                candidate.action,
+                GameAction::ActivateAbility {
+                    source_id,
+                    ability_index,
+                } if source_id == hand_sliver && ability_index == printed_len
+            )
+        }));
     }
 
     #[test]

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2674,9 +2674,9 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
         for &obj_id in &state.battlefield {
             if let Some(obj) = state.objects.get(&obj_id) {
                 if obj.controller == player {
-                    for (i, ability_def) in obj.abilities.iter().enumerate() {
+                    for (i, ability_def) in casting::activated_ability_definitions(state, obj_id) {
                         if ability_def.kind == crate::types::ability::AbilityKind::Activated
-                            && !crate::game::mana_abilities::is_mana_ability(ability_def)
+                            && !crate::game::mana_abilities::is_mana_ability(&ability_def)
                             && casting::can_activate_ability_now(state, player, obj_id, i)
                         {
                             actions.push(candidate(
@@ -2748,10 +2748,10 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
         for &obj_id in &state.players[player.0 as usize].hand {
             if let Some(obj) = state.objects.get(&obj_id) {
                 if obj.controller == player {
-                    for (i, ability_def) in obj.abilities.iter().enumerate() {
+                    for (i, ability_def) in casting::activated_ability_definitions(state, obj_id) {
                         if ability_def.kind == crate::types::ability::AbilityKind::Activated
                             && ability_def.activation_zone == Some(crate::types::zones::Zone::Hand)
-                            && !crate::game::mana_abilities::is_mana_ability(ability_def)
+                            && !crate::game::mana_abilities::is_mana_ability(&ability_def)
                             && casting::can_activate_ability_now(state, player, obj_id, i)
                         {
                             actions.push(candidate(
@@ -2780,11 +2780,11 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
                 // doesn't have a controller) can activate its activated
                 // ability." Restrict candidates to the acting player.
                 if obj.controller == player {
-                    for (i, ability_def) in obj.abilities.iter().enumerate() {
+                    for (i, ability_def) in casting::activated_ability_definitions(state, obj_id) {
                         if ability_def.kind == crate::types::ability::AbilityKind::Activated
                             && ability_def.activation_zone
                                 == Some(crate::types::zones::Zone::Graveyard)
-                            && !crate::game::mana_abilities::is_mana_ability(ability_def)
+                            && !crate::game::mana_abilities::is_mana_ability(&ability_def)
                             && casting::can_activate_ability_now(state, player, obj_id, i)
                         {
                             actions.push(candidate(

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -938,9 +938,9 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::{
-        AbilityCost, AbilityDefinition, AbilityKind, ChoiceType, ControllerRef, Effect,
-        ManaContribution, ManaProduction, QuantityExpr, ResolvedAbility, SearchSelectionConstraint,
-        TargetFilter, TypedFilter,
+        AbilityCost, AbilityDefinition, AbilityKind, ChoiceType, ContinuousModification,
+        ControllerRef, Effect, FilterProp, ManaContribution, ManaProduction, QuantityExpr,
+        ResolvedAbility, SearchSelectionConstraint, StaticDefinition, TargetFilter, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -949,6 +949,7 @@ mod tests {
         WaitingFor,
     };
     use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::keywords::{Keyword, KeywordKind};
     use crate::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
     use crate::types::player::PlayerId;
     use crate::types::zones::Zone;
@@ -1419,6 +1420,111 @@ mod tests {
                 },
             ),
             "cycling ActivateAbility must still be offered"
+        );
+    }
+
+    #[test]
+    fn legal_actions_offer_runtime_granted_typecycling_from_homing_sliver() {
+        let mut state = setup_priority();
+        state.phase = crate::types::phase::Phase::PreCombatMain;
+
+        let homing_sliver = create_object(
+            &mut state,
+            CardId(100),
+            PlayerId(0),
+            "Homing Sliver".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&homing_sliver)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::card()
+                            .subtype("Sliver".to_string())
+                            .properties(vec![FilterProp::InZone { zone: Zone::Hand }]),
+                    ))
+                    .modifications(vec![ContinuousModification::AddKeyword {
+                        keyword: Keyword::Typecycling {
+                            cost: ManaCost::NoCost,
+                            subtype: "Sliver".to_string(),
+                        },
+                    }]),
+            );
+
+        let hand_sliver = create_object(
+            &mut state,
+            CardId(101),
+            PlayerId(0),
+            "Striking Sliver".to_string(),
+            Zone::Hand,
+        );
+        let printed_len = {
+            let obj = state.objects.get_mut(&hand_sliver).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Sliver".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.abilities.len()
+        };
+
+        assert!(
+            crate::game::off_zone_characteristics::off_zone_has_keyword_kind(
+                &state,
+                hand_sliver,
+                KeywordKind::Typecycling,
+            ),
+            "Homing Sliver static should grant Typecycling to the Sliver card in hand"
+        );
+
+        let transient_index = printed_len;
+        assert!(
+            crate::game::casting::can_activate_ability_now(
+                &state,
+                PlayerId(0),
+                hand_sliver,
+                transient_index,
+            ),
+            "runtime-granted Typecycling should be activatable at the first transient index"
+        );
+
+        let (_, _, grouped) = legal_actions_full(&state);
+        assert!(
+            bucket_has(
+                &grouped,
+                hand_sliver,
+                &GameAction::ActivateAbility {
+                    source_id: hand_sliver,
+                    ability_index: transient_index,
+                },
+            ),
+            "legal actions must expose the runtime-granted Slivercycling activation"
+        );
+
+        let _result = apply_as_current(
+            &mut state,
+            GameAction::ActivateAbility {
+                source_id: hand_sliver,
+                ability_index: transient_index,
+            },
+        )
+        .expect("runtime-granted Typecycling activation should be accepted");
+
+        assert!(
+            state.stack.iter().any(|entry| {
+                matches!(
+                    entry.kind,
+                    StackEntryKind::ActivatedAbility { source_id, .. } if source_id == hand_sliver
+                )
+            }),
+            "activating runtime-granted Slivercycling should put the ability on the stack"
+        );
+        assert_eq!(
+            state.objects[&hand_sliver].zone,
+            Zone::Graveyard,
+            "activating runtime-granted Slivercycling should discard the source as a cost"
         );
     }
 

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1600,128 +1600,129 @@ pub fn compute_oathbreaker(mtgjson: &super::mtgjson::AtomicCard, face: &CardFace
 /// Typecycling: "[Cost], Discard this card: Search library for a [type] card,
 ///   reveal it, put it into your hand. Then shuffle."
 ///
-/// DEFERRED RUNTIME GAP (CR 702.29e + CR 113.6b) — Homing Sliver class:
+/// RUNTIME-GRANTED PATH (CR 702.29e + CR 113.6b) — Homing Sliver class:
 /// This build-time synthesis reads only the face's INTRINSIC printed keywords.
 /// A Typecycling/Cycling keyword GRANTED at runtime by a continuous effect
 /// (Homing Sliver: "Each Sliver card in each player's hand has slivercycling
 /// {3}.") lands on the recipient's runtime keyword set (CR 113.6b zone-of-
-/// function + `TargetFilter::extract_in_zone` resolves it in the Hand zone), but
-/// is NOT synthesized into a runtime-activatable ability — synthesis never runs
-/// over runtime-granted keywords. Closing this needs a general runtime
-/// granted-keyword -> activatable-ability primitive (not card-specific), which
-/// is deferred. The parser/grant half is correct and covered by
-/// `static_homing_sliver_grants_typecycling_to_slivers_in_hand` in
-/// `parser/oracle_static/tests.rs`.
+/// function + `TargetFilter::extract_in_zone` resolves it in the Hand zone).
+/// Those grants are converted on demand by `game::casting` through
+/// `cycling_ability_for_keyword`, keeping printed and runtime-granted cycling
+/// ability shapes identical.
 pub fn synthesize_cycling(face: &mut CardFace) {
     let cycling_abilities: Vec<AbilityDefinition> = face
         .keywords
         .iter()
-        .filter_map(|kw| match kw {
-            // CR 702.29a: Basic cycling — discard self, draw a card.
-            // Cost may be mana ("cycling {2}") or non-mana ("cycling—pay 2 life").
-            Keyword::Cycling(cycling_cost) => {
-                // CR 702.29a: "Discard THIS card" — self_ref = true.
-                let discard_self = AbilityCost::Discard {
-                    count: QuantityExpr::Fixed { value: 1 },
-                    filter: None,
-                    random: false,
-                    self_ref: true,
-                };
-                let composite_cost = match cycling_cost {
-                    CyclingCost::Mana(cost) => AbilityCost::Composite {
-                        costs: vec![AbilityCost::Mana { cost: cost.clone() }, discard_self],
-                    },
-                    CyclingCost::NonMana(ac) => match ac {
-                        // Flatten an already-Composite non-mana cost so the discard joins
-                        // the existing sub-costs instead of nesting.
-                        AbilityCost::Composite { costs } => {
-                            let mut flat = costs.clone();
-                            flat.push(discard_self);
-                            AbilityCost::Composite { costs: flat }
-                        }
-                        other => AbilityCost::Composite {
-                            costs: vec![other.clone(), discard_self],
-                        },
-                    },
-                };
-                let mut def = AbilityDefinition::new(
-                    AbilityKind::Activated,
-                    Effect::Draw {
-                        count: QuantityExpr::Fixed { value: 1 },
-                        target: TargetFilter::Controller,
-                    },
-                )
-                .cost(composite_cost);
-                def.activation_zone = Some(Zone::Hand);
-                Some(def)
-            }
-            // CR 702.29e: Typecycling — discard self, search library for [type] card.
-            Keyword::Typecycling { cost, subtype } => {
-                let composite_cost = AbilityCost::Composite {
-                    costs: vec![
-                        AbilityCost::Mana { cost: cost.clone() },
-                        AbilityCost::Discard {
-                            count: QuantityExpr::Fixed { value: 1 },
-                            filter: None,
-                            random: false,
-                            self_ref: true,
-                        },
-                    ],
-                };
-                let filter = typecycling_subtype_to_filter(subtype);
-                let shuffle_def = AbilityDefinition::new(
-                    AbilityKind::Spell,
-                    Effect::Shuffle {
-                        target: TargetFilter::Controller,
-                    },
-                );
-                let mut put_in_hand_def = AbilityDefinition::new(
-                    AbilityKind::Spell,
-                    Effect::ChangeZone {
-                        origin: Some(Zone::Library),
-                        destination: Zone::Hand,
-                        target: TargetFilter::Any,
-                        owner_library: false,
-                        enter_transformed: false,
-                        enters_under: None,
-                        enter_tapped: false,
-                        enters_attacking: false,
-                        up_to: false,
-                        enter_with_counters: vec![],
-                        face_down_profile: None,
-                    },
-                );
-                put_in_hand_def.sub_ability = Some(Box::new(shuffle_def));
-                let mut def = AbilityDefinition::new(
-                    AbilityKind::Activated,
-                    Effect::SearchLibrary {
-                        filter,
-                        count: QuantityExpr::Fixed { value: 1 },
-                        reveal: true,
-                        target_player: None,
-                        selection_constraint: SearchSelectionConstraint::None,
-                        split: None,
-                        source_zones: vec![crate::types::zones::Zone::Library],
-                    },
-                )
-                .cost(composite_cost);
-                def.activation_zone = Some(Zone::Hand);
-                def.sub_ability = Some(Box::new(put_in_hand_def));
-                Some(def)
-            }
-            _ => None,
-        })
+        .filter_map(cycling_ability_for_keyword)
         .collect();
+    face.abilities.extend(cycling_abilities);
+}
+
+/// CR 702.29a/e: Build the activated ability represented by a Cycling or
+/// Typecycling keyword. Used both by printed-card synthesis and by runtime
+/// grants such as Homing Sliver.
+pub fn cycling_ability_for_keyword(keyword: &Keyword) -> Option<AbilityDefinition> {
+    let mut def = match keyword {
+        // CR 702.29a: Basic cycling — discard self, draw a card.
+        // Cost may be mana ("cycling {2}") or non-mana ("cycling—pay 2 life").
+        Keyword::Cycling(cycling_cost) => {
+            // CR 702.29a: "Discard THIS card" — self_ref = true.
+            let discard_self = AbilityCost::Discard {
+                count: QuantityExpr::Fixed { value: 1 },
+                filter: None,
+                random: false,
+                self_ref: true,
+            };
+            let composite_cost = match cycling_cost {
+                CyclingCost::Mana(cost) => AbilityCost::Composite {
+                    costs: vec![AbilityCost::Mana { cost: cost.clone() }, discard_self],
+                },
+                CyclingCost::NonMana(ac) => match ac {
+                    // Flatten an already-Composite non-mana cost so the discard joins
+                    // the existing sub-costs instead of nesting.
+                    AbilityCost::Composite { costs } => {
+                        let mut flat = costs.clone();
+                        flat.push(discard_self);
+                        AbilityCost::Composite { costs: flat }
+                    }
+                    other => AbilityCost::Composite {
+                        costs: vec![other.clone(), discard_self],
+                    },
+                },
+            };
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )
+            .cost(composite_cost);
+            def.activation_zone = Some(Zone::Hand);
+            def
+        }
+        // CR 702.29e: Typecycling — discard self, search library for [type] card.
+        Keyword::Typecycling { cost, subtype } => {
+            let composite_cost = AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana { cost: cost.clone() },
+                    AbilityCost::Discard {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        filter: None,
+                        random: false,
+                        self_ref: true,
+                    },
+                ],
+            };
+            let filter = typecycling_subtype_to_filter(subtype);
+            let shuffle_def = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Shuffle {
+                    target: TargetFilter::Controller,
+                },
+            );
+            let mut put_in_hand_def = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::ChangeZone {
+                    origin: Some(Zone::Library),
+                    destination: Zone::Hand,
+                    target: TargetFilter::Any,
+                    owner_library: false,
+                    enter_transformed: false,
+                    enters_under: None,
+                    enter_tapped: false,
+                    enters_attacking: false,
+                    up_to: false,
+                    enter_with_counters: vec![],
+                    face_down_profile: None,
+                },
+            );
+            put_in_hand_def.sub_ability = Some(Box::new(shuffle_def));
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::SearchLibrary {
+                    filter,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    reveal: true,
+                    target_player: None,
+                    selection_constraint: SearchSelectionConstraint::None,
+                    split: None,
+                    source_zones: vec![crate::types::zones::Zone::Library],
+                },
+            )
+            .cost(composite_cost);
+            def.activation_zone = Some(Zone::Hand);
+            def.sub_ability = Some(Box::new(put_in_hand_def));
+            def
+        }
+        _ => return None,
+    };
 
     // CR 702.29a + CR 702.29c + CR 702.29e: Tag every synthesized cycling /
     // typecycling ability with `AbilityTag::Cycling` so that activating it emits
     // a `GameEvent::Cycled` ("When you cycle this card" triggers, CR 702.29c).
-    let mut cycling_abilities = cycling_abilities;
-    for def in &mut cycling_abilities {
-        def.ability_tag = Some(AbilityTag::Cycling);
-    }
-
-    face.abilities.extend(cycling_abilities);
+    def.ability_tag = Some(AbilityTag::Cycling);
+    Some(def)
 }
 
 /// CR 702.53a: Synthesize Transmute into an activated ability that functions

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -49,7 +49,7 @@ use super::targeting;
 
 const FORETELL_SPECIAL_ACTION_COST: u32 = 2;
 
-fn runtime_granted_activated_abilities(
+fn runtime_granted_cycling_abilities(
     state: &GameState,
     source_id: ObjectId,
 ) -> Vec<AbilityDefinition> {
@@ -81,7 +81,7 @@ pub fn activated_ability_definitions(
     let mut abilities: Vec<(usize, AbilityDefinition)> =
         obj.abilities.iter().cloned().enumerate().collect();
     abilities.extend(
-        runtime_granted_activated_abilities(state, source_id)
+        runtime_granted_cycling_abilities(state, source_id)
             .into_iter()
             .enumerate()
             .map(|(offset, ability)| (printed_len + offset, ability)),
@@ -100,7 +100,7 @@ fn activation_ability_definition(
     }
 
     let offset = ability_index.checked_sub(obj.abilities.len())?;
-    runtime_granted_activated_abilities(state, source_id)
+    runtime_granted_cycling_abilities(state, source_id)
         .into_iter()
         .nth(offset)
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -49,6 +49,62 @@ use super::targeting;
 
 const FORETELL_SPECIAL_ACTION_COST: u32 = 2;
 
+fn runtime_granted_activated_abilities(
+    state: &GameState,
+    source_id: ObjectId,
+) -> Vec<AbilityDefinition> {
+    let Some(obj) = state.objects.get(&source_id) else {
+        return Vec::new();
+    };
+    if obj.zone != Zone::Hand {
+        return Vec::new();
+    }
+
+    crate::game::off_zone_characteristics::effective_off_zone_keywords(state, source_id)
+        .into_iter()
+        .filter(|keyword| {
+            matches!(keyword, Keyword::Cycling(_) | Keyword::Typecycling { .. })
+                && !obj.base_keywords.iter().any(|printed| printed == keyword)
+        })
+        .filter_map(|keyword| crate::database::synthesis::cycling_ability_for_keyword(&keyword))
+        .collect()
+}
+
+pub fn activated_ability_definitions(
+    state: &GameState,
+    source_id: ObjectId,
+) -> Vec<(usize, AbilityDefinition)> {
+    let Some(obj) = state.objects.get(&source_id) else {
+        return Vec::new();
+    };
+    let printed_len = obj.abilities.len();
+    let mut abilities: Vec<(usize, AbilityDefinition)> =
+        obj.abilities.iter().cloned().enumerate().collect();
+    abilities.extend(
+        runtime_granted_activated_abilities(state, source_id)
+            .into_iter()
+            .enumerate()
+            .map(|(offset, ability)| (printed_len + offset, ability)),
+    );
+    abilities
+}
+
+fn activation_ability_definition(
+    state: &GameState,
+    source_id: ObjectId,
+    ability_index: usize,
+) -> Option<AbilityDefinition> {
+    let obj = state.objects.get(&source_id)?;
+    if let Some(ability) = obj.abilities.get(ability_index) {
+        return Some(ability.clone());
+    }
+
+    let offset = ability_index.checked_sub(obj.abilities.len())?;
+    runtime_granted_activated_abilities(state, source_id)
+        .into_iter()
+        .nth(offset)
+}
+
 pub(crate) fn variable_speed_payment_range(cost: &AbilityCost, max_speed: u8) -> Option<(u8, u8)> {
     match cost {
         AbilityCost::PaySpeed {
@@ -10948,19 +11004,22 @@ pub fn can_activate_ability_now(
     let Some(obj) = state.objects.get(&source_id) else {
         return false;
     };
-    if obj.controller != player || ability_index >= obj.abilities.len() {
+    if obj.controller != player {
         return false;
     }
+    let Some(mut ability_def) = activation_ability_definition(state, source_id, ability_index)
+    else {
+        return false;
+    };
 
     // CR 702.61a + CR 702.61b: While a spell with split second is on the stack,
     // players can't activate abilities that aren't mana abilities.
     if super::keywords::stack_has_split_second(state)
-        && !super::mana_abilities::is_mana_ability(&obj.abilities[ability_index])
+        && !super::mana_abilities::is_mana_ability(&ability_def)
     {
         return false;
     }
 
-    let mut ability_def = obj.abilities[ability_index].clone();
     // CR 602.1: Check activation zone — default to battlefield.
     let required_zone = ability_def.activation_zone.unwrap_or(Zone::Battlefield);
     if obj.zone != required_zone {
@@ -11180,13 +11239,12 @@ pub fn handle_activate_ability(
     if obj.controller != player {
         return Err(EngineError::NotYourPriority);
     }
-    if ability_index >= obj.abilities.len() {
+    let Some(mut ability_def) = activation_ability_definition(state, source_id, ability_index)
+    else {
         return Err(EngineError::InvalidAction(
             "Invalid ability index".to_string(),
         ));
-    }
-
-    let mut ability_def = obj.abilities[ability_index].clone();
+    };
     // CR 602.1: Check activation zone — default to battlefield.
     let required_zone = ability_def.activation_zone.unwrap_or(Zone::Battlefield);
     if obj.zone != required_zone {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14471,11 +14471,9 @@ fn static_selfref_cant_be_blocked_except_by_disjunction_top_level() {
 /// CR 702.29e + CR 113.6b: Homing Sliver's top-level static grants Typecycling
 /// to all Sliver cards in their owner's hand. This asserts the PARSE is correct
 /// (affected = Typed(Subtype:Sliver) in the Hand zone; modification =
-/// AddKeyword(Typecycling { cost {3}, subtype "Sliver" })). NOTE: a deferred
-/// RUNTIME gap remains — `synthesize_cycling` reads intrinsic printed keywords
-/// only, so a Typecycling keyword GRANTED at runtime is on the recipient's
-/// keyword set but is not synthesized into an activatable ability. See the
-/// doc comment at `database/synthesis.rs::synthesize_cycling`.
+/// AddKeyword(Typecycling { cost {3}, subtype "Sliver" })). Runtime-granted
+/// cycling abilities are surfaced by `game::casting` from the effective
+/// off-zone keyword set.
 #[test]
 fn static_homing_sliver_grants_typecycling_to_slivers_in_hand() {
     // Real Oracle text. The "Each <type> in each player's hand has <keyword>"

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -154,6 +154,7 @@ pub enum KeywordKind {
     Protection,
     Kicker,
     Cycling,
+    Typecycling,
     Flashback,
     Retrace,
     Ward,
@@ -1039,6 +1040,7 @@ impl Keyword {
             Keyword::Protection(_) => KeywordKind::Protection,
             Keyword::Kicker(_) => KeywordKind::Kicker,
             Keyword::Cycling(_) => KeywordKind::Cycling,
+            Keyword::Typecycling { .. } => KeywordKind::Typecycling,
             Keyword::Flashback(_) => KeywordKind::Flashback,
             Keyword::Retrace => KeywordKind::Retrace,
             Keyword::Ward(_) => KeywordKind::Ward,
@@ -1170,7 +1172,6 @@ impl Keyword {
             | Keyword::Surge(_)
             | Keyword::Totem
             | Keyword::Toxic(_)
-            | Keyword::Typecycling { .. }
             | Keyword::WebSlinging(_) => KeywordKind::Unknown,
         }
     }


### PR DESCRIPTION
## Summary
- factor Cycling/Typecycling ability construction into a shared helper used by printed synthesis and runtime grants
- derive transient hand activated abilities from effective off-zone Cycling/Typecycling keywords
- expose those transient abilities through legal-action generation and activation dispatch
- add a Homing Sliver regression covering runtime-granted Slivercycling activation

Fixes #2700

## Testing
- `cargo fmt --all -- --check`
- `git diff --check`

`cargo check -p engine --lib` could not complete locally because the Windows MSVC linker `link.exe` is not installed in this environment.