### PR TITLE
Keyword backlog: sacrifice-replacement, toxic/infect poison routing, craft material links

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1825,9 +1825,13 @@ pub(crate) fn handle_exile_materials_for_cost(
         pending.object_id,
         &materials,
     );
+    // Capture the crafting source id before `pending` is moved into the helper.
+    // The craft source self-exiles and returns with the same ObjectId (CR
+    // 702.167a), so this id is also the returned permanent's id.
+    let source_id = pending.object_id;
     // CR 702.167a/b + CR 601.2h: chosen materials are revalidated against the
     // live battlefield/graveyard union immediately before payment.
-    finish_exile_selection_for_cost(
+    let result = finish_exile_selection_for_cost(
         state,
         player,
         pending,
@@ -1845,7 +1849,21 @@ pub(crate) fn handle_exile_materials_for_cost(
             }
             Ok(())
         },
-    )
+    )?;
+    // CR 702.167c: link each exiled material to the crafting source so a
+    // "cares what was used to craft it" ability can read them after the
+    // permanent returns transformed (same ObjectId across the exile round-trip;
+    // the link survives the source's battlefield exit via the zones.rs preserve
+    // arm). `push_with_kind` is idempotent on (exiled_id, source_id).
+    for &material_id in chosen {
+        crate::game::exile_links::push_with_kind(
+            state,
+            material_id,
+            source_id,
+            crate::types::game_state::ExileLinkKind::CraftMaterial,
+        );
+    }
+    Ok(result)
 }
 
 /// Push an activated ability to the stack after costs are paid.

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use crate::game::ability_utils::append_to_sub_chain;
+use crate::game::effects::player_counter;
 use crate::game::effects::{append_to_pending_continuation, mark_pending_continuation_parent};
 use crate::game::filter;
 use crate::game::keywords;
@@ -18,8 +19,8 @@ use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{DamageRecord, GameState};
 use crate::types::identifiers::ObjectId;
-use crate::types::keywords::{Keyword, KeywordKind};
-use crate::types::player::PlayerId;
+use crate::types::keywords::KeywordKind;
+use crate::types::player::{PlayerCounterKind, PlayerId};
 use crate::types::proposed_event::ProposedEvent;
 
 /// Source attributes needed for damage application (CR 120.3).
@@ -103,14 +104,11 @@ impl DamageContext {
                 source_id,
                 KeywordKind::Infect,
             ),
-            combat_damage_poison: obj
-                .keywords
-                .iter()
-                .filter_map(|keyword| match keyword {
-                    Keyword::Toxic(amount) => Some(*amount),
-                    _ => None,
-                })
-                .sum(),
+            // CR 702.164b: total toxic value = sum of N over ALL effective toxic
+            // instances (printed + granted, on/off battlefield), matching the
+            // sibling effective-keyword flags above rather than reading printed
+            // `obj.keywords` directly.
+            combat_damage_poison: keywords::effective_total_toxic_value(state, source_id),
         })
     }
 
