### PR TITLE
fix(client): remove deck builder page scrolling and unify scrollbar styling

### DIFF
--- a/client/src/components/deck-builder/DeckBuilder.tsx
+++ b/client/src/components/deck-builder/DeckBuilder.tsx
@@ -221,7 +221,7 @@ export function DeckBuilder({
   const infoVisible = activeSurface === "info" ? "flex" : "hidden md:flex";
 
   return (
-    <div className="flex h-screen flex-col bg-transparent">
+    <div className="flex h-full min-h-0 flex-col bg-transparent">
       <DeckBuilderToolbar
         onBack={requestBack}
         deckName={deckName}
@@ -284,7 +284,7 @@ export function DeckBuilder({
               {t("filters.done")}
             </button>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto pb-16">
+          <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto pb-16">
             <CardSearch
               onResults={handleSearchResults}
               onSearchTrigger={handleSearchTrigger}
@@ -356,7 +356,7 @@ export function DeckBuilder({
 
           <div className="min-h-0 flex-1 overflow-hidden">
             {searchActive ? (
-              <div className="h-full overflow-y-auto pb-16">
+              <div className="thin-scrollbar h-full overflow-y-auto pb-16">
                 <CardGrid
                   cards={searchResults}
                   onAddCard={handleAddCard}
@@ -373,7 +373,7 @@ export function DeckBuilder({
               // swallow the canvas.
               <div className="flex h-full flex-col">
                 {warnings.length > 0 && (
-                  <div className="max-h-32 shrink-0 space-y-0.5 overflow-y-auto border-b border-white/8 px-3 py-2">
+                  <div className="thin-scrollbar max-h-32 shrink-0 space-y-0.5 overflow-y-auto border-b border-white/8 px-3 py-2">
                     {warnings.map((w) => (
                       <div
                         key={w}
@@ -386,7 +386,7 @@ export function DeckBuilder({
                 )}
                 <div className="min-h-0 flex-1 overflow-hidden">
                   {deckView === "list" ? (
-                    <div className="h-full overflow-y-auto px-3 pt-3 pb-16">
+                    <div className="thin-scrollbar h-full overflow-y-auto px-3 pt-3 pb-16">
                       <DeckList
                         deck={currentDeck}
                         onRemoveCard={handleRemoveCard}
@@ -430,7 +430,7 @@ export function DeckBuilder({
           aria-labelledby={tabId("info")}
           className={`${infoVisible} min-h-0 w-full flex-col overflow-hidden border-white/8 bg-black/12 backdrop-blur-sm md:w-80 md:shrink-0 md:border-l lg:w-96`}
         >
-          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-3 pt-3 pb-16">
+          <div className="thin-scrollbar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-3 pt-3 pb-16">
             {isCommander && (
               <CommanderPanel
                 commanders={commanders}

--- a/client/src/components/deck-builder/DeckStack.tsx
+++ b/client/src/components/deck-builder/DeckStack.tsx
@@ -528,7 +528,7 @@ export function DeckStack({
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-3 pt-4 pb-16">
+      <div className="thin-scrollbar flex-1 overflow-auto px-3 pt-4 pb-16">
         {!hasCards ? (
           <div className="flex h-full items-center justify-center rounded-[20px] border border-dashed border-white/10 bg-black/12 text-sm text-slate-500">
             {t("stack.emptyHint")}

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -250,7 +250,7 @@ export function PreferencesModal({
       subtitle={t("modal.subtitle")}
       onClose={onClose}
       maxWidthClassName="max-w-5xl"
-      bodyClassName="thin-scrollbar overflow-y-auto p-4 sm:p-6"
+      bodyClassName="overflow-y-auto p-4 sm:p-6"
     >
       <div className="grid gap-4 md:grid-cols-[200px_minmax(0,1fr)]">
             <nav className="flex snap-x gap-2 overflow-x-auto pb-1 md:flex-col md:overflow-visible md:pb-0">

--- a/client/src/components/ui/ModalPanelShell.tsx
+++ b/client/src/components/ui/ModalPanelShell.tsx
@@ -68,7 +68,7 @@ export function ModalPanelShell({
             </button>
           </div>
 
-          <div className={`min-h-0 flex-1 pb-[env(safe-area-inset-bottom)] ${bodyClassName}`}>
+          <div className={`thin-scrollbar min-h-0 flex-1 pb-[env(safe-area-inset-bottom)] ${bodyClassName}`}>
             {children}
           </div>
         </motion.div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -356,6 +356,18 @@ body {
   display: none;
 }
 
+/* Deck builder fills the shell content column without forcing a page scrollbar.
+   Subtracts the sticky social header and (on narrow viewports) the bottom tab
+   bar reserve that shell-content already applies via pb-[76px]. */
+.deck-builder-shell {
+  height: calc(100dvh - env(safe-area-inset-top) - 44px - 76px - env(safe-area-inset-bottom));
+}
+@media (min-width: 820px) {
+  .deck-builder-shell {
+    height: calc(100dvh - env(safe-area-inset-top) - 56px - env(safe-area-inset-bottom));
+  }
+}
+
 @media (min-width: 1200px) {
   :root {
     --card-base: clamp(4.5rem, calc((5.9vw + 12vh) / 2), 7.25rem);
@@ -503,24 +515,55 @@ body {
   overscroll-behavior-x: contain;
 }
 
-/* Thin scrollbar for scrollable panels and modals */
+/* Thin scrollbar for scrollable panels and modals — pill thumb, subtle track, arrow buttons */
 .thin-scrollbar {
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  scrollbar-color: rgba(255, 255, 255, 0.45) rgba(255, 255, 255, 0.06);
 }
 .thin-scrollbar::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-.thin-scrollbar::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
-  border-radius: 3px;
-}
-.thin-scrollbar::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.28);
+  width: 8px;
+  height: 8px;
 }
 .thin-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 9999px;
+}
+.thin-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.42);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.thin-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.62);
+  background-clip: padding-box;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button {
+  display: block;
+  height: 10px;
+  background-color: transparent;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button:vertical:decrement {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 5'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M4 0 8 5H0z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button:vertical:increment {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 5'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M0 0h8L4 5z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button:horizontal:decrement {
+  width: 10px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5 8'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M0 4 5 0v8z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.thin-scrollbar::-webkit-scrollbar-button:single-button:horizontal:increment {
+  width: 10px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5 8'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M5 4 0 0v8z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 /* Thin scrollbar for zone viewer (graveyard/exile) */

--- a/client/src/pages/DeckBuilderPage.tsx
+++ b/client/src/pages/DeckBuilderPage.tsx
@@ -119,7 +119,7 @@ export function DeckBuilderPage() {
   }, [updateSearchParams]);
 
   return (
-    <div className="menu-scene h-screen overflow-hidden">
+    <div className="menu-scene deck-builder-shell flex flex-col overflow-hidden">
       <DeckBuilder
         onCardHover={useCallback((name: string | null, scryfallId?: string) => {
           setHoveredCard(name ? { name, scryfallId } : null);


### PR DESCRIPTION
## Summary

Improves the deck builder scrolling experience by removing unintended page-level scrolling and standardizing scrollbar styling across deck builder panels and modals.

Previously, the deck builder could show both a page scrollbar and panel scrollbars due to the layout using `100vh`, which did not account for the application header and mobile navigation spacing. This change replaces the fixed viewport height with a layout-aware height calculation so scrolling remains contained within the appropriate panels.

Additionally, the enhanced `thin-scrollbar` styling is now applied consistently across deck builder scroll areas, and modal scrollbar behavior is centralized through `ModalPanelShell`.

## Changes

* Replace `100vh` deck builder sizing with a layout-aware `.deck-builder-shell` height calculation
* Remove unintended page-level scrolling in the deck builder
* Apply enhanced `thin-scrollbar` styling to:

  * Filter sidebar
  * Search results
  * Deck list and stack views
  * Validation warnings
  * Commander and stats panel
* Apply shared scrollbar styling through `ModalPanelShell`
* Remove redundant scrollbar styling from `PreferencesModal`

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/4ff3a967-bcf3-4359-8103-052d78c931bd" />

### After

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/2b467953-8a2c-4ba4-bd1b-c7a550fd0004" />


## Test Plan

* [ ] Open `/deck-builder` on desktop and confirm no page-level scrollbar appears
* [ ] Verify deck builder panels scroll independently when content overflows
* [ ] Verify all deck builder scroll areas use the styled thin scrollbar
* [ ] Repeat on mobile/narrow viewports and confirm no page scrolling occurs
* [ ] Switch between list and stack views and verify scrolling remains correct
* [ ] Open Preferences and confirm modal scrollbar styling remains consistent
