### PR TITLE
Fix Unstoppable Plan end-step untap when phase entry is deferred

### DIFF
--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -480,19 +480,19 @@ pub(super) fn handle_replacement_choice(
                     if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
                         waiting_for = state.waiting_for.clone();
                     }
-                } else if state.deferred_step_trigger_resume
+                } else if state.deferred_step_trigger_resume.is_some()
                     && matches!(state.waiting_for, WaitingFor::Priority { .. })
                 {
-                    // CR 513.1a / CR 503.2: A CR 616.1 mana-pool choice can
+                    // CR 513.1 + CR 603.3b: A CR 616.1 mana-pool choice can
                     // defer completion of `enter_phase`. In that case
                     // `auto_advance` returned before its per-step trigger arm
                     // ran (it bails while `pending_phase_transition_progress`
                     // is set). Resume only when that bail happened — not when
                     // `advance_phase` alone paused the drain (unit tests).
-                    state.deferred_step_trigger_resume = false;
+                    state.deferred_step_trigger_resume = None;
                     waiting_for = super::turns::auto_advance(state, events);
                 } else {
-                    state.deferred_step_trigger_resume = false;
+                    state.deferred_step_trigger_resume = None;
                 }
             }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -476,10 +476,23 @@ pub(super) fn handle_replacement_choice(
                 && state.pending_phase_transition_progress.is_some()
             {
                 super::turns::drain_pending_phase_transition_progress(state, events);
-                if !matches!(state.waiting_for, WaitingFor::Priority { .. })
-                    && state.pending_phase_transition_progress.is_some()
+                if state.pending_phase_transition_progress.is_some() {
+                    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                        waiting_for = state.waiting_for.clone();
+                    }
+                } else if state.deferred_step_trigger_resume
+                    && matches!(state.waiting_for, WaitingFor::Priority { .. })
                 {
-                    waiting_for = state.waiting_for.clone();
+                    // CR 513.1a / CR 503.2: A CR 616.1 mana-pool choice can
+                    // defer completion of `enter_phase`. In that case
+                    // `auto_advance` returned before its per-step trigger arm
+                    // ran (it bails while `pending_phase_transition_progress`
+                    // is set). Resume only when that bail happened — not when
+                    // `advance_phase` alone paused the drain (unit tests).
+                    state.deferred_step_trigger_resume = false;
+                    waiting_for = super::turns::auto_advance(state, events);
+                } else {
+                    state.deferred_step_trigger_resume = false;
                 }
             }
 

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1433,7 +1433,7 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
         // trips through `GameAction::ChooseReplacement`; the drain resumes
         // via the `EmptyManaPool` arm of `handle_replacement_choice`.
         if state.pending_phase_transition_progress.is_some() {
-            state.deferred_step_trigger_resume = true;
+            state.deferred_step_trigger_resume = Some(state.phase);
             return state.waiting_for.clone();
         }
 

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1433,6 +1433,7 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
         // trips through `GameAction::ChooseReplacement`; the drain resumes
         // via the `EmptyManaPool` arm of `handle_replacement_choice`.
         if state.pending_phase_transition_progress.is_some() {
+            state.deferred_step_trigger_resume = true;
             return state.waiting_for.clone();
         }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5907,13 +5907,14 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_phase_transition_progress: Option<PhaseTransitionProgress>,
 
-    /// Transient: set when `auto_advance` returns early because
+    /// Transient: set to the phase whose beginning-of-step triggers still need
+    /// to run when `auto_advance` returns early because
     /// `pending_phase_transition_progress` is set (CR 616.1 mana-pool choice
     /// deferred `enter_phase`). Cleared when `handle_replacement_choice`
     /// resumes `auto_advance` after the drain completes so beginning-of-step
-    /// triggers (CR 503.2 / CR 513.1a) still fire.
-    #[serde(default, skip_serializing)]
-    pub deferred_step_trigger_resume: bool,
+    /// triggers (CR 513.1 + CR 603.3b) still fire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred_step_trigger_resume: Option<Phase>,
 
     /// Transient: set by stack.rs before resolving a triggered ability, cleared after.
     /// Used by event-context TargetFilter variants to resolve trigger event data.
