### PR TITLE
fix(engine): scope exploit triggers by subject filter + LKI self-exploit look-back

### DIFF
--- a/crates/engine/src/game/effects/exploit.rs
+++ b/crates/engine/src/game/effects/exploit.rs
@@ -115,4 +115,57 @@ mod tests {
             .iter()
             .any(|e| matches!(e, GameEvent::CreatureExploited { .. })));
     }
+
+    /// CR 603.10a + CR 702.110b: a creature carrying a "when ~ exploits a
+    /// creature" trigger that exploits ITSELF must still fire that trigger even
+    /// though it is sacrificed (off the battlefield) before `CreatureExploited`
+    /// is emitted. Drives the real pipeline: resolve the exploit (which sacrifices
+    /// the source and emits the event), then run trigger collection over the
+    /// produced events and assert the dependent trigger lands on the stack. This
+    /// flips to an empty stack if the `CreatureExploited` LKI look-back block in
+    /// `collect_pending_triggers` is reverted.
+    #[test]
+    fn self_exploit_dependent_trigger_lands_on_stack() {
+        let mut state = GameState::new_two_player(42);
+        let creature = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Sidisi's Faithful".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut trig_def = crate::parser::oracle_trigger::parse_trigger_line(
+            "When Sidisi's Faithful exploits a creature, return target creature to its owner's hand.",
+            "Sidisi's Faithful",
+        );
+        trig_def.execute = Some(Box::new(crate::types::ability::AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Database,
+            Effect::Draw {
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )));
+        {
+            let obj = state.objects.get_mut(&creature).unwrap();
+            obj.trigger_definitions.push(trig_def.clone());
+            std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trig_def);
+        }
+
+        let mut events = Vec::new();
+        let ability = make_exploit_ability(creature, creature);
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // The exploiter is now in the graveyard (sacrificed itself).
+        assert!(state.players[0].graveyard.contains(&creature));
+
+        crate::game::triggers::process_triggers(&mut state, &events);
+
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "CR 603.10a: the self-exploiter's own exploit trigger must land on the \
+             stack via last-known information"
+        );
+    }
 }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2642,17 +2642,27 @@ pub(super) fn match_foretell(
     }
 }
 
-/// CR 702.110a: "When this creature exploits" = source is the exploiter.
+/// CR 702.110b: "exploits a creature" — fires when a creature matching the
+/// trigger's subject filter exploits. `valid_card`/`valid_source` scope the
+/// EXPLOITER: `SelfRef` ⇒ "this creature exploits", a typed/controller
+/// filter ⇒ "a creature you control exploits". With no filter, defaults to
+/// the source ("this creature exploits").
 pub(super) fn match_exploited(
     event: &GameEvent,
-    _trigger: &TriggerDefinition,
+    trigger: &TriggerDefinition,
     source_id: ObjectId,
-    _state: &GameState,
+    state: &GameState,
 ) -> bool {
-    matches!(
-        event,
-        GameEvent::CreatureExploited { exploiter, .. } if *exploiter == source_id
-    )
+    let GameEvent::CreatureExploited { exploiter, .. } = event else {
+        return false;
+    };
+    if let Some(filter) = &trigger.valid_source {
+        return target_filter_matches_object(state, *exploiter, filter, source_id);
+    }
+    if let Some(filter) = &trigger.valid_card {
+        return target_filter_matches_object(state, *exploiter, filter, source_id);
+    }
+    *exploiter == source_id
 }
 
 /// CR 702.112b: "When [subject] becomes renowned" — fires when Renown
@@ -11225,5 +11235,119 @@ mod tests {
             std::slice::from_ref(&event),
         );
         assert_eq!(count, None);
