### PR TITLE
feat(engine): gate enters-this-way riders on cast-variant-paid

### DIFF
--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1113,6 +1113,32 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 }
             }
 
+            // CR 702.117a: Surge-cast permanent is tagged so "if its surge cost
+            // was paid" ETB triggers (Reckless Bushwhacker, Tyrant of Valakut)
+            // can distinguish a surge cast from a hard-cast. The intervening-if
+            // re-checks at resolution (CR 603.4) and the marker must be present.
+            if casting_variant == CastingVariant::Surge {
+                if let Some(obj) = state.objects.get_mut(&entry.id) {
+                    obj.cast_variant_paid = Some((
+                        crate::types::ability::CastVariantPaid::Surge,
+                        state.turn_number,
+                    ));
+                }
+            }
+
+            // CR 702.137a: Spectacle-cast permanent is tagged so "if its
+            // spectacle cost was paid" ETB triggers (Rafter Demon) and
+            // "...instead" clauses (Rix Maadi Reveler) can distinguish a
+            // spectacle cast from a hard-cast.
+            if casting_variant == CastingVariant::Spectacle {
+                if let Some(obj) = state.objects.get_mut(&entry.id) {
+                    obj.cast_variant_paid = Some((
+                        crate::types::ability::CastVariantPaid::Spectacle,
+                        state.turn_number,
+                    ));
+                }
+            }
+
             // CR 702.176a: Impending-cast permanent gets the `cast_variant_paid`
             // tag re-applied after `reset_for_battlefield_entry` cleared it.
             // The "not a creature" layer fixup and the end-step counter-removal

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -470,6 +470,46 @@ pub(super) fn strip_additional_cost_conditional(text: &str) -> (Option<AbilityCo
             );
         }
     }
+    if body.is_none() && scan_contains_phrase(&lower, "surge cost was paid") {
+        if let Some(after) = tp.strip_after("instead ") {
+            return (
+                Some(AbilityCondition::CastVariantPaidInstead {
+                    variant: CastVariantPaid::Surge,
+                }),
+                after.original.to_string(),
+            );
+        }
+        // CR 702.117a: "if its surge cost was paid, [effect]" — non-"instead"
+        // variant that gates a sub-ability on surge payment.
+        if let Some(after) = tp.strip_after("surge cost was paid, ") {
+            return (
+                Some(AbilityCondition::CastVariantPaid {
+                    variant: CastVariantPaid::Surge,
+                }),
+                after.original.to_string(),
+            );
+        }
+    }
+    if body.is_none() && scan_contains_phrase(&lower, "spectacle cost was paid") {
+        if let Some(after) = tp.strip_after("instead ") {
+            return (
+                Some(AbilityCondition::CastVariantPaidInstead {
+                    variant: CastVariantPaid::Spectacle,
+                }),
+                after.original.to_string(),
+            );
+        }
+        // CR 702.137a: "if its spectacle cost was paid, [effect]" — non-"instead"
+        // variant that gates a sub-ability on spectacle payment.
+        if let Some(after) = tp.strip_after("spectacle cost was paid, ") {
+            return (
+                Some(AbilityCondition::CastVariantPaid {
+                    variant: CastVariantPaid::Spectacle,
+                }),
+                after.original.to_string(),
+            );
+        }
+    }
 
     match body {
         Some(body) => {
@@ -4369,6 +4409,40 @@ mod tests {
         let (cond, body) = strip_additional_cost_conditional("If a Dragon was beheld, surveil 2.");
         assert_eq!(cond, Some(AbilityCondition::additional_cost_paid_any()));
         assert_eq!(body, "surveil 2.");
+    }
+
+    /// CR 702.137a + CR 603.4: Rix Maadi Reveler — "If this creature's
+    /// spectacle cost was paid, instead [effect]" → CastVariantPaidInstead
+    /// { Spectacle }, stripping the leading "instead ".
+    #[test]
+    fn spectacle_instead_emits_cast_variant_paid_instead() {
+        let (cond, body) = strip_additional_cost_conditional(
+            "If this creature's spectacle cost was paid, instead discard your hand, then draw three cards.",
+        );
+        assert_eq!(
+            cond,
+            Some(AbilityCondition::CastVariantPaidInstead {
+                variant: CastVariantPaid::Spectacle,
+            })
+        );
+        assert_eq!(body, "discard your hand, then draw three cards.");
+    }
+
+    /// CR 702.117a + CR 603.4: surge "...instead" rider mirrors the spectacle
+    /// path — building-block coverage of the parameterized condition over a
+    /// second variant.
+    #[test]
+    fn surge_instead_emits_cast_variant_paid_instead() {
+        let (cond, body) = strip_additional_cost_conditional(
+            "If its surge cost was paid, instead draw two cards.",
+        );
+        assert_eq!(
+            cond,
+            Some(AbilityCondition::CastVariantPaidInstead {
+                variant: CastVariantPaid::Surge,
+            })
+        );
+        assert_eq!(body, "draw two cards.");
     }
 
     /// CR 702.33b + CR 603.4: "if it was kicked twice, …" → min_count = 2.

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
@@ -98,7 +98,10 @@ expression: "&ir"
         "valid_source": null,
         "description": "When ~ enters, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
         "constraint": null,
-        "condition": null,
+        "condition": {
+          "type": "CastVariantPaid",
+          "variant": "Surge"
+        },
         "batched": false
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_lowered.snap
@@ -97,7 +97,10 @@ expression: "&lowered"
       "valid_source": null,
       "description": "When ~ enters, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
       "constraint": null,
-      "condition": null,
+      "condition": {
+        "type": "CastVariantPaid",
+        "variant": "Surge"
+      },
       "batched": false
     }
   ],

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2886,9 +2886,10 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
         return result;
     }
 
