### PR TITLE
Keyword backlog: X-cost cap perf, escape floor, split-search, each-of-N parse

### DIFF
--- a/crates/engine/src/database/search.rs
+++ b/crates/engine/src/database/search.rs
@@ -81,7 +81,11 @@ impl CardDatabase {
     /// then alphabetically.
     pub fn search(&self, query: &CardSearchQuery) -> CardSearchResults {
         let needle = query.text.trim().to_lowercase();
-        let words: Vec<&str> = needle.split_whitespace().collect();
+        // Drop the bare "//" combined-name separator: it is punctuation, never a
+        // searchable term. Searching "Commit // Memory" tokenizes to
+        // ["commit", "//", "memory"]; the "//" would otherwise fail every
+        // face's haystack (split/DFC/Adventure faces are indexed individually).
+        let words: Vec<&str> = needle.split_whitespace().filter(|w| *w != "//").collect();
         let requested_colors: Vec<ManaColor> = query
             .colors
             .iter()
@@ -101,7 +105,7 @@ impl CardDatabase {
         for (key, face) in self.face_index.iter() {
             let name_lower = face.name.to_lowercase();
 
-            if !words.is_empty() && !text_matches(&name_lower, face, &words) {
+            if !words.is_empty() && !self.text_matches(&name_lower, face, &words) {
                 continue;
             }
             if !requested_colors.is_empty() {
@@ -197,17 +201,34 @@ impl CardDatabase {
             legalities,
         }
     }
-}
 
-/// Word-AND match across the card's name, oracle text, and type line — the
-/// fields Scryfall's default full-text search covers.
-fn text_matches(name_lower: &str, face: &CardFace, words: &[&str]) -> bool {
-    let mut haystack = name_lower.to_string();
-    if let Some(text) = &face.oracle_text {
-        haystack.push(' ');
-        haystack.push_str(&text.to_lowercase());
+    /// Word-AND match across the card's name, its sibling faces' names, and its
+    /// oracle text. Sibling names are folded in so a combined `A // B` query
+    /// matches each individual face: split/Aftermath/Fuse cards plus DFC,
+    /// Adventure, and MDFC are all indexed per-face, so without the sibling
+    /// names no single face's haystack contains every word of its combined
+    /// name. Siblings are enumerated layout-agnostically via
+    /// `scryfall_oracle_id` → `oracle_id_index` → `face_index`.
+    fn text_matches(&self, name_lower: &str, face: &CardFace, words: &[&str]) -> bool {
+        let mut haystack = name_lower.to_string();
+        if let Some(oid) = face.scryfall_oracle_id.as_deref() {
+            if let Some(keys) = self.oracle_id_index.get(oid) {
+                for key in keys {
+                    if let Some(sibling) = self.face_index.get(key) {
+                        if !sibling.name.eq_ignore_ascii_case(&face.name) {
+                            haystack.push(' ');
+                            haystack.push_str(&sibling.name.to_lowercase());
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(text) = &face.oracle_text {
+            haystack.push(' ');
+            haystack.push_str(&text.to_lowercase());
+        }
+        words.iter().all(|w| haystack.contains(w))
     }
-    words.iter().all(|w| haystack.contains(w))
 }
 
 /// A card's colors per CR 105.2: the colors of its mana-cost symbols, plus any
@@ -532,6 +553,95 @@ mod tests {
         assert_eq!(
             bolt.legalities.get("modern").map(String::as_str),
             Some("legal")
+        );
+    }
+
+    /// A two-faced card (split/Aftermath/DFC) is indexed per-face, so searching
+    /// its combined `A // B` name must still match (and dedupe to one result)
+    /// via the sibling-name fold. Single-face searches still work, and the fold
+    /// does not produce cross-card false positives.
+    fn split_db() -> CardDatabase {
+        db_from(&[
+            (
+                "commit",
+                card(
+                    "Commit",
+                    "o-commit-memory",
+                    &["Blue"],
+                    3,
+                    "Instant",
+                    &["Blue"],
+                    "Put target spell or permanent into its owner's library second from the top.",
+                    json!({}),
+                    &["AKH"],
+                ),
+            ),
+            (
+                "memory",
+                card(
+                    "Memory",
+                    "o-commit-memory",
+                    &["Blue"],
+                    4,
+                    "Sorcery",
+                    &["Blue"],
+                    "Each player shuffles their hand and graveyard into their library, then draws seven cards.",
+                    json!({}),
+                    &["AKH"],
+                ),
+            ),
+            (
+                "lightning bolt",
+                card(
+                    "Lightning Bolt",
+                    "o-bolt",
+                    &["Red"],
+                    0,
+                    "Instant",
+                    &["Red"],
+                    "Lightning Bolt deals 3 damage to any target.",
+                    json!({}),
+                    &["LEA"],
+                ),
+            ),
+        ])
+    }
+
+    #[test]
+    fn split_card_matches_combined_name_and_dedupes() {
+        let res = split_db().search(&CardSearchQuery {
+            text: "Commit // Memory".into(),
+            ..Default::default()
+        });
+        assert_eq!(
+            res.results.len(),
+            1,
+            "combined name matches via sibling fold and dedupes by oracle id"
+        );
+    }
+
+    #[test]
+    fn split_card_single_face_search_still_matches() {
+        for face in ["commit", "memory"] {
+            let res = split_db().search(&CardSearchQuery {
+                text: face.into(),
+                ..Default::default()
+            });
+            assert_eq!(res.results.len(), 1, "single-face search '{face}' matches");
+        }
+    }
+
+    #[test]
+    fn sibling_fold_does_not_cross_match_unrelated_cards() {
+        // "commit" (a split face) + "lightning" (a different card) share no
+        // single card, so the sibling fold must not produce a false positive.
+        let res = split_db().search(&CardSearchQuery {
+            text: "commit lightning".into(),
+            ..Default::default()
+        });
+        assert!(
+            res.results.is_empty(),
+            "sibling fold only joins same-oracle faces, not arbitrary cards"
         );
     }
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5832,20 +5832,61 @@ pub(super) fn max_x_value_excluding(
     // `concretize_x` adds `x * x_count` generic; non-floor and target-dependent
     // reductions subtract an X-independent amount capped via `saturating_sub`
     // (never below {0}, CR 601.2f); floors are `max(., N)`. The composition of
-    // these monotonic non-decreasing maps is monotonic non-decreasing, so we may
-    // ascend from X=0 to the first X whose total overshoots `available` and
-    // return the prior X. Termination: `mana_value(x) >= x * x_count - C` for the
-    // fixed total reduction cap C, which grows without bound, so the overshoot is
-    // always reached.
-    let mut x = 0u32;
-    loop {
-        let probe =
-            super::casting::concrete_cost_for_x(state, player, spell_id, &ability, &base, x);
-        if probe.mana_value() > available {
-            return x.saturating_sub(1);
-        }
-        x += 1;
+    // these monotonic non-decreasing maps is monotonic non-decreasing, so the
+    // predicate `P(x) := concrete_cost_for_x(x).mana_value() <= available` is a
+    // monotone gate: once false it stays false. The answer is the largest X with
+    // `P(x)` true. A linear ascent finds it in O(maxX) cost recomputations; an
+    // exponential probe + bisection over the same monotone predicate finds the
+    // identical value in O(log maxX). `concrete_cost_for_x` is pure read-only
+    // (clones `base`, mutates only the local), so probing X out of ascending
+    // order is safe. The explicit `!probe(0)` early return below reproduces the
+    // old linear loop's `saturating_sub(1)` floor exactly: when even X=0
+    // overshoots, the cap is 0 (not an underflow).
+    largest_x_satisfying(formula_max, |x| {
+        super::casting::concrete_cost_for_x(state, player, spell_id, &ability, &base, x)
+            .mana_value()
+            <= available
+    })
+}
+
+/// Largest `x` for which `predicate(x)` holds, given `predicate` is a monotone
+/// gate — true for an initial prefix `[0, cap]` and false above it. This is the
+/// search underlying the X-cost cap (CR 601.2f): the per-X concrete cost is
+/// monotonic non-decreasing, so "the largest affordable X" is the top of the
+/// true-prefix.
+///
+/// `formula_max` is only a starting estimate for the exponential probe;
+/// correctness does NOT depend on it (the true cap can be lower — Trinisphere
+/// floor — or higher — reductions exceeding the fixed generic). Returns `0` when
+/// even `predicate(0)` is false, reproducing the linear ascent's
+/// `saturating_sub(1)` floor at the `X=0` boundary. O(log cap) evaluations of
+/// `predicate` versus the linear scan's O(cap); identical result by monotonicity.
+fn largest_x_satisfying(formula_max: u32, predicate: impl Fn(u32) -> bool) -> u32 {
+    if !predicate(0) {
+        return 0;
     }
+
+    // Exponential probe: grow `hi` off `formula_max` until `predicate(hi)` is
+    // false, yielding a proven upper bound above the true cap regardless of
+    // whether `formula_max` under- or over-states it. `saturating_mul` guards
+    // overflow; `max(saturating_add(1))` guards `hi == 0`.
+    let mut hi = formula_max.max(1);
+    while predicate(hi) {
+        hi = hi.saturating_mul(2).max(hi.saturating_add(1));
+    }
+
+    // Bisect `[lo, hi]` with invariant `predicate(lo)` true, `predicate(hi)`
+    // false. `lo` starts at 0 (proven true above). Returns the top of the prefix.
+    let mut lo = 0u32;
+    while hi - lo > 1 {
+        let mid = lo + (hi - lo) / 2;
+        if predicate(mid) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    lo
 }
 
 /// Single authority for transitioning into the payment step of a cast.
@@ -6642,6 +6683,54 @@ mod tests {
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::replacements::ReplacementEvent;
     use crate::types::statics::StaticMode;
+
+    /// Reference implementation of the X-cap search: the pre-refactor linear
+    /// ascent. Returns the largest `x` with `predicate(x)` true, clamped at 0.
+    fn linear_x_reference(predicate: impl Fn(u32) -> bool) -> u32 {
+        let mut x = 0u32;
+        loop {
+            if !predicate(x) {
+                return x.saturating_sub(1);
+            }
+            x += 1;
+        }
+    }
+
+    /// `largest_x_satisfying` (exponential probe + bisection) must return the
+    /// byte-identical X cap of the old linear ascent for every monotone cost
+    /// shape. Each shape models `concrete_cost_for_x(x).mana_value()` as a
+    /// monotone-non-decreasing function of X, then asserts the two searches agree.
+    #[test]
+    fn largest_x_satisfying_matches_linear_reference() {
+        // cost(x) = max(fixed + x * x_count - reduction, floor); predicate is
+        // cost(x) <= available. `reduction` and `floor` exercise the understate
+        // (reduction > fixed) and overstate (Trinisphere floor) cases the cap
+        // computation warns about.
+        let cost = |fixed: u32, x_count: u32, reduction: u32, floor: u32, x: u32| -> u32 {
+            (fixed + x * x_count).saturating_sub(reduction).max(floor)
+        };
+
+        for available in [0u32, 1, 2, 3, 5, 8, 13, 50, 100] {
+            for fixed in [0u32, 1, 3, 6] {
+                for x_count in [1u32, 2] {
+                    for reduction in [0u32, 2, 9] {
+                        for floor in [0u32, 3, 9] {
+                            let predicate =
+                                |x: u32| cost(fixed, x_count, reduction, floor, x) <= available;
+                            // The arithmetic estimate the real function passes in.
+                            let formula_max = available.saturating_sub(fixed) / x_count;
+                            assert_eq!(
+                                largest_x_satisfying(formula_max, predicate),
+                                linear_x_reference(predicate),
+                                "mismatch at available={available} fixed={fixed} \
+                                 x_count={x_count} reduction={reduction} floor={floor}",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     fn make_pending(source_id: ObjectId) -> PendingCast {
         PendingCast {

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -91,10 +91,22 @@ pub fn effective_disturb_cost(state: &GameState, object_id: ObjectId) -> Option<
 pub fn effective_escape_data(state: &GameState, object_id: ObjectId) -> Option<(ManaCost, u32)> {
     let keyword = effective_keyword_for_object(state, object_id, KeywordKind::Escape)?;
     match keyword {
-        Keyword::Escape { cost, exile_count } => Some((
-            resolve_keyword_mana_cost(state, object_id, &cost),
-            exile_count,
-        )),
+        Keyword::Escape { cost, exile_count } => {
+            // CR 702.138a: "Escape [cost]" always specifies "Exile N other cards"
+            // with N >= 1 — the exile is part of the escape cost. A leaked
+            // exile_count == 0 is a parse failure (the "Exile N" clause was not
+            // extracted), not a legal "exile 0 cards" escape. Refuse the escape so
+            // the mis-parse surfaces instead of allowing an illegal 0-card escape
+            // cast (the exile-selection path would build bounds (0, 0) and accept
+            // an empty selection).
+            if exile_count == 0 {
+                return None;
+            }
+            Some((
+                resolve_keyword_mana_cost(state, object_id, &cost),
+                exile_count,
+            ))
+        }
         _ => None,
     }
 }
@@ -661,6 +673,49 @@ mod tests {
         obj.keywords.push(Keyword::Flying);
         assert!(has_keyword(&obj, &Keyword::Flying));
         assert!(!has_keyword(&obj, &Keyword::Haste));
+    }
+
+    /// CR 702.138a: a placeholder `exile_count == 0` is a parse failure, not a
+    /// legal "exile 0 cards" escape. `effective_escape_data` must refuse it
+    /// (return `None`) so the mis-parse can't produce an illegal 0-card escape
+    /// cast, while well-parsed counts (N >= 1) pass through unchanged.
+    #[test]
+    fn effective_escape_data_refuses_zero_exile_count() {
+        let escape_cost = ManaCost::Cost {
+            generic: 2,
+            shards: vec![ManaCostShard::Black],
+        };
+        let make_escape_obj = |state: &mut GameState, exile_count: u32| {
+            let id = create_object(
+                state,
+                CardId(1),
+                PlayerId(0),
+                "Escape Test".to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.keywords.push(Keyword::Escape {
+                cost: escape_cost.clone(),
+                exile_count,
+            });
+            id
+        };
+
+        // Placeholder 0 -> refused.
+        let mut state = GameState::new_two_player(1);
+        let zero_id = make_escape_obj(&mut state, 0);
+        assert_eq!(effective_escape_data(&state, zero_id), None);
+
+        // Well-parsed counts pass through with the resolved cost.
+        for n in [1u32, 2, 5] {
+            let mut state = GameState::new_two_player(1);
+            let id = make_escape_obj(&mut state, n);
+            assert_eq!(
+                effective_escape_data(&state, id),
+                Some((escape_cost.clone(), n)),
+                "exile_count {n} must be accepted unchanged",
+            );
+        }
     }
 
     /// CR 702.16 + CR 205.2: `source_matches_protection_target`'s

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -1,8 +1,8 @@
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
-use nom::character::complete::multispace0;
-use nom::combinator::{eof, value};
+use nom::character::complete::{multispace0, space1};
+use nom::combinator::{eof, peek, value};
 use nom::sequence::terminated;
 use nom::Parser;
 
@@ -221,6 +221,21 @@ fn resolve_counter_placement_target<'a>(
             let on_offset = lower.len() - on_rest.len();
             (&text[on_offset..], None)
         }
+    } else if let Some((count, after_target)) = nom_on_lower(on_rest, on_rest, |i| {
+        // CR 601.2c: "each of <N|X> target <type>" — an EXACT-count multi-target
+        // distribution (not "up to"). The count binds the number of targets; X
+        // resolves from the activation cost's {X}. `peek("target")` does not
+        // consume, so the downstream `parse_target_with_ctx` still sees
+        // "target <type>". The `space1` + `peek("target")` requirement excludes
+        // "each of those creatures" / "each creature" from this arm.
+        let (i, ()) = value((), tag("each of ")).parse(i)?;
+        let (i, count) = super::parse_multi_target_count_expr(i)?;
+        let (i, ()) = value((), space1).parse(i)?;
+        let (i, _) = peek(tag("target")).parse(i)?;
+        Ok((i, count))
+    }) {
+        let on_offset = lower.len() - after_target.len();
+        (&text[on_offset..], Some(MultiTargetSpec::exact(count)))
     } else {
         let on_offset = lower.len() - on_rest.len();
         (&text[on_offset..], None)
@@ -1505,6 +1520,46 @@ mod tests {
                     name: "X".to_string()
                 }
             }))
+        );
+    }
+
+    /// CR 601.2c: "each of X target creatures" (no "up to") is an EXACT-count
+    /// multi-target — exactly X chosen targets, X bound from the activation
+    /// cost. Must be `MultiTargetSpec::exact(Variable("X"))`, NOT `up_to` and
+    /// NOT an unconstrained all-creatures filter (the misparse this fixes).
+    #[test]
+    fn put_counter_each_of_x_target_creatures_exact_count() {
+        let (_effect, _, multi) = try_parse_put_counter(
+            "put a -1/-1 counter on each of x target creatures",
+            "put a -1/-1 counter on each of x target creatures",
+            &mut default_ctx(),
+        )
+        .expect("parse");
+
+        assert_eq!(
+            multi,
+            Some(MultiTargetSpec::exact(QuantityExpr::Ref {
+                qty: crate::types::ability::QuantityRef::Variable {
+                    name: "X".to_string()
+                }
+            }))
+        );
+    }
+
+    /// CR 601.2c: fixed-count form "each of two target creatures" ⇒
+    /// `MultiTargetSpec::exact(Fixed(2))`.
+    #[test]
+    fn put_counter_each_of_two_target_creatures_exact_count() {
+        let (_effect, _, multi) = try_parse_put_counter(
+            "put a -1/-1 counter on each of two target creatures",
+            "put a -1/-1 counter on each of two target creatures",
+            &mut default_ctx(),
+        )
+        .expect("parse");
+
+        assert_eq!(
+            multi,
+            Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 2 }))
         );
     }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -20,7 +20,9 @@ use crate::types::keywords::{Keyword, KeywordKind};
 use crate::types::mana::ManaColor;
 use crate::types::zones::Zone;
 
-use super::oracle_effect::{is_bare_object_pronoun, resolve_it_pronoun};
+use super::oracle_effect::{
+    is_bare_object_pronoun, parse_multi_target_count_expr, resolve_it_pronoun,
+};
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
 use super::oracle_nom::error::OracleError;
@@ -1039,6 +1041,25 @@ pub fn parse_target_with_syntax<'a>(
                 syntax,
             );
         }
+    }
+
+    // CR 601.2c: "each of <count> target <type>" is an exact-count multi-target
+    // distribution (handled upstream by the counter.rs strip), NOT an all-matching
+    // "each" filter. For any non-counter effect that reaches here, route the type
+    // through "target" parsing rather than the bare "each " path below — which
+    // would call `parse_type_phrase_with_ctx("of <count> target <type>")` and
+    // degenerate to an all-matching TypedFilter.
+    if let Ok((rest_lower, ())) = (|i| {
+        let (i, ()) = value((), tag::<_, _, OracleError<'_>>("each of ")).parse(i)?;
+        let (i, _count) = parse_multi_target_count_expr(i)?;
+        let (i, ()) = value((), space1).parse(i)?;
+        let (i, _) = peek(tag::<_, _, OracleError<'_>>("target")).parse(i)?;
+        Ok::<_, nom::Err<OracleError<'_>>>((i, ()))
+    })(lower.as_str())
+    {
+        let tail = &text[lower.len() - rest_lower.len()..];
+        let (filter, rest) = parse_target_with_ctx(tail, ctx);
+        return (filter, rest, syntax);
     }
 
     // "each " + type phrase
@@ -7491,6 +7512,17 @@ mod tests {
                 id: TrackedSetId(0)
             }
         ));
+        assert_eq!(rest, "");
+    }
+
+    /// CR 601.2c: "each of <count> target <type>" must route through "target"
+    /// parsing (a concrete creature filter), NOT degenerate to the bare "each "
+    /// all-matching path. This guard is the safety net for any non-counter
+    /// effect that reaches `parse_target` with the exact-count form.
+    #[test]
+    fn each_of_count_target_creatures_routes_to_target_filter() {
+        let (filter, rest) = parse_target("each of two target creatures");
+        assert_eq!(filter, TargetFilter::Typed(TypedFilter::creature()));
         assert_eq!(rest, "");
     }
 


### PR DESCRIPTION
Small batch of four isolated, independently-reviewed keyword-backlog fixes. All green on Tilt clippy + test-engine.

- **perf(engine): bisect the X-cost cap** — `max_x_value_excluding` replaced its O(maxX) linear ascent over `concrete_cost_for_x` with an O(log maxX) exponential-probe + bisection over the monotone cost predicate (CR 601.2b/601.2f), extracted as the testable `largest_x_satisfying` helper. Byte-identical result (differential test vs. linear reference). Clears the bestow/ravenous/foretell/devour X-announcement lag at the shared locus.
- **fix(engine): refuse escape with placeholder `exile_count == 0`** — `effective_escape_data` now returns `None` for the leaked placeholder (CR 702.138a — escape always exiles N≥1), so a mis-parse can't produce an illegal 0-card escape cast.
- **fix(engine): split/multi-face combined-name search** — `text_matches` folds sibling face names via `scryfall_oracle_id → oracle_id_index`, so `"Commit // Memory"` matches and dedupes; DFC/Adventure/MDFC benefit for free.
- **fix(parser): `each of N/X target` exact-count multi-target** — new exact-count arm in the counter strip + safety-net guard in `oracle_target.rs`, distinguishing `exact` (CR 601.2c) from `up_to` (CR 115.1d). Fixes Rot-Curse Rakshasa's Renew applying to every creature.

Each fix carries unit tests; all CR numbers grep-verified against `docs/MagicCompRules.txt`.