@@ -419,9 +417,19 @@ pub(crate) fn apply_damage_after_replacement(
                 return DamageResult::Applied(0);
             }
             if ctx.has_infect {
-                // CR 702.90: Infect deals damage to players as poison counters.
-                if let Some(player) = state.players.iter_mut().find(|p| p.id == *player_id) {
-                    player.poison_counters += actual_amount;
+                // CR 120.3b + CR 614.17: Infect deals damage to players as poison
+                // counters. Route through the player-counter replacement pipeline
+                // so "players can't get poison counters" / poison-doublers apply;
+                // the actor is the source's controller.
+                if !player_counter::add_player_counter_with_replacement(
+                    state,
+                    ctx.controller,
+                    *player_id,
+                    PlayerCounterKind::Poison,
+                    actual_amount,
+                    events,
+                ) {
+                    return DamageResult::NeedsChoice;
                 }
             } else {
                 // CR 120.3a: Damage to a player causes life loss.
@@ -437,10 +445,19 @@ pub(crate) fn apply_damage_after_replacement(
                 && ctx.source_is_creature
                 && ctx.combat_damage_poison > 0
             {
-                // CR 702.164c: Toxic adds poison counters when a creature
-                // deals combat damage to a player.
-                if let Some(player) = state.players.iter_mut().find(|p| p.id == *player_id) {
-                    player.poison_counters += ctx.combat_damage_poison;
+                // CR 120.3g + CR 702.164c + CR 614.17: Toxic adds poison counters
+                // when a creature deals combat damage to a player. Route through
+                // the player-counter replacement pipeline (prevention/doublers);
+                // the actor is the source's controller.
+                if !player_counter::add_player_counter_with_replacement(
+                    state,
+                    ctx.controller,
+                    *player_id,
+                    PlayerCounterKind::Poison,
+                    ctx.combat_damage_poison,
+                    events,
+                ) {
+                    return DamageResult::NeedsChoice;
                 }
             }
         }
@@ -2220,7 +2237,7 @@ mod tests {
             Duration::UntilEndOfTurn,
             TargetFilter::SpecificObject { id: spell_id },
             vec![ContinuousModification::AddKeyword {
-                keyword: Keyword::Lifelink,
+                keyword: crate::types::keywords::Keyword::Lifelink,
             }],
             None,
         );

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -23,7 +23,7 @@ use super::effects::mill::apply_mill_after_replacement;
 use super::effects::scry::apply_scry_after_replacement;
 use super::effects::token::apply_create_token_after_replacement;
 use super::engine::EngineError;
-use super::sacrifice::apply_sacrifice_after_replacement;
+use super::sacrifice::{apply_sacrifice_after_replacement, SacrificeApply};
 use super::zones;
 
 /// CR 614.13a + CR 702.82a/c: matches the broad as-enters shape of a Devour
@@ -341,11 +341,17 @@ pub(super) fn handle_replacement_choice(
                         return Ok(state.waiting_for.clone());
                     }
                 }
-                // CR 701.21a + CR 614: Sacrifice accepted after replacement choice —
-                // delegate to the shared helper. Regeneration cannot apply (CR
-                // 701.21a) but Moved replacements on the graveyard transfer still do.
+                // CR 701.21a + CR 614.1: Sacrifice accepted after replacement
+                // choice — delegate to the shared helper. Regeneration cannot
+                // apply (CR 701.21a) but Moved replacements on the inner graveyard
+                // transfer do; if that inner transfer itself needs a choice, the
+                // helper sets `state.waiting_for` and we propagate it back.
                 sacrifice @ ProposedEvent::Sacrifice { .. } => {
-                    apply_sacrifice_after_replacement(state, sacrifice, events);
+                    if let SacrificeApply::NeedsChoice(_) =
+                        apply_sacrifice_after_replacement(state, sacrifice, events)
+                    {
+                        return Ok(state.waiting_for.clone());
+                    }
                 }
                 // CR 111.1 + CR 614.1a: CreateToken accepted after replacement choice
                 // — the `spec` field carries the full self-describing token

--- a/crates/engine/src/game/exile_links.rs
+++ b/crates/engine/src/game/exile_links.rs
@@ -167,6 +167,61 @@ mod tests {
     use crate::types::player::PlayerId;
     use crate::types::zones::Zone;
 
+    /// CR 702.167a/c: a `CraftMaterial` link must survive the craft source's
+    /// battlefield exit (it self-exiles mid-activation and returns with the same
+    /// ObjectId), so the returned permanent can still read what it was crafted
+    /// with. A plain `TrackedBySource` link from the same source is pruned on
+    /// that exit — the contrast that motivates the dedicated kind.
+    #[test]
+    fn craft_material_link_survives_source_battlefield_exit() {
+        use crate::game::zones::{create_object, move_to_zone};
+        use crate::types::game_state::{ExileLinkKind, GameState};
+        use crate::types::identifiers::CardId;
+
+        let mut state = GameState::new_two_player(1);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Crafted Artifact".to_string(),
+            Zone::Battlefield,
+        );
+        let material = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Craft Material".to_string(),
+            Zone::Exile,
+        );
+        push_with_kind(&mut state, material, source, ExileLinkKind::CraftMaterial);
+        let tracked = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Tracked".to_string(),
+            Zone::Exile,
+        );
+        push_with_kind(&mut state, tracked, source, ExileLinkKind::TrackedBySource);
+
+        // The craft source self-exiles mid-activation (battlefield -> exile).
+        let mut events = Vec::new();
+        move_to_zone(&mut state, source, Zone::Exile, &mut events);
+
+        assert!(
+            state.exile_links.iter().any(|l| l.exiled_id == material
+                && l.source_id == source
+                && matches!(l.kind, ExileLinkKind::CraftMaterial)),
+            "CraftMaterial link must survive the source's battlefield exit"
+        );
+        assert!(
+            !state
+                .exile_links
+                .iter()
+                .any(|l| l.exiled_id == tracked && l.source_id == source),
+            "TrackedBySource link must be pruned on the source's battlefield exit"
+        );
+    }
+
     #[test]
     fn plain_exile_effect_has_no_linked_exile_consumer() {
         let ability = ResolvedAbility::new(

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -111,6 +111,24 @@ pub fn effective_escape_data(state: &GameState, object_id: ObjectId) -> Option<(
     }
 }
 
+/// CR 702.164b: A creature's total toxic value is the sum of N over ALL its
+/// effective toxic instances (printed + granted, on or off the battlefield).
+/// Sums over the plural `effective_off_zone_keywords` primitive (battlefield →
+/// `obj.keywords`; off-battlefield → off-zone continuous-effect resolution),
+/// matching the effective view used by the sibling `object_has_effective_keyword_kind`
+/// flags rather than reading printed `obj.keywords` directly. (Toxic has no
+/// distinct `KeywordKind` — it collapses to `Unknown` — so the sum is taken over
+/// the `Keyword::Toxic` variant, not a kind filter.)
+pub fn effective_total_toxic_value(state: &GameState, object_id: ObjectId) -> u32 {
+    crate::game::off_zone_characteristics::effective_off_zone_keywords(state, object_id)
+        .iter()
+        .filter_map(|keyword| match keyword {
+            Keyword::Toxic(amount) => Some(*amount),
+            _ => None,
+        })
+        .sum()
+}
+
 /// CR 702.187b: Effective Mayhem alt-cost for a card in the graveyard, honoring
 /// off-zone characteristic grants (e.g. Green Goblin's "Each nonland card in
 /// your graveyard has mayhem. The mayhem cost is equal to its mana cost.") in
@@ -673,6 +691,41 @@ mod tests {
         obj.keywords.push(Keyword::Flying);
         assert!(has_keyword(&obj, &Keyword::Flying));
         assert!(!has_keyword(&obj, &Keyword::Haste));
+    }
+
+    /// CR 702.164b: a creature's total toxic value is the sum of N over ALL its
+    /// toxic instances. `effective_total_toxic_value` must enumerate every
+    /// instance (here a distinct `Toxic(2)` + `Toxic(1)`) and sum to 3, rather
+    /// than collapsing to the first match.
+    #[test]
+    fn effective_total_toxic_value_sums_all_instances() {
+        let mut state = GameState::new_two_player(1);
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Toxic Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.keywords.push(Keyword::Toxic(2));
+        obj.keywords.push(Keyword::Toxic(1));
+
+        assert_eq!(
+            effective_total_toxic_value(&state, id),
+            3,
+            "total toxic value sums all distinct instances"
+        );
+
+        // A creature with no toxic has total toxic value 0.
+        let plain = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Plain".to_string(),
+            Zone::Battlefield,
+        );
+        assert_eq!(effective_total_toxic_value(&state, plain), 0);
     }
 
     /// CR 702.138a: a placeholder `exile_count == 0` is a parse failure, not a

