### PR TITLE
feat(emblem): display-only source provenance for emblems (CR 114)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -725,6 +725,14 @@ export interface GameObject {
   casting_permissions?: CastingPermission[];
   is_emblem?: boolean;
   /**
+   * CR 114: Display-only provenance of the source that created this emblem
+   * (e.g. the planeswalker whose ultimate made it). The frontend renders the
+   * emblem as a small chip bearing the source's art crop and a "from <name>"
+   * label. Distinct from `printed_ref` — an emblem is not represented by that
+   * card (CR 114.5); this is purely presentational. Present only on emblems.
+   */
+  emblem_source?: { name: string; printed_ref?: PrintedRef | null } | null;
+  /**
    * CR 111.1: Whether this object is a token (not a card). Independent of
    * `display_source`: a token-copy of a real card (Twinflame, Helm of the
    * Host) carries `is_token = true` AND `display_source = "Card"`, so it

--- a/client/src/components/zone/CommandZone.tsx
+++ b/client/src/components/zone/CommandZone.tsx
@@ -2,8 +2,15 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GameObject, PlayerId } from "../../adapter/types.ts";
+import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
+
+/** Emblem chips are deliberately rendered well below card size (Arena-style):
+ *  they never compete with real permanents for board space. Scales the shared
+ *  `--art-crop-w/h` vars set by the support container. */
+const EMBLEM_CHIP_SCALE = 0.62;
 
 interface CommandZoneProps {
   playerId: PlayerId;
@@ -11,17 +18,27 @@ interface CommandZoneProps {
 
 interface GroupedEmblem {
   description: string;
+  sourceName: string | null;
   count: number;
   representative: GameObject;
 }
 
+/** The emblem's granted rules text ("what it does"). The engine attaches it to
+ *  the produced ability definition's `description` — a static for static
+ *  emblems, the first trigger for triggered emblems (CR 114.4) — so pull from
+ *  both definition lists. Falls back to the generic "Emblem" label only when no
+ *  text is available. */
 function descriptionOf(emblem: GameObject, fallback: string): string {
-  return (
-    (emblem.static_definitions as Array<{ description?: string }>)
-      ?.map((sd) => sd.description)
-      .filter(Boolean)
-      .join("; ") || fallback
-  );
+  const descriptionsOf = (defs: unknown[] | undefined): string[] =>
+    ((defs as Array<{ description?: string }> | undefined) ?? [])
+      .map((def) => def.description)
+      .filter((desc): desc is string => Boolean(desc));
+
+  const parts = [
+    ...descriptionsOf(emblem.static_definitions),
+    ...descriptionsOf(emblem.trigger_definitions),
+  ];
+  return parts.join("; ") || fallback;
 }
 
 /**
@@ -43,19 +60,24 @@ export function CommandZone({ playerId }: CommandZoneProps) {
           obj != null && obj.is_emblem === true && obj.controller === playerId,
       );
 
-    // Group identical emblems by description
-    const byDesc = new Map<string, GroupedEmblem>();
+    // Group identical emblems by source + effect (CR 114). Keying on the source
+    // as well as the effect keeps emblems from different planeswalkers visually
+    // distinct even when their granted-ability text happens to coincide, so
+    // each chip shows the correct source art.
+    const byKey = new Map<string, GroupedEmblem>();
     for (const emblem of emblems) {
       const desc = descriptionOf(emblem, t("zone.emblemFallback"));
-      const existing = byDesc.get(desc);
+      const sourceName = emblem.emblem_source?.name ?? null;
+      const key = `${sourceName ?? ""}|${desc}`;
+      const existing = byKey.get(key);
       if (existing) {
         existing.count++;
       } else {
-        byDesc.set(desc, { description: desc, count: 1, representative: emblem });
+        byKey.set(key, { description: desc, sourceName, count: 1, representative: emblem });
       }
     }
 
-    return [...byDesc.values()];
+    return [...byKey.values()];
   }, [gameState, playerId, t]);
 
   if (groups.length === 0) return null;
@@ -70,58 +92,86 @@ export function CommandZone({ playerId }: CommandZoneProps) {
 }
 
 /**
- * Renders an emblem as a card-shaped art-crop tile that visually matches the
- * adjacent permanents in the support row. Emblems carry no Scryfall art (the
- * engine names them all "Emblem" with no printed_ref, and the image pipeline
- * excludes the emblem layout), so the art area is a gold emblem seal showing
- * the granted-ability text rather than a real card image. Sized via the
- * shared --art-crop-w/h vars set by the support container's zoneStyle.
+ * Renders an emblem as a small Arena-style chip — deliberately well below card
+ * size — that shows the source's art crop (the planeswalker/spell that created
+ * it), an "Emblem" ribbon, and a stack count. An emblem has no art of its own
+ * (CR 114.5: it is neither a card nor a permanent), so the art is resolved from
+ * the engine-provided `emblem_source` provenance via the normal card-image
+ * pipeline. When no source art is available, falls back to a gold emblem seal
+ * showing the granted-ability text. The full source + effect text is always
+ * available on hover.
  */
 function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
   const isCompactHeight = useIsCompactHeight();
+  const printedRef = group.representative.emblem_source?.printed_ref ?? null;
+  const { src: artSrc } = useCardImage(group.sourceName ?? "", {
+    size: "art_crop",
+    oracleId: printedRef?.oracle_id,
+    faceName: printedRef?.face_name,
+  });
+
   return (
     <div
-      className="relative select-none drop-shadow-[0_4px_6px_rgba(0,0,0,0.6)]"
-      style={{ width: "var(--art-crop-w)", height: "var(--art-crop-h)" }}
-      title={group.description}
+      // `hover:z-50` lifts the chip above later DOM siblings (the commander
+      // column) within the support column so its tooltip paints on top.
+      className="group relative select-none drop-shadow-[0_3px_5px_rgba(0,0,0,0.6)] hover:z-50"
+      style={{
+        width: `calc(var(--art-crop-w) * ${EMBLEM_CHIP_SCALE})`,
+        height: `calc(var(--art-crop-h) * ${EMBLEM_CHIP_SCALE})`,
+      }}
       data-testid="emblem-card"
     >
-      {/* Outer black border */}
-      <div className="absolute inset-0 rounded-[6px] border border-black bg-[#151515] p-[3px]">
-        {/* Gold emblem frame */}
-        <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[3px] bg-gradient-to-b from-amber-600 via-amber-800 to-stone-950 shadow-[inset_0_1px_1px_rgba(255,255,255,0.3)]">
-          {/* Header light reflection */}
-          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-[20px] bg-gradient-to-b from-white/30 to-transparent" />
-
-          {/* Header */}
-          <div
-            className={`${isCompactHeight ? "h-[12px] px-1" : "h-[20px] px-1.5"} z-10 flex w-full shrink-0 items-center border-b border-black/40 shadow-[0_1px_2px_rgba(0,0,0,0.4)]`}
-          >
-            <span
-              className={`${isCompactHeight ? "text-[8px]" : "text-[11.5px]"} mt-[1px] truncate font-extrabold uppercase leading-none tracking-wide text-[#2a1a05] drop-shadow-[0_1px_0_rgba(255,255,255,0.45)]`}
-            >
-              {label}
-            </span>
-          </div>
-
-          {/* Art area: emblem seal + granted-ability text */}
-          <div className="relative z-0 flex w-full flex-1 flex-col px-[2px] pb-[2px]">
-            <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-[1.5px] border border-black/80 bg-gradient-to-br from-stone-800 via-stone-900 to-black shadow-[inset_0_1px_3px_rgba(0,0,0,0.6)]">
+      {/* No-delay custom hover tooltip — the chip is too small to show "where
+          it came from" and "what it does" inline. */}
+      <GameplayTooltip>
+        <span className="font-semibold text-amber-200">
+          {label}
+          {group.sourceName ? ` — ${group.sourceName}` : ""}
+        </span>
+        <span className="mt-0.5 block text-slate-200">{group.description}</span>
+      </GameplayTooltip>
+      {/* Outer black border + gold inlay so the chip reads as an emblem even
+          over arbitrary source art. */}
+      <div className="absolute inset-0 rounded-[5px] border border-black bg-[#151515] p-[2px]">
+        <div className="relative h-full w-full overflow-hidden rounded-[3px] border border-amber-500/40 bg-gradient-to-b from-amber-700 via-amber-900 to-stone-950">
+          {artSrc ? (
+            <img
+              src={artSrc}
+              alt={group.sourceName ?? label}
+              draggable={false}
+              className="absolute inset-0 h-full w-full object-cover"
+            />
+          ) : (
+            // Fallback: gold emblem seal + effect text when source art is absent.
+            <div className="absolute inset-0 flex items-center justify-center">
               <span
                 aria-hidden="true"
-                className="absolute font-black leading-none text-amber-500/20"
-                style={{ fontSize: "calc(var(--art-crop-h) * 0.55)" }}
+                className="absolute font-black leading-none text-amber-400/25"
+                style={{ fontSize: "calc(var(--art-crop-h) * 0.4)" }}
               >
                 ✦
               </span>
               <p
-                className={`relative z-10 px-1 text-center leading-tight text-amber-100/90 drop-shadow-[0_1px_1px_rgba(0,0,0,0.9)] ${
-                  isCompactHeight ? "line-clamp-2 text-[6.5px]" : "line-clamp-4 text-[8px]"
+                className={`relative z-10 px-1 text-center leading-tight text-amber-50/90 drop-shadow-[0_1px_1px_rgba(0,0,0,0.9)] ${
+                  isCompactHeight ? "line-clamp-2 text-[6px]" : "line-clamp-3 text-[7px]"
                 }`}
               >
                 {group.description}
               </p>
             </div>
+          )}
+
+          {/* "Emblem" ribbon along the bottom — always visible so the chip is
+              identifiable regardless of the underlying art. */}
+          <div className="absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-black/85 via-black/60 to-transparent px-1 pb-[2px] pt-[6px]">
+            <span
+              className={`flex items-center gap-[2px] font-extrabold uppercase leading-none tracking-wide text-amber-300 drop-shadow-[0_1px_1px_rgba(0,0,0,0.9)] ${
+                isCompactHeight ? "text-[6px]" : "text-[7.5px]"
+              }`}
+            >
+              <span aria-hidden="true">✦</span>
+              {label}
+            </span>
           </div>
         </div>
       </div>
@@ -130,7 +180,7 @@ function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
       {group.count > 1 && (
         <div
           className={`absolute -bottom-[3px] -right-[3px] z-20 inline-flex items-center justify-center rounded-full border border-black/80 bg-amber-600 px-1 font-bold text-black shadow-[0_2px_4px_rgba(0,0,0,0.8)] ${
-            isCompactHeight ? "h-3.5 min-w-3.5 text-[8px]" : "h-5 min-w-5 text-[10px]"
+            isCompactHeight ? "h-3.5 min-w-3.5 text-[8px]" : "h-4 min-w-4 text-[9px]"
           }`}
         >
           ×{group.count}

--- a/crates/engine/src/game/effects/create_emblem.rs
+++ b/crates/engine/src/game/effects/create_emblem.rs
@@ -1,3 +1,4 @@
+use crate::game::game_object::EmblemSource;
 use crate::game::zones::create_object;
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::GameEvent;
@@ -20,6 +21,19 @@ pub fn resolve(
         _ => return Err(EffectError::MissingParam("CreateEmblem".into())),
     };
 
+    // CR 114: Capture display-only provenance from the ability's source (the
+    // planeswalker/spell that created the emblem) BEFORE borrowing the emblem
+    // mutably. The client renders the emblem as a chip bearing the source's art
+    // crop + name; an emblem has no art of its own (CR 114.5). Read here while
+    // the source still exists on the stack/battlefield — it may leave later.
+    let emblem_source = state
+        .objects
+        .get(&ability.source_id)
+        .map(|src| EmblemSource {
+            name: src.name.clone(),
+            printed_ref: src.printed_ref.clone(),
+        });
+
     // CR 114.1: Create emblem in command zone owned by the ability's controller
     let emblem_id = create_object(
         state,
@@ -35,6 +49,7 @@ pub fn resolve(
     // to admit command-zone objects, so the first trigger/static scan after
     // creation sees the emblem's abilities.
     obj.is_emblem = true;
+    obj.emblem_source = emblem_source;
     obj.static_definitions = statics.clone().into();
     obj.base_static_definitions = Arc::new(statics.clone());
     // CR 113.1c + CR 114.4: Install triggered abilities on the emblem so
@@ -113,6 +128,52 @@ mod tests {
         assert_eq!(emblem.controller, PlayerId(0));
         assert_eq!(emblem.static_definitions.len(), 1);
         assert_eq!(emblem.base_static_definitions.len(), 1);
+    }
+
+    #[test]
+    fn create_emblem_captures_source_provenance() {
+        // CR 114: the emblem records its source's display name + printed_ref so
+        // the client can render the source's art crop as a chip. The emblem has
+        // no art of its own (CR 114.5), so this provenance is the only handle
+        // the display layer has on "where it came from".
+        use crate::types::card::PrintedCardRef;
+        let mut state = GameState::new_two_player(42);
+
+        // A planeswalker-style source on the battlefield with a printed ref.
+        let source_id = create_object(
+            &mut state,
+            CardId(7),
+            PlayerId(0),
+            "Jace, the Mind Sculptor".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&source_id).unwrap().printed_ref = Some(PrintedCardRef {
+            oracle_id: "jace-oracle".to_string(),
+            face_name: "Jace, the Mind Sculptor".to_string(),
+        });
+
+        let ability = ResolvedAbility::new(
+            Effect::CreateEmblem {
+                statics: vec![ninja_pump_static()],
+                triggers: Vec::new(),
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let emblem = state.objects.get(&state.command_zone[0]).unwrap();
+        let provenance = emblem
+            .emblem_source
+            .as_ref()
+            .expect("emblem records source provenance");
+        assert_eq!(provenance.name, "Jace, the Mind Sculptor");
+        assert_eq!(
+            provenance.printed_ref.as_ref().unwrap().oracle_id,
+            "jace-oracle"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -288,6 +288,22 @@ pub struct RoomUnlockOutcome {
     pub fully_unlocked: bool,
 }
 
+/// CR 114: Display-only provenance for an emblem — the name and printed-card
+/// reference of the source that created it (e.g. the planeswalker whose
+/// ultimate ability made the emblem). This is deliberately NOT the emblem's
+/// own `printed_ref`: an emblem is neither a card nor a permanent (CR 114.5),
+/// and setting `printed_ref` would make the layer system treat the emblem as
+/// represented by that card and leak its types/P-T/abilities. This field is
+/// purely presentational — the client uses it to render the emblem as a small
+/// chip bearing the source's art crop and a "from <name>" label, mirroring
+/// MTG Arena's emblem display.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmblemSource {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub printed_ref: Option<PrintedCardRef>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GameObject {
     pub id: ObjectId,
@@ -654,6 +670,12 @@ pub struct GameObject {
     /// CR 114.5: Whether this object is an emblem (immune to removal, persists in command zone)
     #[serde(default)]
     pub is_emblem: bool,
+
+    /// CR 114: Display-only provenance of the source that created this emblem
+    /// (planeswalker, spell, etc.). Populated at creation in `create_emblem`;
+    /// `None` for every non-emblem object. See [`EmblemSource`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emblem_source: Option<EmblemSource>,
 
     /// CR 111.1: Whether this object is a token (not a card).
     #[serde(default)]
@@ -1060,6 +1082,7 @@ impl GameObject {
             commander_tax: None,
             is_renowned: false,
             is_emblem: false,
+            emblem_source: None,
             is_token: false,
             is_copy: false,
             display_source: DisplaySource::Card,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2965,7 +2965,8 @@ fn try_parse_no_max_hand_size_effect(tp: TextPair<'_>) -> Option<Effect> {
     }
 
     Some(Effect::CreateEmblem {
-        statics: vec![StaticDefinition::new(StaticMode::NoMaximumHandSize)],
+        statics: vec![StaticDefinition::new(StaticMode::NoMaximumHandSize)
+            .description("You have no maximum hand size.".to_string())],
         triggers: Vec::new(),
     })
 }
@@ -11098,10 +11099,17 @@ fn try_parse_emblem_creation(lower: &str, original: &str) -> Option<Effect> {
         // `collect_matching_triggers` zone guard must admit them. Declare
         // `trigger_zones = [Zone::Command]` explicitly (the default empty
         // vector is interpreted as battlefield-only by the scanner).
-        let triggers: Vec<TriggerDefinition> = trig_defs
+        let mut triggers: Vec<TriggerDefinition> = trig_defs
             .into_iter()
             .map(|t| t.trigger_zones(vec![Zone::Command]))
             .collect();
+        // CR 114: retain the emblem's granted rules text so the display layer
+        // can show "what it does" in the emblem tooltip. Attach to the first
+        // trigger only — the joined display text would otherwise repeat the
+        // clause for multi-trigger emblems.
+        if let Some(first) = triggers.first_mut() {
+            first.description = Some(inner.to_string());
+        }
         return Some(Effect::CreateEmblem {
             statics: Vec::new(),
             triggers,
@@ -11109,7 +11117,10 @@ fn try_parse_emblem_creation(lower: &str, original: &str) -> Option<Effect> {
     }
 
     // Try to parse the emblem text as a static ability line.
-    if let Some(static_def) = super::oracle_static::parse_static_line(inner) {
+    if let Some(mut static_def) = super::oracle_static::parse_static_line(inner) {
+        // CR 114: retain the emblem's granted rules text for the display
+        // tooltip, mirroring the trigger and fallback branches.
+        static_def.description = Some(inner.to_string());
         Some(Effect::CreateEmblem {
             statics: vec![static_def],
             triggers: Vec::new(),
@@ -27319,6 +27330,16 @@ mod tests {
                     .modifications
                     .iter()
                     .any(|m| matches!(m, ContinuousModification::AddToughness { value: 1 })));
+                // CR 114: the granted rules text is retained on the static so
+                // the display layer can show "what it does" in the tooltip.
+                assert!(
+                    def.description
+                        .as_deref()
+                        // allow-noncombinator: test assertion on retained display text, not parser dispatch
+                        .is_some_and(|d| d.contains("Ninjas you control get +1/+1")),
+                    "static emblem must retain granted rules text, got {:?}",
+                    def.description
+                );
             }
             other => panic!("expected CreateEmblem, got {:?}", other),
         }
@@ -27375,6 +27396,16 @@ mod tests {
                 // CR 114.4: trigger_zones must include Command so the
                 // scanner's zone guard admits the fire.
                 assert_eq!(t.trigger_zones, vec![Zone::Command]);
+                // CR 114: the granted rules text is retained on the (first)
+                // trigger so the display layer can show "what it does".
+                assert!(
+                    t.description
+                        .as_deref()
+                        // allow-noncombinator: test assertion on retained display text, not parser dispatch
+                        .is_some_and(|d| d.contains("deals 5 damage to any target")),
+                    "trigger emblem must retain granted rules text, got {:?}",
+                    t.description
+                );
             }
             other => panic!("expected CreateEmblem with triggers, got {other:?}"),
         }


### PR DESCRIPTION
## Summary

Records the creating source's identity on each emblem so the client can render it as an Arena-style chip bearing the source's art crop and a "from <name>" label — emblems currently have no visual identity of their own.

- **engine:** `EmblemSource` struct + `GameObject.emblem_source` field, populated in `create_emblem` from the ability's source (the planeswalker/spell that made the emblem). Captured before the emblem is borrowed mutably, while the source still exists.
- **parser:** retains the emblem's granted rules text on the first trigger/static definition so the display layer can show *what the emblem does* in a tooltip (CR 114.4).
- **client:** `emblem_source` type + `CommandZone` renders the source-art chip and rules tooltip; emblems scale well below card size so they never compete with real permanents for board space.

## Rules correctness
Provenance is deliberately **separate** from `printed_ref`. An emblem is neither a card nor a permanent (CR 114.5); reusing `printed_ref` would make the layer system treat the emblem as represented by that card and leak its types / P-T / abilities. `emblem_source` is purely presentational and `None` on every non-emblem object.

## Tests
Added `create_emblem_captures_source_provenance` (engine) + parser assertions that emblem trigger/static definitions retain their granted rules text.