### PR TITLE
fix(client): single-source commander-column visibility; keep emblems on-screen

### DIFF
--- a/client/src/components/board/CommanderDamage.tsx
+++ b/client/src/components/board/CommanderDamage.tsx
@@ -5,6 +5,7 @@ import { usePlayerId } from "../../hooks/usePlayerId.ts";
 import { getSeatColor } from "../../hooks/useSeatColor.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { getPlayerDisplayName, useMultiplayerStore } from "../../stores/multiplayerStore.ts";
+import { commanderDamageEntriesFor } from "../../viewmodel/commanderColumn.ts";
 
 interface CommanderDamageProps {
   playerId: PlayerId;
@@ -36,19 +37,10 @@ export function CommanderDamage({ playerId }: CommanderDamageProps) {
     gameState?.format_config?.commander_damage_threshold ??
     DEFAULT_COMMANDER_DAMAGE_LETHAL;
 
-  const byAttacker = gameState?.derived?.commander_damage_by_attacker ?? {};
-  // Filter to entries inflicted on *this* player (the victim axis), then
-  // group by attacker for HUD rendering. The inner arrays are already
-  // per-commander thanks to engine-side partner handling.
-  const entriesForVictim: Array<{
-    attacker: string;
-    views: { commander: number; damage: number }[];
-  }> = [];
-  for (const [attackerKey, views] of Object.entries(byAttacker)) {
-    const forMe = views.filter((v) => v.victim === playerId && v.damage > 0);
-    if (forMe.length === 0) continue;
-    entriesForVictim.push({ attacker: attackerKey, views: forMe });
-  }
+  // Per-victim grouping lives in viewmodel/commanderColumn, shared with
+  // PlayerArea's column-visibility gate so the wrapper renders from the exact
+  // same set this component does (they previously drifted — see that module).
+  const entriesForVictim = gameState ? commanderDamageEntriesFor(gameState, playerId) : [];
 
   if (entriesForVictim.length === 0) return null;
 

--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { PlayerId } from "../../adapter/types.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
+import { commanderDamageEntriesFor, commandersInZone } from "../../viewmodel/commanderColumn.ts";
 import type { GroupedPermanent } from "../../viewmodel/battlefieldProps.ts";
 import type { PlayerBattlefieldView } from "../../viewmodel/gameStateView.ts";
 import { BattlefieldRow } from "./BattlefieldRow.tsx";
@@ -84,7 +85,6 @@ export function PlayerArea({
   }
 
   const player = gameState.players[playerId];
-  const hasCommanderDamage = gameState.format_config?.commander_damage_threshold != null;
   const isEliminated = player?.is_eliminated ?? false;
   // CR 702.26-style player phasing: while phased out, dim the player area
   // to mirror the engine-side exclusion (targeting/damage/attack/SBA). Use
@@ -109,17 +109,11 @@ export function PlayerArea({
   // Render the commander column only when it has real content — a commander
   // still in the command zone, or live commander-damage entries. Gating on the
   // format flag alone reserved an empty column (and its divider) for the whole
-  // game once the commander was cast. These mirror the visibility filters in
-  // CommanderCardZone and CommanderDamage so the wrapper appears iff a child will.
-  const hasCommanderInZone = (gameState.command_zone ?? []).some((id) => {
-    const obj = gameState.objects[id];
-    return obj?.is_commander === true && obj.owner === playerId && obj.zone === "Command";
-  });
-  const hasActiveCommanderDamage =
-    hasCommanderDamage &&
-    Object.values(gameState.derived?.commander_damage_by_attacker ?? {}).some((views) =>
-      views.some((view) => view.victim === playerId && view.damage > 0),
-    );
+  // game once the commander was cast. These go through the same selectors
+  // CommanderCardZone and CommanderDamage render from, so the wrapper appears
+  // iff a child will (single source of truth in viewmodel/commanderColumn).
+  const hasCommanderInZone = commandersInZone(gameState, playerId).length > 0;
+  const hasActiveCommanderDamage = commanderDamageEntriesFor(gameState, playerId).length > 0;
   const commanderSection = hasCommanderInZone || hasActiveCommanderDamage ? (
     // No `min-w-0` here: this column holds the commander-damage labels, and
     // allowing it to shrink below its content width lets the adjacent
@@ -129,7 +123,7 @@ export function PlayerArea({
       style={zoneStyle(commanderScale)}
     >
       <CommanderCardZone playerId={playerId} />
-      {hasCommanderDamage && <CommanderDamage playerId={playerId} />}
+      <CommanderDamage playerId={playerId} />
     </div>
   ) : null;
   const supportExtras = (
@@ -143,8 +137,13 @@ export function PlayerArea({
   const supportSection = hasSupportExtras ? (
     <>
       <div className="mx-2 h-3/4 w-px shrink-0 bg-white/20" />
+      {/* No `min-w-0`: the support track is justify-end, so letting this
+          wrapper collapse below its content width pushes the right-rail cards
+          (emblems/commander) off the right edge of the screen. Holding its
+          intrinsic width clamps the right edge to the track and grows the
+          cluster leftward on-screen instead. */}
       <div
-        className="flex min-w-0 items-center gap-2"
+        className="flex items-center gap-2"
         style={zoneStyle(isCompactHeight ? OTHER_BASE_SCALE_COMPACT : OTHER_BASE_SCALE)}
       >
         {supportExtras}

--- a/client/src/components/zone/CommanderCardZone.tsx
+++ b/client/src/components/zone/CommanderCardZone.tsx
@@ -12,6 +12,7 @@ import { useDragToCast } from "../../hooks/useDragToCast.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
+import { commandersInZone } from "../../viewmodel/commanderColumn.ts";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
 
 interface CommanderCardZoneProps {
@@ -26,19 +27,10 @@ interface CommanderCardZoneProps {
 export function CommanderCardZone({ playerId }: CommanderCardZoneProps) {
   const gameState = useGameStore((s) => s.gameState);
 
-  const commanders = useMemo(() => {
-    if (!gameState) return [];
-    const czIds = gameState.command_zone ?? [];
-    return czIds
-      .map((id) => gameState.objects[id])
-      .filter(
-        (obj): obj is GameObject =>
-          obj != null &&
-          obj.is_commander === true &&
-          obj.owner === playerId &&
-          obj.zone === "Command",
-      );
-  }, [gameState, playerId]);
+  const commanders = useMemo(
+    () => (gameState ? commandersInZone(gameState, playerId) : []),
+    [gameState, playerId],
+  );
 
   if (commanders.length === 0) return null;
 

--- a/client/src/viewmodel/__tests__/commanderColumn.test.ts
+++ b/client/src/viewmodel/__tests__/commanderColumn.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { GameObject, GameState, PlayerId } from "../../adapter/types";
+import { commanderDamageEntriesFor, commandersInZone } from "../commanderColumn";
+
+function obj(overrides: Partial<GameObject>): GameObject {
+  return {
+    id: 1,
+    owner: 0,
+    is_commander: false,
+    zone: "Battlefield",
+    ...overrides,
+  } as unknown as GameObject;
+}
+
+function stateWith(objects: GameObject[], commandZone: number[]): GameState {
+  return {
+    command_zone: commandZone,
+    objects: Object.fromEntries(objects.map((o) => [String(o.id), o])),
+  } as unknown as GameState;
+}
+
+describe("commandersInZone", () => {
+  it("returns only this player's commanders that are still in the command zone", () => {
+    const mine = obj({ id: 1, owner: 0, is_commander: true, zone: "Command" });
+    const cast = obj({ id: 2, owner: 0, is_commander: true, zone: "Battlefield" });
+    const opponent = obj({ id: 3, owner: 1, is_commander: true, zone: "Command" });
+    const nonCommander = obj({ id: 4, owner: 0, is_commander: false, zone: "Command" });
+    const state = stateWith([mine, cast, opponent, nonCommander], [1, 2, 3, 4]);
+
+    expect(commandersInZone(state, 0 as PlayerId).map((o) => o.id)).toEqual([1]);
+  });
+
+  it("is empty once the commander has left the command zone", () => {
+    const cast = obj({ id: 1, owner: 0, is_commander: true, zone: "Battlefield" });
+    expect(commandersInZone(stateWith([cast], [1]), 0 as PlayerId)).toEqual([]);
+  });
+});
+
+describe("commanderDamageEntriesFor", () => {
+  function damageState(
+    byAttacker: Record<string, Array<{ victim: PlayerId; commander: number; damage: number }>>,
+    formatThreshold?: number,
+  ): GameState {
+    return {
+      format_config: formatThreshold == null ? {} : { commander_damage_threshold: formatThreshold },
+      derived: { commander_damage_by_attacker: byAttacker },
+    } as unknown as GameState;
+  }
+
+  it("surfaces live damage entries for the victim even when no format threshold is set", () => {
+    // Regression: the PlayerArea wrapper once gated on the format flag while
+    // CommanderDamage renders on damage alone (fallback threshold). The shared
+    // selector must NOT require commander_damage_threshold, or the wrapper hides
+    // a render path its child supports.
+    const state = damageState({ "1": [{ victim: 0, commander: 99, damage: 7 }] });
+    expect(commanderDamageEntriesFor(state, 0 as PlayerId)).toEqual([
+      { attacker: "1", views: [{ victim: 0, commander: 99, damage: 7 }] },
+    ]);
+  });
+
+  it("filters out zero-damage entries and other victims", () => {
+    const state = damageState(
+      {
+        "1": [
+          { victim: 0, commander: 10, damage: 0 },
+          { victim: 1, commander: 11, damage: 5 },
+        ],
+      },
+      21,
+    );
+    expect(commanderDamageEntriesFor(state, 0 as PlayerId)).toEqual([]);
+  });
+
+  it("is empty when there are no derived entries", () => {
+    expect(commanderDamageEntriesFor(damageState({}), 0 as PlayerId)).toEqual([]);
+  });
+});

--- a/client/src/viewmodel/commanderColumn.ts
+++ b/client/src/viewmodel/commanderColumn.ts
@@ -1,0 +1,60 @@
+import type { GameObject, GameState, PlayerId } from "../adapter/types.ts";
+
+/**
+ * Single source of truth for what the commander column (CommanderCardZone +
+ * CommanderDamage) renders, and therefore whether PlayerArea should render the
+ * column wrapper + its divider at all.
+ *
+ * These selectors exist because the visibility predicate was previously
+ * duplicated across PlayerArea (the wrapper gate), CommanderCardZone, and
+ * CommanderDamage — and the copies drifted: an earlier wrapper gate required
+ * the Commander-format flag, while CommanderDamage renders on damage alone
+ * (using a fallback threshold for non-Commander formats that produced
+ * commander damage). The wrapper then suppressed a render path its child
+ * supported. Routing all three through these helpers keeps them in lockstep.
+ */
+
+/**
+ * Commanders this player owns that are currently in the command zone — the
+ * exact set CommanderCardZone renders. Used both there and by PlayerArea's
+ * column-visibility gate so the wrapper appears iff the card zone will.
+ */
+export function commandersInZone(gameState: GameState, playerId: PlayerId): GameObject[] {
+  return (gameState.command_zone ?? [])
+    .map((id) => gameState.objects[id])
+    .filter(
+      (obj): obj is GameObject =>
+        obj != null &&
+        obj.is_commander === true &&
+        obj.owner === playerId &&
+        obj.zone === "Command",
+    );
+}
+
+/** One attacker's commander-damage badges inflicted on a given victim. */
+export interface CommanderDamageEntry {
+  /** Attacking commander's controller (PlayerId as string key). */
+  attacker: string;
+  /** Per-commander damage badges, already filtered to this victim. */
+  views: { commander: number; damage: number }[];
+}
+
+/**
+ * Commander-damage entries inflicted on this player, grouped by attacker — the
+ * exact set CommanderDamage renders. Gated on `damage > 0` alone, with no
+ * format-flag check: the child uses a fallback threshold so non-Commander
+ * formats that somehow produced commander damage still display. Used both
+ * there and by PlayerArea's column-visibility gate (`.length > 0`).
+ */
+export function commanderDamageEntriesFor(
+  gameState: GameState,
+  playerId: PlayerId,
+): CommanderDamageEntry[] {
+  const byAttacker = gameState.derived?.commander_damage_by_attacker ?? {};
+  const entries: CommanderDamageEntry[] = [];
+  for (const [attacker, views] of Object.entries(byAttacker)) {
+    const forVictim = views.filter((view) => view.victim === playerId && view.damage > 0);
+    if (forVictim.length > 0) entries.push({ attacker, views: forVictim });
+  }
+  return entries;
+}


### PR DESCRIPTION
Follow-up to #2716, addressing PR review (mike-theDude + Gemini).

- Bug: the PlayerArea commander-column wrapper gated commander-damage on the
  format flag (commander_damage_threshold != null), but CommanderDamage renders
  on damage>0 alone via a fallback threshold (non-Commander formats that
  produced commander damage). The wrapper was stricter than its child, so it
  could suppress a supported render path. Fixed by dropping the format-flag
  conjunct.
- Collapse the triplicated visibility predicate (PlayerArea + CommanderCardZone
  + CommanderDamage) into one source of truth: viewmodel/commanderColumn.ts
  (commandersInZone + commanderDamageEntriesFor). All three now render from the
  same selectors, so the wrapper appears iff a child will and they can't drift.
  Adds unit tests locking the no-format-flag behavior that drifted.
- Emblem overflow: removing min-w-0 from the support-extras wrapper. The track
  is justify-end, so letting the wrapper collapse below content width pushed the
  card-shaped emblems/commander off the right edge of the screen; holding its
  width clamps the right edge to the track and grows the cluster leftward.
