### PR TITLE
Fix Thespian's Stage losing copy ability after copying land

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2571,6 +2571,9 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
         ContinuousModification::RetainPrintedTriggerFromSource {
             source_trigger_index,
         } => format!("retain printed trigger {source_trigger_index}"),
+        ContinuousModification::RetainPrintedAbilityFromSource {
+            source_ability_index,
+        } => format!("retain printed ability {source_ability_index}"),
         ContinuousModification::AddSupertype { supertype } => {
             format!("add supertype {supertype}")
         }

--- a/crates/engine/src/game/effects/become_copy.rs
+++ b/crates/engine/src/game/effects/become_copy.rs
@@ -1260,6 +1260,60 @@ mod tests {
         );
     }
 
+    // CR 707.9a: Activated-ability "except it has this ability" (Thespian's
+    // Stage class) retains the source's printed activated ability on the copy.
+    #[test]
+    fn become_copy_retains_printed_ability_from_source() {
+        use crate::types::ability::{
+            AbilityCost, AbilityDefinition, AbilityKind, ContinuousModification,
+        };
+
+        let mut state = GameState::new_two_player(42);
+        let target = create_creature(&mut state, 1, PlayerId(0), "Urza's Saga", 2, 2);
+        state.objects.get_mut(&target).unwrap().base_keywords = vec![Keyword::Trample];
+
+        let source = create_creature(&mut state, 2, PlayerId(0), "Thespian's Stage", 0, 0);
+        let copy_ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::BecomeCopy {
+                target: TargetFilter::Any,
+                duration: None,
+                mana_value_limit: None,
+                additional_modifications: vec![],
+            },
+        )
+        .cost(AbilityCost::Tap);
+        state.objects.get_mut(&source).unwrap().base_abilities =
+            Arc::new(vec![copy_ability.clone()]);
+
+        let ability = ResolvedAbility::new(
+            Effect::BecomeCopy {
+                target: TargetFilter::Any,
+                duration: None,
+                mana_value_limit: None,
+                additional_modifications: vec![
+                    ContinuousModification::RetainPrintedAbilityFromSource {
+                        source_ability_index: 0,
+                    },
+                ],
+            },
+            vec![TargetRef::Object(target)],
+            source,
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        let copied = state.objects.get(&source).unwrap();
+        assert!(
+            copied.abilities.iter().any(|a| a == &copy_ability),
+            "retained activated copy ability must survive Layer 1; got {:?}",
+            copied.abilities
+        );
+    }
+
     // ── Reset regression: abilities revert when copy ends ─────────────────
     #[test]
     fn abilities_revert_to_empty_when_copy_expires() {

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2696,6 +2696,7 @@ fn depends_on(a: &ActiveContinuousEffect, b: &ActiveContinuousEffect, _state: &G
             | ContinuousModification::AddStaticMode { .. }
             | ContinuousModification::GrantStaticAbility { .. }
             | ContinuousModification::RetainPrintedTriggerFromSource { .. }
+            | ContinuousModification::RetainPrintedAbilityFromSource { .. }
     );
 
     if b_changes_abilities && filter_references_ability(&a.affected_filter) {
@@ -2991,6 +2992,7 @@ fn modification_dynamic_quantity(m: &ContinuousModification) -> Option<&Quantity
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
+        | ContinuousModification::RetainPrintedAbilityFromSource { .. }
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. } => None,
     }
@@ -3192,6 +3194,20 @@ fn apply_continuous_effect_filtered(
                 .get(*source_trigger_index)
                 .cloned()
         })
+    } else {
+        None
+    };
+    // CR 707.9a: Pre-read the printed activated ability to retain from the
+    // source object's `base_abilities`. Cloned before the per-object mutable
+    // borrow inside the loop (mirrors the trigger retain pre-read above).
+    let retained_printed_ability = if let ContinuousModification::RetainPrintedAbilityFromSource {
+        source_ability_index,
+    } = &effect.modification
+    {
+        state
+            .objects
+            .get(&effect.source_id)
+            .and_then(|src| src.base_abilities.get(*source_ability_index).cloned())
     } else {
         None
     };
@@ -3640,6 +3656,18 @@ fn apply_continuous_effect_filtered(
                     }
                 }
             }
+            // CR 707.9a: Retain the source's printed activated ability on the
+            // copy. After `CopyValues` overwrote `obj.abilities` with the
+            // copied values, push the source's printed ability back so the
+            // copy retains "this ability". Idempotent — duplicate retain calls
+            // (same ability structurally) collapse into one.
+            ContinuousModification::RetainPrintedAbilityFromSource { .. } => {
+                if let Some(ability) = retained_printed_ability.clone() {
+                    if !obj.abilities.iter().any(|a| a == &ability) {
+                        Arc::make_mut(&mut obj.abilities).push(ability);
+                    }
+                }
+            }
         }
     }
 }