+    }
+
+    // CR 702.110b: `match_exploited` scopes the exploiter via `valid_card` /
+    // `valid_source` rather than hard-coding `exploiter == source`.
+
+    #[test]
+    fn exploited_self_ref_matches_self_exploit() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Self Exploiter".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::Exploited);
+        trigger.valid_card = Some(TargetFilter::SelfRef);
+
+        let event = GameEvent::CreatureExploited {
+            exploiter: source,
+            sacrificed: source,
+        };
+
+        assert!(match_exploited(&event, &trigger, source, &state));
+    }
+
+    #[test]
+    fn exploited_self_ref_rejects_other_exploiter() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Self Exploiter".to_string(),
+            Zone::Battlefield,
+        );
+        let other = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Other Exploiter".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::Exploited);
+        trigger.valid_card = Some(TargetFilter::SelfRef);
+
+        let event = GameEvent::CreatureExploited {
+            exploiter: other,
+            sacrificed: other,
+        };
+
+        assert!(!match_exploited(&event, &trigger, source, &state));
+    }
+
+    #[test]
+    fn exploited_typed_controller_matches_other_controlled_exploiter() {
+        let mut state = setup();
+        // "Whenever a creature you control exploits a creature, …": the trigger
+        // source and the (different) exploiter share a controller.
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Exploit Payoff".to_string(),
+            Zone::Battlefield,
+        );
+        let other = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Other Exploiter".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&other)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let mut trigger = make_trigger(TriggerMode::Exploited);
+        trigger.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+
+        let event = GameEvent::CreatureExploited {
+            exploiter: other,
+            sacrificed: other,
+        };
+
+        assert!(match_exploited(&event, &trigger, source, &state));
+    }
+
+    #[test]
+    fn exploited_no_filter_defaults_to_source() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Self Exploiter".to_string(),
+            Zone::Battlefield,
+        );
+        let trigger = make_trigger(TriggerMode::Exploited);
+        assert!(trigger.valid_card.is_none());
+        assert!(trigger.valid_source.is_none());
+
+        let event = GameEvent::CreatureExploited {
+            exploiter: source,
+            sacrificed: source,
+        };
+
+        assert!(match_exploited(&event, &trigger, source, &state));
     }
 }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2656,13 +2656,50 @@ pub(super) fn match_exploited(
     let GameEvent::CreatureExploited { exploiter, .. } = event else {
         return false;
     };
-    if let Some(filter) = &trigger.valid_source {
-        return target_filter_matches_object(state, *exploiter, filter, source_id);
+    // `valid_source`/`valid_card` scope the EXPLOITER's subject filter. With no
+    // filter, "this creature exploits" — match the source by identity.
+    match trigger
+        .valid_source
+        .as_ref()
+        .or(trigger.valid_card.as_ref())
+    {
+        Some(filter) => exploiter_matches_subject_filter(state, *exploiter, filter, source_id),
+        None => *exploiter == source_id,
     }
-    if let Some(filter) = &trigger.valid_card {
-        return target_filter_matches_object(state, *exploiter, filter, source_id);
+}
+
+/// CR 603.10a + CR 400.7: Match an exploiter against the trigger's subject
+/// filter. Exploit emits `CreatureExploited` only AFTER the sacrifice resolves
+/// (CR 702.110b), so a creature that exploited ITSELF is already in the
+/// graveyard and its live object has had all battlefield characteristics
+/// (control, types, granted abilities) stripped. A typed filter like "a
+/// creature you control" would then fail to match. When the exploiter has left
+/// the battlefield, evaluate the filter against its last-known battlefield
+/// snapshot (`lki_cache`) instead of the stripped graveyard object. An exploiter
+/// that sacrificed a DIFFERENT creature is still on the battlefield and matches
+/// on the live path.
+fn exploiter_matches_subject_filter(
+    state: &GameState,
+    exploiter: ObjectId,
+    filter: &TargetFilter,
+    source_id: ObjectId,
+) -> bool {
+    if target_filter_matches_object(state, exploiter, filter, source_id) {
+        return true;
     }
-    *exploiter == source_id
+    if state
+        .objects
+        .get(&exploiter)
+        .is_none_or(|o| o.zone != Zone::Battlefield)
+    {
+        if let Some(lki) = state.lki_cache.get(&exploiter) {
+            let ctx = super::filter::FilterContext::from_source(state, source_id);
+            return super::filter::matches_target_filter_on_lki_snapshot(
+                state, exploiter, lki, filter, &ctx,
+            );
+        }
+    }
+    false
 }
 
 /// CR 702.112b: "When [subject] becomes renowned" — fires when Renown
@@ -11349,5 +11386,59 @@ mod tests {
         };
 
         assert!(match_exploited(&event, &trigger, source, &state));
+    }
+
+    /// CR 603.10a + CR 400.7: a creature that exploits ITSELF satisfies a typed
+    /// subject filter ("a creature you control") via its last-known battlefield
+    /// snapshot. Drives the REAL zone-change pipeline (`move_to_zone`) so the
+    /// graveyard object is genuinely stripped (control/types cleared) and
+    /// `lki_cache` is populated exactly as it is in a live game. This flips to
+    /// `false` if the LKI fallback in `exploiter_matches_subject_filter` is
+    /// reverted, because `target_filter_matches_object` reads the stripped
+    /// graveyard object.
+    #[test]
+    fn exploited_typed_filter_matches_self_sacrificed_exploiter_via_lki() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Sidisi's Faithful".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        // Real zone-change pipeline: snapshots LKI and strips the graveyard object.
+        crate::game::zones::move_to_zone(&mut state, source, Zone::Graveyard, &mut Vec::new());
+        assert!(state.lki_cache.contains_key(&source));
+
+        let event = GameEvent::CreatureExploited {
+            exploiter: source,
+            sacrificed: source,
+        };
+
+        let mut you = make_trigger(TriggerMode::Exploited);
+        you.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        assert!(
+            match_exploited(&event, &you, source, &state),
+            "CR 603.10a: self-sacrificed exploiter matches 'a creature you control' via LKI"
+        );
+
+        let mut opponent = make_trigger(TriggerMode::Exploited);
+        opponent.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::Opponent),
+        ));
+        assert!(
+            !match_exploited(&event, &opponent, source, &state),
+            "an opponent-controlled subject filter must NOT match the controller's own exploiter"
+        );
     }
 }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1371,6 +1371,54 @@ fn collect_pending_triggers(
             }
         }
 
