### PR TITLE
fix(parser): typed QuantityRef::VoteCount for vote tallies (#1446)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1109,6 +1109,7 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         QuantityRef::DistinctCounterKindsAmong { filter } => {
             format!("# of counter kinds among {}", fmt_target(filter))
         }
+        QuantityRef::VoteCount { choice_index } => format!("# of votes for choice {choice_index}"),
         QuantityRef::PreviousEffectAmount => "amount from preceding effect".into(),
         QuantityRef::TrackedSetSize => "cards moved".into(),
         QuantityRef::FilteredTrackedSetSize { filter } => {
@@ -5449,6 +5450,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ("DistinctColorsAmongPermanents", Handled)
         }
         QuantityRef::DistinctCounterKindsAmong { .. } => ("DistinctCounterKindsAmong", Handled),
+        QuantityRef::VoteCount { .. } => ("VoteCount", Handled),
         QuantityRef::PreviousEffectAmount => ("PreviousEffectAmount", Handled),
         QuantityRef::TrackedSetSize => ("TrackedSetSize", Handled),
         QuantityRef::FilteredTrackedSetSize { .. } => ("FilteredTrackedSetSize", Handled),

--- a/crates/engine/src/game/effects/vote.rs
+++ b/crates/engine/src/game/effects/vote.rs
@@ -221,7 +221,20 @@ pub fn resolve_tally(
         let per_choice_player_scope = per_choice_effect[idx].player_scope.clone();
         let repeat_for = if per_choice_player_scope.is_some() {
             None
+        } else if per_choice_effect[idx]
+            .effect
+            .count_expr()
+            .is_some_and(QuantityExpr::contains_vote_count)
+        {
+            // CR 111.1 / CR 122.1 + CR 701.38 + CR 608.2c: aggregate-tally body
+            // (Emissary Green). Its count slot is bound to a
+            // `QuantityRef::VoteCount`, so the effect resolves as ONE aggregate
+            // event whose `resolve_ref` sums the full tally — do NOT repeat it
+            // per ballot, which would multiply the tally by itself.
+            None
         } else {
+            // Classic "For each <choice> vote, <effect>" (Tivit / Capital
+            // Punishment): the body has a fixed count and fires once per ballot.
             Some(QuantityExpr::Fixed {
                 value: *votes as i32,
             })

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -320,6 +320,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::ConvokedCreatureCount
         | QuantityRef::ManaSpentToCast { .. }
         | QuantityRef::ColorsInCommandersColorIdentity
+        | QuantityRef::VoteCount { .. }
         | QuantityRef::CommanderCastFromCommandZoneCount => false,
     }
 }
@@ -489,6 +490,7 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::ConvokedCreatureCount
         | QuantityRef::ManaSpentToCast { .. }
         | QuantityRef::ColorsInCommandersColorIdentity
+        | QuantityRef::VoteCount { .. }
         | QuantityRef::CommanderCastFromCommandZoneCount => false,
     }
 }
