### PR TITLE
Wire granted-keyword seams: fabricate, blitz, riot, encore

### DIFF
--- a/crates/engine/src/database/encore.rs
+++ b/crates/engine/src/database/encore.rs
@@ -35,12 +35,22 @@ pub fn synthesize_encore(face: &mut CardFace) {
     let abilities: Vec<AbilityDefinition> = face
         .keywords
         .iter()
-        .filter_map(|keyword| match keyword {
-            Keyword::Encore(cost) => Some(encore_ability(cost.clone())),
-            _ => None,
-        })
+        .filter_map(encore_ability_for_keyword)
         .collect();
     face.abilities.extend(abilities);
+}
+
+/// CR 702.141a + CR 604.1: Standalone keyword→ability builder so the Encore
+/// activated ability can be synthesized both at card-build time
+/// (`synthesize_encore`) and on the fly for runtime-granted Encore (the
+/// graveyard activated-ability gather in `casting.rs`). Mirrors the
+/// `cycling_ability_for_keyword` precedent. Returns `None` for non-Encore
+/// keywords.
+pub(crate) fn encore_ability_for_keyword(keyword: &Keyword) -> Option<AbilityDefinition> {
+    match keyword {
+        Keyword::Encore(cost) => Some(encore_ability(cost.clone())),
+        _ => None,
+    }
 }
 
 /// CR 702.141a + CR 602.1a: Build the activated ability

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -223,6 +223,10 @@ impl KeywordTriggerInstaller {
             // instance triggers separately, so one trigger is emitted per
             // `Keyword::Afterlife(_)` on the face.
             Keyword::Afterlife(n) => vec![build_afterlife_trigger(*n)],
+            // CR 702.123a/b: Fabricate N — ETB ChooseOneOf{+1/+1 counters |
+            // Servo tokens} trigger. Per CR 702.123b each instance triggers
+            // separately, so one trigger is emitted per `Keyword::Fabricate(_)`.
+            Keyword::Fabricate(n) => vec![build_fabricate_trigger(*n)],
             // CR 702.46a: Soulshift N — dies trigger optionally returning a
             // target Spirit card with mana value N or less from your graveyard
             // to your hand. Per CR 702.46b each instance triggers separately, so
@@ -345,6 +349,9 @@ impl KeywordTriggerInstaller {
                 is_dies_return_with_counter_trigger(trigger, &CounterType::Minus1Minus1)
             }
             Keyword::Afterlife(n) => is_afterlife_trigger_for_count(trigger, *n),
+            // CR 702.123b + CR 604.1: symmetric removal — the count is
+            // load-bearing so distinct Fabricate instances do not dedupe.
+            Keyword::Fabricate(n) => is_fabricate_trigger_for_count(trigger, *n),
             // CR 702.46b: the mana-value threshold is load-bearing so multiple
             // Soulshift instances with differing N do not dedupe each other.
             Keyword::Soulshift(n) => is_soulshift_trigger_for_value(trigger, *n),
@@ -1931,53 +1938,77 @@ fn transmute_same_mana_value_filter() -> TargetFilter {
 /// target for "this card's power" in the graveyard reminder text. No new quantity
 /// ref is needed; `SelfPower` is already the right abstraction.
 pub fn synthesize_scavenge(face: &mut CardFace) {
-    use crate::types::ability::QuantityRef;
-
     let scavenge_abilities: Vec<AbilityDefinition> = face
         .keywords
         .iter()
-        .filter_map(|kw| {
-            let Keyword::Scavenge(cost) = kw else {
-                return None;
-            };
-            // CR 118.3: Composite cost — pay mana, then exile this card from graveyard.
-            let composite_cost = AbilityCost::Composite {
-                costs: vec![
-                    AbilityCost::Mana { cost: cost.clone() },
-                    // CR 702.97a: "Exile this card from your graveyard" — SelfRef + Graveyard
-                    // is auto-paid by pay_ability_cost (no player choice needed).
-                    AbilityCost::Exile {
-                        count: 1,
-                        zone: Some(Zone::Graveyard),
-                        filter: Some(TargetFilter::SelfRef),
-                    },
-                ],
-            };
-            // CR 702.97a: "Put a number of +1/+1 counters equal to this card's power on
-            // target creature." SelfPower is resolved via LKI at resolution time so the
-            // power read is the card's last known power before it was exiled.
-            let effect = Effect::PutCounter {
-                counter_type: CounterType::Plus1Plus1,
-                count: QuantityExpr::Ref {
-                    qty: QuantityRef::Power {
-                        scope: crate::types::ability::ObjectScope::Source,
-                    },
-                },
-                target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
-            };
-            let mut def = AbilityDefinition::new(AbilityKind::Activated, effect)
-                .cost(composite_cost)
-                // CR 702.97a: "Activate only as a sorcery." The `.sorcery_speed()`
-                // builder sets both the display flag and pushes
-                // `ActivationRestriction::AsSorcery` for runtime enforcement.
-                .sorcery_speed();
-            // CR 702.97a: "functions only while the card with scavenge is in a graveyard."
-            def.activation_zone = Some(Zone::Graveyard);
-            Some(def)
-        })
+        .filter_map(scavenge_ability_for_keyword)
         .collect();
 
     face.abilities.extend(scavenge_abilities);
+}
+
+/// CR 702.97a + CR 604.1: Standalone keyword→ability builder so the Scavenge
+/// activated ability can be synthesized both at card-build time
+/// (`synthesize_scavenge`) and on the fly for runtime-granted Scavenge (the
+/// graveyard activated-ability gather in `casting.rs`). Mirrors the
+/// `cycling_ability_for_keyword` precedent. Returns `None` for non-Scavenge
+/// keywords.
+pub(crate) fn scavenge_ability_for_keyword(keyword: &Keyword) -> Option<AbilityDefinition> {
+    use crate::types::ability::QuantityRef;
+
+    let Keyword::Scavenge(cost) = keyword else {
+        return None;
+    };
+    // CR 118.3: Composite cost — pay mana, then exile this card from graveyard.
+    let composite_cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana { cost: cost.clone() },
+            // CR 702.97a: "Exile this card from your graveyard" — SelfRef + Graveyard
+            // is auto-paid by pay_ability_cost (no player choice needed).
+            AbilityCost::Exile {
+                count: 1,
+                zone: Some(Zone::Graveyard),
+                filter: Some(TargetFilter::SelfRef),
+            },
+        ],
+    };
+    // CR 702.97a: "Put a number of +1/+1 counters equal to this card's power on
+    // target creature." SelfPower is resolved via LKI at resolution time so the
+    // power read is the card's last known power before it was exiled.
+    let effect = Effect::PutCounter {
+        counter_type: CounterType::Plus1Plus1,
+        count: QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: crate::types::ability::ObjectScope::Source,
+            },
+        },
+        target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+    };
+    let mut def = AbilityDefinition::new(AbilityKind::Activated, effect)
+        .cost(composite_cost)
+        // CR 702.97a: "Activate only as a sorcery." The `.sorcery_speed()`
+        // builder sets both the display flag and pushes
+        // `ActivationRestriction::AsSorcery` for runtime enforcement.
+        .sorcery_speed();
+    // CR 702.97a: "functions only while the card with scavenge is in a graveyard."
+    def.activation_zone = Some(Zone::Graveyard);
+    Some(def)
+}
+
+/// CR 604.1: General "granted graveyard activated keyword → ability" builder
+/// (seam 4: activated-ability-on-grant). The runtime activated-ability gather
+/// (`activated_ability_definitions` in `casting.rs`) calls this for each keyword
+/// in a graveyard card's *effective* keyword set so a keyword granted by a
+/// static (e.g. Encore/Scavenge granted to a graveyard card) surfaces its
+/// activatable ability — the `AddKeyword` layer seam installs only the keyword
+/// and triggers, never activated abilities. Returns `None` for keywords whose
+/// behavior is not a graveyard activated ability. Extend this match as new
+/// graveyard activated keywords gain runtime-grant support.
+pub(crate) fn graveyard_activated_ability_for_keyword(
+    keyword: &Keyword,
+) -> Option<AbilityDefinition> {
+    crate::database::encore::encore_ability_for_keyword(keyword)
+        .or_else(|| scavenge_ability_for_keyword(keyword))
 }
 
 /// CR 702.107a: Synthesize the Outlast activated ability from a `Keyword::Outlast(cost)`.
