### PR TITLE
fix(engine): Wishclaw Talisman passes control to chosen opponent (Fixes #564)

### DIFF
--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -22,25 +22,30 @@ pub fn resolve(
     // CR 613.1b: Layer 2 — control-changing effects are applied.
     let duration = ability.duration.clone().unwrap_or(Duration::Permanent);
 
-    for target in &ability.targets {
-        if let TargetRef::Object(obj_id) = target {
-            // Verify target exists
-            if !state.objects.contains_key(obj_id) {
-                return Err(EffectError::ObjectNotFound(*obj_id));
-            }
+    let Effect::GainControl { target } = &ability.effect else {
+        return Err(EffectError::InvalidParam(
+            "expected GainControl effect".to_string(),
+        ));
+    };
 
-            // CR 613.3: Create a transient continuous effect at Layer 2 (Control).
-            // The affected filter targets this specific object by ID.
-            state.add_transient_continuous_effect(
-                ability.source_id,
-                ability.controller,
-                duration.clone(),
-                TargetFilter::SpecificObject { id: *obj_id },
-                vec![ContinuousModification::ChangeController],
-                None,
-            );
-            mark_echo_due_for_new_controller(state, *obj_id);
+    let new_controller = gain_control_controller(ability, target);
+    let object_ids = gain_control_object_targets(state, ability, target);
+
+    for obj_id in object_ids {
+        if !state.objects.contains_key(&obj_id) {
+            return Err(EffectError::ObjectNotFound(obj_id));
         }
+
+        // CR 613.3: Create a transient continuous effect at Layer 2 (Control).
+        state.add_transient_continuous_effect(
+            ability.source_id,
+            new_controller,
+            duration.clone(),
+            TargetFilter::SpecificObject { id: obj_id },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+        mark_echo_due_for_new_controller(state, obj_id);
     }
 
     events.push(GameEvent::EffectResolved {
@@ -49,6 +54,52 @@ pub fn resolve(
     });
 
     Ok(())
+}
+
+/// CR 613.3: The player who gains control. Normally the ability controller;
+/// after a resolution-scoped `Choose(Opponent)` whose dependent effect is
+/// `GainControl { SelfRef }`, the chosen opponent is the recipient
+/// (Wishclaw Talisman — "an opponent gains control of ~").
+fn gain_control_controller(ability: &ResolvedAbility, target: &TargetFilter) -> PlayerId {
+    if matches!(target, TargetFilter::SelfRef) {
+        if let Some(&recipient) = ability.chosen_players.last() {
+            return recipient;
+        }
+    }
+    ability.controller
+}
+
+fn gain_control_object_targets(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    filter: &TargetFilter,
+) -> Vec<ObjectId> {
+    // CR 608.2c: `SelfRef` binds to the ability source even when target
+    // propagation has populated `ability.targets`.
+    if matches!(filter, TargetFilter::SelfRef) {
+        return vec![ability.source_id];
+    }
+
+    let chosen_objects: Vec<ObjectId> = ability
+        .targets
+        .iter()
+        .filter_map(|target| match target {
+            TargetRef::Object(id) => Some(*id),
+            TargetRef::Player(_) => None,
+        })
+        .collect();
+
+    if !chosen_objects.is_empty() {
+        return chosen_objects;
+    }
+
+    crate::game::targeting::resolved_targets(ability, filter, state)
+        .into_iter()
+        .filter_map(|target| match target {
+            TargetRef::Object(id) => Some(id),
+            TargetRef::Player(_) => None,
+        })
+        .collect()
 }
 
 /// CR 110.2: Give control of target permanent to a specified recipient player.
@@ -818,6 +869,40 @@ mod tests {
             state.objects.get(&target_id).unwrap().controller,
             PlayerId(1),
             "control must revert to the owner once the tapped source leaves the battlefield",
+        );
+    }
+
+    /// Issue #564: Wishclaw Talisman encodes "an opponent gains control of ~"
+    /// as `Choose(Opponent)` → `GainControl { SelfRef }`. The chosen opponent
+    /// must receive control, not the activator.
+    #[test]
+    fn issue_564_gain_control_self_ref_uses_chosen_opponent() {
+        let mut state = GameState::new_two_player(42);
+        let talisman = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Wishclaw Talisman".to_string(),
+            Zone::Battlefield,
+        );
+        let mut ability = ResolvedAbility::new(
+            Effect::GainControl {
+                target: TargetFilter::SelfRef,
+            },
+            vec![],
+            talisman,
+            PlayerId(0),
+        );
+        ability.chosen_players = vec![PlayerId(1)];
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(
+            state.objects.get(&talisman).unwrap().controller,
+            PlayerId(1),
+            "SelfRef GainControl after Choose(Opponent) must transfer to the chosen opponent"
         );
     }
 

--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -80,14 +80,7 @@ fn gain_control_object_targets(
         return vec![ability.source_id];
     }
 
-    let chosen_objects: Vec<ObjectId> = ability
-        .targets
-        .iter()
-        .filter_map(|target| match target {
-            TargetRef::Object(id) => Some(*id),
-            TargetRef::Player(_) => None,
-        })
-        .collect();
+    let chosen_objects = super::effect_object_targets(filter, &ability.targets);
 
     if !chosen_objects.is_empty() {
         return chosen_objects;

--- a/crates/engine/tests/integration/issue_564_wishclaw_talisman_control.rs
+++ b/crates/engine/tests/integration/issue_564_wishclaw_talisman_control.rs
@@ -1,0 +1,89 @@
+//! Regression (issue #564): Wishclaw Talisman's activated ability searches,
+//! then prompts to choose an opponent, then that opponent must gain control
+//! of the Talisman — not the activator.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::ChoiceType;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const WISHCLAW_ACTIVATED: &str =
+    "{1}, {T}, Remove a wish counter from ~: Search your library for a \
+     card, put it into your hand, then shuffle. An opponent gains control of ~. \
+     Activate only during your turn.";
+
+fn floating_colorless(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn choose_opponent(runner: &mut GameRunner, opponent: engine::types::PlayerId) {
+    match &runner.state().waiting_for {
+        WaitingFor::NamedChoice {
+            choice_type,
+            options,
+            ..
+        } => {
+            assert_eq!(*choice_type, ChoiceType::Opponent);
+            assert!(
+                options.contains(&opponent.0.to_string()),
+                "opponent must be legal; options={options:?}"
+            );
+        }
+        other => panic!("expected NamedChoice for opponent, got {other:?}"),
+    }
+    runner
+        .act(GameAction::ChooseOption {
+            choice: opponent.0.to_string(),
+        })
+        .expect("ChooseOption(opponent) must succeed");
+}
+
+fn drain_stack(runner: &mut GameRunner) {
+    for _ in 0..32 {
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } if !runner.state().stack.is_empty() => {
+                runner.act(GameAction::PassPriority).ok();
+            }
+            _ => break,
+        }
+    }
+}
+
+#[test]
+fn issue_564_wishclaw_activation_passes_control_to_chosen_opponent() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Forest"]);
+
+    let talisman_id = scenario
+        .add_creature(P0, "Wishclaw Talisman", 0, 0)
+        .as_artifact()
+        .from_oracle_text(WISHCLAW_ACTIVATED)
+        .id();
+
+    scenario.with_counter(talisman_id, CounterType::Generic("wish".to_string()), 1);
+    scenario.with_mana_pool(P0, floating_colorless(1));
+
+    let mut runner = scenario.build();
+    runner
+        .activate(talisman_id, 0)
+        .search_first_legal()
+        .resolve();
+
+    choose_opponent(&mut runner, P1);
+    drain_stack(&mut runner);
+
+    let state = runner.state();
+    assert_eq!(
+        state.objects.get(&talisman_id).unwrap().controller,
+        P1,
+        "chosen opponent must control Wishclaw after the ability resolves; waiting_for={:?}",
+        state.waiting_for
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -123,6 +123,7 @@ mod issue_2430_shifting_woodland;
 mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
+mod issue_564_wishclaw_talisman_control;
 mod issue_580_solitude_evoke_prompt;
 mod issue_709_regression;
 mod issue_860_luminarch_aspirant;


### PR DESCRIPTION
## Summary
- When `GainControl { SelfRef }` follows a resolution-scoped `Choose(Opponent)`, use the chosen opponent as the new controller instead of the activator.
- Resolve `SelfRef` gain-control targets from the ability source even when `ability.targets` is empty (matching the existing `GiveControl` path).
- Add unit and integration regression tests for Wishclaw Talisman's activated ability.

Fixes #564

## Test plan
- [x] `cargo test -p engine --lib issue_564`
- [x] `cargo test -p engine --lib gain_control::tests`
- [x] `cargo test -p engine --test integration issue_564`
