### PR TITLE
fix: lifecraft Engine causing Vehicles to crew each other.

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2927,7 +2927,8 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
                                     && state.objects.get(&cid).is_some_and(|c| {
                                         c.controller == player
                                             && !c.tapped
-                                            && crate::game::static_abilities::object_can_contribute_to_crew(
+                                            && c.card_types.core_types.contains(&CoreType::Creature)
+                                            && !crate::game::static_abilities::object_has_cant_crew(
                                                 state, cid,
                                             )
                                     })

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2914,7 +2914,9 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
                                     && state.objects.get(&cid).is_some_and(|c| {
                                         c.controller == player
                                             && !c.tapped
-                                            && c.card_types.core_types.contains(&CoreType::Creature)
+                                            && crate::game::static_abilities::object_can_contribute_to_crew(
+                                                state, cid,
+                                            )
                                     })
                             });
                             if has_eligible {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5743,7 +5743,10 @@ fn handle_crew_activation(
                     .map(|o| {
                         o.controller == player
                             && !o.tapped
-                            && super::static_abilities::object_can_contribute_to_crew(state, id)
+                            && o.card_types
+                                .core_types
+                                .contains(&crate::types::card_type::CoreType::Creature)
+                            && !super::static_abilities::object_has_cant_crew(state, id)
                     })
                     .unwrap_or(false)
         })
@@ -5859,9 +5862,9 @@ fn handle_crew_announcement(
                 "Creature is no longer eligible for crewing".to_string(),
             ));
         }
-        if !super::static_abilities::object_can_contribute_to_crew(state, cid) {
+        if super::static_abilities::object_has_cant_crew(state, cid) {
             return Err(EngineError::InvalidAction(
-                "Creature is not eligible to crew Vehicles".to_string(),
+                "Creature can't crew Vehicles".to_string(),
             ));
         }
         // CR 702.122c: apply any crew power-contribution modifier.
@@ -20629,61 +20632,8 @@ mod crew_tests {
         }
     }
 
-    // CR 301.7 + CR 702.122b: Uncrewed Vehicles are artifacts, not creatures.
-    // A misparsed Lifecraft Engine static that adds CoreType::Creature must not
-    // make Vehicles eligible to crew one another.
-    #[test]
-    fn test_uncrewed_vehicle_with_creature_type_not_eligible_to_crew() {
-        let (mut state, vehicle_a, _creature_a, _creature_b) = setup_crew_scenario();
-
-        let vehicle_b = create_object(
-            &mut state,
-            CardId(203),
-            PlayerId(0),
-            "Second Vehicle".to_string(),
-            Zone::Battlefield,
-        );
-        {
-            let obj = state.objects.get_mut(&vehicle_b).unwrap();
-            obj.card_types.core_types.push(CoreType::Artifact);
-            obj.card_types.subtypes.push("Vehicle".to_string());
-            obj.keywords.push(crate::types::keywords::Keyword::Crew {
-                power: 3,
-                once_per_turn: crate::types::keywords::ActivationCadence::Unlimited,
-            });
-            obj.power = Some(4);
-            obj.toughness = Some(4);
-            // Simulate the Lifecraft Engine misparses: Vehicle gains Creature type.
-            obj.card_types.core_types.push(CoreType::Creature);
-        }
-
-        assert!(
-            !crate::game::static_abilities::object_can_contribute_to_crew(&state, vehicle_b),
-            "uncrewed Vehicle must not contribute to crew even with Creature type"
-        );
-
-        apply_as_current(
-            &mut state,
-            GameAction::CrewVehicle {
-                vehicle_id: vehicle_a,
-                creature_ids: vec![],
-            },
-        )
-        .unwrap();
-
-        match &state.waiting_for {
-            WaitingFor::CrewVehicle {
-                eligible_creatures, ..
-            } => assert!(
-                !eligible_creatures.contains(&vehicle_b),
-                "uncrewed Vehicle must not be offered as crew even with Creature type"
-            ),
-            other => panic!("Expected CrewVehicle, got {:?}", other),
-        }
-    }
-
-    // CR 702.122d: A Vehicle that has become an artifact creature via Crew may
-    // contribute to crewing another Vehicle.
+    // CR 702.122a + CR 702.122b: A Vehicle that has become an artifact creature
+    // via Crew may contribute to crewing another Vehicle.
     #[test]
     fn test_crewed_vehicle_may_crew_another_vehicle() {
         let (mut state, vehicle_a, creature_a, _creature_b) = setup_crew_scenario();

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5743,10 +5743,7 @@ fn handle_crew_activation(
                     .map(|o| {
                         o.controller == player
                             && !o.tapped
-                            && o.card_types
-                                .core_types
-                                .contains(&crate::types::card_type::CoreType::Creature)
-                            && !super::static_abilities::object_has_cant_crew(state, id)
+                            && super::static_abilities::object_can_contribute_to_crew(state, id)
                     })
                     .unwrap_or(false)
         })
