### PR TITLE
feat(server): self-host reachability — ngrok tunnel + shareable join link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,10 +89,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -107,13 +127,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "awaitdrop"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771051cdc7eec2dc1b23fbf870bb7fbb89136fe374227c875e377f1eed99a429"
+dependencies = [
+ "futures",
+ "generational-arena",
+ "parking_lot",
+ "slotmap",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
- "base64",
+ "axum-core 0.5.6",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -144,6 +198,26 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
@@ -160,6 +234,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -181,6 +261,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -240,6 +326,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -248,6 +336,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -292,7 +391,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -300,6 +399,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -359,6 +467,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -427,7 +544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -450,7 +567,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -461,7 +578,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -488,7 +605,7 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -515,8 +632,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "draft-core"
@@ -524,10 +647,10 @@ version = "0.1.52"
 dependencies = [
  "engine",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -541,7 +664,7 @@ dependencies = [
  "js-sys",
  "phase-ai",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -562,6 +685,12 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -609,14 +738,14 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rustc-hash",
  "serde",
  "serde_json",
  "smallvec",
  "strum",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -632,7 +761,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -646,7 +775,7 @@ dependencies = [
  "js-sys",
  "phase-ai",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "seat-reducer",
  "serde",
  "serde-wasm-bindgen",
@@ -748,6 +877,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +890,21 @@ checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -774,10 +924,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "futures-sink"
@@ -797,8 +980,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -813,6 +998,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generational-arena"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -868,6 +1062,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -931,6 +1126,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +1160,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
 
 [[package]]
 name = "html5ever"
@@ -1022,6 +1252,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1281,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs 0.8.4",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1058,7 +1309,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1286,6 +1537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,7 +1668,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1451,8 +1718,27 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "syn",
+ "syn 2.0.117",
  "tempfile",
+]
+
+[[package]]
+name = "muxado"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2d52e2794a4ecef95b6e9b9930ae5e0a73a8518dc2a388f5fe066af824a2f9"
+dependencies = [
+ "async-trait",
+ "awaitdrop",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rand 0.8.6",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1464,10 +1750,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1477,6 +1763,46 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "ngrok"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ad94d0fd5a5e1f5bb6a99f06b8babc62594799785451f4aeb048c9b2848ef8"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "awaitdrop",
+ "axum-core 0.4.5",
+ "base64 0.21.7",
+ "bitflags 2.11.1",
+ "bytes",
+ "futures",
+ "futures-rustls",
+ "futures-util",
+ "hostname",
+ "hyper-http-proxy",
+ "hyper-util",
+ "muxado",
+ "once_cell",
+ "parking_lot",
+ "pin-project",
+ "proxy-protocol",
+ "regex",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio-socks",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "url",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "nom"
@@ -1529,7 +1855,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1545,8 +1871,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -1629,6 +1961,7 @@ dependencies = [
  "engine",
  "http",
  "lobby-broker",
+ "ngrok",
  "phase-ai",
  "rand 0.9.4",
  "rusqlite",
@@ -1642,6 +1975,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -1684,7 +2018,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1694,6 +2028,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1755,7 +2109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1775,15 +2129,25 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proxy-protocol"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e50c72c21c738f5c5f350cc33640aee30bf7cd20f9d9da20ed41bce2671d532"
+dependencies = [
+ "bytes",
+ "snafu",
 ]
 
 [[package]]
@@ -1819,6 +2183,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1828,8 +2194,29 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1847,6 +2234,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -1856,6 +2246,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -1901,7 +2297,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1921,7 +2317,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1959,7 +2355,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -2015,7 +2411,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2035,7 +2431,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2048,11 +2444,47 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2070,6 +2502,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2174,11 +2607,24 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2201,7 +2647,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cssparser",
  "derive_more",
  "fxhash",
@@ -2258,7 +2704,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2312,7 +2758,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -2335,7 +2781,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2348,7 +2794,7 @@ dependencies = [
  "phase-ai",
  "proptest",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "seat-reducer",
  "serde",
  "serde_json",
@@ -2373,7 +2819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2431,12 +2877,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "snafu"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2504,7 +2980,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2518,6 +2994,17 @@ name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2547,7 +3034,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2556,7 +3043,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2597,11 +3084,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2612,7 +3119,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2705,7 +3212,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2719,12 +3226,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.1",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -2748,6 +3278,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -2816,7 +3347,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2860,7 +3391,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -2873,7 +3404,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2947,7 +3478,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3128,7 +3659,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3169,7 +3700,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -3196,6 +3727,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3750,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3225,7 +3778,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3236,7 +3789,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3276,11 +3829,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3294,19 +3856,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3316,9 +3899,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3334,9 +3929,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3346,9 +3953,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3401,7 +4020,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3417,7 +4036,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3429,7 +4048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -3490,7 +4109,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3511,7 +4130,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3531,7 +4150,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3571,7 +4190,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -16,7 +16,7 @@ import {
   openPhaseSocket,
   type PhaseSocket,
 } from "../services/openPhaseSocket";
-import { isValidWebSocketUrl } from "../services/serverDetection";
+import { isValidWebSocketUrl, mixedContentBlockReason } from "../services/serverDetection";
 import type { WsSessionData } from "../services/multiplayerSession";
 
 /** Deck data format matching server protocol. */
@@ -50,6 +50,9 @@ export interface ServerInfo {
   buildCommit: string;
   protocolVersion: number;
   mode: "Full" | "LobbyOnly";
+  /** Public base URL the server advertises for `<code>@<host>` join strings
+   * (a tunnel/proxy URL), or undefined when the server has none to share. */
+  publicUrl?: string;
 }
 
 /** Events emitted by the WebSocketAdapter for UI state updates. */
@@ -195,6 +198,16 @@ export class WebSocketAdapter implements EngineAdapter {
 
       if (!isValidWebSocketUrl(this.serverUrl)) {
         reject(new AdapterError("WS_ERROR", "Invalid WebSocket URL", false));
+        this.initResolve = null;
+        this.initReject = null;
+        return;
+      }
+
+      // A ws:// target from an HTTPS page is blocked by the browser before the
+      // handshake — surface why instead of letting it fail as "unreachable".
+      const blockReason = mixedContentBlockReason(this.serverUrl);
+      if (blockReason) {
+        reject(new AdapterError("WS_ERROR", blockReason, false));
         this.initResolve = null;
         this.initReject = null;
         return;

--- a/client/src/components/chrome/HostControlTile.tsx
+++ b/client/src/components/chrome/HostControlTile.tsx
@@ -11,6 +11,7 @@ import {
   type SeatKind,
 } from "../../stores/multiplayerStore";
 import { useAiDeckCatalog } from "../../services/aiDeckCatalog";
+import { formatJoinShare } from "../../services/serverDetection";
 import { expandParsedDeck } from "../../services/deckParser";
 import { SelectField } from "../ui/SelectField";
 
@@ -277,9 +278,18 @@ export function HostControlTile() {
     (s) => s.startLobbyWithCurrentPlayers,
   );
   const showToast = useMultiplayerStore((s) => s.showToast);
+  const serverInfo = useMultiplayerStore((s) => s.serverInfo);
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
+
+  // The reachable `<code>@<host>` join string, available only when the server
+  // advertised a public URL (server-run hosting). P2P/broker hosts have no
+  // such URL and share the bare code instead (handled below).
+  const joinShare =
+    hostGameCode && serverInfo?.publicUrl
+      ? formatJoinShare(hostGameCode, serverInfo.publicUrl)
+      : null;
   const aiDeckCatalog = useAiDeckCatalog({
     selectedFormat: hostSession?.formatConfig.format,
     selectedMatchType: hostSession?.matchType,
@@ -421,12 +431,18 @@ export function HostControlTile() {
           <button
             type="button"
             onClick={() => {
-              if (location.pathname.startsWith("/game/") && hostGameCode) {
+              if (joinShare) {
+                // Server-run host: copy the reachable `<code>@<host>` join link.
+                void navigator.clipboard?.writeText(joinShare);
+                showToast(t("hostControl.joinLinkCopied"));
+              } else if (location.pathname.startsWith("/game/") && hostGameCode) {
+                // P2P host in-game: the bare code (friends join via direct code).
                 void navigator.clipboard?.writeText(hostGameCode);
               } else {
                 navigate("/multiplayer");
               }
             }}
+            title={joinShare ? t("hostControl.copyJoinLink", { joinShare }) : undefined}
             className="flex min-w-0 items-center gap-2 text-xs text-slate-300 transition-colors hover:text-white"
           >
             <StatusDot connecting={isConnecting} />

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -71,7 +71,9 @@
     "seatsOccupied": "{{occupied}}/{{total}} Plätze belegt",
     "startGame": "Spiel starten",
     "startNow": "Jetzt starten",
-    "fillWithAi": "Mit KI auffüllen"
+    "fillWithAi": "Mit KI auffüllen",
+    "joinLinkCopied": "Beitrittslink kopiert",
+    "copyJoinLink": "Beitrittslink kopieren: {{joinShare}}"
   },
   "grantDebug": {
     "heading": "Sandbox: Debug-Berechtigungen",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -71,7 +71,9 @@
     "seatsOccupied": "{{occupied}}/{{total}} seats occupied",
     "startGame": "Start Game",
     "startNow": "Start Now",
-    "fillWithAi": "Fill With AI"
+    "fillWithAi": "Fill With AI",
+    "joinLinkCopied": "Join link copied",
+    "copyJoinLink": "Copy join link: {{joinShare}}"
   },
   "grantDebug": {
     "heading": "Sandbox: Debug Permissions",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -71,7 +71,9 @@
     "seatsOccupied": "{{occupied}}/{{total}} asientos ocupados",
     "startGame": "Empezar partida",
     "startNow": "Empezar ahora",
-    "fillWithAi": "Rellenar con IA"
+    "fillWithAi": "Rellenar con IA",
+    "joinLinkCopied": "Enlace de partida copiado",
+    "copyJoinLink": "Copiar enlace de partida: {{joinShare}}"
   },
   "grantDebug": {
     "heading": "Sandbox: Permisos de depuración",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -71,7 +71,9 @@
     "seatsOccupied": "{{occupied}}/{{total}} sièges occupés",
     "startGame": "Démarrer la partie",
     "startNow": "Démarrer maintenant",
-    "fillWithAi": "Compléter avec des IA"
+    "fillWithAi": "Compléter avec des IA",
+    "joinLinkCopied": "Lien d'invitation copié",
+    "copyJoinLink": "Copier le lien d'invitation : {{joinShare}}"
   },
   "grantDebug": {
     "heading": "Bac à sable : permissions de débogage",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -71,7 +71,9 @@
     "seatsOccupied": "{{occupied}}/{{total}} posti occupati",
     "startGame": "Avvia partita",
     "startNow": "Avvia ora",
-    "fillWithAi": "Riempi con IA"
+    "fillWithAi": "Riempi con IA",
+    "joinLinkCopied": "Link di accesso copiato",
+    "copyJoinLink": "Copia link di accesso: {{joinShare}}"
   },
   "grantDebug": {
     "heading": "Sandbox: permessi di debug",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -71,7 +71,9 @@
     "seatsOccupied": "{{occupied}}/{{total}} miejsc zajętych",
     "startGame": "Rozpocznij grę",
     "startNow": "Rozpocznij teraz",
-    "fillWithAi": "Wypełnij przez AI"
+    "fillWithAi": "Wypełnij przez AI",
+    "joinLinkCopied": "Skopiowano link dołączenia",
+    "copyJoinLink": "Kopiuj link dołączenia: {{joinShare}}"
   },
   "grantDebug": {
     "heading": "Piaskownica: uprawnienia debugowania",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -71,7 +71,9 @@
     "seatsOccupied": "{{occupied}}/{{total}} assentos ocupados",
     "startGame": "Iniciar Jogo",
     "startNow": "Iniciar Agora",
-    "fillWithAi": "Preencher com IA"
+    "fillWithAi": "Preencher com IA",
+    "joinLinkCopied": "Link de entrada copiado",
+    "copyJoinLink": "Copiar link de entrada: {{joinShare}}"
   },
   "grantDebug": {
     "heading": "Sandbox: Permissões de Depuração",

--- a/client/src/services/__tests__/serverDetection.test.ts
+++ b/client/src/services/__tests__/serverDetection.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { formatJoinShare, mixedContentBlockReason, parseJoinCode } from "../serverDetection";
+
+describe("parseJoinCode", () => {
+  it("returns just the code when no server address is present", () => {
+    expect(parseJoinCode("ABC123")).toEqual({ code: "ABC123" });
+  });
+
+  it("defaults a bare remote host to wss on the standard TLS port (443)", () => {
+    // A no-port remote host is a TLS proxy/tunnel (ngrok, Cloudflare, Caddy),
+    // so the port suffix is omitted rather than defaulting to the raw port.
+    expect(parseJoinCode("ABC123@play.example.com")).toEqual({
+      code: "ABC123",
+      serverAddress: "wss://play.example.com/ws",
+    });
+  });
+
+  it("respects an explicit ws:// scheme for a plain-ws LAN server", () => {
+    expect(parseJoinCode("ABC123@ws://192.168.1.5:9374")).toEqual({
+      code: "ABC123",
+      serverAddress: "ws://192.168.1.5:9374/ws",
+    });
+  });
+
+  it("respects an explicit wss:// scheme and drops the default 443 suffix", () => {
+    expect(parseJoinCode("ABC123@wss://play.example.com:443")).toEqual({
+      code: "ABC123",
+      serverAddress: "wss://play.example.com/ws",
+    });
+  });
+
+  it("defaults a bare remote host with an explicit port to wss on that port", () => {
+    expect(parseJoinCode("ABC123@1.2.3.4:9374")).toEqual({
+      code: "ABC123",
+      serverAddress: "wss://1.2.3.4:9374/ws",
+    });
+  });
+
+  it("uses ws:// for loopback hosts", () => {
+    expect(parseJoinCode("ABC123@localhost:9374")).toEqual({
+      code: "ABC123",
+      serverAddress: "ws://localhost:9374/ws",
+    });
+  });
+
+  it("returns just the code when the address is empty after @", () => {
+    expect(parseJoinCode("ABC123@")).toEqual({ code: "ABC123" });
+  });
+
+  it("resolves an ngrok tunnel host (no port) to wss on 443", () => {
+    // The share string emits the bare ngrok host; the joiner must reach it over wss.
+    expect(parseJoinCode("ABC123@x.ngrok-free.app")).toEqual({
+      code: "ABC123",
+      serverAddress: "wss://x.ngrok-free.app/ws",
+    });
+  });
+});
+
+describe("formatJoinShare", () => {
+  it("emits host only for an https tunnel/proxy URL", () => {
+    expect(formatJoinShare("K42QQS", "https://x.ngrok-free.app")).toBe(
+      "K42QQS@x.ngrok-free.app",
+    );
+  });
+
+  it("preserves ws:// for a plain-ws LAN PUBLIC_URL so the joiner reaches the non-TLS server", () => {
+    expect(formatJoinShare("K42QQS", "ws://192.168.1.5:9374")).toBe(
+      "K42QQS@ws://192.168.1.5:9374",
+    );
+  });
+
+  it("drops the path and keeps a non-default port", () => {
+    expect(formatJoinShare("K42QQS", "https://play.example.com:8443/ws")).toBe(
+      "K42QQS@play.example.com:8443",
+    );
+  });
+
+  it("returns null on a malformed public URL", () => {
+    expect(formatJoinShare("K42QQS", "not a url")).toBeNull();
+  });
+
+  it("round-trips: an https share string parses back to the wss connect URL", () => {
+    const share = formatJoinShare("K42QQS", "https://x.ngrok-free.app");
+    expect(share).not.toBeNull();
+    expect(parseJoinCode(share!)).toEqual({
+      code: "K42QQS",
+      serverAddress: "wss://x.ngrok-free.app/ws",
+    });
+  });
+
+  it("round-trips: a ws:// LAN share string preserves the plain-ws scheme", () => {
+    const share = formatJoinShare("K42QQS", "ws://192.168.1.5:9374");
+    expect(share).not.toBeNull();
+    expect(parseJoinCode(share!)).toEqual({
+      code: "K42QQS",
+      serverAddress: "ws://192.168.1.5:9374/ws",
+    });
+  });
+});
+
+describe("mixedContentBlockReason", () => {
+  const originalLocation = window.location;
+
+  function setPageProtocol(protocol: "http:" | "https:") {
+    Object.defineProperty(window, "location", {
+      value: { ...originalLocation, protocol },
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("blocks a remote ws:// target from an HTTPS page", () => {
+    setPageProtocol("https:");
+    const reason = mixedContentBlockReason("ws://70.249.47.161:9374/ws");
+    expect(reason).toMatch(/HTTPS/);
+    expect(reason).toContain("70.249.47.161:9374");
+  });
+
+  it("allows ws:// to loopback even from an HTTPS page", () => {
+    setPageProtocol("https:");
+    expect(mixedContentBlockReason("ws://localhost:9374/ws")).toBeNull();
+  });
+
+  it("allows ws:// from an http:// page", () => {
+    setPageProtocol("http:");
+    expect(mixedContentBlockReason("ws://70.249.47.161:9374/ws")).toBeNull();
+  });
+
+  it("never blocks a wss:// target", () => {
+    setPageProtocol("https:");
+    expect(mixedContentBlockReason("wss://play.example.com/ws")).toBeNull();
+  });
+});

--- a/client/src/services/openPhaseSocket.ts
+++ b/client/src/services/openPhaseSocket.ts
@@ -178,12 +178,14 @@ export function openPhaseSocket(
         build_commit: string;
         protocol_version: number;
         mode: "Full" | "LobbyOnly";
+        public_url?: string;
       };
       const info: ServerInfo = {
         version: data.server_version,
         buildCommit: data.build_commit,
         protocolVersion: data.protocol_version,
         mode: data.mode,
+        publicUrl: data.public_url,
       };
 
       // Accept any server in [MIN_SUPPORTED_SERVER_PROTOCOL, PROTOCOL_VERSION].

--- a/client/src/services/serverDetection.ts
+++ b/client/src/services/serverDetection.ts
@@ -82,10 +82,17 @@ export async function detectServerUrl(): Promise<string> {
 /**
  * Parse a join code that may contain a server address.
  *
+ * An explicit `ws://`/`wss://` scheme in the address is respected; otherwise the
+ * scheme defaults to `wss://` for remote hosts and `ws://` for loopback. A bare
+ * remote host with no port resolves to the standard TLS port (443), since a
+ * remote `wss://` endpoint is virtually always a reverse proxy or tunnel
+ * (ngrok, Cloudflare, Caddy) on 443 rather than the raw phase-server port.
+ *
  * Formats:
- *   "ABC123"                     -> { code: "ABC123" }
- *   "ABC123@192.168.1.5:9374"   -> { code: "ABC123", serverAddress: "ws://192.168.1.5:9374/ws" }
- *   "ABC123@myserver.com"       -> { code: "ABC123", serverAddress: "ws://myserver.com:9374/ws" }
+ *   "ABC123"                        -> { code: "ABC123" }
+ *   "ABC123@play.example.com"       -> { ..., serverAddress: "wss://play.example.com/ws" }
+ *   "ABC123@ws://192.168.1.5:9374"  -> { ..., serverAddress: "ws://192.168.1.5:9374/ws" }
+ *   "ABC123@192.168.1.5:9374"       -> { ..., serverAddress: "wss://192.168.1.5:9374/ws" }
  */
 export function parseJoinCode(input: string): { code: string; serverAddress?: string } {
   const trimmed = input.trim();
@@ -102,28 +109,96 @@ export function parseJoinCode(input: string): { code: string; serverAddress?: st
     return { code };
   }
 
-  // Parse host:port
-  const colonIndex = address.lastIndexOf(":");
-  let host: string;
-  let port: number;
-
-  if (colonIndex !== -1 && colonIndex < address.length - 1) {
-    host = address.slice(0, colonIndex);
-    const parsedPort = parseInt(address.slice(colonIndex + 1), 10);
-    port = isNaN(parsedPort) ? DEFAULT_PORT : parsedPort;
-  } else {
-    host = address;
-    port = DEFAULT_PORT;
+  // Respect an explicit scheme the host typed (e.g. `ws://` for a plain-ws LAN
+  // server, or a `wss://` tunnel URL). Check `wss://` first; neither prefix is a
+  // prefix of the other, but the ordering keeps the intent obvious.
+  let explicitScheme: "ws" | "wss" | null = null;
+  let hostPort = address;
+  if (address.startsWith("wss://")) {
+    explicitScheme = "wss";
+    hostPort = address.slice("wss://".length);
+  } else if (address.startsWith("ws://")) {
+    explicitScheme = "ws";
+    hostPort = address.slice("ws://".length);
   }
 
+  // Split host:port on the last colon so a host:port pair splits correctly.
+  const colonIndex = hostPort.lastIndexOf(":");
+  const hasPort = colonIndex !== -1 && colonIndex < hostPort.length - 1;
+  const host = hasPort ? hostPort.slice(0, colonIndex) : hostPort;
+
   const isLocal = host === "localhost" || host === "127.0.0.1";
-  const scheme = isLocal ? "ws" : "wss";
-  const portSuffix = isLocal ? `:${port}` : port !== 443 ? `:${port}` : "";
+  const scheme = explicitScheme ?? (isLocal ? "ws" : "wss");
+
+  // No explicit port: a wss:// host is a standard-port (443) TLS endpoint; a
+  // ws:// host is the phase-server default.
+  let port: number;
+  if (hasPort) {
+    const parsedPort = parseInt(hostPort.slice(colonIndex + 1), 10);
+    port = isNaN(parsedPort) ? DEFAULT_PORT : parsedPort;
+  } else {
+    port = scheme === "wss" ? 443 : DEFAULT_PORT;
+  }
+
+  // Omit the suffix when the port is the scheme's default.
+  const isDefaultPort = (scheme === "wss" && port === 443) || (scheme === "ws" && port === 80);
+  const portSuffix = isDefaultPort ? "" : `:${port}`;
 
   return {
     code,
     serverAddress: `${scheme}://${host}${portSuffix}/ws`,
   };
+}
+
+/**
+ * Build the shareable join string `CODE@host` for a server-run host from the
+ * server-advertised public URL — the inverse of {@link parseJoinCode}. An
+ * `https`/`wss` URL (tunnel or TLS proxy) yields a scheme-less host that
+ * parseJoinCode resolves to `wss://`; an `http`/`ws` URL (a plain-ws LAN
+ * `PUBLIC_URL`) keeps an explicit `ws://` so the joiner reaches the non-TLS
+ * server. Returns `null` on a malformed URL.
+ *
+ * Only meaningful when the server advertised a `publicUrl` (server-run hosting).
+ * P2P/broker hosts have no game-server URL and share the bare code instead.
+ */
+export function formatJoinShare(code: string, publicUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(publicUrl);
+  } catch {
+    return null;
+  }
+  const insecure = url.protocol === "ws:" || url.protocol === "http:";
+  return `${code}@${insecure ? "ws://" : ""}${url.host}`;
+}
+
+/**
+ * Returns an actionable error message if connecting to `serverAddress` would be
+ * blocked by the browser's mixed-content policy, or `null` if it is allowed.
+ *
+ * A page served over HTTPS cannot open an insecure `ws://` WebSocket — the
+ * browser blocks it before the handshake is ever attempted, so the failure is
+ * otherwise indistinguishable from an unreachable server. Loopback hosts are
+ * exempt: browsers treat `localhost`/`127.0.0.1` as potentially trustworthy, so
+ * `ws://localhost` is permitted even from an HTTPS origin (this is the Tauri
+ * sidecar path). Outside a browser (`window` undefined) nothing is blocked.
+ */
+export function mixedContentBlockReason(serverAddress: string): string | null {
+  const url = parseWebSocketUrl(serverAddress);
+  if (!url || url.protocol !== "ws:") {
+    return null;
+  }
+  if (typeof window === "undefined" || window.location.protocol !== "https:") {
+    return null;
+  }
+  if (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") {
+    return null;
+  }
+  return (
+    `This page is served over HTTPS, so it can't connect to an insecure ws:// server (${url.host}). ` +
+    `Host phase-server behind HTTPS — a wss:// reverse proxy or tunnel (ngrok, Cloudflare, Caddy) — ` +
+    `or open the app over http://.`
+  );
 }
 
 /** Convert ws:// URL to http:// health check URL. */

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -1015,6 +1015,10 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
               matchType: settings.matchType,
             },
             playerSlots: adapter.getPlayerSlots(),
+            // P2P/broker hosting has no advertised game-server URL. Clear any
+            // serverInfo left by a prior online-host session so the P2P share
+            // string is the bare room code, never a stale `code@<old-server>`.
+            serverInfo: null,
           });
 
           for (const seat of settings.aiSeats) {

--- a/crates/phase-server/Cargo.toml
+++ b/crates/phase-server/Cargo.toml
@@ -27,6 +27,14 @@ tracing = { workspace = true }
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
+url = "2"
+ngrok = { version = "0.18", optional = true }
+
+[features]
+# Embed an ngrok tunnel so self-hosters can share a join code without
+# port-forwarding or TLS setup. Off by default (keeps the standard build lean);
+# enable in the Docker image with `--features ngrok` + NGROK_AUTHTOKEN.
+ngrok = ["dep:ngrok"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -67,6 +67,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tower_http::cors::CorsLayer;
 use tracing::{debug, error, info, info_span, warn, Instrument};
+use url::Url;
 
 type SharedState = Arc<Mutex<SessionManager>>;
 type SharedConnections =
@@ -488,6 +489,14 @@ struct Cli {
     /// drift between host and server.
     #[arg(long, env = "PHASE_LOBBY_ONLY")]
     lobby_only: bool,
+
+    /// Public base URL to advertise to clients for sharing join codes (e.g.
+    /// `https://play.example.com` when running behind a TLS reverse proxy or
+    /// tunnel). Clients surface `<code>@<host>` so friends can join without the
+    /// host reading server logs. When the `ngrok` feature is built and
+    /// `NGROK_AUTHTOKEN` is set, the live tunnel URL is used when this is unset.
+    #[arg(long, env = "PUBLIC_URL")]
+    public_url: Option<String>,
 }
 
 /// Per-socket state tracking which game/player this connection belongs to.
@@ -1081,6 +1090,32 @@ async fn main() {
     let shutdown_draft_state = draft_sessions.clone();
     let shutdown_game_db = game_db.clone();
 
+    // Resolve the public URL advertised to clients for `<code>@<host>` join
+    // strings. An explicit `--public-url` (validated at the boundary) wins;
+    // otherwise an embedded ngrok tunnel supplies one when the `ngrok` feature
+    // is built and NGROK_AUTHTOKEN is set. `_ngrok_forwarder` keeps the tunnel
+    // open for the process lifetime (dropped on shutdown ⇒ tunnel closed); a
+    // tunnel that fails to establish never blocks local boot.
+    let configured_public_url = cli.public_url.as_deref().and_then(validate_public_url);
+    #[cfg(feature = "ngrok")]
+    let (advertised_public_url, _ngrok_forwarder) = match start_ngrok_tunnel(cli.port).await {
+        Some((url, fwd)) => (configured_public_url.clone().or(Some(url)), Some(fwd)),
+        None => (configured_public_url, None),
+    };
+    #[cfg(not(feature = "ngrok"))]
+    let advertised_public_url = {
+        if std::env::var_os("NGROK_AUTHTOKEN").is_some() {
+            warn!(
+                "NGROK_AUTHTOKEN is set but phase-server was built without the `ngrok` feature; \
+                 embedded tunnel disabled. Rebuild with `--features ngrok`."
+            );
+        }
+        configured_public_url
+    };
+    if let Some(url) = &advertised_public_url {
+        info!(public_url = %url, "advertising public URL for join-code sharing");
+    }
+
     let app = Router::new()
         .route("/ws", get(ws_handler))
         .route("/health", get(health))
@@ -1108,6 +1143,7 @@ async fn main() {
             draft_spectators,
             game_spectators,
             mode,
+            public_url: advertised_public_url,
         });
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", cli.port))
@@ -1192,6 +1228,59 @@ async fn health() -> &'static str {
     "ok"
 }
 
+/// Validate an operator-supplied public URL at the system boundary. It must
+/// parse as an absolute URL with a host; a malformed value is dropped (logged)
+/// rather than advertised to clients verbatim. Returns the URL with any
+/// trailing slash trimmed.
+fn validate_public_url(raw: &str) -> Option<String> {
+    match Url::parse(raw) {
+        Ok(u) if u.host_str().is_some() => Some(raw.trim_end_matches('/').to_string()),
+        _ => {
+            warn!(value = %raw, "ignoring malformed PUBLIC_URL (need an absolute URL with a host)");
+            None
+        }
+    }
+}
+
+/// Open an embedded ngrok HTTP tunnel that forwards public traffic to the local
+/// server on `port`, returning `(public_url, forwarder_handle)`. The handle
+/// keeps the tunnel open while held; dropping it closes the tunnel. Any failure
+/// (missing/invalid `NGROK_AUTHTOKEN`, network) is logged and returns `None` —
+/// the local server still runs, so the tunnel is strictly additive.
+#[cfg(feature = "ngrok")]
+async fn start_ngrok_tunnel(port: u16) -> Option<(String, Box<dyn std::any::Any + Send>)> {
+    use ngrok::prelude::*;
+
+    let upstream = match Url::parse(&format!("http://localhost:{port}")) {
+        Ok(u) => u,
+        Err(e) => {
+            error!(error = %e, "ngrok: invalid upstream URL; tunnel disabled");
+            return None;
+        }
+    };
+    let session = match ngrok::Session::builder()
+        .authtoken_from_env()
+        .connect()
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            error!(error = %e, "ngrok: session connect failed; tunnel disabled, local server still running");
+            return None;
+        }
+    };
+    let forwarder = match session.http_endpoint().listen_and_forward(upstream).await {
+        Ok(f) => f,
+        Err(e) => {
+            error!(error = %e, "ngrok: tunnel start failed; disabled, local server still running");
+            return None;
+        }
+    };
+    let url = forwarder.url().to_string();
+    info!(url = %url, "ngrok tunnel established");
+    Some((url, Box::new(forwarder)))
+}
+
 #[derive(Clone)]
 struct AppState {
     sessions: SharedState,
@@ -1206,6 +1295,10 @@ struct AppState {
     draft_spectators: SharedDraftSpectators,
     game_spectators: SharedGameSpectators,
     mode: Mode,
+    /// Public base URL advertised in `ServerHello` (from `--public-url`/an
+    /// embedded ngrok tunnel), or `None` when the server has no reachable
+    /// address to share. Cloned per connection at greet time only.
+    public_url: Option<String>,
 }
 
 async fn ws_handler(ws: WebSocketUpgrade, State(app_state): State<AppState>) -> impl IntoResponse {
@@ -1235,6 +1328,7 @@ async fn ws_handler(ws: WebSocketUpgrade, State(app_state): State<AppState>) -> 
                 app_state.draft_spectators,
                 app_state.game_spectators,
                 app_state.mode,
+                app_state.public_url,
             )
         })
         .into_response()
@@ -1255,6 +1349,7 @@ async fn handle_socket(
     draft_spectators: SharedDraftSpectators,
     game_spectators: SharedGameSpectators,
     mode: Mode,
+    public_url: Option<String>,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<ServerMessage>();
 
@@ -1291,6 +1386,7 @@ async fn handle_socket(
         build_commit: build_commit().to_string(),
         protocol_version: PROTOCOL_VERSION,
         mode,
+        public_url,
     };
     if let Ok(json) = serde_json::to_string(&hello) {
         if socket.send(Message::text(json)).await.is_err() {
@@ -1520,6 +1616,9 @@ fn to_server_message(m: lobby_broker::LobbyServerMessage) -> ServerMessage {
                 lobby_broker::ServerMode::Full => ServerMode::Full,
                 lobby_broker::ServerMode::LobbyOnly => ServerMode::LobbyOnly,
             },
+            // LobbyOnly brokers run no server-side game, so there is no
+            // game-server URL to advertise for a `<code>@<host>` share string.
+            public_url: None,
         },
         L::GameCreated {
             game_code,

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -265,6 +265,14 @@ pub enum ServerMessage {
         build_commit: String,
         protocol_version: u32,
         mode: ServerMode,
+        /// Public base URL clients should advertise when sharing a join code
+        /// (e.g. `https://x.ngrok-free.app` from an embedded tunnel, or a
+        /// `PUBLIC_URL` reverse proxy). Lets a host connected over `localhost`
+        /// still surface a reachable `<code>@<host>` string. Additive and
+        /// optional: older clients ignore it, older servers omit it. `None` for
+        /// LobbyOnly brokers and for servers with no advertised address.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        public_url: Option<String>,
     },
     GameCreated {
         game_code: String,
@@ -1200,7 +1208,8 @@ mod tests {
             server_version: "0.1.11".to_string(),
             build_commit: "abc1234".to_string(),
             protocol_version: PROTOCOL_VERSION,
-            mode: ServerMode::LobbyOnly,
+            mode: ServerMode::Full,
+            public_url: Some("https://x.ngrok-free.app".to_string()),
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
@@ -1210,14 +1219,32 @@ mod tests {
                 build_commit,
                 protocol_version,
                 mode,
+                public_url,
             } => {
                 assert_eq!(server_version, "0.1.11");
                 assert_eq!(build_commit, "abc1234");
                 assert_eq!(protocol_version, PROTOCOL_VERSION);
-                assert_eq!(mode, ServerMode::LobbyOnly);
+                assert_eq!(mode, ServerMode::Full);
+                assert_eq!(public_url.as_deref(), Some("https://x.ngrok-free.app"));
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn server_hello_omits_public_url_when_none() {
+        // `skip_serializing_if` keeps the wire identical to a server with no
+        // advertised URL — and identical to the lobby-broker ServerHello, which
+        // has no such field (asserted by the lobby wire-contract test).
+        let msg = ServerMessage::ServerHello {
+            server_version: "0.1.11".to_string(),
+            build_commit: "abc1234".to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            mode: ServerMode::LobbyOnly,
+            public_url: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(!json.contains("public_url"), "None must be omitted: {json}");
     }
 
     #[test]

--- a/crates/server-core/tests/lobby_wire_contract.rs
+++ b/crates/server-core/tests/lobby_wire_contract.rs
@@ -152,6 +152,9 @@ fn server_hello_mode_byte_identical() {
         build_commit: "abc".into(),
         protocol_version: 7,
         mode: sc::ServerMode::LobbyOnly,
+        // None + skip_serializing_if keeps the wire identical to the lobby
+        // broker's ServerHello, which has no public_url field.
+        public_url: None,
     };
     assert_eq!(
         serde_json::to_string(&lb_hello).unwrap(),


### PR DESCRIPTION
Let self-hosters run phase-server for friends without port-forwarding or TLS
setup, and surface a reachable join string to the host instead of the logs.

Server (phase-server):
- Advertise a public URL in ServerHello (additive Option<String>, omitted on
  the wire when None; lobby/server-core ServerHello stays byte-identical).
- Source it from --public-url/PUBLIC_URL (validated at the boundary) or an
  optional embedded ngrok tunnel behind the `ngrok` cargo feature
  (NGROK_AUTHTOKEN). The tunnel forwards to the existing local listener via
  listen_and_forward, so the serve/teardown path is unchanged; a tunnel that
  fails to start never blocks local boot. Warns when the token is set but the
  feature was not built.

Client:
- Decode public_url into ServerInfo; HostControlTile copies a host-type-aware
  share string: `<code>@<host>` for a server-run host (gated on the advertised
  publicUrl), the bare code for a P2P host (joined via direct code). Clear
  stale serverInfo when starting a P2P host so an online publicUrl never leaks
  into a P2P share.
- parseJoinCode honors an explicit ws://|wss:// scheme and scheme-aware default
  ports; formatJoinShare is its inverse. Block ws:// from an https page (mixed
  content) with an actionable error instead of a silent failure.