@@ -1801,6 +1803,19 @@ fn resolve_ref(
         QuantityRef::DistinctCounterKindsAmong { filter } => {
             usize_to_i32_saturating(distinct_counter_kinds_among(state, filter, &filter_ctx).len())
         }
+        // CR 701.38 + CR 608.2c: Number of votes tallied for `choice_index`,
+        // counting ballots (not voters) from `state.last_vote_ballots`. Summing
+        // ballots — rather than counting distinct voters — is the consequence of
+        // CR 701.38d: a player granted multiple votes casts multiple ballots, so
+        // a single player can contribute more than one to a choice's tally.
+        QuantityRef::VoteCount { choice_index } => i32::try_from(
+            state
+                .last_vote_ballots
+                .iter()
+                .filter(|(_, ballot_choice)| *ballot_choice == *choice_index)
+                .count(),
+        )
+        .unwrap_or(i32::MAX),
         // CR 305.6: Count distinct basic land types among lands controlled by
         // the referenced player. Domain counts distinct land subtypes, not
         // lands, so multiple Forests still contribute one.
@@ -9625,5 +9640,36 @@ mod tests {
             cause: PhaseOutCause::Directly,
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(0)), 1);
+    }
+
+    /// CR 701.38 + CR 701.38d + CR 608.2c: `VoteCount` counts ballots, not
+    /// voters. A player granted multiple votes casts multiple ballots, so a
+    /// single player can contribute more than one to a choice's tally. Build a
+    /// ledger where P1 voted twice for choice 0 and assert the tally is 3
+    /// (P0 once + P1 twice), with choice 1 resolving to 0 (no ballots).
+    #[test]
+    fn vote_count_sums_ballots_not_voters() {
+        let mut state = GameState::new_two_player(42);
+        // (voter, choice_index): P0 → 0, P1 → 0, P1 → 0 (multi-vote player).
+        state.last_vote_ballots.push_back((PlayerId(0), 0));
+        state.last_vote_ballots.push_back((PlayerId(1), 0));
+        state.last_vote_ballots.push_back((PlayerId(1), 0));
+
+        let choice0 = QuantityExpr::Ref {
+            qty: QuantityRef::VoteCount { choice_index: 0 },
+        };
+        let choice1 = QuantityExpr::Ref {
+            qty: QuantityRef::VoteCount { choice_index: 1 },
+        };
+        // 3 ballots for choice 0 (votes, not the 2 distinct voters).
+        assert_eq!(
+            resolve_quantity(&state, &choice0, PlayerId(0), ObjectId(0)),
+            3
+        );
+        // No ballots for choice 1.
+        assert_eq!(
+            resolve_quantity(&state, &choice1, PlayerId(0), ObjectId(0)),
+            0
+        );
     }
 }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1808,14 +1808,13 @@ fn resolve_ref(
         // ballots — rather than counting distinct voters — is the consequence of
         // CR 701.38d: a player granted multiple votes casts multiple ballots, so
         // a single player can contribute more than one to a choice's tally.
-        QuantityRef::VoteCount { choice_index } => i32::try_from(
+        QuantityRef::VoteCount { choice_index } => usize_to_i32_saturating(
             state
                 .last_vote_ballots
                 .iter()
                 .filter(|(_, ballot_choice)| *ballot_choice == *choice_index)
                 .count(),
-        )
-        .unwrap_or(i32::MAX),
+        ),
         // CR 305.6: Count distinct basic land types among lands controlled by
         // the referenced player. Domain counts distinct land subtypes, not
         // lands, so multiple Forests still contribute one.

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -409,18 +409,31 @@ pub(super) fn try_parse_put_counter<'a>(
                 remainder = after_clause.trim_start();
             }
             Err(_) => {
-                // CR 122.1 + CR 608.2c: A "a number of {type} counters" body with
-                // no in-line "equal to {qty}" clause carries its count externally
-                // (e.g. a vote-tally clause binds it via `Effect::count_expr_mut`).
-                // Emit the same survivable `Variable { "count" }` placeholder the
-                // token path uses (token.rs `parse_token_count` "a number of"
-                // branch) instead of returning None, so the PutCounter/
-                // PutCounterAll effect still builds and is available for the
-                // external bind. An unbound `Variable { "count" }` resolves to 0
-                // at runtime (quantity.rs `resolve_ref` — no `last_named_choice`),
-                // so leaving it unbound is inert rather than wrong-count; the
-                // external bind is what gives it meaning. Symmetric with the
-                // token path's ungated placeholder.
+                // CR 122.1 + CR 608.2c: Emit the survivable `Variable { "count" }`
+                // placeholder ONLY when there is no in-line "equal to {qty}" clause
+                // — i.e. the count is carried externally (a vote-tally head whose
+                // "equal to ... votes" suffix was stripped before parsing). Then
+                // the PutCounter/PutCounterAll effect still builds and is available
+                // for the external bind (`Effect::count_expr_mut`); an unbound
+                // `Variable { "count" }` resolves to 0 (quantity.rs `resolve_ref`),
+                // so it is inert until bound. Symmetric with the token path's
+                // "a number of" placeholder, which is likewise only reached when
+                // no inline count was found.
+                //
+                // If an "equal to" clause IS present but its quantity failed to
+                // parse, fall through (return None) to preserve prior dispatch.
+                // Emitting a placeholder here would bind a wrong 0-count AND orphan
+                // the unparsed quantity / trailing conditional as a swallowed
+                // clause — the regression this guard prevents: Drizzt Do'Urden
+                // ("...equal to the difference") and Jared Carthalion ("...equal to
+                // the number of colors it is") left their following intervening-if
+                // / conditional clauses swallowed (Condition_If) when the count
+                // silently became a placeholder.
+                if nom_on_lower(trimmed, trimmed, |i| value((), tag("equal to ")).parse(i))
+                    .is_some()
+                {
+                    return None;
+                }
                 count_expr = QuantityExpr::Ref {
                     qty: QuantityRef::Variable {
                         name: "count".to_string(),

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -399,13 +399,35 @@ pub(super) fn try_parse_put_counter<'a>(
     // the clause wasn't found before "on {target}" and must appear here.
     if dynamic_deferred {
         let trimmed = remainder.trim_start();
-        let (after_clause, qty) = nom_quantity::parse_equal_to(trimmed).ok()?;
-        count_expr = if rebind_deferred_to_placement_object {
-            rebind_post_target_counter_quantity(qty, trimmed, &target)
-        } else {
-            qty
-        };
-        remainder = after_clause.trim_start();
+        match nom_quantity::parse_equal_to(trimmed) {
+            Ok((after_clause, qty)) => {
+                count_expr = if rebind_deferred_to_placement_object {
+                    rebind_post_target_counter_quantity(qty, trimmed, &target)
+                } else {
+                    qty
+                };
+                remainder = after_clause.trim_start();
+            }
+            Err(_) => {
+                // CR 122.1 + CR 608.2c: A "a number of {type} counters" body with
+                // no in-line "equal to {qty}" clause carries its count externally
+                // (e.g. a vote-tally clause binds it via `Effect::count_expr_mut`).
+                // Emit the same survivable `Variable { "count" }` placeholder the
+                // token path uses (token.rs `parse_token_count` "a number of"
+                // branch) instead of returning None, so the PutCounter/
+                // PutCounterAll effect still builds and is available for the
+                // external bind. An unbound `Variable { "count" }` resolves to 0
+                // at runtime (quantity.rs `resolve_ref` — no `last_named_choice`),
+                // so leaving it unbound is inert rather than wrong-count; the
+                // external bind is what gives it meaning. Symmetric with the
+                // token path's ungated placeholder.
+                count_expr = QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "count".to_string(),
+                    },
+                };
+            }
+        }
     }
 
     if let Some((for_each_count, after_suffix)) = parse_counter_for_each_suffix(remainder) {
@@ -1366,6 +1388,39 @@ mod tests {
             .properties
             .iter()
             .any(|p| matches!(p, FilterProp::Named { name } if name.eq_ignore_ascii_case("Gruff Triplets"))));
+    }
+
+    /// CR 122.1 + CR 608.2c: a "put a number of {type} counters on {target}"
+    /// body with NO in-line "equal to {qty}" clause carries its count
+    /// externally (a vote-tally clause binds it later). The dynamic-deferred
+    /// branch must still build the `PutCounter` effect with the survivable
+    /// `Variable { "count" }` placeholder instead of returning `None` (which
+    /// would lose the effect). This is the load-bearing parser change for the
+    /// Emissary Green counter clause. An unbound `Variable { "count" }`
+    /// resolves to 0, so the placeholder is inert until the external bind.
+    #[test]
+    fn put_counter_a_number_of_no_equal_to_emits_count_placeholder() {
+        use crate::types::ability::{QuantityExpr, QuantityRef};
+        let text = "put a number of +1/+1 counters on each creature you control";
+        let (effect, _, _) = try_parse_put_counter(text, text, &mut default_ctx()).expect("parse");
+        let Effect::PutCounter {
+            counter_type,
+            count,
+            ..
+        } = effect
+        else {
+            panic!("expected PutCounter, got {effect:?}");
+        };
+        assert_eq!(counter_type, CounterType::Plus1Plus1);
+        assert_eq!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "count".to_string(),
+                },
+            },
+            "deferred 'a number of' with no 'equal to' must emit the survivable count placeholder"
+        );
     }
 
     /// CR 122.1 + CR 208.3: target-then-count ordering with NO "a number of"

--- a/crates/engine/src/parser/oracle_vote.rs
+++ b/crates/engine/src/parser/oracle_vote.rs
@@ -27,7 +27,8 @@ use nom::combinator::{map, success, value};
 use nom::Parser;
 
 use crate::types::ability::{
-    AbilityDefinition, AbilityKind, ControllerRef, Effect, PlayerFilter, VoterScope,
+    AbilityDefinition, AbilityKind, ControllerRef, Effect, PlayerFilter, QuantityExpr, QuantityRef,
+    VoterScope,
 };
 
 use super::oracle_effect::parse_effect_chain_with_context;
