### PR TITLE
feat(engine): model the saddled designation as gated state (OTJ Mounts)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -433,6 +433,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             FilterProp::CombatRelation { .. } => parts.push("combat related".into()),
             FilterProp::Unblocked => parts.push("unblocked".into()),
             FilterProp::Tapped => parts.push("tapped".into()),
+            FilterProp::IsSaddled => parts.push("saddled".into()),
             FilterProp::Untapped => parts.push("untapped".into()),
             FilterProp::HasHasteOrControlledSinceTurnBegan => {
                 parts.push("haste or controlled since turn began".into())
@@ -5551,6 +5552,7 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::IsRingBearer => ("IsRingBearer", Handled),
         StaticCondition::RingLevelAtLeast { .. } => ("RingLevelAtLeast", Handled),
         StaticCondition::SourceIsTapped => ("SourceIsTapped", Handled),
+        StaticCondition::SourceIsSaddled => ("SourceIsSaddled", Handled),
         StaticCondition::SourceControllerEquals { .. } => ("SourceControllerEquals", Handled),
         StaticCondition::Unrecognized { .. } => ("Unrecognized", Handled),
         StaticCondition::None => ("None", Handled),

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3717,6 +3717,11 @@ fn apply_action(
             &creature_ids,
             &mut events,
         )?,
+        // CR 601.2c: no cost is paid until the saddle announcement, so backing out
+        // restores priority with no state to undo.
+        (WaitingFor::SaddleMount { player, .. }, GameAction::CancelCast) => {
+            WaitingFor::Priority { player: *player }
+        }
         (WaitingFor::Priority { player }, GameAction::Transform { object_id }) => {
             let p = *player;
             let obj = state

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -147,6 +147,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::CombatRelation { .. }
         | FilterProp::Unblocked
         | FilterProp::Tapped
+        | FilterProp::IsSaddled
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::WithKeyword { .. }
@@ -338,6 +339,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::CombatRelation { .. }
         | FilterProp::Unblocked
         | FilterProp::Tapped
+        | FilterProp::IsSaddled
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::WithKeyword { .. }
@@ -2394,6 +2396,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         | FilterProp::CombatRelation { .. }
         | FilterProp::Unblocked
         | FilterProp::Tapped
+        | FilterProp::IsSaddled
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::Counters { .. }
@@ -2693,6 +2696,8 @@ fn matches_filter_prop(
         // unblocked_attackers checks the permanent `blocked` flag, not the current blocker list.
         FilterProp::Unblocked => combat::unblocked_attackers(state).contains(&object_id),
         FilterProp::Tapped => obj.tapped,
+        // CR 702.171b: Matches permanents with the saddled designation.
+        FilterProp::IsSaddled => obj.is_saddled,
         // CR 302.6 / CR 110.5: Untapped status as targeting qualifier.
         FilterProp::Untapped => !obj.tapped,
         // CR 302.6 + CR 702.10b + CR 702.154a: Enlist may tap a creature only
@@ -3526,6 +3531,7 @@ fn zone_change_record_matches_property(
             comparator.evaluate(actual, resolve_filter_threshold(state, count, source))
         }),
         FilterProp::Tapped
+        | FilterProp::IsSaddled
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::AttackedThisTurn
@@ -5265,6 +5271,23 @@ mod tests {
 
         let filter =
             TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Tapped]));