@@ -6477,7 +6478,7 @@ impl GameState {
             pending_damage_replacements: Vec::new(),
             pending_step_end_mana_handlers: Vec::new(),
             pending_phase_transition_progress: None,
-            deferred_step_trigger_resume: false,
+            deferred_step_trigger_resume: None,
             current_trigger_event: None,
             current_trigger_match_count: None,
             resolving_stack_entry: None,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5907,6 +5907,14 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_phase_transition_progress: Option<PhaseTransitionProgress>,
 
+    /// Transient: set when `auto_advance` returns early because
+    /// `pending_phase_transition_progress` is set (CR 616.1 mana-pool choice
+    /// deferred `enter_phase`). Cleared when `handle_replacement_choice`
+    /// resumes `auto_advance` after the drain completes so beginning-of-step
+    /// triggers (CR 503.2 / CR 513.1a) still fire.
+    #[serde(default, skip_serializing)]
+    pub deferred_step_trigger_resume: bool,
+
     /// Transient: set by stack.rs before resolving a triggered ability, cleared after.
     /// Used by event-context TargetFilter variants to resolve trigger event data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6469,6 +6477,7 @@ impl GameState {
             pending_damage_replacements: Vec::new(),
             pending_step_end_mana_handlers: Vec::new(),
             pending_phase_transition_progress: None,
+            deferred_step_trigger_resume: false,
             current_trigger_event: None,
             current_trigger_match_count: None,
             resolving_stack_entry: None,

--- a/crates/engine/tests/integration/issue_1308_unstoppable_plan.rs
+++ b/crates/engine/tests/integration/issue_1308_unstoppable_plan.rs
@@ -1,0 +1,263 @@
+//! Issue #1308 — Unstoppable Plan must untap all nonland permanents you control
+//! at the beginning of your end step.
+//!
+//! Oracle: "At the beginning of your end step, untap all nonland permanents
+//! you control."
+
+use super::rules::{GameRunner, GameScenario, Phase, WaitingFor, P0};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, StaticDefinition, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor as EngineWaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaType, ManaUnit};
+use engine::types::phase::Phase as EnginePhase;
+use engine::types::statics::StaticMode;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const UNSTOPPABLE_PLAN: &str =
+    "At the beginning of your end step, untap all nonland permanents you control.";
+
+fn advance_until_end_step_trigger_resolved(runner: &mut GameRunner) {
+    for _ in 0..200 {
+        let in_end_step = runner.state().phase == Phase::End;
+        let stack_empty = runner.state().stack.is_empty();
+        if in_end_step
+            && stack_empty
+            && matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+        {
+            return;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority while advancing to end step");
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declare no attackers");
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("declare no blockers");
+            }
+            other => panic!(
+                "unexpected waiting state advancing to end step: {other:?} \
+                 (phase={:?}, stack_len={})",
+                runner.state().phase,
+                runner.state().stack.len()
+            ),
+        }
+    }
+    panic!(
+        "engine did not resolve Unstoppable Plan's end-step trigger within 200 steps \
+         (phase={:?}, stack_len={})",
+        runner.state().phase,
+        runner.state().stack.len()
+    );
+}
+
+#[test]
+fn unstoppable_plan_parses_end_step_untap_all() {
+    let parsed = parse_oracle_text(
+        UNSTOPPABLE_PLAN,
+        "Unstoppable Plan",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("Unstoppable Plan must have an end-step trigger");
+    assert_eq!(trigger.mode, TriggerMode::Phase);
+    assert_eq!(trigger.phase, Some(EnginePhase::End));
+    let execute = trigger.execute.as_ref().expect("trigger must execute");
+    assert!(
+        matches!(*execute.effect, Effect::UntapAll { .. }),
+        "expected UntapAll effect, got {:?}",
+        execute.effect
+    );
+}
+
+#[test]
+fn unstoppable_plan_untaps_nonland_permanents_at_end_step() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature(P0, "Unstoppable Plan", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(UNSTOPPABLE_PLAN);
+    let creature = scenario.add_creature(P0, "Soldier", 2, 2).id();
+    let land = scenario.add_basic_land(P0, ManaColor::Blue);
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .tapped = true;
+    runner.state_mut().objects.get_mut(&land).unwrap().tapped = true;
+
+    advance_until_end_step_trigger_resolved(&mut runner);
+
+    assert!(
+        !runner.state().objects[&creature].tapped,
+        "creature must be untapped by Unstoppable Plan's end-step trigger"
+    );
+    assert!(
+        runner.state().objects[&land].tapped,
+        "lands must remain tapped — only nonland permanents untap"
+    );
+}
+
+/// Cast Unstoppable Plan from hand, tap a creature, then reach end step — the
+/// ETB trigger registration must survive the cast pipeline.
+#[test]
+fn unstoppable_plan_untaps_after_cast_from_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let plan = scenario
+        .add_creature_to_hand_from_oracle(P0, "Unstoppable Plan", 0, 0, UNSTOPPABLE_PLAN)
+        .as_enchantment()
+        .id();
+    let creature = scenario.add_creature(P0, "Soldier", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .tapped = true;
+
+    let card_id = runner.state().objects[&plan].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: plan,
+            card_id,
+            targets: vec![],
+        })
+        .expect("Unstoppable Plan is 0-cost in scenario shell");
+    runner.advance_until_stack_empty();
+
+    advance_until_end_step_trigger_resolved(&mut runner);
+
+    assert!(
+        !runner.state().objects[&creature].tapped,
+        "end-step untap must fire after casting Unstoppable Plan from hand"
+    );
+}
+
+/// When entering the end step pauses on a CR 616.1 empty-mana-pool choice,
+/// `auto_advance` returns before its `Phase::End` arm runs. After the choice
+/// resolves, phase-begin triggers must still fire (CR 513.1a).
+#[test]
+fn unstoppable_plan_untaps_after_deferred_end_step_entry() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+
+    scenario
+        .add_creature(P0, "Unstoppable Plan", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(UNSTOPPABLE_PLAN);
+    let creature = scenario.add_creature(P0, "Soldier", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    // Two retention handlers force a ReplacementChoice while entering End step.
+    for (n, color) in [(1u64, ManaColor::Green), (2, ManaColor::Blue)] {
+        let source = engine::game::zones::create_object(
+            runner.state_mut(),
+            engine::types::identifiers::CardId(100 + n),
+            P0,
+            format!("Retention {n}"),
+            Zone::Battlefield,
+        );
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::StepEndUnspentMana {
+                    filter: Some(color),
+                    action: engine::types::mana::StepEndManaAction::Retain,
+                })
+                .affected(TargetFilter::Controller),
+            );
+    }
+
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .tapped = true;
+    runner.state_mut().players[0].mana_pool.add(ManaUnit::new(
+        ManaType::Green,
+        ObjectId(900),
+        false,
+        vec![],
+    ));
+    runner.state_mut().players[0].mana_pool.add(ManaUnit::new(
+        ManaType::Blue,
+        ObjectId(901),
+        false,
+        vec![],
+    ));
+
+    // Leave postcombat main — entering End step pauses on mana retention choice.
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 pass from postcombat main");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P1 pass from postcombat main");
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            EngineWaitingFor::ReplacementChoice { .. }
+        ),
+        "expected mana-retention choice entering end step, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        runner.state().phase,
+        Phase::End,
+        "enter_phase sets End immediately; the mana drain may still be pending"
+    );
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("choose first retention handler");
+
+    assert_eq!(
+        runner.state().phase,
+        Phase::End,
+        "phase entry must complete after the deferred mana choice"
+    );
+
+    // Resolve the end-step trigger if it reached the stack.
+    runner.advance_until_stack_empty();
+
+    assert!(
+        !runner.state().objects[&creature].tapped,
+        "Unstoppable Plan must untap nonlands even when end-step entry was deferred \
+         by a CR 616.1 mana-pool choice"
+    );
+}