+        // CR 603.10a: Abilities that trigger when a player sacrifices a permanent
+        // look back in time. An exploit ability emits `CreatureExploited` only
+        // after the sacrifice resolves (CR 702.110b), so a creature that exploits
+        // ITSELF has already left the battlefield when this event fires. Scan the
+        // exploiter with zone_filter=Battlefield (last-known information) so its
+        // own "when ~ exploits a creature" trigger still fires. Guarded to the
+        // off-battlefield case only: when the exploiter sacrificed a DIFFERENT
+        // creature it is still on the battlefield and the live scan + per-event
+        // dedup already cover it.
+        if let GameEvent::CreatureExploited { exploiter, .. } = event {
+            if state
+                .objects
+                .get(exploiter)
+                .is_some_and(|o| o.zone != Zone::Battlefield)
+            {
+                let matched_triggers = {
+                    let obj = &state.objects[exploiter];
+                    collect_matching_triggers(
+                        state,
+                        event,
+                        events,
+                        obj,
+                        obj.entered_battlefield_turn.unwrap_or(0),
+                        Some(Zone::Battlefield),
+                        &mut batched_this_pass,
+                        &mut registered_this_event,
+                    )
+                };
+                for matched in matched_triggers {
+                    record_trigger_fired(
+                        state,
+                        matched.constraint.as_ref(),
+                        *exploiter,
+                        matched.trig_idx,
+                        event,
+                    );
+                    if matched.batched {
+                        batched_this_pass.insert((*exploiter, matched.trig_idx));
+                    }
+                    registered_this_event.insert((*exploiter, matched.trig_idx));
+                    pending.push(PendingTriggerContext::batched(
+                        matched.pending,
+                        matched.trigger_events,
+                    ));
+                }
+            }
+        }
+
         // CR 603.10a (continued): an observer that left the battlefield in the
         // SAME simultaneous event as this departure observes it via last-known
         // information. The producer stamps that group onto `record.co_departed`
@@ -11926,6 +11974,61 @@ pub mod tests {
         assert_eq!(run(PlayerId(0), Phase::PostCombatMain), 1);
         assert_eq!(run(PlayerId(0), Phase::Upkeep), 0);
         assert_eq!(run(PlayerId(1), Phase::PreCombatMain), 0);
+    }
+
+    /// CR 603.10a + CR 702.110b: A creature that exploits ITSELF has already left
+    /// the battlefield (sacrificed) when `CreatureExploited` is emitted. Its own
+    /// "when ~ exploits a creature" trigger must still fire via the
+    /// last-known-information look-back in `collect_pending_triggers`. This is the
+    /// discriminating exploit-self-sac test: it flips to 0 on the stack if the
+    /// `CreatureExploited` LKI block is reverted, because the live battlefield
+    /// scan cannot find a graveyard object.
+    #[test]
+    fn self_exploit_trigger_fires_from_graveyard_via_lki() {
+        let mut state = setup();
+        let source = make_creature(&mut state, PlayerId(0), "Sidisi's Faithful", 1, 1);
+        let mut trig_def = crate::parser::oracle_trigger::parse_trigger_line(
+            "When Sidisi's Faithful exploits a creature, return target creature to its owner's hand.",
+            "Sidisi's Faithful",
+        );
+        assert_eq!(trig_def.mode, TriggerMode::Exploited);
+        assert_eq!(trig_def.valid_card, Some(TargetFilter::SelfRef));
+        trig_def.execute = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )));
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.trigger_definitions.push(trig_def.clone());
+            std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trig_def);
+        }
+
+        // The exploiter sacrificed itself: it is in the graveyard, off the
+        // battlefield, when `CreatureExploited` fires (CR 702.110b emits the
+        // event after the sacrifice resolves).
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.zone = Zone::Graveyard;
+        }
+        state.battlefield.retain(|id| *id != source);
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::CreatureExploited {
+                exploiter: source,
+                sacrificed: source,
+            }],
+        );
+
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "CR 603.10a: a self-exploiter's own exploit trigger must fire from the \
+             graveyard via last-known information"
+        );
     }
 
     /// CR 601.2h + CR 603.4: Increment intervening-if gates the counter-placement

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -11976,60 +11976,13 @@ pub mod tests {
         assert_eq!(run(PlayerId(1), Phase::PreCombatMain), 0);
     }
 