-    // CR 702.49 + CR 603.4: "if [possessive] sneak/ninjutsu cost was paid [this turn]"
+    // CR 702.49 / CR 702.117a / CR 702.137a + CR 603.4: "if [possessive]
+    // sneak/ninjutsu/surge/spectacle cost was paid [this turn]"
     // Guard: "instead" means conditional override, not intervening-if.
-    if let Some(result) = try_extract_ninjutsu_condition(&tp, &lower, text) {
+    if let Some(result) = try_extract_cast_variant_paid_condition(&tp, &lower, text) {
         return result;
     }
 
@@ -3670,9 +3671,10 @@ fn try_parse_ability_activation_trigger(lower: &str) -> Option<(TriggerMode, Tri
     None
 }
 
-/// CR 702.49: Extract ninjutsu/sneak cost-paid conditions.
+/// CR 702.49 / CR 702.117a / CR 702.137a: Extract alternative-cost "cost was
+/// paid" intervening-if conditions (ninjutsu/sneak/surge/spectacle).
 /// Guard: "instead" after the condition means conditional override, not intervening-if.
-fn try_extract_ninjutsu_condition(
+fn try_extract_cast_variant_paid_condition(
     tp: &TextPair<'_>,
     lower: &str,
     text: &str,
@@ -3680,6 +3682,8 @@ fn try_extract_ninjutsu_condition(
     for (keyword, variant) in &[
         ("sneak cost was paid", CastVariantPaid::Sneak),
         ("ninjutsu cost was paid", CastVariantPaid::Ninjutsu),
+        ("surge cost was paid", CastVariantPaid::Surge), // CR 702.117a
+        ("spectacle cost was paid", CastVariantPaid::Spectacle), // CR 702.137a
     ] {
         if scan_contains(lower, keyword) && !scan_contains(lower, "instead") {
             let pos = tp.find("if ").unwrap_or(0);
@@ -5210,6 +5214,18 @@ fn parse_single_subject<'a>(text: &'a str, ctx: &mut ParseContext) -> (TargetFil
         return (TargetFilter::SelfRef, "");
     }
 
+    // CR 702.138c + CR 603.11: "it enters [this way]" — the linked triggered
+    // ability of an "[this permanent] escapes with [counters]" replacement
+    // effect refers to the source permanent by the pronoun "it". Resolve "it"
+    // to `SelfRef` only when immediately followed by the "enters" event verb so
+    // the bare pronoun is not over-broadened to other event types (the
+    // remaining "enters this way" qualifier is consumed by the ETB rider).
+    if let Ok((rest, ())) = value((), tag::<_, _, OracleError<'_>>("it ")).parse(text) {
+        if tag::<_, _, OracleError<'_>>("enters").parse(rest).is_ok() {
+            return (TargetFilter::SelfRef, rest);
+        }
+    }
+
     if let Ok((rest, ())) = value((), tag::<_, _, OracleError<'_>>("this ")).parse(text) {
         let noun_end = rest.find(' ').unwrap_or(rest.len());
         if noun_end > 0 {
@@ -5629,6 +5645,44 @@ fn parse_enters_tapped_state_rider(input: &str) -> Option<TriggerCondition> {
     })
 }
 
+/// CR 702.138c + CR 603.11: After consuming the `"enter"` prefix in a SelfRef
+/// ETB trigger clause, recognize the linked-ability rider `"enters this way"` —
+/// the triggered ability linked to an `"[this permanent] escapes with [counters]"`
+/// replacement effect. Per CR 702.138c such a trigger "triggers when that
+/// permanent enters the battlefield after its replacement effect was applied,"
+/// i.e. only when the permanent escaped. Emit `CastVariantPaid { Escape }` so
+/// the intervening-if (CR 603.4, checked at fire AND resolution) gates the ETB
+/// effect on the escape cast (Pharika's Spawn).
+///
+/// The `input` is the remainder after `tag("enter")`, so the rider begins with
+/// `"s "` (the rest of "enters") followed by `"this way"`. A word-boundary check
+/// rejects accidental prefix matches.
+fn parse_enters_this_way_rider(input: &str) -> Option<TriggerCondition> {
+    let (after, ()) = value(
+        (),
+        preceded(
+            tag::<_, _, OracleError<'_>>("s "),
+            tag::<_, _, OracleError<'_>>("this way"),
+        ),
+    )
+    .parse(input)
+    .ok()?;
+
+    // Word-boundary: reject false prefix matches (e.g. "this ways").
+    if !after.is_empty()
+        && after
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_')
+    {
+        return None;
+    }
+
+    Some(TriggerCondition::CastVariantPaid {
+        variant: CastVariantPaid::Escape,
+    })
+}
+
 fn parse_enters_control_rider(input: &str) -> Option<ControllerRef> {
     scan_preceded(input, |input| {
         preceded(
@@ -5916,6 +5970,14 @@ fn try_parse_event(
         // triggering zone-change event, which by then reflects the
         // post-replacement state.
         if let Some(cond) = parse_enters_tapped_state_rider(after_enter) {
+            def.condition = Some(append_trigger_condition(def.condition.take(), cond));
+        }
+
+        // CR 702.138c + CR 603.11: "enters this way" — the linked triggered
+        // ability of an "[this permanent] escapes with [counters]" replacement
+        // effect. Gate the ETB trigger on `CastVariantPaid { Escape }` so it
+        // fires only when the permanent escaped (Pharika's Spawn).
+        if let Some(cond) = parse_enters_this_way_rider(after_enter) {
             def.condition = Some(append_trigger_condition(def.condition.take(), cond));
         }
 
@@ -21185,6 +21247,61 @@ mod tests {
             def.condition,
             Some(TriggerCondition::CastVariantPaid {
                 variant: CastVariantPaid::Ninjutsu,
+            })
+        );
+    }
+
+    #[test]
+    fn cast_variant_paid_surge_condition() {
+        // CR 702.117a + CR 603.4: "if its surge cost was paid" intervening-if
+        // (Reckless Bushwhacker class) → CastVariantPaid { variant: Surge }.
+        let def = parse_trigger_line(
+            "When this creature enters, if its surge cost was paid, creatures you control get +1/+1 until end of turn.",
+            "Test Surge",
+        );
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::CastVariantPaid {
+                variant: CastVariantPaid::Surge,
+            })
+        );
+    }
+
+    #[test]
+    fn cast_variant_paid_spectacle_condition() {
+        // CR 702.137a + CR 603.4: "if its spectacle cost was paid" intervening-if
+        // (Rafter Demon) → CastVariantPaid { variant: Spectacle }.
+        let def = parse_trigger_line(
+            "When this creature enters, if its spectacle cost was paid, each opponent discards a card.",
+            "Test Spectacle",
+        );
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::CastVariantPaid {
+                variant: CastVariantPaid::Spectacle,
+            })
+        );
+    }
+
+    // CR 702.138c + CR 603.11: Pharika's Spawn — the linked triggered ability of
+    // an "[this permanent] escapes with [counters]" replacement effect. "When it
+    // enters this way" must (a) resolve the pronoun "it" to SelfRef, (b) lower to
+    // an ETB ChangesZone→Battlefield trigger, and (c) attach a
+    // CastVariantPaid { Escape } intervening-if so the linked effect fires only
+    // when the permanent escaped.
+    #[test]
+    fn pharikas_spawn_enters_this_way_gated_on_escape() {
+        let def = parse_trigger_line(
+            "When it enters this way, each opponent sacrifices a non-Gorgon creature of their choice.",
+            "Pharika's Spawn",
+        );
+        assert_eq!(def.mode, TriggerMode::ChangesZone);
+        assert_eq!(def.destination, Some(Zone::Battlefield));
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::CastVariantPaid {
+                variant: CastVariantPaid::Escape,
             })
         );
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4917,6 +4917,14 @@ pub enum CastVariantPaid {
     /// while any remain. Read by the end-step counter-removal trigger and
     /// the "not a creature" layer fixup.
     Impending,
+    /// CR 702.117a: Surge alternative cast cost was paid from hand. Read by the
+    /// "if its surge cost was paid" intervening-if (Reckless Bushwhacker,
+    /// Tyrant of Valakut).
+    Surge,
+    /// CR 702.137a: Spectacle alternative cast cost was paid from hand. Read by
+    /// the "if its spectacle cost was paid" intervening-if (Rafter Demon) and the
+    /// "...if its spectacle cost was paid, instead" clause (Rix Maadi Reveler).
+    Spectacle,
 }
 
 /// CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell.


### PR DESCRIPTION
Stamp the cast variant a spell was paid for (Surge, Spectacle, Ninjutsu,
Sneak, Web-slinging, Evoke, ...) onto the permanent in
stack.rs::resolve_top, and add a CastVariantPaid trigger condition so
'as ~ enters' / 'when it enters this way' riders fire only when the
matching alternative cost was paid.

CR 702.117a (Surge) / CR 702.137a (Spectacle) / CR 702.49a (Ninjutsu):
alternative-cost 'cost was paid' riders, gated via the CR 603.4
intervening-if (checked at fire and resolution). CR 702.138c + CR 603.11:
'When it enters this way' linked triggered abilities.

Parses the riders into the gated condition; updates the
reckless_bushwhacker IR + lowered snapshots.