@@ -3181,71 +3212,122 @@ pub fn synthesize_fabricate(face: &mut CardFace) {
         return;
     }
 
+    // CR 702.123b: each Fabricate instance triggers separately — one trigger
+    // per `Keyword::Fabricate(_)` on the face.
     for n in fabricate_values {
-        let count_expr = QuantityExpr::Fixed { value: n as i32 };
-        let counter_word = if n == 1 { "counter" } else { "counters" };
-        let token_word = if n == 1 { "token" } else { "tokens" };
+        face.triggers.push(build_fabricate_trigger(n));
+    }
+}
 
-        let counters_branch = AbilityDefinition::new(
-            AbilityKind::Spell,
+/// CR 702.123a: Fabricate N — "When this permanent enters, you may put N +1/+1
+/// counters on it. If you don't, create N 1/1 colorless Servo artifact creature
+/// tokens." Modeled as an ETB `ChooseOneOf{ PutCounter | Token }` trigger.
+///
+/// Shared building block called by both `synthesize_fabricate` (build-time) and
+/// `KeywordTriggerInstaller::triggers_for` (runtime grant via `AddKeyword`),
+/// mirroring the `build_afterlife_trigger` precedent.
+fn build_fabricate_trigger(n: u32) -> TriggerDefinition {
+    let count_expr = QuantityExpr::Fixed { value: n as i32 };
+    let counter_word = if n == 1 { "counter" } else { "counters" };
+    let token_word = if n == 1 { "token" } else { "tokens" };
+
+    let counters_branch = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PutCounter {
+            counter_type: CounterType::Plus1Plus1,
+            count: count_expr.clone(),
+            target: TargetFilter::SelfRef,
+        },
+    )
+    .description(format!("Put {n} +1/+1 {counter_word} on it"));
+
+    // CR 111.1 + CR 111.4: Token is a 1/1 colorless Servo artifact
+    // creature token. `types` carries both core types ("Artifact",
+    // "Creature") and the creature subtype ("Servo") — mirrors the
+    // Treasure pattern (`["Artifact", "Treasure"]`) and Mobilize Warrior
+    // pattern (`["Creature", "Warrior"]`). Colorless is represented as
+    // an empty `colors` vec.
+    let servos_branch = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Token {
+            name: "Servo".to_string(),
+            power: PtValue::Fixed(1),
+            toughness: PtValue::Fixed(1),
+            types: vec![
+                "Artifact".to_string(),
+                "Creature".to_string(),
+                "Servo".to_string(),
+            ],
+            colors: vec![],
+            keywords: vec![],
+            tapped: false,
+            count: count_expr,
+            owner: TargetFilter::Controller,
+            attach_to: None,
+            enters_attacking: false,
+            supertypes: vec![],
+            static_abilities: vec![],
+            enter_with_counters: vec![],
+        },
+    )
+    .description(format!(
+        "Create {n} 1/1 colorless Servo artifact creature {token_word}"
+    ));
+
+    let choose = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChooseOneOf {
+            chooser: crate::types::ability::PlayerFilter::Controller,
+            branches: vec![counters_branch, servos_branch],
+        },
+    );
+
+    TriggerDefinition::new(TriggerMode::ChangesZone)
+        .destination(Zone::Battlefield)
+        .valid_card(TargetFilter::SelfRef)
+        .execute(choose)
+        .description(format!(
+            "CR 702.123a: Fabricate {n} — when this permanent enters, put {n} +1/+1 {counter_word} on it or create {n} 1/1 colorless Servo artifact creature {token_word}."
+        ))
+}
+
+/// Idempotency / strip-symmetry predicate for `build_fabricate_trigger`-shaped
+/// triggers. Discriminates on the full CR 702.123a Servo-token branch so a
+/// granted-then-removed Fabricate strips exactly its own trigger and never
+/// collides with another self-ref ETB `ChooseOneOf` trigger. The `n` is
+/// load-bearing (CR 702.123b: distinct instances must not dedupe each other).
+fn is_fabricate_trigger_for_count(t: &TriggerDefinition, n: u32) -> bool {
+    if !matches!(t.mode, TriggerMode::ChangesZone)
+        || t.destination != Some(Zone::Battlefield)
+        || !matches!(t.valid_card, Some(TargetFilter::SelfRef))
+    {
+        return false;
+    }
+    let Some(execute) = t.execute.as_deref() else {
+        return false;
+    };
+    let Effect::ChooseOneOf { branches, .. } = &*execute.effect else {
+        return false;
+    };
+    let count = QuantityExpr::Fixed { value: n as i32 };
+    let counters_ok = branches.iter().any(|b| {
+        matches!(
+            &*b.effect,
             Effect::PutCounter {
                 counter_type: CounterType::Plus1Plus1,
-                count: count_expr.clone(),
+                count: c,
                 target: TargetFilter::SelfRef,
-            },
+            } if *c == count
         )
-        .description(format!("Put {n} +1/+1 {counter_word} on it"));
-
-        // CR 111.1 + CR 111.4: Token is a 1/1 colorless Servo artifact
-        // creature token. `types` carries both core types ("Artifact",
-        // "Creature") and the creature subtype ("Servo") — mirrors the
-        // Treasure pattern (`["Artifact", "Treasure"]`) and Mobilize Warrior
-        // pattern (`["Creature", "Warrior"]`). Colorless is represented as
-        // an empty `colors` vec.
-        let servos_branch = AbilityDefinition::new(
-            AbilityKind::Spell,
-            Effect::Token {
-                name: "Servo".to_string(),
-                power: PtValue::Fixed(1),
-                toughness: PtValue::Fixed(1),
-                types: vec![
-                    "Artifact".to_string(),
-                    "Creature".to_string(),
-                    "Servo".to_string(),
-                ],
-                colors: vec![],
-                keywords: vec![],
-                tapped: false,
-                count: count_expr,
-                owner: TargetFilter::Controller,
-                attach_to: None,
-                enters_attacking: false,
-                supertypes: vec![],
-                static_abilities: vec![],
-                enter_with_counters: vec![],
-            },
+    });
+    let servos_ok = branches.iter().any(|b| {
+        matches!(
+            &*b.effect,
+            Effect::Token { name, count: c, .. }
+                if name == "Servo" && *c == count
         )
-        .description(format!(
-            "Create {n} 1/1 colorless Servo artifact creature {token_word}"
-        ));
-
-        let choose = AbilityDefinition::new(
-            AbilityKind::Spell,
-            Effect::ChooseOneOf {
-                chooser: crate::types::ability::PlayerFilter::Controller,
-                branches: vec![counters_branch, servos_branch],
-            },
-        );
-
-        let trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
-            .destination(Zone::Battlefield)
-            .valid_card(TargetFilter::SelfRef)
-            .execute(choose)
-            .description(format!(
-                "CR 702.123a: Fabricate {n} — when this permanent enters, put {n} +1/+1 {counter_word} on it or create {n} 1/1 colorless Servo artifact creature {token_word}."
-            ));
-        face.triggers.push(trigger);
-    }
+    });
+    counters_ok && servos_ok
 }
 
 /// CR 702.136a: Riot — "You may have this permanent enter with an additional