@@ -5862,9 +5859,9 @@ fn handle_crew_announcement(
                 "Creature is no longer eligible for crewing".to_string(),
             ));
         }
-        if super::static_abilities::object_has_cant_crew(state, cid) {
+        if !super::static_abilities::object_can_contribute_to_crew(state, cid) {
             return Err(EngineError::InvalidAction(
-                "Creature can't crew Vehicles".to_string(),
+                "Creature is not eligible to crew Vehicles".to_string(),
             ));
         }
         // CR 702.122c: apply any crew power-contribution modifier.
@@ -20628,6 +20625,134 @@ mod crew_tests {
                 // Vehicle should NOT be in eligible creatures even though it's a creature
                 assert!(!eligible_creatures.contains(&vehicle_id));
             }
+            other => panic!("Expected CrewVehicle, got {:?}", other),
+        }
+    }
+
+    // CR 301.7 + CR 702.122b: Uncrewed Vehicles are artifacts, not creatures.
+    // A misparsed Lifecraft Engine static that adds CoreType::Creature must not
+    // make Vehicles eligible to crew one another.
+    #[test]
+    fn test_uncrewed_vehicle_with_creature_type_not_eligible_to_crew() {
+        let (mut state, vehicle_a, _creature_a, _creature_b) = setup_crew_scenario();
+
+        let vehicle_b = create_object(
+            &mut state,
+            CardId(203),
+            PlayerId(0),
+            "Second Vehicle".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&vehicle_b).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.card_types.subtypes.push("Vehicle".to_string());
+            obj.keywords.push(crate::types::keywords::Keyword::Crew {
+                power: 3,
+                once_per_turn: crate::types::keywords::ActivationCadence::Unlimited,
+            });
+            obj.power = Some(4);
+            obj.toughness = Some(4);
+            // Simulate the Lifecraft Engine misparses: Vehicle gains Creature type.
+            obj.card_types.core_types.push(CoreType::Creature);
+        }
+
+        assert!(
+            !crate::game::static_abilities::object_can_contribute_to_crew(&state, vehicle_b),
+            "uncrewed Vehicle must not contribute to crew even with Creature type"
+        );
+
+        apply_as_current(
+            &mut state,
+            GameAction::CrewVehicle {
+                vehicle_id: vehicle_a,
+                creature_ids: vec![],
+            },
+        )
+        .unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::CrewVehicle {
+                eligible_creatures, ..
+            } => assert!(
+                !eligible_creatures.contains(&vehicle_b),
+                "uncrewed Vehicle must not be offered as crew even with Creature type"
+            ),
+            other => panic!("Expected CrewVehicle, got {:?}", other),
+        }
+    }
+
+    // CR 702.122d: A Vehicle that has become an artifact creature via Crew may
+    // contribute to crewing another Vehicle.
+    #[test]
+    fn test_crewed_vehicle_may_crew_another_vehicle() {
+        let (mut state, vehicle_a, creature_a, _creature_b) = setup_crew_scenario();
+
+        let vehicle_b = create_object(
+            &mut state,
+            CardId(204),
+            PlayerId(0),
+            "Second Vehicle".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&vehicle_b).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.card_types.subtypes.push("Vehicle".to_string());
+            obj.keywords.push(crate::types::keywords::Keyword::Crew {
+                power: 3,
+                once_per_turn: crate::types::keywords::ActivationCadence::Unlimited,
+            });
+            obj.power = Some(6);
+            obj.toughness = Some(5);
+        }
+
+        apply_as_current(
+            &mut state,
+            GameAction::CrewVehicle {
+                vehicle_id: vehicle_a,
+                creature_ids: vec![],
+            },
+        )
+        .unwrap();
+        apply_as_current(
+            &mut state,
+            GameAction::CrewVehicle {
+                vehicle_id: vehicle_a,
+                creature_ids: vec![creature_a],
+            },
+        )
+        .unwrap();
+        apply(&mut state, PlayerId(0), GameAction::PassPriority).unwrap();
+        apply(&mut state, PlayerId(1), GameAction::PassPriority).unwrap();
+
+        assert!(
+            state
+                .objects
+                .get(&vehicle_a)
+                .unwrap()
+                .card_types
+                .core_types
+                .contains(&CoreType::Creature),
+            "Vehicle A should be an artifact creature after crew resolves"
+        );
+
+        apply_as_current(
+            &mut state,
+            GameAction::CrewVehicle {
+                vehicle_id: vehicle_b,
+                creature_ids: vec![],
+            },
+        )
+        .unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::CrewVehicle {
+                eligible_creatures, ..
+            } => assert!(
+                eligible_creatures.contains(&vehicle_a),
+                "crewed Vehicle A should be eligible to crew Vehicle B"
+            ),
             other => panic!("Expected CrewVehicle, got {:?}", other),
         }
     }

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -1161,54 +1161,6 @@ pub fn object_has_cant_crew(state: &GameState, object_id: ObjectId) -> bool {
     })
 }
 