@@ -3797,6 +3825,24 @@ pub(crate) fn compute_current_copiable_values(
                     let triggers = Arc::make_mut(&mut values.trigger_definitions);
                     if !triggers.iter().any(|t| t == &trigger) {
                         triggers.push(trigger);
+                    }
+                }
+            }
+            // CR 707.9a: A copy effect that retains an activated ability makes
+            // that ability part of the copiable values of the copy. Read the
+            // printed ability from the effect's source object by index,
+            // mirroring the trigger retain path above.
+            ContinuousModification::RetainPrintedAbilityFromSource {
+                source_ability_index,
+            } => {
+                if let Some(ability) = state
+                    .objects
+                    .get(&effect.source_id)
+                    .and_then(|src| src.base_abilities.get(*source_ability_index).cloned())
+                {
+                    let abilities = Arc::make_mut(&mut values.abilities);
+                    if !abilities.iter().any(|a| a == &ability) {
+                        abilities.push(ability);
                     }
                 }
             }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -506,6 +506,7 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
+        | ContinuousModification::RetainPrintedAbilityFromSource { .. }
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }
         | ContinuousModification::AddCounterOnEnter { .. } => {}

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2197,6 +2197,7 @@ pub(crate) fn parse_oracle_ir(
                 effect_text,
                 &line,
                 card_name,
+                Some(result.abilities.len()),
                 &mut ctx,
             );
             if ability_cant_be_copied {
@@ -2286,6 +2287,7 @@ pub(crate) fn parse_oracle_ir(
                         activated_effect_text,
                         &line,
                         card_name,
+                        Some(result.abilities.len()),
                         &mut ctx,
                     );
                     result.abilities.push(def);
@@ -3266,6 +3268,7 @@ fn parse_activated_ability_definition(
     effect_text: &str,
     description: &str,
     card_name: &str,
+    current_ability_index: Option<usize>,
     ctx: &mut ParseContext,
 ) -> (AbilityDefinition, String) {
     let (effect_text, constraints) = strip_activated_constraints(effect_text);
@@ -3277,12 +3280,17 @@ fn parse_activated_ability_definition(
     // reference. Restored after the effect parse — no leak to sibling abilities.
     let prev_exile_zone = ctx.current_ability_exile_cost_zone.take();
     ctx.current_ability_exile_cost_zone = non_self_exile_cost_zone(&cost);
+    // CR 707.9a: thread the activated-ability index so "except it has this
+    // ability" inside the effect body resolves to RetainPrintedAbilityFromSource.
+    let prev_ability_index = ctx.current_ability_index;
+    ctx.current_ability_index = current_ability_index;
 
     // Retry with `~` normalization if the first pass left an Unimplemented node
     // or emitted a target-fallback warning.
     let mut def = parse_activated_with_self_ref_fallback(&effect_text, card_name, ctx);
 
     ctx.current_ability_exile_cost_zone = prev_exile_zone;
+    ctx.current_ability_index = prev_ability_index;
     normalize_activated_mana_instead_delta(&mut def);
     if def.activation_zone.is_none() {
         def.activation_zone = activation_zone_from_self_cost(&cost);
@@ -14622,6 +14630,40 @@ mod tests {
                 );
             }
             other => panic!("expected CopyTokenOf at trigger.execute.effect, got {other:?}"),
+        }
+    }
+
+    /// CR 707.9a + CR 602.1: Thespian's Stage "{2}, {T}: becomes a copy of
+    /// target land, except it has this ability" must emit
+    /// `RetainPrintedAbilityFromSource` keyed to the activated ability's index
+    /// in the printed ability list (index 1 — the mana ability is index 0).
+    #[test]
+    fn thespians_stage_emits_retain_printed_ability_from_source() {
+        let r = parse(
+            "{T}: Add {C}.\n{2}, {T}: This land becomes a copy of target land, except it has this ability.",
+            "Thespian's Stage",
+            &[],
+            &["Land"],
+            &[],
+        );
+        assert_eq!(r.abilities.len(), 2, "mana ability + copy ability");
+        let copy_ability = &r.abilities[1];
+        match &*copy_ability.effect {
+            Effect::BecomeCopy {
+                additional_modifications,
+                ..
+            } => {
+                assert!(
+                    additional_modifications.iter().any(|m| matches!(
+                        m,
+                        ContinuousModification::RetainPrintedAbilityFromSource {
+                            source_ability_index: 1
+                        }
+                    )),
+                    "expected RetainPrintedAbilityFromSource(1); got {additional_modifications:?}"
+                );
+            }
+            other => panic!("expected BecomeCopy on second activated ability, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -36,12 +36,14 @@
 //! - `it has {keyword[, keyword, ...]}`
 //!   → [`ContinuousModification::AddKeyword`] per recognised keyword.
 //! - `<subject pronoun> has this ability`
-//!   → [`ContinuousModification::RetainPrintedTriggerFromSource`] referencing
-//!   the trigger that contains the BecomeCopy effect (CR 707.9a). The
-//!   subject pronoun accepts `he`/`she`/`it` so cards from any gender print
-//!   route through the same arm. Requires `current_trigger_index` to be set
-//!   in the parse context — when absent, the arm declines (no modification
-//!   produced) so the rest of the except clause still parses.
+//!   → [`ContinuousModification::RetainPrintedTriggerFromSource`] when
+//!   `current_trigger_index` is set (triggered abilities), or
+//!   [`ContinuousModification::RetainPrintedAbilityFromSource`] when
+//!   `current_ability_index` is set (activated abilities). Both reference
+//!   the ability containing the BecomeCopy effect (CR 707.9a). The subject
+//!   pronoun accepts `he`/`she`/`it` so cards from any gender print route
+//!   through the same arm. When neither index is set, the arm declines (no
+//!   modification produced) so the rest of the except clause still parses.
 //!
 //! # Fail-soft semantics
 //!
@@ -151,7 +153,8 @@ pub(crate) fn parse_except_clause<'a>(
 ///   - `<subject> power/toughness is half <copy source> power/toughness`
 ///     → SetPowerDynamic + SetToughnessDynamic using copied source values
 ///   - `<subject pronoun> has this ability`
-///     → RetainPrintedTriggerFromSource (when ctx provides the index)
+///     → RetainPrintedTriggerFromSource or RetainPrintedAbilityFromSource
+///     (when ctx provides the trigger or activated-ability index)
 ///   - `it's a(n) {core_type} in addition to its other types`  → AddType
 ///   - `it's a(n) {subtype} in addition to its other types`    → AddSubtype
 ///   - `it has "<triggered/activated/static ability>"`         → GrantTrigger/GrantAbility/etc.
@@ -505,23 +508,23 @@ fn append_color_and_type_modifications(
     mods.extend(type_mods);
 }
 
-/// CR 707.9a: "<subject pronoun> has this ability" — emit a
-/// [`ContinuousModification::RetainPrintedTriggerFromSource`] keyed to the
-/// printed trigger that contains the `BecomeCopy` effect.
+/// CR 707.9a: "<subject pronoun> has this ability" — emit a retain modification
+/// keyed to the printed ability that contains the `BecomeCopy` effect.
 ///
 /// "this ability" inside a triggered ability's body refers to that very
-/// trigger (CR 603.1). For the copy to retain it, the runtime must reach back
-/// into the *source* object's printed triggers (by index) at Layer 1 and push
-/// a clone onto the copied object's triggers — `GrantTrigger` would require a
-/// pre-built `TriggerDefinition`, which we cannot construct mid-parse without
-/// a forward reference to the partial trigger.
+/// trigger (CR 603.1); inside an activated ability it refers to that activated
+/// ability (CR 602.1). For the copy to retain it, the runtime must reach back
+/// into the *source* object's printed triggers or abilities (by index) at
+/// Layer 1 and push a clone onto the copied object — `GrantTrigger` /
+/// `GrantAbility` would require a pre-built definition, which we cannot
+/// construct mid-parse without a forward reference to the partial ability.
 ///
-/// When `ctx.current_trigger_index` is `None` (e.g. parsing inside a
-/// replacement effect or a non-trigger spell body), the arm declines so the
+/// When neither `ctx.current_trigger_index` nor `ctx.current_ability_index`
+/// is set (e.g. parsing inside a replacement effect), the arm declines so the
 /// surrounding except clause continues parsing.
 ///
 /// Subject pronouns accepted: `he`, `she`, `it` (and `they` for plural). All
-/// are treated identically — this clause is a self-reference to the trigger
+/// are treated identically — this clause is a self-reference to the ability
 /// containing it.
 fn parse_has_this_ability<'a>(
     input: &'a str,
@@ -535,11 +538,19 @@ fn parse_has_this_ability<'a>(
     ))
     .parse(input)
     .ok()?;
-    let source_trigger_index = ctx.current_trigger_index?;
+    if let Some(source_trigger_index) = ctx.current_trigger_index {
+        return Some((
+            rest,
+            ContinuousModification::RetainPrintedTriggerFromSource {
+                source_trigger_index,
+            },
+        ));
+    }
+    let source_ability_index = ctx.current_ability_index?;
     Some((
         rest,
-        ContinuousModification::RetainPrintedTriggerFromSource {
-            source_trigger_index,
+        ContinuousModification::RetainPrintedAbilityFromSource {
+            source_ability_index,
         },
     ))
 }
@@ -1153,6 +1164,38 @@ mod tests {
         )
         .unwrap();
         assert!(mods.is_empty());
+    }
+
+    #[test]
+    fn it_has_this_ability_with_ability_index_emits_retain_ability() {
+        let ctx = ParseContext {
+            current_ability_index: Some(1),
+            ..Default::default()
+        };
+        let (_, mods) =
+            parse_except_clause(", except it has this ability", "Thespian's Stage", &ctx).unwrap();
+        assert_eq!(
+            mods,
+            vec![ContinuousModification::RetainPrintedAbilityFromSource {
+                source_ability_index: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn trigger_index_takes_precedence_over_ability_index() {
+        let ctx = ParseContext {
+            current_trigger_index: Some(0),
+            current_ability_index: Some(1),
+            ..Default::default()
+        };
+        let (_, mods) = parse_except_clause(", except it has this ability", "Card", &ctx).unwrap();
+        assert_eq!(
+            mods,
+            vec![ContinuousModification::RetainPrintedTriggerFromSource {
+                source_trigger_index: 0,
+            }]
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14559,6 +14559,7 @@ pub(crate) fn parse_effect_chain_ir(
             // reference via `RetainPrintedTriggerFromSource`. Actor, by contrast,
             // is per-chunk (re-derived from each chunk's stripped prefix above).
             current_trigger_index: ctx.current_trigger_index,
+            current_ability_index: ctx.current_ability_index,
             actor: chunk_actor,
             // CR 109.4 + CR 115.1 + CR 506.2: propagate relative-player scope
             // from the trigger condition so "that player controls" inside any

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -20,6 +20,10 @@ pub(crate) struct ParseContext {
     /// CR 707.9a + CR 603.1: Index of the printed trigger whose body is being
     /// parsed. Consumed by BecomeCopy "has this ability" arm.
     pub current_trigger_index: Option<usize>,
+    /// CR 707.9a + CR 602.1: Index of the printed activated ability whose
+    /// effect is being parsed. Consumed by BecomeCopy "has this ability" arm
+    /// inside activated abilities (Thespian's Stage, Cytoshape, …).
+    pub current_ability_index: Option<usize>,
     /// CR 701.21a + CR 608.2k: The actor performing the effect ("you", "an opponent").
     pub actor: Option<ControllerRef>,
     /// Resolved quantity reference ("that many", "that much").

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11552,6 +11552,19 @@ pub enum ContinuousModification {
     RetainPrintedTriggerFromSource {
         source_trigger_index: usize,
     },
+    /// CR 707.9a: Retain a printed activated ability from the source object's
+    /// printed ability list at the given index. Used by "becomes a copy of
+    /// <X>, except it has this ability" patterns inside activated abilities
+    /// (Thespian's Stage, Cytoshape), where "this ability" refers to the
+    /// activated ability containing the BecomeCopy effect.
+    ///
+    /// Applied at Layer 1 because CR 707.9a states the granted ability
+    /// "becomes part of the copiable values for the copy". The runtime reads
+    /// the source object's `base_abilities[source_ability_index]` and pushes
+    /// a clone onto the affected object's `abilities`.
+    RetainPrintedAbilityFromSource {
+        source_ability_index: usize,
+    },
     /// CR 205.4 + CR 707.9d: Add a supertype to the affected object's
     /// supertypes (e.g., Sarkhan, Soul Aflame: "it's legendary in addition
     /// to its other types"). Idempotent: pushing an already-present supertype

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -137,7 +137,8 @@ impl ContinuousModification {
             // ability part of the copiable values. Applied at Layer 1 alongside
             // CopyValues / SetName so downstream copy effects observe the
             // retained ability when reading copiable values.
-            ContinuousModification::RetainPrintedTriggerFromSource { .. } => Layer::Copy,
+            ContinuousModification::RetainPrintedTriggerFromSource { .. }
+            | ContinuousModification::RetainPrintedAbilityFromSource { .. } => Layer::Copy,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `RetainPrintedAbilityFromSource` and `current_ability_index` so activated BecomeCopy effects retain "except it has this ability"
- Thread ability index through activated-ability parsing (`parse_activated_ability_definition`) and Layer 1 runtime (`layers.rs`)
- Fixes Thespian's Stage copying a land (e.g. Urza's Saga) while keeping its `{2}, {T}` copy ability

Fixes #1310

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy -p engine -- -D warnings`
- [x] Parser unit tests: `it_has_this_ability_with_ability_index_emits_retain_ability`, `trigger_index_takes_precedence_over_ability_index`
- [x] Parser integration: `thespians_stage_emits_retain_printed_ability_from_source`
- [x] Runtime: `become_copy_retains_printed_ability_from_source`


Made with [Cursor](https://cursor.com)