### PR TITLE
fix(engine): carry token art routing through copy-of-token (CR 111.1 / 707.2)

### DIFF
--- a/crates/engine/src/game/effects/become_copy.rs
+++ b/crates/engine/src/game/effects/become_copy.rs
@@ -42,15 +42,28 @@ pub fn resolve(
     let values = compute_current_copiable_values(state, target_id)
         .ok_or(EffectError::ObjectNotFound(target_id))?;
 
-    // Display identity follows the copy: carry the source's image pointer so the
-    // copying object renders the copied card's art. Not a CR 707.2 copiable
+    // Display identity follows the copy: carry the source's image routing so the
+    // copying object renders the copied source's art. Not a CR 707.2 copiable
     // value (kept off `CopiableValues`); rides on the modification so it reverts
     // with the effect. The source is guaranteed present — the copiable-values
     // lookup above returned `Some` for `target_id`.
-    let source_printed_ref = state
+    //
+    // CR 111.1 + CR 707.2: when the source is a true token, `printed_ref` is
+    // `None` and the token's art lives only in the token database — so capture
+    // `display_source` + `token_image_ref` too, otherwise a copy-of-token (e.g.
+    // Mockingbird copying a Rabbit token) is stranded on the real-card name path
+    // for a name that has no real-card printing and renders blank.
+    let (source_display_source, source_printed_ref, source_token_image_ref) = state
         .objects
         .get(&target_id)
-        .and_then(|o| o.printed_ref.clone());
+        .map(|o| {
+            (
+                o.display_source,
+                o.printed_ref.clone(),
+                o.token_image_ref.clone(),
+            )
+        })
+        .unwrap_or_default();
 
     // CR 202.1b + CR 707.9: "except it has no mana cost" is a copy-value
     // exception consumed at resolution — strip the copied mana cost from the
@@ -83,7 +96,9 @@ pub fn resolve(
 
     let mut modifications = vec![ContinuousModification::CopyValues {
         values: Box::new(values),
+        display_source: source_display_source,
         printed_ref: source_printed_ref,
+        token_image_ref: source_token_image_ref,
     }];
     modifications.extend(layered_mods);
 
@@ -432,6 +447,98 @@ mod tests {
             Some(own_ref),
             "when the temporary copy expires, the art reverts to the object's own"
         );
+    }
+
+    #[test]
+    fn become_copy_of_token_carries_token_display_routing_and_reverts() {
+        // CR 111.1 + CR 707.2: a nontoken that becomes a copy of a *token* (e.g.
+        // Mockingbird copying a Rabbit token) stays a nontoken but takes the
+        // token's name — which only resolves in the token art database. The copy
+        // must therefore carry the source token's `display_source = Token` +
+        // `token_image_ref` (not `printed_ref`), or it renders blank on the
+        // real-card name path. On a temporary copy that routing reverts to the
+        // copier's own when the effect expires. Drives the real pipeline
+        // (resolve → evaluate_layers → cleanup → evaluate_layers). Token-source
+        // analog of `become_copy_propagates_source_printed_ref_and_reverts_at_cleanup`.
+        let mut state = GameState::new_two_player(42);
+
+        let token_ref = crate::types::card::TokenImageRef {
+            scryfall_id: "rabbit-scryfall-id".to_string(),
+            scryfall_oracle_id: Some("rabbit-oracle-id".to_string()),
+            face_name: None,
+            preset_id: "rabbit-preset".to_string(),
+        };
+        let own_ref = crate::types::card::PrintedCardRef {
+            oracle_id: "mockingbird-oracle-id".to_string(),
+            face_name: "Mockingbird".to_string(),
+        };
+
+        // Copy source: a true 1/1 Rabbit token (no printed identity).
+        let token_id = create_creature(&mut state, 1, PlayerId(0), "Rabbit", 1, 1);
+        {
+            let token = state.objects.get_mut(&token_id).unwrap();
+            token.is_token = true;
+            token.display_source = crate::game::game_object::DisplaySource::Token;
+            token.token_image_ref = Some(token_ref.clone());
+        }
+        // Copier: a real nontoken card with its own printed identity.
+        let copier_id = create_creature(&mut state, 2, PlayerId(0), "Mockingbird", 1, 1);
+        {
+            let copier = state.objects.get_mut(&copier_id).unwrap();
+            copier.printed_ref = Some(own_ref.clone());
+            copier.base_printed_ref = Some(own_ref.clone());
+        }
+
+        let mut events = Vec::new();
+        let ability = make_copy_ability(
+            token_id,
+            copier_id,
+            PlayerId(0),
+            Some(Duration::UntilEndOfTurn),
+        );
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        let copy = &state.objects[&copier_id];
+        assert_eq!(
+            copy.display_source,
+            crate::game::game_object::DisplaySource::Token,
+            "a copy of a token must route art through the token database"
+        );
+        assert_eq!(
+            copy.token_image_ref,
+            Some(token_ref),
+            "the copy must carry the source token's exact art pointer"
+        );
+        assert_eq!(
+            copy.printed_ref, None,
+            "a token source has no printed identity to carry"
+        );
+        assert_eq!(copy.name, "Rabbit");
+        assert!(
+            !copy.is_token,
+            "CR 111.1: copying a token does not make the copy a token"
+        );
+
+        // Temporary copy expires: display routing reverts to the copier's own.
+        execute_cleanup(&mut state, &mut events);
+        evaluate_layers(&mut state);
+        let reverted = &state.objects[&copier_id];
+        assert_eq!(
+            reverted.display_source,
+            crate::game::game_object::DisplaySource::Card,
+            "when the copy expires, a nontoken reverts to card-database routing"
+        );
+        assert_eq!(
+            reverted.token_image_ref, None,
+            "the stale token-art pointer is cleared on revert"
+        );
+        assert_eq!(
+            reverted.printed_ref,
+            Some(own_ref),
+            "the copier's own printed identity is restored"
+        );
+        assert_eq!(reverted.name, "Mockingbird");
     }
 
     #[test]

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -206,6 +206,7 @@ pub fn resolve(
                 values: Box::new(values),
                 display_source: source.display_source,
                 printed_ref: source.printed_ref.clone(),
+                token_image_ref: source.token_image_ref.clone(),
                 extra_keywords: extra_keywords.clone(),
                 additional_modifications: additional_modifications.clone(),
                 tapped,
@@ -317,6 +318,7 @@ pub(crate) fn apply_copy_token_after_replacement(
         values,
         display_source,
         printed_ref,
+        token_image_ref,
         extra_keywords,
         additional_modifications,
         tapped,
@@ -342,6 +344,9 @@ pub(crate) fn apply_copy_token_after_replacement(
         token.display_source = display_source;
         token.printed_ref = printed_ref.clone();
         token.base_printed_ref = printed_ref.clone();
+        // CR 111.1 + CR 707.2: when copying a true token, carry its exact token
+        // art pointer so the copy resolves the same art (not a name fallback).
+        token.token_image_ref = token_image_ref.clone();
         token.name = values.name.clone();
         token.base_name = values.name.clone();
         token.mana_cost = values.mana_cost.clone();
@@ -410,6 +415,7 @@ pub(crate) fn apply_copy_token_after_replacement(
                             values: values.clone(),
                             display_source,
                             printed_ref: printed_ref.clone(),
+                            token_image_ref: token_image_ref.clone(),
                             extra_keywords: extra_keywords.clone(),
                             additional_modifications: additional_modifications.clone(),
                             tapped,
@@ -480,6 +486,7 @@ pub(crate) fn apply_copy_token_after_replacement(
                                     values: values.clone(),
                                     display_source,
                                     printed_ref: printed_ref.clone(),
+                                    token_image_ref: token_image_ref.clone(),
                                     extra_keywords: extra_keywords.clone(),
                                     additional_modifications: additional_modifications.clone(),
                                     tapped,

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -5,6 +5,7 @@ use crate::database::synthesis::KeywordTriggerInstaller;
 use crate::game::arithmetic::saturating_pt_add;
 use crate::game::devotion::count_devotion;
 use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::game::game_object::DisplaySource;
 use crate::game::printed_cards::{apply_copiable_values, intrinsic_copiable_values};
 use crate::game::quantity::{filter_uses_recipient, quantity_expr_uses_recipient, QuantityContext};
 use crate::game::speed::{effective_speed, has_max_speed};
@@ -1201,6 +1202,28 @@ pub fn evaluate_layers(state: &mut GameState) {
             // re-applies the copied source's `printed_ref` below for objects
             // under a copy effect, so a temporary copy's art reverts on expiry.
             obj.printed_ref = obj.base_printed_ref.clone();
+            // Reset display routing to the object's own derived baseline so a
+            // copy effect's override (set by `CopyValues` below) reverts on
+            // expiry. Display routing is derived state, not a copiable value
+            // (CR 707.2): a true token — created by a token-making effect
+            // (CR 111.1), so carrying no printed identity — routes to the token
+            // art database; everything else (a real card, or a token-copy *of a
+            // real card*, which carries `base_printed_ref`) routes to the card
+            // database. Deriving here (rather than storing a `base_display_source`)
+            // keeps tokens in pre-existing saved states correct on load.
+            obj.display_source = if obj.is_token && obj.base_printed_ref.is_none() {
+                DisplaySource::Token
+            } else {
+                DisplaySource::Card
+            };
+            // A nontoken never has its own token-art pointer, so clear it to its
+            // baseline (`None`); a copy-of-token effect re-applies the source
+            // token's `token_image_ref` below while active. A true token keeps
+            // its own pointer (its baseline), which the copy layer overrides only
+            // while it is copying another object.
+            if !obj.is_token {
+                obj.token_image_ref = None;
+            }
             // CR 613.1b: Reset controller to the object's base controller;
             // Layer 2 re-applies continuous control-changing effects.
             obj.controller = obj.base_controller.unwrap_or(obj.owner);
@@ -3333,13 +3356,22 @@ fn apply_continuous_effect_filtered(
         match &effect.modification {
             ContinuousModification::CopyValues {
                 values,
+                display_source,
                 printed_ref,
+                token_image_ref,
             } => {
                 apply_copiable_values(obj, values);
-                // Display identity follows the copy: override the baseline
+                // Display routing follows the copy: override the baseline
                 // restored by the layer reset so the copy renders the source's
                 // art. Reverts automatically when the copy effect expires.
+                // CR 111.1 + CR 707.2: for a copy of a true token, the source's
+                // `display_source = Token` + `token_image_ref` carry the art (the
+                // copied name has no real-card printing); for a printed source,
+                // `display_source = Card` + `printed_ref`. None are copiable
+                // values — purely display routing.
+                obj.display_source = *display_source;
                 obj.printed_ref = printed_ref.clone();
+                obj.token_image_ref = token_image_ref.clone();
             }
             // CR 707.9b + CR 707.2: Name override is a copiable-value override
             // applied at Layer 1 after the base CopyValues (ordered by timestamp
@@ -10526,7 +10558,9 @@ mod tests {
             TargetFilter::SpecificObject { id: target },
             vec![ContinuousModification::CopyValues {
                 values: Box::new(copy_values),
+                display_source: crate::game::game_object::DisplaySource::Card,
                 printed_ref: None,
+                token_image_ref: None,
             }],
             None,
         );

--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -134,7 +134,9 @@ pub fn merge_object_onto(
     // base values rather than the prior merged form.
     remove_merge_layer_effect(state, target_id);
 
-    let Some((values, printed_ref)) = merged_copiable_values(state, &ordered, topmost_id) else {
+    let Some((values, display_source, printed_ref, token_image_ref)) =
+        merged_copiable_values(state, &ordered, topmost_id)
+    else {
         return;
     };
 
@@ -142,7 +144,15 @@ pub fn merge_object_onto(
         survivor.merged_components = ordered;
     }
 
-    install_merge_layer_effect(state, target_id, controller, values, printed_ref);
+    install_merge_layer_effect(
+        state,
+        target_id,
+        controller,
+        values,
+        display_source,
+        printed_ref,
+        token_image_ref,
+    );
 
     // CR 702.140c-d: the mutation is observable. NO ETB (CR 730.2b/c).
     events.push(GameEvent::Mutated {
@@ -159,12 +169,22 @@ fn merged_copiable_values(
     state: &GameState,
     ordered: &[ObjectId],
     topmost_id: ObjectId,
-) -> Option<(CopiableValues, Option<crate::types::card::PrintedCardRef>)> {
+) -> Option<(
+    CopiableValues,
+    crate::game::game_object::DisplaySource,
+    Option<crate::types::card::PrintedCardRef>,
+    Option<crate::types::card::TokenImageRef>,
+)> {
     let topmost = state.objects.get(&topmost_id)?;
     let printed_ref = topmost
         .base_printed_ref
         .clone()
         .or_else(|| topmost.printed_ref.clone());
+    // CR 730.2a: the merged permanent presents the topmost component's identity,
+    // so its art routing follows the topmost too (a token-topmost mutate carries
+    // the token's `display_source`/`token_image_ref`, not just `printed_ref`).
+    let display_source = topmost.display_source;
+    let token_image_ref = topmost.token_image_ref.clone();
     let mut values = crate::game::layers::compute_current_copiable_values(state, topmost_id)
         .unwrap_or_else(|| intrinsic_copiable_values(topmost));
     let mut abilities = Vec::new();
@@ -208,7 +228,7 @@ fn merged_copiable_values(
     values.static_definitions = Arc::new(statics);
     values.replacement_definitions = Arc::new(replacements);
     values.keywords = keywords;
-    Some((values, printed_ref))
+    Some((values, display_source, printed_ref, token_image_ref))
 }
 
 fn remove_merge_layer_effect(state: &mut GameState, target_id: ObjectId) {
@@ -233,7 +253,9 @@ fn install_merge_layer_effect(
     target_id: ObjectId,
     controller: crate::types::player::PlayerId,
     values: CopiableValues,
+    display_source: crate::game::game_object::DisplaySource,
     printed_ref: Option<crate::types::card::PrintedCardRef>,
+    token_image_ref: Option<crate::types::card::TokenImageRef>,
 ) {
     let effect_id = state.add_transient_continuous_effect(
         target_id,
@@ -242,7 +264,9 @@ fn install_merge_layer_effect(
         TargetFilter::SpecificObject { id: target_id },
         vec![ContinuousModification::CopyValues {
             values: Box::new(values),
+            display_source,
             printed_ref,
+            token_image_ref,
         }],
         None,
     );

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6,7 +6,7 @@ use serde::ser::SerializeStructVariant;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
-use super::card::PrintedCardRef;
+use super::card::{PrintedCardRef, TokenImageRef};
 use super::card_type::{CardType, CoreType, SubtypeSet, Supertype};
 use super::counter::{CounterMatch, CounterType};
 use super::events::BendingType;
@@ -23,6 +23,7 @@ use super::replacements::ReplacementEvent;
 use super::statics::{ActivationExemption, CastFrequency, StaticMode};
 use super::triggers::TriggerMode;
 use super::zones::Zone;
+use crate::game::game_object::DisplaySource;
 use crate::types::events::PlayerActionKind;
 
 // ---------------------------------------------------------------------------
@@ -12086,14 +12087,31 @@ pub struct CopiableValues {
 pub enum ContinuousModification {
     CopyValues {
         values: Box<CopiableValues>,
-        /// Display-identity pointer of the copy source (oracle id + displayed
-        /// face name). NOT a CR 707.2 copiable characteristic — it carries no
-        /// rules weight and is deliberately kept off `CopiableValues`. It rides
-        /// on the modification so the copy's art is applied (and reverts) through
-        /// the same layer pass as the copied characteristics. `None` when the
-        /// source is a true token with no printed identity.
+        /// Image-routing identity of the copy source, carried so the copy renders
+        /// the source's art and reverts through the same layer pass as the copied
+        /// characteristics. NONE of these three are CR 707.2 copiable values
+        /// (status/art are not copied per CR 707.2) — they are display routing
+        /// only, deliberately kept off `CopiableValues`, and mirror the flat
+        /// `GameObject`/`CopyTokenSpec` storage (`display_source` discriminates:
+        /// `Card` ⇒ read `printed_ref`; `Token` ⇒ read `token_image_ref`).
+        ///
+        /// CR 111.1 + CR 707.2: a permanent that becomes a copy of a *token*
+        /// stays a nontoken (token-ness is created by a token-making effect per
+        /// CR 111.1, and is not among the CR 707.2 copiable values), but its name
+        /// is the token's, which only resolves in the token art database — so the
+        /// source's `display_source = Token` and `token_image_ref` must ride
+        /// along, not just `printed_ref`.
+        #[serde(default)]
+        display_source: DisplaySource,
+        /// Scryfall oracle-id pointer of the source when it is a printed card.
+        /// `None` when the source is a true token (then `token_image_ref` carries
+        /// the routing).
         #[serde(default)]
         printed_ref: Option<PrintedCardRef>,
+        /// Exact token-art pointer of the source when it is a true token.
+        /// `None` for printed-card sources.
+        #[serde(default)]
+        token_image_ref: Option<TokenImageRef>,
     },
     /// CR 707.9 + CR 707.2: Override the copy's name after `CopyValues` applies.
     /// Used by "enter as a copy, except its name is X" (e.g., Superior Spider-Man's

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -237,7 +237,9 @@ mod tests {
                     replacement_definitions: Default::default(),
                     static_definitions: Default::default(),
                 }),
+                display_source: crate::game::game_object::DisplaySource::Card,
                 printed_ref: None,
+                token_image_ref: None,
             }
             .layer(),
             Layer::Copy

--- a/crates/engine/src/types/proposed_event.rs
+++ b/crates/engine/src/types/proposed_event.rs
@@ -9,7 +9,7 @@ use super::counter::CounterType;
 use super::ability::{
     ContinuousModification, CopiableValues, Duration, FaceDownProfile, StaticDefinition, TargetRef,
 };
-use super::card::PrintedCardRef;
+use super::card::{PrintedCardRef, TokenImageRef};
 use super::card_type::{CoreType, Supertype};
 use super::identifiers::ObjectId;
 use super::keywords::Keyword;
@@ -185,6 +185,12 @@ pub struct CopyTokenSpec {
     pub display_source: DisplaySource,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub printed_ref: Option<PrintedCardRef>,
+    /// CR 111.1 + CR 707.2: exact token-art pointer of the copy source when it
+    /// is itself a true token (`display_source == Token`). Carried so a
+    /// token-copy of a token resolves the source token's art instead of falling
+    /// back to a name+filter Scryfall search. `None` for printed-card sources.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_image_ref: Option<TokenImageRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_keywords: Vec<Keyword>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
A nontoken that becomes a copy of a token (e.g. Mockingbird copying a
Rabbit token) rendered with no card art. The copy took the token's name
("Rabbit") but the copy modification carried only the source's
`printed_ref`, which is `None` for a true token — so the frontend was
left on the real-card name path for a name that only resolves in the
token art database (`token:rabbit`, never a plain `rabbit` card key),
a deterministic blank.

Carry the source's full display routing (`display_source` +
`token_image_ref`, alongside `printed_ref`) on the copy modification,
mirroring how `GameObject` and `CopyTokenSpec` already store it.
`display_source` discriminates: `Card` => read `printed_ref`; `Token`
=> read `token_image_ref`. None of these are CR 707.2 copiable values
(status/art are not copied; the copy stays a nontoken per CR 111.1) —
they are display routing only.

The layer reset derives the display-routing baseline from `is_token` +
`base_printed_ref` rather than a stored `base_display_source`, so
temporary copies revert on expiry and tokens in pre-existing saved
states stay correct on load (no new serialized base field to default
wrong). A nontoken's `token_image_ref` is cleared to its `None`
baseline on reset; the copy layer re-applies the source's while active.

Fixes the same gap across all three copy paths that present a copied
identity:
- BecomeCopy (Mockingbird) — the reported bug
- CopyTokenOf (`CopyTokenSpec` dropped `token_image_ref` when copying a
  true token, degrading to a name+filter Scryfall search)
- Merge/mutate (CR 730 token-topmost now carries token routing)

Regression test drives the real pipeline (resolve -> evaluate_layers ->
cleanup -> evaluate_layers) and asserts both the active copy routing and
the revert; it is the token-source analog of the existing
`become_copy_propagates_source_printed_ref_and_reverts_at_cleanup`.
