### PR TITLE
Fix Electrodominance hand cast selection (Fixes #1313)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -23189,7 +23189,7 @@ mod tests {
         let prepared = prepare_spell_cast(&state, PlayerId(0), spell)
             .expect("hand CastFromZone permission must allow the spell to be prepared");
 
-        assert_eq!(prepared.mana_cost, ManaCost::zero());
+        assert!(prepared.mana_cost.is_without_paying_mana());
     }
 
     fn add_borrowed_exile_sorcery_with_mana_value(

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1415,6 +1415,19 @@ fn has_graveyard_timed_alt_cost_permission(
         })
 }
 
+/// CR 601.2a: Object-level alt-cost grants that allow casting a chosen card
+/// from hand without moving it first (Electrodominance).
+fn has_hand_alt_cost_permission(
+    state: &GameState,
+    obj: &crate::game::game_object::GameObject,
+    player: PlayerId,
+) -> bool {
+    obj.zone == Zone::Hand
+        && obj.casting_permissions.iter().any(|permission| {
+            exile_alt_cost_permission_supports_cast(state, obj, player, permission, None)
+        })
+}
+
 /// CR 608.2g: An object carries a *cast-during-resolution* alt-cost permission —
 /// the runtime `ExileWithAltCost` stamped by `initiate_cast_during_resolution`,
 /// identified by `resolution_cleanup.is_some()`. Unlike Cascade/Discover/Suspend
@@ -2760,6 +2773,7 @@ fn prepare_spell_cast_with_variant_override_inner(
     };
     let has_graveyard_permission = graveyard_permission_src.is_some();
     let has_graveyard_alt_cost = has_graveyard_timed_alt_cost_permission(state, obj, player);
+    let has_hand_alt_cost = has_hand_alt_cost_permission(state, obj, player);
     // CR 608.2g: A free-cast window (Invoke Calamity) may drive a
     // cast-during-resolution on a card still in the controller's HAND. The
     // runtime `ExileWithAltCost { resolution_cleanup: Some(_) }` is the
