### PR TITLE
fix(client): stop leaking opponent library cards in the reveal-aware viewer

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1827,6 +1827,11 @@ export interface GameState {
   outside_game_cards_brought_in?: OutsideGameCardUse[];
   sideboard_submitted?: PlayerId[];
   revealed_cards?: ObjectId[];
+  /** CR 701.20e: ids the looker is privately peeking during a look-at-top
+   * window (Mishra's Bauble, scry looks). Visible only to `private_look_player`. */
+  private_look_ids?: ObjectId[];
+  /** CR 701.20e: the player to whom `private_look_ids` is visible (the looker). */
+  private_look_player?: PlayerId;
   restrictions?: GameRestriction[];
   command_zone?: ObjectId[];
   auto_pass?: Record<number, AutoPassMode>;

--- a/client/src/components/zone/LibraryPile.tsx
+++ b/client/src/components/zone/LibraryPile.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { HIDDEN_CARD_NAME, type ObjectId } from "../../adapter/types.ts";
+import type { ObjectId } from "../../adapter/types.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
 import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
@@ -12,6 +12,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { CASTABLE_AFFORDANCE_IDLE } from "../../viewmodel/castableAffordance.ts";
 import { playOrCastActionsForObject } from "../../viewmodel/cardActionChoice.ts";
+import { isLibraryCardRevealedToViewer } from "../../viewmodel/gameStateView.ts";
 
 interface LibraryPileProps {
   playerId: number;
@@ -69,14 +70,14 @@ export function LibraryPile({ playerId, size, onView }: LibraryPileProps) {
     const peek =
       playerId === myId &&
       (s.gameState?.players[playerId]?.can_look_at_top_of_library ?? false);
-    const revealed = s.gameState?.revealed_cards?.includes(topObjectId) ?? false;
-    const name = s.gameState?.objects[topObjectId]?.name ?? null;
-    // Engine viewer filtering exposes opponent library tops for private looks
-    // (CR 701.20e) and other visibility windows; masked tops stay hidden.
-    const opponentVisibleTop =
-      playerId !== myId && name != null && name !== HIDDEN_CARD_NAME;
-    if (!peek && !revealed && !opponentVisibleTop) return null;
-    return name;
+    // Gate visibility on the engine's reveal sets (mirrors OpponentHand), never
+    // on name redaction: single-player renders the raw, unredacted state, so the
+    // top card name is present even for an opponent's hidden top. CR 701.20b
+    // (public reveal) and CR 701.20e (private look, e.g. Mishra's Bauble) are
+    // the only windows that expose an opponent's top.
+    const revealedToMe = isLibraryCardRevealedToViewer(s.gameState ?? null, topObjectId, myId);
+    if (!peek && !revealedToMe) return null;
+    return s.gameState?.objects[topObjectId]?.name ?? null;
   });
 
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);

--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { HIDDEN_CARD_NAME, type GameAction, type GameObject } from "../../adapter/types.ts";
+import type { GameAction, GameObject } from "../../adapter/types.ts";
 import { CardImage } from "../card/CardImage.tsx";
 import { ModalPanelShell } from "../ui/ModalPanelShell.tsx";
 import { ScrollableCardStrip } from "../modal/ChoiceOverlay.tsx";
@@ -9,9 +9,13 @@ import { useLongPress } from "../../hooks/useLongPress.ts";
 import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
-import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
-import { getPlayerZoneIds, getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
+import {
+  getPlayerZoneIds,
+  getWaitingForObjectChoiceIds,
+  isLibraryCardRevealedToViewer,
+} from "../../viewmodel/gameStateView.ts";
 import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
 import { playOrCastActionsForObject, resolveSingleActionDispatch } from "../../viewmodel/cardActionChoice.ts";
 
@@ -44,6 +48,7 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
   const dispatchAction = useGameDispatch();
   const canActForWaitingState = useCanActForWaitingState();
+  const viewerId = usePlayerId();
   const zoneIds = useMemo(
     () => getPlayerZoneIds(gameState, zone, playerId),
     [gameState, playerId, zone],
@@ -51,8 +56,31 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
 
   const cards = useMemo(() => {
     if (!objects) return [];
-    return zoneIds.map((id) => objects[id]).filter(Boolean);
-  }, [objects, zoneIds]);
+    const resolved = zoneIds.map((id) => objects[id]).filter(Boolean) as GameObject[];
+    // CR 701.20: the library viewer shows only the cards the engine has revealed
+    // to this viewer (top-of-library reveals + private looks), top-first.
+    // Unrevealed cards are omitted entirely — visibility is gated on the engine's
+    // reveal sets, never inferred from name redaction (single-player renders the
+    // raw, unredacted state).
+    if (zone === "library") {
+      // The "look at the top card of your library" capability (Future Sight,
+      // Bolas's Citadel, Oracle of Mul Daya) is a continuous static that exposes
+      // the OWNER's own top card without adding it to revealed_cards/private_look
+      // — mirror LibraryPile's `peek` clause so that top still shows (and stays
+      // castable) through the modal.
+      const ownTopId =
+        viewerId === playerId &&
+        (gameState?.players[playerId]?.can_look_at_top_of_library ?? false)
+          ? gameState?.players[playerId]?.library?.[0]
+          : undefined;
+      return resolved.filter(
+        (obj) =>
+          isLibraryCardRevealedToViewer(gameState, obj.id, viewerId) ||
+          obj.id === ownTopId,
+      );
+    }
+    return resolved;
+  }, [objects, zoneIds, zone, gameState, viewerId, playerId]);
 
   const hasPriority = waitingFor?.type === "Priority" && canActForWaitingState;
 