-/// CR 702.122b: Whether an object may be tapped to crew a Vehicle.
-/// Uncrewed Vehicles are artifacts (CR 301.7), not creatures, even when
-/// continuous effects grant them creature subtypes (Lifecraft Engine). A
-/// Vehicle becomes a creature only while crewed (CR 702.122d).
-pub fn object_can_contribute_to_crew(state: &GameState, object_id: ObjectId) -> bool {
-    let Some(obj) = state.objects.get(&object_id) else {
-        return false;
-    };
-    if !obj
-        .card_types
-        .core_types
-        .contains(&crate::types::card_type::CoreType::Creature)
-    {
-        return false;
-    }
-    if obj
-        .card_types
-        .subtypes
-        .iter()
-        .any(|s| s.eq_ignore_ascii_case("Vehicle"))
-        && !vehicle_has_crew_creature_effect(state, object_id)
-    {
-        return false;
-    }
-    !object_has_cant_crew(state, object_id)
-}
-
-/// CR 702.122d: Detect the UntilEndOfTurn `AddType(Creature)` transient a
-/// Vehicle receives when its own Crew ability resolves.
-fn vehicle_has_crew_creature_effect(state: &GameState, vehicle_id: ObjectId) -> bool {
-    use crate::types::ability::{ContinuousModification, TargetFilter};
-    use crate::types::card_type::CoreType;
-
-    state.transient_continuous_effects.iter().any(|tce| {
-        matches!(
-            &tce.affected,
-            TargetFilter::SpecificObject { id } if *id == vehicle_id
-        ) && tce.modifications.iter().any(|m| {
-            matches!(
-                m,
-                ContinuousModification::AddType {
-                    core_type: CoreType::Creature
-                }
-            )
-        })
-    })
-}
-
 /// CR 702.122c / 702.171a / 702.184a: The power a creature contributes toward a
 /// crew / saddle / station cost, after applying any active `CrewContribution`
 /// static whose action list contains `action`. "Using its toughness rather than

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -1161,6 +1161,54 @@ pub fn object_has_cant_crew(state: &GameState, object_id: ObjectId) -> bool {
     })
 }
 