@@ -3272,6 +3354,54 @@ pub fn synthesize_riot(face: &mut CardFace) {
     for filter in static_grants {
         add_riot_replacements(face, filter, 1);
     }
+}
+
+/// General "keyword → as-enters replacement" mapping (seam 3: replacement-on-grant).
+///
+/// CR 614.12: an as-enters replacement that affects "a general subset of
+/// permanents that includes" the entering object comes from the granting source,
+/// scoped to the static's `affected` filter — NOT `SelfRef` on the recipient.
+/// Callers therefore thread the granting static's `affected` filter through.
+///
+/// Returns `None` for keywords whose behavior is not an as-enters replacement.
+/// Extend this match as new as-enters replacement keywords (e.g. Ravenous's
+/// "enters with X +1/+1 counters", CR 702.156a) gain runtime-grant support.
+pub(crate) fn keyword_entry_replacement(
+    keyword: &Keyword,
+    affected: TargetFilter,
+) -> Option<ReplacementDefinition> {
+    match keyword {
+        // CR 702.136a: Riot — optional "enter with a +1/+1 counter, else gain haste".
+        Keyword::Riot => Some(build_riot_replacement(affected)),
+        _ => None,
+    }
+}
+
+/// Runtime mirror of `synthesize_riot`'s static-grant half (seam 3).
+///
+/// CR 604.1: a runtime-added Continuous static that grants `AddKeyword{Riot}` (or
+/// another as-enters replacement keyword) must contribute the corresponding
+/// as-enters replacement on its source permanent, scoped to the static's
+/// `affected` filter (CR 614.12). Build-time `synthesize_riot` does this once on
+/// `face.replacements`; at runtime the per-pass layer reset discards persistent
+/// installs, so the layer system re-derives the replacement each pass by calling
+/// this for every active Continuous static and pushing the result onto the
+/// source's live `replacement_definitions`.
+///
+/// Returns `None` if the static is not a Continuous as-enters-replacement grant.
+pub(crate) fn entry_replacement_for_grant_static(
+    static_def: &StaticDefinition,
+) -> Option<ReplacementDefinition> {
+    if static_def.mode != StaticMode::Continuous {
+        return None;
+    }
+    let affected = static_def.affected.clone().unwrap_or(TargetFilter::Any);
+    static_def.modifications.iter().find_map(|modification| {
+        let ContinuousModification::AddKeyword { keyword } = modification else {
+            return None;
+        };
+        keyword_entry_replacement(keyword, affected.clone())
+    })
 }
 
 /// CR 702.64a: Absorb N — "If a source would deal damage to this creature,
