### PR TITLE
Fix/parser optional as though permission grants 2274

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -110,6 +110,28 @@ pub(crate) fn parse_static_line_inner(
             if let Some(def) = parse_static_line_inner(&split.canonical, InvertedAsLongAs::Skip) {
                 return Some(def.description(text.to_string()));
             }
+            // CR 601.3b + CR 702.8a: Inverted flash-grant conditional:
+            // "As long as X, you may cast [type] spells as though they had flash."
+            // The recursed call above fails because `parse_cast_as_though_flash_static`
+            // uses `eof` and the canonical form carries a trailing condition clause.
+            // Try the flash parser against the isolated effect slice; if it succeeds,
+            // attach the condition from the split.
+            {
+                let effect_lower = split.effect_text.to_lowercase();
+                let tp_effect = TextPair::new(&split.effect_text, &effect_lower);
+                if let Some(mut def) =
+                    parse_cast_as_though_flash_static(&tp_effect, &split.effect_text)
+                {
+                    let condition = parse_static_condition(&split.condition_text).unwrap_or(
+                        StaticCondition::Unrecognized {
+                            text: split.condition_text.clone(),
+                        },
+                    );
+                    def.condition = Some(condition);
+                    def.description = Some(text.to_string());
+                    return Some(def);
+                }
+            }
             // Rewrite succeeded (we cleanly separated condition from effect), but the
             // recursed parser could not model the effect clause. Produce a generic
             // Continuous static whose condition is typed via `parse_static_condition`

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -517,6 +517,12 @@ fn static_carries_optional_modification(s: &StaticDefinition) -> bool {
         ContinuousModification::AssignDamageAsThoughUnblocked => true,
         ContinuousModification::GrantTrigger { trigger } => trigger_tree_has_optional(trigger),
         ContinuousModification::GrantAbility { definition } => def_tree_has_optional(definition),
+        // CR 113.3d + CR 613.1f: GrantStaticAbility conveys a static as if printed on the
+        // recipient (CR 113.3d: static abilities are simply true; CR 613.1f: layer 6).
+        // Recurse into the granted static definition to detect optional markers it may carry.
+        ContinuousModification::GrantStaticAbility { definition } => {
+            static_definition_has_optional(definition)
+        }
         _ => false,
     })
 }
@@ -554,6 +560,13 @@ fn static_mode_is_optional_permission(mode: &StaticMode) -> bool {
             // CR 601.2f: Defiler-style cost reductions encode the optional
             // life payment inside the static cost-modification primitive.
             | StaticMode::DefilerCostReduction { .. }
+            // CR 609.4b: "You may spend mana as though it were mana of any color" —
+            // opt-in mana-color substitution, inherently optional by the "you may" surface.
+            | StaticMode::SpendManaAsAnyColor
+            // CR 602.5a + CR 702.10c: "You may activate abilities of X as though those
+            // creatures had haste" — lifts the summoning-sickness gate on {T}/{Q}
+            // activated abilities; the permission is opt-in by the "you may" surface.
+            | StaticMode::CanActivateAbilitiesAsThoughHaste
     )
 }
 
@@ -594,6 +607,12 @@ fn static_definition_has_unimplemented(s: &StaticDefinition) -> bool {
         ContinuousModification::GrantTrigger { trigger } => trigger_tree_has_unimplemented(trigger),
         ContinuousModification::GrantAbility { definition } => {
             def_tree_has_unimplemented(definition)
+        }
+        // CR 113.3d + CR 613.1f: Parallel to static_carries_optional_modification —
+        // recurse into GrantStaticAbility so an Unimplemented-carrying granted static
+        // suppresses swallow detectors rather than double-reporting the parse gap.
+        ContinuousModification::GrantStaticAbility { definition } => {
+            static_definition_has_unimplemented(definition)
         }
         _ => false,
     })
