### PR TITLE
Fix Banner of Kinship fellowship counters and +1/+1s

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -3759,11 +3759,32 @@ fn extract_etb_counters(
     source_id: ObjectId,
     event: &ProposedEvent,
 ) -> Vec<(CounterType, u32)> {
-    let exec = match ability {
-        Some(e) => e,
-        None => return Vec::new(),
-    };
-    let mut counters = match &*exec.effect {
+    let mut counters = Vec::new();
+    let mut current = ability;
+    // CR 614.1c: Only walk the event-modifier prefix of the ability chain.
+    // `Effect::Choose` and other post-entry work live after that prefix and
+    // must not have their `PutCounter` counts folded into `enter_with_counters`
+    // before the choice resolves (Banner of Kinship: fellowship counters keyed
+    // to the chosen creature type).
+    while let Some(exec) = current {
+        if !EventModifiers::is_event_modifier_effect(&exec.effect) {
+            break;
+        }
+        counters.extend(extract_etb_counters_from_effect(
+            &exec.effect, state, source_id, event,
+        ));
+        current = exec.sub_ability.as_deref();
+    }
+    counters
+}
+
+fn extract_etb_counters_from_effect(
+    effect: &Effect,
+    state: &GameState,
+    source_id: ObjectId,
+    event: &ProposedEvent,
+) -> Vec<(CounterType, u32)> {
+    match effect {
         Effect::PutCounter {
             counter_type,
             count,
@@ -3831,14 +3852,7 @@ fn extract_etb_counters(
             })
             .collect(),
         _ => Vec::new(),
-    };
-    counters.extend(extract_etb_counters(
-        exec.sub_ability.as_deref(),
-        state,
-        source_id,
-        event,
-    ));
-    counters
+    }
 }
 
 /// CR 614.1c + CR 614.12: ProposedEvent modifications that a replacement ability would
@@ -4993,7 +5007,7 @@ mod tests {
     use crate::game::game_object::{AttachTarget, GameObject};
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, ChosenAttribute, Effect, FilterProp,
-        QuantityExpr, QuantityModification, ReplacementDefinition, ReplacementMode,
+        QuantityExpr, QuantityModification, QuantityRef, ReplacementDefinition, ReplacementMode,
         ReplacementPlayerScope, TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
@@ -5043,6 +5057,59 @@ mod tests {
                 (CounterType::Plus1Plus1, 1),
                 (CounterType::Generic("shield".to_string()), 1)
             ]
+        );
+    }
+
+    #[test]
+    fn choose_then_chosen_dependent_counter_defers_to_post_replacement() {
+        let choose = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Choose {
+                choice_type: crate::types::ability::ChoiceType::CreatureType,
+                persist: true,
+            },
+        );
+        let mut execute = choose;
+        execute.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type: CounterType::Generic("fellowship".to_string()),
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::creature()
+                                .controller(crate::types::ability::ControllerRef::You)
+                                .properties(vec![FilterProp::IsChosenCreatureType]),
+                        ),
+                    },
+                },
+                target: TargetFilter::SelfRef,
+            },
+        )));
+        let repl = ReplacementDefinition::new(ReplacementEvent::Moved)
+            .execute(execute)
+            .valid_card(TargetFilter::SelfRef);
+        let mut state = test_state_with_object(ObjectId(10), Zone::Hand, vec![repl]);
+        let mut events = Vec::new();
+        let proposed =
+            ProposedEvent::zone_change(ObjectId(10), Zone::Hand, Zone::Battlefield, None);
+
+        let result = replace_event(&mut state, proposed, &mut events);
+        let ReplacementResult::Execute(ProposedEvent::ZoneChange {
+            enter_with_counters,
+            ..
+        }) = result
+        else {
+            panic!("expected Execute with ZoneChange, got {result:?}");
+        };
+
+        assert!(
+            enter_with_counters.is_empty(),
+            "chosen-dependent counters must not fold pre-choice"
+        );
+        assert!(
+            state.post_replacement_continuation.is_some(),
+            "Choose + chosen-dependent PutCounter must stash post-replacement work"
         );
     }
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -3771,7 +3771,10 @@ fn extract_etb_counters(
             break;
         }
         counters.extend(extract_etb_counters_from_effect(
-            &exec.effect, state, source_id, event,
+            &exec.effect,
+            state,
+            source_id,
+            event,
         ));
         current = exec.sub_ability.as_deref();
     }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -11,11 +11,12 @@ use serde::{Deserialize, Serialize};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag,
     ActivationRestriction, AdditionalCost, CastTimingPermission, CastingRestriction, ChoiceType,
