### PR TITLE
fix(engine): decompose Case 'To solve' conditions via the single condition authority (CR 719.3a)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4163,9 +4163,11 @@ pub(crate) fn check_trigger_condition(
         }
         // CR 719.2: True when the source Case is unsolved and its solve condition is met.
         TriggerCondition::SolveConditionMet => source_id
-            .and_then(|id| state.objects.get(&id))
-            .and_then(|obj| obj.case_state.as_ref())
-            .is_some_and(|cs| !cs.is_solved && evaluate_solve_condition(state, cs, controller)),
+            .and_then(|id| state.objects.get(&id).map(|obj| (id, obj)))
+            .and_then(|(id, obj)| obj.case_state.as_ref().map(|cs| (id, cs)))
+            .is_some_and(|(id, cs)| {
+                !cs.is_solved && evaluate_solve_condition(state, cs, controller, id)
+            }),
         // CR 716.2a: True when the source Class is at or above the specified level.
         TriggerCondition::ClassLevelGE { level } => {
             source_id.is_some_and(|id| eval_class_level_ge(state, id, *level))
@@ -4848,6 +4850,7 @@ fn evaluate_solve_condition(
     state: &GameState,
     cs: &crate::game::game_object::CaseState,
     controller: PlayerId,
+    source_id: ObjectId,
 ) -> bool {
     use crate::types::ability::SolveCondition;
 
@@ -4873,6 +4876,12 @@ fn evaluate_solve_condition(
                 })
                 .count() as i32;
             comparator.evaluate(count, *threshold as i32)
+        }
+        // CR 719.3a: A general game-state solve condition is evaluated at the
+        // controller's end step through the single condition
+        // evaluator that powers intervening-ifs and static abilities.
+        SolveCondition::Condition { condition } => {
+            crate::game::layers::evaluate_condition(state, condition, controller, source_id)
         }
         SolveCondition::Text { .. } => false, // Undecomposed conditions never auto-solve
     }

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -19,6 +19,7 @@ use super::oracle_cost::{parse_or_separated_mana_costs, parse_single_cost};
 use super::oracle_effect::imperative::try_parse_die_result_line;
 use super::oracle_effect::{capitalize, parse_effect_chain};
 use super::oracle_nom::bridge::nom_on_lower;