@@ -2876,12 +2890,13 @@ fn prepare_spell_cast_with_variant_override_inner(
 
     let flash_cost = restrictions::flash_timing_cost(state, player, obj);
     // ExileWithAltCost / ExileWithAltAbilityCost: override mana cost when
-    // casting from exile via an alt-cost permission. The non-mana branch
+    // casting via an object-level alt-cost permission. The non-mana branch
     // (ExileWithAltAbilityCost) zeroes the mana cost — its `AbilityCost` is
     // routed through `pay_additional_cost` in `check_additional_cost_or_pay`
     // (CR 118.9 + CR 119.4).
     let alt_cost_from_exile = if obj.zone == Zone::Exile
         || has_graveyard_alt_cost
+        || has_hand_alt_cost
         || has_during_resolution_alt_cost
     {
         // CR 611.2a: When a permission carries `granted_to: Some(p)`, only
@@ -23137,6 +23152,44 @@ mod tests {
         assert!(spell_objects_available_to_cast(&state, PlayerId(0)).contains(&bauble));
         prepare_spell_cast(&state, PlayerId(0), bauble)
             .expect("bauble must be castable from graveyard");
+    }
+
+    #[test]
+    fn hand_alt_cost_permission_overrides_printed_mana_cost() {
+        let mut state = setup_game_at_main_phase();
+        let spell = create_object(
+            &mut state,
+            CardId(1313),
+            PlayerId(0),
+            "Hand Spell".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            ));
+            obj.mana_cost = ManaCost::generic(5);
+            obj.casting_permissions
+                .push(CastingPermission::ExileWithAltCost {
+                    cost: ManaCost::zero(),
+                    cast_transformed: false,
+                    constraint: None,
+                    granted_to: Some(PlayerId(0)),
+                    resolution_cleanup: None,
+                    duration: None,
+                });
+        }
+
+        let prepared = prepare_spell_cast(&state, PlayerId(0), spell)
+            .expect("hand CastFromZone permission must allow the spell to be prepared");
+
+        assert_eq!(prepared.mana_cost, ManaCost::zero());
     }
 
     fn add_borrowed_exile_sorcery_with_mana_value(

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -1,11 +1,76 @@
 use crate::game::zones;
 use crate::types::ability::{
-    CastingPermission, Duration, Effect, EffectError, EffectKind, ResolvedAbility, TargetRef,
+    CastingPermission, Duration, Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter,
+    TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaCost;
 use crate::types::zones::Zone;
+
+/// CR 115.1 + CR 601.2c: "You may cast a spell ... from your hand without paying
+/// its mana cost" (Electrodominance, Baral's Expertise) has no "target" word —
+/// the spell is chosen at resolution from the granting player's private zone via
+/// `EffectZoneChoice`, not stack-time targeting.
+fn open_private_zone_cast_selection(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    target_filter: &TargetFilter,
+    source_zone: Zone,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let ctx = crate::game::filter::FilterContext::from_ability(ability);
+    let eligible: Vec<_> = match source_zone {
+        Zone::Hand => state.players[ability.controller.0 as usize]
+            .hand
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        Zone::Library => state.players[ability.controller.0 as usize]
+            .library
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        _ => unreachable!(),
+    }
+    .into_iter()
+    .filter(|id| {
+        crate::game::filter::matches_target_filter(state, *id, target_filter, &ctx)
+    })
+    .collect();
+
+    if eligible.is_empty() {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::CastFromZone,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
+    let mut stash = ability.clone();
+    stash.targets.clear();
+    crate::game::effects::append_to_pending_continuation(state, Some(Box::new(stash)));
+    state.waiting_for = WaitingFor::EffectZoneChoice {
+        player: ability.controller,
+        cards: eligible,
+        count: 1,
+        min_count: 1,
+        up_to: false,
+        source_id: ability.source_id,
+        effect_kind: EffectKind::CastFromZone,
+        zone: source_zone,
+        destination: None,
+        enter_tapped: false,
+        enter_transformed: false,
+        enters_under_player: None,
+        enters_attacking: false,
+        owner_library: false,
+        track_exiled_by_source: false,
+        count_param: 0,
+    };
+    Ok(())
+}
 
 /// CR 601.2a + CR 118.9: Cast a card from a zone without paying its mana cost.
 ///
@@ -82,6 +147,17 @@ pub fn resolve(
     }
 
     if target_ids.is_empty() {
+        if let Some(source_zone) = target_filter.extract_in_zone() {
+            if matches!(source_zone, Zone::Hand | Zone::Library) {
+                return open_private_zone_cast_selection(
+                    state,
+                    ability,
+                    target_filter,
+                    source_zone,
+                    events,
+                );
+            }
+        }
         // No targets resolved — nothing to cast.
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::CastFromZone,
@@ -178,7 +254,41 @@ pub fn resolve(
         return Ok(());
     }
 
-    for &obj_id in &target_ids {
+    grant_lingering_permissions(
+        state,
+        ability,
+        &target_ids,
+        without_paying,
+        cast_transformed,
+        alt_ability_cost,
+        constraint,
+        duration,
+        events,
+    )?;
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::CastFromZone,
+        source_id: ability.source_id,
+    });
+
+    Ok(())
+}
+
+/// CR 118.9: Stamp `ExileWithAltCost` / `ExileWithAltAbilityCost` on resolved
+/// targets. Shared by the direct resolve path and the `EffectZoneChoice` resume
+/// path (Electrodominance hand pick).
+pub(crate) fn grant_lingering_permissions(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    target_ids: &[ObjectId],
+    without_paying: bool,
+    cast_transformed: bool,
+    alt_ability_cost: Option<crate::types::ability::AbilityCost>,
+    constraint: Option<crate::types::ability::CastPermissionConstraint>,
+    duration: Option<Duration>,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    for &obj_id in target_ids {
         // CR 601.2a: Impulse-draw and similar grants move non-exile cards to
         // exile before attaching `ExileWithAltCost`. Targeted graveyard grants
         // (Emry, Lurker in the Loch) keep the card in the graveyard and grant
@@ -244,12 +354,6 @@ pub fn resolve(
             }
         }
     }
-
-    events.push(GameEvent::EffectResolved {
-        kind: EffectKind::CastFromZone,
-        source_id: ability.source_id,
-    });
-
     Ok(())
 }
 
@@ -258,8 +362,8 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        CardPlayMode, CastPermissionConstraint, Comparator, Effect, QuantityExpr, TargetFilter,
-        TypeFilter, TypedFilter,
+        CardPlayMode, CastPermissionConstraint, Comparator, ControllerRef, Effect, QuantityExpr,
+        TargetFilter, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
     use crate::types::game_state::{ExileLink, ExileLinkKind};
@@ -593,6 +697,72 @@ mod tests {
             state.objects[&creature].casting_permissions.is_empty(),
             "composed filter must preserve the typed restriction"
         );
+    }
+
+    /// Issue #1313 — Electrodominance's "you may cast a spell with mana value X
+    /// or less from your hand" must open a resolution-time hand pick, not
+    /// silently no-op when `ability.targets` is empty.
+    #[test]
+    fn hand_cast_without_targets_emits_effect_zone_choice() {
+        use crate::types::ability::{
+            CardPlayMode, CastFromZoneDriver, Comparator, FilterProp, TypedFilter,
+        };
+        use crate::types::game_state::WaitingFor;
+
+        let mut state = make_test_state();
+        let cheap = add_card_to_hand(&mut state, PlayerId(0), CardId(501));
+        state.objects.get_mut(&cheap).unwrap().mana_cost = ManaCost::generic(2);
+        let expensive = add_card_to_hand(&mut state, PlayerId(0), CardId(502));
+        state.objects.get_mut(&expensive).unwrap().mana_cost = ManaCost::generic(5);
+
+        let ability = ResolvedAbility::new(
+            Effect::CastFromZone {
+                target: TargetFilter::Typed(
+                    TypedFilter::default()
+                        .with_type(TypeFilter::Card)
+                        .controller(ControllerRef::You)
+                        .properties(vec![
+                            FilterProp::InZone { zone: Zone::Hand },
+                            FilterProp::Cmc {
+                                comparator: Comparator::LE,
+                                value: QuantityExpr::Fixed { value: 3 },
+                            },
+                        ]),
+                ),
+                without_paying_mana_cost: true,
+                mode: CardPlayMode::Cast,
+                cast_transformed: false,
+                alt_ability_cost: None,
+                constraint: None,
+                duration: None,
+                driver: CastFromZoneDriver::LingeringPermission,
+            },
+            vec![],
+            ObjectId(999),
+            PlayerId(0),
+        );
+
+        let mut events = vec![];
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::EffectZoneChoice {
+                player,
+                cards,
+                count,
+                effect_kind,
+                zone,
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(*count, 1);
+                assert_eq!(*effect_kind, EffectKind::CastFromZone);
+                assert_eq!(*zone, Zone::Hand);
+                assert!(cards.contains(&cheap));
+                assert!(!cards.contains(&expensive));
+            }
+            other => panic!("expected EffectZoneChoice, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -11,7 +11,7 @@ use crate::types::zones::Zone;
 
 /// CR 115.1 + CR 601.2c: "You may cast a spell ... from your hand without paying
 /// its mana cost" (Electrodominance, Baral's Expertise) has no "target" word —
-/// the spell is chosen at resolution from the granting player's private zone via
+/// the spell is chosen at resolution from the granting player's hand via
 /// `EffectZoneChoice`, not stack-time targeting.
 fn open_private_zone_cast_selection(
     state: &mut GameState,
@@ -26,8 +26,7 @@ fn open_private_zone_cast_selection(
     };
     let cards_iter = match source_zone {
         Zone::Hand => player.hand.iter(),
-        Zone::Library => player.library.iter(),
-        _ => unreachable!(),
+        _ => unreachable!("private CastFromZone selection is currently hand-only"),
     };
     let eligible: Vec<_> = cards_iter
         .copied()
@@ -49,8 +48,8 @@ fn open_private_zone_cast_selection(
         player: ability.controller,
         cards: eligible,
         count: 1,
-        min_count: 1,
-        up_to: false,
+        min_count: 0,
+        up_to: true,
         source_id: ability.source_id,
         effect_kind: EffectKind::CastFromZone,
         zone: source_zone,
@@ -142,7 +141,7 @@ pub fn resolve(
 
     if target_ids.is_empty() {
         if let Some(source_zone) = target_filter.extract_in_zone() {
-            if matches!(source_zone, Zone::Hand | Zone::Library) {
+            if source_zone == Zone::Hand {
                 return open_private_zone_cast_selection(
                     state,
                     ability,
@@ -289,10 +288,12 @@ pub(crate) fn grant_lingering_permissions(
     for &obj_id in target_ids {
         // CR 601.2a: Impulse-draw and similar grants move non-exile cards to
         // exile before attaching `ExileWithAltCost`. Targeted graveyard grants
-        // (Emry, Lurker in the Loch) keep the card in the graveyard and grant
-        // a durational permission the casting pipeline consumes in place.
+        // (Emry, Lurker in the Loch) and resolution-time hand picks
+        // (Electrodominance) keep the card in its source zone and grant a
+        // permission the casting pipeline consumes in place.
         let current_zone = state.objects.get(&obj_id).map(|o| o.zone);
-        if current_zone.is_some_and(|z| z != Zone::Exile && z != Zone::Graveyard) {
+        if current_zone.is_some_and(|z| z != Zone::Exile && z != Zone::Graveyard && z != Zone::Hand)
+        {
             zones::move_to_zone(state, obj_id, Zone::Exile, events);
         }
 
@@ -358,13 +359,15 @@ pub(crate) fn grant_lingering_permissions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::engine::apply_as_current;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        CardPlayMode, CastPermissionConstraint, Comparator, ControllerRef, Effect, QuantityExpr,
-        TargetFilter, TypeFilter, TypedFilter,
+        CardPlayMode, CastFromZoneDriver, CastPermissionConstraint, Comparator, ControllerRef,
+        Effect, FilterProp, QuantityExpr, TargetFilter, TypeFilter, TypedFilter,
     };
+    use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
-    use crate::types::game_state::{ExileLink, ExileLinkKind};
+    use crate::types::game_state::{ExileLink, ExileLinkKind, WaitingFor};
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
 
@@ -394,6 +397,35 @@ mod tests {
         );
         state.objects.get_mut(&obj_id).unwrap().mana_cost = ManaCost::zero();
         obj_id
+    }
+
+    fn electrodominance_hand_ability(max_value: i32) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::CastFromZone {
+                target: TargetFilter::Typed(
+                    TypedFilter::default()
+                        .with_type(TypeFilter::Card)
+                        .controller(ControllerRef::You)
+                        .properties(vec![
+                            FilterProp::InZone { zone: Zone::Hand },
+                            FilterProp::Cmc {
+                                comparator: Comparator::LE,
+                                value: QuantityExpr::Fixed { value: max_value },
+                            },
+                        ]),
+                ),
+                without_paying_mana_cost: true,
+                mode: CardPlayMode::Cast,
+                cast_transformed: false,
+                alt_ability_cost: None,
+                constraint: None,
+                duration: None,
+                driver: CastFromZoneDriver::LingeringPermission,
+            },
+            vec![],
+            ObjectId(999),
+            PlayerId(0),
+        )
     }
 
     #[test]
@@ -558,10 +590,15 @@ mod tests {
     #[test]
     fn exiles_card_not_in_exile_then_grants_permission() {
         let mut state = make_test_state();
-        let obj_id = add_card_to_hand(&mut state, PlayerId(1), CardId(200));
+        let obj_id = create_object(
+            &mut state,
+            CardId(200),
+            PlayerId(1),
+            "Library Spell".to_string(),
+            Zone::Library,
+        );
 
-        // Card starts in opponent's hand.
-        assert_eq!(state.objects.get(&obj_id).unwrap().zone, Zone::Hand);
+        assert_eq!(state.objects.get(&obj_id).unwrap().zone, Zone::Library);
 
         let ability = ResolvedAbility::new(
             Effect::CastFromZone {
@@ -582,7 +619,7 @@ mod tests {
         let mut events = vec![];
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        // Card should have been moved to exile and granted permission.
+        // Non-hand, non-graveyard cards should be moved to exile and granted permission.
         let obj = state.objects.get(&obj_id).unwrap();
         assert_eq!(obj.zone, Zone::Exile);
         assert!(obj.casting_permissions.iter().any(|p| matches!(
@@ -702,43 +739,13 @@ mod tests {
     /// silently no-op when `ability.targets` is empty.
     #[test]
     fn hand_cast_without_targets_emits_effect_zone_choice() {
-        use crate::types::ability::{
-            CardPlayMode, CastFromZoneDriver, Comparator, FilterProp, TypedFilter,
-        };
-        use crate::types::game_state::WaitingFor;
-
         let mut state = make_test_state();
         let cheap = add_card_to_hand(&mut state, PlayerId(0), CardId(501));
         state.objects.get_mut(&cheap).unwrap().mana_cost = ManaCost::generic(2);
         let expensive = add_card_to_hand(&mut state, PlayerId(0), CardId(502));
         state.objects.get_mut(&expensive).unwrap().mana_cost = ManaCost::generic(5);
 
-        let ability = ResolvedAbility::new(
-            Effect::CastFromZone {
-                target: TargetFilter::Typed(
-                    TypedFilter::default()
-                        .with_type(TypeFilter::Card)
-                        .controller(ControllerRef::You)
-                        .properties(vec![
-                            FilterProp::InZone { zone: Zone::Hand },
-                            FilterProp::Cmc {
-                                comparator: Comparator::LE,
-                                value: QuantityExpr::Fixed { value: 3 },
-                            },
-                        ]),
-                ),
-                without_paying_mana_cost: true,
-                mode: CardPlayMode::Cast,
-                cast_transformed: false,
-                alt_ability_cost: None,
-                constraint: None,
-                duration: None,
-                driver: CastFromZoneDriver::LingeringPermission,
-            },
-            vec![],
-            ObjectId(999),
-            PlayerId(0),
-        );
+        let ability = electrodominance_hand_ability(3);
 
         let mut events = vec![];
         resolve(&mut state, &ability, &mut events).unwrap();
@@ -748,12 +755,16 @@ mod tests {
                 player,
                 cards,
                 count,
+                min_count,
+                up_to,
                 effect_kind,
                 zone,
                 ..
             } => {
                 assert_eq!(*player, PlayerId(0));
                 assert_eq!(*count, 1);
+                assert_eq!(*min_count, 0);
+                assert!(*up_to);
                 assert_eq!(*effect_kind, EffectKind::CastFromZone);
                 assert_eq!(*zone, Zone::Hand);
                 assert!(cards.contains(&cheap));
@@ -761,6 +772,69 @@ mod tests {
             }
             other => panic!("expected EffectZoneChoice, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn hand_cast_without_eligible_cards_resolves_without_prompt() {
+        let mut state = make_test_state();
+        let expensive = add_card_to_hand(&mut state, PlayerId(0), CardId(503));
+        state.objects.get_mut(&expensive).unwrap().mana_cost = ManaCost::generic(5);
+
+        let ability = electrodominance_hand_ability(3);
+        let mut events = vec![];
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(!matches!(
+            &state.waiting_for,
+            WaitingFor::EffectZoneChoice { .. }
+        ));
+        assert!(state.pending_continuation.is_none());
+        assert!(events.iter().any(|e| matches!(
+            e,
+            GameEvent::EffectResolved {
+                kind: EffectKind::CastFromZone,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn hand_cast_decline_consumes_prompt_without_permission() {
+        let mut state = make_test_state();
+        let cheap = add_card_to_hand(&mut state, PlayerId(0), CardId(504));
+        let ability = electrodominance_hand_ability(3);
+
+        let mut events = vec![];
+        resolve(&mut state, &ability, &mut events).unwrap();
+        apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] }).unwrap();
+
+        assert!(state.pending_continuation.is_none());
+        assert_eq!(state.objects[&cheap].zone, Zone::Hand);
+        assert!(state.objects[&cheap].casting_permissions.is_empty());
+    }
+
+    #[test]
+    fn hand_cast_selection_grants_zero_cost_permission_in_hand() {
+        let mut state = make_test_state();
+        let cheap = add_card_to_hand(&mut state, PlayerId(0), CardId(505));
+        let ability = electrodominance_hand_ability(3);
+
+        let mut events = vec![];
+        resolve(&mut state, &ability, &mut events).unwrap();
+        apply_as_current(&mut state, GameAction::SelectCards { cards: vec![cheap] }).unwrap();
+
+        assert_eq!(state.objects[&cheap].zone, Zone::Hand);
+        assert!(state.objects[&cheap]
+            .casting_permissions
+            .iter()
+            .any(|p| matches!(
+                p,
+                CastingPermission::ExileWithAltCost {
+                    cost,
+                    granted_to: Some(PlayerId(0)),
+                    ..
+                } if *cost == ManaCost::zero()
+            )));
     }
 
     #[test]

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -21,24 +21,18 @@ fn open_private_zone_cast_selection(
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
     let ctx = crate::game::filter::FilterContext::from_ability(ability);
-    let eligible: Vec<_> = match source_zone {
-        Zone::Hand => state.players[ability.controller.0 as usize]
-            .hand
-            .iter()
-            .copied()
-            .collect::<Vec<_>>(),
-        Zone::Library => state.players[ability.controller.0 as usize]
-            .library
-            .iter()
-            .copied()
-            .collect::<Vec<_>>(),
+    let Some(player) = state.players.iter().find(|p| p.id == ability.controller) else {
+        return Err(EffectError::PlayerNotFound);
+    };
+    let cards_iter = match source_zone {
+        Zone::Hand => player.hand.iter(),
+        Zone::Library => player.library.iter(),
         _ => unreachable!(),
-    }
-    .into_iter()
-    .filter(|id| {
-        crate::game::filter::matches_target_filter(state, *id, target_filter, &ctx)
-    })
-    .collect();
+    };
+    let eligible: Vec<_> = cards_iter
+        .copied()
+        .filter(|id| crate::game::filter::matches_target_filter(state, *id, target_filter, &ctx))
+        .collect();
 
     if eligible.is_empty() {
         events.push(GameEvent::EffectResolved {
@@ -94,7 +88,7 @@ pub fn resolve(
         cast_transformed,
         alt_ability_cost,
         constraint,
-        duration,
+        _duration,
         driver,
     ) = match &ability.effect {
         Effect::CastFromZone {
@@ -254,17 +248,7 @@ pub fn resolve(
         return Ok(());
     }
 
-    grant_lingering_permissions(
-        state,
-        ability,
-        &target_ids,
-        without_paying,
-        cast_transformed,
-        alt_ability_cost,
-        constraint,
-        duration,
-        events,
-    )?;
+    grant_lingering_permissions(state, ability, &target_ids, events)?;
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::CastFromZone,
@@ -281,13 +265,27 @@ pub(crate) fn grant_lingering_permissions(
     state: &mut GameState,
     ability: &ResolvedAbility,
     target_ids: &[ObjectId],
-    without_paying: bool,
-    cast_transformed: bool,
-    alt_ability_cost: Option<crate::types::ability::AbilityCost>,
-    constraint: Option<crate::types::ability::CastPermissionConstraint>,
-    duration: Option<Duration>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
+    let (without_paying, cast_transformed, alt_ability_cost, constraint, duration) =
+        match &ability.effect {
+            Effect::CastFromZone {
+                without_paying_mana_cost,
+                cast_transformed,
+                alt_ability_cost,
+                constraint,
+                duration,
+                ..
+            } => (
+                *without_paying_mana_cost,
+                *cast_transformed,
+                alt_ability_cost.clone(),
+                constraint.clone(),
+                duration.clone(),
+            ),
+            _ => return Err(EffectError::MissingParam("CastFromZone".to_string())),
+        };
+
     for &obj_id in target_ids {
         // CR 601.2a: Impulse-draw and similar grants move non-exile cards to
         // exile before attaching `ExileWithAltCost`. Targeted graveyard grants

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2285,6 +2285,55 @@ pub(super) fn handle_resolution_choice(
                         super::zones::move_to_library_at_index(state, card_id, Some(0), events);
                     }
                 }
+                // CR 601.2c + CR 115.1: Resolution-time hand/library pick for
+                // `CastFromZone` (Electrodominance, Baral's Expertise).
+                EffectKind::CastFromZone => {
+                    let Some(cont) = state.pending_continuation.take() else {
+                        return Err(EngineError::InvalidAction(
+                            "CastFromZone EffectZoneChoice missing stashed ability".to_string(),
+                        ));
+                    };
+                    let ability = *cont.chain;
+                    let (
+                        without_paying,
+                        cast_transformed,
+                        alt_ability_cost,
+                        constraint,
+                        duration,
+                    ) = match &ability.effect {
+                        Effect::CastFromZone {
+                            without_paying_mana_cost,
+                            cast_transformed,
+                            alt_ability_cost,
+                            constraint,
+                            duration,
+                            ..
+                        } => (
+                            *without_paying_mana_cost,
+                            *cast_transformed,
+                            alt_ability_cost.clone(),
+                            constraint.clone(),
+                            duration.clone(),
+                        ),
+                        _ => {
+                            return Err(EngineError::InvalidAction(
+                                "CastFromZone EffectZoneChoice ability mismatch".to_string(),
+                            ));
+                        }
+                    };
+                    effects::cast_from_zone::grant_lingering_permissions(
+                        &mut *state,
+                        &ability,
+                        &chosen,
+                        without_paying,
+                        cast_transformed,
+                        alt_ability_cost,
+                        constraint,
+                        duration,
+                        events,
+                    )
+                    .map_err(|e| EngineError::InvalidAction(e.to_string()))?;
+                }
                 // CR 701.68a: Place `count_param` -1/-1 counters on the creature
                 // the controller chose. The choice is non-targeted; the pool was
                 // restricted to the controller's creatures in `blight::resolve`,
@@ -2349,6 +2398,7 @@ pub(super) fn handle_resolution_choice(
                     | EffectKind::Tap
                     | EffectKind::Untap
                     | EffectKind::PutAtLibraryPosition
+                    | EffectKind::CastFromZone
             ) && state.pending_continuation.is_some()
             {
                 let tracked = if matches!(effect_kind, EffectKind::Sacrifice) {

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2109,6 +2109,24 @@ pub(super) fn handle_resolution_choice(
                 let _ = state.devour_eligible_snapshot.take();
             }
 
+            if chosen.is_empty() && matches!(effect_kind, EffectKind::CastFromZone) {
+                // CR 609.1 / CR 601.2a: Declining an optional
+                // Electrodominance-style hand cast consumes the stashed
+                // CastFromZone continuation without granting a permission. Do
+                // not call the generic resume path here; the pending ability
+                // would re-open the same optional prompt.
+                state.pending_continuation.take();
+                state.last_effect_count = Some(0);
+                events.push(GameEvent::EffectResolved {
+                    kind: effect_kind,
+                    source_id,
+                });
+                set_priority(state, player);
+                return Ok(ResolutionChoiceOutcome::WaitingFor(
+                    state.waiting_for.clone(),
+                ));
+            }
+
             if chosen.is_empty() {
                 // Issue #423 audit: no cards chosen — this branch moves no
                 // objects and emits no battlefield-exit events, so no
@@ -2285,7 +2303,7 @@ pub(super) fn handle_resolution_choice(
                         super::zones::move_to_library_at_index(state, card_id, Some(0), events);
                     }
                 }
-                // CR 601.2c + CR 115.1: Resolution-time hand/library pick for
+                // CR 601.2c + CR 115.1: Resolution-time hand pick for
                 // `CastFromZone` (Electrodominance, Baral's Expertise).
                 EffectKind::CastFromZone => {
                     let Some(cont) = state.pending_continuation.take() else {

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2294,42 +2294,10 @@ pub(super) fn handle_resolution_choice(
                         ));
                     };
                     let ability = *cont.chain;
-                    let (
-                        without_paying,
-                        cast_transformed,
-                        alt_ability_cost,
-                        constraint,
-                        duration,
-                    ) = match &ability.effect {
-                        Effect::CastFromZone {
-                            without_paying_mana_cost,
-                            cast_transformed,
-                            alt_ability_cost,
-                            constraint,
-                            duration,
-                            ..
-                        } => (
-                            *without_paying_mana_cost,
-                            *cast_transformed,
-                            alt_ability_cost.clone(),
-                            constraint.clone(),
-                            duration.clone(),
-                        ),
-                        _ => {
-                            return Err(EngineError::InvalidAction(
-                                "CastFromZone EffectZoneChoice ability mismatch".to_string(),
-                            ));
-                        }
-                    };
                     effects::cast_from_zone::grant_lingering_permissions(
                         &mut *state,
                         &ability,
                         &chosen,
-                        without_paying,
-                        cast_transformed,
-                        alt_ability_cost,
-                        constraint,
-                        duration,
                         events,
                     )
                     .map_err(|e| EngineError::InvalidAction(e.to_string()))?;


### PR DESCRIPTION
## Summary
- When `CastFromZone` resolves with an `InZone { Hand }` (or library) filter and no pre-selected targets, the engine now opens `EffectZoneChoice` so the player can pick an eligible spell at resolution time.
- The `EffectZoneChoice` handler grants the lingering `ExileWithAltCost` permission after selection, matching the existing exile/graveyard grant path.

## Root cause
`cast_from_zone::resolve` returned early when `ability.targets` was empty, even for hand-cast permissions like Electrodominance's optional rider. The UI then waited for a second target with nothing selectable.

## Test plan
- [x] `cargo test -p engine cast_from_zone::`
- [ ] Cast Electrodominance with X=3, accept the optional cast, and confirm hand spells with MV ≤ 3 are offered

Fixes #1313
