### PR TITLE
feat(client): reveal-aware library viewer with hover preview and play-from-top

### DIFF
--- a/client/src/components/zone/LibraryPile.tsx
+++ b/client/src/components/zone/LibraryPile.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { HIDDEN_CARD_NAME, type ObjectId } from "../../adapter/types.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useLongPress } from "../../hooks/useLongPress.ts";
 import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
 import { CARD_BACK_URL } from "../../services/scryfall.ts";
@@ -15,6 +16,15 @@ import { playOrCastActionsForObject } from "../../viewmodel/cardActionChoice.ts"
 interface LibraryPileProps {
   playerId: number;
   size?: { width: string; height: string };
+  /**
+   * Opens the full library viewer (ZoneViewer, zone="library"). When provided
+   * and the top of the library is visible to this viewer (a public reveal or a
+   * private look — CR 701.20b), a pile click opens the modal instead of
+   * casting directly; play-from-top then happens inside the modal, matching the
+   * graveyard/exile click→view→cast flow. Without this prop the pile falls back
+   * to its standalone click-to-play behavior.
+   */
+  onView?: () => void;
 }
 
 function TopCard({ cardName }: { cardName: string }) {
@@ -38,7 +48,7 @@ function TopCard({ cardName }: { cardName: string }) {
   );
 }
 