+/// CR 702.122b: Whether an object may be tapped to crew a Vehicle.
+/// Uncrewed Vehicles are artifacts (CR 301.7), not creatures, even when
+/// continuous effects grant them creature subtypes (Lifecraft Engine). A
+/// Vehicle becomes a creature only while crewed (CR 702.122d).
+pub fn object_can_contribute_to_crew(state: &GameState, object_id: ObjectId) -> bool {
+    let Some(obj) = state.objects.get(&object_id) else {
+        return false;
+    };
+    if !obj
+        .card_types
+        .core_types
+        .contains(&crate::types::card_type::CoreType::Creature)
+    {
+        return false;
+    }
+    if obj
+        .card_types
+        .subtypes
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case("Vehicle"))
+        && !vehicle_has_crew_creature_effect(state, object_id)
+    {
+        return false;
+    }
+    !object_has_cant_crew(state, object_id)
+}
+
+/// CR 702.122d: Detect the UntilEndOfTurn `AddType(Creature)` transient a
+/// Vehicle receives when its own Crew ability resolves.
+fn vehicle_has_crew_creature_effect(state: &GameState, vehicle_id: ObjectId) -> bool {
+    use crate::types::ability::{ContinuousModification, TargetFilter};
+    use crate::types::card_type::CoreType;
+
+    state.transient_continuous_effects.iter().any(|tce| {
+        matches!(
+            &tce.affected,
+            TargetFilter::SpecificObject { id } if *id == vehicle_id
+        ) && tce.modifications.iter().any(|m| {
+            matches!(
+                m,
+                ContinuousModification::AddType {
+                    core_type: CoreType::Creature
+                }
+            )
+        })
+    })
+}
+
 /// CR 702.122c / 702.171a / 702.184a: The power a creature contributes toward a
 /// crew / saddle / station cost, after applying any active `CrewContribution`
 /// static whose action list contains `action`. "Using its toughness rather than

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -11145,6 +11145,37 @@ fn parser_shape_arcane_adaptation_chosen_type_applies_to_creatures_you_control()
     }
 }
 
+// CR 607.2d + CR 301.7: Lifecraft Engine grants the chosen creature subtype to
+// Vehicle permanents you control — not the Creature card type. The additive-type
+// fallback must not mis-tokenize "the chosen creature type" as AddType(Creature).
+#[test]
+fn parser_shape_lifecraft_engine_vehicle_chosen_creature_type_static() {
+    let def = parse_static_line(
+        "Vehicle creatures you control are the chosen creature type in addition to their other types.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(def.modifications.iter().all(|modification| matches!(
+        modification,
+        ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType
+        }
+    )));
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert_eq!(tf.get_subtype(), Some("Vehicle"));
+            assert!(
+                !tf.type_filters
+                    .iter()
+                    .any(|filter| matches!(filter, TypeFilter::Creature)),
+                "Vehicle scope must not require the Creature card type"
+            );
+        }
+        other => panic!("Expected Some(Typed filter), got {other:?}"),
+    }
+}
+
 // CR 613.1d + CR 205.3m: Maskwood Nexus's battlefield static — "Creatures
 // you control are every creature type." — must lower to a Layer 4
 // type-changing effect that adds every creature type (CR 205.3m) to each

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -59,21 +59,45 @@ pub(crate) fn parse_enchanted_land_chosen_type_static_sentence(
     Ok((input, ()))
 }
 