--- a/crates/engine/src/game/sacrifice.rs
+++ b/crates/engine/src/game/sacrifice.rs
@@ -224,7 +224,7 @@ mod tests {
                         owner_library: false,
                         enter_transformed: false,
                         enters_under: None,
-                        enter_tapped: false,
+                        enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                         enters_attacking: false,
                         up_to: false,
                         enter_with_counters: vec![],

--- a/crates/engine/src/game/sacrifice.rs
+++ b/crates/engine/src/game/sacrifice.rs
@@ -59,7 +59,13 @@ pub(crate) fn sacrifice_permanent(
 
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(event) => {
-            apply_sacrifice_after_replacement(state, event, events)
+            match apply_sacrifice_after_replacement(state, event, events) {
+                SacrificeApply::Complete => {}
+                SacrificeApply::NeedsChoice(player) => {
+                    // `state.waiting_for` is already set by the inner pass.
+                    return Ok(SacrificeOutcome::NeedsReplacementChoice(player));
+                }
+            }
         }
         ReplacementResult::Prevented => {}
         ReplacementResult::NeedsChoice(choice_player) => {
@@ -70,12 +76,26 @@ pub(crate) fn sacrifice_permanent(
     Ok(SacrificeOutcome::Complete)
 }
 
-/// CR 701.21a + CR 614: Apply an accepted Sacrifice proposed event.
+/// Outcome of delivering an accepted Sacrifice proposed event through the inner
+/// graveyard-move replacement pass. `NeedsChoice` carries the player who must
+/// order/choose among multiple applicable graveyard replacements (CR 616.1);
+/// `state.waiting_for` is already set when it is returned.
+pub(crate) enum SacrificeApply {
+    Complete,
+    NeedsChoice(PlayerId),
+}
+
+/// CR 701.21a + CR 614.1: Apply an accepted Sacrifice proposed event.
 ///
-/// Moves the permanent to its owner's graveyard (or the replaced destination
-/// if a `Moved` replacement redirected the inner zone change), records the
-/// sacrifice for restriction tracking (CR 701.21), and emits the
-/// `PermanentSacrificed` event.
+/// The sacrifice's move to the graveyard is itself a zone change subject to
+/// replacement (CR 701.21a + CR 614.1), so this routes the inner graveyard
+/// `ZoneChange` through the replacement pipeline — mirroring
+/// `apply_destroy_after_replacement` — instead of moving straight to the
+/// graveyard. A "would be put into a graveyard from anywhere → exile/redirect
+/// instead" `Moved` replacement (Disturb back faces, Rest in Peace, Leyline of
+/// the Void) therefore applies on sacrifice too. Records the sacrifice for
+/// restriction tracking (CR 701.21) and emits `PermanentSacrificed` regardless
+/// of the redirected zone (leaves-the-battlefield is still a sacrifice).
 ///
 /// Shared by the cost/effect path (`sacrifice_permanent`) and the
 /// post-replacement-choice delivery path (`handle_replacement_choice`).
@@ -83,29 +103,53 @@ pub(crate) fn apply_sacrifice_after_replacement(
     state: &mut GameState,
     event: ProposedEvent,
     events: &mut Vec<GameEvent>,
-) {
+) -> SacrificeApply {
     match event {
         ProposedEvent::Sacrifice {
             object_id: oid,
             player_id: pid,
             ..
         } => {
+            // CR 701.21: record the sacrifice for restriction tracking before any
+            // redirect — leaving the battlefield is still a sacrifice.
             restrictions::record_sacrifice(state, oid, pid);
-            zones::move_to_zone(state, oid, Zone::Graveyard, events);
-            crate::game::layers::mark_layers_full(state);
+            // CR 701.21a + CR 614.1: propose the inner graveyard move so a Moved
+            // replacement can intercept it. The Sacrifice proposal carries no
+            // source, so `cause` is None.
+            let zone_proposed =
+                ProposedEvent::zone_change(oid, Zone::Battlefield, Zone::Graveyard, None);
+            match replacement::replace_event(state, zone_proposed, events) {
+                ReplacementResult::Execute(ProposedEvent::ZoneChange { object_id, to, .. }) => {
+                    zones::move_to_zone(state, object_id, to, events);
+                    crate::game::layers::mark_layers_full(state);
+                }
+                // Defensive: the inner proposal is always a ZoneChange.
+                ReplacementResult::Execute(_) => {}
+                ReplacementResult::Prevented => {}
+                ReplacementResult::NeedsChoice(player) => {
+                    // CR 616.1: an ordered/optional Moved replacement needs a
+                    // choice — pause and let the caller resume.
+                    state.waiting_for = replacement::replacement_choice_waiting_for(player, state);
+                    return SacrificeApply::NeedsChoice(player);
+                }
+            }
+            // CR 701.21: PermanentSacrificed fires regardless of the redirected
+            // zone (leaves-the-battlefield is still a sacrifice).
             events.push(GameEvent::PermanentSacrificed {
                 object_id: oid,
                 player_id: pid,
             });
+            SacrificeApply::Complete
         }
         ProposedEvent::ZoneChange {
             object_id: oid, to, ..
         } => {
-            // Replacement redirected (e.g., exile instead of graveyard)
+            // Outer Sacrifice replacement redirected directly to a zone change.
             zones::move_to_zone(state, oid, to, events);
             crate::game::layers::mark_layers_full(state);
+            SacrificeApply::Complete
         }
-        _ => {}
+        _ => SacrificeApply::Complete,
     }
 }
 
@@ -133,6 +177,89 @@ mod tests {
         assert!(matches!(result, Ok(SacrificeOutcome::Complete)));
         assert!(!state.battlefield.contains(&obj_id));
         assert!(state.players[0].graveyard.contains(&obj_id));
+    }
+
+    /// CR 701.21a + CR 614.1: a sacrificed permanent's inner graveyard move is
+    /// subject to replacement. With a Rest-in-Peace-style "would be put into a
+    /// graveyard → exile instead" Moved replacement in play, sacrifice must land
+    /// the permanent in exile (not the graveyard), still emit
+    /// `PermanentSacrificed`, and still record the sacrifice. This is the general
+    /// fix for Disturb back faces and global graveyard hate on sacrifice.
+    #[test]
+    fn sacrifice_redirected_to_exile_by_moved_replacement() {
+        use crate::game::game_object::GameObject;
+        use crate::types::ability::{AbilityDefinition, AbilityKind, Effect};
+        use crate::types::replacements::ReplacementEvent;
+
+        let mut state = GameState::new_two_player(42);
+        let victim = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Sacrifice Victim".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Rest in Peace: "If a card or token would be put into a graveyard from
+        // anywhere, exile it instead." Modeled as a Moved (→Graveyard)
+        // replacement that redirects to Exile.
+        let rip_id = ObjectId(state.next_object_id);
+        state.next_object_id += 1;
+        let mut rip = GameObject::new(
+            rip_id,
+            CardId(888),
+            PlayerId(1),
+            "Rest in Peace".to_string(),
+            Zone::Battlefield,
+        );
+        rip.replacement_definitions.push(
+            crate::types::ability::ReplacementDefinition::new(ReplacementEvent::Moved)
+                .destination_zone(Zone::Graveyard)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::ChangeZone {
+                        destination: Zone::Exile,
+                        origin: None,
+                        target: TargetFilter::Any,
+                        owner_library: false,
+                        enter_transformed: false,
+                        enters_under: None,
+                        enter_tapped: false,
+                        enters_attacking: false,
+                        up_to: false,
+                        enter_with_counters: vec![],
+                        face_down_profile: None,
+                    },
+                ))
+                .description("Rest in Peace".to_string()),
+        );
+        state.objects.insert(rip_id, rip);
+        state.battlefield.push_back(rip_id);
+
+        let mut events = Vec::new();
+        let result = sacrifice_permanent(&mut state, victim, PlayerId(0), &mut events);
+
+        assert!(matches!(result, Ok(SacrificeOutcome::Complete)));
+        assert!(
+            state.exile.contains(&victim),
+            "the inner graveyard move must re-enter replacement; Moved→Exile sends the victim to exile"
+        );
+        assert!(
+            !state.players[0].graveyard.contains(&victim),
+            "redirected sacrifice must not land in the graveyard"
+        );
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                GameEvent::PermanentSacrificed { object_id, .. } if *object_id == victim
+            )),
+            "PermanentSacrificed must fire regardless of the redirected zone"
+        );
+        assert_eq!(
+            state.sacrificed_permanents_this_turn.len(),
+            1,
+            "the sacrifice must still be recorded for restriction tracking"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -281,12 +281,17 @@ fn apply_zone_exit_cleanup(state: &mut GameState, object_id: ObjectId, from: Zon
         // creature leaving the battlefield (its death) is exactly when the
         // card's haunt-payoff trigger reads the link to fire from exile. The
         // link is pruned later, when the haunting card itself leaves exile.
+        // CR 702.167a/c: `CraftMaterial` links are preserved too — the craft
+        // source self-exiles mid-activation and returns with the same ObjectId,
+        // so the material links must survive its battlefield exit for the
+        // returned permanent to still read what it was crafted with.
         state.exile_links.retain(|link| {
             link.source_id != object_id
                 || matches!(
                     link.kind,
                     crate::types::game_state::ExileLinkKind::UntilSourceLeaves { .. }
                         | crate::types::game_state::ExileLinkKind::Haunt
+                        | crate::types::game_state::ExileLinkKind::CraftMaterial
                 )
         });
     }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -733,6 +733,18 @@ pub enum ExileLinkKind {
     /// redacted. Pruned on exile-exit / source-exit like `Cipher` (not an
     /// `UntilSourceLeaves` link, so no automatic return).
     HideawayLookable,
+    /// CR 702.167c: Craft material — the card (`exiled_id`) was exiled to pay the
+    /// craft activation cost of the permanent (`source_id`) that returns to the
+    /// battlefield transformed. "An ability of a permanent may refer to the
+    /// exiled cards used to craft it." Unlike `TrackedBySource`, this link is
+    /// **preserved** when the craft source leaves the battlefield — the source
+    /// self-exiles mid-activation (CR 702.167a) and returns with the SAME
+    /// ObjectId, so the link must survive its battlefield exit for the returned
+    /// permanent to read it. Unlike `UntilSourceLeaves` it triggers NO automatic
+    /// return (the materials stay in exile). Read by the kind-agnostic
+    /// `ExiledBySource` / `CardsExiledBySource` consumers; pruned only when a
+    /// material itself leaves exile (`zones.rs` exile-exit).
+    CraftMaterial,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Three independent engine fixes from the keyword backlog. Engine compiles + `test-engine` and `clippy` green locally on Tilt.

- **fix(engine): route sacrifice's graveyard move through replacement** — a sacrificed permanent's graveyard move is itself a zone change subject to replacement (CR 701.21a + CR 614.1), but it moved straight to the graveyard, bypassing the inner replacement pass that destroy/mill/SBA-death run. A "graveyard → exile instead" Moved replacement (Disturb back faces, Rest in Peace, Leyline of the Void) was skipped only on sacrifice. Now mirrors `apply_destroy_after_replacement` with a typed `SacrificeApply { Complete, NeedsChoice }` return (CR 616.1 pause).
- **fix(engine): route toxic/infect poison through replacement; sum effective toxic** — combat toxic/infect wrote `poison_counters` directly, bypassing the player-counter replacement pipeline (prevention/doublers). Both sites now route through `add_player_counter_with_replacement`. `combat_damage_poison` now sums **all effective** Toxic instances via the new `effective_total_toxic_value` (CR 702.164b) instead of reading printed keywords. (Identical-value layer-6 dedup is a tracked follow-up needing a live repro.)
- **feat(engine): link craft materials to the crafting source** — adds `ExileLinkKind::CraftMaterial`, stamped from each exiled material to the craft source, preserved across the source's mid-activation self-exile (same ObjectId, CR 702.167a) so CR 702.167c "cares what it was crafted with" abilities can read them via the existing kind-agnostic `ExiledBySource` readers.

Each carries unit tests; all CR numbers grep-verified.