@@ -105,13 +133,6 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
             innerClassName="flex items-center gap-2 lg:gap-3"
           >
             {cards.map((obj) => {
-              // CR 701.20b: A library card the engine hasn't revealed to this
-              // viewer arrives redacted (`Hidden Card`, face_down). Render it as
-              // a non-interactive card-back — it has no identity to inspect,
-              // target, or play. Only revealed top cards carry a real name.
-              if (zone === "library" && obj.name === HIDDEN_CARD_NAME) {
-                return <FaceDownCard key={obj.id} />;
-              }
               // CR 702.81a + CR 702.143a + CR 715.3a + CR 702.62a + CR 702.170d + CR 702.185a:
               // Engine surfaces a CastSpell-family action for every legally
               // castable graveyard/exile card (Retrace, Adventure, Foretell,
@@ -149,17 +170,6 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
         )}
       </div>
     </ModalPanelShell>
-  );
-}
-
-// A non-revealed library card. Deliberately hook-free (no inspect/long-press
-// subscriptions) so a full-size library of mostly-hidden cards stays cheap to
-// render — only revealed cards pay for the interactive ZoneCard.
-function FaceDownCard() {
-  return (
-    <div className="relative inline-flex shrink-0 rounded-lg">
-      <CardImage cardName="" faceDown size="normal" />
-    </div>
   );
 }
 

--- a/client/src/components/zone/__tests__/LibraryPile.test.tsx
+++ b/client/src/components/zone/__tests__/LibraryPile.test.tsx
@@ -138,7 +138,14 @@ function playLandAction(objectId: number): GameAction {
   } as unknown as GameAction;
 }
 
