### PR TITLE
fix(engine): scan command zone for CastFromHandFree emblem sources

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2276,6 +2276,18 @@ fn cast_free_origin_admits_object(
     }
 }
 
+/// CR 114.4: `CastFromHandFree` granting sources function on the battlefield
+/// (Omniscience, Zaffai, Dracogenesis) and from the command zone when they are
+/// emblems (Tamiyo, Field Researcher). `active_static_definitions` applies the
+/// CR 113.6b opt-in gate for non-emblem command-zone objects.
+fn iter_cast_free_permission_source_ids(state: &GameState) -> impl Iterator<Item = ObjectId> + '_ {
+    state
+        .battlefield
+        .iter()
+        .chain(state.command_zone.iter())
+        .copied()
+}
+
 fn cast_free_permission_from_source(
     state: &GameState,
     player: PlayerId,
@@ -2318,7 +2330,7 @@ pub(crate) fn hand_cast_free_permission_source(
     player: PlayerId,
     obj: &crate::game::game_object::GameObject,
 ) -> Option<(ObjectId, CastFrequency)> {
-    state.battlefield.iter().find_map(|&src_id| {
+    iter_cast_free_permission_source_ids(state).find_map(|src_id| {
         cast_free_permission_from_source(state, player, obj, src_id)
             .map(|frequency| (src_id, frequency))
     })
@@ -8671,32 +8683,31 @@ pub fn hand_cast_free_candidates(
 ) -> Vec<(ObjectId, ObjectId, CastFrequency)> {
     // CR 601.2b + CR 400.7: Collect active (source_id, frequency, filter)
     // triples for OncePerTurn permissions that haven't been consumed this turn.
-    let sources: Vec<(ObjectId, TargetFilter, CastFrequency, CastFreeOrigin)> = state
-        .battlefield
-        .iter()
-        .filter_map(|&src_id| {
-            let src_obj = state.objects.get(&src_id)?;
-            if src_obj.controller != player {
-                return None;
-            }
-            active_static_definitions(state, src_obj).find_map(|s| match s.mode {
-                StaticMode::CastFromHandFree { frequency, origin } => {
-                    if frequency == CastFrequency::OncePerTurn
-                        && state.hand_cast_free_permissions_used.contains(&src_id)
-                    {
-                        None
-                    } else if frequency == CastFrequency::OncePerTurn {
-                        s.affected
-                            .as_ref()
-                            .map(|f| (src_id, f.clone(), frequency, origin))
-                    } else {
-                        None
-                    }
+    let sources: Vec<(ObjectId, TargetFilter, CastFrequency, CastFreeOrigin)> =
+        iter_cast_free_permission_source_ids(state)
+            .filter_map(|src_id| {
+                let src_obj = state.objects.get(&src_id)?;
+                if src_obj.controller != player {
+                    return None;
                 }
-                _ => None,
+                active_static_definitions(state, src_obj).find_map(|s| match s.mode {
+                    StaticMode::CastFromHandFree { frequency, origin } => {
+                        if frequency == CastFrequency::OncePerTurn
+                            && state.hand_cast_free_permissions_used.contains(&src_id)
+                        {
+                            None
+                        } else if frequency == CastFrequency::OncePerTurn {
+                            s.affected
+                                .as_ref()
+                                .map(|f| (src_id, f.clone(), frequency, origin))
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                })
             })
-        })
-        .collect();
+            .collect();
 
     if sources.is_empty() {
         return Vec::new();
@@ -21329,6 +21340,125 @@ mod tests {
         assert!(
             !matches!(cost, ManaCost::NoCost),
             "Omniscience must not apply to command-zone commanders, got {cost:?}"
+        );
+    }
+
+    /// CR 114.4 + CR 601.2b + CR 118.9a (issue #1355): Tamiyo, Field
+    /// Researcher's emblem grants `CastFromHandFree` from the command zone.
+    #[test]
+    fn tamiyo_emblem_free_casts_spells_from_hand() {
+        let mut state = setup_game_at_main_phase();
+
+        let emblem_id = create_object(
+            &mut state,
+            CardId(920),
+            PlayerId(0),
+            "Emblem".to_string(),
+            Zone::Command,
+        );
+        {
+            let emblem = state.objects.get_mut(&emblem_id).unwrap();
+            emblem.is_emblem = true;
+            emblem.static_definitions.push(
+                parse_static_line(
+                    "You may cast spells from your hand without paying their mana costs.",
+                )
+                .expect("Tamiyo emblem static should parse"),
+            );
+        }
+
+        let spell_id = create_object(
+            &mut state,
+            CardId(921),
+            PlayerId(0),
+            "Counterspell".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+                generic: 0,
+            };
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Unimplemented {
+                    name: "Counterspell".to_string(),
+                    description: None,
+                },
+            ));
+        }
+
+        let cost = effective_spell_cost(&state, PlayerId(0), spell_id)
+            .expect("hand spell cost should compute");
+        assert!(
+            matches!(cost, ManaCost::NoCost),
+            "Tamiyo emblem should zero the hand spell's mana cost, got {cost:?}"
+        );
+        assert!(can_cast_object_now(&state, PlayerId(0), spell_id));
+        assert_eq!(
+            hand_cast_free_permission_source(
+                &state,
+                PlayerId(0),
+                state.objects.get(&spell_id).unwrap()
+            ),
+            Some((emblem_id, CastFrequency::Unlimited)),
+            "permission source should be the command-zone emblem"
+        );
+    }
+
+    /// Issue #1355 regression: Tamiyo emblem's hand qualifier must not free-cast
+    /// commanders from the command zone (mirrors Omniscience guard).
+    #[test]
+    fn tamiyo_emblem_does_not_free_cast_commander_from_command_zone() {
+        let mut state = setup_game_at_main_phase();
+        state.format_config.command_zone = true;
+
+        let emblem_id = create_object(
+            &mut state,
+            CardId(922),
+            PlayerId(0),
+            "Emblem".to_string(),
+            Zone::Command,
+        );
+        {
+            let emblem = state.objects.get_mut(&emblem_id).unwrap();
+            emblem.is_emblem = true;
+            emblem.static_definitions.push(
+                parse_static_line(
+                    "You may cast spells from your hand without paying their mana costs.",
+                )
+                .expect("Tamiyo emblem static should parse"),
+            );
+        }
+
+        let commander_id = create_object(
+            &mut state,
+            CardId(923),
+            PlayerId(0),
+            "Dragon Commander".to_string(),
+            Zone::Command,
+        );
+        {
+            let obj = state.objects.get_mut(&commander_id).unwrap();
+            obj.is_commander = true;
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = ManaCost::generic(5);
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Unimplemented {
+                    name: "Commander".to_string(),
+                    description: None,
+                },
+            ));
+        }
+
+        let cost = effective_spell_cost(&state, PlayerId(0), commander_id)
+            .expect("commander cost should compute");
+        assert!(
+            !matches!(cost, ManaCost::NoCost),
+            "Tamiyo emblem must not apply to command-zone commanders, got {cost:?}"
         );
     }
 

--- a/crates/engine/src/game/effects/create_emblem.rs
+++ b/crates/engine/src/game/effects/create_emblem.rs
@@ -76,7 +76,7 @@ mod tests {
     };
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
-    use crate::types::statics::StaticMode;
+    use crate::types::statics::{CastFreeOrigin, CastFrequency, StaticMode};
 
     fn ninja_pump_static() -> StaticDefinition {
         StaticDefinition {
@@ -338,5 +338,87 @@ mod tests {
         let count =
             crate::game::functioning_abilities::active_trigger_definitions(&state, emblem).count();
         assert_eq!(count, 1, "command-zone emblem trigger must be active");
+    }
+
+    /// CR 114.4 + CR 601.2b (issue #1355): Tamiyo, Field Researcher's emblem
+    /// installs a functioning `CastFromHandFree` static in the command zone.
+    #[test]
+    fn create_tamiyo_emblem_grants_hand_free_cast_permission() {
+        use crate::game::casting::{can_cast_object_now, effective_spell_cost};
+        use crate::parser::oracle_static::parse_static_line;
+        use crate::types::ability::{AbilityDefinition, AbilityKind};
+        use crate::types::card_type::CoreType;
+        use crate::types::mana::{ManaCost, ManaCostShard};
+        use std::sync::Arc;
+
+        let static_def = parse_static_line(
+            "You may cast spells from your hand without paying their mana costs.",
+        )
+        .expect("Tamiyo emblem static should parse");
+        assert!(
+            matches!(
+                static_def.mode,
+                StaticMode::CastFromHandFree {
+                    frequency: CastFrequency::Unlimited,
+                    origin: CastFreeOrigin::Hand,
+                }
+            ),
+            "expected CastFromHandFree static, got {:?}",
+            static_def.mode
+        );
+
+        let mut state = GameState::new_two_player(42);
+        let ability = ResolvedAbility::new(
+            Effect::CreateEmblem {
+                statics: vec![static_def],
+                triggers: Vec::new(),
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let emblem_id = state.command_zone[0];
+        let spell_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Counterspell".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+                generic: 0,
+            };
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Unimplemented {
+                    name: "Counterspell".to_string(),
+                    description: None,
+                },
+            ));
+        }
+
+        let cost = effective_spell_cost(&state, PlayerId(0), spell_id)
+            .expect("hand spell cost should compute");
+        assert!(
+            matches!(cost, ManaCost::NoCost),
+            "Tamiyo emblem should zero the hand spell's mana cost, got {cost:?}"
+        );
+        assert!(can_cast_object_now(&state, PlayerId(0), spell_id));
+        assert_eq!(
+            crate::game::casting::hand_cast_free_permission_source(
+                &state,
+                PlayerId(0),
+                state.objects.get(&spell_id).unwrap(),
+            ),
+            Some((emblem_id, CastFrequency::Unlimited)),
+            "permission source should be the created emblem"
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -110,6 +110,8 @@ use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
 use crate::types::replacements::ReplacementEvent;
 use crate::types::statics::{ActivationExemption, CastFrequency, StaticMode};
+#[cfg(test)]
+use crate::types::statics::CastFreeOrigin;
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 
@@ -27471,6 +27473,33 @@ mod tests {
                         .is_some_and(|d| d.contains("Ninjas you control get +1/+1")),
                     "static emblem must retain granted rules text, got {:?}",
                     def.description
+                );
+            }
+            other => panic!("expected CreateEmblem, got {:?}", other),
+        }
+    }
+
+    /// CR 114.1 + CR 601.2b (issue #1355): Tamiyo, Field Researcher's ultimate
+    /// emblem text parses as `CastFromHandFree` static, not `EmblemStatic`.
+    #[test]
+    fn effect_emblem_tamiyo_field_researcher_hand_free_cast() {
+        let e = parse_effect(
+            "You get an emblem with \"You may cast spells from your hand without paying their mana costs.\"",
+        );
+        match e {
+            Effect::CreateEmblem { statics, triggers } => {
+                assert!(triggers.is_empty());
+                assert_eq!(statics.len(), 1);
+                assert!(
+                    matches!(
+                        statics[0].mode,
+                        StaticMode::CastFromHandFree {
+                            frequency: CastFrequency::Unlimited,
+                            origin: CastFreeOrigin::Hand,
+                        }
+                    ),
+                    "expected CastFromHandFree static, got {:?}",
+                    statics[0].mode
                 );
             }
             other => panic!("expected CreateEmblem, got {:?}", other),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -109,9 +109,9 @@ use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
 use crate::types::replacements::ReplacementEvent;
-use crate::types::statics::{ActivationExemption, CastFrequency, StaticMode};
 #[cfg(test)]
 use crate::types::statics::CastFreeOrigin;
+use crate::types::statics::{ActivationExemption, CastFrequency, StaticMode};
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -1641,32 +1641,36 @@ fn add_expensive_dragon_commander(scenario: &mut GameScenario) -> ObjectId {
 /// emblem functions from the command zone and waives mana for hand spells.
 #[test]
 fn tamiyo_emblem_allows_free_cast_from_hand() {
-    use engine::game::zones::create_object;
-    use engine::parser::oracle_static::parse_static_line;
-    use engine::types::zones::Zone;
-
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
+    let source_id = scenario
+        .add_creature(P0, "Tamiyo, Field Researcher", 0, 0)
+        .id();
     let bolt_id = scenario.add_bolt_to_hand(P0);
 
     let mut runner = scenario.build();
-    let emblem_id = create_object(
-        runner.state_mut(),
-        CardId(1_355),
+    let emblem_static = engine::parser::oracle_static::parse_static_line(
+        "You may cast spells from your hand without paying their mana costs.",
+    )
+    .expect("Tamiyo emblem static should parse");
+    let ability = engine::types::ability::ResolvedAbility::new(
+        Effect::CreateEmblem {
+            statics: vec![emblem_static],
+            triggers: Vec::new(),
+        },
+        vec![],
+        source_id,
         P0,
-        "Emblem".to_string(),
-        Zone::Command,
     );
-    {
-        let emblem = runner.state_mut().objects.get_mut(&emblem_id).unwrap();
-        emblem.is_emblem = true;
-        emblem.static_definitions.push(
-            parse_static_line(
-                "You may cast spells from your hand without paying their mana costs.",
-            )
-            .expect("Tamiyo emblem static should parse"),
-        );
-    }
+    let mut events = Vec::<GameEvent>::new();
+    engine::game::effects::create_emblem::resolve(runner.state_mut(), &ability, &mut events)
+        .expect("Tamiyo emblem should be created");
+    let emblem_id = *runner
+        .state()
+        .command_zone
+        .last()
+        .expect("CreateEmblem should put an emblem in the command zone");
+    assert!(runner.state().objects[&emblem_id].is_emblem);
 
     let card_id = runner.state().objects[&bolt_id].card_id;
     let mana_before = runner.state().players[0].mana_pool.clone();

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -1637,6 +1637,61 @@ fn add_expensive_dragon_commander(scenario: &mut GameScenario) -> ObjectId {
     commander_id
 }
 
+/// CR 114.4 + CR 601.2b + CR 118.9a (issue #1355): Tamiyo, Field Researcher's
+/// emblem functions from the command zone and waives mana for hand spells.
+#[test]
+fn tamiyo_emblem_allows_free_cast_from_hand() {
+    use engine::game::zones::create_object;
+    use engine::parser::oracle_static::parse_static_line;
+    use engine::types::zones::Zone;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let bolt_id = scenario.add_bolt_to_hand(P0);
+
+    let mut runner = scenario.build();
+    let emblem_id = create_object(
+        runner.state_mut(),
+        CardId(1_355),
+        P0,
+        "Emblem".to_string(),
+        Zone::Command,
+    );
+    {
+        let emblem = runner.state_mut().objects.get_mut(&emblem_id).unwrap();
+        emblem.is_emblem = true;
+        emblem.static_definitions.push(
+            parse_static_line(
+                "You may cast spells from your hand without paying their mana costs.",
+            )
+            .expect("Tamiyo emblem static should parse"),
+        );
+    }
+
+    let card_id = runner.state().objects[&bolt_id].card_id;
+    let mana_before = runner.state().players[0].mana_pool.clone();
+
+    let result = runner
+        .act(GameAction::CastSpell {
+            object_id: bolt_id,
+            card_id,
+            targets: vec![],
+        })
+        .expect("Tamiyo emblem should allow casting a hand spell");
+    handle_target_selection(&mut runner, &result);
+
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "bolt should be on the stack after a free cast"
+    );
+    assert_eq!(
+        runner.state().players[0].mana_pool,
+        mana_before,
+        "no mana should have been paid under Tamiyo emblem"
+    );
+}
+
 /// CR 601.2a + CR 118.9a + CR 903.8: A hand-qualified free-cast static
 /// (Omniscience class) does not replace the mana cost for a commander cast from
 /// the command zone.


### PR DESCRIPTION
## Summary

- Fix Tamiyo, Field Researcher's emblem not granting free casts from hand (fixes #1355)
- The emblem text already parsed as `CastFromHandFree`; the bug was runtime lookup only scanning battlefield permanents
- Add `iter_cast_free_permission_source_ids` to scan battlefield + command zone (CR 114.4), and wire it into `hand_cast_free_permission_source` and `hand_cast_free_candidates`
- Add unit, integration, parser, and `create_emblem` tests covering free hand casts and the commander-zone regression guard

## Test plan

- [x] `cargo test -p engine tamiyo`
- [x] `tamiyo_emblem_free_casts_spells_from_hand`
- [x] `tamiyo_emblem_does_not_free_cast_commander_from_command_zone`
- [x] `tamiyo_emblem_allows_free_cast_from_hand` (integration cast pipeline)
- [x] `create_tamiyo_emblem_grants_hand_free_cast_permission`
- [x] `effect_emblem_tamiyo_field_researcher_hand_free_cast`
- [ ] Manual: activate Tamiyo −7, confirm emblem appears, cast a hand spell without paying mana