+use super::oracle_nom::condition::parse_inner_condition;
 use super::oracle_nom::error::OracleResult;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_util::{
@@ -62,6 +63,21 @@ pub(super) fn parse_solve_condition(text: &str) -> SolveCondition {
             comparator: Comparator::EQ,
             threshold: 0,
         };
+    }
+
+    // CR 719.3a: A solve condition is a general game-state condition. Route it
+    // through the single condition authority (`parse_inner_condition`) so every
+    // condition shape the engine already understands (life totals, hand size,
+    // control counts, event history, quantity comparisons) makes a Case
+    // auto-solve. The caller lowercases the text (`oracle.rs` passes `rest_lower`);
+    // bridge defensively through `nom_on_lower` exactly as the arm above.
+    let trimmed = text.trim_end_matches('.').trim();
+    if let Some((condition, rest)) = nom_on_lower(trimmed, trimmed, parse_inner_condition) {
+        // Only accept a fully-consumed parse (trailing punctuation/whitespace
+        // already stripped); a partial parse falls through to `Text`.
+        if rest.trim().trim_end_matches('.').trim().is_empty() {
+            return SolveCondition::Condition { condition };
+        }
     }
 
     SolveCondition::Text {
@@ -493,4 +509,84 @@ pub(super) fn parse_cumulative_upkeep_keyword(line: &str) -> Option<Keyword> {
     let cost_text = stripped.trim().trim_end_matches('.');
     let cost = parse_cumulative_upkeep_cost(cost_text)?;
     Some(Keyword::CumulativeUpkeep(cost))
+}
+
+#[cfg(test)]
+mod solve_condition_tests {
+    use super::parse_solve_condition;
+    use crate::types::ability::{
+        Comparator, PlayerScope, QuantityExpr, QuantityRef, SolveCondition, StaticCondition,
+    };
+
+    // CR 719.3a: "you have no cards in hand" (Case of the Crimson Pulse) decomposes
+    // through the single condition authority into a hand-size comparison.
+    #[test]
+    fn hand_size_solve_condition_decomposes() {
+        let cond = parse_solve_condition("you have no cards in hand");
+        assert_eq!(
+            cond,
+            SolveCondition::Condition {
+                condition: StaticCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize {
+                            player: PlayerScope::Controller,
+                        },
+                    },
+                    comparator: Comparator::EQ,
+                    rhs: QuantityExpr::Fixed { value: 0 },
+                },
+            }
+        );
+    }
+
+    // A life-total threshold decomposes to a quantity comparison.
+    #[test]
+    fn life_total_solve_condition_decomposes() {
+        let cond = parse_solve_condition("you have 10 or more life");
+        match cond {
+            SolveCondition::Condition {
+                condition:
+                    StaticCondition::QuantityComparison {
+                        lhs:
+                            QuantityExpr::Ref {
+                                qty: QuantityRef::LifeTotal { .. },
+                            },
+                        comparator: Comparator::GE,
+                        rhs: QuantityExpr::Fixed { value: 10 },
+                    },
+            } => {}
+            other => panic!("expected life-total QuantityComparison, got {other:?}"),
+        }
+    }
+
+    // A control-count solve condition routes through the condition authority
+    // (no longer the inert `Text` fallback).
+    #[test]
+    fn control_count_solve_condition_decomposes() {
+        let cond = parse_solve_condition("you control three or more creatures");
+        assert!(
+            matches!(cond, SolveCondition::Condition { .. }),
+            "expected a decomposed Condition, got {cond:?}"
+        );
+    }
+
+    // The existing bespoke subtype-count arm still produces `ObjectCount`.
+    #[test]
+    fn subtype_count_solve_condition_uses_object_count() {
+        let cond = parse_solve_condition("you control no suspected skeletons");
+        assert!(
+            matches!(cond, SolveCondition::ObjectCount { .. }),
+            "expected ObjectCount for the suspected-subtype arm, got {cond:?}"
+        );
+    }
+
+    // A condition the shared combinator cannot decompose falls back to `Text`.
+    #[test]
+    fn unparseable_solve_condition_falls_back_to_text() {
+        let cond = parse_solve_condition("the stars align in your favor");
+        assert!(
+            matches!(cond, SolveCondition::Text { .. }),
+            "expected Text fallback, got {cond:?}"
+        );
+    }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4289,6 +4289,12 @@ pub enum SolveCondition {
         comparator: Comparator,
         threshold: u32,
     },
+    /// CR 719.3a: A general game-state solve condition decomposed via the single
+    /// condition authority (`parse_inner_condition` → `StaticCondition`) and
+    /// evaluated at end step through `layers::evaluate_condition`. Covers life
+    /// totals, hand size, control counts, event history, quantity comparisons —
+    /// every condition shape the engine already understands.
+    Condition { condition: StaticCondition },
     /// Fallback for conditions the parser cannot decompose.
     Text { description: String },
 }