-function setOpponentLibraryTop(topCardName: string) {
+function setOpponentLibraryTop(
+  topCardName: string,
+  reveal: {
+    revealedCards?: number[];
+    privateLookPlayer?: number;
+    privateLookIds?: number[];
+  } = {},
+) {
   const topCardId = 77;
   const top = makeObject(topCardId, topCardName);
   const gameState = {
@@ -176,7 +183,9 @@ function setOpponentLibraryTop(topCardName: string) {
     exile: [],
     stack: [],
     combat: null,
-    revealed_cards: [],
+    revealed_cards: reveal.revealedCards ?? [],
+    private_look_player: reveal.privateLookPlayer,
+    private_look_ids: reveal.privateLookIds ?? [],
     waiting_for: { type: "Priority", data: { player: 0 } },
   } as unknown as GameState;
 
@@ -245,12 +254,35 @@ describe("LibraryPile play/cast surfacing (#297)", () => {
   });
 
   it("shows opponent library top after a private look peek (Mishra's Bauble)", () => {
-    setOpponentLibraryTop("Lightning Bolt");
+    // CR 701.20e: I (player 0) privately look at the opponent's (player 1) top.
+    // The engine records the look in private_look_player/ids; the pile shows it.
+    setOpponentLibraryTop("Lightning Bolt", { privateLookPlayer: 0, privateLookIds: [77] });
     render(<LibraryPile playerId={1} />);
     const button = screen.getByRole("button", { name: /library \(1 card\)/i });
     expect(button).toBeInTheDocument();
     // Peeked tops use the cyan border; card-back alt text is hidden.
     expect(button.className).toContain("border-cyan-600");
+    expect(screen.queryByAltText("Library")).not.toBeInTheDocument();
+  });
+
+  it("keeps an opponent library top hidden when nothing reveals it (no leak)", () => {
+    // Regression guard (#2631): single-player renders the raw, unredacted state,
+    // so the opponent's top carries a real name. With NO reveal set membership it
+    // must stay a card-back — never inferred visible from the name.
+    setOpponentLibraryTop("Lightning Bolt");
+    render(<LibraryPile playerId={1} />);
+    const button = screen.getByRole("button", { name: /library \(1 card\)/i });
+    expect(button.className).toContain("border-gray-600");
+    expect(screen.getByAltText("Library")).toBeInTheDocument();
+  });
+
+  it("shows an opponent library top that is publicly revealed (revealed_cards)", () => {
+    // CR 701.20b: opponent's own public reveal (Oracle of Mul Daya) — visible to
+    // all players via revealed_cards, so the pile shows it with the amber border.
+    setOpponentLibraryTop("Lightning Bolt", { revealedCards: [77] });
+    render(<LibraryPile playerId={1} />);
+    const button = screen.getByRole("button", { name: /library \(1 card\)/i });
+    expect(button.className).toContain("border-amber-500");
     expect(screen.queryByAltText("Library")).not.toBeInTheDocument();
   });
 

--- a/client/src/components/zone/__tests__/ZoneViewer.test.tsx
+++ b/client/src/components/zone/__tests__/ZoneViewer.test.tsx
@@ -146,11 +146,11 @@ describe("ZoneViewer", () => {
     );
   });
 
-  it("renders revealed library tops face-up and unrevealed cards as backs", () => {
-    // CR 701.20b: a RevealTop / Oracle of Mul Daya look surfaces the top card's
-    // identity; the rest of the library arrives redacted (`Hidden Card`). The
-    // library viewer shows the revealed card face-up and the remainder as
-    // card-backs, top-first.
+  it("shows only the engine-revealed library cards, omitting unrevealed ones", () => {
+    // CR 701.20b: a RevealTop / "play with top revealed" surfaces specific top
+    // cards via `revealed_cards`. Visibility is gated on that engine set, NOT on
+    // the card name — single-player renders the raw, unredacted state, so the
+    // unrevealed cards below carry real names yet must NOT appear in the viewer.
     const revealed = makeObject({
       id: 20,
       zone: "Library",
@@ -158,14 +158,16 @@ describe("ZoneViewer", () => {
       keywords: [],
       base_keywords: [],
     });
-    const hiddenA = makeObject({ id: 21, zone: "Library", name: "Hidden Card", face_down: true });
-    const hiddenB = makeObject({ id: 22, zone: "Library", name: "Hidden Card", face_down: true });
+    // Real names, but absent from revealed_cards → must be filtered out.
+    const unrevealedA = makeObject({ id: 21, zone: "Library", name: "Black Lotus" });
+    const unrevealedB = makeObject({ id: 22, zone: "Library", name: "Mox Sapphire" });
     const base = makeState(revealed);
     const gameState = {
       ...base,
-      objects: { [revealed.id]: revealed, [hiddenA.id]: hiddenA, [hiddenB.id]: hiddenB },
+      objects: { [revealed.id]: revealed, [unrevealedA.id]: unrevealedA, [unrevealedB.id]: unrevealedB },
+      revealed_cards: [revealed.id],
       players: [
-        { ...base.players[0], graveyard: [], library: [revealed.id, hiddenA.id, hiddenB.id] },
+        { ...base.players[0], graveyard: [], library: [revealed.id, unrevealedA.id, unrevealedB.id] },
         base.players[1],
       ],
     } as unknown as GameState;
@@ -182,12 +184,12 @@ describe("ZoneViewer", () => {
 
     render(<ZoneViewer zone="library" playerId={0} onClose={vi.fn()} />);
 
-    // All three cards render; only the revealed one carries a real name. The two
-    // hidden cards render via the hook-free FaceDownCard (mocked CardImage with
-    // an empty name).
-    expect(screen.getAllByTestId("card-image")).toHaveLength(3);
+    // Only the one revealed card renders; the unrevealed real-named cards are
+    // omitted (no card-backs) — the leak-safe "just the revealed" behavior.
+    expect(screen.getAllByTestId("card-image")).toHaveLength(1);
     expect(screen.getByLabelText("Llanowar Elves")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Hidden Card")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Black Lotus")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Mox Sapphire")).not.toBeInTheDocument();
   });
 
   it("dispatches the engine-surfaced play-from-top action for a revealed library top", () => {
@@ -202,14 +204,15 @@ describe("ZoneViewer", () => {
       keywords: [],
       base_keywords: [],
     });
-    const hidden = makeObject({ id: 31, zone: "Library", name: "Hidden Card", face_down: true });
+    const unrevealed = makeObject({ id: 31, zone: "Library", name: "Sol Ring" });
     const action = makeCastAction(revealed.id);
     const base = makeState(revealed);
     const gameState = {
       ...base,
-      objects: { [revealed.id]: revealed, [hidden.id]: hidden },
+      objects: { [revealed.id]: revealed, [unrevealed.id]: unrevealed },
+      revealed_cards: [revealed.id],
       players: [
-        { ...base.players[0], graveyard: [], library: [revealed.id, hidden.id] },
+        { ...base.players[0], graveyard: [], library: [revealed.id, unrevealed.id] },
         base.players[1],
       ],
     } as unknown as GameState;
@@ -233,13 +236,68 @@ describe("ZoneViewer", () => {
     );
   });
 
-  it("shows an opponent's revealed library top face-up with no castable affordance", () => {
-    // CR 701.20b: an opponent's library top revealed to all players (e.g. an
-    // Oracle of Mul Daya the opponent controls, or a public RevealTop) is
-    // visible to this viewer, but the viewer has NO play permission on the
-    // opponent's library — so legalActionsByObject is empty and clicking the
-    // revealed card must not dispatch. The rest of the opponent's library stays
-    // redacted and renders as backs.
+  it("shows the owner's own top under a continuous look (Future Sight) and keeps it castable", () => {
+    // Future Sight / Bolas's Citadel / Oracle of Mul Daya grant
+    // `can_look_at_top_of_library` — a continuous static that exposes the OWNER's
+    // top WITHOUT adding it to revealed_cards/private_look. The modal must still
+    // show that top (and the engine-surfaced play action), mirroring the pile.
+    const top = makeObject({
+      id: 50,
+      zone: "Library",
+      name: "Future Sight Top",
+      keywords: [],
+      base_keywords: [],
+    });
+    const buried = makeObject({ id: 51, zone: "Library", name: "Buried Secret" });
+    const action = makeCastAction(top.id);
+    const base = makeState(top);
+    const gameState = {
+      ...base,
+      objects: { [top.id]: top, [buried.id]: buried },
+      revealed_cards: [],
+      players: [
+        {
+          ...base.players[0],
+          graveyard: [],
+          library: [top.id, buried.id],
+          can_look_at_top_of_library: true,
+        },
+        base.players[1],
+      ],
+    } as unknown as GameState;
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [action],
+      legalActionsByObject: { [String(top.id)]: [action] },
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="library" playerId={0} onClose={vi.fn()} />);
+
+    // Only the looked-at top renders; the buried card (real name, not visible to
+    // the viewer) is omitted.
+    expect(screen.getAllByTestId("card-image")).toHaveLength(1);
+    expect(screen.getByLabelText("Future Sight Top")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Buried Secret")).not.toBeInTheDocument();
+
+    // The engine-surfaced play-from-top action stays reachable through the modal.
+    fireEvent.click(screen.getByLabelText("Future Sight Top"));
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "CastSpell" }),
+    );
+  });
+
+  it("shows an opponent's publicly-revealed library top with no castable affordance, hiding the rest", () => {
+    // CR 701.20b: an opponent's library top revealed to all players (their own
+    // Oracle of Mul Daya / a public RevealTop) is visible to this viewer via
+    // `revealed_cards`, but the viewer has NO play permission — legalActionsByObject
+    // is empty and clicking is inert. The rest of the opponent's library is NOT
+    // in revealed_cards, so it must not leak even though raw state carries names.
     const revealed = makeObject({
       id: 40,
       owner: 1,
@@ -249,21 +307,21 @@ describe("ZoneViewer", () => {
       keywords: [],
       base_keywords: [],
     });
-    const hidden = makeObject({
+    const unrevealed = makeObject({
       id: 41,
       owner: 1,
       controller: 1,
       zone: "Library",
-      name: "Hidden Card",
-      face_down: true,
+      name: "Lightning Bolt",
     });
     const base = makeState(revealed);
     const gameState = {
       ...base,
-      objects: { [revealed.id]: revealed, [hidden.id]: hidden },
+      objects: { [revealed.id]: revealed, [unrevealed.id]: unrevealed },
+      revealed_cards: [revealed.id],
       players: [
         { ...base.players[0], graveyard: [] },
-        { ...base.players[1], graveyard: [], library: [revealed.id, hidden.id] },
+        { ...base.players[1], graveyard: [], library: [revealed.id, unrevealed.id] },
       ],
     } as unknown as GameState;
 
@@ -279,9 +337,11 @@ describe("ZoneViewer", () => {
 
     render(<ZoneViewer zone="library" playerId={1} onClose={vi.fn()} />);
 
-    expect(screen.getAllByTestId("card-image")).toHaveLength(2);
+    // Only the publicly-revealed card shows; the unrevealed opponent card (real
+    // name in raw state) is filtered out — no leak.
+    expect(screen.getAllByTestId("card-image")).toHaveLength(1);
     expect(screen.getByLabelText("Courser of Kruphix")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Hidden Card")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Lightning Bolt")).not.toBeInTheDocument();
 
     // No play permission → clicking the revealed opponent card is inert.
     fireEvent.click(screen.getByLabelText("Courser of Kruphix"));

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -54,21 +54,45 @@ export function getPlayerZoneIds(
     return gameState.players[playerId]?.graveyard ?? [];
   }
   if (zone === "library") {
-    // library[0] = top of library (engine convention from zones.rs). Hidden
-    // cards are still present here as redacted objects (`Hidden Card`), so the
-    // viewer can render card-backs for everything the engine hasn't revealed.
-    //
-    // CR 701.20b: returning the library in its true Vec order is safe even
-    // though that order reaches the viewer. The engine only un-redacts a card's
-    // identity during an active look/reveal (visibility.rs — revealed_cards /
-    // private_look / dig / search), never from the persistent
-    // `public_revealed_cards` memory, so the only cards shown face-up are ones
-    // whose position the viewer is already entitled to know. Card-backs are an
-    // identical image, so their relative order carries no observable
-    // information — the engine's "never surface draw order" stance is preserved.
+    // library[0] = top of library (engine convention from zones.rs). Returns
+    // the full ordered library; the library viewer filters to the cards the
+    // engine has revealed to the viewer (isLibraryCardRevealedToViewer) so
+    // unrevealed cards are never shown.
     return gameState.players[playerId]?.library ?? [];
   }
   return gameState.exile.filter((id) => gameState.objects[id]?.owner === playerId);
+}
+
+/**
+ * Whether the engine has revealed a given library card's identity to `viewerId`.
+ *
+ * Mirrors the engine's library visibility (`crates/engine/src/game/visibility.rs`)
+ * using the explicit reveal sets — NEVER the card name. In single-player the
+ * client renders the raw, unredacted state (the `showAiHand` debug toggle depends
+ * on it), so `name !== "Hidden Card"` is always true and cannot be used to infer
+ * visibility; doing so leaks every opponent library card. This is the same
+ * pattern `OpponentHand` uses for opponent hand cards.
+ *
+ * Deliberately excludes `public_revealed_cards`: the engine does not un-redact
+ * library cards by that persistent memory set (a card revealed once and put back
+ * must not leak its new position).
+ */
+export function isLibraryCardRevealedToViewer(
+  gameState: GameState | null,
+  objectId: ObjectId,
+  viewerId: PlayerId,
+): boolean {
+  if (!gameState) return false;
+  // CR 701.20b: publicly revealed top cards (RevealTop, "play with the top card
+  // revealed") are visible to every player.
+  if (gameState.revealed_cards?.includes(objectId)) return true;
+  // CR 701.20e: a private "look at the top card" (Mishra's Bauble at an
+  // opponent's library; your own scry look) surfaces the peeked ids only to the
+  // looking player.
+  return (
+    gameState.private_look_player === viewerId &&
+    (gameState.private_look_ids?.includes(objectId) ?? false)
+  );
 }
 
 export function getWaitingForObjectChoiceIds(


### PR DESCRIPTION
Follow-up to #2704. In single-player the client renders the raw, unredacted
engine state (the showAiHand debug toggle depends on it), so opponent library
card names are always present in gameState.objects. #2704 (and the earlier
#2631) inferred visibility from name !== "Hidden Card", which on the raw path
is always true — leaking the opponent's top card (LibraryPile) and the entire
opponent library (the new modal rendered every card face-up).

Gate library-card visibility on the engine's explicit reveal sets instead,
mirroring OpponentHand:
- New isLibraryCardRevealedToViewer helper — revealed_cards (CR 701.20b public
  reveals) + private_look_ids/private_look_player (CR 701.20e looks, e.g.
  Mishra's Bauble), never the card name. public_revealed_cards is deliberately
  excluded (the engine does not un-redact library cards by it).
- LibraryPile top and the library modal both use it; the modal now shows ONLY
  the revealed cards (no card-backs).
- The owner's continuous 'look at top' (Future Sight / Bolas's Citadel / Oracle
  of Mul Daya) is preserved in both pile and modal via can_look_at_top_of_library.

Adds the serialized private_look_ids / private_look_player fields to the client
GameState type. Tests cover the leak regression, public reveals, private looks,
and the owner continuous-look path.