-export function LibraryPile({ playerId, size }: LibraryPileProps) {
+export function LibraryPile({ playerId, size, onView }: LibraryPileProps) {
   const { t } = useTranslation("game");
   const myId = usePlayerId();
   const count = useGameStore(
@@ -75,6 +85,7 @@ export function LibraryPile({ playerId, size }: LibraryPileProps) {
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
+  const hoverProps = useInspectHoverProps();
   const dispatchAction = useGameDispatch();
 
   const isMyLibrary = playerId === myId;
@@ -117,6 +128,14 @@ export function LibraryPile({ playerId, size }: LibraryPileProps) {
 
   const stackDepth = Math.min(count - 1, 4);
   const isPeeking = topCardName != null;
+  // A visible top (public reveal or private look) means there's something to
+  // see in the library viewer; clicking opens it (when the parent wires onView)
+  // rather than casting directly. Cast-from-top then lives inside the modal.
+  const canView = isPeeking && onView != null;
+  // Desktop hover preview for the revealed top card (skipped on mobile by the
+  // hook, where a tap would spuriously open the full-screen preview overlay).
+  const topHoverProps =
+    isPeeking && topObjectId != null ? hoverProps(topObjectId as ObjectId) : undefined;
   const libraryLabel = t("zone.libraryCount", { count });
   const playLabel = t("zone.playFromTop", { name: topCardName ?? t("zone.topOfLibrary") });
   const w = size?.width ?? "var(--card-w)";
@@ -151,19 +170,27 @@ export function LibraryPile({ playerId, size }: LibraryPileProps) {
             longPressFired.current = false;
             return;
           }
+          // Prefer opening the viewer when the top is visible — the modal is
+          // where play-from-top happens (mirrors graveyard/exile). Fall back to
+          // direct cast only when no viewer is wired.
+          if (canView) {
+            onView();
+            return;
+          }
           if (canPlay) handlePlay();
         }}
-        disabled={!canPlay && topCardName == null}
+        disabled={!canView && !canPlay && topCardName == null}
         aria-label={canPlay ? playLabel : libraryLabel}
         data-library-top-cast={canPlay ? "true" : "false"}
+        {...topHoverProps}
         {...longPressHandlers}
         className={`relative block h-full w-full overflow-hidden rounded-lg border shadow-md ${
           canPlay
             ? `border-amber-400 ${CASTABLE_AFFORDANCE_IDLE} cursor-pointer`
             : isRevealed
-              ? "border-amber-500 cursor-default"
+              ? `border-amber-500 ${canView ? "cursor-pointer" : "cursor-default"}`
               : isPeeking
-                ? "border-cyan-600 cursor-default"
+                ? `border-cyan-600 ${canView ? "cursor-pointer" : "cursor-default"}`
                 : "border-gray-600 cursor-default"
         }`}
       >

--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { GameAction, GameObject } from "../../adapter/types.ts";
+import { HIDDEN_CARD_NAME, type GameAction, type GameObject } from "../../adapter/types.ts";
 import { CardImage } from "../card/CardImage.tsx";
 import { ModalPanelShell } from "../ui/ModalPanelShell.tsx";
 import { ScrollableCardStrip } from "../modal/ChoiceOverlay.tsx";
@@ -16,7 +16,7 @@ import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.t
 import { playOrCastActionsForObject, resolveSingleActionDispatch } from "../../viewmodel/cardActionChoice.ts";
 
 interface ZoneViewerProps {
-  zone: "graveyard" | "exile";
+  zone: "graveyard" | "exile" | "library";
   playerId: number;
   onClose: () => void;
 }
@@ -24,11 +24,13 @@ interface ZoneViewerProps {
 const ZONE_TITLE_KEYS: Record<string, string> = {
   graveyard: "zone.graveyard",
   exile: "zone.exile",
+  library: "zone.library",
 };
 
 const ZONE_TITLE_LOWER_KEYS: Record<string, string> = {
   graveyard: "zone.graveyardLower",
   exile: "zone.exileLower",
+  library: "zone.libraryLower",
 };
 
 export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
@@ -103,11 +105,23 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
             innerClassName="flex items-center gap-2 lg:gap-3"
           >
             {cards.map((obj) => {
+              // CR 701.20b: A library card the engine hasn't revealed to this
+              // viewer arrives redacted (`Hidden Card`, face_down). Render it as
+              // a non-interactive card-back — it has no identity to inspect,
+              // target, or play. Only revealed top cards carry a real name.
+              if (zone === "library" && obj.name === HIDDEN_CARD_NAME) {
+                return <FaceDownCard key={obj.id} />;
+              }
               // CR 702.81a + CR 702.143a + CR 715.3a + CR 702.62a + CR 702.170d + CR 702.185a:
               // Engine surfaces a CastSpell-family action for every legally
               // castable graveyard/exile card (Retrace, Adventure, Foretell,
               // Suspend, Plot, Warp, etc.). The zone viewer surfaces whatever
               // the engine reports — no per-mechanic permission inspection.
+              //
+              // CR 401.5 + CR 118.9: for `library`, the engine only surfaces a
+              // play/cast action on the top card when a TopOfLibraryCastPermission
+              // (Future Sight, Bolas's Citadel, Mystic Forge, …) is active, so
+              // the playable affordance naturally lands on the revealed top.
               //
               // CR 715.3d / CR 400.7i: this includes opponent-OWNED cards in
               // exile the viewer was granted permission to play (Hostage Taker,
@@ -115,7 +129,7 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
               // so castability must NOT be gated on the pile belonging to the
               // viewer — `legalActionsByObject` (engine authority, keyed to the
               // player the permission was granted to) is the sole gate.
-              const castActions = (zone === "graveyard" || zone === "exile") && hasPriority
+              const castActions = hasPriority
                 ? playOrCastActionsForObject(legalActionsByObject, obj.id)
                 : [];
               const isValidTarget = currentLegalTargets.has(obj.id);
@@ -135,6 +149,17 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
         )}
       </div>
     </ModalPanelShell>
+  );
+}
+
+// A non-revealed library card. Deliberately hook-free (no inspect/long-press
+// subscriptions) so a full-size library of mostly-hidden cards stays cheap to
+// render — only revealed cards pay for the interactive ZoneCard.
+function FaceDownCard() {
+  return (
+    <div className="relative inline-flex shrink-0 rounded-lg">
+      <CardImage cardName="" faceDown size="normal" />
+    </div>
   );
 }
 

--- a/client/src/components/zone/__tests__/LibraryPile.test.tsx
+++ b/client/src/components/zone/__tests__/LibraryPile.test.tsx
@@ -315,6 +315,38 @@ describe("LibraryPile play/cast surfacing (#297)", () => {
     expect(useUiStore.getState().previewSticky).toBe(true);
   });
 
+  it("opens the library viewer instead of casting when onView is wired and the top is visible", () => {
+    // With a viewer available, a visible top routes the click to the modal
+    // (where play-from-top lives), mirroring graveyard/exile. canView wins over
+    // the direct-cast fast path.
+    const onView = vi.fn();
+    setStore({ canPeek: true, actions: [castAction(42)] });
+    render(<LibraryPile playerId={0} onView={onView} />);
+    const button = screen.getByRole("button", { name: /play sol ring from top of library/i });
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+    expect(onView).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("opens the library viewer for a revealed top with no play action", () => {
+    const onView = vi.fn();
+    setStore({ canPeek: true, actions: [] });
+    render(<LibraryPile playerId={0} onView={onView} />);
+    fireEvent.click(screen.getByRole("button", { name: /library \(1 card\)/i }));
+    expect(onView).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open the viewer when the top is hidden (nothing revealed)", () => {
+    // A masked top (no peek, no reveal) has nothing to show — clicking must not
+    // open the modal even though onView is wired.
+    const onView = vi.fn();
+    setStore({ canPeek: false, actions: [] });
+    render(<LibraryPile playerId={0} onView={onView} />);
+    fireEvent.click(screen.getByRole("button", { name: /library \(1 card\)/i }));
+    expect(onView).not.toHaveBeenCalled();
+  });
+
   it("surfaces engine-reported play action even without peek (engine is authoritative)", () => {
     setStore({ canPeek: false, actions: [castAction(42)] });
     render(<LibraryPile playerId={0} />);

--- a/client/src/components/zone/__tests__/ZoneViewer.test.tsx
+++ b/client/src/components/zone/__tests__/ZoneViewer.test.tsx
@@ -146,6 +146,148 @@ describe("ZoneViewer", () => {
     );
   });
 
+  it("renders revealed library tops face-up and unrevealed cards as backs", () => {
+    // CR 701.20b: a RevealTop / Oracle of Mul Daya look surfaces the top card's
+    // identity; the rest of the library arrives redacted (`Hidden Card`). The
+    // library viewer shows the revealed card face-up and the remainder as
+    // card-backs, top-first.
+    const revealed = makeObject({
+      id: 20,
+      zone: "Library",
+      name: "Llanowar Elves",
+      keywords: [],
+      base_keywords: [],
+    });
+    const hiddenA = makeObject({ id: 21, zone: "Library", name: "Hidden Card", face_down: true });
+    const hiddenB = makeObject({ id: 22, zone: "Library", name: "Hidden Card", face_down: true });
+    const base = makeState(revealed);
+    const gameState = {
+      ...base,
+      objects: { [revealed.id]: revealed, [hiddenA.id]: hiddenA, [hiddenB.id]: hiddenB },
+      players: [
+        { ...base.players[0], graveyard: [], library: [revealed.id, hiddenA.id, hiddenB.id] },
+        base.players[1],
+      ],
+    } as unknown as GameState;
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [],
+      legalActionsByObject: {},
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="library" playerId={0} onClose={vi.fn()} />);
+
+    // All three cards render; only the revealed one carries a real name. The two
+    // hidden cards render via the hook-free FaceDownCard (mocked CardImage with
+    // an empty name).
+    expect(screen.getAllByTestId("card-image")).toHaveLength(3);
+    expect(screen.getByLabelText("Llanowar Elves")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Hidden Card")).not.toBeInTheDocument();
+  });
+
+  it("dispatches the engine-surfaced play-from-top action for a revealed library top", () => {
+    // CR 401.5 + CR 118.9: with a TopOfLibraryCastPermission active (Future
+    // Sight, Bolas's Citadel, Mystic Forge, …) the engine surfaces a play/cast
+    // action on the revealed top. The viewer dispatches it just like a
+    // graveyard/exile cast — no library-specific permission inspection.
+    const revealed = makeObject({
+      id: 30,
+      zone: "Library",
+      name: "Mystic Sanctuary",
+      keywords: [],
+      base_keywords: [],
+    });
+    const hidden = makeObject({ id: 31, zone: "Library", name: "Hidden Card", face_down: true });
+    const action = makeCastAction(revealed.id);
+    const base = makeState(revealed);
+    const gameState = {
+      ...base,
+      objects: { [revealed.id]: revealed, [hidden.id]: hidden },
+      players: [
+        { ...base.players[0], graveyard: [], library: [revealed.id, hidden.id] },
+        base.players[1],
+      ],
+    } as unknown as GameState;
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [action],
+      legalActionsByObject: { [String(revealed.id)]: [action] },
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="library" playerId={0} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Mystic Sanctuary"));
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "CastSpell" }),
+    );
+  });
+
+  it("shows an opponent's revealed library top face-up with no castable affordance", () => {
+    // CR 701.20b: an opponent's library top revealed to all players (e.g. an
+    // Oracle of Mul Daya the opponent controls, or a public RevealTop) is
+    // visible to this viewer, but the viewer has NO play permission on the
+    // opponent's library — so legalActionsByObject is empty and clicking the
+    // revealed card must not dispatch. The rest of the opponent's library stays
+    // redacted and renders as backs.
+    const revealed = makeObject({
+      id: 40,
+      owner: 1,
+      controller: 1,
+      zone: "Library",
+      name: "Courser of Kruphix",
+      keywords: [],
+      base_keywords: [],
+    });
+    const hidden = makeObject({
+      id: 41,
+      owner: 1,
+      controller: 1,
+      zone: "Library",
+      name: "Hidden Card",
+      face_down: true,
+    });
+    const base = makeState(revealed);
+    const gameState = {
+      ...base,
+      objects: { [revealed.id]: revealed, [hidden.id]: hidden },
+      players: [
+        { ...base.players[0], graveyard: [] },
+        { ...base.players[1], graveyard: [], library: [revealed.id, hidden.id] },
+      ],
+    } as unknown as GameState;
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [],
+      legalActionsByObject: {},
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="library" playerId={1} onClose={vi.fn()} />);
+
+    expect(screen.getAllByTestId("card-image")).toHaveLength(2);
+    expect(screen.getByLabelText("Courser of Kruphix")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Hidden Card")).not.toBeInTheDocument();
+
+    // No play permission → clicking the revealed opponent card is inert.
+    fireEvent.click(screen.getByLabelText("Courser of Kruphix"));
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
   it("dispatches a CastSpell for an opponent-owned exiled card the viewer may play", () => {
     // Hostage Taker / Gonti / Thief of Sanity: the card is owned by the
     // opponent (player 1) and sits in their exile pile, but the engine granted

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -283,6 +283,8 @@
     "graveyardShort": "FH",
     "graveyardTitle": "Friedhof ({{count}})",
     "libraryAlt": "Bibliothek",
+    "library": "Bibliothek",
+    "libraryLower": "Bibliothek",
     "libraryCount_one": "Bibliothek ({{count}} Karte)",
     "libraryCount_other": "Bibliothek ({{count}} Karten)",
     "playFromTop": "{{name}} von oben aus der Bibliothek spielen",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -283,6 +283,8 @@
     "graveyardShort": "GY",
     "graveyardTitle": "Graveyard ({{count}})",
     "libraryAlt": "Library",
+    "library": "Library",
+    "libraryLower": "library",
     "libraryCount_one": "Library ({{count}} card)",
     "libraryCount_other": "Library ({{count}} cards)",
     "playFromTop": "Play {{name}} from top of library",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -283,6 +283,8 @@
     "graveyardShort": "CE",
     "graveyardTitle": "Cementerio ({{count}})",
     "libraryAlt": "Biblioteca",
+    "library": "Biblioteca",
+    "libraryLower": "biblioteca",
     "libraryCount_one": "Biblioteca ({{count}} carta)",
     "libraryCount_other": "Biblioteca ({{count}} cartas)",
     "playFromTop": "Juega {{name}} desde la parte superior de la biblioteca",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -283,6 +283,8 @@
     "graveyardShort": "CIM",
     "graveyardTitle": "Cimetière ({{count}})",
     "libraryAlt": "Bibliothèque",
+    "library": "Bibliothèque",
+    "libraryLower": "bibliothèque",
     "libraryCount_one": "Bibliothèque ({{count}} carte)",
     "libraryCount_other": "Bibliothèque ({{count}} cartes)",
     "playFromTop": "Jouer {{name}} depuis le dessus de la bibliothèque",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -283,6 +283,8 @@
     "graveyardShort": "CIM",
     "graveyardTitle": "Cimitero ({{count}})",
     "libraryAlt": "Grimorio",
+    "library": "Grimorio",
+    "libraryLower": "grimorio",
     "libraryCount_one": "Grimorio ({{count}} carta)",
     "libraryCount_other": "Grimorio ({{count}} carte)",
     "playFromTop": "Gioca {{name}} dalla cima del grimorio",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -283,6 +283,8 @@
     "graveyardShort": "CM",
     "graveyardTitle": "Cmentarz ({{count}})",
     "libraryAlt": "Biblioteka",
+    "library": "Biblioteka",
+    "libraryLower": "biblioteka",
     "libraryCount_one": "Biblioteka ({{count}} karta)",
     "libraryCount_other": "Biblioteka ({{count}} kart)",
     "playFromTop": "Zagraj {{name}} z wierzchu biblioteki",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -283,6 +283,8 @@
     "graveyardShort": "CEM",
     "graveyardTitle": "Cemitério ({{count}})",
     "libraryAlt": "Grimório",
+    "library": "Grimório",
+    "libraryLower": "grimório",
     "libraryCount_one": "Grimório ({{count}} carta)",
     "libraryCount_other": "Grimório ({{count}} cartas)",
     "playFromTop": "Jogue {{name}} do topo do grimório",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -746,7 +746,7 @@ function GamePageContent({
   const [showAiHand, setShowAiHand] = useState(false);
   const [showDebugBounds, setShowDebugBounds] = useState(false);
   const [viewingZone, setViewingZone] = useState<{
-    zone: "graveyard" | "exile";
+    zone: "graveyard" | "exile" | "library";
     playerId: number;
   } | null>(null);
   const [preferencesOpen, setPreferencesOpen] = useState<
@@ -1099,7 +1099,11 @@ function GamePageContent({
               size={pileSize}
               onClick={() => setViewingZone({ zone: "exile", playerId: activeOpponentId })}
             />
-            <LibraryPile playerId={activeOpponentId} size={pileSize} />
+            <LibraryPile
+              playerId={activeOpponentId}
+              size={pileSize}
+              onView={() => setViewingZone({ zone: "library", playerId: activeOpponentId })}
+            />
             <GraveyardPile
               playerId={activeOpponentId}
               size={pileSize}
@@ -1137,7 +1141,11 @@ function GamePageContent({
                 size={pileSize}
                 onClick={() => setViewingZone({ zone: "graveyard", playerId: perspectivePlayerId })}
               />
-              <LibraryPile playerId={perspectivePlayerId} size={pileSize} />
+              <LibraryPile
+                playerId={perspectivePlayerId}
+                size={pileSize}
+                onView={() => setViewingZone({ zone: "library", playerId: perspectivePlayerId })}
+              />
             </div>
           </div>
           <div

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -46,12 +46,27 @@ export function isOneOnOne(gameState: GameState | null): boolean {
 
 export function getPlayerZoneIds(
   gameState: GameState | null,
-  zone: "graveyard" | "exile",
+  zone: "graveyard" | "exile" | "library",
   playerId: PlayerId,
 ): ObjectId[] {
   if (!gameState) return [];
   if (zone === "graveyard") {
     return gameState.players[playerId]?.graveyard ?? [];
+  }
+  if (zone === "library") {
+    // library[0] = top of library (engine convention from zones.rs). Hidden
+    // cards are still present here as redacted objects (`Hidden Card`), so the
+    // viewer can render card-backs for everything the engine hasn't revealed.
+    //
+    // CR 701.20b: returning the library in its true Vec order is safe even
+    // though that order reaches the viewer. The engine only un-redacts a card's
+    // identity during an active look/reveal (visibility.rs — revealed_cards /
+    // private_look / dig / search), never from the persistent
+    // `public_revealed_cards` memory, so the only cards shown face-up are ones
+    // whose position the viewer is already entitled to know. Card-backs are an
+    // identical image, so their relative order carries no observable
+    // information — the engine's "never surface draw order" stance is preserved.
+    return gameState.players[playerId]?.library ?? [];
   }
   return gameState.exile.filter((id) => gameState.objects[id]?.owner === playerId);
 }


### PR DESCRIPTION
Surface revealed top-of-library cards in the UI:
- Desktop hover preview on the revealed top card of a library pile.
- Clicking a library whose top is visible (public reveal or private look)
  opens the zone viewer (extended to zone="library"), rendering the library
  top-first with revealed cards face-up and unrevealed cards as card-backs.
- Play/cast from the top happens inside the modal, gated solely by the
  engine's legalActionsByObject (TopOfLibraryCastPermission). Frontend-only;
  engine visibility filtering already redacts hidden identities in place.

Adds zone.library / zone.libraryLower across all 7 locales.
