### PR TITLE
docs(pr-handler): cut GitHub core rate-limit use; harden comment-resolution gate

### DIFF
--- a/.claude/agents/pr-review-comment-resolver.md
+++ b/.claude/agents/pr-review-comment-resolver.md
@@ -55,23 +55,26 @@ Accept:
 Fetch all feedback in ONE GraphQL call. **Most actionable feedback on this repo is top-level — PR review bodies (where Gemini's summary review and most human reviews land) and issue/conversation comments — not file/line-anchored inline threads.** GraphQL is the idle rate-limit bucket, so one query avoids the per-PR REST `--paginate` walk that drains `core`; more importantly it fetches all three feedback objects **comprehensively**, which the "all blocking review comments resolved" gate requires:
 
 ```bash
+# First page: omit the cursor vars (they default to null = from the start).
+# To paginate, pass the connection's endCursor back via -F <conn>Cursor=<endCursor>.
 gh api graphql -F owner=phase-rs -F name=phase -F pr=<PR> -f query='
-query($owner:String!,$name:String!,$pr:Int!) {
+query($owner:String!,$name:String!,$pr:Int!,$reviewsCursor:String,$commentsCursor:String,$threadsCursor:String) {
   repository(owner:$owner, name:$name) {
     pullRequest(number:$pr) {
       reviewDecision
-      reviews(first:100) {                    # top-level review bodies (Gemini summary, human reviews) — the MAJORITY
+      reviews(first:100, after:$reviewsCursor) {              # top-level review bodies (Gemini summary, human reviews) — the MAJORITY
         pageInfo { hasNextPage endCursor }
         nodes { author{login} body state submittedAt url }
       }
-      comments(first:100) {                   # top-level issue/conversation comments
+      comments(first:100, after:$commentsCursor) {            # top-level issue/conversation comments
         pageInfo { hasNextPage endCursor }
         nodes { author{login} body url createdAt }
       }
-      reviewThreads(first:100) {              # inline (file/line) threads + resolved state — the minority
+      reviewThreads(first:100, after:$threadsCursor) {        # inline (file/line) threads + resolved state — the minority
         pageInfo { hasNextPage endCursor }
         nodes { isResolved isOutdated path line
-                comments(first:50) { nodes { author{login} body url createdAt } } }
+                comments(first:50) { pageInfo { hasNextPage endCursor }
+                                     nodes { author{login} body url createdAt } } }
       }
     }
   }
@@ -82,7 +85,7 @@ Comprehensiveness rules for the gate:
 
 - **Top-level `reviews` and `comments` have no `isResolved` flag** — read every one's **body** for actionable findings and judge whether each is addressed in the current commits. Do NOT gate on review `state`: the dominant reviewer here (Gemini) posts its findings in a `COMMENTED` review with `reviewDecision: null` (verified on live PRs), so a `state`-based gate would skip the majority of review content. Treat `state == CHANGES_REQUESTED` as an *additional* hard block, never the sole blocking signal. Compare reviews by each author's **latest** `submittedAt` — a later approval from the same author supersedes their earlier change-request, and vice-versa.
 - **Inline `reviewThreads`** are the minority here but still binding: filter to `isResolved == false` for actionable items.
-- If ANY connection's `pageInfo.hasNextPage` is true, paginate with `endCursor` — do not stop at the first page; this is the comprehensive gate, not a triage slice. Truncating `reviews`/`comments` would silently hide top-level blockers, the majority case. (The nested per-thread `comments(first:50)` cap only matters for a single thread with 50+ replies — rare; refetch that thread if it hits the cap.)
+- If ANY connection's `pageInfo.hasNextPage` is true, paginate by passing that connection's `endCursor` back via its cursor variable (`-F reviewsCursor=<endCursor>`, `-F commentsCursor=…`, `-F threadsCursor=…`) and re-running — do not stop at the first page; this is the comprehensive gate, not a triage slice. Truncating `reviews`/`comments` would silently hide top-level blockers, the majority case. The nested per-thread `comments` connection also exposes `pageInfo`: if a single thread's `comments.pageInfo.hasNextPage` is true (50+ replies — rare), refetch that thread's comments with its own `after` cursor.
 
 Never substitute a per-PR `gh api .../pulls/<PR>/comments --paginate` REST walk (drains `core`, inline-only, lacks resolved-state) or a time-windowed `since=` sweep (risks dropping old unaddressed top-level feedback).
 

--- a/.claude/agents/pr-review-comment-resolver.md
+++ b/.claude/agents/pr-review-comment-resolver.md
@@ -52,13 +52,39 @@ Accept:
 
 ### 2. Fetch Review Feedback
 
-Fetch all relevant feedback:
+Fetch all feedback in ONE GraphQL call. **Most actionable feedback on this repo is top-level — PR review bodies (where Gemini's summary review and most human reviews land) and issue/conversation comments — not file/line-anchored inline threads.** GraphQL is the idle rate-limit bucket, so one query avoids the per-PR REST `--paginate` walk that drains `core`; more importantly it fetches all three feedback objects **comprehensively**, which the "all blocking review comments resolved" gate requires:
 
 ```bash
-gh pr view <PR> --repo phase-rs/phase --json reviewDecision,reviews,comments
-gh api repos/phase-rs/phase/pulls/<PR>/comments --paginate
-gh api repos/phase-rs/phase/issues/<PR>/comments --paginate
+gh api graphql -F owner=phase-rs -F name=phase -F pr=<PR> -f query='
+query($owner:String!,$name:String!,$pr:Int!) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$pr) {
+      reviewDecision
+      reviews(first:100) {                    # top-level review bodies (Gemini summary, human reviews) — the MAJORITY
+        pageInfo { hasNextPage endCursor }
+        nodes { author{login} body state submittedAt url }
+      }
+      comments(first:100) {                   # top-level issue/conversation comments
+        pageInfo { hasNextPage endCursor }
+        nodes { author{login} body url createdAt }
+      }
+      reviewThreads(first:100) {              # inline (file/line) threads + resolved state — the minority
+        pageInfo { hasNextPage endCursor }
+        nodes { isResolved isOutdated path line
+                comments(first:50) { nodes { author{login} body url createdAt } } }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest'
 ```
+
+Comprehensiveness rules for the gate:
+
+- **Top-level `reviews` and `comments` have no `isResolved` flag** — read every one's **body** for actionable findings and judge whether each is addressed in the current commits. Do NOT gate on review `state`: the dominant reviewer here (Gemini) posts its findings in a `COMMENTED` review with `reviewDecision: null` (verified on live PRs), so a `state`-based gate would skip the majority of review content. Treat `state == CHANGES_REQUESTED` as an *additional* hard block, never the sole blocking signal. Compare reviews by each author's **latest** `submittedAt` — a later approval from the same author supersedes their earlier change-request, and vice-versa.
+- **Inline `reviewThreads`** are the minority here but still binding: filter to `isResolved == false` for actionable items.
+- If ANY connection's `pageInfo.hasNextPage` is true, paginate with `endCursor` — do not stop at the first page; this is the comprehensive gate, not a triage slice. Truncating `reviews`/`comments` would silently hide top-level blockers, the majority case. (The nested per-thread `comments(first:50)` cap only matters for a single thread with 50+ replies — rare; refetch that thread if it hits the cap.)
+
+Never substitute a per-PR `gh api .../pulls/<PR>/comments --paginate` REST walk (drains `core`, inline-only, lacks resolved-state) or a time-windowed `since=` sweep (risks dropping old unaddressed top-level feedback).
 
 For each item, extract source, author, body, file path and line/range, timestamps, and whether it is resolved, outdated, duplicated, or still actionable. Skip resolved and informational comments. If uncertain, keep the item and mark it `needs-human-confirmation`.
 

--- a/.claude/skills/pr-contribution-handler/SKILL.md
+++ b/.claude/skills/pr-contribution-handler/SKILL.md
@@ -61,6 +61,15 @@ Before changing code, read these files from the repo root and apply their logic:
 
 Do not paraphrase these from memory. Re-read them each time because they are the source of truth.
 
+## Rate-Limit Discipline (governs every `gh` call)
+
+A non-stop fleet exhausts GitHub's **5,000-req/hr REST `core`** bucket long before the separate GraphQL bucket. Minimize `core` reads:
+
+- **Scan diffs locally, not via API.** After fetching the PR head ref (needed for checkout anyway), use `git diff origin/main...pr/<N>` — never `gh pr diff <N>`, which spends one `core` request per PR and returns a truncatable payload. The local diff is free and carries the full patch (gitlink modes, binary flags, deletion counts).
+- **Comments: comprehensive via GraphQL for the gate; a windowed sweep only for triage.** Most feedback here is **top-level** — review bodies (Gemini's summary, human reviews) and issue comments — which have no resolved-flag, so the "all blocking comments resolved" gate must read every one. Fetch `reviews` + `comments` + inline `reviewThreads` comprehensively in one GraphQL call per PR (idle bucket), paginating every connection whose `hasNextPage` is true — never a time-windowed slice, which can drop an old unaddressed blocker (see `pr-review-comment-resolver.md` §2). A repo-wide `since=` REST sweep is acceptable **only** for lightweight "what's new across the batch" triage: derive `since` from the run window, dedup by comment `id` (`since` is inclusive), never a per-PR un-`since`'d `--paginate` walk (the top `core` drain). Do NOT persist a shared global high-water-mark file: concurrent fleet agents race on it and skip each other's new comments.
+- **Prefer GraphQL builders for state.** `gh pr view --json` / `gh pr list --json` / `gh pr checks` are GraphQL (the idle bucket) — they do not relieve `core`, but they are the right place to read PR state and check rollups.
+- **Back-pressure off response headers.** Watch `x-ratelimit-remaining` on calls you already make; consult `gh api rate_limit` at most once per batch (it counts against the *secondary* limit). When `core` runs low, pause **only at PR boundaries** — never inside the approve → label → enqueue → verify sequence (that critical section must not be interrupted; a half-enqueued PR is worse than waiting).
+
 ## Intake
 
 1. Parse the PR number(s), URL(s), or branch name(s).
@@ -75,7 +84,7 @@ Do not paraphrase these from memory. Re-read them each time because they are the
 
 **The goal of this skill is to MERGE PRs into `main`.** Most "out of place" changes are unintentional and fixable inline. A small subset is malicious or destructive enough that you should stop and flag the maintainer instead of patching forward.
 
-Run these checks against the diff (`gh pr diff <N>` or `git diff origin/main...HEAD` after checkout — you can do it pre-checkout via `gh pr diff <N>`):
+Run these checks against the **local** diff. Fetch the PR head ref once (`git fetch origin pull/<N>/head:pr/<N>` — required for checkout regardless) and scan `git diff origin/main...pr/<N>`, which costs no API quota and returns the full, untruncated patch (gitlink `160000` modes, binary flags, deletion counts). Avoid `gh pr diff <N>` — it spends a REST `core` request per PR, the bucket a non-stop fleet drains first, and its API payload can be truncated for very large diffs:
 
 ### Hard stops (do not attempt fixes — report and skip)
 
@@ -212,12 +221,16 @@ If `origin/main` is already an ancestor and there are no conflicts, skip the mer
 
 ## Review Comment Resolution
 
-**Operational — posting and fetching.** Post every PR comment, review body, and final report through a temp file (`gh pr comment <N> --body-file /tmp/body.md`, `gh pr review <N> --body-file /tmp/review.md`), **never** an inline `--body "…"` string. Inline bodies are mangled by the shell — zsh strips backticked identifiers and code spans, which has silently corrupted the technical claims of a *blocking* review. Write the body to a file, then pass `--body-file`. When handling many PRs, fetch comments in one batched repo-wide sweep rather than looping per-PR `gh` calls — the per-PR pattern drains the 5,000/hr GitHub core rate limit at fleet scale:
+**Operational — posting and fetching.** Post every PR comment, review body, and final report through a temp file (`gh pr comment <N> --body-file /tmp/body.md`, `gh pr review <N> --body-file /tmp/review.md`), **never** an inline `--body "…"` string. Inline bodies are mangled by the shell — zsh strips backticked identifiers and code spans, which has silently corrupted the technical claims of a *blocking* review. Write the body to a file, then pass `--body-file`.
+
+**Fetching — gate vs triage.** For per-PR comment **resolution** (the gate), fetch `reviews` + `comments` + `reviewThreads` comprehensively via one GraphQL call per PR (the idle bucket — cheap even at fleet scale; query and pagination rules in `pr-review-comment-resolver.md` §2). Most feedback here is top-level review bodies and issue comments, which carry no resolved-flag — read every one's body for findings (Gemini posts its review as `COMMENTED` with `reviewDecision: null`, so do NOT gate on review `state`; treat `CHANGES_REQUESTED` as an additional hard block). The repo-wide `since=` REST sweep below is **only** for lightweight cross-batch triage of what changed recently — never the resolution gate, and never a per-PR un-`since`'d `--paginate` walk (that drains the 5,000/hr `core` bucket at fleet scale):
 
 ```bash
-gh api --paginate 'repos/phase-rs/phase/pulls/comments?since=<ISO8601>&per_page=100'
-gh api --paginate 'repos/phase-rs/phase/issues/comments?since=<ISO8601>&per_page=100'
+gh api --paginate 'repos/phase-rs/phase/pulls/comments?since=<ISO8601>&per_page=100'   # inline review comments
+gh api --paginate 'repos/phase-rs/phase/issues/comments?since=<ISO8601>&per_page=100'  # issue/conversation comments
 ```
+
+Derive `<ISO8601>` from the run's time window (e.g. one hour prior) rather than re-sweeping all history, filter each PR's comments locally by `pull_request_url`/`issue_url`, and **dedup by comment `id`** — `since` is inclusive, so the boundary comment re-returns. Do NOT persist a shared global high-water-mark across runs: concurrent fleet agents race on it and silently skip each other's new comments (per **Rate-Limit Discipline**).
 
 Apply `.claude/agents/pr-review-comment-resolver.md` directly:
 
@@ -387,7 +400,7 @@ gh pr edit <PR> --add-label <type-label>                              # see "## 
 gh pr merge <PR> --auto
 ```
 
-Verify via the GraphQL API (gh CLI output is unreliable under the rtk filter): `reviewDecision == APPROVED`, the type label present, and `mergeQueueEntry.state` is QUEUED or AWAITING_CHECKS. A bare `gh pr merge --auto` that prints "queued" is NOT proof — re-check the entry state, because the queue silently sheds unapproved PRs.
+Verify via the GraphQL API (gh CLI output is unreliable under the rtk filter): `reviewDecision == APPROVED`, the type label present, and `mergeQueueEntry.state` is QUEUED or AWAITING_CHECKS. A bare `gh pr merge --auto` that prints "queued" is NOT proof — re-check the entry state, because the queue silently sheds unapproved PRs. These mergeability/queue-state reads must be **live** — never serve them from a `--cache`d snapshot, because a push during handling changes them.
 
 `--auto` under a merge queue means "add to queue when required checks pass." The queue speculatively rebases the PR against the latest `main`, runs CI once on the synthesized future-main commit (batching up to the configured group size with any other queued PRs), and merges all green PRs in order. Failed PRs are bisected out of the group and kicked back to the author.
 


### PR DESCRIPTION
The pr-contribution-handler fleet runs non-stop and exhausts GitHub's
5000/hr REST core bucket. Move reads off core without weakening review rigor.

- Add a Rate-Limit Discipline section: scan the local git diff (free,
  untruncated) instead of gh pr diff; fetch comments comprehensively via
  GraphQL (the idle bucket); the repo-wide since= REST sweep is triage-only;
  apply back-pressure only at PR boundaries, never inside approve->enqueue->
  verify; queue-state reads stay live, never cached.
- pr-review-comment-resolver: replace the per-PR un-since'd REST --paginate
  comment walk (the core drain) with ONE GraphQL call for reviews + comments +
  reviewThreads, comprehensive with pagination guards. Lead with top-level
  review bodies and issue comments (the majority; where Gemini lands), not
  inline threads.
- Gate fix: do NOT gate on review state. Gemini submits findings as a
  COMMENTED review with reviewDecision:null, so a state gate would skip the
  majority of review content. Read every review body; CHANGES_REQUESTED is an
  additional hard block; compare each author's latest review by submittedAt.

GraphQL query live-validated against an open PR.
