### PR TITLE
fix: map until end of next turn duration correctly

### DIFF
--- a/crates/mtgish-import/src/convert/static_effect.rs
+++ b/crates/mtgish-import/src/convert/static_effect.rs
@@ -645,9 +645,16 @@ pub fn expiration_to_duration(exp: &Expiration) -> ConvResult<Duration> {
         // effect's controller. Player-scoped variants only convert for
         // `SelfPlayer` because the engine resolves `PlayerScope::Controller`
         // against the grantee/controller.
-        Expiration::UntilPlayersNextTurn(p)
-        | Expiration::UntilTheEndOfPlayersNextTurn(p)
-        | Expiration::UntilEndOfNextTurn(p)
+        // CR 514.2: "until the end of [your/their] next turn" — persists through
+        // that entire turn and expires at cleanup (Light Up the Stage, Reckless
+        // Impulse). Distinct from `UntilNextTurnOf`, which expires at the
+        // beginning of the next turn.
+        Expiration::UntilTheEndOfPlayersNextTurn(p) if is_self_player(p) => {
+            Duration::UntilEndOfNextTurnOf {
+                player: PlayerScope::Controller,
+            }
+        }
+        Expiration::UntilPlayersNextTurn(p) | Expiration::UntilEndOfNextTurn(p)
             if is_self_player(p) =>
         {
             Duration::UntilNextTurnOf {
@@ -1072,6 +1079,19 @@ mod tests {
             expiration_to_duration(&Expiration::UntilPlayersNextTurn(Box::new(Player::You)))
                 .unwrap(),
             Duration::UntilNextTurnOf {
+                player: PlayerScope::Controller,
+            }
+        );
+    }
+
+    #[test]
+    fn until_the_end_of_your_next_turn_lowers_to_end_of_next_turn_duration() {
+        assert_eq!(
+            expiration_to_duration(&Expiration::UntilTheEndOfPlayersNextTurn(Box::new(
+                Player::You
+            )))
+            .unwrap(),
+            Duration::UntilEndOfNextTurnOf {
                 player: PlayerScope::Controller,
             }
         );

--- a/crates/mtgish-import/src/convert/static_effect.rs
+++ b/crates/mtgish-import/src/convert/static_effect.rs
@@ -649,18 +649,16 @@ pub fn expiration_to_duration(exp: &Expiration) -> ConvResult<Duration> {
         // that entire turn and expires at cleanup (Light Up the Stage, Reckless
         // Impulse). Distinct from `UntilNextTurnOf`, which expires at the
         // beginning of the next turn.
-        Expiration::UntilTheEndOfPlayersNextTurn(p) if is_self_player(p) => {
+        Expiration::UntilTheEndOfPlayersNextTurn(p) | Expiration::UntilEndOfNextTurn(p)
+            if is_self_player(p) =>
+        {
             Duration::UntilEndOfNextTurnOf {
                 player: PlayerScope::Controller,
             }
         }
-        Expiration::UntilPlayersNextTurn(p) | Expiration::UntilEndOfNextTurn(p)
-            if is_self_player(p) =>
-        {
-            Duration::UntilNextTurnOf {
-                player: PlayerScope::Controller,
-            }
-        }
+        Expiration::UntilPlayersNextTurn(p) if is_self_player(p) => Duration::UntilNextTurnOf {
+            player: PlayerScope::Controller,
+        },
         // CR 502.1: "during your next untap step" — Π-2 parameterized
         // `UntilNextStepOf { step: Untap, player: Controller }` ends at the affected
         // permanent's controller's next untap step, matching the SelfPlayer scope.
@@ -699,7 +697,7 @@ pub fn expiration_to_duration(exp: &Expiration) -> ConvResult<Duration> {
 
 /// True when the `Player` reference resolves to the effect's own controller —
 /// the only `PlayerScope` (`Controller`) the `Duration::UntilNextTurnOf` /
-/// `UntilNextStepOf` parameterizations bind today.
+/// `UntilEndOfNextTurnOf` / `UntilNextStepOf` parameterizations bind today.
 fn is_self_player(p: &Player) -> bool {
     matches!(p, Player::You | Player::SelfPlayer | Player::ItsController)
 }
@@ -1091,6 +1089,16 @@ mod tests {
                 Player::You
             )))
             .unwrap(),
+            Duration::UntilEndOfNextTurnOf {
+                player: PlayerScope::Controller,
+            }
+        );
+    }
+
+    #[test]
+    fn until_end_of_next_turn_lowers_to_end_of_next_turn_duration() {
+        assert_eq!(
+            expiration_to_duration(&Expiration::UntilEndOfNextTurn(Box::new(Player::You))).unwrap(),
             Duration::UntilEndOfNextTurnOf {
                 player: PlayerScope::Controller,
             }


### PR DESCRIPTION
## Summary
- Split `Expiration::UntilTheEndOfPlayersNextTurn` out of the shared `UntilNextTurnOf` arm in mtgish-import's `expiration_to_duration` converter.
- Map it to `Duration::UntilEndOfNextTurnOf { player: Controller }` so play-from-exile effects (Clockwork Percussionist, Light Up the Stage, etc.) persist through the controller's entire next turn and expire at cleanup, not at the beginning of that turn.
- Add a unit test covering the new lowering.

Fixes #1300

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p mtgish-import static_effect::tests` (includes `until_the_end_of_your_next_turn_lowers_to_end_of_next_turn_duration`)