+/// CR 607.2d: Subject scope for "<[scope]> are/is the chosen [creature] type in
+/// addition to [their/its] other types" statics (Arcane Adaptation, Lifecraft
+/// Engine, Xenograft, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChosenCreatureTypeStaticScope {
+    CreaturesYouControl,
+    EachCreatureYouControl,
+    VehicleCreaturesYouControl,
+}
+
+impl ChosenCreatureTypeStaticScope {
+    fn target_filter(self) -> TargetFilter {
+        match self {
+            Self::CreaturesYouControl | Self::EachCreatureYouControl => {
+                TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You))
+            }
+            // CR 301.7 + CR 607.2d: Lifecraft Engine grants a creature subtype to
+            // Vehicle permanents you control — not the Creature card type.
+            Self::VehicleCreaturesYouControl => TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Subtype("Vehicle".to_string()))
+                    .controller(ControllerRef::You),
+            ),
+        }
+    }
+}
+
 pub(crate) fn parse_arcane_adaptation_chosen_type_static(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    let ((), _) = nom_on_lower(
+    let (scope, _) = nom_on_lower(
         tp.original,
         tp.lower,
-        parse_chosen_creature_type_static_sentence,
+        parse_chosen_creature_type_static_sentence_with_scope,
     )?;
 
     Some(
         StaticDefinition::continuous()
-            .affected(TargetFilter::Typed(
-                TypedFilter::creature().controller(ControllerRef::You),
-            ))
+            .affected(scope.target_filter())
             .modifications(vec![ContinuousModification::AddChosenSubtype {
                 kind: ChosenSubtypeKind::CreatureType,
             }])
@@ -81,27 +105,52 @@ pub(crate) fn parse_arcane_adaptation_chosen_type_static(
     )
 }
 
-pub(crate) fn parse_chosen_creature_type_static_sentence(input: &str) -> OracleResult<'_, ()> {
-    let (input, _) = parse_chosen_creature_type_static_prefix(input)?;
-    let (input, _) = eof.parse(input)?;
-    Ok((input, ()))
+fn parse_chosen_creature_type_static_sentence_with_scope(
+    input: &str,
+) -> OracleResult<'_, ChosenCreatureTypeStaticScope> {
+    let (input, scope) = parse_chosen_creature_type_static_scope_body(input)?;
+    Ok((input, scope))
 }
 
 pub(crate) fn parse_chosen_creature_type_static_prefix(input: &str) -> OracleResult<'_, ()> {
-    let (input, pronoun) = parse_chosen_creature_type_static_subject(input)?;
-    let (input, _) = tag(" the chosen type in addition to ").parse(input)?;
+    let (input, _) = parse_chosen_creature_type_static_scope_body(input)?;
+    Ok((input, ()))
+}
+
+fn parse_chosen_creature_type_static_scope_body(
+    input: &str,
+) -> OracleResult<'_, ChosenCreatureTypeStaticScope> {
+    let (input, (pronoun, scope)) = parse_chosen_creature_type_static_subject(input)?;
+    let (input, _) = alt((
+        tag(" the chosen type in addition to "),
+        tag(" the chosen creature type in addition to "),
+    ))
+    .parse(input)?;
     let (input, _) = tag(pronoun).parse(input)?;
     let (input, _) = tag(" other types").parse(input)?;
     let (input, _) = opt(tag(".")).parse(input)?;
-    Ok((input, ()))
+    Ok((input, scope))
 }
 
 pub(crate) fn parse_chosen_creature_type_static_subject(
     input: &str,
-) -> OracleResult<'_, &'static str> {
+) -> OracleResult<'_, (&'static str, ChosenCreatureTypeStaticScope)> {
     alt((
-        value("their", tag("creatures you control are")),
-        value("its", tag("each creature you control is")),
+        value(
+            ("their", ChosenCreatureTypeStaticScope::CreaturesYouControl),
+            tag("creatures you control are"),
+        ),
+        value(
+            ("its", ChosenCreatureTypeStaticScope::EachCreatureYouControl),
+            tag("each creature you control is"),
+        ),
+        value(
+            (
+                "their",
+                ChosenCreatureTypeStaticScope::VehicleCreaturesYouControl,
+            ),
+            tag("vehicle creatures you control are"),
+        ),
     ))
     .parse(input)
 }
@@ -142,7 +191,7 @@ pub(crate) fn parse_every_creature_type_static_sentence(input: &str) -> OracleRe
 }
 
 pub(crate) fn parse_every_creature_type_static_prefix(input: &str) -> OracleResult<'_, ()> {