@@ -11446,6 +11576,50 @@ mod undying_persist_synthesis_tests {
         ));
     }
 
+    /// CR 604.1 + CR 702.123a/b runtime-grant path: `triggers_for` produces the
+    /// Fabricate ETB trigger and `trigger_matches_keyword_kind` recognizes it,
+    /// and `build_fabricate_trigger` is structurally identical to what the
+    /// build-time `synthesize_fabricate` installs (building-block equivalence).
+    #[test]
+    fn fabricate_triggers_for_and_matcher_roundtrip() {
+        let triggers = KeywordTriggerInstaller::triggers_for(&Keyword::Fabricate(2));
+        assert_eq!(triggers.len(), 1, "fabricate yields exactly one trigger");
+        assert!(
+            KeywordTriggerInstaller::trigger_matches_keyword_kind(
+                &triggers[0],
+                &Keyword::Fabricate(2)
+            ),
+            "matcher must recognize the synthesized fabricate trigger"
+        );
+        // The count is load-bearing (CR 702.123b: distinct instances must not
+        // dedupe each other).
+        assert!(!KeywordTriggerInstaller::trigger_matches_keyword_kind(
+            &triggers[0],
+            &Keyword::Fabricate(1)
+        ));
+        // It must NOT be recognized as some other keyword's trigger.
+        assert!(!KeywordTriggerInstaller::trigger_matches_keyword_kind(
+            &triggers[0],
+            &Keyword::Afterlife(2)
+        ));
+
+        // Build-block equivalence: synthesize_fabricate must install the exact
+        // same trigger shape the grant path installs.
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Fabricate(2));
+        synthesize_fabricate(&mut face);
+        let synthesized: Vec<_> = face
+            .triggers
+            .iter()
+            .filter(|t| is_fabricate_trigger_for_count(t, 2))
+            .collect();
+        assert_eq!(
+            synthesized.len(),
+            1,
+            "synthesize_fabricate installs the same builder-produced trigger"
+        );
+    }
+
     /// Runtime-grant removal uses `trigger_matches_keyword_kind`, so the matcher
     /// must discriminate `Afterlife(N)` by N rather than stripping every
     /// Afterlife-style Spirit trigger for the same discriminant.
