### PR TITLE
feat(engine): thread non-mana activation costs through Embalm/Eternalize

### DIFF
--- a/crates/engine/src/database/embalm_eternalize.rs
+++ b/crates/engine/src/database/embalm_eternalize.rs
@@ -9,8 +9,10 @@
 //!
 //! The two keywords differ only in the per-token *override set* applied on top
 //! of the copy, so this module factors the shared shape into a single builder
-//! (`token_copy_ability`) parameterized by the keyword's mana cost and its
-//! `ContinuousModification` overrides — the "build for the class" pattern. The
+//! (`token_copy_ability`) parameterized by the keyword's activation cost (mana
+//! or a composite mana + non-mana cost, e.g. the Champion of Wits "{3}{U}{U},
+//! Discard a card") and its `ContinuousModification` overrides — the "build for
+//! the class" pattern. The
 //! overrides reuse the existing copy-exception building block
 //! (`Effect::CopyTokenOf.additional_modifications`), which the token-copy
 //! resolver bakes into the synthesized token at creation
@@ -38,8 +40,8 @@ use crate::types::ability::{
     TargetFilter,
 };
 use crate::types::card::CardFace;
-use crate::types::keywords::Keyword;
-use crate::types::mana::{ManaColor, ManaCost};
+use crate::types::keywords::{EmbalmCost, EternalizeCost, Keyword};
+use crate::types::mana::ManaColor;
 use crate::types::zones::Zone;
 
 /// CR 702.128a + CR 702.129a: Synthesize the graveyard-activated token-copy
@@ -50,10 +52,14 @@ pub fn synthesize_embalm_eternalize(face: &mut CardFace) {
         .keywords
         .iter()
         .filter_map(|keyword| match keyword {
-            Keyword::Embalm(cost) => Some(token_copy_ability(cost.clone(), embalm_overrides())),
-            Keyword::Eternalize(cost) => {
-                Some(token_copy_ability(cost.clone(), eternalize_overrides()))
-            }
+            Keyword::Embalm(cost) => Some(token_copy_ability(
+                embalm_cost_part(cost),
+                embalm_overrides(),
+            )),
+            Keyword::Eternalize(cost) => Some(token_copy_ability(
+                eternalize_cost_part(cost),
+                eternalize_overrides(),
+            )),
             _ => None,
         })
         .collect();
@@ -92,27 +98,53 @@ fn eternalize_overrides() -> Vec<ContinuousModification> {
     ]
 }
 
