### PR TITLE
docs(pr-handler): add cooperative PR assignment lock

### DIFF
--- a/.claude/skills/pr-contribution-handler/SKILL.md
+++ b/.claude/skills/pr-contribution-handler/SKILL.md
@@ -77,7 +77,7 @@ A non-stop fleet exhausts GitHub's **5,000-req/hr REST `core`** bucket long befo
 3. If multiple PRs are provided, process them sequentially unless the user explicitly asks for parallel work and the PRs have independent worktrees.
 4. Capture the initial state:
    - `git status --short`
-   - `gh pr view <PR> --json number,title,state,author,headRefName,headRepository,baseRefName,isCrossRepository,mergeStateStatus,reviewDecision,url`
+   - `gh pr view <PR> --json number,title,state,author,assignees,headRefName,headRepository,baseRefName,isCrossRepository,mergeStateStatus,reviewDecision,url`
    - `gh pr checks <PR>` if available
 
 ## Security and Sanity Pre-Check (per PR — runs first, before anything else)
@@ -120,6 +120,56 @@ These are the recurring accidental-damage patterns. Fix inline as part of your n
 
 Run these checks BEFORE prioritization. A PR with hard-stop issues is removed from the queue entirely; a PR with auto-fix issues stays in the queue and gets handled.
 
+**The security scan runs on every PR, including ones another agent has locked** (see "Assignment Lock" below). The scan is on the free local diff, so the assignment-lock skip must never suppress hard-stop reporting: a malicious PR another agent grabbed (or whose lock went stale) must still be caught and reported. The lock is acquired only *after* a clean security pass — never acquire the lock for a PR that fired a hard stop.
+
+## Assignment Lock (cooperative, per PR — acquire after a clean security pass)
+
+A non-stop fleet of agents handles PRs concurrently. PR **assignment is a cooperative lock**: it prevents two agents from redundantly processing the same PR. Acquire it when you pick a PR up for processing; release it the moment you stop working the PR (see "Releasing the Assignment Lock").
+
+**Acting identity.** Resolve the acting account **once per invocation** and cache it: `ACTING_LOGIN=$(gh api user --jq '.login')`. Reads compare assignee logins against `ACTING_LOGIN`; writes use `@me` (GitHub resolves `@me` to the same account under your token). `assignees` is already captured by the intake `gh pr view` call — do not re-fetch it.
+
+**Skip-if-owned gate (do not process PRs assigned to someone else).** If any assignee login ≠ `ACTING_LOGIN`, **skip the PR**: no checkout, no comment resolution, no review, no fixes, no enqueue. Record `skipped: assigned to <login>` in the Final Report and move to the next PR. Notes:
+
+- This gate sits *before* `## Checkout` in the flow, so an owned PR is skipped before any worktree is created or any fix work begins. Apply it as each PR is picked up for processing.
+- "Someone else" includes a **human maintainer** who self-assigned — that is intended (a human has claimed the PR). The report does not distinguish a human from another agent; both are "assigned to <login>".
+- A PR assigned **only** to `ACTING_LOGIN` is **not** "someone else" — it is your own lock from a prior run. Reuse it and proceed.
+- The security hard-stop scan above runs regardless of ownership; a hard stop on an owned PR is still reported.
+
+**Acquire.** After the security pre-check is clean and before checkout, if the PR is unassigned (or already assigned only to you):
+
+```bash
+gh pr edit <PR> --add-assignee @me
+```
+
+This is a single command — do not re-read to confirm. *Known limitation, acceptable for now:* acquire is not atomic, so two agents racing on an unassigned PR could both assign; the loser's release at its next stop point cleans up. There is deliberately no durable/atomic lock and no staleness-based reclaim.
+
+The only new REST `core` read is `gh api user`, once per invocation. The acquire/release `gh pr edit` mutations use the GraphQL/idle bucket (like the other `gh pr` operations in **Rate-Limit Discipline**), not the contended `core` bucket — negligible quota impact.
+
+## Releasing the Assignment Lock
+
+```bash
+gh pr edit <PR> --remove-assignee @me
+```
+
+This command is idempotent — a harmless no-op if you are not currently assigned (e.g. you lost an acquire race, or never acquired because security hard-stopped first).
+
+**Governing principle:** release the lock at **every point where you cease active work on the PR** — any handoff to the maintainer, any BLOCK/skip/stop, any error exit — in **both** default and authorized modes. The list below is illustrative, not exhaustive; the principle governs. The discrete stop sites in this skill each carry a one-line reminder pointing back here — but if you reach any other stop the list omits, release anyway.
+
+Concrete release points:
+
+- **Auto-fix-then-continue** (the security auto-fix classes) is **not** a stop — keep the lock and continue handling.
+- **Security hard-stop** — the lock was never acquired (acquire happens only after a clean security pass), so no release is needed; do not special-case it.
+- **Checkout collision** — the local `pr/<PR>` branch holds unrelated work and you bail rather than reset.
+- **Bring-current obsolete-merge** — merging `origin/main` reveals the PR approach is obsolete and you route it to a full engine cycle instead of finishing.
+- **Duplicate-PR loser** — you keep the more rules-correct base and report the other for close/supersede.
+- **Scope-contamination BLOCK-pending-rebase** — the PR is far behind and its diff would revert other agents' work.
+- **Architecture-review BLOCK / wrong-seam** — the fix belongs at a different seam (the prose-verdict site, not the enqueue checklist).
+- **Full engine cycle required but unavailable**, or a significant deferral is left and you stop.
+- **Enqueue-checklist failure** (any item) — you leave the PR for the maintainer to decide.
+- **`gh pr merge` returns an error** — you surface it verbatim and leave the PR for the maintainer.
+- **Default mode (no enqueue authority)** — the skill never runs `gh pr merge`; it hands every PR back with a recommended command. Release at the **end of every PR**, because there is no enqueue step to release after.
+- **After a successful enqueue (authorized mode)** — release **after** the approve → label → enqueue → verify critical section completes. Place the release mutation *outside* that critical section; never interleave it (per **Rate-Limit Discipline**, that section must not be interrupted).
+
 ## Duplicate-PR and Scope-Contamination Check (per PR — at intake)
 
 Two recurring, expensive intake problems that are neither security hard-stops nor mechanical auto-fixes. Surface them as evidence **before** investing review effort.