-    let (input, _pronoun) = parse_chosen_creature_type_static_subject(input)?;
+    let (input, _) = parse_chosen_creature_type_static_subject(input)?;
     let (input, _) = tag(" every creature type").parse(input)?;
     let (input, _) = opt(tag(".")).parse(input)?;
     Ok((input, ()))
@@ -241,7 +290,7 @@ pub(crate) fn parse_additive_type_clause_modifications(
     // chosen-type statics). Let those branches produce the correct modification.
     if matches!(
         normalized_type_words,
-        "every basic land type" | "the chosen type"
+        "every basic land type" | "the chosen type" | "the chosen creature type"
     ) {
         return None;
     }

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -64,20 +64,20 @@ pub(crate) fn parse_enchanted_land_chosen_type_static_sentence(
 /// Engine, Xenograft, …).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ChosenCreatureTypeStaticScope {
-    CreaturesYouControl,
-    EachCreatureYouControl,
-    VehicleCreaturesYouControl,
+    Creatures,
+    EachCreature,
+    VehicleCreatures,
 }
 
 impl ChosenCreatureTypeStaticScope {
     fn target_filter(self) -> TargetFilter {
         match self {
-            Self::CreaturesYouControl | Self::EachCreatureYouControl => {
+            Self::Creatures | Self::EachCreature => {
                 TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You))
             }
             // CR 301.7 + CR 607.2d: Lifecraft Engine grants a creature subtype to
             // Vehicle permanents you control — not the Creature card type.
-            Self::VehicleCreaturesYouControl => TargetFilter::Typed(
+            Self::VehicleCreatures => TargetFilter::Typed(
                 TypedFilter::new(TypeFilter::Subtype("Vehicle".to_string()))
                     .controller(ControllerRef::You),
             ),
@@ -137,18 +137,15 @@ pub(crate) fn parse_chosen_creature_type_static_subject(
 ) -> OracleResult<'_, (&'static str, ChosenCreatureTypeStaticScope)> {
     alt((
         value(
-            ("their", ChosenCreatureTypeStaticScope::CreaturesYouControl),
+            ("their", ChosenCreatureTypeStaticScope::Creatures),
             tag("creatures you control are"),
         ),
         value(
-            ("its", ChosenCreatureTypeStaticScope::EachCreatureYouControl),
+            ("its", ChosenCreatureTypeStaticScope::EachCreature),
             tag("each creature you control is"),
         ),
         value(
-            (
-                "their",
-                ChosenCreatureTypeStaticScope::VehicleCreaturesYouControl,
-            ),
+            ("their", ChosenCreatureTypeStaticScope::VehicleCreatures),
             tag("vehicle creatures you control are"),
         ),
     ))


### PR DESCRIPTION
## Summary

- Fixes [#1377](https://github.com/phase-rs/phase/issues/1377): with Lifecraft Engine on the board, uncrewed Vehicles were incorrectly offered as crew for other Vehicles.
- **Parser:** Lifecraft Engine's static now parses as `AddChosenSubtype(CreatureType)` scoped to `Vehicle` permanents you control, accepting both "the chosen type" and "the chosen creature type" phrasing. The additive-type fallback no longer mis-tokenizes "the chosen creature type" as `AddType(Creature)`.
- **Engine:** New `object_can_contribute_to_crew()` enforces CR 702.122b — uncrewed Vehicles (artifacts per CR 301.7) cannot crew, even if they erroneously have Creature type. Crewed Vehicles (CR 702.122d transient) still can crew other Vehicles. Wired into crew activation, validation, and AI candidates.

## Test plan

- [x] `parser_shape_lifecraft_engine_vehicle_chosen_creature_type_static` — static lowers to subtype grant on Vehicles, not Creature type
- [x] `test_uncrewed_vehicle_with_creature_type_not_eligible_to_crew` — simulates the old misparses; Vehicle excluded from crew list
- [x] `test_crewed_vehicle_may_crew_another_vehicle` — crewed Vehicle A is eligible to crew Vehicle B
- [x] Existing Arcane Adaptation / crew tests still pass