@@ -99,14 +100,30 @@ pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityD
                 parse_effect_chain_with_context(effect_text, kind, &mut ParseContext::default());
             (rest, idx, parsed, who_chose)
         } else {
-            // CR 701.38 + CR 122.1: aggregate-tally shape (Emissary Green). The
-            // per-vote multiplier folds into the sub-effect's fixed count, and
-            // the Vote resolver runs each per-choice sub-effect once per tallied
-            // vote, so `count = multiplier` yields `multiplier × votes` total.
-            let (rest, choice, rewritten) = parse_aggregate_tally_clause(walk, &choices)?;
+            // CR 701.38 + CR 122.1 + CR 608.2c: aggregate-tally shape (Emissary
+            // Green). The effect body carries a placeholder count slot (the
+            // "a number of <X>" form); we parse it, then bind that slot to a
+            // typed `QuantityRef::VoteCount { choice_index }` scaled by the
+            // per-vote multiplier. The Vote resolver runs an aggregate-count
+            // body exactly ONCE and `resolve_ref` sums the full tally, so the
+            // bound count yields `multiplier × votes` total without re-running
+            // the body per vote.
+            let (rest, choice, head, multiplier) = parse_aggregate_tally_clause(walk, &choices)?;
             let idx = choices.iter().position(|c| c == &choice)?;
-            let parsed =
-                parse_effect_chain_with_context(&rewritten, kind, &mut ParseContext::default());
+            let mut parsed =
+                parse_effect_chain_with_context(head, kind, &mut ParseContext::default());
+            // CR 608.2c: bind the tally count into the parsed effect's count
+            // slot. A tally body whose effect exposes no bindable count slot
+            // (GAP 2 strict-failure) must NOT silently mis-parse with a wrong
+            // count — `?` falls through by returning None so dispatch can try
+            // another shape or emit a diagnostic, rather than producing an
+            // effect with the wrong (placeholder) count.
+            *parsed.effect.count_expr_mut()? = QuantityExpr::Ref {
+                qty: QuantityRef::VoteCount {
+                    choice_index: idx as u8,
+                },
+            }
+            .scaled_by(multiplier);
             (rest, idx, parsed, false)
         };
         if slots[idx].is_some() {
@@ -407,18 +424,21 @@ fn read_effect_until_next_clause(input: &str) -> (&str, &str) {
 ///   * "You create a number of Treasure tokens equal to twice the number of profit votes."
 ///   * "Put a number of +1/+1 counters on each creature you control equal to the number of security votes."
 ///
-/// The per-vote multiplier ("twice" → 2, "<n> times" → n, absent → 1) folds
-/// into the sub-effect's fixed count. The Vote resolver runs each per-choice
-/// sub-effect once per tallied vote (CR 701.38), so a `count = multiplier`
-/// sub-effect produces `multiplier × votes` total — exactly the aggregate the
-/// Oracle text describes.
+/// The per-vote multiplier ("twice" → 2, "<n> times" → n, absent → 1) scales
+/// the typed `QuantityRef::VoteCount` the caller binds into the effect's count
+/// slot. The Vote resolver runs an aggregate-count body once and `resolve_ref`
+/// sums the full tally (CR 701.38 + CR 608.2c), so the bound count yields
+/// `multiplier × votes` total — exactly the aggregate the Oracle text describes.
 ///
-/// Returns `(remainder_after_sentence, choice_lowercase, rewritten_effect_text)`.
-/// `None` when the clause is not in this shape, letting the caller fall through.
+/// Returns `(remainder_after_sentence, choice_lowercase, effect_head, multiplier)`,
+/// where `effect_head` is the effect text preceding the "equal to ... votes"
+/// tally suffix (still carrying its "a number of <X>" placeholder count, which
+/// the caller rebinds). `None` when the clause is not in this shape, letting the
+/// caller fall through.
 fn parse_aggregate_tally_clause<'a>(
     input: &'a str,
     choices: &[String],
-) -> Option<(&'a str, String, String)> {
+) -> Option<(&'a str, String, &'a str, u32)> {
     let (sentence, rest) = read_sentence(input);
     // Locate "equal to [<multiplier>] the number of <choice> votes" at a word
     // boundary via a single combinator; `scan_preceded` returns the head before
@@ -444,8 +464,7 @@ fn parse_aggregate_tally_clause<'a>(
     if !tail.trim().is_empty() {
         return None;
     }
-    let rewritten = rewrite_a_number_of(head.trim_end(), multiplier)?;
-    Some((rest, choice, rewritten))
+    Some((rest, choice, head.trim_end(), multiplier))
 }
 
 /// Parse the optional per-vote multiplier preceding "the number of <choice>
@@ -459,17 +478,6 @@ fn parse_tally_multiplier(input: &str) -> OracleResult<'_, u32> {
         success(1u32),
     ))
     .parse(input)
-}
-
-/// Rewrite an effect head of the form `"...a number of <X>..."` into the
-/// fixed-count imperative `"...<count> <X>..."`, which the standard effect
-/// chain parser maps to a `Fixed` count. Returns `None` when the head lacks the
-/// "a number of " quantity phrase (i.e. not an aggregate-tally effect).
-fn rewrite_a_number_of(head: &str, count: u32) -> Option<String> {
-    let (before, _, after) = scan_preceded(head, |i| {
-        tag_no_case::<_, _, OracleError<'_>>("a number of ").parse(i)
-    })?;
-    Some(format!("{before}{count} {after}"))
 }
 
 /// Split the input at the first period: returns `(sentence, remainder)` with
@@ -762,15 +770,17 @@ mod tests {
         assert!(parse_vote_block("Draw a card.", AbilityKind::Spell).is_none());
     }
 