-    /// CR 603.10a + CR 702.110b: A creature that exploits ITSELF has already left
-    /// the battlefield (sacrificed) when `CreatureExploited` is emitted. Its own
-    /// "when ~ exploits a creature" trigger must still fire via the
-    /// last-known-information look-back in `collect_pending_triggers`. This is the
-    /// discriminating exploit-self-sac test: it flips to 0 on the stack if the
-    /// `CreatureExploited` LKI block is reverted, because the live battlefield
-    /// scan cannot find a graveyard object.
-    #[test]
-    fn self_exploit_trigger_fires_from_graveyard_via_lki() {
-        let mut state = setup();
-        let source = make_creature(&mut state, PlayerId(0), "Sidisi's Faithful", 1, 1);
-        let mut trig_def = crate::parser::oracle_trigger::parse_trigger_line(
-            "When Sidisi's Faithful exploits a creature, return target creature to its owner's hand.",
-            "Sidisi's Faithful",
-        );
-        assert_eq!(trig_def.mode, TriggerMode::Exploited);
-        assert_eq!(trig_def.valid_card, Some(TargetFilter::SelfRef));
-        trig_def.execute = Some(Box::new(AbilityDefinition::new(
-            AbilityKind::Database,
-            Effect::Draw {
-                count: QuantityExpr::Fixed { value: 1 },
-                target: TargetFilter::Controller,
-            },
-        )));
-        {
-            let obj = state.objects.get_mut(&source).unwrap();
-            obj.trigger_definitions.push(trig_def.clone());
-            std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trig_def);
-        }
-
-        // The exploiter sacrificed itself: it is in the graveyard, off the
-        // battlefield, when `CreatureExploited` fires (CR 702.110b emits the
-        // event after the sacrifice resolves).
-        {
-            let obj = state.objects.get_mut(&source).unwrap();
-            obj.zone = Zone::Graveyard;
-        }
-        state.battlefield.retain(|id| *id != source);
-
-        process_triggers(
-            &mut state,
-            &[GameEvent::CreatureExploited {
-                exploiter: source,
-                sacrificed: source,
-            }],
-        );
-
-        assert_eq!(
-            state.stack.len(),
-            1,
-            "CR 603.10a: a self-exploiter's own exploit trigger must fire from the \
-             graveyard via last-known information"
-        );
-    }
+    // NOTE: The discriminating real-pipeline test for the `CreatureExploited` LKI
+    // look-back lives in `effects::exploit::tests::self_exploit_dependent_trigger_lands_on_stack`.
+    // That test drives the actual exploit resolution (real sacrifice → real zone
+    // change → real trigger collection), so it exercises CR 400.7 graveyard
+    // clearing faithfully. A previous unit test here manually set `obj.zone =
+    // Graveyard` while leaving the object's triggers/continuous effects intact,
+    // which masked the very clearing it claimed to cover (Gemini [MED]).
 
     /// CR 601.2h + CR 603.4: Increment intervening-if gates the counter-placement
     /// trigger on the amount of mana spent to cast the triggering spell exceeding


### PR DESCRIPTION
match_exploited hard-coded exploiter == source and ignored the
valid_card/valid_source filter the parser already sets, so two defects
converged on it:

- exploit-cares-other: subject-filtered payoffs ('Whenever a creature you
  control exploits a creature, ...') never fired. The matcher now honors
  valid_source/valid_card via target_filter_matches_object, mirroring
  match_become_renowned. CR 702.110b.
- exploit-self-sac: CreatureExploited is emitted after the sacrifice
  (CR 702.110b), so a self-exploiter has left the battlefield and the live
  candidate scan missed it. Add a CR 603.10a last-known-information
  look-back in collect_pending_triggers (mirroring the ZoneChanged block),
  guarded to the off-battlefield case; the shared registered_this_event
  dedup prevents any double-fire with the live scan.

No event reorder (would violate CR 702.110b), no new variant/field/parser
change — scoping rides the existing valid_card axis.