-    ChosenSubtypeKind, ContinuousModification, DelayedTriggerCondition, Effect, ManaProduction,
-    ModalChoice, ParsedCondition, QuantityExpr, ReplacementDefinition, SolveCondition,
-    SpellCastingOption, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition,
-    TriggerDefinition, TypedFilter,
+    ChosenSubtypeKind, ContinuousModification, DelayedTriggerCondition, Effect, FilterProp,
+    ManaProduction, ModalChoice, ParsedCondition, QuantityExpr, QuantityRef, ReplacementDefinition,
+    SolveCondition, SpellCastingOption, StaticCondition, StaticDefinition, TargetFilter,
+    TriggerCondition, TriggerDefinition, TypedFilter,
 };
+use crate::types::replacements::ReplacementEvent;
 use crate::types::format::DeckCopyLimit;
 use crate::types::keywords::{ActivationCadence, FlashbackCost, Keyword, KeywordKind};
 use crate::types::mana::ManaCost;
@@ -726,6 +727,158 @@ fn parse_static_line_with_graveyard_keyword_continuation(line: &str) -> Vec<Stat
 
 /// CR 607.2d: Reconcile self-chosen type statics with the source's linked
 /// persisted choice.
+/// CR 614.1c + CR 608.2d: Cards like Banner of Kinship parse "as ~ enters,
+/// choose a creature type" and "~ enters with a fellowship counter … for each
+/// creature you control of the chosen type" as two Moved replacements. The
+/// counter count depends on the persisted choice, so it must chain after the
+/// `Choose` post-entry effect — not fold into `enter_with_counters` during the
+/// replacement pipeline.
+fn reconcile_choose_then_chosen_dependent_etb_counters(result: &mut ParsedAbilities) {
+    let choose_idx = result.replacements.iter().position(|replacement| {
+        replacement.event == ReplacementEvent::Moved
+            && replacement
+                .execute
+                .as_ref()
+                .is_some_and(|def| is_persisted_as_enters_choice(def))
+    });
+    let counter_idx = result.replacements.iter().position(|replacement| {
+        replacement.event == ReplacementEvent::Moved
+            && replacement
+                .execute
+                .as_ref()
+                .is_some_and(|def| is_chosen_dependent_self_etb_counter(def))
+    });
+    let (Some(choose_idx), Some(counter_idx)) = (choose_idx, counter_idx) else {
+        return;
+    };
+    if choose_idx == counter_idx {
+        return;
+    }
+
+    let counter_repl = result.replacements.remove(counter_idx);
+    let choose_idx = if counter_idx < choose_idx {
+        choose_idx - 1
+    } else {
+        choose_idx
+    };
+    let Some(counter_exec) = counter_repl.execute else {
+        return;
+    };
+    let choose_repl = &mut result.replacements[choose_idx];
+    let Some(mut choose_exec) = choose_repl.execute.take() else {
+        return;
+    };
+    append_sub_ability(&mut choose_exec, *counter_exec);
+    choose_repl.execute = Some(choose_exec);
+}
+
+fn is_persisted_as_enters_choice(def: &AbilityDefinition) -> bool {
+    matches!(
+        &*def.effect,
+        Effect::Choose {
+            persist: true,
+            ..
+        }
+    )
+}
+
+fn is_chosen_dependent_self_etb_counter(def: &AbilityDefinition) -> bool {
+    match &*def.effect {
+        Effect::PutCounter {
+            target: TargetFilter::SelfRef,
+            count,
+            ..
+        }
+        | Effect::AddCounter {
+            target: TargetFilter::SelfRef,
+            count,
+            ..
+        } => quantity_expr_uses_chosen_filter(count),
+        _ => false,
+    }
+}
+
+fn quantity_expr_uses_chosen_filter(expr: &QuantityExpr) -> bool {
+    quantity_expr_uses_filter_prop(expr, &|prop| {
+        matches!(
+            prop,
+            FilterProp::IsChosenCreatureType | FilterProp::IsChosenColor
+        )
+    })
+}
+
+fn quantity_expr_uses_filter_prop(
+    expr: &QuantityExpr,
+    pred: &impl Fn(&FilterProp) -> bool,
+) -> bool {
+    match expr {
+        QuantityExpr::Ref { qty } => quantity_ref_uses_filter_prop(qty, pred),
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Multiply { inner, .. } => quantity_expr_uses_filter_prop(inner, pred),
+        QuantityExpr::Sum { exprs } => exprs
+            .iter()
+            .any(|inner| quantity_expr_uses_filter_prop(inner, pred)),
+        QuantityExpr::Fixed { .. } => false,
+        QuantityExpr::UpTo { max } => quantity_expr_uses_filter_prop(max, pred),
+        QuantityExpr::Power { exponent, .. } => quantity_expr_uses_filter_prop(exponent, pred),
+        QuantityExpr::Difference { left, right } => {
+            quantity_expr_uses_filter_prop(left, pred)
+                || quantity_expr_uses_filter_prop(right, pred)
+        }
+    }
+}
+
+fn quantity_ref_uses_filter_prop(
+    qty: &QuantityRef,
+    pred: &impl Fn(&FilterProp) -> bool,
+) -> bool {
+    match qty {
+        QuantityRef::ObjectCount { filter }
+        | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::ObjectCountBySharedQuality { filter, .. }
+        | QuantityRef::CountersOnObjects { filter, .. }
+        | QuantityRef::Aggregate { filter, .. }
+        | QuantityRef::ControlledByEachPlayer { filter, .. }
+        | QuantityRef::DistinctColorsAmongPermanents { filter }
+        | QuantityRef::DistinctCounterKindsAmong { filter }
+        | QuantityRef::EnteredThisTurn { filter } => target_filter_uses_filter_prop(filter, pred),
+        QuantityRef::DistinctCardTypes { source } => match source {
+            crate::types::ability::CardTypeSetSource::Objects { filter } => {
+                target_filter_uses_filter_prop(filter, pred)
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn target_filter_uses_filter_prop(
+    filter: &TargetFilter,
+    pred: &impl Fn(&FilterProp) -> bool,
+) -> bool {
+    match filter {
+        TargetFilter::Typed(tf) => tf.properties.iter().any(pred),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => filters
+            .iter()
+            .any(|inner| target_filter_uses_filter_prop(inner, pred)),
+        TargetFilter::Not { filter } => target_filter_uses_filter_prop(filter, pred),
+        _ => false,
+    }
+}
+
+fn append_sub_ability(chain: &mut AbilityDefinition, tail: AbilityDefinition) {
+    let mut cursor = chain;
+    loop {
+        if cursor.sub_ability.is_none() {
+            cursor.sub_ability = Some(Box::new(tail));
+            return;
+        }
+        cursor = cursor.sub_ability.as_mut().expect("sub_ability present");
+    }
+}
+
 fn reconcile_self_chosen_type_statics(result: &mut ParsedAbilities, types: &[String]) {
     let Some(chosen_kind) = chosen_subtype_kind_from_persisted_choice(result)
         .or_else(|| chosen_kind_from_card_types(types))
@@ -3393,6 +3546,7 @@ pub(crate) fn parse_oracle_ir(
         i += 1;
     }
 
+    reconcile_choose_then_chosen_dependent_etb_counters(&mut result);
     reconcile_self_chosen_type_statics(&mut result, types);
 
     // Architectural rule: the parser must never silently discard Oracle
@@ -16784,6 +16938,44 @@ mod tests {
             ),
             "ETB execute must be ChangeZone→Exile"
         );
+    }
+
+    #[test]
+    fn banner_of_kinship_composes_choose_and_chosen_dependent_counters() {
+        let oracle = "As this artifact enters, choose a creature type. This artifact enters with a \
+                      fellowship counter on it for each creature you control of the chosen type.\n\
+                      Creatures you control of the chosen type get +1/+1 for each fellowship counter \
+                      on this artifact.";
+        let result = parse(oracle, "Banner of Kinship", &[], &["Artifact"], &[]);
+
+        assert_eq!(
+            result.replacements.len(),
+            1,
+            "choose + chosen-dependent ETB counters must compose into one replacement"
+        );
+        let execute = result.replacements[0]
+            .execute
+            .as_ref()
+            .expect("composed replacement must have execute");
+        assert!(matches!(
+            &*execute.effect,
+            Effect::Choose {
+                choice_type: ChoiceType::CreatureType,
+                persist: true,
+            }
+        ));
+        let counter = execute
+            .sub_ability
+            .as_ref()
+            .expect("PutCounter must chain after Choose");
+        assert!(matches!(
+            &*counter.effect,
+            Effect::PutCounter {
+                counter_type: crate::types::counter::CounterType::Generic(ref name),
+                target: TargetFilter::SelfRef,
+                ..
+            } if name == "fellowship"
+        ));
     }
 }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -16,12 +16,12 @@ use crate::types::ability::{
     SolveCondition, SpellCastingOption, StaticCondition, StaticDefinition, TargetFilter,
     TriggerCondition, TriggerDefinition, TypedFilter,
 };
-use crate::types::replacements::ReplacementEvent;
 use crate::types::format::DeckCopyLimit;
 use crate::types::keywords::{ActivationCadence, FlashbackCost, Keyword, KeywordKind};
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
+use crate::types::replacements::ReplacementEvent;
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 
@@ -765,21 +765,13 @@ fn reconcile_choose_then_chosen_dependent_etb_counters(result: &mut ParsedAbilit
         return;
     };
     let choose_repl = &mut result.replacements[choose_idx];
-    let Some(mut choose_exec) = choose_repl.execute.take() else {
-        return;
-    };
-    append_sub_ability(&mut choose_exec, *counter_exec);
-    choose_repl.execute = Some(choose_exec);
+    if let Some(ref mut choose_exec) = choose_repl.execute {
+        append_sub_ability(choose_exec, *counter_exec);
+    }
 }
 
 fn is_persisted_as_enters_choice(def: &AbilityDefinition) -> bool {
-    matches!(
-        &*def.effect,
-        Effect::Choose {
-            persist: true,
-            ..
-        }
-    )
+    matches!(&*def.effect, Effect::Choose { persist: true, .. })
 }
 
 fn is_chosen_dependent_self_etb_counter(def: &AbilityDefinition) -> bool {
@@ -830,10 +822,7 @@ fn quantity_expr_uses_filter_prop(
     }
 }
 
-fn quantity_ref_uses_filter_prop(
-    qty: &QuantityRef,
-    pred: &impl Fn(&FilterProp) -> bool,
-) -> bool {
+fn quantity_ref_uses_filter_prop(qty: &QuantityRef, pred: &impl Fn(&FilterProp) -> bool) -> bool {
     match qty {
         QuantityRef::ObjectCount { filter }
         | QuantityRef::ObjectCountDistinct { filter, .. }
@@ -844,12 +833,9 @@ fn quantity_ref_uses_filter_prop(
         | QuantityRef::DistinctColorsAmongPermanents { filter }
         | QuantityRef::DistinctCounterKindsAmong { filter }
         | QuantityRef::EnteredThisTurn { filter } => target_filter_uses_filter_prop(filter, pred),
-        QuantityRef::DistinctCardTypes { source } => match source {
-            crate::types::ability::CardTypeSetSource::Objects { filter } => {
-                target_filter_uses_filter_prop(filter, pred)
-            }
-            _ => false,
-        },
+        QuantityRef::DistinctCardTypes {
+            source: crate::types::ability::CardTypeSetSource::Objects { filter },
+        } => target_filter_uses_filter_prop(filter, pred),
         _ => false,
     }
 }
@@ -870,13 +856,10 @@ fn target_filter_uses_filter_prop(
 
 fn append_sub_ability(chain: &mut AbilityDefinition, tail: AbilityDefinition) {
     let mut cursor = chain;
-    loop {
-        if cursor.sub_ability.is_none() {
-            cursor.sub_ability = Some(Box::new(tail));
-            return;
-        }
-        cursor = cursor.sub_ability.as_mut().expect("sub_ability present");
+    while let Some(ref mut next) = cursor.sub_ability {
+        cursor = next;
     }
+    cursor.sub_ability = Some(Box::new(tail));
 }
 
 fn reconcile_self_chosen_type_statics(result: &mut ParsedAbilities, types: &[String]) {


### PR DESCRIPTION
## Summary
- Compose "choose a creature type" and "enters with fellowship counters for each creature of the chosen type" into one ETB replacement chain
- Stop `extract_etb_counters` at non-modifier effects so chosen-dependent counters resolve after the type choice, not before

Fixes #1315

## Test plan
- [x] `cargo test -p engine --lib banner_of_kinship`
- [x] `cargo test -p engine --lib choose_then_chosen_dependent`
