### PR TITLE
fix(engine): apply self-spell cost reductions from graveyard

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -3871,7 +3871,7 @@ fn apply_non_floor_cost_modifiers(
     object_id: ObjectId,
     mana_cost: &mut ManaCost,
 ) {
-    // CR 117.7 + CR 601.2f: collect self-spell statics ("This spell costs
+    // CR 601.2f: collect self-spell statics ("This spell costs
     // {N} less ...") and battlefield statics together so all increases apply
     // before any reductions across both passes.
     let mut collected = collect_self_spell_cost_modifiers(state, player, object_id, None, false);
@@ -4071,10 +4071,9 @@ pub(super) fn recompute_pending_cast_cost(
     apply_cost_modifiers_to_base(state, player, object_id, obj.mana_cost.clone())
 }
 
-/// CR 117.7 + CR 601.2f: Apply self-spell cost modifications — `ReduceCost` / `RaiseCost`
+/// CR 601.2f: Apply self-spell cost modifications — `ReduceCost` / `RaiseCost`
 /// statics printed on the spell being cast, with `affected = SelfRef` and `active_zones`
-/// covering the card's current zone (Hand for normal casting, Stack for the cost-
-/// determination step). Handles cards like Tolarian Terror where the cost reduction is
+/// covering the card's current castable zone. Handles cards like Tolarian Terror where the cost reduction is
 /// inherent to the spell and must apply before the spell resolves.
 ///
 /// Test-only isolation helper: production cost calculation now collects self-spell
@@ -4136,7 +4135,7 @@ fn collect_self_spell_cost_modifiers(
         if !def.active_zones.contains(&spell_obj.zone) {
             continue;
         }
-        // CR 117.7: Only self-referential cost statics apply here. Any other
+        // CR 601.2f: Only self-referential cost statics apply here. Any other
         // `affected` scoping would indicate a battlefield-style static that
         // should be handled by the battlefield scanner.
         if !matches!(def.affected, Some(TargetFilter::SelfRef)) {
@@ -18371,11 +18370,11 @@ mod tests {
         );
     }
 
-    /// CR 117.7 + CR 601.2f: A self-spell cost reduction printed on the card itself
+    /// CR 601.2f: A self-spell cost reduction printed on the card itself
     /// ("This spell costs {1} less to cast for each instant and sorcery card in your
     /// graveyard.") must fire while the card is in hand. Verifies the parser-emitted
-    /// static (affected = SelfRef, active_zones = [Hand, Stack, Command]) is picked up by the
-    /// casting-time scanner and reduces the spell's generic cost.
+    /// static (affected = SelfRef, active_zones = self_spell_cost_mod_active_zones()) is
+    /// picked up by the casting-time scanner and reduces the spell's generic cost.
     #[test]
     fn tolarian_terror_self_cost_reduction_applies_from_hand() {
         use crate::types::statics::StaticMode;

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12641,12 +12641,13 @@ mod tests {
         AbilityCost, AbilityTag, ActivationRestriction, AdditionalCost, AggregateFunction,
         BasicLandType, CastPermissionConstraint, CastVariantPaid, CastingPermission,
         ChosenAttribute, ChosenSubtypeKind, Comparator, ContinuousModification, ControllerRef,
-        CountScope, CostCategory, FilterProp, GameRestriction, KickerVariant, ManaContribution, ManaProduction,
-        ManaSpendPermission, ManaSpendRestriction, ModalChoice, ModalSelectionCondition,
-        ModalSelectionConstraint, MultiTargetSpec, ObjectProperty, ProhibitedActivity, PtStat,
-        PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode,
-        RestrictionExpiry, RestrictionPlayerScope, SearchSelectionConstraint, StaticCondition,
-        StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+        CostCategory, CountScope, FilterProp, GameRestriction, KickerVariant, ManaContribution,
+        ManaProduction, ManaSpendPermission, ManaSpendRestriction, ModalChoice,
+        ModalSelectionCondition, ModalSelectionConstraint, MultiTargetSpec, ObjectProperty,
+        ProhibitedActivity, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
+        ReplacementDefinition, ReplacementMode, RestrictionExpiry, RestrictionPlayerScope,
+        SearchSelectionConstraint, StaticCondition, StaticDefinition, TargetFilter, TargetRef,
+        TypeFilter, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::{CoreType, Supertype};

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12641,7 +12641,7 @@ mod tests {
         AbilityCost, AbilityTag, ActivationRestriction, AdditionalCost, AggregateFunction,
         BasicLandType, CastPermissionConstraint, CastVariantPaid, CastingPermission,
         ChosenAttribute, ChosenSubtypeKind, Comparator, ContinuousModification, ControllerRef,
-        CostCategory, FilterProp, GameRestriction, KickerVariant, ManaContribution, ManaProduction,
+        CountScope, CostCategory, FilterProp, GameRestriction, KickerVariant, ManaContribution, ManaProduction,
         ManaSpendPermission, ManaSpendRestriction, ModalChoice, ModalSelectionCondition,
         ModalSelectionConstraint, MultiTargetSpec, ObjectProperty, ProhibitedActivity, PtStat,
         PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode,
@@ -18409,7 +18409,7 @@ mod tests {
                 }),
             })
             .affected(TargetFilter::SelfRef);
-            def.active_zones = vec![Zone::Hand, Zone::Stack, Zone::Command];
+            def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
             obj.static_definitions.push(def);
         }
 
@@ -18647,7 +18647,7 @@ mod tests {
                 }),
             })
             .affected(TargetFilter::SelfRef);
