### PR TITLE
fix(client): restore opponent HUD visibility in 1v1 games

### DIFF
--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -179,13 +179,15 @@ export function PlayerArea({
   // than wedged into its own column or lane. As a content-width absolute overlay
   // it consumes zero vertical space, so the flex-1 creature row keeps its full
   // height, and the box hugs the HUD instead of spanning the row. Centered
-  // horizontally (`left-1/2 -translate-x-1/2`) and dropped below the land row
-  // (`top-[200%]`), mirrored upward for the focused opponent. z-20 keeps it
+  // horizontally (`left-1/2 -translate-x-1/2`) and dropped just below the middle
+  // row for the player (`top-[130%] -translate-y-full`); the focused opponent
+  // uses the vertical mirror (`bottom-[130%] translate-y-full`) so the HUD sits
+  // just above its middle row. z-20 keeps it
   // above resting cards (lands/support are z-10) but below a hovered card
   // (PermanentCard lifts to z-60), so a card slides over the HUD on hover.
   const hudBand = hud ? (
     <div
-      className={`absolute left-1/2 z-20 -translate-x-1/2 ${isMirrored ? "bottom-[320%]" : "top-[130%] -translate-y-full"}`}
+      className={`absolute left-1/2 z-20 -translate-x-1/2 ${isMirrored ? "bottom-[130%] translate-y-full" : "top-[130%] -translate-y-full"}`}
       data-debug-label="HUD"
     >
       {hud}


### PR DESCRIPTION
The two-column board layout (#2733) replaced the opponent HUD's in-flow
column with an absolutely-positioned hudBand overlay. The mirrored
(focused opponent) branch used bottom-[320%], floating the HUD ~3.2
band-heights above its middle row — out of the opponent's area and
off-screen. Only 1v1 hit this, since multiplayer renders oppHud in its
own in-flow z-40 block.

Replace bottom-[320%] with the true vertical mirror of the player's
top-[130%] -translate-y-full, i.e. bottom-[130%] translate-y-full, so the
opponent HUD anchors symmetrically just above its middle row.