-    /// CR 701.38 + CR 122.1: Emissary Green's aggregate-tally vote. The
-    /// per-choice effects reference the vote count via "a number of … equal to
-    /// [twice] the number of <choice> votes" rather than the classic "For each
-    /// <choice> vote, …" repetition. Each per-choice sub-effect must carry a
-    /// fixed count equal to the multiplier (the Vote resolver runs it once per
-    /// tallied vote), and must NOT be VotedFor-scoped (controller-performed).
+    /// CR 701.38 + CR 122.1 + CR 608.2c: Emissary Green's aggregate-tally vote.
+    /// The per-choice effects reference the vote count via "a number of … equal
+    /// to [twice] the number of <choice> votes" rather than the classic "For
+    /// each <choice> vote, …" repetition. Each per-choice sub-effect's count
+    /// slot is bound to a typed `QuantityRef::VoteCount { choice_index }` (scaled
+    /// by the per-vote multiplier), and must NOT be VotedFor-scoped
+    /// (controller-performed). The Vote resolver runs an aggregate-count body
+    /// once; `resolve_ref` sums the full tally so `multiplier × votes` results.
     #[test]
     fn parses_emissary_green_aggregate_vote_block() {
-        use crate::types::ability::QuantityExpr;
+        use crate::types::ability::{QuantityExpr, QuantityRef};
         let text = "starting with you, each player votes for profit or security. \
                     You create a number of Treasure tokens equal to twice the number of profit votes. \
                     Put a number of +1/+1 counters on each creature you control equal to the number of security votes.";
@@ -787,20 +797,35 @@ mod tests {
                 assert_eq!(voter_scope, VoterScope::AllPlayers);
                 assert_eq!(per_choice_effect.len(), 2);
 
-                // profit → "create Treasure tokens", count = 2 (the "twice"
-                // multiplier), so each profit vote makes 2 Treasures.
+                // profit → "create Treasure tokens", count = 2 × VoteCount{0}
+                // (the "twice" multiplier scales the profit tally). scaled_by(2)
+                // wraps the dynamic ref in Multiply.
                 match &*per_choice_effect[0].effect {
                     Effect::Token { name, count, .. } => {
                         assert_eq!(name, "Treasure");
-                        assert_eq!(*count, QuantityExpr::Fixed { value: 2 });
+                        assert_eq!(
+                            *count,
+                            QuantityExpr::Multiply {
+                                factor: 2,
+                                inner: Box::new(QuantityExpr::Ref {
+                                    qty: QuantityRef::VoteCount { choice_index: 0 },
+                                }),
+                            }
+                        );
                     }
                     other => panic!("expected profit → Token, got {:?}", other),
                 }
                 // security → "put +1/+1 counters on each creature you control",
-                // count = 1, so each security vote adds one counter to each.
+                // count = VoteCount{1} (multiplier 1 is identity, so scaled_by
+                // returns the bare ref).
                 match &*per_choice_effect[1].effect {
                     Effect::PutCounterAll { count, target, .. } => {
-                        assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+                        assert_eq!(
+                            *count,
+                            QuantityExpr::Ref {
+                                qty: QuantityRef::VoteCount { choice_index: 1 },
+                            }
+                        );
                         match target {
                             TargetFilter::Typed(tf) => {
                                 assert_eq!(tf.controller, Some(ControllerRef::You));
@@ -844,24 +869,6 @@ mod tests {
         let (rest, m) = parse_tally_multiplier("the number of security votes").unwrap();
         assert_eq!(m, 1);
         assert_eq!(rest, "the number of security votes");
-    }
-
-    #[test]
-    fn rewrite_a_number_of_inserts_fixed_count() {
-        assert_eq!(
-            rewrite_a_number_of("You create a number of Treasure tokens", 2).unwrap(),
-            "You create 2 Treasure tokens"
-        );
-        assert_eq!(
-            rewrite_a_number_of(
-                "Put a number of +1/+1 counters on each creature you control",
-                1
-            )
-            .unwrap(),
-            "Put 1 +1/+1 counters on each creature you control"
-        );
-        // No "a number of " phrase → not an aggregate-tally effect.
-        assert!(rewrite_a_number_of("create a Treasure token", 1).is_none());
     }
 
     /// CR 608.2c + CR 701.38: Documented parser gap (R5 in the

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -13866,6 +13866,32 @@ mod tests {
         };
         assert_eq!(draw.count_expr(), Some(&fixed(2)));
 
+        // Token and mass-counter vote tally forms bind through the same count slot.
+        let token = Effect::Token {
+            name: "Treasure".to_string(),
+            power: PtValue::Fixed(0),
+            toughness: PtValue::Fixed(0),
+            types: vec!["Artifact".to_string()],
+            colors: Vec::new(),
+            keywords: Vec::new(),
+            tapped: false,
+            count: fixed(4),
+            owner: default_target_filter_controller(),
+            attach_to: None,
+            enters_attacking: false,
+            supertypes: Vec::new(),
+            static_abilities: Vec::new(),
+            enter_with_counters: Vec::new(),
+        };
+        assert_eq!(token.count_expr(), Some(&fixed(4)));
+
+        let counters = Effect::PutCounterAll {
+            counter_type: CounterType::Plus1Plus1,
+            count: fixed(6),
+            target: default_target_filter_any(),
+        };
+        assert_eq!(counters.count_expr(), Some(&fixed(6)));
+
         // `amount:` family — DealDamage exposes its amount through the same API.
         let damage = Effect::DealDamage {
             amount: fixed(5),

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3698,6 +3698,13 @@ pub enum QuantityRef {
     /// dual because counters (CR 122.1) and colors (CR 105/106) are distinct
     /// rule sections the engine resolves independently.
     DistinctCounterKindsAmong { filter: TargetFilter },
+    /// CR 701.38 + CR 608.2c: Number of votes tallied for this choice index,
+    /// summed from `state.last_vote_ballots`. Counts votes, not voters — a
+    /// consequence of CR 701.38d (a player granted multiple votes casts
+    /// multiple ballots, so a single player can contribute more than one to
+    /// the tally). Used by vote-tally effects ("for each X vote, do Y") whose
+    /// per-choice count is bound to this ref during vote-block parsing.
+    VoteCount { choice_index: u8 },
 }
 
 /// CR 107.1a: Rounding direction for fractional Oracle-text expressions.
@@ -4114,6 +4121,35 @@ impl QuantityExpr {
             } => inner.contains_x(),
             QuantityExpr::Sum { exprs } => exprs.iter().any(QuantityExpr::contains_x),
             QuantityExpr::Difference { left, right } => left.contains_x() || right.contains_x(),
+            QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => false,
+        }
+    }
+
+    /// Returns true if this expression resolves through a
+    /// `QuantityRef::VoteCount { .. }` anywhere in its tree — i.e. its value
+    /// is a vote tally bound during vote-block parsing. Mirrors `contains_x`:
+    /// the match is exhaustive so a new `QuantityExpr` variant forces every
+    /// consumer to reconsider vote-tally dependence rather than silently
+    /// defaulting to false. Used by `Effect::resolve_tally` (CR 701.38) to
+    /// decide whether a tally body resolves once as an aggregate (the count
+    /// ref sums the whole tally) versus once per vote.
+    pub fn contains_vote_count(&self) -> bool {
+        match self {
+            QuantityExpr::Ref {
+                qty: QuantityRef::VoteCount { .. },
+            } => true,
+            QuantityExpr::Offset { inner, .. }
+            | QuantityExpr::ClampMin { inner, .. }
+            | QuantityExpr::Multiply { inner, .. }
+            | QuantityExpr::DivideRounded { inner, .. }
+            | QuantityExpr::UpTo { max: inner }
+            | QuantityExpr::Power {
+                exponent: inner, ..
+            } => inner.contains_vote_count(),
+            QuantityExpr::Sum { exprs } => exprs.iter().any(QuantityExpr::contains_vote_count),
+            QuantityExpr::Difference { left, right } => {
+                left.contains_vote_count() || right.contains_vote_count()
+            }
             QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => false,
         }
     }
@@ -8846,6 +8882,409 @@ impl Effect {
             // CR 701.23a: SearchLibrary has an optional player target for opponent search.
             Effect::SearchLibrary { target_player, .. } => target_player.as_ref(),
             Effect::ChooseDrawnThisTurnPayOrTopdeck { player, .. } => Some(player),
+        }
+    }
+
+    /// CR 107.3 + CR 608.2c: Returns the `QuantityExpr` carrying this effect's
+    /// primary count/amount, for the full class of count- and amount-bearing
+    /// effects (token creation, counters, draws, damage, mill, discard, etc.).
+    /// Returns `None` for effects whose magnitude is not a `QuantityExpr`
+    /// (fixed structural effects, choices, zone-level operations).
+    ///
+    /// Single authority used to bind and inspect a dynamic count after an
+    /// effect body has been parsed — e.g. vote-tally parsing binds the
+    /// per-choice `QuantityRef::VoteCount` into this slot (`count_expr_mut`),
+    /// and `Effect::resolve_tally` reads it back (`count_expr`) to decide
+    /// aggregate vs. per-vote resolution.
+    ///
+    /// Exhaustive match — no wildcards — so the compiler forces an update when
+    /// a new count/amount-bearing Effect variant is added.
+    pub fn count_expr(&self) -> Option<&QuantityExpr> {
+        match self {
+            // --- Effects whose magnitude is a `count: QuantityExpr` ---
+            Effect::Draw { count, .. }
+            | Effect::Token { count, .. }
+            | Effect::AddCounter { count, .. }
+            | Effect::Sacrifice { count, .. }
+            | Effect::Mill { count, .. }
+            | Effect::Scry { count, .. }
+            | Effect::Dig { count, .. }
+            | Effect::Surveil { count, .. }
+            | Effect::CopyTokenOf { count, .. }
+            | Effect::PutCounter { count, .. }
+            | Effect::PutCounterAll { count, .. }
+            | Effect::Discard { count, .. }
+            | Effect::SearchLibrary { count, .. }
+            | Effect::SearchOutsideGame { count, .. }
+            | Effect::ExileTop { count, .. }
+            | Effect::AddPendingETBCounters { count, .. }
+            | Effect::RollDie { count, .. }
+            | Effect::FlipCoins { count, .. }
+            | Effect::GivePlayerCounter { count, .. }
+            | Effect::PutAtLibraryPosition { count, .. }
+            | Effect::ChooseDrawnThisTurnPayOrTopdeck { count, .. }
+            | Effect::Manifest { count, .. }
+            | Effect::SkipNextTurn { count, .. }
+            | Effect::SkipNextStep { count, .. }
+            | Effect::AdditionalPhase { count, .. }
+            | Effect::Incubate { count, .. }
+            | Effect::Amass { count, .. }
+            | Effect::Monstrosity { count, .. }
+            | Effect::Renown { count, .. }
+            | Effect::Bolster { count, .. }
+            | Effect::Adapt { count, .. }
+            | Effect::Seek { count, .. } => Some(count),
+
+            // --- Effects whose magnitude is an `amount: QuantityExpr` ---
+            Effect::ChangeSpeed { amount, .. }
+            | Effect::DealDamage { amount, .. }
+            | Effect::GainLife { amount, .. }
+            | Effect::LoseLife { amount, .. }
+            | Effect::DamageAll { amount, .. }
+            | Effect::DamageEachPlayer { amount, .. }
+            | Effect::GainEnergy { amount, .. }
+            | Effect::GrantExtraLoyaltyActivations { amount, .. }
+            | Effect::SetLifeTotal { amount, .. }
+            | Effect::Intensify { amount, .. } => Some(amount),
+
+            // --- Effects whose count/amount is an `Option<QuantityExpr>` ---
+            Effect::BounceAll { count, .. }
+            | Effect::MoveCounters { count, .. }
+            | Effect::RevealHand { count, .. } => count.as_ref(),
+
+            // --- Effects with no QuantityExpr count/amount ---
+            Effect::StartYourEngines { .. }
+            | Effect::Pump { .. }
+            | Effect::PairWith { .. }
+            | Effect::Destroy { .. }
+            | Effect::Regenerate { .. }
+            | Effect::Counter { .. }
+            | Effect::CounterAll { .. }
+            | Effect::Tap { .. }
+            | Effect::Untap { .. }
+            | Effect::TapAll { .. }
+            | Effect::UntapAll { .. }
+            | Effect::RemoveCounter { .. }
+            | Effect::DiscardCard { .. }
+            | Effect::ChangeZone { .. }
+            | Effect::ChangeZoneAll { .. }
+            | Effect::GainControl { .. }
+            | Effect::ControlNextTurn { .. }
+            | Effect::Attach { .. }
+            | Effect::UnattachAll { .. }
+            | Effect::Fight { .. }
+            | Effect::Bounce { .. }
+            | Effect::Explore
+            | Effect::ExploreAll { .. }
+            | Effect::Investigate
+            | Effect::Tribute { .. }
+            | Effect::TimeTravel
+            | Effect::BecomeMonarch
+            | Effect::Proliferate
+            | Effect::ProliferateTarget { .. }
+            | Effect::EndTheTurn
+            | Effect::EndCombatPhase
+            | Effect::Populate
+            | Effect::Clash
+            | Effect::Vote { .. }
+            | Effect::SeparateIntoPiles { .. }
+            | Effect::SwitchPT { .. }
+            | Effect::CopySpell { .. }
+            | Effect::EpicCopy { .. }
+            | Effect::CastCopyOfCard { .. }
+            | Effect::Myriad
+            | Effect::Encore
+            | Effect::ExileHaunting { .. }
+            | Effect::HideawayConceal { .. }
+            | Effect::CopyTokenBlockingAttacker { .. }
+            | Effect::BecomeCopy { .. }
+            | Effect::ChooseCard { .. }
+            | Effect::MultiplyCounter { .. }
+            | Effect::DoublePT { .. }
+            | Effect::DoublePTAll { .. }
+            | Effect::Animate { .. }
+            | Effect::ReturnAsAura { .. }
+            | Effect::RegisterBending { .. }
+            | Effect::GenericEffect { .. }
+            | Effect::PumpAll { .. }
+            | Effect::DestroyAll { .. }
+            | Effect::GoadAll { .. }
+            | Effect::Goad { .. }
+            | Effect::Detain { .. }
+            | Effect::ExtraTurn { .. }
+            | Effect::Transform { .. }
+            | Effect::RevealTop { .. }
+            | Effect::Reveal { .. }
+            | Effect::TargetOnly { .. }
+            | Effect::Suspect { .. }
+            | Effect::Connive { .. }
+            | Effect::PhaseOut { .. }
+            | Effect::PhaseIn { .. }
+            | Effect::ForceBlock { .. }
+            | Effect::ForceAttack { .. }
+            | Effect::BecomePrepared { .. }
+            | Effect::BecomeUnprepared { .. }
+            | Effect::CastFromZone { .. }
+            | Effect::PreventDamage { .. }
+            | Effect::Exploit { .. }
+            | Effect::LoseAllPlayerCounters { .. }
+            | Effect::PutOnTopOrBottom { .. }
+            | Effect::Double { .. }
+            | Effect::GiveControl { .. }
+            | Effect::RemoveFromCombat { .. }
+            | Effect::ChangeTargets { .. }
+            | Effect::AddRestriction { .. }
+            | Effect::AddTargetReplacement { .. }
+            | Effect::BlightEffect { .. }
+            | Effect::Cascade
+            | Effect::Choose { .. }
+            | Effect::ChooseAndSacrificeRest { .. }
+            | Effect::ChooseDamageSource { .. }
+            | Effect::ChooseFromZone { .. }
+            | Effect::ChooseObjectsIntoTrackedSet { .. }
+            | Effect::ChooseOneOf { .. }
+            | Effect::Cleanup { .. }
+            | Effect::CollectEvidence { .. }
+            | Effect::Conjure { .. }
+            | Effect::CreateDamageReplacement { .. }
+            | Effect::CreateDelayedTrigger { .. }
+            | Effect::CreateEmblem { .. }
+            | Effect::Discover { .. }
+            | Effect::DraftFromSpellbook { .. }
+            | Effect::Endure { .. }
+            | Effect::ExchangeControl { .. }
+            | Effect::ExchangeLifeWithStat { .. }
+            | Effect::ExileFromTopUntil { .. }
+            | Effect::FlipCoin { .. }
+            | Effect::FlipCoinUntilLose { .. }
+            | Effect::Forage
+            | Effect::FreeCastFromZones { .. }
+            | Effect::GiftDelivery { .. }
+            | Effect::GrantCastingPermission { .. }
+            | Effect::GrantNextSpellAbility { .. }
+            | Effect::Learn
+            | Effect::LoseTheGame { .. }
+            | Effect::MadnessCast { .. }
+            | Effect::Mana { .. }
+            | Effect::ManifestDread
+            | Effect::MiracleCast { .. }
+            | Effect::OpenAttractions { .. }
+            | Effect::PayCost { .. }
+            | Effect::ProcessRadCounters
+            | Effect::ReduceNextSpellCost { .. }
+            | Effect::RevealFromHand { .. }
+            | Effect::RevealUntil { .. }
+            | Effect::RingTemptsYou
+            | Effect::Ripple { .. }
+            | Effect::RollToVisitAttractions
+            | Effect::RuntimeHandled { .. }
+            | Effect::SetClassLevel { .. }
+            | Effect::SetDayNight { .. }
+            | Effect::Shuffle { .. }
+            | Effect::SolveCase
+            | Effect::Specialize
+            | Effect::TakeTheInitiative
+            | Effect::Unimplemented { .. }
+            | Effect::VentureInto { .. }
+            | Effect::VentureIntoDungeon
+            | Effect::WinTheGame { .. } => None,
+        }
+    }
+
+    /// Mutable counterpart of [`Effect::count_expr`]. Returns a mutable handle
+    /// to this effect's count/amount `QuantityExpr` so callers can rebind it
+    /// after the effect body has been parsed (vote-tally binding writes the
+    /// per-choice `QuantityRef::VoteCount` here). Exhaustive — mirrors
+    /// `count_expr` arm-for-arm.
+    pub fn count_expr_mut(&mut self) -> Option<&mut QuantityExpr> {
+        match self {
+            // --- Effects whose magnitude is a `count: QuantityExpr` ---
+            Effect::Draw { count, .. }
+            | Effect::Token { count, .. }
+            | Effect::AddCounter { count, .. }
+            | Effect::Sacrifice { count, .. }
+            | Effect::Mill { count, .. }
+            | Effect::Scry { count, .. }
+            | Effect::Dig { count, .. }
+            | Effect::Surveil { count, .. }
+            | Effect::CopyTokenOf { count, .. }
+            | Effect::PutCounter { count, .. }
+            | Effect::PutCounterAll { count, .. }
+            | Effect::Discard { count, .. }
+            | Effect::SearchLibrary { count, .. }
+            | Effect::SearchOutsideGame { count, .. }
+            | Effect::ExileTop { count, .. }
+            | Effect::AddPendingETBCounters { count, .. }
+            | Effect::RollDie { count, .. }
+            | Effect::FlipCoins { count, .. }
+            | Effect::GivePlayerCounter { count, .. }
+            | Effect::PutAtLibraryPosition { count, .. }
+            | Effect::ChooseDrawnThisTurnPayOrTopdeck { count, .. }
+            | Effect::Manifest { count, .. }
+            | Effect::SkipNextTurn { count, .. }
+            | Effect::SkipNextStep { count, .. }
+            | Effect::AdditionalPhase { count, .. }
+            | Effect::Incubate { count, .. }
+            | Effect::Amass { count, .. }
+            | Effect::Monstrosity { count, .. }
+            | Effect::Renown { count, .. }
+            | Effect::Bolster { count, .. }
+            | Effect::Adapt { count, .. }
+            | Effect::Seek { count, .. } => Some(count),
+
+            // --- Effects whose magnitude is an `amount: QuantityExpr` ---
+            Effect::ChangeSpeed { amount, .. }
+            | Effect::DealDamage { amount, .. }
+            | Effect::GainLife { amount, .. }
+            | Effect::LoseLife { amount, .. }
+            | Effect::DamageAll { amount, .. }
+            | Effect::DamageEachPlayer { amount, .. }
+            | Effect::GainEnergy { amount, .. }
+            | Effect::GrantExtraLoyaltyActivations { amount, .. }
+            | Effect::SetLifeTotal { amount, .. }
+            | Effect::Intensify { amount, .. } => Some(amount),
+
+            // --- Effects whose count/amount is an `Option<QuantityExpr>` ---
+            Effect::BounceAll { count, .. }
+            | Effect::MoveCounters { count, .. }
+            | Effect::RevealHand { count, .. } => count.as_mut(),
+
+            // --- Effects with no QuantityExpr count/amount ---
+            Effect::StartYourEngines { .. }
+            | Effect::Pump { .. }
+            | Effect::PairWith { .. }
+            | Effect::Destroy { .. }
+            | Effect::Regenerate { .. }
+            | Effect::Counter { .. }
+            | Effect::CounterAll { .. }
+            | Effect::Tap { .. }
+            | Effect::Untap { .. }
+            | Effect::TapAll { .. }
+            | Effect::UntapAll { .. }
+            | Effect::RemoveCounter { .. }
+            | Effect::DiscardCard { .. }
+            | Effect::ChangeZone { .. }
+            | Effect::ChangeZoneAll { .. }
+            | Effect::GainControl { .. }
+            | Effect::ControlNextTurn { .. }
+            | Effect::Attach { .. }
+            | Effect::UnattachAll { .. }
+            | Effect::Fight { .. }
+            | Effect::Bounce { .. }
+            | Effect::Explore
+            | Effect::ExploreAll { .. }
+            | Effect::Investigate
+            | Effect::Tribute { .. }
+            | Effect::TimeTravel
+            | Effect::BecomeMonarch
+            | Effect::Proliferate
+            | Effect::ProliferateTarget { .. }
+            | Effect::EndTheTurn
+            | Effect::EndCombatPhase
+            | Effect::Populate
+            | Effect::Clash
+            | Effect::Vote { .. }
+            | Effect::SeparateIntoPiles { .. }
+            | Effect::SwitchPT { .. }
+            | Effect::CopySpell { .. }
+            | Effect::EpicCopy { .. }
+            | Effect::CastCopyOfCard { .. }
+            | Effect::Myriad
+            | Effect::Encore
+            | Effect::ExileHaunting { .. }
+            | Effect::HideawayConceal { .. }
+            | Effect::CopyTokenBlockingAttacker { .. }
+            | Effect::BecomeCopy { .. }
+            | Effect::ChooseCard { .. }
+            | Effect::MultiplyCounter { .. }
+            | Effect::DoublePT { .. }
+            | Effect::DoublePTAll { .. }
+            | Effect::Animate { .. }
+            | Effect::ReturnAsAura { .. }
+            | Effect::RegisterBending { .. }
+            | Effect::GenericEffect { .. }
+            | Effect::PumpAll { .. }
+            | Effect::DestroyAll { .. }
+            | Effect::GoadAll { .. }
+            | Effect::Goad { .. }
+            | Effect::Detain { .. }
+            | Effect::ExtraTurn { .. }
+            | Effect::Transform { .. }
+            | Effect::RevealTop { .. }
+            | Effect::Reveal { .. }
+            | Effect::TargetOnly { .. }
+            | Effect::Suspect { .. }
+            | Effect::Connive { .. }
+            | Effect::PhaseOut { .. }
+            | Effect::PhaseIn { .. }
+            | Effect::ForceBlock { .. }
+            | Effect::ForceAttack { .. }
+            | Effect::BecomePrepared { .. }
+            | Effect::BecomeUnprepared { .. }
+            | Effect::CastFromZone { .. }
+            | Effect::PreventDamage { .. }
+            | Effect::Exploit { .. }
+            | Effect::LoseAllPlayerCounters { .. }
+            | Effect::PutOnTopOrBottom { .. }
+            | Effect::Double { .. }
+            | Effect::GiveControl { .. }
+            | Effect::RemoveFromCombat { .. }
+            | Effect::ChangeTargets { .. }
+            | Effect::AddRestriction { .. }
+            | Effect::AddTargetReplacement { .. }
+            | Effect::BlightEffect { .. }
+            | Effect::Cascade
+            | Effect::Choose { .. }
+            | Effect::ChooseAndSacrificeRest { .. }
+            | Effect::ChooseDamageSource { .. }
+            | Effect::ChooseFromZone { .. }
+            | Effect::ChooseObjectsIntoTrackedSet { .. }
+            | Effect::ChooseOneOf { .. }
+            | Effect::Cleanup { .. }
+            | Effect::CollectEvidence { .. }
+            | Effect::Conjure { .. }
+            | Effect::CreateDamageReplacement { .. }
+            | Effect::CreateDelayedTrigger { .. }
+            | Effect::CreateEmblem { .. }
+            | Effect::Discover { .. }
+            | Effect::DraftFromSpellbook { .. }
+            | Effect::Endure { .. }
+            | Effect::ExchangeControl { .. }
+            | Effect::ExchangeLifeWithStat { .. }
+            | Effect::ExileFromTopUntil { .. }
+            | Effect::FlipCoin { .. }
+            | Effect::FlipCoinUntilLose { .. }
+            | Effect::Forage
+            | Effect::FreeCastFromZones { .. }
+            | Effect::GiftDelivery { .. }
+            | Effect::GrantCastingPermission { .. }
+            | Effect::GrantNextSpellAbility { .. }
+            | Effect::Learn
+            | Effect::LoseTheGame { .. }
+            | Effect::MadnessCast { .. }
+            | Effect::Mana { .. }
+            | Effect::ManifestDread
+            | Effect::MiracleCast { .. }
+            | Effect::OpenAttractions { .. }
+            | Effect::PayCost { .. }
+            | Effect::ProcessRadCounters
+            | Effect::ReduceNextSpellCost { .. }
+            | Effect::RevealFromHand { .. }
+            | Effect::RevealUntil { .. }
+            | Effect::RingTemptsYou
+            | Effect::Ripple { .. }
+            | Effect::RollToVisitAttractions
+            | Effect::RuntimeHandled { .. }
+            | Effect::SetClassLevel { .. }
+            | Effect::SetDayNight { .. }
+            | Effect::Shuffle { .. }
+            | Effect::SolveCase
+            | Effect::Specialize
+            | Effect::TakeTheInitiative
+            | Effect::Unimplemented { .. }
+            | Effect::VentureInto { .. }
+            | Effect::VentureIntoDungeon
+            | Effect::WinTheGame { .. } => None,
         }
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -13848,6 +13848,64 @@ mod tests {
         assert!(benign_json.get("consumes_source").is_none());
     }
 
+    /// #1446: `Effect::count_expr`/`count_expr_mut` are the building block the
+    /// vote-tally assembly layer uses to bind a typed `QuantityRef::VoteCount`
+    /// into a per-choice effect's magnitude slot. Exercise the accessor directly
+    /// across all three structural families (`count:`, `amount:`,
+    /// `Option<count>`) plus a magnitude-free effect, rather than only through
+    /// the vote path, so a future single-target/draw/damage vote-tally form
+    /// binds against verified field mappings.
+    #[test]
+    fn count_expr_maps_each_magnitude_family() {
+        let fixed = |v| QuantityExpr::Fixed { value: v };
+
+        // `count:` family — Draw exposes its count, mutably and immutably.
+        let mut draw = Effect::Draw {
+            count: fixed(2),
+            target: default_target_filter_controller(),
+        };
+        assert_eq!(draw.count_expr(), Some(&fixed(2)));
+
+        // `amount:` family — DealDamage exposes its amount through the same API.
+        let damage = Effect::DealDamage {
+            amount: fixed(5),
+            target: default_target_filter_any(),
+            damage_source: None,
+        };
+        assert_eq!(damage.count_expr(), Some(&fixed(5)));
+
+        // `Option<count>` family — None when absent, Some when present.
+        let mut bounce_none = Effect::BounceAll {
+            target: default_target_filter_none(),
+            destination: None,
+            count: None,
+        };
+        assert_eq!(bounce_none.count_expr(), None);
+        assert_eq!(bounce_none.count_expr_mut(), None);
+        let bounce_some = Effect::BounceAll {
+            target: default_target_filter_none(),
+            destination: None,
+            count: Some(fixed(3)),
+        };
+        assert_eq!(bounce_some.count_expr(), Some(&fixed(3)));
+
+        // Magnitude-free effect — no count slot to bind.
+        let destroy = Effect::Destroy {
+            target: default_target_filter_any(),
+            cant_regenerate: false,
+        };
+        assert_eq!(destroy.count_expr(), None);
+
+        // The vote-layer use case: rebind the count slot to a typed VoteCount.
+        *draw.count_expr_mut().expect("Draw has a count slot") = QuantityExpr::Ref {
+            qty: QuantityRef::VoteCount { choice_index: 0 },
+        };
+        assert!(draw
+            .count_expr()
+            .expect("count slot present")
+            .contains_vote_count());
+    }
+
     #[test]
     fn per_counter_cost_delegates_categories_to_base() {
         let base = AbilityCost::Mana {


### PR DESCRIPTION
Fixes #1446.

## Problem
The aggregate vote-tally parser (`rewrite_a_number_of` in `oracle_vote.rs`) lowered *"create/put a number of X equal to [twice] the number of `<choice>` votes"* by **rewriting the Oracle string** (`format!`) and re-feeding it to the chain parser with a fixed count + `repeat_for`. That is:
- the prohibited **string-construction-for-matching** anti-pattern (CLAUDE.md);
- a one-card special case (Emissary Green) that did not generalize to the draw/damage vote-tally forms (Truth or Consequences class);
- a per-vote **fan-out** (N single events) rather than one aggregate event — which diverges under non-linear count modifiers.

## Fix — typed `QuantityRef::VoteCount`, built for the class
Add `QuantityRef::VoteCount { choice_index: u8 }`, resolved in `game/quantity.rs::resolve_ref` by **summing** `state.last_vote_ballots` for that choice — counting **votes, not voters** (a player granted multiple votes per **CR 701.38d** casts multiple ballots; summing ballots is correct, deduping voters would undercount). Distinct from `PlayerFilter::VotedFor`, which is a voter population.

The per-choice effect's count slot is bound to `Ref(VoteCount).scaled_by(multiplier)` at the **vote-block assembly layer** (the only layer that owns the choice list), so **no shared count combinator is touched and no string is constructed**. The `"twice"` multiplier composes via the existing `QuantityExpr::scaled_by` (→ `Multiply{2, Ref(VoteCount)}`).

### Changes
- **`types/ability.rs`** — `QuantityRef::VoteCount`; `QuantityExpr::contains_vote_count` (mirrors `contains_x`); exhaustive **wildcard-free** `Effect::count_expr` / `count_expr_mut` over *all* count/amount-bearing variants (45 of 180) — built for the class, not just Emissary's Token/PutCounterAll, so future single-target/draw/damage vote-tally forms bind cleanly.
- **`game/effects/vote.rs`** — `resolve_tally` `repeat_for` is now 3-way: a count referencing `VoteCount` runs **once** (one aggregate `CreateToken`/`PutCounterAll` per **CR 111.1 / 122.1**); the classic per-vote fan-out (Tivit/Capital Punishment) is preserved.
- **`parser/oracle_effect/counter.rs`** — emit the survivable `Variable{count}` placeholder when *"a number of"* counters lacks an inline *"equal to"* clause (symmetric with the existing token path), so the vote-block layer can bind the typed count.
- **`parser/oracle_vote.rs`** — retire `rewrite_a_number_of` (the `format!` rewrite); bind the typed count via `count_expr_mut`, with a strict-failure fall-through if a tally body has no bindable count slot.

## Tests & verification
- New discriminating resolver test (`vote_count_sums_ballots_not_voters`): a ledger where one player casts **two** ballots for a choice asserts the tally is **3** (votes), not 2 (voters).
- `parses_emissary_green_aggregate_vote_block` now asserts the typed AST (`Multiply{2, Ref(VoteCount{0})}` / `Ref(VoteCount{1})`); the `format!`-rewrite + its test are deleted.
- New counter-placeholder parser test.
- Full suites green locally: parser **5300/0**, quantity **518/0**, vote **39/0**, counter **30/0**; clippy `-D warnings` clean; parser-combinator gate green. **Emissary Green integration tests unchanged and passing** (end-state parity: 4 Treasures from profit×2, counters from security).

## Follow-up (post-merge)
`card-data.json` is gitignored/served from R2, so the corpus audits (`cargo coverage` / `cargo semantic-audit`) and the **Truth or Consequences** draw/damage form could not be exercised in-tree — they compile clean and are deferred to a post-merge `gen-card-data` + coverage check.

CR 701.38 / 701.38d / 608.2c / 111.1 / 122.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)