-            def.active_zones = vec![Zone::Hand, Zone::Stack, Zone::Command];
+            def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
             obj.static_definitions.push(def);
         }
 
@@ -18677,6 +18677,107 @@ mod tests {
             ManaCost::Cost { generic, shards } => {
                 assert_eq!(generic, 5);
                 assert_eq!(shards, vec![ManaCostShard::Green, ManaCostShard::Green]);
+            }
+            other => panic!("expected ManaCost::Cost, got {other:?}"),
+        }
+    }
+
+    /// CR 601.2f + CR 702.138a: Demilich's self-spell cost reduction must apply
+    /// while the card is in the graveyard, before it is cast via its graveyard
+    /// permission.
+    #[test]
+    fn self_cost_reduction_applies_from_graveyard() {
+        use crate::types::statics::StaticMode;
+
+        let mut state = setup_game_at_main_phase();
+        let demilich = create_object(
+            &mut state,
+            CardId(993),
+            PlayerId(0),
+            "Demilich".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&demilich).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![
+                    ManaCostShard::Blue,
+                    ManaCostShard::Blue,
+                    ManaCostShard::Blue,
+                    ManaCostShard::Blue,
+                ],
+                generic: 0,
+            };
+            let instant_sorcery_filter = TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Typed(TypedFilter::new(TypeFilter::Instant)),
+                    TargetFilter::Typed(TypedFilter::new(TypeFilter::Sorcery)),
+                ],
+            };
+            let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
+                amount: ManaCost::Cost {
+                    generic: 0,
+                    shards: vec![ManaCostShard::Blue],
+                },
+                spell_filter: None,
+                dynamic_count: Some(QuantityRef::SpellsCastThisTurn {
+                    scope: CountScope::Controller,
+                    filter: Some(instant_sorcery_filter),
+                }),
+            })
+            .affected(TargetFilter::SelfRef);
+            def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
+            obj.static_definitions.push(def);
+        }
+
+        state.spells_cast_this_turn_by_player.insert(
+            PlayerId(0),
+            crate::im::Vector::from(vec![
+                crate::types::SpellCastRecord {
+                    name: "Shock".to_string(),
+                    core_types: vec![CoreType::Instant],
+                    supertypes: vec![],
+                    subtypes: vec![],
+                    keywords: vec![],
+                    colors: vec![],
+                    mana_value: 1,
+                    has_x_in_cost: false,
+                    from_zone: Zone::Hand,
+                    cast_variant: CastingVariant::Normal,
+                },
+                crate::types::SpellCastRecord {
+                    name: "Opt".to_string(),
+                    core_types: vec![CoreType::Instant],
+                    supertypes: vec![],
+                    subtypes: vec![],
+                    keywords: vec![],
+                    colors: vec![],
+                    mana_value: 1,
+                    has_x_in_cost: false,
+                    from_zone: Zone::Hand,
+                    cast_variant: CastingVariant::Normal,
+                },
+            ]),
+        );
+
+        let mut mana_cost = state.objects.get(&demilich).unwrap().mana_cost.clone();
+        super::super::casting::apply_self_spell_cost_modifiers(
+            &state,
+            PlayerId(0),
+            demilich,
+            &mut mana_cost,
+        );
+
+        match mana_cost {
+            ManaCost::Cost { shards, generic } => {
+                assert_eq!(generic, 0);
+                assert_eq!(
+                    shards,
+                    vec![ManaCostShard::Blue, ManaCostShard::Blue],
+                    "two instant/sorcery spells cast this turn should reduce UUUU by UU"
+                );
             }
             other => panic!("expected ManaCost::Cost, got {other:?}"),
         }