@@ -13988,6 +14162,46 @@ mod riot_synthesis_tests {
             "static Riot grant should add ETB replacement for affected filter, got {:?}",
             face.replacements
         );
+    }
+
+    /// CR 614.12 + CR 604.1: the runtime seam-3 builder must derive the SAME
+    /// affected-filter Riot replacement build-time `synthesize_riot` produces from
+    /// a Continuous `AddKeyword{Riot}` static — scoped to the static's `affected`
+    /// filter, NOT SelfRef. This is the building block the layer pass calls each
+    /// recompute to re-install the replacement on the granting permanent.
+    #[test]
+    fn entry_replacement_for_grant_static_mirrors_synthesize_riot() {
+        let affected = TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You));
+        let static_def = StaticDefinition::continuous()
+            .affected(affected.clone())
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Riot,
+            }]);
+
+        let derived = entry_replacement_for_grant_static(&static_def)
+            .expect("Riot-granting Continuous static must derive an entry replacement");
+        assert!(
+            is_riot_replacement(&derived, &affected),
+            "derived replacement must be the affected-filter Riot replacement, got {derived:?}"
+        );
+        // Build-block parity: identical to what build-time synthesis installs.
+        assert_eq!(derived, build_riot_replacement(affected));
+
+        // A non-as-enters-replacement keyword grant derives nothing.
+        let flying_static = StaticDefinition::continuous().modifications(vec![
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying,
+            },
+        ]);
+        assert!(entry_replacement_for_grant_static(&flying_static).is_none());
+
+        // A non-Continuous static derives nothing.
+        let noncontinuous = StaticDefinition::new(StaticMode::CantBlock).modifications(vec![
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Riot,
+            },
+        ]);
+        assert!(entry_replacement_for_grant_static(&noncontinuous).is_none());
     }
 
     #[test]

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -71,6 +71,34 @@ fn runtime_granted_cycling_abilities(
         .collect()
 }
 