--- a/crates/engine/tests/integration/issue_1308_unstoppable_plan.rs
+++ b/crates/engine/tests/integration/issue_1308_unstoppable_plan.rs
@@ -163,7 +163,7 @@ fn unstoppable_plan_untaps_after_cast_from_hand() {
 
 /// When entering the end step pauses on a CR 616.1 empty-mana-pool choice,
 /// `auto_advance` returns before its `Phase::End` arm runs. After the choice
-/// resolves, phase-begin triggers must still fire (CR 513.1a).
+/// resolves, phase-begin triggers must still fire (CR 513.1 + CR 603.3b).
 #[test]
 fn unstoppable_plan_untaps_after_deferred_end_step_entry() {
     let mut scenario = GameScenario::new();

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -83,6 +83,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod invoke_calamity_free_cast;
+mod issue_1308_unstoppable_plan;
 mod issue_1509_sorcery_main_phase_cast;
 mod issue_1971_enduring_tenacity;
 mod issue_1973_rise_of_dark_realms;


### PR DESCRIPTION
## Summary
- Unstoppable Plan's "At the beginning of your end step, untap all nonland permanents you control" was parsed correctly but did not fire when entering the end step was deferred by a CR 616.1 empty-mana-pool replacement choice.
- When `auto_advance` bails on `pending_phase_transition_progress`, set a transient `deferred_step_trigger_resume` flag and resume `auto_advance` after the mana drain completes so beginning-of-step triggers (CR 513.1a) still reach the stack.
- Resume only when that bail occurred — not after `advance_phase`-only drains — avoiding regressions in existing mana-retention unit tests.

Fixes #1308

## Test plan
- [x] `cargo test -p engine --test integration issue_1308` (4 tests: parser, normal end step, cast-from-hand, deferred end-step entry)
- [x] `cargo test -p engine --lib step_end_mana_two_retention_handlers` (regression guard)
- [x] `cargo fmt --all`


Made with [Cursor](https://cursor.com)