@@ -19007,7 +19108,7 @@ mod tests {
                 dynamic_count: None,
             })
             .affected(TargetFilter::SelfRef);
-            def.active_zones = vec![Zone::Hand, Zone::Stack, Zone::Command];
+            def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
             obj.static_definitions.push(def);
         }
 
@@ -19134,7 +19235,7 @@ mod tests {
                 dynamic_count: None,
             })
             .affected(TargetFilter::SelfRef);
-            def.active_zones = vec![Zone::Hand, Zone::Stack, Zone::Command];
+            def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
             obj.static_definitions.push(def);
         }
 
@@ -28972,7 +29073,7 @@ mod tests {
                 dynamic_count: None,
             })
             .affected(TargetFilter::SelfRef);
-            reduction.active_zones = vec![Zone::Hand, Zone::Stack];
+            reduction.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
             obj.static_definitions.push(reduction);
         }
 
@@ -36690,7 +36791,7 @@ mod tests {
                 dynamic_count: None,
             })
             .affected(TargetFilter::SelfRef);
-            def.active_zones = vec![Zone::Hand, Zone::Stack, Zone::Command];
+            def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
             obj.static_definitions.push(def);
         }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -13611,7 +13611,7 @@ mod tests {
         assert!(matches!(r.statics[0].affected, Some(TargetFilter::SelfRef)));
         assert_eq!(
             r.statics[0].active_zones,
-            vec![Zone::Hand, Zone::Stack, Zone::Command]
+            crate::types::zones::self_spell_cost_mod_active_zones()
         );
         assert!(
             r.parse_warnings

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1498,7 +1498,7 @@ pub(crate) fn first_qualified_spell_condition(filter: &TargetFilter) -> StaticCo
 /// a spell reduces/raises its own cast cost (e.g., Tolarian Terror:
 /// "This spell costs {1} less to cast for each instant and sorcery card in
 /// your graveyard."). Callers use this to flag self-reference so the static
-/// is emitted with `affected = SelfRef` and `active_zones = [Hand, Stack, Command]`
+/// is emitted with `affected = SelfRef` and `active_zones = self_spell_cost_mod_active_zones()`
 /// instead of the default battlefield scope.
 pub(crate) fn parse_self_spell_cost_subject(lower: &str) -> Option<()> {
     nom_on_lower(lower, lower, |i| {

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -12,7 +12,7 @@ use super::support::*;
 /// 3. Global taxing: "Noncreature spells cost {1} more to cast" (Thalia)
 /// 4. Broad: "Spells you cast cost {1} less to cast"
 /// 5. Self-spell: "This spell costs {N} less to cast for each ..." (Tolarian Terror)
-///    — emitted with `affected = SelfRef`, `active_zones = [Hand, Stack, Command]`.
+///    — emitted with `affected = SelfRef`, `active_zones = self_spell_cost_mod_active_zones()`.
 ///
 /// CR 601.2f: Parse the spell-type prefix of a cost-modification line before
 /// `"cost"`. Handles compound subjects such as Goblin Anarchomancer's
@@ -493,12 +493,12 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
 
     // CR 117.7 + CR 601.2f: A self-spell cost reduction must apply while the
     // card is in hand (pre-cast affordability checks), in the command zone
-    // (commander casting), and on the stack (final cost determination during
-    // casting). Without opting in via `active_zones`, layer collection would
-    // ignore the static outside the battlefield, and the card would never
-    // reduce its own cost.
+    // (commander casting), in the graveyard or exile (alternative-zone casting),
+    // and on the stack (final cost determination during casting). Without opting
+    // in via `active_zones`, layer collection would ignore the static outside
+    // the battlefield, and the card would never reduce its own cost.
     if is_self_spell {
-        definition.active_zones = vec![Zone::Hand, Zone::Stack, Zone::Command];
+        definition.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
     }
     if let Some(filter) = first_qualified_spell_filter.as_ref() {
         definition.condition = Some(first_qualified_spell_condition(filter));

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -173,14 +173,12 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         return None;
     }
 
-    // CR 601.2f + CR 117.7: Detect self-spell cost reduction ("this spell costs {N} less ...").
+    // CR 601.2f: Detect self-spell cost reduction ("this spell costs {N} less ...").
     // Distinct from battlefield cost modification (e.g., "creature spells you cast cost {1} less")
     // because the static must apply to the card while it is in hand (or on the stack during
     // casting), not once it has entered the battlefield. The caller wires this into
-    // `active_zones = [Hand, Stack, Command]` with `affected = SelfRef` so
-    // the casting-time scanner finds it on the spell being cast from normal
-    // hand casting, the cost-determination stack step, and commander casting
-    // from the command zone.
+    // `active_zones = self_spell_cost_mod_active_zones()` with `affected =
+    // SelfRef` so the casting-time scanner finds it on the spell being cast.
     let is_self_spell = parse_self_spell_cost_subject(lower).is_some();
 
     let amount_is_variable_x = nom_primitives::scan_contains(lower, "{x}");
@@ -457,7 +455,7 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
     // Build the affected filter for the static definition.
     // This controls which objects are "affected" — for cost modification statics,
     // this is the source permanent's controller scope (used by the registry).
-    // CR 117.7: Self-spell cost reduction ("This spell costs {N} less ...") uses
+    // CR 601.2f: Self-spell cost reduction ("This spell costs {N} less ...") uses
     // SelfRef so the casting-time self-cost scanner matches it on the spell itself.
     let affected = if is_self_spell {
         TargetFilter::SelfRef
@@ -491,7 +489,7 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         .affected(affected)
         .description(text.to_string());
 
-    // CR 117.7 + CR 601.2f: A self-spell cost reduction must apply while the
+    // CR 601.2f: A self-spell cost reduction must apply while the
     // card is in hand (pre-cast affordability checks), in the command zone
     // (commander casting), in the graveyard or exile (alternative-zone casting),
     // and on the stack (final cost determination during casting). Without opting

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1768,7 +1768,7 @@ fn static_cant_be_countered_typed_subject() {
     }
 }
 
-/// CR 117.7 + CR 601.2f: "This spell costs {N} less ..." must parse into a
+/// CR 601.2f: "This spell costs {N} less ..." must parse into a
 /// self-scoped static — affected = SelfRef, active_zones = self_spell_cost_mod_active_zones() —
 /// so the cast-time scanner finds it on the spell itself (not on the
 /// battlefield). Regression guard for Tolarian Terror class.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1769,7 +1769,7 @@ fn static_cant_be_countered_typed_subject() {
 }
 
 /// CR 117.7 + CR 601.2f: "This spell costs {N} less ..." must parse into a
-/// self-scoped static — affected = SelfRef, active_zones = [Hand, Stack, Command] —
+/// self-scoped static — affected = SelfRef, active_zones = self_spell_cost_mod_active_zones() —
 /// so the cast-time scanner finds it on the spell itself (not on the
 /// battlefield). Regression guard for Tolarian Terror class.
 #[test]
@@ -1790,7 +1790,23 @@ fn static_this_spell_cost_less_self_scoped_in_castable_zones() {
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
+    );
+}
+
+/// Issue #1372: Demilich's self-spell reduction must function from the graveyard
+/// during cast-time cost determination.
+#[test]
+fn static_demilich_self_cost_reduction_includes_graveyard() {
+    let def = parse_static_line(
+        "This spell costs {U} less to cast for each instant and sorcery spell you've cast this turn.",
+    )
+    .unwrap();
+    assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
+    assert!(
+        def.active_zones.contains(&Zone::Graveyard),
+        "Demilich must reduce its cost while in the graveyard, got {:?}",
+        def.active_zones
     );
 }
 
@@ -1851,7 +1867,7 @@ fn chandras_incinerator_self_cost_reduction_uses_noncombat_damage_to_opponents()
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
     );
 }
 
@@ -1878,7 +1894,7 @@ fn ghalta_self_cost_reduction_is_active_from_command_zone() {
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
     );
 }
 