+        assert!(matches_target_filter(&state, id, &filter, id));
+    }
+
+    // CR 702.171b: `IsSaddled` matches only objects with the saddled designation.
+    #[test]
+    fn is_saddled_property_matches_only_saddled() {
+        let mut state = setup();
+        let id = add_creature(&mut state, PlayerId(0), "Mount");
+
+        let filter =
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::IsSaddled]));
+
+        // Not saddled → no match.
+        assert!(!matches_target_filter(&state, id, &filter, id));
+
+        // Saddled → match.
+        state.objects.get_mut(&id).unwrap().is_saddled = true;
         assert!(matches_target_filter(&state, id, &filter, id));
     }
 

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -773,6 +773,12 @@ pub struct GameObject {
     #[serde(default)]
     pub is_saddled: bool,
 
+    /// CR 702.171c: The creatures that saddled this permanent (tapped to pay the
+    /// saddle cost). Cleared in lockstep with `is_saddled` at end of turn or when
+    /// the permanent leaves the battlefield.
+    #[serde(default)]
+    pub saddled_by: Vec<ObjectId>,
+
     /// CR 613.11 + CR 510.1a: This creature assigns combat damage equal to its
     /// toughness rather than its power. Set after object-characteristic layers.
     #[serde(default)]
@@ -1100,6 +1106,7 @@ impl GameObject {
             monstrous: false,
             prepared: None,
             is_saddled: false,
+            saddled_by: Vec::new(),
             assigns_damage_from_toughness: false,
             assigns_damage_as_though_unblocked: false,
             assigns_no_combat_damage: false,
@@ -1190,6 +1197,7 @@ impl GameObject {
         // state. Assign when WotC publishes SOS CR update.
         self.prepared = None;
         self.is_saddled = false;
+        self.saddled_by.clear();
         self.paired_with = None;
         self.pair_controller = None;
         self.chosen_attributes.clear();
@@ -1272,6 +1280,7 @@ impl GameObject {
         self.phyrexian_life_paid = 0;
         // CR 702.171b: Saddled clears when the Mount leaves the battlefield.
         self.is_saddled = false;
+        self.saddled_by.clear();
         // CR 702.xxx: Prepared (Strixhaven) is a battlefield-only designation —
         // clears on BF exit, paralleling monstrous/suspected. CR 400.7: a
         // re-entering permanent is a new object with no memory of its previous

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -604,6 +604,7 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
         | StaticCondition::SourceIsTapped
+        | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceControllerEquals { .. }
         | StaticCondition::SourceIsEquipped
         | StaticCondition::SourceIsMonstrous
@@ -718,6 +719,7 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
         | StaticCondition::SourceIsTapped
+        | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceControllerEquals { .. }
         | StaticCondition::SourceIsEquipped
         | StaticCondition::SourceIsMonstrous
@@ -906,6 +908,10 @@ fn evaluate_condition_with_context(
         // Callous Oppressor dying while tapped) fails this predicate and any
         // `ForAsLongAs { SourceIsTapped }` continuous effect (gain-control, etc.) ends.
         StaticCondition::SourceIsTapped => eval_source_is_tapped_on_battlefield(state, source_id),
+        // CR 702.171b + CR 110.5d: off-battlefield permanents have no saddled designation.
+        StaticCondition::SourceIsSaddled => state.objects.get(&source_id).is_some_and(|obj| {
+            obj.zone == crate::types::zones::Zone::Battlefield && obj.is_saddled
+        }),
         // CR 702.62a + CR 611.2b: True when the source object's current controller
         // equals the stored player. Drives the Suspend haste duration: when a
         // suspended creature spell resolves, a transient continuous effect with
@@ -8238,6 +8244,42 @@ mod tests {
             &StaticCondition::Not {
                 condition: Box::new(StaticCondition::SourceIsTapped),
             },
+            PlayerId(0),
+            id,
+        ));
+    }
+
+    // CR 702.171b: `SourceIsSaddled` gates a continuous modification on the
+    // saddled designation. Not saddled → no gather; saddled → gathered;
+    // off-battlefield → false (CR 110.5d, no designation off the battlefield).
+    #[test]
+    fn source_is_saddled_gates_continuous_effect() {
+        let mut state = setup();
+        let id = make_creature(&mut state, "Mount", 2, 2, PlayerId(0));
+
+        // Not saddled → condition false (no bonus).
+        assert!(!evaluate_condition_for_test(
+            &state,
+            &StaticCondition::SourceIsSaddled,
+            PlayerId(0),
+            id,
+        ));
+
+        // Saddled → condition true (regression for "mounts always behave as if saddled").
+        state.objects.get_mut(&id).unwrap().is_saddled = true;
+        assert!(evaluate_condition_for_test(
+            &state,
+            &StaticCondition::SourceIsSaddled,
+            PlayerId(0),
+            id,
+        ));
+
+        // CR 110.5d: off the battlefield there is no saddled designation.
+        state.objects.get_mut(&id).unwrap().zone = Zone::Graveyard;
+        assert!(state.objects.get(&id).unwrap().is_saddled);
+        assert!(!evaluate_condition_for_test(
+            &state,
+            &StaticCondition::SourceIsSaddled,
             PlayerId(0),
             id,
         ));

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1307,6 +1307,8 @@ fn resolve_keyword_action(
             if let Some(mount) = state.objects.get_mut(&mount_id) {
                 if mount.zone == Zone::Battlefield {
                     mount.is_saddled = true;
+                    // CR 702.171c: record the creatures that saddled this permanent.
+                    mount.saddled_by = paid_creature_ids.clone();
                 }
             }
             events.push(GameEvent::Saddled {

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1308,7 +1308,11 @@ fn resolve_keyword_action(
                 if mount.zone == Zone::Battlefield {
                     mount.is_saddled = true;
                     // CR 702.171c: record the creatures that saddled this permanent.
-                    mount.saddled_by = paid_creature_ids.clone();
+                    for creature_id in &paid_creature_ids {
+                        if !mount.saddled_by.contains(creature_id) {
+                            mount.saddled_by.push(*creature_id);
+                        }
+                    }
                 }
             }
             events.push(GameEvent::Saddled {

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1139,7 +1139,9 @@ pub fn execute_cleanup(state: &mut GameState, events: &mut Vec<GameEvent>) -> Op
     // at cleanup (CR 514).
     for obj in state.objects.iter_mut().map(|(_, v)| v) {
         if obj.is_saddled {
+            // CR 702.171b: the designation (and the saddling-creature record) ends at end of turn.
             obj.is_saddled = false;
+            obj.saddled_by.clear();
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2353,6 +2353,9 @@ pub(crate) fn static_condition_to_ability_condition(
         | StaticCondition::SourceIsEquipped
         | StaticCondition::SourceIsPaired
         | StaticCondition::SourceIsMonstrous
+        // CR 702.171b: the saddled designation is a static-only predicate with no
+        // effect-resolution (`AbilityCondition`) equivalent.
+        | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceAttachedToCreature
         | StaticCondition::OpponentPoisonAtLeast { .. }
         | StaticCondition::UnlessPay { .. }

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -887,6 +887,14 @@ fn parse_source_is_monstrous(input: &str) -> OracleResult<'_, StaticCondition> {
     value(StaticCondition::SourceIsMonstrous, tag("is monstrous")).parse(rest)
 }
 
+/// CR 702.171b: Parse "<subject> is saddled" → SourceIsSaddled.
+/// Affirmative only — Saddle has no negated Oracle idiom; "as long as ~ is not
+/// saddled" would compose `Not { SourceIsSaddled }` but no current card prints it.
+fn parse_source_is_saddled(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = parse_source_subject(input)?;
+    value(StaticCondition::SourceIsSaddled, tag("is saddled")).parse(rest)
+}
+
 /// CR 301.5 + CR 303.4: Parse "<subject> is attached to a creature" → SourceAttachedToCreature.
 fn parse_source_attached_to_creature(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = parse_source_subject(input)?;
@@ -911,6 +919,8 @@ fn parse_source_state_conditions(input: &str) -> OracleResult<'_, StaticConditio
         parse_source_is_equipped,
         // CR 701.37: "~ is monstrous" / "this creature is monstrous" / etc.
         parse_source_is_monstrous,
+        // CR 702.171b: "~ is saddled" / "this creature is saddled" / etc.
+        parse_source_is_saddled,
         // CR 301.5 + CR 303.4: "~ is attached to a creature" / "this equipment is attached to a creature".
         // Must precede `parse_source_is_type` so the specific "is attached to a creature"
         // predicate wins over generic "is <type>" dispatch.
@@ -5563,6 +5573,14 @@ mod tests {
         let (rest, c) = parse_condition("as long as ~ is tapped").unwrap();
         assert_eq!(rest, "");
         assert!(matches!(c, StaticCondition::SourceIsTapped));
+    }
+
+    // CR 702.171b: "as long as ~ is saddled" → SourceIsSaddled.
+    #[test]
+    fn test_parse_condition_as_long_as_saddled() {
+        let (rest, c) = parse_condition("as long as ~ is saddled").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(c, StaticCondition::SourceIsSaddled));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -95,6 +95,8 @@ pub fn parse_property_filter(input: &str) -> OracleResult<'_, FilterProp> {
     alt((
         value(FilterProp::Tapped, tag("tapped")),
         value(FilterProp::Untapped, tag("untapped")),
+        // CR 702.171b: "saddled Mount/creature" selector.
+        value(FilterProp::IsSaddled, tag("saddled")),
         value(FilterProp::Attacking, tag("attacking")),
         value(FilterProp::Blocking, tag("blocking")),
         value(FilterProp::Token, tag("token")),
@@ -402,6 +404,14 @@ mod tests {
         let (rest, p) = parse_property_filter("tapped creatures").unwrap();
         assert_eq!(p, FilterProp::Tapped);
         assert_eq!(rest, " creatures");
+    }
+
+    // CR 702.171b: "saddled Mount/creature" selector → FilterProp::IsSaddled.
+    #[test]
+    fn test_parse_property_filter_saddled() {
+        let (rest, p) = parse_property_filter("saddled Mount you control").unwrap();
+        assert_eq!(p, FilterProp::IsSaddled);
+        assert_eq!(rest, " Mount you control");
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2621,6 +2621,8 @@ fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
             // CR 110.5: "tapped [type]" / "untapped [type]".
             | FilterProp::Tapped
             | FilterProp::Untapped
+            // CR 702.171b: "saddled [type]" adjective prefix.
+            | FilterProp::IsSaddled
             // CR 509.1h: combat-status prefixes "attacking/blocking/unblocked".
             | FilterProp::Attacking
             | FilterProp::Blocking
@@ -2957,6 +2959,9 @@ pub(crate) fn parse_combat_status_prefix(text: &str) -> Option<(FilterProp, usiz
                 | FilterProp::Blocking
                 | FilterProp::Tapped
                 | FilterProp::Untapped
+                // CR 702.171b: "saddled" designation as a type-phrase prefix
+                // ("saddled Mount", "saddled creature").
+                | FilterProp::IsSaddled
                 | FilterProp::FaceDown
                 // CR 701.60b: "suspected" is a battlefield designation that appears
                 // as an adjective prefix in type phrases ("suspected creatures").
@@ -5621,6 +5626,29 @@ mod tests {
                     .properties(vec![FilterProp::Tapped])
             )
         );
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn saddled_type_phrase_parses_as_target() {
+        // CR 702.171b: a "saddled <type>" selector must carry FilterProp::IsSaddled
+        // through the full parse_target path (not just parse_property_filter) —
+        // guards the parse_combat_status_prefix / is_adjective_prefix_prop allowlist
+        // wiring against silent regression if the prefix allowlist is reordered.
+        let (f, rest) = parse_target("saddled creature you control");
+        if let TargetFilter::Typed(tf) = &f {
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "missing Creature in {tf:?}"
+            );
+            assert!(
+                tf.properties.contains(&FilterProp::IsSaddled),
+                "missing IsSaddled in {tf:?}"
+            );
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+        } else {
+            panic!("expected Typed filter, got {f:?}");
+        }
         assert_eq!(rest, "");
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2567,6 +2567,9 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
         | StaticCondition::SourceIsEquipped
         | StaticCondition::SourceIsPaired
         | StaticCondition::SourceIsMonstrous
+        // CR 702.171b: the saddled designation has no intervening-if
+        // (`TriggerCondition`) equivalent.
+        | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceAttachedToCreature
         | StaticCondition::OpponentPoisonAtLeast { .. }
         | StaticCondition::UnlessPay { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2116,6 +2116,8 @@ pub enum FilterProp {
     Tapped,
     /// CR 302.6 / CR 110.5: Untapped status as targeting qualifier.
     Untapped,
+    /// CR 702.171b: Matches permanents with the saddled designation.
+    IsSaddled,
     /// CR 302.6 + CR 702.10b + CR 702.154a: Matches creatures that either have
     /// haste or have been under their controller's control continuously since
     /// that player's most recent turn began. Used by Enlist's tap eligibility.
@@ -4546,6 +4548,8 @@ pub enum StaticCondition {
     /// CR 110.5b: True when the source object is tapped.
     /// Used for "for as long as ~ remains tapped" duration conditions.
     SourceIsTapped,
+    /// CR 702.171b: True when the source permanent is saddled. Negation via Not { SourceIsSaddled }.
+    SourceIsSaddled,
     /// CR 702.62a + CR 611.2b: True when the source object's current controller
     /// equals the stored player. General-purpose "while you control this"
     /// predicate; the runtime-installed Suspend haste static uses

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -170,6 +170,7 @@ mod ripples_of_undeath_regression;
 mod rite_of_consumption_damage;
 mod roots_of_wisdom_if_you_cant_draw;
 mod rules;
+mod saddle_state_model;
 mod scarab_god_regression;
 mod screaming_nemesis_life_lock;
 mod seasoned_dungeoneer_initiative_room_trigger;

--- a/crates/engine/tests/integration/saddle_state_model.rs
+++ b/crates/engine/tests/integration/saddle_state_model.rs
@@ -1,0 +1,158 @@
+//! Saddle state model (P3) — `saddled_by` persistence + `WaitingFor::SaddleMount`
+//! cancel transition, driven through the real engine pipeline.
+//!
+//! CR 702.171a (Saddle is an activated ability, sorcery-speed), CR 702.171b
+//! (the saddled designation lasts until end of turn / leaving the battlefield),
+//! CR 702.171c (the creatures that saddled the permanent), CR 601.2c (backing
+//! out of a mid-selection choice restores priority with no state to undo).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+
+/// CR 702.171c: after a Saddle activation resolves, the Mount records the
+/// creatures that saddled it in `saddled_by`; CR 702.171b: the record clears at
+/// the end of the turn in lockstep with the saddled designation.
+#[test]
+fn saddled_by_records_payers_and_clears_at_end_of_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mount = {
+        let mut b = scenario.add_creature(P0, "Test Mount", 0, 4);
+        b.with_keyword(Keyword::Saddle(2));
+        b.id()
+    };
+    // CR 702.171a: a single 3-power creature satisfies "total power 2 or greater".
+    let rider = scenario.add_creature(P0, "Rider", 3, 3).id();
+
+    let mut runner = scenario.build();
+
+    // Announce the saddle activation (Priority → SaddleMount).
+    runner
+        .act(GameAction::SaddleMount {
+            mount_id: mount,
+            creature_ids: vec![],
+        })
+        .expect("entering SaddleMount should succeed at sorcery speed");
+    assert_eq!(runner.waiting_for_kind(), "SaddleMount");
+
+    // Pay the cost by tapping the rider; pushes the Saddle stack entry.
+    runner
+        .act(GameAction::SaddleMount {
+            mount_id: mount,
+            creature_ids: vec![rider],
+        })
+        .expect("announcing the saddle should succeed");
+
+    // Resolve the Saddle stack entry through the real pipeline.
+    runner.advance_until_stack_empty();
+
+    let m = runner.state().objects.get(&mount).unwrap();
+    assert!(m.is_saddled, "Mount must be saddled after resolution");
+    // CR 702.171c: the saddling creature is recorded.
+    assert_eq!(
+        m.saddled_by,
+        vec![rider],
+        "saddled_by must record the creatures that saddled the Mount"
+    );
+
+    // CR 702.171b: advance the real pipeline across the cleanup step (CR 514) into
+    // the next turn. Cleanup clears the designation and the saddling-creature
+    // record in lockstep. Drive the engine with its own `legal_actions` so the
+    // turn keeps moving through combat declarations and step triggers without ever
+    // casting or paying mana.
+    let start_turn = runner.state().turn_number;
+    let mut crossed_turn = false;
+    for _ in 0..400 {
+        if runner.state().turn_number > start_turn {
+            crossed_turn = true;
+            break;
+        }
+        let actions = engine::ai_support::legal_actions(runner.state());
+        let progress = actions
+            .iter()
+            .find(|a| matches!(a, GameAction::PassPriority))
+            .or_else(|| {
+                actions.iter().find(|a| {
+                    matches!(
+                        a,
+                        GameAction::DeclareAttackers { .. }
+                            | GameAction::DeclareBlockers { .. }
+                            | GameAction::SelectCards { .. }
+                            | GameAction::ChooseTarget { .. }
+                    )
+                })
+            })
+            .cloned();
+        match progress {
+            Some(action) => {
+                if runner.act(action).is_err() {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+    assert!(
+        crossed_turn,
+        "harness must cross the turn boundary; parked at turn {} phase {:?} waiting {:?}",
+        runner.state().turn_number,
+        runner.state().phase,
+        runner.state().waiting_for,
+    );
+
+    let m = runner.state().objects.get(&mount).unwrap();
+    assert!(
+        !m.is_saddled,
+        "saddled designation must clear at end of turn"
+    );
+    assert!(
+        m.saddled_by.is_empty(),
+        "saddled_by must clear at end of turn alongside is_saddled"
+    );
+}
+
+/// CR 601.2c: backing out of the Saddle creature-selection state restores
+/// priority with no state to undo — no creatures are tapped and the Mount is
+/// not saddled.
+#[test]
+fn cancel_saddle_restores_priority_without_side_effects() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mount = {
+        let mut b = scenario.add_creature(P0, "Test Mount", 0, 4);
+        b.with_keyword(Keyword::Saddle(2));
+        b.id()
+    };
+    let rider = scenario.add_creature(P0, "Rider", 3, 3).id();
+
+    let mut runner = scenario.build();
+
+    runner
+        .act(GameAction::SaddleMount {
+            mount_id: mount,
+            creature_ids: vec![],
+        })
+        .expect("entering SaddleMount should succeed at sorcery speed");
+    assert_eq!(runner.waiting_for_kind(), "SaddleMount");
+
+    // CR 601.2c: cancel out of the selection.
+    runner
+        .act(GameAction::CancelCast)
+        .expect("cancelling the saddle should succeed");
+
+    assert_eq!(
+        runner.waiting_for_kind(),
+        "Priority",
+        "cancelling SaddleMount must restore priority"
+    );
+    assert!(
+        !runner.state().objects.get(&rider).unwrap().tapped,
+        "cancelling must not tap any creature (cost is paid only at announcement)"
+    );
+    assert!(
+        !runner.state().objects.get(&mount).unwrap().is_saddled,
+        "cancelling must leave the Mount unsaddled"
+    );
+}

--- a/crates/engine/tests/integration/saddle_state_model.rs
+++ b/crates/engine/tests/integration/saddle_state_model.rs
@@ -25,6 +25,7 @@ fn saddled_by_records_payers_and_clears_at_end_of_turn() {
     };
     // CR 702.171a: a single 3-power creature satisfies "total power 2 or greater".
     let rider = scenario.add_creature(P0, "Rider", 3, 3).id();
+    let second_rider = scenario.add_creature(P0, "Second Rider", 3, 3).id();
 
     let mut runner = scenario.build();
 
@@ -55,6 +56,29 @@ fn saddled_by_records_payers_and_clears_at_end_of_turn() {
         m.saddled_by,
         vec![rider],
         "saddled_by must record the creatures that saddled the Mount"
+    );
+
+    // CR 702.171c: a later Saddle activation in the same turn adds the new
+    // saddling creature instead of replacing the earlier record.
+    runner
+        .act(GameAction::SaddleMount {
+            mount_id: mount,
+            creature_ids: vec![],
+        })
+        .expect("entering a second SaddleMount should succeed");
+    runner
+        .act(GameAction::SaddleMount {
+            mount_id: mount,
+            creature_ids: vec![second_rider],
+        })
+        .expect("announcing the second saddle should succeed");
+    runner.advance_until_stack_empty();
+
+    let m = runner.state().objects.get(&mount).unwrap();
+    assert_eq!(
+        m.saddled_by,
+        vec![rider, second_rider],
+        "saddled_by must accumulate creatures across same-turn Saddle activations"
     );
 
     // CR 702.171b: advance the real pipeline across the cleanup step (CR 514) into


### PR DESCRIPTION
Add StaticCondition::SourceIsSaddled and FilterProp::IsSaddled as
orthogonal status siblings of the verified SourceIsTapped / Tapped
clusters, persist the saddling-creature set (saddled_by) on the Mount,
and add a WaitingFor::SaddleMount cancel transition.

- Mount self-statics now gate on the saddled designation instead of
  applying unconditionally (saddle-mounts-always). CR 702.171b.
- 'saddled Mount/creature' selectors and anthems carry FilterProp::IsSaddled
  through the full parse_target path (saddle-cares-about / -legal-targets).
- saddled_by records the creatures that tapped to saddle, cleared at
  end of turn in lockstep with the designation. CR 702.171c.
- CancelCast out of SaddleMount restores priority with no state to undo,
  since the cost is paid only at announcement (saddle-backout). CR 601.2c.

Mirrors SourceIsTapped/Tapped at every eval, grouping, and coverage site;
negation is the free Not { SourceIsSaddled } composition (no sibling).
CR 110.5d guards off-battlefield permanents from carrying the designation.