+/// CR 602.1a: Unwrap the per-keyword `EmbalmCost` to the single keyword-cost
+/// `AbilityCost` (mana or composite/non-mana) that precedes the self-exile.
+/// Cost composition itself stays in `token_copy_ability` (single authority).
+fn embalm_cost_part(cost: &EmbalmCost) -> AbilityCost {
+    match cost {
+        EmbalmCost::Mana(m) => AbilityCost::Mana { cost: m.clone() },
+        EmbalmCost::NonMana(ac) => ac.clone(),
+    }
+}
+
+/// CR 602.1a: `EternalizeCost` analogue of `embalm_cost_part`.
+fn eternalize_cost_part(cost: &EternalizeCost) -> AbilityCost {
+    match cost {
+        EternalizeCost::Mana(m) => AbilityCost::Mana { cost: m.clone() },
+        EternalizeCost::NonMana(ac) => ac.clone(),
+    }
+}
+
 /// CR 702.128a / CR 702.129a + CR 707.2: Build the activated ability
 /// "[cost], Exile this card from your graveyard: Create a token that's a copy
 /// of this card, except <overrides>. Activate only as a sorcery."
 fn token_copy_ability(
-    mana_cost: ManaCost,
+    keyword_cost: AbilityCost,
     overrides: Vec<ContinuousModification>,
 ) -> AbilityDefinition {
     // CR 602.1a: The activation cost is everything before the colon — here a
-    // composite of the keyword's mana cost plus exiling this card from the
-    // graveyard. The SelfRef graveyard exile is auto-paid by `pay_ability_cost`
-    // (no player choice). An explicit `Zone::Graveyard` validates the source's
-    // location when the cost is paid.
-    let cost = AbilityCost::Composite {
-        costs: vec![
-            AbilityCost::Mana { cost: mana_cost },
-            AbilityCost::Exile {
-                count: 1,
-                zone: Some(Zone::Graveyard),
-                filter: Some(TargetFilter::SelfRef),
-            },
-        ],
+    // composite of the keyword's cost (mana, or a composite mana + non-mana such
+    // as the Champion of Wits "{3}{U}{U}, Discard a card") plus exiling this card
+    // from the graveyard. The SelfRef graveyard exile is auto-paid by
+    // `pay_ability_cost` (no player choice). An explicit `Zone::Graveyard`
+    // validates the source's location when the cost is paid.
+    let exile_self = AbilityCost::Exile {
+        count: 1,
+        zone: Some(Zone::Graveyard),
+        filter: Some(TargetFilter::SelfRef),
+    };
+    // Flatten an already-Composite keyword cost so the self-exile joins the
+    // existing sub-costs instead of nesting (mirrors `synthesize_cycling`).
+    let cost = match keyword_cost {
+        AbilityCost::Composite { costs } => {
+            let mut flat = costs;
+            flat.push(exile_self);
+            AbilityCost::Composite { costs: flat }
+        }
+        other => AbilityCost::Composite {
+            costs: vec![other, exile_self],
+        },
     };
 
     // CR 707.2: Create a token that's a copy of this card. `SelfRef` resolves

--- a/crates/engine/src/database/embalm_eternalize_tests.rs
+++ b/crates/engine/src/database/embalm_eternalize_tests.rs
@@ -10,13 +10,14 @@ use crate::game::casting::{can_activate_ability_now, handle_activate_ability};
 use crate::game::stack::resolve_top;
 use crate::game::zones::create_object;
 use crate::types::ability::{
-    AbilityCost, AbilityKind, ContinuousModification, Effect, QuantityExpr, TargetFilter,
+    AbilityCost, AbilityKind, CardSelectionMode, ContinuousModification, DiscardSelfScope, Effect,
+    QuantityExpr, TargetFilter,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::{CardId, ObjectId};
-use crate::types::keywords::Keyword;
+use crate::types::keywords::{EmbalmCost, EternalizeCost, Keyword};
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
@@ -87,7 +88,7 @@ fn synthesize_embalm_builds_white_zombie_no_mana_cost_copy() {
         shards: vec![ManaCostShard::White],
         generic: 3,
     };
-    let mut face = face_with(Keyword::Embalm(cost.clone()));
+    let mut face = face_with(Keyword::Embalm(EmbalmCost::Mana(cost.clone())));
     synthesize_embalm_eternalize(&mut face);
 
     let mods = assert_token_copy_ability_shape(&face, &cost);
@@ -115,7 +116,7 @@ fn synthesize_eternalize_builds_4_4_black_zombie_no_mana_cost_copy() {
         shards: vec![ManaCostShard::Black, ManaCostShard::Black],
         generic: 4,
     };
-    let mut face = face_with(Keyword::Eternalize(cost.clone()));
+    let mut face = face_with(Keyword::Eternalize(EternalizeCost::Mana(cost.clone())));
     synthesize_embalm_eternalize(&mut face);
 
     let mods = assert_token_copy_ability_shape(&face, &cost);
@@ -144,6 +145,79 @@ fn synthesize_is_noop_without_keyword() {
     let mut face = face_with(Keyword::Flying);
     synthesize_embalm_eternalize(&mut face);
     assert!(face.abilities.is_empty());
+}
+
+/// CR 602.1a + CR 702.129a: Champion of Wits family —
+/// `EternalizeCost::NonMana(Composite[Mana{3UU}, Discard])` must synthesize a
+/// cost `Composite[Mana, Discard, Exile-self]`: the discard sub-cost survives
+/// (it is NOT dropped) and the self-exile is appended flat (not nested).
+#[test]
+fn synthesize_eternalize_nonmana_composite_keeps_discard_and_appends_exile_self() {
+    let mana = ManaCost::Cost {
+        shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+        generic: 3,
+    };
+    let discard = AbilityCost::Discard {
+        count: QuantityExpr::Fixed { value: 1 },
+        filter: None,
+        selection: CardSelectionMode::Chosen,
+        self_scope: DiscardSelfScope::FromHand,
+    };
+    let keyword = Keyword::Eternalize(EternalizeCost::NonMana(AbilityCost::Composite {
+        costs: vec![AbilityCost::Mana { cost: mana.clone() }, discard.clone()],
+    }));
+    let mut face = face_with(keyword);
+    synthesize_embalm_eternalize(&mut face);
+
+    assert_eq!(face.abilities.len(), 1);
+    let AbilityCost::Composite { costs } = face.abilities[0]
+        .cost
+        .as_ref()
+        .expect("synthesized ability must have a cost")
+    else {
+        panic!("expected Composite cost");
+    };
+    assert_eq!(
+        costs.len(),
+        3,
+        "mana + discard + exile-self, flattened (not nested)"
+    );
+    assert!(matches!(&costs[0], AbilityCost::Mana { cost } if cost == &mana));
+    assert_eq!(
+        costs[1], discard,
+        "the discard activation cost must survive synthesis"
+    );
+    assert!(matches!(
+        &costs[2],
+        AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Graveyard),
+            filter: Some(TargetFilter::SelfRef),
+        }
+    ));
+}
+
+/// Backward-compat: a legacy bare-`ManaCost` JSON keyword payload (MTGJSON
+/// shape, lacking the `type` discriminant) deserializes to the `Mana` variant.
+#[test]
+fn legacy_bare_mana_json_parses_to_eternalize_mana_variant() {
+    // Legacy externally-tagged keyword: the value under "Eternalize" is a bare
+    // ManaCost (no `EternalizeCost` `{type, data}` discriminant). The JSON arm
+    // must fall back to EternalizeCost::Mana for this shape. Serialize a real
+    // ManaCost so the legacy payload's exact serde shape is used.
+    let legacy_mana = ManaCost::Cost {
+        shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+        generic: 3,
+    };
+    let json = serde_json::json!({
+        "Eternalize": serde_json::to_value(&legacy_mana).unwrap()
+    });
+    let kw: Keyword =
+        serde_json::from_value(json).expect("legacy bare-mana eternalize must deserialize");
+    let Keyword::Eternalize(EternalizeCost::Mana(mana)) = kw else {
+        panic!("expected Eternalize(Mana), got {kw:?}");
+    };
+    assert_eq!(mana, legacy_mana);
 }
 
 // ---------------------------------------------------------------------------
@@ -197,7 +271,10 @@ fn main_phase_state() -> GameState {
 #[test]
 fn token_copy_keyword_activatable_from_graveyard_at_sorcery_speed() {
     let mut state = main_phase_state();
-    let source = setup_graveyard_source(&mut state, Keyword::Embalm(ManaCost::default()));
+    let source = setup_graveyard_source(
+        &mut state,
+        Keyword::Embalm(EmbalmCost::Mana(ManaCost::default())),
+    );
     assert!(
         can_activate_ability_now(&state, PlayerId(0), source, 0),
         "Embalm must be activatable from graveyard in the sorcery window"
@@ -209,7 +286,10 @@ fn token_copy_keyword_activatable_from_graveyard_at_sorcery_speed() {
 fn token_copy_keyword_rejects_instant_speed() {
     let mut state = main_phase_state();
     state.phase = Phase::Upkeep;
-    let source = setup_graveyard_source(&mut state, Keyword::Embalm(ManaCost::default()));
+    let source = setup_graveyard_source(
+        &mut state,
+        Keyword::Embalm(EmbalmCost::Mana(ManaCost::default())),
+    );
     assert!(
         !can_activate_ability_now(&state, PlayerId(0), source, 0),
         "Embalm must reject activation outside the sorcery-speed window"
@@ -230,7 +310,10 @@ fn created_token(state: &GameState) -> ObjectId {
 #[test]
 fn embalm_activation_creates_white_zombie_copy_with_no_mana_cost() {
     let mut state = main_phase_state();
-    let source = setup_graveyard_source(&mut state, Keyword::Embalm(ManaCost::default()));
+    let source = setup_graveyard_source(
+        &mut state,
+        Keyword::Embalm(EmbalmCost::Mana(ManaCost::default())),
+    );
 
     let mut events = Vec::new();
     handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut events)
@@ -262,7 +345,10 @@ fn embalm_activation_creates_white_zombie_copy_with_no_mana_cost() {
 #[test]
 fn eternalize_activation_creates_4_4_black_zombie_copy_with_no_mana_cost() {
     let mut state = main_phase_state();
-    let source = setup_graveyard_source(&mut state, Keyword::Eternalize(ManaCost::default()));
+    let source = setup_graveyard_source(
+        &mut state,
+        Keyword::Eternalize(EternalizeCost::Mana(ManaCost::default())),
+    );
 
     let mut events = Vec::new();
     handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut events)

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -19,8 +19,8 @@ use crate::types::ability::{
     TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::keywords::{
-    normalize_bands_with_other_quality, BloodthirstValue, BuybackCost, CyclingCost, FlashbackCost,
-    Keyword, WardCost,
+    normalize_bands_with_other_quality, BloodthirstValue, BuybackCost, CyclingCost, EmbalmCost,
+    EternalizeCost, FlashbackCost, Keyword, WardCost,
 };
 use crate::types::mana::{ManaCost, ManaCostShard};
 use crate::types::zones::Zone;
@@ -713,6 +713,48 @@ fn parse_cycling_cost(cost_text: &str) -> Option<CyclingCost> {
     }
 }
 
+/// CR 702.128a + CR 602.1a: Parse an Embalm em-dash cost ("embalm—{2}{W}{W},
+/// discard a card" → `EmbalmCost::NonMana(Composite[..])`). Mirrors
+/// `parse_cycling_cost`: reminder-strip, delegate to `parse_oracle_cost`, wrap a
+/// single `Mana` cost in `Mana`, anything composite/non-mana in `NonMana`, and
+/// reject `Unimplemented`.
+fn parse_embalm_cost(cost_text: &str) -> Option<EmbalmCost> {
+    let trimmed = cost_text.trim().trim_end_matches('.').trim_end_matches(')');
+    let clean = opt(take_until::<_, _, OracleError<'_>>(" ("))
+        .parse(trimmed)
+        .map(|(_, before)| before.unwrap_or(trimmed))
+        .unwrap_or(trimmed)
+        .trim();
+    if clean.is_empty() {
+        return None;
+    }
+    match super::oracle_cost::parse_oracle_cost(clean) {
+        AbilityCost::Mana { cost: mana_cost } => Some(EmbalmCost::Mana(mana_cost)),
+        AbilityCost::Unimplemented { .. } => None,
+        other => Some(EmbalmCost::NonMana(other)),
+    }
+}
+
+/// CR 702.129a + CR 602.1a: Parse an Eternalize em-dash cost
+/// ("eternalize—{3}{U}{U}, discard a card" → `EternalizeCost::NonMana(..)`,
+/// Champion of Wits family). Mirrors `parse_embalm_cost`/`parse_cycling_cost`.
+fn parse_eternalize_cost(cost_text: &str) -> Option<EternalizeCost> {
+    let trimmed = cost_text.trim().trim_end_matches('.').trim_end_matches(')');
+    let clean = opt(take_until::<_, _, OracleError<'_>>(" ("))
+        .parse(trimmed)
+        .map(|(_, before)| before.unwrap_or(trimmed))
+        .unwrap_or(trimmed)
+        .trim();
+    if clean.is_empty() {
+        return None;
+    }
+    match super::oracle_cost::parse_oracle_cost(clean) {
+        AbilityCost::Mana { cost: mana_cost } => Some(EternalizeCost::Mana(mana_cost)),
+        AbilityCost::Unimplemented { .. } => None,
+        other => Some(EternalizeCost::NonMana(other)),
+    }
+}
+
 fn parse_bloodthirst_keyword_line(line: &str) -> Option<Keyword> {
     let lower = line.to_ascii_lowercase();
     let stripped = strip_reminder_text(&lower);
@@ -1138,6 +1180,27 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("echo\u{2014}").parse(text) {
         if let Some(echo_cost) = parse_echo_cost(rest) {
             return Some(Keyword::Echo(echo_cost));
+        }
+    }
+
+    // CR 702.128a + CR 602.1a: Embalm with em-dash cost — composite mana +
+    // non-mana ("embalm—{2}{W}{W}, discard a card"). Pure-mana embalm
+    // ("Embalm {3}{W}") arrives via MTGJSON's keywords array (FromStr path).
+    // `parse_embalm_cost` delegates to `parse_oracle_cost` so comma-separated
+    // parts compose into `AbilityCost::Composite`; synthesis then appends the
+    // mandatory self-exile sub-cost.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("embalm\u{2014}").parse(text) {
+        if let Some(embalm_cost) = parse_embalm_cost(rest) {
+            return Some(Keyword::Embalm(embalm_cost));
+        }
+    }
+
+    // CR 702.129a + CR 602.1a: Eternalize with em-dash cost — composite mana +
+    // non-mana ("eternalize—{3}{U}{U}, discard a card", Champion of Wits family).
+    // Pure-mana eternalize arrives via the FromStr path above.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("eternalize\u{2014}").parse(text) {
+        if let Some(eternalize_cost) = parse_eternalize_cost(rest) {
+            return Some(Keyword::Eternalize(eternalize_cost));
         }
     }
 
@@ -3207,6 +3270,61 @@ mod tests {
                 amount: QuantityExpr::Fixed { value: 3 }
             }
         );
+    }
+
+    /// CR 702.129a + CR 602.1a: Champion of Wits family —
+    /// "eternalize—{3}{U}{U}, discard a card" must parse to
+    /// `Eternalize(EternalizeCost::NonMana(Composite[Mana{3UU}, Discard]))`,
+    /// i.e. the discard suffix is NOT dropped.
+    #[test]
+    fn parse_keyword_from_oracle_eternalize_em_dash_discard() {
+        use crate::types::mana::ManaCostShard;
+
+        let kw = parse_keyword_from_oracle("eternalize\u{2014}{3}{u}{u}, discard a card").unwrap();
+        let Keyword::Eternalize(EternalizeCost::NonMana(AbilityCost::Composite { costs })) = kw
+        else {
+            panic!("expected Eternalize NonMana(Composite), got {kw:?}");
+        };
+        assert_eq!(
+            costs.len(),
+            2,
+            "mana + discard, no exile-self yet (synthesis)"
+        );
+        let AbilityCost::Mana { cost: mana } = &costs[0] else {
+            panic!("expected Mana sub-cost, got {:?}", costs[0]);
+        };
+        assert_eq!(
+            mana,
+            &ManaCost::Cost {
+                generic: 3,
+                shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+            }
+        );
+        assert!(
+            matches!(&costs[1], AbilityCost::Discard { .. }),
+            "discard suffix must survive, got {:?}",
+            costs[1]
+        );
+    }
+
+    /// CR 702.128a: Embalm em-dash composite cost parses the discard suffix.
+    #[test]
+    fn parse_keyword_from_oracle_embalm_em_dash_discard() {
+        let kw = parse_keyword_from_oracle("embalm\u{2014}{2}{w}{w}, discard a card").unwrap();
+        let Keyword::Embalm(EmbalmCost::NonMana(AbilityCost::Composite { costs })) = kw else {
+            panic!("expected Embalm NonMana(Composite), got {kw:?}");
+        };
+        assert_eq!(costs.len(), 2);
+        assert!(matches!(&costs[0], AbilityCost::Mana { .. }));
+        assert!(matches!(&costs[1], AbilityCost::Discard { .. }));
+    }
+
+    /// Regression: pure-mana embalm/eternalize still dispatch through the direct
+    /// `FromStr` path to the `Mana` variant (backward compat at the keyword level).
+    #[test]
+    fn parse_keyword_from_oracle_eternalize_mana_backward_compat() {
+        let kw = parse_keyword_from_oracle("eternalize {3}{b}{b}").unwrap();
+        assert!(matches!(kw, Keyword::Eternalize(EternalizeCost::Mana(_))));
     }
 
     /// CR 702.34a regression: Battle Screech's tap-creatures flashback shape

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -27,6 +27,28 @@ pub enum FlashbackCost {
     NonMana(AbilityCost),
 }
 
+/// CR 702.128a + CR 602.1a: Embalm cost — either a mana cost ("Embalm {3}{W}")
+/// or a non-mana/composite cost ("Embalm—{2}{W}{W}, Discard a card."). Mirrors
+/// `CyclingCost`/`FlashbackCost` so a composite non-mana cost composes through
+/// the existing `AbilityCost::Composite` activated-ability pipeline in
+/// `database::embalm_eternalize::token_copy_ability`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum EmbalmCost {
+    Mana(ManaCost),
+    NonMana(AbilityCost),
+}
+
+/// CR 702.129a + CR 602.1a: Eternalize cost — either a mana cost or a
+/// non-mana/composite cost ("Eternalize—{3}{U}{U}, Discard a card." — the
+/// Champion of Wits family). Mirrors `EmbalmCost`/`CyclingCost`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum EternalizeCost {
+    Mana(ManaCost),
+    NonMana(AbilityCost),
+}
+
 /// CR 702.29a: Cycling cost — either a mana cost or a non-mana cost
 /// (e.g., Street Wraith's "Pay 2 life"). Mirrors `FlashbackCost` so the
 /// synthesis in `database::synthesis::synthesize_cycling` can route
@@ -529,8 +551,8 @@ pub enum Keyword {
     Bestow(ManaCost),
 
     // Graveyard
-    Embalm(ManaCost),
-    Eternalize(ManaCost),
+    Embalm(EmbalmCost),
+    Eternalize(EternalizeCost),
 
     // Token / counter
     Fading(u32),
@@ -1711,8 +1733,16 @@ impl FromStr for Keyword {
                 "afterlife" => return Ok(Keyword::Afterlife(p.parse().unwrap_or(1))),
                 "reconfigure" => return Ok(Keyword::Reconfigure(parse_keyword_mana_cost(p))),
                 "bestow" => return Ok(Keyword::Bestow(parse_keyword_mana_cost(p))),
-                "embalm" => return Ok(Keyword::Embalm(parse_keyword_mana_cost(p))),
-                "eternalize" => return Ok(Keyword::Eternalize(parse_keyword_mana_cost(p))),
+                "embalm" => {
+                    return Ok(Keyword::Embalm(EmbalmCost::Mana(parse_keyword_mana_cost(
+                        p,
+                    ))))
+                }
+                "eternalize" => {
+                    return Ok(Keyword::Eternalize(EternalizeCost::Mana(
+                        parse_keyword_mana_cost(p),
+                    )))
+                }
                 "unearth" => return Ok(Keyword::Unearth(parse_keyword_mana_cost(p))),
                 "prowl" => return Ok(Keyword::Prowl(parse_keyword_mana_cost(p))),
                 "morph" => return Ok(Keyword::Morph(parse_keyword_mana_cost(p))),
@@ -2471,8 +2501,22 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "CommanderNinjutsu" => Ok(Keyword::CommanderNinjutsu(mana(data)?)),
         "Reconfigure" => Ok(Keyword::Reconfigure(mana(data)?)),
         "Bestow" => Ok(Keyword::Bestow(mana(data)?)),
-        "Embalm" => Ok(Keyword::Embalm(mana(data)?)),
-        "Eternalize" => Ok(Keyword::Eternalize(mana(data)?)),
+        "Embalm" => {
+            // Accept both legacy ManaCost format and new EmbalmCost tagged format.
+            if let Ok(embalm_cost) = serde_json::from_value::<EmbalmCost>(data.clone()) {
+                Ok(Keyword::Embalm(embalm_cost))
+            } else {
+                Ok(Keyword::Embalm(EmbalmCost::Mana(mana(data)?)))
+            }
+        }
+        "Eternalize" => {
+            // Accept both legacy ManaCost format and new EternalizeCost tagged format.
+            if let Ok(eternalize_cost) = serde_json::from_value::<EternalizeCost>(data.clone()) {
+                Ok(Keyword::Eternalize(eternalize_cost))
+            } else {
+                Ok(Keyword::Eternalize(EternalizeCost::Mana(mana(data)?)))
+            }
+        }
         "Unearth" => Ok(Keyword::Unearth(mana(data)?)),
         "Prowl" => Ok(Keyword::Prowl(mana(data)?)),
         "Morph" => Ok(Keyword::Morph(mana(data)?)),

--- a/crates/mtgish-import/src/convert/keyword.rs
+++ b/crates/mtgish-import/src/convert/keyword.rs
@@ -172,10 +172,16 @@ pub fn try_convert(rule: &Rule, path: &str) -> ConvResult<Option<Keyword>> {
             "Rule::Echo",
             path,
         )?)),
-        Rule::Embalm(c) => Keyword::Embalm(pure_mana(c, "Rule::Embalm", path)?),
+        Rule::Embalm(c) => Keyword::Embalm(engine::types::keywords::EmbalmCost::Mana(pure_mana(
+            c,
+            "Rule::Embalm",
+            path,
+        )?)),
         Rule::Emerge(c) => Keyword::Emerge(pure_mana(c, "Rule::Emerge", path)?),
         Rule::Encore(c) => Keyword::Encore(pure_mana(c, "Rule::Encore", path)?),
-        Rule::Eternalize(c) => Keyword::Eternalize(pure_mana(c, "Rule::Eternalize", path)?),
+        Rule::Eternalize(c) => Keyword::Eternalize(engine::types::keywords::EternalizeCost::Mana(
+            pure_mana(c, "Rule::Eternalize", path)?,
+        )),
         Rule::Evoke(c) => Keyword::Evoke(engine::types::keywords::EvokeCost::Mana(pure_mana(
             c,
             "Rule::Evoke",


### PR DESCRIPTION
Champion of Wits prints 'Eternalize—{3}{U}{U}, Discard a card.' but both
parse paths dropped the discard, so the whole class lost its non-mana
activation cost. Add EmbalmCost / EternalizeCost { Mana | NonMana }
enums (mirroring CyclingCost) and thread them through types, FromStr,
JSON (backward-compatible with legacy bare-mana payloads), the em-dash
parser, and synthesis. CR 702.128a / 702.129a + CR 602.1a (the
activation cost is everything before the colon).

token_copy_ability remains the single cost authority: call sites only
unwrap the tagged cost enum to its AbilityCost payload; all composition
(Composite flatten + self-exile append) lives in token_copy_ability,
mirroring synthesize_cycling. mtgish-import's keyword converter wraps in
*Cost::Mana to match the retyped Keyword variants.

NOTE: card-data.json (gitignored / R2-served) must be regenerated via
oracle-gen and redeployed so the live Eternalize abilities carry the
discard cost; the engine change is what lands here.