@@ -1910,7 +1926,7 @@ fn self_cost_reduction_where_x_distinct_named_lands_uses_static_cost_seam() {
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
     );
 }
 
@@ -1944,7 +1960,7 @@ fn static_this_spell_cost_less_for_each_creature_that_attacked_this_turn() {
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
     );
 }
 
@@ -1967,7 +1983,7 @@ fn static_this_spell_cost_less_for_each_creature_you_attacked_with_this_turn() {
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
     );
 }
 
@@ -2030,7 +2046,7 @@ fn self_cost_reduction_if_night_uses_day_night_condition() {
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
     );
 }
 
@@ -2135,7 +2151,7 @@ fn static_this_spell_cost_less_if_it_targets_creature_filter() {
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
     );
 }
 
@@ -2207,7 +2223,7 @@ fn static_this_spell_cost_less_if_it_targets_spell_or_ability_targeting_large_cr
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
-        vec![Zone::Hand, Zone::Stack, Zone::Command]
+        crate::types::zones::self_spell_cost_mod_active_zones()
     );
 }
 

--- a/crates/engine/src/types/zones.rs
+++ b/crates/engine/src/types/zones.rs
@@ -98,8 +98,8 @@ impl EtbTapState {
 }
 
 /// CR 113.6 + CR 601.2f: Zones where a self-spell cost-reduction static must
