### PR TITLE
ci: guard scheduled/deploy workflows against fork execution

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   tarpaulin:
     name: Rust code coverage (tarpaulin)
+    # No secrets needed, but a fork would still burn ~30 min of Actions minutes
+    # daily for a report nobody consumes. Restrict to the canonical repository.
+    if: github.repository == 'phase-rs/phase'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
   # binaryen.
   card-data:
     name: Card data & R2
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -246,7 +246,7 @@ jobs:
   # parallel. The output feeds the frontend build via artifact.
   build-wasm:
     name: Build WASM
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -399,7 +399,7 @@ jobs:
   # warming the workspace compile would need sccache or similar.
   build-server-binary:
     name: Build server binary
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -16,6 +16,10 @@ permissions:
 jobs:
   cut-nightly-release:
     name: Cut Nightly Release
+    # Forks inherit this workflow's schedule but not upstream secrets
+    # (RELEASE_BOT_TOKEN), so a scheduled run in a fork can only fail noisily.
+    # Restrict the whole release graph to the canonical repository.
+    if: github.repository == 'phase-rs/phase'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     outputs:

--- a/.github/workflows/refresh-feeds.yml
+++ b/.github/workflows/refresh-feeds.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   refresh-feeds:
     name: Scrape & Commit Feeds
+    # Forks inherit the schedule but not CI_PAT, so a fork run only fails and
+    # spams the owner. Keep the daily scrape on the canonical repository.
+    if: github.repository == 'phase-rs/phase'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ permissions:
 jobs:
   resolve-release-ref:
     name: Resolve Release Ref
+    # Every downstream job needs this one, so guarding the root skips the entire
+    # release graph in forks (which lack the deploy/release secrets anyway).
+    if: github.repository == 'phase-rs/phase'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
Forks inherit a workflow's schedule, workflow_run, and tag-push triggers
but not the upstream's secrets, so these jobs fire daily in forks where
they can only fail noisily (emailing fork owners) or, where GITHUB_TOKEN
suffices, push a server image into the fork owner's own ghcr namespace.

Add 'if: github.repository == "phase-rs/phase"' to the choke-point job of
each auto-firing workflow; downstream jobs skip via needs propagation:

- nightly-release.yml: cut-nightly-release (dispatch-recovery follows)
- release.yml:         resolve-release-ref (root of the whole graph)
- deploy.yml:          card-data, build-wasm, build-server-binary roots
- refresh-feeds.yml:   refresh-feeds
- coverage.yml:        tarpaulin

ci.yml is intentionally left open so fork contributors still get CI.