@@ -131,7 +181,7 @@ gh pr view <N> --json closingIssuesReferences,title --jq '{title, closes: [.clos
 gh pr list --repo phase-rs/phase --state open --json number,title --jq '.[] | select(.number != <N>)'   # scan for the same issue / card / mechanic
 ```
 
-If a duplicate exists, do not handle both: hand-trace each, keep the more rules-correct base, report the other for close/supersede, and note it in the Final Report. Two PRs for one issue are never both enqueued.
+If a duplicate exists, do not handle both: hand-trace each, keep the more rules-correct base, report the other for close/supersede (if you hold its assignment lock, release it — see *Releasing the Assignment Lock*), and note it in the Final Report. Two PRs for one issue are never both enqueued.
 
 **Scope contamination / stale branch.** Diff the PR against current `origin/main` and confirm the change set matches the PR's stated scope.
 
@@ -140,7 +190,7 @@ gh pr view <N> --json mergeable,mergeStateStatus --jq '{mergeable, mergeStateSta
 git diff --stat origin/main...HEAD
 ```
 
-- `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY` / branch far behind → needs a rebase before review. If the diff would revert other agents' landed work (token data, deploy config, concurrent integration tests), that is **BLOCK-pending-rebase**, not an inline fix (precedent: #2519 was 53 commits behind and its diff would have reverted ~5,800 unrelated lines; #2520 was 40 behind and bundled two features).
+- `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY` / branch far behind → needs a rebase before review. If the diff would revert other agents' landed work (token data, deploy config, concurrent integration tests), that is **BLOCK-pending-rebase**, not an inline fix (precedent: #2519 was 53 commits behind and its diff would have reverted ~5,800 unrelated lines; #2520 was 40 behind and bundled two features). On a BLOCK-pending-rebase, release the assignment lock (see *Releasing the Assignment Lock*) — you are handing the PR back, not processing it.
 - Diff touches generated registries (`known-tokens.toml`), stray gitlinks/submodules (`new file mode 160000`), or subsystems unrelated to the stated scope → handle via the Security/Sanity auto-fix classes (strip/revert); if the contamination is load-bearing to the PR's logic, reduce the PR to its real change before review.
 - A PR body claiming "Scope Expansion: None" whose diff is large and cross-cutting is a contradiction to verify, not to trust.
 