-/// function during cast-time cost determination (hand, commander, graveyard
-/// cast, exile cast, and the stack step).
+/// function during cast-time cost determination (hand, library cast, commander,
+/// graveyard cast, exile cast, and the stack step).
 pub fn self_spell_cost_mod_active_zones() -> Vec<Zone> {
     vec![
         Zone::Hand,
@@ -107,6 +107,7 @@ pub fn self_spell_cost_mod_active_zones() -> Vec<Zone> {
         Zone::Command,
         Zone::Graveyard,
         Zone::Exile,
+        Zone::Library,
     ]
 }
 

--- a/crates/engine/src/types/zones.rs
+++ b/crates/engine/src/types/zones.rs
@@ -97,6 +97,19 @@ impl EtbTapState {
     }
 }
 
+/// CR 113.6 + CR 601.2f: Zones where a self-spell cost-reduction static must
+/// function during cast-time cost determination (hand, commander, graveyard
+/// cast, exile cast, and the stack step).
+pub fn self_spell_cost_mod_active_zones() -> Vec<Zone> {
+    vec![
+        Zone::Hand,
+        Zone::Stack,
+        Zone::Command,
+        Zone::Graveyard,
+        Zone::Exile,
+    ]
+}
+
 /// Serde adapter for on-disk `enter_tapped: bool` fields in card-data.json.
 pub mod etb_tap_bool_compat {
     use super::EtbTapState;

--- a/crates/mtgish-import/src/convert/cast_effect.rs
+++ b/crates/mtgish-import/src/convert/cast_effect.rs
@@ -142,15 +142,15 @@ pub fn apply(eff: &CastEffect, stub: &mut EngineFaceStub) -> ConvResult<()> {
             engine_type: "ParsedCondition",
             needed_variant: "CastEffect/CantBeCastIf (negation)".into(),
         }),