--- a/crates/engine/tests/integration/case_solve_condition.rs
+++ b/crates/engine/tests/integration/case_solve_condition.rs
@@ -1,0 +1,96 @@
+//! CR 719.3a end-to-end: a Case whose "To solve" condition is a general
+//! game-state condition (here "you have no cards in hand", as on Case of the
+//! Crimson Pulse) auto-solves at the controller's end step once the condition
+//! is met.
+//!
+//! Before this change `parse_solve_condition` decomposed only the bespoke
+//! "you control no <subtype>" phrasing into `SolveCondition::ObjectCount`;
+//! every other condition fell to the inert `SolveCondition::Text`, whose
+//! evaluator arm returns `false`, so the Case never solved. Routing the
+//! parse through the single condition authority (`parse_inner_condition`)
+//! produces a `SolveCondition::Condition { condition }` that the end-step
+//! evaluator hands to `layers::evaluate_condition` (CR 719.3a).
+//!
+//! These tests drive the real engine pipeline (build → synthesized end-step
+//! `SolveCase` trigger → `TriggerCondition::SolveConditionMet` →
+//! `Effect::SolveCase` → `is_solved`), not a hand-constructed expected state.
+//! Reverting the parser/evaluator change makes the solve condition parse to
+//! `Text` and the positive assertion (`is_solved == true`) flips to false.
+
+use super::rules::{GameScenario, Phase, P0};
+use engine::types::identifiers::ObjectId;
+
+// CR 719.3a: "To solve" is a general game-state condition; "Solved" grants a
+// dummy keyword-only ability so the line parses, but only the solve trigger
+// matters for these assertions.
+const CRIMSON_PULSE_LIKE: &str =
+    "To solve \u{2014} You have no cards in hand.\nSolved \u{2014} {T}: Add {R}.";
+
+fn is_solved(runner: &super::rules::GameRunner, id: ObjectId) -> bool {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("Case object still present")
+        .case_state
+        .as_ref()
+        .expect("Case object carries case_state")
+        .is_solved
+}
+
+fn build_case(scenario: &mut GameScenario) -> ObjectId {
+    // A Case is an Enchantment with the "Case" subtype. The subtype/type must be
+    // set BEFORE `from_oracle_text`, because the parse + synthesis pipeline gates
+    // both the solve-condition decomposition and the auto-solve trigger on the
+    // "Case" subtype.
+    let mut builder = scenario.add_creature(P0, "Test Case", 0, 0);
+    builder
+        .as_enchantment()
+        .with_subtypes(vec!["Case"])
+        .from_oracle_text(CRIMSON_PULSE_LIKE);
+    builder.id()
+}
+
+#[test]
+fn case_auto_solves_at_end_step_when_condition_met() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // P0 has an empty hand by default — the "you have no cards in hand"
+    // condition is met.
+    let case = build_case(&mut scenario);
+
+    let mut runner = scenario.build();
+    assert!(
+        !is_solved(&runner, case),
+        "Case starts unsolved before its end step"
+    );
+
+    // Advance to (and through) P0's end step; the synthesized auto-solve trigger
+    // fires, its `SolveConditionMet` predicate evaluates the hand-size condition
+    // via `layers::evaluate_condition`, and `Effect::SolveCase` flips `is_solved`.
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        is_solved(&runner, case),
+        "Case must auto-solve at end step when 'you have no cards in hand' is met (CR 719.3a)"
+    );
+}
+
+#[test]
+fn case_does_not_solve_when_condition_unmet() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Give P0 a card in hand so the "you have no cards in hand" condition is NOT met.
+    scenario.add_card_to_hand(P0, "Filler Card");
+    let case = build_case(&mut scenario);
+
+    let mut runner = scenario.build();
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        !is_solved(&runner, case),
+        "Case must NOT solve while the solve condition is unmet (CR 719.3a — condition gate)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -25,6 +25,7 @@ mod boon_reflection_gain_life_drain;
 mod braids_arisen_nightmare_decline;
 mod brigid_mana_ability;
 mod cascade_intervening_if_pipeline;
+mod case_solve_condition;
 mod cast_during_resolution_pipeline;
 mod chain_of_smog_copy;
 mod chatterstorm_storm;


### PR DESCRIPTION
Route Case solve-condition parsing through parse_inner_condition (the single
StaticCondition authority) and evaluate via layers::evaluate_condition, so every
game-state condition the engine already understands -- life totals, hand size,
control counts, event-history, quantity comparisons -- makes a Case auto-solve at
the controller's end step. Previously only 'you control no <subtype>'
(SolveCondition::ObjectCount) decomposed; every other solve condition fell to
inert SolveCondition::Text and the Case never solved, leaving its 'Solved --'
ability permanently dead.

Adds SolveCondition::Condition { condition: StaticCondition } (parameterized, not
per-phrasing siblings), delegates parsing to parse_inner_condition via nom_on_lower,
and threads the Case's source_id into evaluate_solve_condition so SelfRef/
source-relative conditions resolve against the Case. Keeps the working ObjectCount
arm (the generic combinator does not reproduce its Suspected+subtype filter) and
the Text fallback for genuinely unparseable residue.