@@ -2544,6 +2563,65 @@ mod tests {
             parsed.abilities
         );
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_spend_mana_as_any_color_static() {
+        // CR 609.4b: "You may spend mana as though it were mana of any color."
+        // Must not produce an Optional_YouMay warning.
+        let parsed = parse(
+            "You may spend mana as though it were mana of any color.",
+            &["Artifact"],
+        );
+        assert!(
+            parsed
+                .statics
+                .iter()
+                .any(|s| matches!(s.mode, StaticMode::SpendManaAsAnyColor)),
+            "expected SpendManaAsAnyColor static to parse, got statics: {:#?}",
+            parsed.statics
+        );
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_activate_abilities_as_though_haste_static() {
+        // CR 602.5a + CR 702.10c: "You may activate abilities of creatures you
+        // control as though those creatures had haste."
+        let parsed = parse(
+            "You may activate abilities of creatures you control as though those creatures had haste.",
+            &["Creature"],
+        );
+        assert!(
+            parsed
+                .statics
+                .iter()
+                .any(|s| matches!(s.mode, StaticMode::CanActivateAbilitiesAsThoughHaste)),
+            "expected CanActivateAbilitiesAsThoughHaste static to parse, got statics: {:#?}",
+            parsed.statics
+        );
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn static_carries_optional_modification_recurses_into_grant_static_ability() {
+        // CR 113.3d + CR 613.1f: GrantStaticAbility wrapping an optional modification
+        // must be detected by static_carries_optional_modification via recursion.
+        use crate::types::ability::{ContinuousModification, StaticDefinition};
+
+        let inner_def = Box::new(
+            StaticDefinition::continuous()
+                .modifications(vec![ContinuousModification::AssignDamageAsThoughUnblocked]),
+        );
+        let outer_static = StaticDefinition::continuous().modifications(vec![
+            ContinuousModification::GrantStaticAbility {
+                definition: inner_def,
+            },
+        ]);
+        assert!(
+            super::static_carries_optional_modification(&outer_static),
+            "static_carries_optional_modification must recurse into GrantStaticAbility"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -431,22 +431,27 @@ fn effect_has_internal_optionality(effect: &Effect) -> bool {
         // Veil's "you may activate one of its loyalty abilities once this turn"
         // is the permission itself; the player still decides each activation.
         | Effect::GrantExtraLoyaltyActivations { .. } => true,
-        // CR 117.3a + CR 601.3b + CR 702.8a: a `GenericEffect` that grants a
-        // casting permission carries the "you may cast … as though …" opt-in
-        // inside the granted static, exactly like `GrantCastingPermission` /
-        // `CastFromZone` above. Teferi, Time Raveler's [+1] ("you may cast
-        // sorcery spells as though they had flash") lowers to a `GenericEffect`
-        // whose static grants `StaticMode::CastWithKeyword { Flash }` (directly,
-        // or via `GrantStaticAbility`), so the "may" is the permission itself —
-        // no def-level `optional` flag is needed.
+        // CR 601.3b + CR 702.8a + CR 609.4: a `GenericEffect` whose statics
+        // encode a "you may" opt-in accounts for the marker in two ways:
         //
-        // NARROW BY DESIGN: only casting-permission modes count here. A
-        // `GenericEffect` granting an unrelated static (CantGainLife, +1/+1,
-        // etc.) does NOT carry a "you may" and must remain subject to the
-        // Optional_YouMay detector.
+        //   1. Casting-permission modes (`StaticMode::CastWithKeyword`, etc.):
+        //      detected by `static_mode_is_optional_permission` (via
+        //      `static_definition_has_optional`).
+        //
+        //   2. Optional modification grants (`ContinuousModification::
+        //      AssignDamageAsThoughUnblocked`, `GrantStaticAbility` recursion, etc.):
+        //      detected by `static_carries_optional_modification` (via
+        //      `static_definition_has_optional`). Garruk, Savage Herald's [-7]
+        //      ("Until end of turn, creatures you control gain 'You may have this
+        //      creature assign its combat damage as though it weren't blocked.'")
+        //      is the motivating case — CR 510.1c + CR 609.4.
+        //
+        // STILL NARROW: `static_definition_has_optional` only exempts permission
+        // modes and optional modifications — statics that are neither (CantGainLife,
+        // +1/+1, MustAttack, etc.) remain subject to Optional_YouMay detection.
         Effect::GenericEffect {
             static_abilities, ..
-        } => static_abilities.iter().any(static_grants_cast_permission),
+        } => static_abilities.iter().any(static_definition_has_optional),
         Effect::ChooseOneOf { branches, .. } => branches.iter().any(def_tree_has_optional),
         Effect::CreateDelayedTrigger { effect, .. } => def_tree_has_optional(effect),
         Effect::CreateEmblem { statics, triggers } => {
@@ -455,28 +460,6 @@ fn effect_has_internal_optionality(effect: &Effect) -> bool {
         }
         _ => false,
     }
-}
-
-/// CR 117.3a + CR 601.3b + CR 702.8a: True when a `StaticDefinition` IS (or,
-/// via `GrantStaticAbility`, grants) a casting-permission static of the
-/// "cast as though it had <keyword>" family (`StaticMode::CastWithKeyword`).
-/// Such permissions inherently encode the "you may cast" opt-in, so a
-/// `GenericEffect` carrying one accounts for the "you may " marker without a
-/// def-level `optional` flag (Teferi, Time Raveler's flash grant).
-///
-/// Deliberately narrow: only `CastWithKeyword` permission modes match. This
-/// must NOT exempt grants of unrelated modes (CantGainLife, AddPower, etc.),
-/// or it would suppress legitimate Optional_YouMay detection elsewhere.
-fn static_grants_cast_permission(s: &StaticDefinition) -> bool {
-    if matches!(s.mode, StaticMode::CastWithKeyword { .. }) {
-        return true;
-    }
-    s.modifications.iter().any(|m| match m {
-        ContinuousModification::GrantStaticAbility { definition } => {
-            matches!(definition.mode, StaticMode::CastWithKeyword { .. })
-        }
-        _ => false,
-    })
 }
 
 /// Recursive walk: does any def in the tree carry an `AddTargetReplacement`
@@ -2622,6 +2605,105 @@ mod tests {
             super::static_carries_optional_modification(&outer_static),
             "static_carries_optional_modification must recurse into GrantStaticAbility"
         );
+    }
+
+    #[test]
+    fn optional_you_may_accepts_chromatic_orrery_real_oracle_text() {
+        // Regression test against actual Chromatic Orrery oracle text.
+        // SpendManaAsAnyColor static must suppress Optional_YouMay.
+        let parsed = parse(
+            "You may spend mana as though it were mana of any color.\n\
+             {T}: Add {C}{C}{C}{C}{C}.\n\
+             {5}, {T}: Draw a card for each color among permanents you control.",
+            &["Artifact"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_thousand_year_elixir_real_oracle_text() {
+        // Regression test against actual Thousand-Year Elixir oracle text.
+        // CanActivateAbilitiesAsThoughHaste static must suppress Optional_YouMay.
+        let parsed = parse(
+            "You may activate abilities of creatures you control as though those creatures had haste.\n\
+             {1}, {T}: Untap target creature.",
+            &["Artifact"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_proud_wildbonder_real_oracle_text() {
+        // Regression test against actual Proud Wildbonder oracle text.
+        // "Creatures you control with trample have '...' " is a top-level static
+        // (exercises the parsed.statics path at swallow_check.rs line ~980), not the
+        // Effect::GenericEffect arm. AssignDamageAsThoughUnblocked must suppress
+        // Optional_YouMay via static_carries_optional_modification.
+        let parsed = parse(
+            "Trample\n\
+             Creatures you control with trample have \
+             \"You may have this creature assign its combat damage as though it weren't blocked.\"",
+            &["Creature"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_garruk_savage_herald_minus_seven() {
+        // CR 510.1c + CR 609.4: Garruk, Savage Herald's [-7] ("Until end of
+        // turn, creatures you control gain \"You may have this creature assign
+        // its combat damage as though it weren't blocked.\"") lowers to a
+        // loyalty AbilityDefinition with Effect::GenericEffect whose static
+        // carries AssignDamageAsThoughUnblocked (directly or via GrantStaticAbility).
+        // static_definition_has_optional must recognise this via
+        // static_carries_optional_modification so Optional_YouMay does not fire.
+        let parsed = parse_named(
+            "[+1]: Reveal the top card of your library. If it's a creature card, put it into your hand. Otherwise, put it on the bottom of your library.\n\
+             [\u{2212}2]: Target creature you control deals damage equal to its power to another target creature.\n\
+             [\u{2212}7]: Until end of turn, creatures you control gain \
+             \"You may have this creature assign its combat damage as though it weren't blocked.\"",
+            "Garruk, Savage Herald",
+            &["Planeswalker"],
+        );
+        // Structural guard: the [-7] must lower to a GenericEffect carrying
+        // AssignDamageAsThoughUnblocked (directly or via GrantStaticAbility).
+        // Without this, the negative assertion below could pass vacuously if
+        // the [-7] regresses to Unimplemented (any_ability_has_unimplemented
+        // early-returns from check_swallowed_clauses, masking the gap).
+        use crate::types::ability::ContinuousModification;
+        fn ability_grants_assign_damage_unblocked(def: &AbilityDefinition) -> bool {
+            if let Effect::GenericEffect {
+                ref static_abilities,
+                ..
+            } = *def.effect
+            {
+                if static_abilities.iter().any(|s| {
+                    s.modifications.iter().any(|m| {
+                        matches!(
+                            m,
+                            ContinuousModification::AssignDamageAsThoughUnblocked
+                                | ContinuousModification::GrantStaticAbility { .. }
+                        )
+                    })
+                }) {
+                    return true;
+                }
+            }
+            def.sub_ability
+                .as_deref()
+                .is_some_and(ability_grants_assign_damage_unblocked)
+        }
+        assert!(
+            parsed
+                .abilities
+                .iter()
+                .any(ability_grants_assign_damage_unblocked),
+            "expected Garruk [-7] to lower to GenericEffect with \
+             AssignDamageAsThoughUnblocked/GrantStaticAbility static, \
+             abilities: {:#?}",
+            parsed.abilities
+        );
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
     }
 
     #[test]

--- a/crates/engine/tests/integration/oracle_parser.rs
+++ b/crates/engine/tests/integration/oracle_parser.rs
@@ -1,7 +1,8 @@
 use engine::parser::oracle::{keyword_display_name, parse_oracle_text};
 use engine::types::ability::{
     ChosenSubtypeKind, ContinuousModification, ControllerRef, DamageModification,
-    DamageTargetFilter, DamageTargetPlayerScope, Effect, FilterProp, TargetFilter, TypeFilter,
+    DamageTargetFilter, DamageTargetPlayerScope, Effect, FilterProp, StaticCondition, TargetFilter,
+    TypeFilter,
 };
 use engine::types::keywords::Keyword;
 use engine::types::statics::StaticMode;
@@ -675,4 +676,41 @@ fn snapshot_harold_and_bob_first_numens() {
         &["Troll", "Warrior"],
     );
     insta::assert_json_snapshot!(result);
+}
+
+#[test]
+fn inverted_as_long_as_flash_grant_attaches_condition() {
+    // CR 601.3b + CR 702.8a + CR 611.3a: The inverted conditional flash-grant
+    // "As long as <cond>, you may cast [type] spells as though they had flash"
+    // must lower to a `CastWithKeyword { Flash }` static carrying the condition
+    // — not silently collapse into a bare conditionless Continuous fallback.
+    let result = parse(
+        "As long as it's your turn, you may cast creature spells as though they had flash.",
+        "Test Inverted Flash Grant",
+        &[],
+        &["Enchantment"],
+        &[],
+    );
+
+    let static_def = result
+        .statics
+        .iter()
+        .find(|static_def| {
+            matches!(
+                static_def.mode,
+                StaticMode::CastWithKeyword {
+                    keyword: Keyword::Flash
+                }
+            )
+        })
+        .expect("expected inverted flash grant to lower to CastWithKeyword { Flash }");
+
+    // "it's your turn" is recognized by parse_static_condition → DuringYourTurn,
+    // not just a generic Unrecognized fallback.
+    assert!(
+        matches!(static_def.condition, Some(StaticCondition::DuringYourTurn)),
+        "expected DuringYourTurn condition on the CastWithKeyword static, \
+         got condition: {:#?}",
+        static_def.condition
+    );
 }


### PR DESCRIPTION
## Summary

Closes #2274

- Replaces the narrow `static_grants_cast_permission` predicate (casting-permission modes only) with `static_definition_has_optional`, which also covers optional modification grants (`AssignDamageAsThoughUnblocked`, `GrantStaticAbility` recursion). This fixes false-positive `Optional_YouMay` warnings for cards like Garruk, Savage Herald and Proud Wildbonder.
- Adds `SpendManaAsAnyColor` and `CanActivateAbilitiesAsThoughHaste` to `static_mode_is_optional_permission`, suppressing false positives for Chromatic Orrery / Thousand-Year Elixir patterns.
- Adds `GrantStaticAbility` recursion to `static_carries_optional_modification` and `static_definition_has_unimplemented` so nested statics are walked correctly (CR 113.3d + CR 613.1f).
- Fixes the inverted `as-long-as` flash-grant path in `oracle_static/dispatch.rs` so "As long as X, you may cast … as though they had flash" lowers to `CastWithKeyword { Flash }` with the parsed condition attached, rather than falling through to a conditionless `Continuous` fallback (CR 601.3b + CR 702.8a + CR 611.3a).

## Test plan

- [x] `optional_you_may_accepts_spend_mana_as_any_color_static` — `SpendManaAsAnyColor` static does not produce `Optional_YouMay`
- [x] `optional_you_may_accepts_activate_abilities_as_though_haste_static` — `CanActivateAbilitiesAsThoughHaste` static does not produce `Optional_YouMay`
- [x] `static_carries_optional_modification_recurses_into_grant_static_ability` — unit-level proof that the recursion lands
- [x] `optional_you_may_accepts_chromatic_orrery_real_oracle_text` — regression against full Chromatic Orrery oracle text
- [x] `optional_you_may_accepts_thousand_year_elixir_real_oracle_text` — regression against full Thousand-Year Elixir oracle text
- [x] `optional_you_may_accepts_proud_wildbonder_real_oracle_text` — top-level static path (not `GenericEffect`)
- [x] `optional_you_may_accepts_garruk_savage_herald_minus_seven` — structural guard confirms `[-7]` lowers to `AssignDamageAsThoughUnblocked`/`GrantStaticAbility`; negative assertion confirms no `Optional_YouMay`
- [x] `optional_you_may_still_flags_unrepresented_optional_verb` — existing guard that the exemption did not over-broaden
- [x] `inverted_as_long_as_flash_grant_attaches_condition` — integration test confirming `CastWithKeyword { Flash }` + `DuringYourTurn` condition

Model: claude-sonnet-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