-        // CR 117.7 + CR 601.2f: Self-spell cost reduction. Mirrors the native
+        // CR 601.2f: Self-spell cost reduction. Mirrors the native
         // parser's `try_parse_cost_modification` self-spell branch
         // (oracle_static.rs:6720). Emits `StaticMode::ModifyCost` (Reduce) with
-        // `affected = SelfRef` and `active_zones = self_spell_cost_mod_active_zones()` so the
-        // casting-time scanner finds the static on the spell being cast.
+        // `affected = SelfRef` and `active_zones = self_spell_cost_mod_active_zones()`
+        // so the casting-time scanner finds the static on the spell being cast.
         E::ReduceCastingCost(reduction) => {
             push_self_reduce_cost_static(stub, reduction, None, None)
         }
-        // CR 117.7 + CR 601.2f: Self-spell cost reduction with a dynamic
+        // CR 601.2f: Self-spell cost reduction with a dynamic
         // "for each X" multiplier. The engine `StaticMode::ModifyCost.dynamic_count`
         // is `Option<QuantityRef>` — `QuantityExpr::Ref { qty }` unwraps cleanly;
         // `Fixed`/`Offset`/`Multiply`/`DivideRounded` cannot be expressed as a bare
@@ -159,7 +159,7 @@ pub fn apply(eff: &CastEffect, stub: &mut EngineFaceStub) -> ConvResult<()> {
             let qty_ref = quantity_to_ref(count, "ReduceCastingCostForEach")?;
             push_self_reduce_cost_static(stub, reduction, Some(qty_ref), None)
         }
-        // CR 117.7 + CR 601.2f: X-flavored self-spell cost reduction. The X
+        // CR 601.2f: X-flavored self-spell cost reduction. The X
         // variable resolves at cast time; engine `QuantityRef::Variable { name: "X" }`
         // is the canonical encoding (used by quantity::convert for `GameNumber::ValueX`).
         E::ReduceCastingCostX(_reduction_x, count) => {
@@ -178,7 +178,7 @@ pub fn apply(eff: &CastEffect, stub: &mut EngineFaceStub) -> ConvResult<()> {
                 None,
             )
         }
-        // CR 601.2f + CR 117.7: Self-cost reduction gated on a Condition.
+        // CR 601.2f: Self-cost reduction gated on a Condition.
         // Mirrors the native parser's trailing if-clause attachment in
         // `oracle_static.rs:6850-6917`: build a `StaticMode::ModifyCost` (Reduce) and
         // hang the translated `StaticCondition` off
@@ -211,7 +211,7 @@ pub fn apply(eff: &CastEffect, stub: &mut EngineFaceStub) -> ConvResult<()> {
                 None,
             )
         }
-        // CR 601.2c + CR 117.7: Bargain (MKM) is a built-in condition tied
+        // CR 601.2f: Bargain (MKM) is a built-in condition tied
         // to spell-cast metadata, not a generic StaticCondition. No engine
         // primitive expresses "this spell was bargained" as a self-cost
         // reduction gate. Strict-fail.
@@ -344,7 +344,7 @@ fn require_pure_mana(cost: &Cost, idiom: &'static str) -> ConvResult<ManaCost> {
     }
 }
 
-/// CR 117.7 + CR 601.2f: Build a self-spell `StaticMode::ModifyCost` (Reduce)
+/// CR 601.2f: Build a self-spell `StaticMode::ModifyCost` (Reduce)
 /// matching the native parser's emit shape (oracle_static.rs:6720+):
 /// `affected = SelfRef`, `active_zones = self_spell_cost_mod_active_zones()`
 /// so the casting-time scanner picks it up on the spell being cast from any

--- a/crates/mtgish-import/src/convert/cast_effect.rs
+++ b/crates/mtgish-import/src/convert/cast_effect.rs
@@ -30,7 +30,7 @@ use engine::types::ability::{
     SpellCastingOptionKind, StaticCondition, StaticDefinition, TargetFilter,
 };
 use engine::types::statics::{CostModifyMode, StaticMode};
