### PR TITLE
fix(client): hide empty commander column; emblem compact-height polish

### DIFF
--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -84,7 +84,6 @@ export function PlayerArea({
   }
 
   const player = gameState.players[playerId];
-  const hasCommandZoneCards = gameState.format_config?.command_zone === true;
   const hasCommanderDamage = gameState.format_config?.commander_damage_threshold != null;
   const isEliminated = player?.is_eliminated ?? false;
   // CR 702.26-style player phasing: while phased out, dim the player area
@@ -107,7 +106,21 @@ export function PlayerArea({
   // lands at LAND_BASE_SCALE (0.78), which squeezes the creatures row via
   // flex-1. Stacked CommanderDamage entries compound the warp.
   const commanderScale = isCompactHeight ? LAND_BASE_SCALE_COMPACT : LAND_BASE_SCALE;
-  const commanderSection = hasCommandZoneCards ? (
+  // Render the commander column only when it has real content — a commander
+  // still in the command zone, or live commander-damage entries. Gating on the
+  // format flag alone reserved an empty column (and its divider) for the whole
+  // game once the commander was cast. These mirror the visibility filters in
+  // CommanderCardZone and CommanderDamage so the wrapper appears iff a child will.
+  const hasCommanderInZone = (gameState.command_zone ?? []).some((id) => {
+    const obj = gameState.objects[id];
+    return obj?.is_commander === true && obj.owner === playerId && obj.zone === "Command";
+  });
+  const hasActiveCommanderDamage =
+    hasCommanderDamage &&
+    Object.values(gameState.derived?.commander_damage_by_attacker ?? {}).some((views) =>
+      views.some((view) => view.victim === playerId && view.damage > 0),
+    );
+  const commanderSection = hasCommanderInZone || hasActiveCommanderDamage ? (
     // No `min-w-0` here: this column holds the commander-damage labels, and
     // allowing it to shrink below its content width lets the adjacent
     // (non-shrinking) planeswalker row collapse it and hide the labels.

--- a/client/src/components/zone/CommandZone.tsx
+++ b/client/src/components/zone/CommandZone.tsx
@@ -108,13 +108,17 @@ function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
           <div className="relative z-0 flex w-full flex-1 flex-col px-[2px] pb-[2px]">
             <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-[1.5px] border border-black/80 bg-gradient-to-br from-stone-800 via-stone-900 to-black shadow-[inset_0_1px_3px_rgba(0,0,0,0.6)]">
               <span
-                aria-hidden
+                aria-hidden="true"
                 className="absolute font-black leading-none text-amber-500/20"
                 style={{ fontSize: "calc(var(--art-crop-h) * 0.55)" }}
               >
                 ✦
               </span>
-              <p className="relative z-10 line-clamp-4 px-1 text-center text-[8px] leading-tight text-amber-100/90 drop-shadow-[0_1px_1px_rgba(0,0,0,0.9)]">
+              <p
+                className={`relative z-10 px-1 text-center leading-tight text-amber-100/90 drop-shadow-[0_1px_1px_rgba(0,0,0,0.9)] ${
+                  isCompactHeight ? "line-clamp-2 text-[6.5px]" : "line-clamp-4 text-[8px]"
+                }`}
+              >
                 {group.description}
               </p>
             </div>
@@ -124,7 +128,11 @@ function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
 
       {/* Count badge (CR 114: identical emblems stacked) */}
       {group.count > 1 && (
-        <div className="absolute -bottom-[3px] -right-[3px] z-20 inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-black/80 bg-amber-600 px-1 text-[10px] font-bold text-black shadow-[0_2px_4px_rgba(0,0,0,0.8)]">
+        <div
+          className={`absolute -bottom-[3px] -right-[3px] z-20 inline-flex items-center justify-center rounded-full border border-black/80 bg-amber-600 px-1 font-bold text-black shadow-[0_2px_4px_rgba(0,0,0,0.8)] ${
+            isCompactHeight ? "h-3.5 min-w-3.5 text-[8px]" : "h-5 min-w-5 text-[10px]"
+          }`}
+        >
           ×{group.count}
         </div>
       )}


### PR DESCRIPTION
Follow-up to #2714.

- Gate the commander column on real content (commander still in the command
  zone, or live commander-damage entries) instead of the format flag. Gating
  on the format flag reserved an empty column and its divider for the whole
  game once the commander was cast. The new checks mirror the visibility
  filters in CommanderCardZone and CommanderDamage, so the wrapper renders iff
  a child will. The min-w-0 removal stays, so when the column does have content
  the adjacent planeswalker row still can't render on top of it.
- Emblem card review polish (PR #2714 comments): aria-hidden="true" on the
  decorative seal (matches the majority codebase convention), and scale the
  ability text (line-clamp-2 text-[6.5px]) and count badge (h-3.5 min-w-3.5)
  down in compact-height so they don't overflow the shrunken tile.