@@ -256,7 +306,7 @@ git diff origin/main...HEAD
 
 Ask, explicitly, TWO questions in this order:
 
-1. **Is the change in the architecturally correct LOCATION (the right seam)?** Is this fix made at the layer / module / function where the codebase's design says the responsibility belongs — or is it a symptom-patch at the wrong seam that merely makes the test pass? A change on the wrong code path is **technical debt even when CI is green**: it ossifies a dead or duplicate path, scatters logic that should live in one authority, and the *next* card in the class won't be covered because the real seam was never touched. **This is the single most important check in the entire review.** Increasing PR velocity NEVER justifies merging debt — a wrong-location fix that ships is worse than no fix, because it looks done while leaving the actual seam broken and now obscured. If the correct location is a different function/module than the PR touches, the verdict is **BLOCK** (close or request re-implementation at the right seam), or escalate to the full engine cycle — it is *not* an inline patch of the wrong location. Always cite the correct seam in the report. (Precedent: #1251 added a green, inert branch to `classify_quoted_inner` when the real fix belonged in `parse_spells_have_keyword` / `StaticMode::CastWithKeyword` — BLOCKED despite passing CI, because merging it would have ossified a dead path and left the target card class uncovered.)
+1. **Is the change in the architecturally correct LOCATION (the right seam)?** Is this fix made at the layer / module / function where the codebase's design says the responsibility belongs — or is it a symptom-patch at the wrong seam that merely makes the test pass? A change on the wrong code path is **technical debt even when CI is green**: it ossifies a dead or duplicate path, scatters logic that should live in one authority, and the *next* card in the class won't be covered because the real seam was never touched. **This is the single most important check in the entire review.** Increasing PR velocity NEVER justifies merging debt — a wrong-location fix that ships is worse than no fix, because it looks done while leaving the actual seam broken and now obscured. If the correct location is a different function/module than the PR touches, the verdict is **BLOCK** (close or request re-implementation at the right seam), or escalate to the full engine cycle — it is *not* an inline patch of the wrong location. Always cite the correct seam in the report, and release the assignment lock (see *Releasing the Assignment Lock*) when you BLOCK and hand the PR back. (Precedent: #1251 added a green, inert branch to `classify_quoted_inner` when the real fix belonged in `parse_spells_have_keyword` / `StaticMode::CastWithKeyword` — BLOCKED despite passing CI, because merging it would have ossified a dead path and left the target card class uncovered.)
 2. **Is the change AT that seam the MOST IDIOMATIC change possible?** Once the location is right, the implementation at it must be the one a principal engineer steeped in this codebase would write — the established building block reused rather than re-implemented, an existing typed enum parameterized rather than a new `bool` or sibling variant, `nom` combinators composed rather than string dispatch. A correct-but-unidiomatic change at the right seam is still a finding, not a nit: it passes CI and may even cover the class, but it diverges from house style and seeds the next contributor's copy-paste with a non-idiom. Bring it to the idiom before merge (improve the author's branch per Quality Bar rule 1) — never merge "works, but not how we'd write it."
 
 Apply the relevant lenses from `review-impl.md`, especially:
@@ -297,7 +347,7 @@ Use `$engine-implementer` and the full plan -> implement -> review cycle when th
 - the current PR shape solves one card/screen/case but should become a reusable building block
 - fixing the PR safely requires a reviewed implementation plan rather than direct patching
 
-If the full cycle is required but unavailable in the current environment, stop after writing the review findings and tell the user exactly why inline fixing would be risky.
+If the full cycle is required but unavailable in the current environment, stop after writing the review findings, release the assignment lock (see *Releasing the Assignment Lock*), and tell the user exactly why inline fixing would be risky.
 
 ## Explicit Deferrals
 
@@ -441,10 +491,11 @@ Every item must be satisfied before running `gh pr merge`. Failing any item mean
 After running `gh pr merge <PR> --auto`:
 
 1. Capture the auto-merge confirmation (the CLI prints "Pull request #N will be automatically merged via the merge queue when all requirements are met" or similar).
-2. Do NOT wait for the queue to land the PR — the queue is async and may take minutes (CI run + queue position). Move on to the next PR in the batch.
-3. In the Final Report, note `enqueued: yes` plus the timestamp and any queue-position info from the CLI output.
+2. Release the assignment lock (see *Releasing the Assignment Lock*) — processing is complete. Do this *outside* the approve → label → enqueue → verify critical section, after it finishes.
+3. Do NOT wait for the queue to land the PR — the queue is async and may take minutes (CI run + queue position). Move on to the next PR in the batch.
+4. In the Final Report, note `enqueued: yes` plus the timestamp and any queue-position info from the CLI output.
 
-If `gh pr merge` returns an error (PR not mergeable, missing required checks, auth issue, queue disabled), do NOT retry blindly. Surface the error verbatim in the Final Report and leave the PR for the maintainer.
+If `gh pr merge` returns an error (PR not mergeable, missing required checks, auth issue, queue disabled), do NOT retry blindly. Surface the error verbatim in the Final Report, release the assignment lock (see *Releasing the Assignment Lock*), and leave the PR for the maintainer.
 
 ## Final Report
 
@@ -458,8 +509,9 @@ For each PR, report:
 - deferred items completed vs left open
 - verification commands and results
 - commits created and push status
+- **assignment status**: `assigned: self` (lock acquired and held), `skipped: assigned to <login>` (owned by another agent or a human — not processed), or `released: <reason>` (lock acquired then released at a stop point — name the reason, e.g. `released: changes-requested`, `released: enqueued`, `released: default-mode handoff`).
 - **enqueue status**:
-  - In **default mode** (no enqueue authority): the exact `gh pr merge <PR> --auto` command for the maintainer to run, OR an explicit reason not to enqueue (hard-stop security issue, blocking review comment, requires full-cycle work first, etc.).
+  - In **default mode** (no enqueue authority): the exact `gh pr merge <PR> --auto` command for the maintainer to run, OR an explicit reason not to enqueue (hard-stop security issue, blocking review comment, requires full-cycle work first, etc.). Release the assignment lock (see *Releasing the Assignment Lock*) at the end of every PR in this mode — there is no enqueue step to release after.
   - In **authorized mode**: `enqueued: yes` (with timestamp + any queue-position output from the CLI), OR `enqueued: no` with the failed enqueue-checklist item(s) and evidence.
 
 Include evidence for claims, mark assumptions separately, and state confidence. Also include a short self-challenge: what evidence would contradict the conclusion that the PR is ready?


### PR DESCRIPTION
Self-assign a PR on pickup (after a clean security pre-check, before
checkout), skip PRs assigned to someone else, and unassign at every
stop/handoff point.

- Intake captures `assignees`; acting login resolved once via `gh api user`.
- New "Assignment Lock" section: skip-if-owned gate + acquire-after-clean-
  security. Security scan runs regardless of lock ownership so hard-stops on
  another agent's PR are still reported.
- New "Releasing the Assignment Lock" section: governing release-on-any-
  handoff principle plus one-liner reminders at the discrete stop sites
  (duplicate-loser, BLOCK-pending-rebase, arch BLOCK, full-cycle-unavailable,
  enqueue error, default-mode end-of-PR, after-enqueue).
- Final Report gains an assignment-status line.

Acquire is non-atomic by design (no durable lock / staleness reclaim) per the
"for now" scope. Lock mutations use the GraphQL idle bucket; only the once-
per-invocation `gh api user` touches REST core.