-use engine::types::{ManaCost, Zone};
+use engine::types::ManaCost;
 
 use crate::convert::condition as condition_conv;
 use crate::convert::cost as cost_conv;
@@ -145,7 +145,7 @@ pub fn apply(eff: &CastEffect, stub: &mut EngineFaceStub) -> ConvResult<()> {
         // CR 117.7 + CR 601.2f: Self-spell cost reduction. Mirrors the native
         // parser's `try_parse_cost_modification` self-spell branch
         // (oracle_static.rs:6720). Emits `StaticMode::ModifyCost` (Reduce) with
-        // `affected = SelfRef` and `active_zones = [Hand, Stack]` so the
+        // `affected = SelfRef` and `active_zones = self_spell_cost_mod_active_zones()` so the
         // casting-time scanner finds the static on the spell being cast.
         E::ReduceCastingCost(reduction) => {
             push_self_reduce_cost_static(stub, reduction, None, None)
@@ -346,9 +346,10 @@ fn require_pure_mana(cost: &Cost, idiom: &'static str) -> ConvResult<ManaCost> {
 
 /// CR 117.7 + CR 601.2f: Build a self-spell `StaticMode::ModifyCost` (Reduce)
 /// matching the native parser's emit shape (oracle_static.rs:6720+):
-/// `affected = SelfRef`, `active_zones = [Hand, Stack]` so the
-/// casting-time scanner picks it up on the spell being cast. The amount
-/// is derived from the mtgish `CostReduction` symbol list.
+/// `affected = SelfRef`, `active_zones = self_spell_cost_mod_active_zones()`
+/// so the casting-time scanner picks it up on the spell being cast from any
+/// legal source zone. The amount is derived from the mtgish `CostReduction`
+/// symbol list.
 fn push_self_reduce_cost_static(
     stub: &mut EngineFaceStub,
     reduction: &CostReduction,
@@ -405,7 +406,7 @@ fn push_self_reduce_cost_static_with_amount_and_filter(
         dynamic_count,
     })
     .affected(TargetFilter::SelfRef);
-    def.active_zones = vec![Zone::Hand, Zone::Stack];
+    def.active_zones = engine::types::zones::self_spell_cost_mod_active_zones();
     def.condition = condition;
     stub.statics.push(def);
     Ok(())
@@ -469,7 +470,10 @@ mod tests {
         assert_eq!(stub.statics.len(), 1);
         let static_def = &stub.statics[0];
         assert_eq!(static_def.affected, Some(TargetFilter::SelfRef));
-        assert_eq!(static_def.active_zones, vec![Zone::Hand, Zone::Stack]);
+        assert_eq!(
+            static_def.active_zones,
+            engine::types::zones::self_spell_cost_mod_active_zones()
+        );
 
         let StaticMode::ModifyCost {
             mode: CostModifyMode::Reduce,


### PR DESCRIPTION
## Summary

- Fixes [#1372](https://github.com/phase-rs/phase/issues/1372): Demilich's "costs {U} less for each instant and sorcery spell you've cast this turn" discount was not applied when casting from the graveyard.
- Root cause: self-spell cost-reduction statics used `active_zones = [Hand, Stack, Command]` (mtgish import only had `[Hand, Stack]`), and `collect_self_spell_cost_modifiers` skips statics when the spell's current zone is not listed.
- Adds `self_spell_cost_mod_active_zones()` (`Hand`, `Stack`, `Command`, `Graveyard`, `Exile`) and wires it through the native parser and mtgish `CastEffect` converter.

## Test plan

- [x] `cargo test -p engine self_cost_reduction_applies_from_graveyard`
- [x] `cargo test -p engine static_demilich_self_cost_reduction_includes_graveyard`
- [x] `cargo test -p engine parser::oracle_static::tests::self_cost`
- [x] `cargo test -p mtgish-import reduce_cost`
- [ ] Manually cast Demilich from graveyard after casting instant/sorcery spells and confirm mana cost is reduced