### PR TITLE
fix(engine): count non-tap combination mana toward castability and auto-pass

### DIFF
--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -641,6 +641,19 @@ fn auto_passes_initial_priority_by_default(state: &GameState) -> bool {
     state.stack.is_empty() && matches!(state.phase, Phase::Upkeep | Phase::Draw)
 }
 
+/// CR 117.1d + CR 601.2g: True when the player has a spell the castability gate
+/// accepts via manual mana-ability payment even though the simulation oracle
+/// (`SimulationFilter`) rejects the Auto-mode `CastSpell` candidate (issue #562,
+/// #583). Frontends surface these via `spell_costs` + manual cast dispatch.
+fn has_feasibly_castable_spell(state: &GameState, player: PlayerId) -> bool {
+    if crate::game::keywords::stack_has_split_second(state) {
+        return false;
+    }
+    crate::game::casting::spell_objects_available_to_cast(state, player)
+        .iter()
+        .any(|&object_id| crate::game::casting::can_cast_object_now(state, player, object_id))
+}
+
 /// Determines whether the frontend should auto-pass the current priority window.
 ///
 /// Returns `true` when auto-passing is recommended:
@@ -659,6 +672,10 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
 
     if auto_passes_initial_priority_by_default(state) {
         return true;
+    }
+
+    if has_feasibly_castable_spell(state, player) {
+        return false;
     }
 
     if !has_meaningful_priority_action(state, actions) {

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -646,9 +646,6 @@ fn auto_passes_initial_priority_by_default(state: &GameState) -> bool {
 /// (`SimulationFilter`) rejects the Auto-mode `CastSpell` candidate (issue #562,
 /// #583). Frontends surface these via `spell_costs` + manual cast dispatch.
 fn has_feasibly_castable_spell(state: &GameState, player: PlayerId) -> bool {
-    if crate::game::keywords::stack_has_split_second(state) {
-        return false;
-    }
     crate::game::casting::spell_objects_available_to_cast(state, player)
         .iter()
         .any(|&object_id| crate::game::casting::can_cast_object_now(state, player, object_id))

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9335,12 +9335,10 @@ pub fn can_pay_cost_after_auto_tap(
 /// predicate directly — only the castability/legal-actions surface widens to
 /// "manual is reachable."
 ///
-/// Colored-shard feasibility under non-tap sources is conservatively rejected:
-/// if any colored shard remains after the existing pool is subtracted, this
-/// predicate returns `false`. Pure-generic feasibility is sufficient for the
-/// principal repro (Krark-Clan Ironworks producing `{C}{C}` — issue #562).
-/// Colored-shard widening — covering Phyrexian Altar, Lion's Eye Diamond, and
-/// other any-color non-tap mana abilities — is tracked in issue #1234.
+/// Colored-shard feasibility under non-tap sources is evaluated via
+/// [`super::mana_sources::can_cover_shards_with_activatable_mana`], which
+/// respects CR 106.6 spend restrictions and avoids double-counting the same
+/// activation toward both shard and generic coverage (issues #583, #2011).
 //
 // CR 117.1d + CR 601.2g: Mana abilities (including sacrifice-cost,
 // discard-cost, and pay-life mana abilities) may be activated during cost
@@ -9415,16 +9413,17 @@ fn can_feasibly_pay_mana_cost_without_x(
         crate::types::mana::ManaCost::Cost { shards, generic } => (shards, *generic),
     };
 
-    // CR 117.1d + CR 601.2g: Colored-shard feasibility under non-tap mana
+    // CR 117.1d + CR 601.2g: Residual shard feasibility under non-tap mana
     // sources (issue #583: Vivi Ornitier {0} combination mana; extends #1234).
-    if !residual_shards.is_empty()
-        && !super::mana_sources::can_cover_shards_with_activatable_mana(
+    let (shards_covered, shard_consumed) =
+        super::mana_sources::can_cover_shards_with_activatable_mana(
             state,
             player,
             source_id,
+            spell_ctx.as_ref(),
             residual_shards,
-        )
-    {
+        );
+    if !residual_shards.is_empty() && !shards_covered {
         return false;
     }
     if residual_generic == 0 {
@@ -9437,6 +9436,10 @@ fn can_feasibly_pay_mana_cost_without_x(
     // controller could currently activate (covering Sacrifice / Discard /
     // PayLife costs that auto-tap cannot simulate).
     //
+    // Subtract mana already allocated to shard coverage so one activation is
+    // not counted twice (issue #583 review: power-2 Vivi must not cover {1}
+    // generic after paying {U}{R}).
+    //
     // The per-permanent sum over-counts in chain-sacrifice configurations
     // (e.g. 2× KCI + 1 fodder reports cap=4 when the actual reachable yield
     // is 2). The trade-off — over-count rather than under-count, since
@@ -9448,8 +9451,11 @@ fn can_feasibly_pay_mana_cost_without_x(
         .battlefield
         .iter()
         .filter(|id| Some(**id) != excluded)
-        .map(|&id| super::mana_sources::feasible_mana_capacity(state, id, player))
-        .sum();
+        .map(|&id| {
+            super::mana_sources::feasible_mana_capacity(state, id, player, spell_ctx.as_ref())
+        })
+        .sum::<u32>()
+        .saturating_sub(shard_consumed);
 
     capacity >= residual_generic
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9415,11 +9415,16 @@ fn can_feasibly_pay_mana_cost_without_x(
         crate::types::mana::ManaCost::Cost { shards, generic } => (shards, *generic),
     };
 
-    // CR 117.1: Colored-shard feasibility under non-tap mana sources is
-    // deferred (see issue #1234 — Phyrexian Altar, Lion's Eye Diamond, etc.).
-    // Pure-generic residual is sufficient for the principal repro (KCI
-    // sacrificing artifacts for `{C}{C}`).
-    if !residual_shards.is_empty() {
+    // CR 117.1d + CR 601.2g: Colored-shard feasibility under non-tap mana
+    // sources (issue #583: Vivi Ornitier {0} combination mana; extends #1234).
+    if !residual_shards.is_empty()
+        && !super::mana_sources::can_cover_shards_with_activatable_mana(
+            state,
+            player,
+            source_id,
+            residual_shards,
+        )
+    {
         return false;
     }
     if residual_generic == 0 {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5863,7 +5863,7 @@ pub(super) fn max_x_value_excluding(
         .iter()
         .filter(|id| !excluded_sources.contains(id))
         .map(|&id| {
-            let mana = mana_sources::feasible_mana_capacity(state, id, player);
+            let mana = mana_sources::feasible_mana_capacity(state, id, player, None);
             let tap = pred
                 .filter(|p| state.objects.get(&id).is_some_and(|o| p(o, player)))
                 .map_or(0, |_| 1);

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -19,7 +19,10 @@ use crate::types::ability::{
 use crate::types::card_type::CoreType;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
-use crate::types::mana::{ManaColor, ManaCostShard, ManaPip, ManaRestriction, ManaType};
+use crate::types::ability::ManaSpendRestriction;
+use crate::types::mana::{
+    ManaColor, ManaCostShard, ManaPip, ManaRestriction, ManaType, PaymentContext,
+};
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 use crate::types::TriggerMode;
@@ -759,10 +762,25 @@ pub fn max_mana_yield(state: &GameState, object_id: ObjectId, controller: Player
 // CR 601.2g: After total cost is determined, the player has a chance to
 // activate mana abilities before paying. Affordability must reflect what the
 // player COULD pay manually, not only what the engine could auto-tap.
+fn mana_ability_allowed_for_payment(
+    restrictions: &[ManaSpendRestriction],
+    state: &GameState,
+    object_id: ObjectId,
+    payment_context: Option<&PaymentContext<'_>>,
+) -> bool {
+    let Some(ctx) = payment_context else {
+        return true;
+    };
+    super::effects::mana::resolve_restrictions(restrictions, state, object_id)
+        .iter()
+        .all(|restriction| restriction.allows(ctx))
+}
+
 pub(crate) fn feasible_mana_capacity(
     state: &GameState,
     object_id: ObjectId,
     controller: PlayerId,
+    payment_context: Option<&PaymentContext<'_>>,
 ) -> u32 {
     let Some(obj) = state.objects.get(&object_id) else {
         return 0;
@@ -793,7 +811,20 @@ pub(crate) fn feasible_mana_capacity(
             }
             // CR 604: Static activation restrictions ("only during your
             // upkeep", etc.) must hold — mirrors `is_active_tap_mana_ability`.
-            activation_condition_satisfied(state, controller, object_id, *idx, ability)
+            if !activation_condition_satisfied(state, controller, object_id, *idx, ability) {
+                return false;
+            }
+            // CR 106.6: Restricted mana only counts toward this spell when
+            // the restriction permits it (issue #2011: Eldrazi Temple).
+            match &*ability.effect {
+                Effect::Mana { restrictions, .. } => mana_ability_allowed_for_payment(
+                    restrictions,
+                    state,
+                    object_id,
+                    payment_context,
+                ),
+                _ => false,
+            }
         })
         .filter_map(|(_, ability)| match &*ability.effect {
             Effect::Mana { produced, .. } => {
@@ -841,17 +872,121 @@ pub(crate) fn feasible_mana_capacity(
 /// CR 117.1d + CR 601.2g: One activation's producible mana shape for the
 /// castability gate's colored-shard coverage check (issue #583 / #1234).
 #[derive(Debug, Clone)]
-enum ActivatableManaProfile {
+enum ActivatableManaProfileKind {
     Exact(Vec<ManaType>),
     AnyOneColor { count: u32, options: Vec<ManaType> },
     AnyCombination { count: u32, options: Vec<ManaType> },
     CombinationChoices(Vec<Vec<ManaType>>),
 }
 
+#[derive(Debug, Clone)]
+struct ActivatableManaProfile {
+    object_id: ObjectId,
+    kind: ActivatableManaProfileKind,
+}
+
+fn resolved_production_count(
+    produced: &ManaProduction,
+    state: &GameState,
+    resolved: &crate::types::ability::ResolvedAbility,
+) -> u32 {
+    super::effects::mana::resolve_mana_types_for_ability(produced, state, resolved).len() as u32
+}
+
+fn profile_kind_from_production(
+    state: &GameState,
+    object_id: ObjectId,
+    controller: PlayerId,
+    produced: &ManaProduction,
+    resolved: &crate::types::ability::ResolvedAbility,
+) -> Option<ActivatableManaProfileKind> {
+    match produced {
+        ManaProduction::ChoiceAmongCombinations { options } => Some(
+            ActivatableManaProfileKind::CombinationChoices(
+                options
+                    .iter()
+                    .map(|combo| combo.iter().map(mana_color_to_type).collect())
+                    .collect(),
+            ),
+        ),
+        ManaProduction::AnyOneColor { color_options, .. } => Some(
+            ActivatableManaProfileKind::AnyOneColor {
+                count: resolved_production_count(produced, state, resolved),
+                options: color_options.iter().map(mana_color_to_type).collect(),
+            },
+        ),
+        ManaProduction::AnyCombination { color_options, .. } => Some(
+            ActivatableManaProfileKind::AnyCombination {
+                count: resolved_production_count(produced, state, resolved),
+                options: color_options.iter().map(mana_color_to_type).collect(),
+            },
+        ),
+        ManaProduction::ChosenColor {
+            fixed_alternative, ..
+        } => {
+            let count = resolved_production_count(produced, state, resolved);
+            let mut options = state
+                .objects
+                .get(&object_id)
+                .and_then(|obj| obj.chosen_color())
+                .map(|color| vec![mana_color_to_type(&color)])
+                .unwrap_or_default();
+            if options.is_empty() {
+                return None;
+            }
+            if let Some(alt) = fixed_alternative {
+                let alt_type = mana_color_to_type(alt);
+                if !options.contains(&alt_type) {
+                    options.push(alt_type);
+                }
+            }
+            if count <= 1 && options.len() == 1 {
+                Some(ActivatableManaProfileKind::Exact(options))
+            } else {
+                Some(ActivatableManaProfileKind::AnyOneColor { count, options })
+            }
+        }
+        ManaProduction::OpponentLandColors { .. }
+        | ManaProduction::AnyTypeProduceableBy { .. }
+        | ManaProduction::ChoiceAmongExiledColors { .. }
+        | ManaProduction::AnyInCommandersColorIdentity { .. }
+        | ManaProduction::AnyOneColorAmongPermanents { .. } => {
+            let options = mana_options_from_production(state, controller, object_id, produced);
+            if options.is_empty() {
+                return None;
+            }
+            Some(ActivatableManaProfileKind::AnyOneColor {
+                count: resolved_production_count(produced, state, resolved),
+                options,
+            })
+        }
+        ManaProduction::DistinctColorsAmongPermanents { .. } => {
+            let types =
+                super::effects::mana::resolve_mana_types_for_ability(produced, state, resolved);
+            if types.is_empty() {
+                None
+            } else {
+                Some(ActivatableManaProfileKind::Exact(types))
+            }
+        }
+        ManaProduction::TriggerEventManaType => None,
+        _ => {
+            let types =
+                super::effects::mana::resolve_mana_types_for_ability(produced, state, resolved);
+            if types.is_empty() {
+                None
+            } else {
+                Some(ActivatableManaProfileKind::Exact(types))
+            }
+        }
+    }
+}
+
 fn activatable_mana_profiles_for_object(
     state: &GameState,
     object_id: ObjectId,
     controller: PlayerId,
+    payment_context: Option<&PaymentContext<'_>>,
 ) -> Vec<ActivatableManaProfile> {
     let Some(obj) = state.objects.get(&object_id) else {
         return Vec::new();
@@ -875,47 +1010,21 @@ fn activatable_mana_profiles_for_object(
             if !activation_condition_satisfied(state, controller, object_id, idx, ability) {
                 return None;
             }
-            let Effect::Mana { produced, .. } = &*ability.effect else {
+            let Effect::Mana {
+                produced,
+                restrictions,
+                ..
+            } = &*ability.effect
+            else {
                 return None;
             };
+            if !mana_ability_allowed_for_payment(restrictions, state, object_id, payment_context) {
+                return None;
+            }
             let resolved =
                 super::ability_utils::build_resolved_from_def(ability, object_id, controller);
-            Some(match produced {
-                ManaProduction::ChoiceAmongCombinations { options } => {
-                    ActivatableManaProfile::CombinationChoices(
-                        options
-                            .iter()
-                            .map(|combo| combo.iter().map(mana_color_to_type).collect())
-                            .collect(),
-                    )
-                }
-                ManaProduction::AnyOneColor {
-                    count: _,
-                    color_options,
-                    ..
-                } => ActivatableManaProfile::AnyOneColor {
-                    count: super::effects::mana::resolve_mana_types_for_ability(
-                        produced, state, &resolved,
-                    )
-                    .len() as u32,
-                    options: color_options.iter().map(mana_color_to_type).collect(),
-                },
-                ManaProduction::AnyCombination {
-                    count: _,
-                    color_options,
-                } => ActivatableManaProfile::AnyCombination {
-                    count: super::effects::mana::resolve_mana_types_for_ability(
-                        produced, state, &resolved,
-                    )
-                    .len() as u32,
-                    options: color_options.iter().map(mana_color_to_type).collect(),
-                },
-                _ => ActivatableManaProfile::Exact(
-                    super::effects::mana::resolve_mana_types_for_ability(
-                        produced, state, &resolved,
-                    ),
-                ),
-            })
+            profile_kind_from_production(state, object_id, controller, produced, &resolved)
+                .map(|kind| ActivatableManaProfile { object_id, kind })
         })
         .collect()
 }
@@ -924,12 +1033,15 @@ fn collect_activatable_mana_profiles(
     state: &GameState,
     player: PlayerId,
     exclude: Option<ObjectId>,
+    payment_context: Option<&PaymentContext<'_>>,
 ) -> Vec<ActivatableManaProfile> {
     state
         .battlefield
         .iter()
         .filter(|id| Some(**id) != exclude)
-        .flat_map(|&id| activatable_mana_profiles_for_object(state, id, player))
+        .flat_map(|&id| {
+            activatable_mana_profiles_for_object(state, id, player, payment_context)
+        })
         .collect()
 }
 
@@ -951,112 +1063,143 @@ fn shard_payment_options(shard: ManaCostShard) -> Option<Vec<ManaType>> {
     })
 }
 
-fn can_profiles_cover_shards(
-    profiles: &[ActivatableManaProfile],
-    shards: &[ManaCostShard],
-) -> bool {
-    let requirements: Vec<Vec<ManaType>> = shards
-        .iter()
-        .filter_map(|shard| shard_payment_options(*shard))
-        .collect();
-    if requirements.len() != shards.len() {
-        return false;
+fn group_profiles_by_object(
+    profiles: Vec<ActivatableManaProfile>,
+) -> Vec<(ObjectId, Vec<ActivatableManaProfileKind>)> {
+    use std::collections::HashMap;
+    let mut grouped: HashMap<ObjectId, Vec<ActivatableManaProfileKind>> = HashMap::new();
+    for profile in profiles {
+        grouped
+            .entry(profile.object_id)
+            .or_default()
+            .push(profile.kind);
     }
-    can_profiles_cover_requirements(profiles, &requirements)
+    grouped.into_iter().collect()
 }
 
-fn can_profiles_cover_requirements(
-    profiles: &[ActivatableManaProfile],
+fn apply_profile_kind(
+    profile: &ActivatableManaProfileKind,
     requirements: &[Vec<ManaType>],
-) -> bool {
-    if requirements.is_empty() {
-        return true;
-    }
-    if profiles.is_empty() {
-        return false;
-    }
-    let (head, tail) = profiles.split_first().expect("non-empty profiles");
-    can_profiles_cover_requirements(tail, requirements)
-        || apply_profile_to_requirements(head, requirements, tail)
-}
-
-fn apply_profile_to_requirements(
-    profile: &ActivatableManaProfile,
-    requirements: &[Vec<ManaType>],
-    remaining_profiles: &[ActivatableManaProfile],
-) -> bool {
+) -> Option<(Vec<Vec<ManaType>>, u32)> {
     match profile {
-        ActivatableManaProfile::Exact(types) => {
-            let mut remaining: Vec<Vec<ManaType>> = requirements.to_vec();
+        ActivatableManaProfileKind::Exact(types) => {
+            let mut remaining = requirements.to_vec();
             for mana_type in types {
-                if let Some(pos) = remaining.iter().position(|opts| opts.contains(mana_type)) {
-                    remaining.remove(pos);
-                }
+                let pos = remaining.iter().position(|opts| opts.contains(mana_type))?;
+                remaining.remove(pos);
             }
-            can_profiles_cover_requirements(remaining_profiles, &remaining)
+            Some((remaining, types.len() as u32))
         }
-        ActivatableManaProfile::AnyOneColor { count, options } => options.iter().any(|&color| {
-            combination_assign(
-                *count,
-                std::slice::from_ref(&color),
-                requirements,
-                remaining_profiles,
-            )
-        }),
-        ActivatableManaProfile::AnyCombination { count, options } => {
-            combination_assign(*count, options, requirements, remaining_profiles)
+        ActivatableManaProfileKind::AnyOneColor { count, options } => options
+            .iter()
+            .find_map(|&color| combination_assign(*count, std::slice::from_ref(&color), requirements)),
+        ActivatableManaProfileKind::AnyCombination { count, options } => {
+            combination_assign(*count, options, requirements)
         }
-        ActivatableManaProfile::CombinationChoices(choices) => choices.iter().any(|choice| {
-            apply_profile_to_requirements(
-                &ActivatableManaProfile::Exact(choice.clone()),
-                requirements,
-                remaining_profiles,
-            )
+        ActivatableManaProfileKind::CombinationChoices(choices) => choices.iter().find_map(|choice| {
+            apply_profile_kind(&ActivatableManaProfileKind::Exact(choice.clone()), requirements)
         }),
     }
+}
+
+fn assign_profiles_to_requirements(
+    objects: &[(ObjectId, Vec<ActivatableManaProfileKind>)],
+    object_index: usize,
+    requirements: Vec<Vec<ManaType>>,
+) -> Option<u32> {
+    if requirements.is_empty() {
+        return Some(0);
+    }
+    if object_index >= objects.len() {
+        return None;
+    }
+    if let Some(consumed) = assign_profiles_to_requirements(
+        objects,
+        object_index + 1,
+        requirements.clone(),
+    ) {
+        return Some(consumed);
+    }
+    for profile in &objects[object_index].1 {
+        if let Some((remaining, consumed)) = apply_profile_kind(profile, &requirements) {
+            if let Some(rest) =
+                assign_profiles_to_requirements(objects, object_index + 1, remaining)
+            {
+                return Some(consumed + rest);
+            }
+        }
+    }
+    None
 }
 
 fn combination_assign(
     count: u32,
     options: &[ManaType],
     requirements: &[Vec<ManaType>],
-    remaining_profiles: &[ActivatableManaProfile],
-) -> bool {
-    if requirements.is_empty() {
-        return can_profiles_cover_requirements(remaining_profiles, requirements);
-    }
+) -> Option<(Vec<Vec<ManaType>>, u32)> {
     if count == 0 {
-        return false;
+        return if requirements.is_empty() {
+            Some((Vec::new(), 0))
+        } else {
+            None
+        };
+    }
+    if requirements.is_empty() {
+        return None;
     }
     for (index, payment_options) in requirements.iter().enumerate() {
         for &color in payment_options {
             if !options.contains(&color) {
                 continue;
             }
-            let mut next_requirements: Vec<Vec<ManaType>> = requirements.to_vec();
+            let mut next_requirements = requirements.to_vec();
             next_requirements.remove(index);
-            if combination_assign(count - 1, options, &next_requirements, remaining_profiles) {
-                return true;
+            if let Some((remaining, inner)) =
+                combination_assign(count - 1, options, &next_requirements)
+            {
+                return Some((remaining, 1 + inner));
             }
         }
     }
-    false
+    None
 }
 
-/// CR 117.1d + CR 601.2g: Whether residual colored mana shards could be paid
-/// by activating currently legal mana abilities (non-tap sources like Vivi
-/// Ornitier's {0} power-scaled combination mana, Lion's Eye Diamond, etc.).
+fn assign_profiles_to_shards(
+    profiles: &[ActivatableManaProfile],
+    shards: &[ManaCostShard],
+) -> Option<u32> {
+    let requirements: Vec<Vec<ManaType>> = shards
+        .iter()
+        .filter_map(|shard| shard_payment_options(*shard))
+        .collect();
+    if requirements.len() != shards.len() {
+        return None;
+    }
+    let grouped = group_profiles_by_object(profiles.to_vec());
+    assign_profiles_to_requirements(&grouped, 0, requirements)
+}
+
+/// CR 117.1d + CR 601.2g: Whether residual mana shards could be paid by
+/// activating currently legal mana abilities (non-tap sources like Vivi
+/// Ornitier's {0} combination mana, Lion's Eye Diamond, etc.).
+///
+/// Returns `(covered, consumed_pips)` where `consumed_pips` is the total mana
+/// produced by activations used for shard coverage — callers must subtract
+/// this from generic capacity to avoid double-counting one activation.
 pub(crate) fn can_cover_shards_with_activatable_mana(
     state: &GameState,
     player: PlayerId,
     exclude: Option<ObjectId>,
+    payment_context: Option<&PaymentContext<'_>>,
     shards: &[ManaCostShard],
-) -> bool {
+) -> (bool, u32) {
     if shards.is_empty() {
-        return true;
+        return (true, 0);
     }
-    let profiles = collect_activatable_mana_profiles(state, player, exclude);
-    can_profiles_cover_shards(&profiles, shards)
+    let profiles = collect_activatable_mana_profiles(state, player, exclude, payment_context);
+    assign_profiles_to_shards(&profiles, shards)
+        .map(|consumed| (true, consumed))
+        .unwrap_or((false, 0))
 }
 
 fn land_mana_options(

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -1140,14 +1140,14 @@ fn combination_assign(
     options: &[ManaType],
     requirements: &[Vec<ManaType>],
 ) -> Option<(Vec<Vec<ManaType>>, u32)> {
-    if count == 0 {
-        return if requirements.is_empty() {
-            Some((Vec::new(), 0))
-        } else {
-            None
-        };
-    }
     if requirements.is_empty() {
+        // All shards are covered; any leftover `count` is simply surplus mana
+        // the player never produces (or lets drain). Rejecting over-production
+        // here would falsely mark e.g. a power-3 combination source as unable
+        // to pay a two-shard cost.
+        return Some((Vec::new(), 0));
+    }
+    if count == 0 {
         return None;
     }
     for (index, payment_options) in requirements.iter().enumerate() {

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -19,7 +19,7 @@ use crate::types::ability::{
 use crate::types::card_type::CoreType;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
-use crate::types::mana::{ManaColor, ManaPip, ManaRestriction, ManaType};
+use crate::types::mana::{ManaColor, ManaCostShard, ManaPip, ManaRestriction, ManaType};
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 use crate::types::TriggerMode;
@@ -836,6 +836,227 @@ pub(crate) fn feasible_mana_capacity(
         None if !activatable_mana_options(state, object_id, controller).is_empty() => 1,
         None => 0,
     }
+}
+
+/// CR 117.1d + CR 601.2g: One activation's producible mana shape for the
+/// castability gate's colored-shard coverage check (issue #583 / #1234).
+#[derive(Debug, Clone)]
+enum ActivatableManaProfile {
+    Exact(Vec<ManaType>),
+    AnyOneColor { count: u32, options: Vec<ManaType> },
+    AnyCombination { count: u32, options: Vec<ManaType> },
+    CombinationChoices(Vec<Vec<ManaType>>),
+}
+
+fn activatable_mana_profiles_for_object(
+    state: &GameState,
+    object_id: ObjectId,
+    controller: PlayerId,
+) -> Vec<ActivatableManaProfile> {
+    let Some(obj) = state.objects.get(&object_id) else {
+        return Vec::new();
+    };
+    if obj.zone != Zone::Battlefield || obj.controller != controller {
+        return Vec::new();
+    }
+
+    obj.abilities
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, ability)| {
+            if ability.kind != AbilityKind::Activated || !mana_abilities::is_mana_ability(ability) {
+                return None;
+            }
+            if !mana_abilities::can_activate_mana_ability_now(
+                state, controller, object_id, idx, ability,
+            ) {
+                return None;
+            }
+            if !activation_condition_satisfied(state, controller, object_id, idx, ability) {
+                return None;
+            }
+            let Effect::Mana { produced, .. } = &*ability.effect else {
+                return None;
+            };
+            let resolved =
+                super::ability_utils::build_resolved_from_def(ability, object_id, controller);
+            Some(match produced {
+                ManaProduction::ChoiceAmongCombinations { options } => {
+                    ActivatableManaProfile::CombinationChoices(
+                        options
+                            .iter()
+                            .map(|combo| combo.iter().map(mana_color_to_type).collect())
+                            .collect(),
+                    )
+                }
+                ManaProduction::AnyOneColor {
+                    count: _,
+                    color_options,
+                    ..
+                } => ActivatableManaProfile::AnyOneColor {
+                    count: super::effects::mana::resolve_mana_types_for_ability(
+                        produced, state, &resolved,
+                    )
+                    .len() as u32,
+                    options: color_options.iter().map(mana_color_to_type).collect(),
+                },
+                ManaProduction::AnyCombination {
+                    count: _,
+                    color_options,
+                } => ActivatableManaProfile::AnyCombination {
+                    count: super::effects::mana::resolve_mana_types_for_ability(
+                        produced, state, &resolved,
+                    )
+                    .len() as u32,
+                    options: color_options.iter().map(mana_color_to_type).collect(),
+                },
+                _ => ActivatableManaProfile::Exact(
+                    super::effects::mana::resolve_mana_types_for_ability(
+                        produced, state, &resolved,
+                    ),
+                ),
+            })
+        })
+        .collect()
+}
+
+fn collect_activatable_mana_profiles(
+    state: &GameState,
+    player: PlayerId,
+    exclude: Option<ObjectId>,
+) -> Vec<ActivatableManaProfile> {
+    state
+        .battlefield
+        .iter()
+        .filter(|id| Some(**id) != exclude)
+        .flat_map(|&id| activatable_mana_profiles_for_object(state, id, player))
+        .collect()
+}
+
+fn shard_payment_options(shard: ManaCostShard) -> Option<Vec<ManaType>> {
+    use super::mana_payment::{shard_to_mana_type, ShardRequirement};
+    Some(match shard_to_mana_type(shard) {
+        ShardRequirement::Single(mana_type) => vec![mana_type],
+        ShardRequirement::Hybrid(a, b) => vec![a, b],
+        ShardRequirement::TwoGenericHybrid(mana_type) => vec![mana_type, ManaType::Colorless],
+        ShardRequirement::ColorlessHybrid(mana_type) => vec![ManaType::Colorless, mana_type],
+        ShardRequirement::Phyrexian(mana_type) => vec![mana_type],
+        ShardRequirement::HybridPhyrexian(a, b) => vec![a, b],
+        ShardRequirement::TwoGenericHybridPhyrexian(mana_type) => {
+            vec![mana_type, ManaType::Colorless]
+        }
+        ShardRequirement::Snow | ShardRequirement::TwoOrMoreColorSource | ShardRequirement::X => {
+            return None;
+        }
+    })
+}
+
+fn can_profiles_cover_shards(
+    profiles: &[ActivatableManaProfile],
+    shards: &[ManaCostShard],
+) -> bool {
+    let requirements: Vec<Vec<ManaType>> = shards
+        .iter()
+        .filter_map(|shard| shard_payment_options(*shard))
+        .collect();
+    if requirements.len() != shards.len() {
+        return false;
+    }
+    can_profiles_cover_requirements(profiles, &requirements)
+}
+
+fn can_profiles_cover_requirements(
+    profiles: &[ActivatableManaProfile],
+    requirements: &[Vec<ManaType>],
+) -> bool {
+    if requirements.is_empty() {
+        return true;
+    }
+    if profiles.is_empty() {
+        return false;
+    }
+    let (head, tail) = profiles.split_first().expect("non-empty profiles");
+    can_profiles_cover_requirements(tail, requirements)
+        || apply_profile_to_requirements(head, requirements, tail)
+}
+
+fn apply_profile_to_requirements(
+    profile: &ActivatableManaProfile,
+    requirements: &[Vec<ManaType>],
+    remaining_profiles: &[ActivatableManaProfile],
+) -> bool {
+    match profile {
+        ActivatableManaProfile::Exact(types) => {
+            let mut remaining: Vec<Vec<ManaType>> = requirements.to_vec();
+            for mana_type in types {
+                if let Some(pos) = remaining.iter().position(|opts| opts.contains(mana_type)) {
+                    remaining.remove(pos);
+                }
+            }
+            can_profiles_cover_requirements(remaining_profiles, &remaining)
+        }
+        ActivatableManaProfile::AnyOneColor { count, options } => options.iter().any(|&color| {
+            combination_assign(
+                *count,
+                std::slice::from_ref(&color),
+                requirements,
+                remaining_profiles,
+            )
+        }),
+        ActivatableManaProfile::AnyCombination { count, options } => {
+            combination_assign(*count, options, requirements, remaining_profiles)
+        }
+        ActivatableManaProfile::CombinationChoices(choices) => choices.iter().any(|choice| {
+            apply_profile_to_requirements(
+                &ActivatableManaProfile::Exact(choice.clone()),
+                requirements,
+                remaining_profiles,
+            )
+        }),
+    }
+}
+
+fn combination_assign(
+    count: u32,
+    options: &[ManaType],
+    requirements: &[Vec<ManaType>],
+    remaining_profiles: &[ActivatableManaProfile],
+) -> bool {
+    if requirements.is_empty() {
+        return can_profiles_cover_requirements(remaining_profiles, requirements);
+    }
+    if count == 0 {
+        return false;
+    }
+    for (index, payment_options) in requirements.iter().enumerate() {
+        for &color in payment_options {
+            if !options.contains(&color) {
+                continue;
+            }
+            let mut next_requirements: Vec<Vec<ManaType>> = requirements.to_vec();
+            next_requirements.remove(index);
+            if combination_assign(count - 1, options, &next_requirements, remaining_profiles) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// CR 117.1d + CR 601.2g: Whether residual colored mana shards could be paid
+/// by activating currently legal mana abilities (non-tap sources like Vivi
+/// Ornitier's {0} power-scaled combination mana, Lion's Eye Diamond, etc.).
+pub(crate) fn can_cover_shards_with_activatable_mana(
+    state: &GameState,
+    player: PlayerId,
+    exclude: Option<ObjectId>,
+    shards: &[ManaCostShard],
+) -> bool {
+    if shards.is_empty() {
+        return true;
+    }
+    let profiles = collect_activatable_mana_profiles(state, player, exclude);
+    can_profiles_cover_shards(&profiles, shards)
 }
 
 fn land_mana_options(

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -13,13 +13,13 @@
 //! inline resolution — which is why any irreversible sub-effect (damage,
 //! life loss, sacrifice) disqualifies a source from UI-level undo.
 
+use crate::types::ability::ManaSpendRestriction;
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaProduction, QuantityExpr, TargetFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
-use crate::types::ability::ManaSpendRestriction;
 use crate::types::mana::{
     ManaColor, ManaCostShard, ManaPip, ManaRestriction, ManaType, PaymentContext,
 };
@@ -901,26 +901,26 @@ fn profile_kind_from_production(
     resolved: &crate::types::ability::ResolvedAbility,
 ) -> Option<ActivatableManaProfileKind> {
     match produced {
-        ManaProduction::ChoiceAmongCombinations { options } => Some(
-            ActivatableManaProfileKind::CombinationChoices(
+        ManaProduction::ChoiceAmongCombinations { options } => {
+            Some(ActivatableManaProfileKind::CombinationChoices(
                 options
                     .iter()
                     .map(|combo| combo.iter().map(mana_color_to_type).collect())
                     .collect(),
-            ),
-        ),
-        ManaProduction::AnyOneColor { color_options, .. } => Some(
-            ActivatableManaProfileKind::AnyOneColor {
+            ))
+        }
+        ManaProduction::AnyOneColor { color_options, .. } => {
+            Some(ActivatableManaProfileKind::AnyOneColor {
                 count: resolved_production_count(produced, state, resolved),
                 options: color_options.iter().map(mana_color_to_type).collect(),
-            },
-        ),
-        ManaProduction::AnyCombination { color_options, .. } => Some(
-            ActivatableManaProfileKind::AnyCombination {
+            })
+        }
+        ManaProduction::AnyCombination { color_options, .. } => {
+            Some(ActivatableManaProfileKind::AnyCombination {
                 count: resolved_production_count(produced, state, resolved),
                 options: color_options.iter().map(mana_color_to_type).collect(),
-            },
-        ),
+            })
+        }
         ManaProduction::ChosenColor {
             fixed_alternative, ..
         } => {
@@ -1039,9 +1039,7 @@ fn collect_activatable_mana_profiles(
         .battlefield
         .iter()
         .filter(|id| Some(**id) != exclude)
-        .flat_map(|&id| {
-            activatable_mana_profiles_for_object(state, id, player, payment_context)
-        })
+        .flat_map(|&id| activatable_mana_profiles_for_object(state, id, player, payment_context))
         .collect()
 }
 
@@ -1090,15 +1088,22 @@ fn apply_profile_kind(
             }
             Some((remaining, types.len() as u32))
         }
-        ActivatableManaProfileKind::AnyOneColor { count, options } => options
-            .iter()
-            .find_map(|&color| combination_assign(*count, std::slice::from_ref(&color), requirements)),
+        ActivatableManaProfileKind::AnyOneColor { count, options } => {
+            options.iter().find_map(|&color| {
+                combination_assign(*count, std::slice::from_ref(&color), requirements)
+            })
+        }
         ActivatableManaProfileKind::AnyCombination { count, options } => {
             combination_assign(*count, options, requirements)
         }
-        ActivatableManaProfileKind::CombinationChoices(choices) => choices.iter().find_map(|choice| {
-            apply_profile_kind(&ActivatableManaProfileKind::Exact(choice.clone()), requirements)
-        }),
+        ActivatableManaProfileKind::CombinationChoices(choices) => {
+            choices.iter().find_map(|choice| {
+                apply_profile_kind(
+                    &ActivatableManaProfileKind::Exact(choice.clone()),
+                    requirements,
+                )
+            })
+        }
     }
 }
 
@@ -1113,11 +1118,9 @@ fn assign_profiles_to_requirements(
     if object_index >= objects.len() {
         return None;
     }
-    if let Some(consumed) = assign_profiles_to_requirements(
-        objects,
-        object_index + 1,
-        requirements.clone(),
-    ) {
+    if let Some(consumed) =
+        assign_profiles_to_requirements(objects, object_index + 1, requirements.clone())
+    {
         return Some(consumed);
     }
     for profile in &objects[object_index].1 {

--- a/crates/engine/tests/integration/issue_583_vivi_ornitier_mana_source.rs
+++ b/crates/engine/tests/integration/issue_583_vivi_ornitier_mana_source.rs
@@ -1,0 +1,128 @@
+//! Issue #583 — Vivi Ornitier's {0} combination mana ability must count toward
+//! castability when it is the only remaining mana source.
+
+use engine::game::casting::can_cast_object_now;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, Effect, ManaProduction,
+    ObjectScope, QuantityExpr, QuantityRef,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+use std::sync::Arc;
+
+const P0: PlayerId = PlayerId(0);
+
+fn setup_priority(state: &mut GameState) {
+    state.phase = Phase::PreCombatMain;
+    state.active_player = P0;
+    state.priority_player = P0;
+    state.waiting_for = engine::types::game_state::WaitingFor::Priority { player: P0 };
+}
+
+fn add_vivi(state: &mut GameState, power: i32) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(5830),
+        P0,
+        "Vivi Ornitier".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.power = Some(power);
+    obj.toughness = Some(2);
+    obj.summoning_sick = false;
+    Arc::make_mut(&mut obj.abilities).push(
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::AnyCombination {
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::Power {
+                            scope: ObjectScope::Source,
+                        },
+                    },
+                    color_options: vec![ManaColor::Blue, ManaColor::Red],
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Mana {
+            cost: ManaCost::Cost {
+                shards: vec![],
+                generic: 0,
+            },
+        })
+        .activation_restrictions(vec![
+            ActivationRestriction::DuringYourTurn,
+            ActivationRestriction::OnlyOnceEachTurn,
+        ]),
+    );
+    id
+}
+
+fn add_hand_spell(state: &mut GameState, card_id: CardId, cost: ManaCost) -> ObjectId {
+    let id = create_object(state, card_id, P0, "Test Spell".to_string(), Zone::Hand);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Instant);
+    obj.mana_cost = cost;
+    id
+}
+
+#[test]
+fn vivi_combination_mana_makes_colored_spell_castable_without_other_sources() {
+    let mut state = GameState::new_two_player(583);
+    setup_priority(&mut state);
+    let vivi = add_vivi(&mut state, 2);
+    let spell = add_hand_spell(
+        &mut state,
+        CardId(5831),
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue, ManaCostShard::Red],
+            generic: 0,
+        },
+    );
+
+    assert!(
+        can_cast_object_now(&state, P0, spell),
+        "Vivi's zero-cost combination mana must make {{U}}{{R}} castable when power is 2"
+    );
+
+    let actions = engine::ai_support::legal_actions(&state);
+    assert!(
+        !engine::ai_support::auto_pass_recommended(&state, &actions),
+        "auto_pass must not skip priority when a spell is castable via Vivi mana"
+    );
+
+    let _ = vivi;
+}
+
+#[test]
+fn vivi_single_blue_shard_castable_at_power_one() {
+    let mut state = GameState::new_two_player(583);
+    setup_priority(&mut state);
+    add_vivi(&mut state, 1);
+    let spell = add_hand_spell(
+        &mut state,
+        CardId(5832),
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 0,
+        },
+    );
+
+    assert!(
+        can_cast_object_now(&state, P0, spell),
+        "Vivi power 1 must cover a single {{U}} shard"
+    );
+}

--- a/crates/engine/tests/integration/issue_583_vivi_ornitier_mana_source.rs
+++ b/crates/engine/tests/integration/issue_583_vivi_ornitier_mana_source.rs
@@ -128,6 +128,26 @@ fn vivi_power_two_does_not_cover_colored_shards_plus_generic() {
 }
 
 #[test]
+fn vivi_power_three_surplus_still_covers_two_shards() {
+    let mut state = GameState::new_two_player(583);
+    setup_priority(&mut state);
+    add_vivi(&mut state, 3);
+    let spell = add_hand_spell(
+        &mut state,
+        CardId(5834),
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue, ManaCostShard::Red],
+            generic: 0,
+        },
+    );
+
+    assert!(
+        can_cast_object_now(&state, P0, spell),
+        "Vivi power 3 over-produces for {{U}}{{R}} — surplus mana must not make the spell uncastable"
+    );
+}
+
+#[test]
 fn vivi_single_blue_shard_castable_at_power_one() {
     let mut state = GameState::new_two_player(583);
     setup_priority(&mut state);

--- a/crates/engine/tests/integration/issue_583_vivi_ornitier_mana_source.rs
+++ b/crates/engine/tests/integration/issue_583_vivi_ornitier_mana_source.rs
@@ -108,6 +108,26 @@ fn vivi_combination_mana_makes_colored_spell_castable_without_other_sources() {
 }
 
 #[test]
+fn vivi_power_two_does_not_cover_colored_shards_plus_generic() {
+    let mut state = GameState::new_two_player(583);
+    setup_priority(&mut state);
+    add_vivi(&mut state, 2);
+    let spell = add_hand_spell(
+        &mut state,
+        CardId(5833),
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue, ManaCostShard::Red],
+            generic: 1,
+        },
+    );
+
+    assert!(
+        !can_cast_object_now(&state, P0, spell),
+        "one Vivi activation produces two mana total and cannot also pay {{1}}"
+    );
+}
+
+#[test]
 fn vivi_single_blue_shard_castable_at_power_one() {
     let mut state = GameState::new_two_player(583);
     setup_priority(&mut state);

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -126,6 +126,7 @@ mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_580_solitude_evoke_prompt;
+mod issue_583_vivi_ornitier_mana_source;
 mod issue_709_regression;
 mod issue_860_luminarch_aspirant;
 mod issue_879_obsessive_pursuit;


### PR DESCRIPTION
## Summary
- Extend the castability gate to cover residual colored mana shards using activatable non-tap mana abilities (including `AnyCombination` producers like Vivi Ornitier).
- Prevent auto-pass from skipping priority when a spell is feasibly castable via manual mana activation, even when the simulation filter rejects the Auto `CastSpell` candidate.

Fixes #583

## Test plan
- [x] `cargo test -p engine --test integration issue_583`
- [ ] CI green on merge queue
