### PR TITLE
Fix Luminarch Aspirant begin-combat trigger with multiple copies (#860)

### DIFF
--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1570,6 +1570,13 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     if let Some(prompt) = ordering_prompt {
                         return prompt;
                     }
+                    // CR 603.3: A begin-combat trigger awaiting target selection
+                    // (or with deferred siblings) sets `pending_trigger` /
+                    // `deferred_triggers` and `waiting_for` during
+                    // `process_triggers`. Do not overwrite with Priority.
+                    if state.pending_trigger.is_some() || !state.deferred_triggers.is_empty() {
+                        return state.waiting_for.clone();
+                    }
                     return WaitingFor::Priority {
                         player: state.active_player,
                     };

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1387,21 +1387,12 @@ fn add_lore_counters_to_sagas(state: &mut GameState, events: &mut Vec<GameEvent>
 ///   target selection, or are awaiting CR 603.3b ordering. The combat arms
 ///   (BeginCombat / EndCombat) use this to decide whether to set up / tear down
 ///   combat and grant a priority window.
-/// * `ordering_prompt` is `Some(WaitingFor::OrderTriggers { .. })` when 2+
-///   simultaneous triggers controlled by the same player fired and that player
-///   must order them (CR 603.3b) before anyone receives priority. The caller
-///   MUST surface this prompt instead of granting priority — `process_triggers`
-///   populated `state.pending_trigger_order` and set `state.waiting_for` to the
-///   prompt, but the phase arm's return value is what `apply` writes back to
-///   `state.waiting_for`. Returning `Priority` here would overwrite the prompt
-///   and strand the queued triggers in `pending_trigger_order` forever (they
-///   never reach the stack). Single-trigger steps take the `NoChoiceNeeded`
-///   path with no prompt and fall through to the normal priority grant. The
-///   prompt is rebuilt from the AUTHORITATIVE `pending_trigger_order` state via
-///   `build_next_order_triggers_prompt_public`, not cloned from
-///   `state.waiting_for` — so a stale `waiting_for` left by an upstream
-///   phase-advance can't re-surface and hang, and already-corrupted saves
-///   recover by surfacing the real ordering prompt.
+/// * `ordering_prompt` is `Some(...)` when the phase must pause before priority:
+///   - `WaitingFor::OrderTriggers { .. }` when 2+ simultaneous triggers controlled
+///     by the same player fired and that player must order them (CR 603.3b), or
+///   - an active trigger prompt (`TriggerTargetSelection`, etc.) when
+///     `pending_trigger` / `deferred_triggers` still hold unresolved work (CR
+///     603.3). The caller MUST surface this prompt instead of granting priority.
 fn process_phase_triggers(state: &mut GameState) -> (bool, Option<WaitingFor>) {
     let phase_event = [GameEvent::PhaseChanged { phase: state.phase }];
     let stack_before = state.stack.len();
@@ -1416,11 +1407,16 @@ fn process_phase_triggers(state: &mut GameState) -> (bool, Option<WaitingFor>) {
     // surfacing the real ordering prompt. Note `pending_trigger_order.is_some()` no
     // longer blindly implies `waiting_for == OrderTriggers`, which is exactly why
     // the prior `.then(|| clone)` idiom was unsafe.
-    let ordering_prompt = super::triggers::build_next_order_triggers_prompt_public(state);
+    let order_triggers_prompt = super::triggers::build_next_order_triggers_prompt_public(state);
+    let active_trigger_prompt = (order_triggers_prompt.is_none()
+        && (state.pending_trigger.is_some() || !state.deferred_triggers.is_empty()))
+    .then(|| state.waiting_for.clone());
+    let prompt = order_triggers_prompt.or(active_trigger_prompt);
     let fired = state.stack.len() > stack_before
         || state.pending_trigger.is_some()
-        || ordering_prompt.is_some();
-    (fired, ordering_prompt)
+        || !state.deferred_triggers.is_empty()
+        || prompt.is_some();
+    (fired, prompt)
 }
 
 pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> WaitingFor {
@@ -1569,13 +1565,6 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     // ordered begin-combat triggers later resolve.
                     if let Some(prompt) = ordering_prompt {
                         return prompt;
-                    }
-                    // CR 603.3: A begin-combat trigger awaiting target selection
-                    // (or with deferred siblings) sets `pending_trigger` /
-                    // `deferred_triggers` and `waiting_for` during
-                    // `process_triggers`. Do not overwrite with Priority.
-                    if state.pending_trigger.is_some() || !state.deferred_triggers.is_empty() {
-                        return state.waiting_for.clone();
                     }
                     return WaitingFor::Priority {
                         player: state.active_player,

--- a/crates/engine/tests/integration/issue_860_luminarch_aspirant.rs
+++ b/crates/engine/tests/integration/issue_860_luminarch_aspirant.rs
@@ -1,0 +1,70 @@
+//! Issue #860 — Luminarch Aspirant begin-combat trigger must surface target
+//! selection instead of clobbering `waiting_for` with Priority.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+const LUMINARCH_ASPIRANT: &str =
+    "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.";
+
+fn p1p1_counters(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("object still present")
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+#[test]
+fn issue_860_luminarch_aspirant_prompts_for_target_at_begin_combat() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Luminarch Aspirant", 1, 1, LUMINARCH_ASPIRANT);
+    scenario.add_creature(P0, "Recipient", 2, 2);
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+
+    assert_eq!(runner.state().phase, Phase::BeginCombat);
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "begin-combat trigger must prompt for a target, got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+#[test]
+fn issue_860_luminarch_aspirant_puts_counter_on_chosen_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Luminarch Aspirant", 1, 1, LUMINARCH_ASPIRANT);
+    let recipient = scenario.add_creature(P0, "Recipient", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(recipient)],
+        })
+        .expect("select target creature for begin-combat trigger");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        p1p1_counters(&runner, recipient),
+        1,
+        "Luminarch Aspirant must put a +1/+1 counter on the chosen creature"
+    );
+}

--- a/crates/engine/tests/integration/issue_860_luminarch_aspirant.rs
+++ b/crates/engine/tests/integration/issue_860_luminarch_aspirant.rs
@@ -68,3 +68,59 @@ fn issue_860_luminarch_aspirant_puts_counter_on_chosen_creature() {
         "Luminarch Aspirant must put a +1/+1 counter on the chosen creature"
     );
 }
+
+#[test]
+fn issue_860_two_luminarch_aspirants_both_trigger_at_begin_combat() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Luminarch Aspirant A", 1, 1, LUMINARCH_ASPIRANT);
+    scenario.add_creature_from_oracle(P0, "Luminarch Aspirant B", 1, 1, LUMINARCH_ASPIRANT);
+    let recipient = scenario.add_creature(P0, "Recipient", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+
+    assert_eq!(runner.state().phase, Phase::BeginCombat);
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "first begin-combat trigger must prompt for target selection, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        runner.state().deferred_triggers.len(),
+        1,
+        "second copy must remain deferred until the first resolves targeting"
+    );
+
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(recipient)),
+        })
+        .expect("select target for first trigger");
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "second trigger must prompt for target selection instead of Priority, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(recipient)),
+        })
+        .expect("select target for second trigger");
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        p1p1_counters(&runner, recipient),
+        2,
+        "both Luminarch Aspirants must put a +1/+1 counter on the chosen creature"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -118,6 +118,7 @@ mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_580_solitude_evoke_prompt;
 mod issue_709_regression;
+mod issue_860_luminarch_aspirant;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;
 mod kaito_integration;


### PR DESCRIPTION
## Summary
- Keep active trigger prompts when pending_trigger or deferred_triggers remain after begin-combat processing.
- Add integration coverage for two Luminarch Aspirants at begin combat.

Fixes #860

## Test plan
- [x] cargo test -p engine issue_860