### PR TITLE
ship/planeswalker loyalty and gy art

### DIFF
--- a/client/src/components/zone/GraveyardPile.tsx
+++ b/client/src/components/zone/GraveyardPile.tsx
@@ -50,13 +50,11 @@ export function GraveyardPile({ playerId, onClick, size }: GraveyardPileProps) {
   const graveyard = useGameStore(
     (s) => s.gameState?.players[playerId]?.graveyard ?? EMPTY,
   );
-  const topObjectId = useGameStore((s) => {
+  const topObject = useGameStore((s) => {
     const gy = s.gameState?.players[playerId]?.graveyard;
-    return gy && gy.length > 0 ? gy[gy.length - 1] : null;
+    const id = gy && gy.length > 0 ? gy[gy.length - 1] : null;
+    return id != null ? (s.gameState?.objects[id] ?? null) : null;
   });
-  const topObject = useGameStore((s) =>
-    topObjectId != null ? (s.gameState?.objects[topObjectId] ?? null) : null,
-  );
   const topLookup = useMemo(
     () => (topObject ? cardImageLookup(topObject) : null),
     [topObject],

--- a/client/src/components/zone/GraveyardPile.tsx
+++ b/client/src/components/zone/GraveyardPile.tsx
@@ -1,9 +1,11 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
+import { cardImageLookup, type CardImageLookup } from "../../services/cardImageLookup.ts";
 
 const EMPTY: readonly number[] = [];
 
@@ -13,8 +15,17 @@ interface GraveyardPileProps {
   size?: { width: string; height: string };
 }
 
-function TopCard({ cardName }: { cardName: string }) {
-  const { src } = useCardImage(cardName, { size: "normal" });
+function TopCard({ lookup }: { lookup: CardImageLookup }) {
+  // Resolve via the engine's printed_ref (oracle_id + face) like every other
+  // object-rendering surface — name-only lookup fails for DFC / transformed /
+  // back-face cards (e.g. a transformed planeswalker) and would show the empty
+  // placeholder instead of the card art.
+  const { src } = useCardImage(lookup.name, {
+    size: "normal",
+    oracleId: lookup.oracleId,
+    faceName: lookup.faceName,
+    faceIndex: lookup.faceIndex,
+  });
 
   if (!src) {
     return (
@@ -27,7 +38,7 @@ function TopCard({ cardName }: { cardName: string }) {
   return (
     <img
       src={src}
-      alt={cardName}
+      alt={lookup.name}
       className="h-full w-full rounded-lg object-cover"
       draggable={false}
     />
@@ -39,13 +50,17 @@ export function GraveyardPile({ playerId, onClick, size }: GraveyardPileProps) {
   const graveyard = useGameStore(
     (s) => s.gameState?.players[playerId]?.graveyard ?? EMPTY,
   );
-  const topCardName = useGameStore((s) => {
-    const state = s.gameState;
-    if (!state) return null;
-    const gy = state.players[playerId]?.graveyard;
-    if (!gy || gy.length === 0) return null;
-    return state.objects[gy[gy.length - 1]]?.name ?? null;
+  const topObjectId = useGameStore((s) => {
+    const gy = s.gameState?.players[playerId]?.graveyard;
+    return gy && gy.length > 0 ? gy[gy.length - 1] : null;
   });
+  const topObject = useGameStore((s) =>
+    topObjectId != null ? (s.gameState?.objects[topObjectId] ?? null) : null,
+  );
+  const topLookup = useMemo(
+    () => (topObject ? cardImageLookup(topObject) : null),
+    [topObject],
+  );
 
   // Check if any graveyard card is selectable for the current engine prompt.
   const canActForWaitingState = useCanActForWaitingState();
@@ -87,7 +102,7 @@ export function GraveyardPile({ playerId, onClick, size }: GraveyardPileProps) {
 
       {/* Top card — full card image */}
       <div className="relative h-full w-full overflow-hidden rounded-lg border border-gray-500 shadow-md group-hover:border-gray-300 transition-colors">
-        {topCardName && <TopCard cardName={topCardName} />}
+        {topLookup && <TopCard lookup={topLookup} />}
         <div className="absolute inset-0 bg-black/20 group-hover:bg-black/0 transition-colors" />
       </div>
 

--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import type { GameAction, GameObject } from "../../adapter/types.ts";
 import { CardImage } from "../card/CardImage.tsx";
+import { objectImageProps } from "../../services/cardImageLookup.ts";
 import { ModalPanelShell } from "../ui/ModalPanelShell.tsx";
 import { ScrollableCardStrip } from "../modal/ChoiceOverlay.tsx";
 import { useLongPress } from "../../hooks/useLongPress.ts";
@@ -224,7 +225,13 @@ function ZoneCard({
       onClick={handleClick}
       {...longPressHandlers}
     >
-      <CardImage cardName={obj.name} size="normal" />
+      {/* Resolve the image via the engine's printed_ref (oracle_id + face)
+          like every other object-rendering modal — name-only lookup fails for
+          DFC / transformed / back-face cards (e.g. a transformed planeswalker),
+          which then falls back to the broken-image div. In the zone strip that
+          fallback is sized up to ~560px, so a failed image rendered "huge" with
+          text instead of art. */}
+      <CardImage {...objectImageProps(obj)} size="normal" />
       {canCast && !isValidTarget && (
         <>
           {/* Arena-style purple "playable" affordance — same treatment as the

--- a/client/src/components/zone/__tests__/ZoneViewer.test.tsx
+++ b/client/src/components/zone/__tests__/ZoneViewer.test.tsx
@@ -7,8 +7,8 @@ import { useUiStore } from "../../../stores/uiStore.ts";
 import { ZoneViewer } from "../ZoneViewer.tsx";
 
 vi.mock("../../card/CardImage.tsx", () => ({
-  CardImage: ({ cardName }: { cardName: string }) => (
-    <div aria-label={cardName} data-testid="card-image" />
+  CardImage: ({ cardName, oracleId }: { cardName: string; oracleId?: string }) => (
+    <div aria-label={cardName} data-testid="card-image" data-oracle-id={oracleId ?? ""} />
   ),
 }));
 
@@ -143,6 +143,28 @@ describe("ZoneViewer", () => {
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: "CastSpell" }),
+    );
+  });
+
+  it("resolves graveyard card art via printed_ref oracle_id, not name", () => {
+    // Regression: a transformed / DFC / back-face card (e.g. a transformed
+    // planeswalker) has a back-face name that isn't a scryfall-data key, so the
+    // legacy name-only lookup failed and rendered the oversized broken-image
+    // fallback ("huge, no art"). The viewer must use the engine's printed_ref
+    // (oracle_id) like every other object-rendering surface.
+    const pw = makeObject({
+      id: 42,
+      name: "Ral, Leyline Prodigy",
+      card_types: { supertypes: [], core_types: ["Planeswalker"], subtypes: ["Ral"] },
+      transformed: true,
+      printed_ref: { oracle_id: "ral-oracle-id", face_name: "Ral, Leyline Prodigy" },
+    });
+    useGameStore.setState({ gameState: makeState(pw) });
+
+    render(<ZoneViewer zone="graveyard" playerId={0} onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("card-image").getAttribute("data-oracle-id")).toBe(
+      "ral-oracle-id",
     );
   });
 

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -649,7 +649,23 @@ pub(crate) fn execute_zone_move(
     // reanimate, blink, etc.). Spell-cast entry is handled in stack.rs.
     if dest_zone == Zone::Battlefield {
         if let Some(obj) = state.objects.get(&obj_id) {
-            let intrinsic = crate::game::printed_cards::intrinsic_etb_counters(obj);
+            // CR 712.14a + CR 712.18: A permanent entering transformed (e.g. a
+            // double-faced card exiled and returned with its back face up, like
+            // a creature-front // planeswalker-back DFC) will have its back
+            // face's characteristics on the battlefield. The physical face swap
+            // happens later in `deliver_replaced_zone_change`, so `obj` still
+            // shows its front face here — read the back face's printed
+            // loyalty/defense directly so CR 306.5b/310.4b seeds the counter map
+            // (the source of truth per CR 306.5c). Without this a transforming
+            // planeswalker enters with 0 loyalty counters and dies immediately
+            // to CR 704.5i. Ravenous (front-face cast-time) does not apply to an
+            // effect-driven transformed entry, so only face counters are seeded.
+            let intrinsic = match (enter_transformed, obj.back_face.as_ref()) {
+                (true, Some(back)) => {
+                    crate::game::printed_cards::intrinsic_face_counters(back.loyalty, back.defense)
+                }
+                _ => crate::game::printed_cards::intrinsic_etb_counters(obj),
+            };
             if !intrinsic.is_empty() {
                 if let ProposedEvent::ZoneChange {
                     enter_with_counters,

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -707,6 +707,7 @@ pub(crate) fn apply_counter_removal(
         return;
     };
 
+    let was_present = obj.counters.contains_key(&counter_type);
     let entry = obj.counters.entry(counter_type.clone()).or_insert(0);
     let removed = (*entry).min(count);
     *entry = entry.saturating_sub(count);
@@ -715,9 +716,28 @@ pub(crate) fn apply_counter_removal(
     // sync with the counter map — the field IS the counter count.
     sync_derived_from_counters(obj, &counter_type);
 
-    // CR 122.1: Zero-count entries are absent — prune so proliferate and other
-    // "has a counter" checks cannot resurrect removed counter types.
+    // CR 122.1: Zero-count entries are normally absent — prune so proliferate
+    // and other "has a counter" checks cannot resurrect removed counter types.
+    //
+    // EXCEPTION (CR 306.5c): loyalty is a characteristic-defining counter whose
+    // field IS the counter count, and the layer system RESETS obj.loyalty to
+    // base each evaluation then re-derives it from the counter map. Once the
+    // last loyalty counter is pruned, that re-derive can no longer tell "drained
+    // to 0" (must die, CR 704.5i) from "not counter-tracked, use the field"
+    // (a clone whose loyalty comes from the Copy layer). So a genuinely-tracked
+    // planeswalker drained to exactly 0 must KEEP its 0 entry — the present 0 is
+    // the signal the layer re-derive needs. A phantom 0 created by `or_insert`
+    // on a counter that was never present is still pruned, so un-counter-tracked
+    // objects correctly fall back to their field value. (Defense needs no such
+    // exception: the layer system never resets obj.defense, so a battle drained
+    // to 0 keeps defense 0 without help and the CR 704.5v SBA fires normally.)
+    let keep_zero = was_present
+        && counter_type == CounterType::Loyalty
+        && obj.counters.get(&counter_type).copied() == Some(0);
     crate::types::counter::prune_zero_counters(&mut obj.counters);
+    if keep_zero {
+        obj.counters.insert(counter_type.clone(), 0);
+    }
 
     if counter_type_affects_layers(&counter_type) {
         state.layers_dirty.mark_full();
@@ -3523,11 +3543,48 @@ mod tests {
         remove_counter_with_replacement(&mut state, pw_id, CounterType::Loyalty, 5, &mut events);
 
         let obj = &state.objects[&pw_id];
-        assert!(
-            !obj.counters.contains_key(&CounterType::Loyalty),
-            "zero-count loyalty entry should be pruned after removal"
+        // CR 306.5c + CR 704.5i: a genuinely-tracked planeswalker drained to 0
+        // KEEPS its zero loyalty entry so the layer re-derive reports 0 (not the
+        // printed base) and the state-based action can fire. (Phantom zeros from
+        // removing a counter that was never present are still pruned — see
+        // `apply_counter_removal`.)
+        assert_eq!(
+            obj.counters.get(&CounterType::Loyalty).copied(),
+            Some(0),
+            "drained loyalty entry must persist at 0, not be pruned away"
         );
         assert_eq!(obj.loyalty, Some(0));
+    }
+
+    /// CR 306.5c (hybrid model): removing loyalty from an object that was NOT
+    /// counter-tracked (e.g. a clone whose loyalty comes from the Copy layer)
+    /// must NOT leave a persistent 0 entry. Only genuinely-tracked counters keep
+    /// their 0; a phantom 0 from `or_insert` on an absent counter is pruned, so
+    /// the layer re-derive falls back to the object's field value rather than
+    /// killing it. Guards the `was_present` condition in `apply_counter_removal`.
+    #[test]
+    fn remove_untracked_loyalty_does_not_leave_phantom_zero() {
+        let mut state = GameState::new_two_player(42);
+        let pw_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Cloned PW".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&pw_id).unwrap();
+        // Loyalty present as a field (Copy-layer value) but NO loyalty counter.
+        obj.loyalty = Some(5);
+
+        let mut events = Vec::new();
+        remove_counter_with_replacement(&mut state, pw_id, CounterType::Loyalty, 1, &mut events);
+
+        assert!(
+            !state.objects[&pw_id]
+                .counters
+                .contains_key(&CounterType::Loyalty),
+            "removing an untracked loyalty counter must not create a persistent 0 entry",
+        );
     }
 
     /// CR 310.4c: Defense counters drive `obj.defense` for battles. The same
@@ -3630,6 +3687,59 @@ mod tests {
                 .copied(),
             Some(5),
             "counters[Loyalty] must remain 5 after layer evaluation"
+        );
+    }
+
+    /// CR 306.5c + CR 704.5i regression: a planeswalker drained to 0 loyalty
+    /// must still read `Some(0)` after a layer re-evaluation — not snap back to
+    /// its printed `base_loyalty`. Removing the last loyalty counter prunes the
+    /// zero-count entry (CR 122.1), so the layer re-derive must treat the absent
+    /// key as 0. Pre-fix this returned `Some(4)` (base_loyalty), leaving the
+    /// planeswalker unkillable: check_zero_loyalty never saw 0, so neither a
+    /// `-N` ability nor lethal damage could ever destroy it.
+    #[test]
+    fn loyalty_drained_to_zero_stays_zero_after_layer_re_evaluation() {
+        use crate::game::layers::evaluate_layers;
+        use crate::types::card_type::CoreType;
+
+        let mut state = GameState::new_two_player(42);
+        let pw_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Test PW".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&pw_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Planeswalker);
+        // Printed loyalty 4; currently at 7 (entered at 4, gained 3).
+        obj.base_loyalty = Some(4);
+        obj.loyalty = Some(7);
+        obj.counters.insert(CounterType::Loyalty, 7);
+
+        let mut events = Vec::new();
+        // A "-7" loyalty ability (or 7+ damage) routes through the resolver.
+        remove_counter_with_replacement(&mut state, pw_id, CounterType::Loyalty, 7, &mut events);
+        assert_eq!(state.objects[&pw_id].loyalty, Some(0));
+        // CR 306.5c: the drained loyalty entry persists at 0 (it was genuinely
+        // tracked) so the layer re-derive can distinguish "tracked, drained to 0"
+        // from "not counter-tracked" (absent entry → fall back to base).
+        assert_eq!(
+            state.objects[&pw_id]
+                .counters
+                .get(&CounterType::Loyalty)
+                .copied(),
+            Some(0),
+            "drained loyalty entry must persist at 0",
+        );
+
+        // Force layer re-evaluation: the present 0 entry must re-derive to 0,
+        // NOT revert to base_loyalty (4).
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects[&pw_id].loyalty,
+            Some(0),
+            "drained planeswalker must read 0 after layer re-derive, not snap back to printed 4",
         );
     }
 

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -711,6 +711,7 @@ pub(crate) fn apply_counter_removal(
     let entry = obj.counters.entry(counter_type.clone()).or_insert(0);
     let removed = (*entry).min(count);
     *entry = entry.saturating_sub(count);
+    let is_zero = *entry == 0;
 
     // CR 306.5c / CR 310.4c: Keep obj.loyalty / obj.defense in
     // sync with the counter map — the field IS the counter count.
@@ -731,9 +732,7 @@ pub(crate) fn apply_counter_removal(
     // objects correctly fall back to their field value. (Defense needs no such
     // exception: the layer system never resets obj.defense, so a battle drained
     // to 0 keeps defense 0 without help and the CR 704.5v SBA fires normally.)
-    let keep_zero = was_present
-        && counter_type == CounterType::Loyalty
-        && obj.counters.get(&counter_type).copied() == Some(0);
+    let keep_zero = was_present && counter_type == CounterType::Loyalty && is_zero;
     crate::types::counter::prune_zero_counters(&mut obj.counters);
     if keep_zero {
         obj.counters.insert(counter_type.clone(), 0);

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -330,6 +330,22 @@ pub(crate) fn apply_copy_token_after_replacement(
     let name = values.name.clone();
     let mut created_ids = Vec::with_capacity(final_count as usize);
 
+    // CR 306.5b + CR 707.2: A token that's a copy of a planeswalker enters with
+    // loyalty counters equal to the copied permanent's loyalty — CR 306.5c makes
+    // the counter map the single source of truth for loyalty. The copy path
+    // builds the object directly (not through the ZoneChange ETB-counter seeding
+    // used by cast/play/effect entries), so seed the intrinsic loyalty counters
+    // here, ahead of any explicit `enter_with_counters`, routing them through
+    // `add_counter_with_replacement` below so Doubling Season etc. apply
+    // (CR 614.1a). Without this a copied planeswalker enters with 0 loyalty
+    // counters and dies immediately to CR 704.5i. Copies don't track battle
+    // defense (`CopiableValues` has no defense field), so only loyalty is seeded.
+    let etb_counters: Vec<(crate::types::counter::CounterType, u32)> =
+        crate::game::printed_cards::intrinsic_face_counters(values.loyalty, None)
+            .into_iter()
+            .chain(enter_with_counters.iter().cloned())
+            .collect();
+
     for index in 0..final_count {
         let token_id = zones::create_object(
             state,
@@ -440,8 +456,7 @@ pub(crate) fn apply_copy_token_after_replacement(
         // CR 614.1c + CR 122.6a: ETB-counter replacement mutations are carried
         // on the accepted CreateToken spec, even for copy tokens whose full
         // CR 707 payload lives in `CopyTokenSpec`.
-        for (counter_index, (counter_type, counter_count)) in enter_with_counters.iter().enumerate()
-        {
+        for (counter_index, (counter_type, counter_count)) in etb_counters.iter().enumerate() {
             if *counter_count > 0
                 && !super::counters::add_counter_with_replacement(
                     state,
@@ -453,7 +468,7 @@ pub(crate) fn apply_copy_token_after_replacement(
                 )
             {
                 state.last_created_token_ids = created_ids.clone();
-                let remaining_counters = enter_with_counters[counter_index + 1..]
+                let remaining_counters = etb_counters[counter_index + 1..]
                     .iter()
                     .filter(|(_, count)| *count > 0)
                     .map(|(counter_type, count)| {
@@ -2769,6 +2784,77 @@ mod tests {
             p1p1, 0,
             "if_type=Creature must skip on a Planeswalker copy; counters={:?}",
             token.counters
+        );
+    }
+
+    /// CR 306.5b + CR 306.5c + CR 707.2: A token that's a copy of a planeswalker
+    /// must enter with loyalty counters equal to the copied loyalty — the copy
+    /// path builds the object directly, bypassing the ZoneChange ETB-counter
+    /// seeding, so it must seed loyalty counters itself. Pre-fix the copy carried
+    /// only the `loyalty` field with no counter, so once the layer system treats
+    /// the counter map as the source of truth (CR 306.5c) the copy would read 0
+    /// loyalty and die immediately to CR 704.5i.
+    #[test]
+    fn copy_token_of_planeswalker_seeds_loyalty_counters() {
+        use crate::game::layers::evaluate_layers;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Jace".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let s = state.objects.get_mut(&source_id).unwrap();
+            s.base_loyalty = Some(5);
+            s.loyalty = Some(5);
+            s.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Planeswalker],
+                subtypes: vec!["Jace".to_string()],
+            };
+            s.card_types = s.base_card_types.clone();
+        }
+
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::Any,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            },
+            vec![TargetRef::Object(source_id)],
+            source_id,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let token_id = ObjectId(state.next_object_id - 1);
+        assert_eq!(
+            state.objects[&token_id]
+                .counters
+                .get(&CounterType::Loyalty)
+                .copied(),
+            Some(5),
+            "planeswalker copy must seed loyalty counters equal to copied loyalty",
+        );
+
+        // The copy must survive a layer re-evaluation at its real loyalty, not
+        // snap to 0 (it's still on the battlefield, not in the graveyard).
+        evaluate_layers(&mut state);
+        let token = &state.objects[&token_id];
+        assert_eq!(token.zone, Zone::Battlefield);
+        assert_eq!(
+            token.loyalty,
+            Some(5),
+            "copied planeswalker loyalty must derive from its seeded counters",
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1354,6 +1354,15 @@ pub fn evaluate_layers(state: &mut GameState) {
     // reverts obj.loyalty to base_loyalty, re-derive it from the actual counter.
     // (P/T counters are applied in-loop at Layer::CounterPT above, in layer 7c
     // before the 7d switch.)
+    //
+    // Loyalty is HYBRID: a counter-tracked planeswalker's loyalty IS its counter
+    // count (present entry wins, including 0); an un-counter-tracked planeswalker
+    // (a clone whose loyalty comes from the Copy layer, an in-place transform, an
+    // off-battlefield/pre-seed object) keeps the base/copy-layer value. So the
+    // `if let Some` is load-bearing: an ABSENT entry means "not counter-tracked,
+    // keep the field", while a PRESENT 0 means "drained to 0, must die" (CR
+    // 704.5i). `apply_counter_removal` is what keeps the 0 entry alive for a
+    // genuinely-tracked walker so this re-derive can see it.
     for &id in &bf_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
             if let Some(&loyalty_counters) = obj.counters.get(&CounterType::Loyalty) {

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -318,18 +318,36 @@ pub fn apply_back_face_to_object(obj: &mut GameObject, back_face: BackFaceData) 
 ///
 /// Returns an empty vec for non-planeswalker, non-battle permanents or when
 /// the face carries no printed loyalty/defense number.
-pub fn intrinsic_etb_counters(obj: &GameObject) -> Vec<(CounterType, u32)> {
+/// CR 306.5b + CR 310.4b: A planeswalker enters with loyalty counters equal to
+/// its printed loyalty; a battle enters with defense counters equal to its
+/// printed defense. Computes those intrinsic counters from the loyalty/defense
+/// values of the face the permanent will have *on entry* — the caller passes
+/// the entering face's values, which is the back face for a transformed entry
+/// (CR 712.14a) or the copied permanent's values for a token copy (CR 707.2).
+/// Keeping this separate from [`intrinsic_etb_counters`] lets every entry path
+/// (cast, effect-driven entry, play, transform-return, token-copy) seed the
+/// counter map — the single source of truth for loyalty (CR 306.5c) — without
+/// duplicating the rule.
+pub fn intrinsic_face_counters(
+    loyalty: Option<u32>,
+    defense: Option<u32>,
+) -> Vec<(CounterType, u32)> {
     let mut counters = Vec::new();
-    if let Some(loy) = obj.loyalty {
+    if let Some(loy) = loyalty {
         if loy > 0 {
             counters.push((CounterType::Loyalty, loy));
         }
     }
-    if let Some(def) = obj.defense {
+    if let Some(def) = defense {
         if def > 0 {
             counters.push((CounterType::Defense, def));
         }
     }
+    counters
+}
+
+pub fn intrinsic_etb_counters(obj: &GameObject) -> Vec<(CounterType, u32)> {
+    let mut counters = intrinsic_face_counters(obj.loyalty, obj.defense);
     // CR 702.156a + CR 107.3m: Ravenous is an intrinsic ETB replacement
     // effect. The paid X is stamped on the object when the spell leaves the
     // stack, before the ZoneChange replacement pipeline applies counters.


### PR DESCRIPTION
- **fix(engine): planeswalkers drained to 0 loyalty now die**
- **fix(client): resolve graveyard card art via printed_ref oracle_id**
