### PR TITLE
fix(engine): seed back-face loyalty counters when permanent enters transformed (CR 306.5b + CR 712.14a)

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -6581,4 +6581,106 @@ mod tests {
             "the chosen milled card moves to hand"
         );
     }
+
+    /// Regression test for issue #2382: a DFC that enters the battlefield
+    /// transformed (front face = non-PW, back face = PW with loyalty 3) must
+    /// enter with the correct loyalty counters so the layer system derives
+    /// the right loyalty and the planeswalker survives its own -1 activation.
+    #[test]
+    fn enter_transformed_seeds_back_face_loyalty_counters() {
+        use crate::game::game_object::BackFaceData;
+        use crate::types::ability::TargetRef;
+        use crate::types::card_type::{CardType, CoreType};
+        use crate::types::mana::ManaCost;
+
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Sorin of House Markov".to_string(),
+            Zone::Exile,
+        );
+        {
+            let obj = state.objects.get_mut(&obj_id).unwrap();
+            // Front face: Vampire, no loyalty
+            obj.card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec!["Vampire".to_string()],
+            };
+            obj.loyalty = None;
+            obj.base_characteristics_initialized = true;
+            // Back face: Sorin, Ravenous Neonate — planeswalker with loyalty 3
+            obj.back_face = Some(BackFaceData {
+                name: "Sorin, Ravenous Neonate".to_string(),
+                power: None,
+                toughness: None,
+                loyalty: Some(3),
+                defense: None,
+                card_types: CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Planeswalker],
+                    subtypes: vec!["Sorin".to_string()],
+                },
+                mana_cost: ManaCost::default(),
+                keywords: vec![],
+                abilities: vec![],
+                trigger_definitions: Default::default(),
+                replacement_definitions: Default::default(),
+                static_definitions: Default::default(),
+                color: vec![],
+                printed_ref: None,
+                modal: None,
+                additional_cost: None,
+                strive_cost: None,
+                casting_restrictions: vec![],
+                casting_options: vec![],
+                layout_kind: None,
+            });
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Exile),
+                destination: Zone::Battlefield,
+                target: TargetFilter::Any,
+                owner_library: false,
+                enter_transformed: true,
+                enters_under: None,
+                enter_tapped: false,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+            vec![TargetRef::Object(obj_id)],
+            obj_id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).ok();
+        crate::game::layers::flush_layers(&mut state);
+
+        let obj = state.objects.get(&obj_id).expect("object on battlefield");
+        assert_eq!(
+            obj.zone,
+            Zone::Battlefield,
+            "Sorin must be on the battlefield"
+        );
+        assert!(obj.transformed, "Sorin must show back face");
+        assert_eq!(
+            obj.counters
+                .get(&CounterType::Loyalty)
+                .copied()
+                .unwrap_or(0),
+            3,
+            "back-face loyalty counters must be seeded (issue #2382)"
+        );
+        assert_eq!(
+            obj.loyalty,
+            Some(3),
+            "layer-derived loyalty must equal the seeded loyalty counters"
+        );
+    }
 }

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -6648,7 +6648,7 @@ mod tests {
                 owner_library: false,
                 enter_transformed: true,
                 enters_under: None,
-                enter_tapped: false,
+                enter_tapped: EtbTapState::Unspecified,
                 enters_attacking: false,
                 up_to: false,
                 enter_with_counters: vec![],

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -580,10 +580,10 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
             // mutable permission list is casting-time authorization, not
             // resolution-time cast metadata.
             if let Some(obj) = state.objects.get(&entry.id) {
-                if paid_snapshot
+                let cast_transformed = paid_snapshot
                     .as_ref()
-                    .is_some_and(|snapshot| snapshot.cast_transformed)
-                {
+                    .is_some_and(|snapshot| snapshot.cast_transformed);
+                if cast_transformed {
                     if let crate::types::proposed_event::ProposedEvent::ZoneChange {
                         enter_transformed,
                         ..
@@ -598,7 +598,16 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 // the ZoneChange ProposedEvent so Doubling-Season-class
                 // AddCounter replacements (CR 614.1a) see and modify them as
                 // the replacement pipeline runs.
-                let intrinsic = super::printed_cards::intrinsic_etb_counters(obj);
+                // CR 712.14a: For cast_transformed (Craft / ExileWithAltCost) the
+                // spell is on the stack with the front face but enters as the back
+                // face — read loyalty/defense from the back face directly so the
+                // replacement pipeline sees the correct counter count.
+                let intrinsic = match (cast_transformed, obj.back_face.as_ref()) {
+                    (true, Some(back)) => {
+                        super::printed_cards::intrinsic_face_counters(back.loyalty, back.defense)
+                    }
+                    _ => super::printed_cards::intrinsic_etb_counters(obj),
+                };
                 if !intrinsic.is_empty() {
                     if let crate::types::proposed_event::ProposedEvent::ZoneChange {
                         enter_with_counters,

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -2057,6 +2057,7 @@ pub(crate) fn create_warp_delayed_trigger(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::game_object::BackFaceData;
     use crate::game::zones::create_object;
     use crate::types::ability::{
         CostPaidObjectSnapshot, Effect, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef,
@@ -2069,6 +2070,38 @@ mod tests {
 
     fn setup() -> GameState {
         GameState::new_two_player(42)
+    }
+
+    fn back_face_data(
+        name: &str,
+        core_type: CoreType,
+        loyalty: Option<u32>,
+        defense: Option<u32>,
+    ) -> BackFaceData {
+        let mut card_types = crate::types::card_type::CardType::default();
+        card_types.core_types.push(core_type);
+        BackFaceData {
+            name: name.to_string(),
+            power: None,
+            toughness: None,
+            loyalty,
+            defense,
+            card_types,
+            mana_cost: Default::default(),
+            keywords: vec![],
+            abilities: vec![],
+            trigger_definitions: Default::default(),
+            replacement_definitions: Default::default(),
+            static_definitions: Default::default(),
+            color: vec![],
+            printed_ref: None,
+            modal: None,
+            additional_cost: None,
+            strive_cost: None,
+            casting_restrictions: vec![],
+            casting_options: vec![],
+            layout_kind: None,
+        }
     }
 
     fn create_aura_on_stack(state: &mut GameState, target_id: ObjectId) -> ObjectId {
@@ -6901,5 +6934,108 @@ mod tests {
         // entry resolves (mirrors the batched subject-count lifecycle).
         assert_eq!(state.die_result_this_resolution, None);
         assert_eq!(state.current_trigger_match_count, None);
+    }
+
+    /// CR 306.5b + CR 712.14a: A permanent spell cast transformed enters as its
+    /// back face, so the stack resolution path must seed loyalty counters from
+    /// that back face rather than the front-face spell object.
+    #[test]
+    fn cast_transformed_spell_seeds_back_face_loyalty_counters() {
+        let mut state = setup();
+        let spell_id = create_object(
+            &mut state,
+            CardId(623),
+            PlayerId(0),
+            "Front Creature".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&spell_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.back_face = Some(back_face_data(
+                "Back Planeswalker",
+                CoreType::Planeswalker,
+                Some(6),
+                None,
+            ));
+        }
+        state.stack_paid_facts.insert(
+            spell_id,
+            StackPaidSnapshot {
+                cast_transformed: true,
+                ..Default::default()
+            },
+        );
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(623),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+
+        let mut events = Vec::new();
+        resolve_top(&mut state, &mut events);
+
+        let obj = &state.objects[&spell_id];
+        assert_eq!(obj.zone, Zone::Battlefield);
+        assert!(obj.transformed);
+        assert_eq!(obj.counters.get(&CounterType::Loyalty).copied(), Some(6));
+        assert_eq!(obj.loyalty, Some(6));
+    }
+
+    /// CR 310.4b + CR 712.14a: The same cast-transformed stack path must use the
+    /// back face's printed defense when the resolving back face is a battle.
+    #[test]
+    fn cast_transformed_spell_seeds_back_face_defense_counters() {
+        let mut state = setup();
+        let spell_id = create_object(
+            &mut state,
+            CardId(624),
+            PlayerId(0),
+            "Front Creature".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&spell_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.back_face = Some(back_face_data(
+                "Back Siege",
+                CoreType::Battle,
+                None,
+                Some(5),
+            ));
+        }
+        state.stack_paid_facts.insert(
+            spell_id,
+            StackPaidSnapshot {
+                cast_transformed: true,
+                ..Default::default()
+            },
+        );
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(624),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+
+        let mut events = Vec::new();
+        resolve_top(&mut state, &mut events);
+
+        let obj = &state.objects[&spell_id];
+        assert_eq!(obj.zone, Zone::Battlefield);
+        assert!(obj.transformed);
+        assert_eq!(obj.counters.get(&CounterType::Defense).copied(), Some(5));
+        assert_eq!(obj.defense, Some(5));
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause:** When `Effect::ChangeZone` moves a permanent onto the battlefield with `enter_transformed: true`, intrinsic ETB counters (loyalty/defense) were seeded from the current front face before `transform_permanent` swapped to the back face. For DFC planeswalkers like Sorin, Ravenous Neonate (front: Vampire with no loyalty; back: Planeswalker with printed loyalty 3), the loyalty counter map stayed empty. The layer system re-derived `loyalty = Some(0)` from the empty map, killing the planeswalker on its own −1 activation.
- **Fix:** Add `intrinsic_etb_counters_for_back_face` in `printed_cards.rs` that reads loyalty/defense from `BackFaceData`. Use it in `execute_zone_move` (`change_zone.rs`) when `enter_transformed: true`, and in `stack.rs` for the `cast_transformed` path (Craft-type effects), so the Doubling-Season-class replacement pipeline sees the correct counters.
- **Pattern:** Covers all DFC permanents that enter the battlefield transformed via `Effect::ChangeZone` (triggered exile-and-return effects) or spell-cast Craft alternatives.

## Design

Three files changed:

- **`printed_cards.rs`** — `intrinsic_etb_counters_for_back_face(obj)`: reads `obj.back_face.loyalty` / `.defense` instead of the current face's `obj.loyalty` / `obj.defense`. Annotated CR 306.5b + CR 712.14a.
- **`change_zone.rs`** — `execute_zone_move`: branch on `enter_transformed` to call the back-face helper; the replacement pipeline now runs with the correct counter count before `transform_permanent` swaps the face.
- **`stack.rs`** — same branch on `cast_transformed` for the Craft/ExileWithAltCost-transformed spell-resolution path.

The fix is in the counter-seeding step, which is the correct point: the replacement pipeline must see the final counter value (so Doubling Season, Hardened Scales, etc. apply correctly), and that pipeline runs before the face swap.

## Tests

- **New:** `change_zone::tests::enter_transformed_seeds_back_face_loyalty_counters` — creates a DFC with a non-PW front face (Vampire, no loyalty) and a PW back face (loyalty 3), runs a `ChangeZone { enter_transformed: true }` effect, flushes layers, and asserts:
  - object is on the battlefield in transformed state
  - `counters[Loyalty] == 3`
  - `obj.loyalty == Some(3)` (layer-derived)
- All 68 existing `change_zone` tests pass.

## Verification

```
cargo test -p engine -- "enter_transformed_seeds_back_face_loyalty_counters"
# test result: ok. 1 passed; 0 failed

cargo test -p engine -- "game::effects::change_zone"
# test result: ok. 68 passed; 0 failed
```

Fixes #2382