+/// CR 604.1 (seam 4: activated-ability-on-grant): synthesize graveyard activated
+/// abilities (Encore, Scavenge) for keywords granted to a graveyard card by a
+/// static. The `AddKeyword` layer seam installs only the keyword + triggers, so a
+/// granted graveyard activated keyword carries no activatable ability without
+/// this on-the-fly synthesis. Mirrors `runtime_granted_cycling_abilities`: only
+/// keywords present in the *effective* (granted-inclusive) set but NOT printed on
+/// the card are synthesized, so a printed Encore/Scavenge ability (already in
+/// `obj.abilities`) is never double-counted.
+fn runtime_granted_graveyard_activated_abilities(
+    state: &GameState,
+    source_id: ObjectId,
+) -> Vec<AbilityDefinition> {
+    let Some(obj) = state.objects.get(&source_id) else {
+        return Vec::new();
+    };
+    if obj.zone != Zone::Graveyard {
+        return Vec::new();
+    }
+
+    crate::game::off_zone_characteristics::effective_off_zone_keywords(state, source_id)
+        .into_iter()
+        .filter(|keyword| !obj.base_keywords.iter().any(|printed| printed == keyword))
+        .filter_map(|keyword| {
+            crate::database::synthesis::graveyard_activated_ability_for_keyword(&keyword)
+        })
+        .collect()
+}
+
 pub fn activated_ability_definitions(
     state: &GameState,
     source_id: ObjectId,
@@ -84,6 +112,9 @@ pub fn activated_ability_definitions(
     abilities.extend(
         runtime_granted_cycling_abilities(state, source_id)
             .into_iter()
+            .chain(runtime_granted_graveyard_activated_abilities(
+                state, source_id,
+            ))
             .enumerate()
             .map(|(offset, ability)| (printed_len + offset, ability)),
     );
@@ -101,8 +132,14 @@ fn activation_ability_definition(
     }
 
     let offset = ability_index.checked_sub(obj.abilities.len())?;
+    // Must match the append order in `activated_ability_definitions`: printed
+    // abilities first, then runtime-granted cycling, then runtime-granted
+    // graveyard activated (Encore/Scavenge).
     runtime_granted_cycling_abilities(state, source_id)
         .into_iter()
+        .chain(runtime_granted_graveyard_activated_abilities(
+            state, source_id,
+        ))
         .nth(offset)
 }
 
@@ -2747,10 +2784,12 @@ fn casting_variant_candidates(
 
     // CR 702.152a: Blitz is an opt-in alternative cost from hand; surface it as a
     // candidate so the gate offers it (and so it is reachable when the printed
-    // cost is unaffordable).
+    // cost is unaffordable). Read the *effective* spell keywords so a Blitz cost
+    // granted by a static (CR 604.1) is honored, not just printed Blitz.
+    // CR 702.152b: only one Blitz may be applied to a spell, so the dedup-by-kind
+    // `effective_spell_keywords` is the correct (single-instance) collector here.
     if obj.zone == Zone::Hand
-        && obj
-            .keywords
+        && effective_spell_keywords(state, player, object_id)
             .iter()
             .any(|k| matches!(k, crate::types::keywords::Keyword::Blitz(_)))
     {
@@ -3023,12 +3062,17 @@ fn prepare_spell_cast_with_variant_override_inner(
     };
 
     // CR 702.152a: Blitz — when casting from hand with Keyword::Blitz, the blitz
-    // mana cost replaces the printed cost (opt-in via `variant_override`).
+    // mana cost replaces the printed cost (opt-in via `variant_override`). Read
+    // the *effective* spell keywords so a Blitz cost granted by a static
+    // (CR 604.1) is honored; CR 702.152b makes Blitz single-instance, so the
+    // dedup-by-kind collector is correct.
     let blitz_cost = if obj.zone == Zone::Hand {
-        obj.keywords.iter().find_map(|k| match k {
-            crate::types::keywords::Keyword::Blitz(cost) => Some(cost.clone()),
-            _ => None,
-        })
+        effective_spell_keywords(state, player, object_id)
+            .iter()
+            .find_map(|k| match k {
+                crate::types::keywords::Keyword::Blitz(cost) => Some(cost.clone()),
+                _ => None,
+            })
     } else {
         None
     };
@@ -7144,10 +7188,16 @@ pub fn handle_cast_spell_with_payment_mode(
     // affordable, present the choice; auto-route when only blitz is payable.
     if let Some(obj) = state.objects.get(&object_id) {
         if obj.zone == Zone::Hand {
-            if let Some(blitz_cost) = obj.keywords.iter().find_map(|k| match k {
-                crate::types::keywords::Keyword::Blitz(cost) => Some(cost.clone()),
-                _ => None,
-            }) {
+            // CR 604.1: honor a Blitz cost granted by a static, not only printed
+            // Blitz. CR 702.152b makes Blitz single-instance, so the dedup-by-kind
+            // `effective_spell_keywords` collector is correct here.
+            if let Some(blitz_cost) = effective_spell_keywords(state, player, object_id)
+                .iter()
+                .find_map(|k| match k {
+                    crate::types::keywords::Keyword::Blitz(cost) => Some(cost.clone()),
+                    _ => None,
+                })
+            {
                 // CR 601.2f: affordability and displayed costs reflect active
                 // cost modifiers, applied to both the printed and blitz costs.
                 let normal_cost =
@@ -22028,6 +22078,149 @@ mod tests {
                 .any(|o| o.variant == CastingVariant::Blitz),
             "choice set must include the Blitz option; got {:?}",
             choices.options
+        );
+    }
+
+    /// CR 702.152a + CR 604.1: Blitz granted to a hand creature by a battlefield
+    /// `CastWithKeyword` static (the card itself prints no Blitz) must surface the
+    /// Blitz alternative-cast option. The candidate read routes through
+    /// `effective_spell_keywords`; before that routing, `casting_variant_candidates`
+    /// inspected only printed `obj.keywords`, so the Blitz option would be absent.
+    #[test]
+    fn granted_blitz_offers_blitz_variant() {
+        use crate::types::ability::{TargetFilter, TypeFilter, TypedFilter};
+        use crate::types::keywords::Keyword;
+        use crate::types::statics::StaticMode;
+
+        let mut state = setup_game_at_main_phase();
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 5);
+
+        // Grantor: "creatures you control have blitz {2}" (modeled directly as a
+        // CastWithKeyword static, the same shape the parser emits for such grants).
+        let grantor = create_object(
+            &mut state,
+            CardId(9100),
+            PlayerId(0),
+            "Blitz Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&grantor).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types.core_types.push(CoreType::Creature);
+            let def = StaticDefinition::new(StaticMode::CastWithKeyword {
+                keyword: Keyword::Blitz(ManaCost::generic(2)),
+            })
+            .affected(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)));
+            obj.static_definitions = vec![def].into();
+        }
+
+        // Recipient: a vanilla creature in hand with NO printed Blitz.
+        let spell = create_object(
+            &mut state,
+            CardId(9101),
+            PlayerId(0),
+            "Vanilla Creature".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = ManaCost::generic(4);
+            obj.base_mana_cost = ManaCost::generic(4);
+        }
+
+        assert!(
+            !state
+                .objects
+                .get(&spell)
+                .unwrap()
+                .keywords
+                .iter()
+                .any(|k| matches!(k, Keyword::Blitz(_))),
+            "recipient must have no printed Blitz — the option must come from the grant"
+        );
+
+        let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+        assert!(
+            choices
+                .options
+                .iter()
+                .any(|o| o.variant == CastingVariant::Blitz),
+            "granted Blitz must surface the Blitz option; got {:?}",
+            choices.options
+        );
+    }
+
+    /// CR 702.141a + CR 604.1 (seam 4: activated-ability-on-grant): Encore
+    /// granted to a graveyard card by an `AddKeyword` effect must surface its
+    /// graveyard activated ability. The `AddKeyword` layer seam installs only the
+    /// keyword + triggers (never activated abilities), so the gather
+    /// (`activated_ability_definitions`) must synthesize the Encore ability from
+    /// the card's *effective* keyword set. Before that synthesis, the card had
+    /// the bare Encore keyword but no activatable Encore ability.
+    #[test]
+    fn granted_encore_surfaces_graveyard_activated_ability() {
+        let mut state = setup_game_at_main_phase();
+
+        // Grantor on the battlefield; recipient is a creature card in graveyard
+        // with NO printed Encore.
+        let grantor = create_object(
+            &mut state,
+            CardId(9200),
+            PlayerId(0),
+            "Encore Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        let card = create_object(
+            &mut state,
+            CardId(9201),
+            PlayerId(0),
+            "Some Creature".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&card).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+        }
+
+        // Sanity: before the grant, no Encore ability is surfaced.
+        let before = activated_ability_definitions(&state, card);
+        assert!(
+            !before
+                .iter()
+                .any(|(_, a)| matches!(&*a.effect, crate::types::ability::Effect::Encore)),
+            "no printed Encore ability should exist before the grant"
+        );
+
+        // Grant Encore {2}{R} to this graveyard card.
+        state.add_transient_continuous_effect(
+            grantor,
+            PlayerId(0),
+            crate::types::ability::Duration::UntilEndOfTurn,
+            TargetFilter::SpecificObject { id: card },
+            vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Encore(ManaCost::Cost {
+                    generic: 2,
+                    shards: vec![ManaCostShard::Red],
+                }),
+            }],
+            None,
+        );
+
+        let after = activated_ability_definitions(&state, card);
+        let encore = after
+            .iter()
+            .find(|(_, a)| matches!(&*a.effect, crate::types::ability::Effect::Encore))
+            .expect("granted Encore must surface a graveyard activated ability");
+        assert_eq!(
+            encore.1.activation_zone,
+            Some(Zone::Graveyard),
+            "synthesized Encore ability must function only from the graveyard"
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1371,6 +1371,61 @@ pub fn evaluate_layers(state: &mut GameState) {
         }
     }
 
+    // CR 614.12 + CR 604.1 + CR 702.136a: replacement-on-grant (seam 3).
+    // A Continuous static that grants an as-enters replacement keyword (Riot)
+    // contributes its as-enters `Moved` replacement from the GRANTING permanent,
+    // scoped to the static's `affected` filter — not as a SelfRef replacement on
+    // the recipient (CR 614.12: a grant to "a general subset of permanents that
+    // includes it" comes from the granting source). Build-time `synthesize_riot`
+    // installs this once on `face.replacements`; the per-pass reset above
+    // (CR 613.1) discards persistent installs, so the replacement must be
+    // re-derived each pass onto the source's live `replacement_definitions`. This
+    // runs AFTER Layer 6 (Ability) so a Riot-granting static that was itself
+    // granted to the source is visible in `static_definitions`. The runtime
+    // gather (`find_applicable_replacements`) then applies the affected-filter
+    // replacement to matching entering creatures with no further change.
+    for &id in &bf_ids {
+        let derived: Vec<crate::types::ability::ReplacementDefinition> = {
+            let Some(obj) = state.objects.get(&id) else {
+                continue;
+            };
+            obj.static_definitions
+                .iter_all()
+                .filter_map(|def| {
+                    // Cheap discriminator FIRST: `entry_replacement_for_grant_static`
+                    // is a couple of field checks returning `None` for ~every
+                    // static, whereas `source_condition_gate_passes` can scan all
+                    // objects (e.g. `IsPresent`). Run the condition gate only once
+                    // an as-enters keyword grant is confirmed, so the layer hot
+                    // path pays no board-wide condition tax for non-Riot statics.
+                    let replacement =
+                        crate::database::synthesis::entry_replacement_for_grant_static(def)?;
+                    let active = def.condition.as_ref().is_none_or(|condition| {
+                        source_condition_gate_passes(state, condition, obj.controller, id)
+                    });
+                    active.then_some(replacement)
+                })
+                .collect()
+        };
+        if derived.is_empty() {
+            continue;
+        }
+        if let Some(obj) = state.objects.get_mut(&id) {
+            for replacement in derived {
+                // Idempotent: the per-pass reset already cleared derived
+                // replacements, but a static that also appears in the base set
+                // (printed Riot grant) could double-install otherwise.
+                if !obj
+                    .replacement_definitions
+                    .iter_all()
+                    .any(|r| r == &replacement)
+                {
+                    obj.replacement_definitions.push(replacement);
+                }
+            }
+        }
+    }
+
     // CR 613.11: Rule-changing continuous effects are applied after object
     // characteristics are determined. These flags feed CR 510.1 combat damage
     // assignment and must observe final post-layer characteristics.
@@ -5105,6 +5160,125 @@ mod tests {
                 .unwrap()
                 .has_keyword(&Keyword::Flying),
             "CantHaveKeyword denial must strip Flying granted by the concurrent anthem"
+        );
+    }
+
+    /// CR 604.1 + CR 702.123a/b: a runtime grant of `Fabricate N` via a
+    /// continuous `AddKeyword` static must install the Fabricate ETB trigger
+    /// onto the recipient's `trigger_definitions` (the trigger-on-grant seam at
+    /// `KeywordTriggerInstaller::triggers_for`). Before the `Fabricate` arm
+    /// existed, the recipient gained the bare keyword but no trigger, so this
+    /// assertion would have found zero installed Fabricate triggers.
+    #[test]
+    fn granted_fabricate_installs_etb_trigger_on_recipient() {
+        let mut state = setup();
+        let bear = make_creature(&mut state, "Bear", 2, 2, PlayerId(0));
+
+        // Anthem-style static: grants Fabricate 2 to all creatures.
+        let anthem_static = StaticDefinition::new(StaticMode::Continuous)
+            .affected(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)))
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Fabricate(2),
+            }]);
+        let anthem = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Fabricate Anthem".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&anthem).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions.push(anthem_static);
+        }
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let recipient = state.objects.get(&bear).unwrap();
+        assert!(
+            recipient.has_keyword(&Keyword::Fabricate(2)),
+            "granted Fabricate keyword must land on the recipient"
+        );
+        let fabricate_triggers = recipient
+            .trigger_definitions
+            .iter_all()
+            .filter(|t| {
+                KeywordTriggerInstaller::trigger_matches_keyword_kind(t, &Keyword::Fabricate(2))
+            })
+            .count();
+        assert_eq!(
+            fabricate_triggers, 1,
+            "granted Fabricate must install exactly one ETB ChooseOneOf trigger"
+        );
+    }
+
+    /// CR 614.12 + CR 604.1 + CR 702.136a (seam 3, replacement-on-grant): a
+    /// battlefield permanent whose Continuous static grants `AddKeyword{Riot}` to
+    /// a subset of permanents must, after a layer pass, carry the affected-filter
+    /// as-enters Riot replacement on its OWN `replacement_definitions` (scoped to
+    /// the static's `affected` filter, NOT SelfRef per CR 614.12). Before the
+    /// runtime-derivation pass existed, `AddKeyword` installed only the keyword +
+    /// triggers, never a replacement, so this assertion found none.
+    #[test]
+    fn granted_riot_static_derives_affected_filter_replacement_on_source() {
+        let mut state = setup();
+
+        let affected = TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
+        );
+        let riot_static = StaticDefinition::new(StaticMode::Continuous)
+            .affected(affected.clone())
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Riot,
+            }]);
+        let grantor = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Riot Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&grantor).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions.push(riot_static);
+            obj.base_static_definitions = obj.static_definitions.as_slice().to_vec().into();
+        }
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let expected =
+            crate::database::synthesis::keyword_entry_replacement(&Keyword::Riot, affected.clone())
+                .expect("Riot must map to an entry replacement");
+        let source = state.objects.get(&grantor).unwrap();
+        let installed = source
+            .replacement_definitions
+            .iter_all()
+            .filter(|r| **r == expected)
+            .count();
+        assert_eq!(
+            installed, 1,
+            "granting permanent must carry exactly one affected-filter Riot replacement"
+        );
+
+        // Idempotency across re-evaluation (the per-pass reset + re-derive must
+        // not accumulate duplicates).
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        let source = state.objects.get(&grantor).unwrap();
+        assert_eq!(
+            source
+                .replacement_definitions
+                .iter_all()
+                .filter(|r| **r == expected)
+                .count(),
+            1,
+            "re-evaluation must not duplicate the derived replacement"
         );
     }
 


