### PR TITLE
fix(engine): re-apply aura layers after phasing in

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1150,6 +1150,12 @@ pub fn evaluate_layers(state: &mut GameState) {
     let bf_ids: Vec<ObjectId> = state.battlefield.iter().copied().collect();
     for &id in &bf_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
+            // CR 702.26c: Phased-out permanents are treated as though they don't
+            // exist — skip the Step-1 reset so their derived state isn't wiped
+            // while their continuous-effect sources are offline (CR 702.26e).
+            if obj.is_phased_out() {
+                continue;
+            }
             obj.sync_missing_base_characteristics();
             obj.name = obj.base_name.clone();
             obj.power = obj.base_power;

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1124,14 +1124,14 @@ fn rebuild_static_index_at_top() -> bool {
 pub fn evaluate_layers(state: &mut GameState) {
     #[cfg(test)]
     FULL_EVALUATE_LAYERS_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    // CR 302.6 + CR 613.1b + CR 702.26c: Snapshot effective controllers for
+    // CR 302.6 + CR 613.1b + CR 702.26b: Snapshot effective controllers for
     // phased-in permanents BEFORE the Step 1 reset below wipes them. The
     // post-pass diff at the end of this function compares against this
     // snapshot to detect effective-controller transitions (Layer 2 control-
     // changing effect start/end, exchange-control, gain-control expiry) and
     // re-applies summoning sickness per CR 302.6 ("continuously under that
     // player's control since that player's most recent turn began").
-    // Phased-out permanents are excluded per CR 702.26c.
+    // Phased-out permanents are excluded per CR 702.26b.
     let prev_controllers: Vec<(ObjectId, PlayerId)> = state
         .battlefield_phased_in_ids()
         .into_iter()
@@ -1147,15 +1147,14 @@ pub fn evaluate_layers(state: &mut GameState) {
     // taken by AI search or snapshot diffing retain their own roots, so this
     // does not break structural sharing across `GameState` clones.
     state.attribution.clear();
-    let bf_ids: Vec<ObjectId> = state.battlefield.iter().copied().collect();
+    // CR 702.26b + CR 702.26e: Phased-out permanents are treated as though
+    // they do not exist and are not included in continuous-effect affected
+    // sets. Exclude them from the whole layer pass so the reset/apply invariant
+    // remains intact; they are frozen until phase-in marks layers dirty and
+    // re-includes them.
+    let bf_ids: Vec<ObjectId> = state.battlefield_phased_in_ids();
     for &id in &bf_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
-            // CR 702.26c: Phased-out permanents are treated as though they don't
-            // exist — skip the Step-1 reset so their derived state isn't wiped
-            // while their continuous-effect sources are offline (CR 702.26e).
-            if obj.is_phased_out() {
-                continue;
-            }
             obj.sync_missing_base_characteristics();
             obj.name = obj.base_name.clone();
             obj.power = obj.base_power;

--- a/crates/engine/src/game/phasing.rs
+++ b/crates/engine/src/game/phasing.rs
@@ -113,6 +113,10 @@ pub fn phase_out_object(
         });
     }
 
+    if !phased.is_empty() {
+        crate::game::layers::mark_layers_full(state);
+    }
+
     phased
 }
 
@@ -163,6 +167,13 @@ pub fn phase_in_object(
                 }
             }
         }
+    }
+
+    if !phased.is_empty() {
+        // CR 613.1 + CR 702.26c: Phasing in changes which continuous effects
+        // apply (aura sources re-enter the layer system). Mark dirty so the
+        // next SBA/public-state flush re-derives affected permanents.
+        crate::game::layers::mark_layers_full(state);
     }
 
     for &id in &phased {
@@ -443,6 +454,46 @@ mod tests {
 
         assert!(state.objects[&creature].is_phased_in());
         assert!(state.objects[&aura].is_phased_in());
+    }
+
+    /// CR 613.1 + CR 702.26c: Attached aura continuous effects must re-apply
+    /// after the host phases back in (issue #2373).
+    #[test]
+    fn issue_2373_attached_aura_effect_reapplies_after_phase_in() {
+        use crate::game::layers::flush_layers;
+        use crate::types::ability::{FilterProp, StaticDefinition, TargetFilter, TypedFilter};
+        use crate::types::ContinuousModification;
+
+        let mut state = GameState::new_two_player(42);
+        let creature = setup_creature(&mut state, "Bear", PlayerId(0));
+        let aura = setup_aura(&mut state, "Boon", PlayerId(0), creature);
+        if let Some(aura_obj) = state.objects.get_mut(&aura) {
+            aura_obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                    .modifications(vec![
+                        ContinuousModification::AddPower { value: 2 },
+                        ContinuousModification::AddToughness { value: 2 },
+                    ]),
+            );
+        }
+        flush_layers(&mut state);
+        assert_eq!(state.objects[&creature].power, Some(4));
+
+        let mut events = Vec::new();
+        phase_out_object(&mut state, creature, PhaseOutCause::Directly, &mut events);
+        assert!(state.layers_dirty.is_dirty());
+
+        events.clear();
+        phase_in_object(&mut state, creature, &mut events);
+        flush_layers(&mut state);
+        assert_eq!(
+            state.objects[&creature].power,
+            Some(4),
+            "aura +2/+2 must re-apply after phase-in"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/phasing.rs
+++ b/crates/engine/src/game/phasing.rs
@@ -114,6 +114,10 @@ pub fn phase_out_object(
     }
 
     if !phased.is_empty() {
+        // CR 613.1 + CR 702.26b/e: Phasing out changes which continuous
+        // effects apply and which affected sets may include these permanents.
+        // Mark dirty so the next SBA/public-state flush re-derives layers with
+        // phased-out objects excluded.
         crate::game::layers::mark_layers_full(state);
     }
 


### PR DESCRIPTION
## Summary
- Re-apply aura layers when a permanent phases in so stat and ability effects from auras remain correct after phasing.

Fixes #2373

## Test plan
- [ ] Run engine tests related to phasing and layer application
- [ ] Reproduce #2373 scenario (aura on phased permanent) and verify layers after phase in
