### PR TITLE
fix(client): emblem art-crop tiles, non-wrapping support planeswalkers, unclipped commander damage

### DIFF
--- a/client/src/components/board/BattlefieldRow.tsx
+++ b/client/src/components/board/BattlefieldRow.tsx
@@ -25,6 +25,7 @@ const ROW_JUSTIFY: Record<string, string> = {
   creatures: "justify-center",
   lands: "justify-start",
   support: "justify-end",
+  planeswalkers: "justify-end",
   other: "justify-end",
 };
 
@@ -207,10 +208,17 @@ export function BattlefieldRow({ groups, rowType, className }: BattlefieldRowPro
     ? "flex-wrap items-end content-end"
     : "flex-nowrap items-end";
 
+  // Planeswalkers in the support area stay on a single horizontal line —
+  // wrapping them stacks vertically and warps the surrounding board rows.
+  // All other non-creature rows keep wrapping.
+  const nonCreatureClass = rowType === "planeswalkers"
+    ? "flex-nowrap items-center gap-2"
+    : "flex-wrap items-center gap-2";
+
   return (
     <div
       ref={containerRef}
-      className={`relative flex ${minH} ${rowType === "creatures" ? `${creatureClass} ${creatureWrap ? "gap-x-2 gap-y-3" : "gap-2"}` : "flex-wrap items-center gap-2"} ${ROW_JUSTIFY[rowType]} ${className ?? ""}`}
+      className={`relative flex ${minH} ${rowType === "creatures" ? `${creatureClass} ${creatureWrap ? "gap-x-2 gap-y-3" : "gap-2"}` : nonCreatureClass} ${ROW_JUSTIFY[rowType]} ${className ?? ""}`}
       style={rowStyle}
     >
       {rowType === "creatures" && expandedGroupIds.size > 0 && (

--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -108,8 +108,11 @@ export function PlayerArea({
   // flex-1. Stacked CommanderDamage entries compound the warp.
   const commanderScale = isCompactHeight ? LAND_BASE_SCALE_COMPACT : LAND_BASE_SCALE;
   const commanderSection = hasCommandZoneCards ? (
+    // No `min-w-0` here: this column holds the commander-damage labels, and
+    // allowing it to shrink below its content width lets the adjacent
+    // (non-shrinking) planeswalker row collapse it and hide the labels.
     <div
-      className="flex min-w-0 flex-col items-end gap-1"
+      className="flex flex-col items-end gap-1"
       style={zoneStyle(commanderScale)}
     >
       <CommanderCardZone playerId={playerId} />
@@ -118,7 +121,7 @@ export function PlayerArea({
   ) : null;
   const supportExtras = (
     <>
-      <BattlefieldRow groups={partitioned?.planeswalkers ?? []} rowType="support" />
+      <BattlefieldRow groups={partitioned?.planeswalkers ?? []} rowType="planeswalkers" />
       <CommandZone playerId={playerId} />
       {commanderSection}
     </>

--- a/client/src/components/board/groupRenderMode.ts
+++ b/client/src/components/board/groupRenderMode.ts
@@ -1,6 +1,6 @@
 import type { GroupedPermanent } from "../../viewmodel/battlefieldProps.ts";
 
-export type BattlefieldRowType = "creatures" | "lands" | "support" | "other";
+export type BattlefieldRowType = "creatures" | "lands" | "support" | "planeswalkers" | "other";
 export type GroupRenderMode = "single" | "staggered" | "expanded" | "collapsed";
 
 export const GROUP_COLLAPSE_THRESHOLD = 5;

--- a/client/src/components/zone/CommandZone.tsx
+++ b/client/src/components/zone/CommandZone.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GameObject, PlayerId } from "../../adapter/types.ts";
+import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 
 interface CommandZoneProps {
@@ -68,18 +69,64 @@ export function CommandZone({ playerId }: CommandZoneProps) {
   );
 }
 
+/**
+ * Renders an emblem as a card-shaped art-crop tile that visually matches the
+ * adjacent permanents in the support row. Emblems carry no Scryfall art (the
+ * engine names them all "Emblem" with no printed_ref, and the image pipeline
+ * excludes the emblem layout), so the art area is a gold emblem seal showing
+ * the granted-ability text rather than a real card image. Sized via the
+ * shared --art-crop-w/h vars set by the support container's zoneStyle.
+ */
 function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
+  const isCompactHeight = useIsCompactHeight();
   return (
     <div
-      className="relative flex items-center gap-1.5 rounded-md border border-amber-700/50 bg-amber-950/70 px-2 py-1 text-[10px] leading-tight text-amber-200 shadow-sm"
+      className="relative select-none drop-shadow-[0_4px_6px_rgba(0,0,0,0.6)]"
+      style={{ width: "var(--art-crop-w)", height: "var(--art-crop-h)" }}
       title={group.description}
+      data-testid="emblem-card"
     >
-      <span className="font-semibold text-amber-400">{label}</span>
-      <span className="max-w-[140px] truncate opacity-80">{group.description}</span>
+      {/* Outer black border */}
+      <div className="absolute inset-0 rounded-[6px] border border-black bg-[#151515] p-[3px]">
+        {/* Gold emblem frame */}
+        <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[3px] bg-gradient-to-b from-amber-600 via-amber-800 to-stone-950 shadow-[inset_0_1px_1px_rgba(255,255,255,0.3)]">
+          {/* Header light reflection */}
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-[20px] bg-gradient-to-b from-white/30 to-transparent" />
+
+          {/* Header */}
+          <div
+            className={`${isCompactHeight ? "h-[12px] px-1" : "h-[20px] px-1.5"} z-10 flex w-full shrink-0 items-center border-b border-black/40 shadow-[0_1px_2px_rgba(0,0,0,0.4)]`}
+          >
+            <span
+              className={`${isCompactHeight ? "text-[8px]" : "text-[11.5px]"} mt-[1px] truncate font-extrabold uppercase leading-none tracking-wide text-[#2a1a05] drop-shadow-[0_1px_0_rgba(255,255,255,0.45)]`}
+            >
+              {label}
+            </span>
+          </div>
+
+          {/* Art area: emblem seal + granted-ability text */}
+          <div className="relative z-0 flex w-full flex-1 flex-col px-[2px] pb-[2px]">
+            <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-[1.5px] border border-black/80 bg-gradient-to-br from-stone-800 via-stone-900 to-black shadow-[inset_0_1px_3px_rgba(0,0,0,0.6)]">
+              <span
+                aria-hidden
+                className="absolute font-black leading-none text-amber-500/20"
+                style={{ fontSize: "calc(var(--art-crop-h) * 0.55)" }}
+              >
+                ✦
+              </span>
+              <p className="relative z-10 line-clamp-4 px-1 text-center text-[8px] leading-tight text-amber-100/90 drop-shadow-[0_1px_1px_rgba(0,0,0,0.9)]">
+                {group.description}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Count badge (CR 114: identical emblems stacked) */}
       {group.count > 1 && (
-        <span className="ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-600 px-1 text-[9px] font-bold text-black">
+        <div className="absolute -bottom-[3px] -right-[3px] z-20 inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-black/80 bg-amber-600 px-1 text-[10px] font-bold text-black shadow-[0_2px_4px_rgba(0,0,0,0.8)]">
           ×{group.count}
-        </span>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
- Render emblems as card-shaped art-crop tiles in the support area instead
  of a flat label. Emblems carry no Scryfall art (engine names them all
  "Emblem", no printed_ref, image pipeline excludes the emblem layout), so
  the art area shows a gold emblem seal with the granted-ability text. Tiles
  reuse the shared --art-crop-w/h vars so they scale with adjacent cards.
- Add a dedicated "planeswalkers" BattlefieldRow type that lays out with
  flex-nowrap, so support-area planeswalkers stay on one horizontal line
  instead of wrapping vertically and warping the surrounding board rows.
- Drop min-w-0 from the commander column. It holds the commander-damage
  labels; allowing it to shrink below content width let the adjacent
  non-shrinking planeswalker row collapse it and hide the labels.