### PR DESCRIPTION
Keywords granted at runtime (via `AddKeyword` statics / `CastWithKeyword` grants) were not producing their seams because the read paths consulted printed `obj.keywords` instead of the effective keyword set. Routes each through the effective set so a *granted* keyword behaves like a printed one. `test-engine` + `clippy` green on Tilt; the layer-eval hot path was kept clear (cheap Riot discriminator runs before the object-scanning condition gate).

- **B1 Fabricate** — extract `build_fabricate_trigger(n)` + identity predicate; add `Keyword::Fabricate` arms to `triggers_for` / `trigger_matches_keyword_kind`, so a granted Fabricate installs its ETB ChooseOneOf trigger (CR 702.123a/b).
- **B3 Blitz** — route all three Blitz reads through `effective_spell_keywords`; single-instance dedup is CR-correct (CR 702.152b).
- **B5 Riot** — `entry_replacement_for_grant_static` + a post-Layer-6 derivation pass installing the affected-filter Riot as-enters replacement onto the granting permanent (CR 614.12 + 702.136a), idempotent across passes.
- **B6 Encore/Scavenge** — `runtime_granted_graveyard_activated_abilities` (mirrors cycling) surfaces granted graveyard activated keywords; extracted `encore_ability_for_keyword` / `scavenge_ability_for_keyword` builders (CR 702.141a / 702.97a).

Offspring/Casualty grants (B2/B4) are out of scope — superseded by the multi-additional-cost pipeline. Each B-item carries a discriminating pipeline-driven test; all CR numbers grep-verified. Reviewed by an independent agent (APPROVE-WITH-NITS); the flagged hot-path ordering nit was applied before this PR.