### PR TITLE
style(client): standardize modal scrollbar styling across ModalPanelShell

### DIFF
--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -250,7 +250,7 @@ export function PreferencesModal({
       subtitle={t("modal.subtitle")}
       onClose={onClose}
       maxWidthClassName="max-w-5xl"
-      bodyClassName="thin-scrollbar overflow-y-auto p-4 sm:p-6"
+      bodyClassName="overflow-y-auto p-4 sm:p-6"
     >
       <div className="grid gap-4 md:grid-cols-[200px_minmax(0,1fr)]">
             <nav className="flex snap-x gap-2 overflow-x-auto pb-1 md:flex-col md:overflow-visible md:pb-0">

--- a/client/src/components/ui/ModalPanelShell.tsx
+++ b/client/src/components/ui/ModalPanelShell.tsx
@@ -68,7 +68,7 @@ export function ModalPanelShell({
             </button>
           </div>
 
-          <div className={`min-h-0 flex-1 pb-[env(safe-area-inset-bottom)] ${bodyClassName}`}>
+          <div className={`thin-scrollbar min-h-0 flex-1 pb-[env(safe-area-inset-bottom)] ${bodyClassName}`}>
             {children}
           </div>
         </motion.div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -503,24 +503,55 @@ body {
   overscroll-behavior-x: contain;
 }
 
-/* Thin scrollbar for scrollable panels and modals */
+/* Thin scrollbar for scrollable panels and modals — pill thumb, subtle track, arrow buttons */
 .thin-scrollbar {
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  scrollbar-color: rgba(255, 255, 255, 0.45) rgba(255, 255, 255, 0.06);
 }
 .thin-scrollbar::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-.thin-scrollbar::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
-  border-radius: 3px;
-}
-.thin-scrollbar::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.28);
+  width: 8px;
+  height: 8px;
 }
 .thin-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 9999px;
+}
+.thin-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.42);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.thin-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.62);
+  background-clip: padding-box;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button {
+  display: block;
+  height: 10px;
+  background-color: transparent;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button:vertical:decrement {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 5'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M4 0 8 5H0z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button:vertical:increment {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 5'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M0 0h8L4 5z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button:horizontal:decrement {
+  width: 10px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5 8'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M0 4 5 0v8z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button:horizontal:increment {
+  width: 10px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5 8'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M5 4 0 0v8z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 /* Thin scrollbar for zone viewer (graveyard/exile) */


### PR DESCRIPTION
## Summary

Standardizes scrollbar styling across scrollable modal panels by applying the shared `thin-scrollbar` utility at the `ModalPanelShell` level and refining its visual appearance.

Previously, custom scrollbar styling was only applied to specific modals such as Preferences, while other scrollable modals continued to display browser- or OS-specific scrollbar controls. This resulted in inconsistent visual behavior across the application.

This change centralizes scrollbar styling within the shared modal shell and updates the scrollbar appearance with a more visible pill-shaped thumb, subtle track styling, and browser-specific enhancements where supported.

## Motivation

Several scrollable modals—including the Match Setup format picker—continued to use native browser scrollbars that did not match the application's dark UI. Additionally, the existing scrollbar styling was only applied selectively and lacked the visual prominence used elsewhere in the interface.

By moving scrollbar behavior into `ModalPanelShell`, all modal-based experiences inherit a consistent appearance while reducing styling duplication and maintenance overhead.

## Changes

### Updated Scrollbar Styling

* Refine the shared `.thin-scrollbar` utility
* Introduce a brighter pill-shaped scrollbar thumb for improved visibility
* Add subtle track styling consistent with the application's dark theme
* Add WebKit-specific scrollbar button styling for up/down navigation controls
* Preserve Firefox compatibility via `scrollbar-width` and `scrollbar-color`

### Modal Integration

* Apply `.thin-scrollbar` globally within `ModalPanelShell`
* Ensure all scrollable modal content inherits consistent scrollbar styling
* Remove the now-redundant `thin-scrollbar` usage from `PreferencesModal`

### Affected Areas

Examples include:

* Match Setup → Choose a Format
* Preferences
* Printing picker
* Zone viewer
* Debug library viewer
* Other scrollable `ModalPanelShell`-based interfaces

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/c1324c38-3e6e-406c-a0f3-5cfd8b5782b7" />

### After 

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/bcda2919-a12f-4e99-b632-de823cfc97d6" />

## Test Plan

* [ ] Open Match Setup → **Choose a Format**
* [ ] Verify the scrollbar uses the themed styling with a rounded pill-shaped thumb
* [ ] Verify scrollbar controls render correctly on supported WebKit browsers
* [ ] Confirm hovering the scrollbar increases thumb visibility
* [ ] Open **Preferences** and verify scrollbar styling remains correct
* [ ] Verify scrolling behavior remains unchanged across modal content
* [ ] Smoke-test other `ModalPanelShell` modals for layout or overflow regressions
* [ ] Verify Chrome, Edge, and Safari rendering
* [ ] Verify Firefox uses the expected `scrollbar-width` / `scrollbar-color` fallback styling
* [ ] Confirm no functional regressions in modal interactions
