### PR TITLE
feat(client): two-column board layout with command-zone dock

### DIFF
--- a/client/src/components/board/BattlefieldRow.tsx
+++ b/client/src/components/board/BattlefieldRow.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { Fragment, useRef, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
@@ -19,6 +19,10 @@ interface BattlefieldRowProps {
   groups: GroupedPermanent[];
   rowType: BattlefieldRowType;
   className?: string;
+  /** Render a thin vertical divider immediately before the group at this index,
+   *  keeping two sub-clusters (e.g. enchantments|planeswalkers) on one wrapping
+   *  line while visually separating them. Omit for no divider. */
+  dividerBeforeIndex?: number;
 }
 
 const ROW_JUSTIFY: Record<string, string> = {
@@ -57,7 +61,7 @@ function getCreatureScale(groupCount: number, display: "art_crop" | "full_card")
   return Math.max(min, 1 / Math.sqrt(1 + excess * 0.15));
 }
 
-export function BattlefieldRow({ groups, rowType, className }: BattlefieldRowProps) {
+export function BattlefieldRow({ groups, rowType, className, dividerBeforeIndex }: BattlefieldRowProps) {
   const { t } = useTranslation("game");
   const battlefieldCardDisplay = usePreferencesStore((s) => s.battlefieldCardDisplay);
   const isCompactHeight = useIsCompactHeight();
@@ -208,9 +212,10 @@ export function BattlefieldRow({ groups, rowType, className }: BattlefieldRowPro
     ? "flex-wrap items-end content-end"
     : "flex-nowrap items-end";
 
-  // Planeswalkers in the support area stay on a single horizontal line —
-  // wrapping them stacks vertically and warps the surrounding board rows.
-  // All other non-creature rows keep wrapping.
+  // Planeswalkers stay on a single horizontal line — wrapping them stacks
+  // vertically and warps the surrounding board rows. Every other non-creature
+  // row (lands, support enchantments/artifacts, other) wraps to multiple rows
+  // when crowded, shrinking via the column's count-based zoneScale.
   const nonCreatureClass = rowType === "planeswalkers"
     ? "flex-nowrap items-center gap-2"
     : "flex-wrap items-center gap-2";
@@ -236,24 +241,28 @@ export function BattlefieldRow({ groups, rowType, className }: BattlefieldRowPro
           </span>
         </button>
       )}
-      {renderedGroups.map(({ group, manualExpanded }) => (
-        <GroupedPermanentDisplay
-          key={group.ids[0]}
-          group={group}
-          rowType={rowType}
-          manualExpanded={manualExpanded}
-          onExpand={() => {
-            setExpandedGroupIds((previous) => {
-              const next = new Set(previous);
-              if (next.has(group.ids[0])) {
-                next.delete(group.ids[0]);
-              } else {
-                next.add(group.ids[0]);
-              }
-              return next;
-            });
-          }}
-        />
+      {renderedGroups.map(({ group, manualExpanded }, index) => (
+        <Fragment key={group.ids[0]}>
+          {index === dividerBeforeIndex && (
+            <div aria-hidden className="mx-1 w-px self-stretch rounded bg-white/15" />
+          )}
+          <GroupedPermanentDisplay
+            group={group}
+            rowType={rowType}
+            manualExpanded={manualExpanded}
+            onExpand={() => {
+              setExpandedGroupIds((previous) => {
+                const next = new Set(previous);
+                if (next.has(group.ids[0])) {
+                  next.delete(group.ids[0]);
+                } else {
+                  next.add(group.ids[0]);
+                }
+                return next;
+              });
+            }}
+          />
+        </Fragment>
       ))}
     </div>
   );

--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -1,16 +1,14 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { PlayerId } from "../../adapter/types.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
-import { commanderDamageEntriesFor, commandersInZone } from "../../viewmodel/commanderColumn.ts";
 import type { GroupedPermanent } from "../../viewmodel/battlefieldProps.ts";
 import type { PlayerBattlefieldView } from "../../viewmodel/gameStateView.ts";
 import { BattlefieldRow } from "./BattlefieldRow.tsx";
 import { CompactStrip } from "./CompactStrip.tsx";
-import { CommanderDamage } from "./CommanderDamage.tsx";
-import { CommanderCardZone } from "../zone/CommanderCardZone.tsx";
-import { CommandZone } from "../zone/CommandZone.tsx";
+import { CommandDock } from "../zone/CommandDock.tsx";
 
 /** Base scales — used when few cards; shrinks as more are added.
  *  On compact-height (landscape phones), lands shrink hard so creatures
@@ -70,6 +68,15 @@ export function PlayerArea({
   const { t } = useTranslation("game");
   const gameState = useGameStore((s) => s.gameState);
   const isCompactHeight = useIsCompactHeight();
+  // Combined support cluster: artifacts/enchantments then planeswalkers, in ONE
+  // wrapping row (like the lands column) so it stays a single line until crowded.
+  // Keeping it one row keeps the middle-row band ~one card tall so the flex-1
+  // creature row isn't pinched. Memoized for a stable ref (BattlefieldRow perf);
+  // declared above the early return to keep hook order stable.
+  const supportGroups = useMemo(
+    () => [...(battlefieldView?.support ?? []), ...(battlefieldView?.planeswalkers ?? [])],
+    [battlefieldView?.support, battlefieldView?.planeswalkers],
+  );
 
   if (!gameState) return null;
 
@@ -94,73 +101,34 @@ export function PlayerArea({
   const partitioned = battlefieldView;
 
   const creatures = creatureOverride ?? partitioned?.creatures ?? [];
-  const hasPlaneswalkers = (partitioned?.planeswalkers.length ?? 0) > 0;
-  const hasEmblems = (gameState.command_zone ?? []).some((id) => {
-    const obj = gameState.objects[id];
-    return obj?.is_emblem && obj.controller === playerId;
-  });
-  // Scale the commander column to the land scale (not the support scale) so
-  // presence/absence of a commander doesn't change the middle-row height. The
-  // support row's height is otherwise driven by the tallest card in it, and
-  // the commander card at OTHER_BASE_SCALE (1.0) is ~28% taller than adjacent
-  // lands at LAND_BASE_SCALE (0.78), which squeezes the creatures row via
-  // flex-1. Stacked CommanderDamage entries compound the warp.
-  const commanderScale = isCompactHeight ? LAND_BASE_SCALE_COMPACT : LAND_BASE_SCALE;
-  // Render the commander column only when it has real content — a commander
-  // still in the command zone, or live commander-damage entries. Gating on the
-  // format flag alone reserved an empty column (and its divider) for the whole
-  // game once the commander was cast. These go through the same selectors
-  // CommanderCardZone and CommanderDamage render from, so the wrapper appears
-  // iff a child will (single source of truth in viewmodel/commanderColumn).
-  const hasCommanderInZone = commandersInZone(gameState, playerId).length > 0;
-  const hasActiveCommanderDamage = commanderDamageEntriesFor(gameState, playerId).length > 0;
-  const commanderSection = hasCommanderInZone || hasActiveCommanderDamage ? (
-    // No `min-w-0` here: this column holds the commander-damage labels, and
-    // allowing it to shrink below its content width lets the adjacent
-    // (non-shrinking) planeswalker row collapse it and hide the labels.
-    <div
-      className="flex flex-col items-end gap-1"
-      style={zoneStyle(commanderScale)}
-    >
-      <CommanderCardZone playerId={playerId} />
-      <CommanderDamage playerId={playerId} />
-    </div>
-  ) : null;
-  const supportExtras = (
-    <>
-      <BattlefieldRow groups={partitioned?.planeswalkers ?? []} rowType="planeswalkers" />
-      <CommandZone playerId={playerId} />
-      {commanderSection}
-    </>
-  );
-  const hasSupportExtras = hasPlaneswalkers || hasEmblems || commanderSection != null;
-  const supportSection = hasSupportExtras ? (
-    <>
-      <div className="mx-2 h-3/4 w-px shrink-0 bg-white/20" />
-      {/* No `min-w-0`: the support track is justify-end, so letting this
-          wrapper collapse below its content width pushes the right-rail cards
-          (emblems/commander) off the right edge of the screen. Holding its
-          intrinsic width clamps the right edge to the track and grows the
-          cluster leftward on-screen instead. */}
-      <div
-        className="flex items-center gap-2"
-        style={zoneStyle(isCompactHeight ? OTHER_BASE_SCALE_COMPACT : OTHER_BASE_SCALE)}
-      >
-        {supportExtras}
-      </div>
-    </>
-  ) : null;
   const landAlignClass = isCompactHeight
     ? "flex-nowrap items-center justify-start"
     : "flex-wrap items-center content-center justify-start";
+  // Support cluster mirrors the lands column but right-aligned: one wrapping row
+  // that wraps only when crowded (cards shrink with count via supportStyle).
+  const supportAlignClass = isCompactHeight
+    ? "flex-nowrap items-center justify-end"
+    : "flex-wrap items-center content-center justify-end";
 
   const landCount = partitioned?.lands.length ?? 0;
-  const supportCount = partitioned?.support.length ?? 0;
+  // Count the full support cluster (enchantments/artifacts + planeswalkers) so
+  // zoneScale shrinks the cards as it fills — mirroring lands. Counting only
+  // `support` left the planeswalkers unscaled and overflowing the column.
+  const supportLen = partitioned?.support.length ?? 0;
+  const planeswalkerLen = partitioned?.planeswalkers.length ?? 0;
+  const supportCount = supportLen + planeswalkerLen;
+  // Divider sits at the enchantment/artifact → planeswalker boundary within the
+  // single combined support row, but only when both sub-clusters are present.
+  const supportDividerIndex = supportLen > 0 && planeswalkerLen > 0 ? supportLen : undefined;
   const landBase = isCompactHeight ? LAND_BASE_SCALE_COMPACT : LAND_BASE_SCALE;
   const supportBase = isCompactHeight ? OTHER_BASE_SCALE_COMPACT : OTHER_BASE_SCALE;
   const landStyle = zoneStyle(zoneScale(landBase, landCount));
   const supportStyle = zoneStyle(zoneScale(supportBase, supportCount));
 
+  // Two-column middle row: lands (left, justify-start) and support (right,
+  // justify-end) each take a flex-1 half and meet in the center. The HUD is no
+  // longer wedged between them — it gets its own band (`hudBand`) adjacent to
+  // this row — so the two card tracks reclaim the central corridor.
   const middleRow = (
     <div className="flex min-h-0 min-w-0 items-stretch justify-between gap-2" data-debug-label="Middle Row">
       <div
@@ -175,25 +143,54 @@ export function PlayerArea({
         />
         {landColumnExtra}
       </div>
-      {hud && (
-        <div className="z-20 flex shrink-0 items-center" data-debug-label="Inline HUD">
-          {hud}
-        </div>
-      )}
+      {/* Support column: artifacts/enchantments + planeswalkers in ONE wrapping
+          row (mirrors the lands column) so the band stays ~one card tall and the
+          creature row keeps its height. A thin divider (`supportDividerIndex`)
+          separates the two sub-clusters without stacking them onto a second row. */}
       <div
-        className="z-10 flex min-w-0 basis-0 flex-1 items-center justify-end pr-2"
+        className={`z-10 flex min-w-0 basis-0 flex-1 gap-2 ${supportAlignClass}`}
         style={supportStyle}
         data-debug-label="Support"
       >
         <BattlefieldRow
-          groups={partitioned?.support ?? []}
+          groups={supportGroups}
           rowType="support"
-          className="ml-auto w-full justify-end px-0"
+          dividerBeforeIndex={supportDividerIndex}
+          className="justify-end px-0"
         />
-        {supportSection}
+      </div>
+      {/* Command zone (CR 408) as an in-flow column on the far edge so it reserves
+          real horizontal space — support cards (`justify-end`) no longer slide
+          under it. `self-center` + `shrink-0` lets it claim width without forcing
+          the band taller than its own content: compact mode is a ~48px button
+          (shorter than a land card → zero band growth); inline grows the band
+          only when the user opts into it on a roomy screen. CommandDock renders
+          null when the command zone is empty, collapsing this column to nothing. */}
+      <div
+        className="z-10 flex shrink-0 items-center self-center pr-2"
+        data-debug-label="Command"
+      >
+        <CommandDock playerId={playerId} isMirrored={isMirrored} />
       </div>
     </div>
   );
+
+  // Player HUD (life, mana, phase arrows) overlaid below the middle row rather
+  // than wedged into its own column or lane. As a content-width absolute overlay
+  // it consumes zero vertical space, so the flex-1 creature row keeps its full
+  // height, and the box hugs the HUD instead of spanning the row. Centered
+  // horizontally (`left-1/2 -translate-x-1/2`) and dropped below the land row
+  // (`top-[200%]`), mirrored upward for the focused opponent. z-20 keeps it
+  // above resting cards (lands/support are z-10) but below a hovered card
+  // (PermanentCard lifts to z-60), so a card slides over the HUD on hover.
+  const hudBand = hud ? (
+    <div
+      className={`absolute left-1/2 z-20 -translate-x-1/2 ${isMirrored ? "bottom-[320%]" : "top-[130%] -translate-y-full"}`}
+      data-debug-label="HUD"
+    >
+      {hud}
+    </div>
+  ) : null;
 
   return (
     <div
@@ -215,8 +212,9 @@ export function PlayerArea({
         {isMirrored ? (
           <>
             <BattlefieldRow groups={partitioned?.other ?? []} rowType="other" />
-            <div className={isCompactHeight ? "min-h-0 max-h-[40%]" : "shrink-0"}>
+            <div className={`relative ${isCompactHeight ? "min-h-0 max-h-[40%]" : "shrink-0"}`}>
               {middleRow}
+              {hudBand}
             </div>
             <div className="flex min-h-0 flex-1 items-end px-2" data-debug-label="Opp Creatures">
               <BattlefieldRow groups={creatures} rowType="creatures" className="w-full" />
@@ -227,8 +225,9 @@ export function PlayerArea({
             <div className="min-h-0 flex-1 px-2" data-debug-label="Creatures">
               <BattlefieldRow groups={creatures} rowType="creatures" />
             </div>
-            <div className={isCompactHeight ? "min-h-0 max-h-[40%]" : "shrink-0"}>
+            <div className={`relative ${isCompactHeight ? "min-h-0 max-h-[40%]" : "shrink-0"}`}>
               {middleRow}
+              {hudBand}
             </div>
             <BattlefieldRow groups={partitioned?.other ?? []} rowType="other" />
           </>

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -255,7 +255,7 @@ export function PlayerHand() {
       className={`relative flex items-end justify-center overflow-visible px-4 py-1 ${
         isCompactHeight ? "min-h-[40px]" : "min-h-[calc(var(--card-h)*0.7)]"
       }`}
-      style={{ perspective: "800px", zIndex: draggingCardId != null ? 30 : undefined }}
+      style={{ perspective: "800px", zIndex: draggingCardId != null || expanded ? 40 : undefined }}
       onClick={handleContainerClick}
       onMouseLeave={() => {
         setExpanded(false);

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -30,6 +30,7 @@ import type {
   ArtChainEntry,
   CardPreviewMode,
   CardSizePreference,
+  CommandZoneDisplay,
   LogDefaultState,
 } from "../../stores/preferencesStore.ts";
 import type { SupportedLng } from "../../i18n/resources.ts";
@@ -62,6 +63,7 @@ const LANGUAGE_OPTIONS: { value: SupportedLng; label: string }[] = [
 ];
 
 const CARD_SIZES: CardSizePreference[] = ["small", "medium", "large"];
+const COMMAND_ZONE_DISPLAYS: CommandZoneDisplay[] = ["auto", "inline", "compact"];
 const CARD_PREVIEW_MODES: CardPreviewMode[] = ["follow", "side", "shift"];
 const LOG_DEFAULTS: LogDefaultState[] = ["open", "closed"];
 const VFX_QUALITIES: VfxQuality[] = ["full", "reduced", "minimal"];
@@ -143,6 +145,7 @@ export function PreferencesModal({
   const language = usePreferencesStore((s) => s.language);
   const setLanguage = usePreferencesStore((s) => s.setLanguage);
   const cardSize = usePreferencesStore((s) => s.cardSize);
+  const commandZoneDisplay = usePreferencesStore((s) => s.commandZoneDisplay);
   const logDefaultState = usePreferencesStore((s) => s.logDefaultState);
   const spellPaymentMode = usePreferencesStore((s) => s.spellPaymentMode);
   const boardBackground = usePreferencesStore((s) => s.boardBackground);
@@ -150,6 +153,7 @@ export function PreferencesModal({
   const animationSpeedMultiplier = usePreferencesStore((s) => s.animationSpeedMultiplier);
   const pacingMultipliers = usePreferencesStore((s) => s.pacingMultipliers);
   const setCardSize = usePreferencesStore((s) => s.setCardSize);
+  const setCommandZoneDisplay = usePreferencesStore((s) => s.setCommandZoneDisplay);
   const setLogDefaultState = usePreferencesStore((s) => s.setLogDefaultState);
   const setSpellPaymentMode = usePreferencesStore((s) => s.setSpellPaymentMode);
   const setBoardBackground = usePreferencesStore((s) => s.setBoardBackground);
@@ -298,6 +302,15 @@ export function PreferencesModal({
                       value={cardSize}
                       onChange={setCardSize}
                       renderLabel={(opt) => t(`gameplay.cardSizeOptions.${opt}`)}
+                    />
+                  </SettingGroup>
+
+                  <SettingGroup label={t("gameplay.commandZone")}>
+                    <SegmentedControl
+                      options={COMMAND_ZONE_DISPLAYS}
+                      value={commandZoneDisplay}
+                      onChange={setCommandZoneDisplay}
+                      renderLabel={(opt) => t(`gameplay.commandZoneOptions.${opt}`)}
                     />
                   </SettingGroup>
 

--- a/client/src/components/zone/CommandDock.tsx
+++ b/client/src/components/zone/CommandDock.tsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { GameObject, PlayerId } from "../../adapter/types.ts";
+import { useCardImage } from "../../hooks/useCardImage.ts";
+import { useResolvedCommandZoneDisplay } from "../../hooks/useResolvedCommandZoneDisplay.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import {
+  type CommanderDamageEntry,
+  commanderDamageEntriesFor,
+  commandersInZone,
+} from "../../viewmodel/commanderColumn.ts";
+import { CommanderDamage } from "../board/CommanderDamage.tsx";
+import { CommanderCardZone } from "./CommanderCardZone.tsx";
+import { CommandZone } from "./CommandZone.tsx";
+
+interface CommandDockProps {
+  playerId: PlayerId;
+  /** The focused-opponent area renders mirrored (anchored to the top of the
+   *  screen), so the compact popover must open downward instead of upward. */
+  isMirrored: boolean;
+}
+
+/** Card-size CSS vars the dock's children read (`CommanderCardZone` → --card-*,
+ *  emblems → --art-crop-*). The dock establishes its own scale context because
+ *  it lives outside PlayerArea's support-column `zoneStyle`. */
+function dockStyle(scale: number): React.CSSProperties {
+  return {
+    "--art-crop-w": `calc(var(--art-crop-base) * var(--card-size-scale) * ${scale})`,
+    "--art-crop-h": `calc(var(--art-crop-base) * var(--card-size-scale) * ${scale} * 0.85)`,
+    "--card-w": `calc(var(--card-base) * var(--card-size-scale) * ${scale})`,
+    "--card-h": `calc(var(--card-base) * var(--card-size-scale) * ${scale} * 1.4)`,
+  } as React.CSSProperties;
+}
+
+const INLINE_SCALE = 0.68;
+const POPOVER_SCALE = 0.82;
+
+/**
+ * Command zone (CR 408) rendered as a self-contained corner dock — commander
+ * card(s) + tax, emblems (CR 114), and commander-damage badges — instead of
+ * being interleaved into PlayerArea's battlefield support row. Two layouts,
+ * resolved from the user's `commandZoneDisplay` preference:
+ *  - **inline**: a bounded, always-visible vertical cluster.
+ *  - **compact**: a collapsed pile (commander thumbnail + emblem/damage badges)
+ *    that expands to a popover on hover/click.
+ */
+export function CommandDock({ playerId, isMirrored }: CommandDockProps) {
+  const { t } = useTranslation("game");
+  const mode = useResolvedCommandZoneDisplay();
+  const gameState = useGameStore((s) => s.gameState);
+
+  const commanders = useMemo(
+    () => (gameState ? commandersInZone(gameState, playerId) : []),
+    [gameState, playerId],
+  );
+  const damageEntries = useMemo(
+    () => (gameState ? commanderDamageEntriesFor(gameState, playerId) : []),
+    [gameState, playerId],
+  );
+  // Count this player's emblems for the compact badge + content gate. Mirrors
+  // the filter in CommandZone (kept local rather than refactoring that
+  // concurrently-edited component into a shared selector).
+  const emblemCount = useMemo(() => {
+    if (!gameState) return 0;
+    return (gameState.command_zone ?? []).reduce((n, id) => {
+      const obj = gameState.objects[id];
+      return obj?.is_emblem === true && obj.controller === playerId ? n + 1 : n;
+    }, 0);
+  }, [gameState, playerId]);
+
+  // Same content gate PlayerArea used for `hasSupportExtras` — render nothing
+  // when the command zone is empty so it reserves no corner space.
+  const hasContent = commanders.length > 0 || emblemCount > 0 || damageEntries.length > 0;
+  if (!hasContent) return null;
+
+  // The full cluster — rendered in exactly one place (inline body OR popover),
+  // never both, so the interactive commander card is never duplicated.
+  const fullContent = (
+    <div className="flex flex-col items-end gap-1">
+      <CommanderCardZone playerId={playerId} />
+      <CommandZone playerId={playerId} />
+      <CommanderDamage playerId={playerId} />
+    </div>
+  );
+
+  if (mode === "inline") {
+    return (
+      <div
+        className="flex max-w-[28vw] flex-col items-end gap-1"
+        style={dockStyle(INLINE_SCALE)}
+        data-debug-label="Command"
+      >
+        {fullContent}
+      </div>
+    );
+  }
+
+  return (
+    <CompactCommandDock
+      isMirrored={isMirrored}
+      commanders={commanders}
+      emblemCount={emblemCount}
+      damageEntries={damageEntries}
+      label={t("zone.commandZone")}
+    >
+      {fullContent}
+    </CompactCommandDock>
+  );
+}
+
+interface CompactCommandDockProps {
+  isMirrored: boolean;
+  commanders: GameObject[];
+  emblemCount: number;
+  damageEntries: CommanderDamageEntry[];
+  label: string;
+  children: React.ReactNode;
+}
+
+function CompactCommandDock({
+  isMirrored,
+  commanders,
+  emblemCount,
+  damageEntries,
+  label,
+  children,
+}: CompactCommandDockProps) {
+  const [open, setOpen] = useState(false);
+  const firstCommander = commanders[0];
+  const { src } = useCardImage(firstCommander?.name ?? "", { size: "normal" });
+  const totalDamage = damageEntries.reduce(
+    (sum, entry) => sum + entry.views.reduce((s, v) => s + v.damage, 0),
+    0,
+  );
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      data-debug-label="Command"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-lg border border-amber-400/60 bg-stone-900 shadow-md transition-transform hover:scale-105"
+        title={label}
+        aria-expanded={open}
+      >
+        {firstCommander && src ? (
+          <img src={src} alt={firstCommander.name} className="h-full w-full object-cover" draggable={false} />
+        ) : (
+          <span aria-hidden className="text-2xl leading-none text-amber-500/80">✦</span>
+        )}
+        {commanders.length > 1 && (
+          <span className="absolute left-0 top-0 rounded-br bg-amber-700 px-1 text-[9px] font-bold text-amber-100">
+            ×{commanders.length}
+          </span>
+        )}
+        {emblemCount > 0 && (
+          <span className="absolute -bottom-1 -left-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-black/70 bg-amber-600 px-1 text-[9px] font-bold text-black shadow">
+            ✦{emblemCount}
+          </span>
+        )}
+        {totalDamage > 0 && (
+          <span className="absolute -bottom-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-black/70 bg-red-700 px-1 text-[9px] font-bold text-red-100 shadow">
+            {totalDamage}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div
+          className={`absolute right-0 z-50 rounded-lg border border-white/15 bg-black/85 p-2 shadow-xl backdrop-blur-md ${
+            isMirrored ? "top-full mt-1" : "bottom-full mb-1"
+          }`}
+          style={dockStyle(POPOVER_SCALE)}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/hooks/useResolvedCommandZoneDisplay.ts
+++ b/client/src/hooks/useResolvedCommandZoneDisplay.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+import { usePreferencesStore } from "../stores/preferencesStore.ts";
+
+/** Below this viewport width (px), an always-visible inline command dock crowds
+ *  the board, so "auto" collapses it to the compact pile. */
+const COMMAND_ZONE_COMPACT_WIDTH = 900;
+/** Short viewports (landscape phones) also collapse — mirrors the height
+ *  threshold `useIsCompactHeight` uses for the rest of the compact layout. */
+const COMMAND_ZONE_COMPACT_HEIGHT = 500;
+
+export type ResolvedCommandZoneDisplay = "compact" | "inline";
+
+function autoResolve(): ResolvedCommandZoneDisplay {
+  if (typeof window === "undefined") return "inline";
+  return window.innerWidth < COMMAND_ZONE_COMPACT_WIDTH
+    || window.innerHeight < COMMAND_ZONE_COMPACT_HEIGHT
+    ? "compact"
+    : "inline";
+}
+
+/**
+ * Resolves the user's command-zone display preference to a concrete mode.
+ * Explicit "compact"/"inline" pass through unchanged; "auto" is resolved by the
+ * viewport (compact on narrow or short screens, inline otherwise). Mirrors the
+ * `boardBackground` "auto-wubrg" precedent: the store holds the user's choice,
+ * the use-site resolves it to a concrete value. The resize listener is only
+ * attached while the preference is "auto", so explicit modes never re-render on
+ * resize.
+ */
+export function useResolvedCommandZoneDisplay(): ResolvedCommandZoneDisplay {
+  const preference = usePreferencesStore((s) => s.commandZoneDisplay);
+  const [autoMode, setAutoMode] = useState<ResolvedCommandZoneDisplay>(autoResolve);
+
+  useEffect(() => {
+    if (preference !== "auto") return;
+    function handleResize() {
+      setAutoMode(autoResolve());
+    }
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [preference]);
+
+  return preference === "auto" ? autoMode : preference;
+}

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -264,6 +264,7 @@
     "grantsProperty": "Verleiht dem Zauberspruch eine Eigenschaft"
   },
   "zone": {
+    "commandZone": "Kommandozone",
     "emblem": "Emblem",
     "emblemFallback": "Emblem",
     "commander": "Kommandeur",

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -32,6 +32,12 @@
       "customUrl": "Eigene URL",
       "none": "Keiner"
     },
+    "commandZone": "Kommandozone",
+    "commandZoneOptions": {
+      "compact": "Kompakt",
+      "inline": "Inline",
+      "auto": "Auto"
+    },
     "cardSizeOptions": {
       "small": "Klein",
       "medium": "Mittel",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -264,6 +264,7 @@
     "grantsProperty": "Grants a property to the spell"
   },
   "zone": {
+    "commandZone": "Command Zone",
     "emblem": "Emblem",
     "emblemFallback": "Emblem",
     "commander": "Commander",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -32,6 +32,12 @@
       "customUrl": "Custom URL",
       "none": "None"
     },
+    "commandZone": "Command Zone",
+    "commandZoneOptions": {
+      "compact": "Compact",
+      "inline": "Inline",
+      "auto": "Auto"
+    },
     "cardSizeOptions": {
       "small": "Small",
       "medium": "Medium",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -264,6 +264,7 @@
     "grantsProperty": "Otorga una propiedad al hechizo"
   },
   "zone": {
+    "commandZone": "Zona de mando",
     "emblem": "Emblema",
     "emblemFallback": "Emblema",
     "commander": "Comandante",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -32,6 +32,12 @@
       "customUrl": "URL personalizada",
       "none": "Ninguno"
     },
+    "commandZone": "Zona de mando",
+    "commandZoneOptions": {
+      "compact": "Compacto",
+      "inline": "En línea",
+      "auto": "Automático"
+    },
     "cardSizeOptions": {
       "small": "Pequeño",
       "medium": "Mediano",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -264,6 +264,7 @@
     "grantsProperty": "Accorde une propriété au sort"
   },
   "zone": {
+    "commandZone": "Zone de commandement",
     "emblem": "Emblème",
     "emblemFallback": "Emblème",
     "commander": "Commandant",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -32,6 +32,12 @@
       "customUrl": "URL personnalisée",
       "none": "Aucun"
     },
+    "commandZone": "Zone de commandement",
+    "commandZoneOptions": {
+      "compact": "Compact",
+      "inline": "Intégré",
+      "auto": "Auto"
+    },
     "cardSizeOptions": {
       "small": "Petit",
       "medium": "Moyen",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -264,6 +264,7 @@
     "grantsProperty": "Concede una proprietà alla magia"
   },
   "zone": {
+    "commandZone": "Zona di comando",
     "emblem": "Emblema",
     "emblemFallback": "Emblema",
     "commander": "Comandante",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -32,6 +32,12 @@
       "customUrl": "URL personalizzato",
       "none": "Nessuno"
     },
+    "commandZone": "Zona di comando",
+    "commandZoneOptions": {
+      "compact": "Compatto",
+      "inline": "In linea",
+      "auto": "Auto"
+    },
     "cardSizeOptions": {
       "small": "Piccolo",
       "medium": "Medio",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -264,6 +264,7 @@
     "grantsProperty": "Nadaje czarowi właściwość"
   },
   "zone": {
+    "commandZone": "Strefa dowodzenia",
     "emblem": "Emblemat",
     "emblemFallback": "Emblemat",
     "commander": "Dowódca",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -32,6 +32,12 @@
       "customUrl": "Niestandardowy URL",
       "none": "Brak"
     },
+    "commandZone": "Strefa dowodzenia",
+    "commandZoneOptions": {
+      "compact": "Kompaktowy",
+      "inline": "Wbudowany",
+      "auto": "Auto"
+    },
     "cardSizeOptions": {
       "small": "Małe",
       "medium": "Średnie",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -264,6 +264,7 @@
     "grantsProperty": "Concede uma propriedade à mágica"
   },
   "zone": {
+    "commandZone": "Zona de comando",
     "emblem": "Emblema",
     "emblemFallback": "Emblema",
     "commander": "Comandante",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -32,6 +32,12 @@
       "customUrl": "URL personalizada",
       "none": "Nenhum"
     },
+    "commandZone": "Zona de comando",
+    "commandZoneOptions": {
+      "compact": "Compacto",
+      "inline": "Em linha",
+      "auto": "Automático"
+    },
     "cardSizeOptions": {
       "small": "Pequeno",
       "medium": "Médio",

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -68,6 +68,13 @@ export const CARD_PREVIEW_HOVER_DELAY_STEP = 50;
 export type HudLayout = "inline" | "floating";
 export type LogDefaultState = "open" | "closed";
 export type BattlefieldCardDisplay = "art_crop" | "full_card";
+/** How the command zone (commander card, tax, emblems, commander damage) is laid
+ *  out. "inline" = a bounded always-visible corner dock; "compact" = a collapsed
+ *  pile that expands to a popover on hover; "auto" = pick by viewport at use-site
+ *  (compact on short/narrow screens, inline otherwise). Resolved via
+ *  {@link useResolvedCommandZoneDisplay}, mirroring the `boardBackground`
+ *  "auto-wubrg" resolve-at-use-site precedent. */
+export type CommandZoneDisplay = "compact" | "inline" | "auto";
 export type TapRotation = "mtga" | "classic";
 export type SpellPaymentMode = "auto" | "manual";
 /** Which screen edge the resolving-stack panel docks to (and collapses toward).
@@ -139,6 +146,7 @@ function buildDefaultPreferences(): PreferencesState {
     audioThemeId: "planeswalker",
     customThemeUrls: [],
     battlefieldCardDisplay: "art_crop",
+    commandZoneDisplay: "auto",
     tapRotation: "mtga",
     spellPaymentMode: "auto",
     showKeywordStrip: true,
@@ -192,6 +200,8 @@ interface PreferencesState {
   audioThemeId: string;
   customThemeUrls: Array<{ id: string; url: string }>;
   battlefieldCardDisplay: BattlefieldCardDisplay;
+  /** Command-zone layout mode (inline dock / compact pile / auto-by-viewport). */
+  commandZoneDisplay: CommandZoneDisplay;
   tapRotation: TapRotation;
   spellPaymentMode: SpellPaymentMode;
   showKeywordStrip: boolean;
@@ -258,6 +268,7 @@ interface PreferencesActions {
   addCustomThemeUrl: (id: string, url: string) => void;
   removeCustomThemeUrl: (id: string) => void;
   setBattlefieldCardDisplay: (display: BattlefieldCardDisplay) => void;
+  setCommandZoneDisplay: (display: CommandZoneDisplay) => void;
   setTapRotation: (rotation: TapRotation) => void;
   setSpellPaymentMode: (mode: SpellPaymentMode) => void;
   setShowKeywordStrip: (show: boolean) => void;
@@ -371,6 +382,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
           ...(state.audioThemeId === id ? { audioThemeId: "planeswalker" } : {}),
         })),
       setBattlefieldCardDisplay: (display) => set({ battlefieldCardDisplay: display }),
+      setCommandZoneDisplay: (display) => set({ commandZoneDisplay: display }),
       setTapRotation: (rotation) => set({ tapRotation: rotation }),
       setSpellPaymentMode: (mode) => set({ spellPaymentMode: mode }),
       setShowKeywordStrip: (show) => set({ showKeywordStrip: show }),
@@ -467,7 +479,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
     }),
     {
       name: "phase-preferences",
-      version: 14,
+      version: 15,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -490,6 +502,8 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          prior fixed cursor-following behavior) via the shallow merge.
       // v13 → v14: Add cardPreviewHoverDelayMs; legacy stores default to 0
       //          (instant — the prior behavior) via the shallow merge.
+      // v14 → v15: Add commandZoneDisplay; legacy stores default to "auto"
+      //          via the shallow merge.
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Reclaims board real-estate by restructuring the player area and giving the command zone (CR 408) a proper home.

- **Two-column middle row.** Merges the lands + support tracks into two `flex-1` columns (dropping the center HUD column); the player HUD becomes a content-width absolute band below the row so the `flex-1` creature row keeps its full height.
- **Command-zone dock.** New `CommandDock` as an in-flow column on the far edge — reserving real width so support cards no longer slide under it. Two layouts resolved from a new `commandZoneDisplay` preference:
  - **inline** — always-visible cluster.
  - **compact** — collapsed pile (commander thumbnail + emblem/damage badges) expanding to a hover/click popover.
  - **auto** — picks by viewport (compact on narrow/short screens), user-overridable in Settings → Gameplay.
- **Support cluster** (artifacts/enchantments + planeswalkers) stays one wrapping row with a thin divider at the boundary — visually separated without stacking a second row that would pinch the creature band.
- **Hand z-order.** Hand cards lift above the HUD only on hover/drag, not at rest.

i18n: command-zone label + setting options across all 7 locales (parity-gated).

## Notes
Display-layer only — no engine/game-logic changes. Frontend type-check + i18n parity verified green via Tilt before commit.