### PR TITLE
fix(engine): add 'becomes the target of a backup ability' trigger primitive (CR 702.165a)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -7265,7 +7265,7 @@ pub fn synthesize_backup(face: &mut CardFace) {
         ));
 
         // Chain ability granting if needed, gated on "if that's another creature"
-        let counter_ability = if let Some(grant_effect) = grant_effect.clone() {
+        let mut counter_ability = if let Some(grant_effect) = grant_effect.clone() {
             let grant_sub = AbilityDefinition::new(AbilityKind::Spell, grant_effect)
                 .condition(AbilityCondition::Not {
                     condition: Box::new(AbilityCondition::TargetMatchesFilter {
@@ -7281,6 +7281,12 @@ pub fn synthesize_backup(face: &mut CardFace) {
         } else {
             counter_ability
         };
+
+        // CR 702.165a: mark the synthesized backup ability so "becomes the target
+        // of a backup ability" triggers can identify it on the stack. Stamped on
+        // the final body that reaches `.execute(...)` so the tag survives the
+        // chained sub-ability rebuild above.
+        counter_ability.ability_tag = Some(AbilityTag::Backup);
 
         // Build the ETB trigger
         // CR 702.165a: "when this creature enters"

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -16765,6 +16765,7 @@ mod tests {
                 Effect::CopySpell {
                     target: TargetFilter::StackAbility {
                         controller: Some(ControllerRef::You),
+                        tag: None,
                     },
                     retarget: CopyRetargetPermission::MayChooseNewTargets,
                     copier: None,
@@ -19225,7 +19226,10 @@ mod tests {
                     TargetFilter::Or {
                         filters: vec![
                             TargetFilter::StackSpell,
-                            TargetFilter::StackAbility { controller: None },
+                            TargetFilter::StackAbility {
+                                controller: None,
+                                tag: None,
+                            },
                         ],
                     },
                     TargetFilter::Typed(TypedFilter::default().properties(vec![
@@ -19367,7 +19371,10 @@ mod tests {
         });
         let not_of_this_world_targeting_ability = ResolvedAbility::new(
             Effect::Counter {
-                target: TargetFilter::StackAbility { controller: None },
+                target: TargetFilter::StackAbility {
+                    controller: None,
+                    tag: None,
+                },
                 source_rider: None,
             },
             vec![TargetRef::Object(stack_ability_id)],

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -364,15 +364,22 @@ fn fmt_target(filter: &TargetFilter) -> String {
         TargetFilter::ScopedPlayer => "scoped player".into(),
         TargetFilter::SelfRef => "self".into(),
         TargetFilter::SourceOrPaired => "source or paired creature".into(),
-        TargetFilter::StackAbility { controller: None } => "ability on stack".into(),
+        TargetFilter::StackAbility { tag: Some(tag), .. } => format!("{tag:?} ability on stack"),
+        TargetFilter::StackAbility {
+            controller: None,
+            tag: None,
+        } => "ability on stack".into(),
         TargetFilter::StackAbility {
             controller: Some(ControllerRef::You),
+            tag: None,
         } => "ability you control on stack".into(),
         TargetFilter::StackAbility {
             controller: Some(ControllerRef::Opponent),
+            tag: None,
         } => "ability opponent controls on stack".into(),
         TargetFilter::StackAbility {
             controller: Some(controller),
+            tag: None,
         } => format!("ability scoped to {controller:?} on stack"),
         TargetFilter::StackSpell => "spell on stack".into(),
         TargetFilter::AttachedTo => "attached permanent".into(),

--- a/crates/engine/src/game/effects/bounce.rs
+++ b/crates/engine/src/game/effects/bounce.rs
@@ -641,7 +641,10 @@ mod tests {
 
         let ability = ResolvedAbility::new(
             Effect::Bounce {
-                target: TargetFilter::StackAbility { controller: None },
+                target: TargetFilter::StackAbility {
+                    controller: None,
+                    tag: None,
+                },
                 destination: None,
                 selection: BounceSelection::Targeted,
             },

--- a/crates/engine/src/game/effects/change_targets.rs
+++ b/crates/engine/src/game/effects/change_targets.rs
@@ -359,7 +359,13 @@ mod tests {
                     filters: vec![TargetFilter::StackSpell, single.clone()],
                 },
                 TargetFilter::And {
-                    filters: vec![TargetFilter::StackAbility { controller: None }, single],
+                    filters: vec![
+                        TargetFilter::StackAbility {
+                            controller: None,
+                            tag: None,
+                        },
+                        single,
+                    ],
                 },
             ],
         };

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -1575,6 +1575,7 @@ mod tests {
             Effect::CopySpell {
                 target: TargetFilter::StackAbility {
                     controller: Some(crate::types::ability::ControllerRef::You),
+                    tag: None,
                 },
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
@@ -1599,6 +1600,7 @@ mod tests {
             Effect::CopySpell {
                 target: TargetFilter::StackAbility {
                     controller: Some(crate::types::ability::ControllerRef::You),
+                    tag: None,
                 },
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
@@ -1898,6 +1900,7 @@ mod tests {
         let gogo_entry = ObjectId(40);
         let gogo_target_filter = TargetFilter::StackAbility {
             controller: Some(crate::types::ability::ControllerRef::You),
+            tag: None,
         };
         assert_eq!(
             crate::game::targeting::find_legal_targets(

--- a/crates/engine/src/game/effects/counter.rs
+++ b/crates/engine/src/game/effects/counter.rs
@@ -559,7 +559,10 @@ mod tests {
 
         let counter_ability = ResolvedAbility::new(
             Effect::Counter {
-                target: TargetFilter::StackAbility { controller: None },
+                target: TargetFilter::StackAbility {
+                    controller: None,
+                    tag: None,
+                },
                 source_rider: Some(CounterSourceRider::LosesAbilities {
                     static_def: Box::new(source_static),
                 }),
@@ -711,7 +714,10 @@ mod tests {
 
         let counter_ability = ResolvedAbility::new(
             Effect::Counter {
-                target: TargetFilter::StackAbility { controller: None },
+                target: TargetFilter::StackAbility {
+                    controller: None,
+                    tag: None,
+                },
                 source_rider: Some(CounterSourceRider::Destroy),
             },
             vec![TargetRef::Object(ability_on_stack)],
@@ -1179,7 +1185,7 @@ mod tests {
 
     /// CR 113.3 + CR 405.1: "Counter all abilities" — the resolver matches
     /// every activated/triggered ability on the stack, including keyword actions, via
-    /// `TargetFilter::StackAbility { controller: None }` and removes the entry without moving any
+    /// `TargetFilter::StackAbility { controller: None, tag: None }` and removes the entry without moving any
     /// card to a graveyard (abilities aren't cards).
     #[test]
     fn test_counter_all_abilities_removes_ability_entries() {
@@ -1272,7 +1278,10 @@ mod tests {
 
         let ability = ResolvedAbility::new(
             Effect::CounterAll {
-                target: TargetFilter::StackAbility { controller: None },
+                target: TargetFilter::StackAbility {
+                    controller: None,
+                    tag: None,
+                },
             },
             vec![],
             ObjectId(999),
@@ -1349,6 +1358,7 @@ mod tests {
             Effect::CounterAll {
                 target: TargetFilter::StackAbility {
                     controller: Some(ControllerRef::Opponent),
+                    tag: None,
                 },
             },
             vec![],

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -712,11 +712,16 @@ pub(crate) fn matches_stack_target_filter(
     match filter {
         TargetFilter::Any => true,
         TargetFilter::StackSpell => matches!(&entry.kind, StackEntryKind::Spell { .. }),
-        TargetFilter::StackAbility { controller } => {
+        TargetFilter::StackAbility { controller, tag } => {
             matches!(
                 &entry.kind,
                 StackEntryKind::ActivatedAbility { .. } | StackEntryKind::TriggeredAbility { .. }
             ) && stack_entry_controller_matches(state, controller.as_ref(), entry.controller, ctx)
+                // CR 113.7a: keyword-origin tag (e.g. `AbilityTag::Backup`) must
+                // match the ability on the stack when the filter requires one.
+                && tag.as_ref().is_none_or(|tag| {
+                    entry.ability().and_then(|a| a.context.ability_tag.as_ref()) == Some(tag)
+                })
         }
         TargetFilter::Typed(tf) => {
             if !tf.type_filters.is_empty() {

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -305,6 +305,9 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
                 // CR 702.29c: Cycling emits a dedicated `GameEvent::Cycled`, not a
                 // `KeywordAbilityActivated` event, so this arm is unreachable.
                 AbilityTag::Cycling => " activates cycling: ",
+                // CR 702.165a: Backup is a triggered ability — it never emits a
+                // `KeywordAbilityActivated` event, so this arm is unreachable.
+                AbilityTag::Backup => " activates backup: ",
             };
             vec![
                 player_seg(state, *player_id),

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -581,6 +581,9 @@ fn effective_activation_limit(
         // this fn is only called for abilities carrying an `OnlyOnceEachTurn`
         // restriction, which the synthesized cycling ability never has.
         AbilityTag::Cycling => "cycling",
+        // CR 702.165a: Backup is a triggered ability — it is never activated, so
+        // it carries no activation limit and this arm is unreachable here.
+        AbilityTag::Backup => "backup",
     };
     // Scan battlefield for ModifyActivationLimit statics that affect this keyword
     let mut limit: u32 = 1;

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1113,7 +1113,7 @@ fn stack_ability_matches_filter(
     source_controller: PlayerId,
 ) -> bool {
     match filter {
-        TargetFilter::StackAbility { controller } => {
+        TargetFilter::StackAbility { controller, tag } => {
             if !matches!(
                 &entry.kind,
                 // CR 113.3b / CR 113.3c: Activated and triggered abilities are
@@ -1124,6 +1124,16 @@ fn stack_ability_matches_filter(
                     | StackEntryKind::KeywordAction { .. }
             ) {
                 return false;
+            }
+            // CR 113.7a + CR 115.1: when a keyword-origin `tag` is required (e.g.
+            // `AbilityTag::Backup` for "becomes the target of a backup ability"),
+            // the stack ability must carry that tag. The ability exists on the
+            // stack independently of its source, so the tag is read from the
+            // resolved ability itself.
+            if let Some(tag) = tag {
+                if entry.ability().and_then(|a| a.context.ability_tag.as_ref()) != Some(tag) {
+                    return false;
+                }
             }
             stack_entry_controller_matches(entry, controller.as_ref(), source_controller)
         }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -8113,6 +8113,7 @@ mod tests {
                 },
                 TargetFilter::StackAbility {
                     controller: Some(controller),
+                    tag: None,
                 },
             ],
         }
@@ -8197,6 +8198,87 @@ mod tests {
         trigger.valid_source = Some(TargetFilter::StackSpell);
 
         // Event: trigger_owner becomes the target of an activated ability
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: ability_id,
+        };
+        assert!(!match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
+    }
+
+    /// Build a stack `TriggeredAbility` carrying an optional keyword `ability_tag`,
+    /// mirroring how a synthesized Backup ETB ability reaches the stack.
+    fn setup_with_tagged_triggered_ability(tag: Option<AbilityTag>) -> (GameState, ObjectId) {
+        let mut state = setup();
+        let ability_id = ObjectId(60);
+        let mut ability = ResolvedAbility::new(
+            crate::types::ability::Effect::PutCounter {
+                counter_type: crate::types::counter::CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: crate::types::ability::TargetFilter::Typed(TypedFilter::creature()),
+            },
+            vec![],
+            ObjectId(10),
+            PlayerId(1),
+        );
+        ability.context.ability_tag = tag;
+        state.stack.push_back(StackEntry {
+            id: ability_id,
+            source_id: ObjectId(10),
+            controller: PlayerId(1),
+            kind: StackEntryKind::TriggeredAbility {
+                source_id: ObjectId(10),
+                ability: Box::new(ability),
+                condition: None,
+                trigger_event: None,
+                description: None,
+                source_name: String::new(),
+                subject_match_count: None,
+                die_result: None,
+            },
+        });
+        (state, ability_id)
+    }
+
+    #[test]
+    fn becomes_target_backup_ability_matches_tagged_source() {
+        // CR 702.165a: a `BecomesTarget` trigger whose `valid_source` filters on
+        // `AbilityTag::Backup` matches when the targeting stack ability carries
+        // that tag (Huge Truck targeted by a backup ability).
+        let (state, ability_id) = setup_with_tagged_triggered_ability(Some(AbilityTag::Backup));
+        let trigger_owner = ObjectId(5);
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(TargetFilter::StackAbility {
+            controller: None,
+            tag: Some(AbilityTag::Backup),
+        });
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(trigger_owner),
+            source_id: ability_id,
+        };
+        assert!(match_becomes_target(
+            &event,
+            &trigger,
+            trigger_owner,
+            &state
+        ));
+    }
+
+    #[test]
+    fn becomes_target_backup_ability_rejects_untagged_source() {
+        // CR 702.165a: an untagged stack ability (a plain triggered/activated
+        // ability) is NOT a backup ability and must not fire the trigger.
+        let (state, ability_id) = setup_with_tagged_triggered_ability(None);
+        let trigger_owner = ObjectId(5);
+        let mut trigger = make_trigger(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(TargetFilter::StackAbility {
+            controller: None,
+            tag: Some(AbilityTag::Backup),
+        });
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),
             source_id: ability_id,

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -11267,7 +11267,8 @@ mod tests {
         assert!(matches!(
             target,
             TargetFilter::StackAbility {
-                controller: Some(ControllerRef::You)
+                controller: Some(ControllerRef::You),
+                tag: None,
             }
         ));
         assert!(

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3221,6 +3221,7 @@ fn parse_copy_stack_ability_target(input: &str) -> Option<(TargetFilter, &str)> 
         return Some((
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
+                tag: None,
             },
             rem,
         ));
@@ -3230,7 +3231,13 @@ fn parse_copy_stack_ability_target(input: &str) -> Option<(TargetFilter, &str)> 
             .parse(input)
             .is_ok()
     {
-        return Some((TargetFilter::StackAbility { controller: None }, input));
+        return Some((
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None,
+            },
+            input,
+        ));
     }
     None
 }
@@ -3246,7 +3253,10 @@ pub(super) fn stack_ability_filter_from_text(input: &str) -> TargetFilter {
     } else {
         None
     };
-    TargetFilter::StackAbility { controller }
+    TargetFilter::StackAbility {
+        controller,
+        tag: None,
+    }
 }
 
 fn parse_explicit_targeted_attach(
@@ -7787,9 +7797,13 @@ mod tests {
             panic!("expected Or {{ ability, noncreature-spell }}, got {target:?}");
         };
         assert!(
-            filters
-                .iter()
-                .any(|f| matches!(f, TargetFilter::StackAbility { controller: None })),
+            filters.iter().any(|f| matches!(
+                f,
+                TargetFilter::StackAbility {
+                    controller: None,
+                    tag: None
+                }
+            )),
             "missing the activated/triggered ability disjunct: {target:?}"
         );
         let spell_leg = filters
@@ -10962,7 +10976,8 @@ mod tests {
         assert!(matches!(
             controlled.0,
             TargetFilter::StackAbility {
-                controller: Some(ControllerRef::You)
+                controller: Some(ControllerRef::You),
+                tag: None,
             }
         ));
 
@@ -10971,7 +10986,10 @@ mod tests {
         assert_eq!(unscoped.1, "");
         assert!(matches!(
             unscoped.0,
-            TargetFilter::StackAbility { controller: None }
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None
+            }
         ));
 
         assert!(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17854,13 +17854,19 @@ fn try_parse_change_targets(lower: &str) -> Option<Effect> {
         TargetFilter::Or {
             filters: vec![
                 TargetFilter::StackSpell,
-                TargetFilter::StackAbility { controller: None },
+                TargetFilter::StackAbility {
+                    controller: None,
+                    tag: None,
+                },
             ],
         }
     } else if scan_contains_phrase(spell_phrase_clean, "activated or triggered ability")
         || scan_contains_phrase(spell_phrase_clean, "activated ability")
     {
-        TargetFilter::StackAbility { controller: None }
+        TargetFilter::StackAbility {
+            controller: None,
+            tag: None,
+        }
     } else if scan_contains_phrase(spell_phrase_clean, "spell") {
         // Parse with parse_target for type-specific spells (e.g. "instant or sorcery spell")
         let (parsed, _) = parse_target(spell_phrase_clean);
@@ -22572,7 +22578,8 @@ mod tests {
                 e,
                 Effect::CounterAll {
                     target: TargetFilter::StackAbility {
-                        controller: Some(ControllerRef::Opponent)
+                        controller: Some(ControllerRef::Opponent),
+                        tag: None,
                     },
                 }
             ),
@@ -22611,7 +22618,10 @@ mod tests {
             matches!(
                 e,
                 Effect::Counter {
-                    target: TargetFilter::StackAbility { controller: None },
+                    target: TargetFilter::StackAbility {
+                        controller: None,
+                        tag: None
+                    },
                     ..
                 }
             ),
@@ -23430,7 +23440,8 @@ mod tests {
         assert!(matches!(
             target,
             TargetFilter::StackAbility {
-                controller: Some(ControllerRef::You)
+                controller: Some(ControllerRef::You),
+                tag: None,
             }
         ));
     }

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -351,7 +351,10 @@ pub fn parse_stack_object_target(input: &str) -> OracleResult<'_, TargetFilter> 
             TargetFilter::Or {
                 filters: vec![
                     TargetFilter::StackSpell,
-                    TargetFilter::StackAbility { controller: None },
+                    TargetFilter::StackAbility {
+                        controller: None,
+                        tag: None,
+                    },
                 ],
             },
             alt((
@@ -398,7 +401,10 @@ fn parse_ability_kind_with_optional_spell(input: &str) -> OracleResult<'_, Targe
     ))
     .parse(rest)?;
 
-    let ability = TargetFilter::StackAbility { controller: None };
+    let ability = TargetFilter::StackAbility {
+        controller: None,
+        tag: None,
+    };
     let filter = match spell_leg {
         Some(spell) => TargetFilter::Or {
             filters: vec![ability, spell],
@@ -790,7 +796,10 @@ mod tests {
             filter,
             TargetFilter::Or {
                 filters: vec![
-                    TargetFilter::StackAbility { controller: None },
+                    TargetFilter::StackAbility {
+                        controller: None,
+                        tag: None
+                    },
                     noncreature_spell_leg(),
                 ],
             }
@@ -828,14 +837,26 @@ mod tests {
         // Ability-only counter (e.g. Stifle / Disallow's ability disjunct).
         let (rest, filter) = parse_stack_object_target("activated or triggered ability").unwrap();
         assert_eq!(rest, "");
-        assert_eq!(filter, TargetFilter::StackAbility { controller: None });
+        assert_eq!(
+            filter,
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None
+            }
+        );
     }
 
     #[test]
     fn test_stack_object_activated_ability_only() {
         let (rest, filter) = parse_stack_object_target("activated ability").unwrap();
         assert_eq!(rest, "");
-        assert_eq!(filter, TargetFilter::StackAbility { controller: None });
+        assert_eq!(
+            filter,
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None
+            }
+        );
     }
 
     #[test]
@@ -850,7 +871,10 @@ mod tests {
             TargetFilter::Or {
                 filters: vec![
                     TargetFilter::StackSpell,
-                    TargetFilter::StackAbility { controller: None },
+                    TargetFilter::StackAbility {
+                        controller: None,
+                        tag: None
+                    },
                 ],
             }
         );

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -661,7 +661,10 @@ fn parse_it_targets_that_targets_spell_filter(cond_text: &str) -> Option<TargetF
             TargetFilter::Or {
                 filters: vec![
                     TargetFilter::StackSpell,
-                    TargetFilter::StackAbility { controller: None },
+                    TargetFilter::StackAbility {
+                        controller: None,
+                        tag: None,
+                    },
                 ],
             },
             tag::<_, _, OracleError<'_>>("a spell or ability"),
@@ -671,7 +674,10 @@ fn parse_it_targets_that_targets_spell_filter(cond_text: &str) -> Option<TargetF
             tag::<_, _, OracleError<'_>>("a spell"),
         ),
         value(
-            TargetFilter::StackAbility { controller: None },
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None,
+            },
             alt((
                 tag::<_, _, OracleError<'_>>("an activated or triggered ability"),
                 tag("a triggered or activated ability"),

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2194,7 +2194,7 @@ fn static_this_spell_cost_less_if_it_targets_spell_or_ability_targeting_large_cr
             if filters.iter().any(|f| matches!(f, TargetFilter::StackSpell))
                 && filters
                     .iter()
-                    .any(|f| matches!(f, TargetFilter::StackAbility { controller: None }))
+                    .any(|f| matches!(f, TargetFilter::StackAbility { controller: None, tag: None }))
     )));
     let stack_targets_filter = filters
         .iter()

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -159,6 +159,7 @@ fn becomes_target_source_filter(controller: ControllerRef) -> TargetFilter {
             },
             TargetFilter::StackAbility {
                 controller: Some(controller),
+                tag: None,
             },
         ],
     }
@@ -6453,6 +6454,9 @@ fn try_parse_event(
         BecomesTargetSpell {
             qualifier: Option<TargetFilter>,
         },
+        /// CR 702.165a: the targeting source is a Backup keyword ability on the
+        /// stack (e.g. Huge Truck "becomes the target of a backup ability").
+        BecomesTargetBackupAbility,
         DealtCombatDamage,
         DealtDamage,
         /// CR 120.10 + CR 120.2b: Excess noncombat damage received by the subject.
@@ -6588,6 +6592,20 @@ fn try_parse_event(
             value(SimpleEvent::TappedForMana, tag("is tapped for mana")),
         ))
         .or(alt((
+            // CR 702.165a: "becomes the target of a backup ability" — the source
+            // is specifically a Backup keyword ability on the stack. Lives in this
+            // second `alt` block (the first hit nom's tuple-arity limit); collision-
+            // free with every arm because no other phrase shares its "of a backup
+            // ability" suffix (neither generic spell-or-ability arm matches it).
+            value(
+                SimpleEvent::BecomesTargetBackupAbility,
+                tag("becomes the target of a backup ability"),
+            ),
+            // CR 115.1: Plural form for batched "become the target" triggers.
+            value(
+                SimpleEvent::BecomesTargetBackupAbility,
+                tag("become the target of a backup ability"),
+            ),
             value(SimpleEvent::BecomesUntapped, tag("becomes untapped")),
             // CR 701.26: Plural form for batched "one or more ... become untapped" triggers.
             value(SimpleEvent::BecomesUntapped, tag("become untapped")),
@@ -6696,6 +6714,16 @@ fn try_parse_event(
                     }
                 } else {
                     TargetFilter::StackSpell
+                });
+            }
+            // CR 702.165a + CR 115.1: the targeting source must be a Backup
+            // keyword ability on the stack — filtered by `AbilityTag::Backup`.
+            SimpleEvent::BecomesTargetBackupAbility => {
+                def.mode = TriggerMode::BecomesTarget;
+                set_trigger_subject(&mut def, subject);
+                def.valid_source = Some(TargetFilter::StackAbility {
+                    controller: None,
+                    tag: Some(AbilityTag::Backup),
                 });
             }
             SimpleEvent::DealtCombatDamage => {
@@ -19774,6 +19802,40 @@ mod tests {
                 ],
             })
         );
+    }
+
+    #[test]
+    fn trigger_becomes_target_of_backup_ability() {
+        // CR 702.165a: Huge Truck pattern — "becomes the target of a backup
+        // ability" parses to a `BecomesTarget` trigger whose `valid_source` is a
+        // stack ability tagged `Backup`, with the subject ("another creature you
+        // control") routed to `valid_card`.
+        let def = parse_trigger_line(
+            "Whenever another creature you control becomes the target of a backup ability, draw a card.",
+            "Huge Truck",
+        );
+        assert_eq!(def.mode, TriggerMode::BecomesTarget);
+        // valid_source is the new backup-tag stack-ability filter — this is the
+        // assertion that flips if the converter arm is reverted.
+        assert_eq!(
+            def.valid_source,
+            Some(TargetFilter::StackAbility {
+                controller: None,
+                tag: Some(AbilityTag::Backup),
+            })
+        );
+        // Subject: "another creature you control" → Typed creature / You / Another.
+        let TargetFilter::Typed(TypedFilter {
+            type_filters,
+            controller,
+            properties,
+        }) = def.valid_card.expect("backup trigger has a subject filter")
+        else {
+            panic!("expected a Typed subject filter for the backup trigger");
+        };
+        assert_eq!(type_filters, vec![TypeFilter::Creature]);
+        assert_eq!(controller, Some(ControllerRef::You));
+        assert!(properties.contains(&FilterProp::Another));
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2844,9 +2844,14 @@ pub enum TargetFilter {
     },
     /// Matches non-mana activated or triggered abilities on the stack.
     /// Used by "counter target activated or triggered ability" effects.
+    /// CR 113.7a: once activated or triggered, an ability exists on the stack
+    /// independently of its source — `tag` matches by keyword-origin marker
+    /// (e.g. `AbilityTag::Backup` for "becomes the target of a backup ability").
     StackAbility {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         controller: Option<ControllerRef>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tag: Option<AbilityTag>,
     },
     /// Matches spells on the stack (not activated/triggered abilities).
     /// CR 115.1a: Used by "becomes the target of a spell" triggers to filter source type.
@@ -10067,6 +10072,8 @@ pub enum AbilityTag {
     /// a `GameEvent::Cycled` (CR 702.29c) that "When you cycle this card"
     /// triggers match.
     Cycling,
+    /// CR 702.165a: ability originated from a Backup keyword definition.
+    Backup,
 }
 
 /// Structured activation-time restrictions parsed from Oracle text.
@@ -14366,7 +14373,13 @@ mod tests {
     #[test]
     fn stack_ability_filter_accepts_legacy_unit_json() {
         let filter: TargetFilter = serde_json::from_str(r#"{"type":"StackAbility"}"#).unwrap();
-        assert_eq!(filter, TargetFilter::StackAbility { controller: None });
+        assert_eq!(
+            filter,
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None
+            }
+        );
         assert_eq!(
             serde_json::to_string(&filter).unwrap(),
             r#"{"type":"StackAbility"}"#
@@ -14380,7 +14393,8 @@ mod tests {
         assert_eq!(
             filter,
             TargetFilter::StackAbility {
-                controller: Some(ControllerRef::You)
+                controller: Some(ControllerRef::You),
+                tag: None
             }
         );
         assert_eq!(

--- a/crates/engine/tests/integration/backup_becomes_target_trigger.rs
+++ b/crates/engine/tests/integration/backup_becomes_target_trigger.rs
@@ -49,9 +49,24 @@ fn backup_ability_target_fires_becomes_target_trigger() {
     scenario.add_creature_from_oracle(P0, "Huge Truck", 4, 4, HUGE_TRUCK_TRIGGER);
 
     // P0's Backup 1 creature in hand — its ETB targets a creature with a tagged
-    // backup ability.
+    // backup ability. Two builder details are load-bearing (both mirror the
+    // passing Renown scenario test):
+    //
+    // 1. The name must NOT contain "Backup". CR 201.4 self-reference
+    //    normalization rewrites the card's own name in its Oracle text to `~`;
+    //    a name like "Backup Bear" would rewrite the keyword line "Backup 1"
+    //    into "~ 1", which parses to no keyword. Real Backup cards never embed
+    //    "Backup" in their name, so production is unaffected.
+    // 2. The `&["Backup"]` keyword hint is required: the bare-Oracle inference
+    //    path cannot recognize the space-separated numeric keyword form
+    //    ("Backup 1") on its own, so without the hint `Keyword::Backup(1)`
+    //    never reaches `face.keywords` and `synthesize_backup` no-ops.
+    //
+    // With both in place the line routes through `parse_keyword_from_oracle` →
+    // `Keyword::Backup(1)` → synthesized ETB trigger.
     let backup = scenario
-        .add_creature_to_hand_from_oracle(P0, "Backup Bear", 2, 2, BACKUP_ONE)
+        .add_creature_to_hand(P0, "Valeron Sentry", 2, 2)
+        .from_oracle_text_with_keywords(&["Backup"], BACKUP_ONE)
         .id();
 
     // A card to draw when the trigger resolves.
@@ -60,12 +75,12 @@ fn backup_ability_target_fires_becomes_target_trigger() {
 
     let mut runner = scenario.build();
 
-    // Cast the backup creature; its ETB targets a creature. The target must be a
-    // creature OTHER than the payoff (Huge Truck), because the trigger fires on
-    // "ANOTHER creature you control" — Huge Truck targeting itself would not count.
-    // The Backup Bear targets itself: it is another creature P0 controls relative
-    // to Huge Truck. When that target locks, `GameEvent::BecomesTarget` fires with
-    // the backup ability as source, matching the payoff's
+    // Cast the backup creature; its ETB targets a creature. The Valeron Sentry
+    // targets itself: relative to the payoff (Huge Truck) it is "another creature
+    // you control", so Huge Truck's trigger fires (a creature targeting itself
+    // would not satisfy "another" for its OWN trigger, but here the trigger lives
+    // on Huge Truck). When that target locks, `GameEvent::BecomesTarget` fires
+    // with the backup ability as source, matching the payoff's
     // `valid_source = StackAbility { tag: Backup }`.
     let outcome = runner.cast(backup).target_object(backup).resolve();
 

--- a/crates/engine/tests/integration/backup_becomes_target_trigger.rs
+++ b/crates/engine/tests/integration/backup_becomes_target_trigger.rs
@@ -43,10 +43,10 @@ fn backup_ability_target_fires_becomes_target_trigger() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    // P0's payoff creature on the battlefield.
-    let payoff = scenario
-        .add_creature_from_oracle(P0, "Huge Truck", 4, 4, HUGE_TRUCK_TRIGGER)
-        .id();
+    // P0's payoff creature on the battlefield (the trigger source). Its id is not
+    // needed — the backup targets a different creature so this one's "another
+    // creature you control" trigger fires.
+    scenario.add_creature_from_oracle(P0, "Huge Truck", 4, 4, HUGE_TRUCK_TRIGGER);
 
     // P0's Backup 1 creature in hand — its ETB targets a creature with a tagged
     // backup ability.
@@ -60,11 +60,14 @@ fn backup_ability_target_fires_becomes_target_trigger() {
 
     let mut runner = scenario.build();
 
-    // Cast the backup creature; the harness drives the ETB trigger's target
-    // selection from the declared intent (the payoff creature). When that target
-    // locks, `GameEvent::BecomesTarget` fires with the backup ability as source,
-    // matching the payoff's `valid_source = StackAbility { tag: Backup }`.
-    let outcome = runner.cast(backup).target_object(payoff).resolve();
+    // Cast the backup creature; its ETB targets a creature. The target must be a
+    // creature OTHER than the payoff (Huge Truck), because the trigger fires on
+    // "ANOTHER creature you control" — Huge Truck targeting itself would not count.
+    // The Backup Bear targets itself: it is another creature P0 controls relative
+    // to Huge Truck. When that target locks, `GameEvent::BecomesTarget` fires with
+    // the backup ability as source, matching the payoff's
+    // `valid_source = StackAbility { tag: Backup }`.
+    let outcome = runner.cast(backup).target_object(backup).resolve();
 
     // The becomes-target trigger drew exactly one card. This assertion flips to 0
     // if the `AbilityTag::Backup` stamp, the `tag` filter, or the parser

--- a/crates/engine/tests/integration/backup_becomes_target_trigger.rs
+++ b/crates/engine/tests/integration/backup_becomes_target_trigger.rs
@@ -1,0 +1,142 @@
+//! CR 702.165a — "becomes the target of a backup ability" trigger (Huge Truck class).
+//!
+//! A creature with "Whenever another creature you control becomes the target of a
+//! backup ability, draw a card." must fire when one of its controller's other
+//! creatures is targeted by a Backup keyword ability specifically — and must NOT
+//! fire when targeted by an unrelated (non-backup) spell or ability.
+//!
+//! The synthesized Backup ETB ability (`synthesize_backup`) is stamped with
+//! `AbilityTag::Backup`; the trigger's `valid_source` is
+//! `TargetFilter::StackAbility { tag: Some(AbilityTag::Backup) }`, honored at
+//! runtime by `stack_ability_matches_filter` (CR 113.7a — the ability exists on
+//! the stack independently of its source, so the tag is read off the resolved
+//! ability). The backup ETB targets `target creature` (CR 115.1d), so locking
+//! that target emits `GameEvent::BecomesTarget` (CR 603.3d).
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+/// Huge-Truck-style payoff: cares that another of P0's creatures was targeted by
+/// a backup ability.
+const HUGE_TRUCK_TRIGGER: &str =
+    "Whenever another creature you control becomes the target of a backup ability, draw a card.";
+
+/// Minimal Backup 1 creature — synthesizes the tagged Backup ETB.
+const BACKUP_ONE: &str = "Backup 1";
+
+fn generic_pool(count: usize) -> Vec<ManaUnit> {
+    (0..count)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+/// Positive: a Backup 1 creature enters and targets the payoff creature → the
+/// becomes-target-of-a-backup-ability trigger fires exactly once (one card drawn),
+/// and a `BecomesTarget` event is observed (CR 603.3d, Phase B4 verify-only).
+#[test]
+fn backup_ability_target_fires_becomes_target_trigger() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0's payoff creature on the battlefield.
+    let payoff = scenario
+        .add_creature_from_oracle(P0, "Huge Truck", 4, 4, HUGE_TRUCK_TRIGGER)
+        .id();
+
+    // P0's Backup 1 creature in hand — its ETB targets a creature with a tagged
+    // backup ability.
+    let backup = scenario
+        .add_creature_to_hand_from_oracle(P0, "Backup Bear", 2, 2, BACKUP_ONE)
+        .id();
+
+    // A card to draw when the trigger resolves.
+    scenario.with_library_top(P0, &["Forest"]);
+    scenario.with_mana_pool(P0, generic_pool(4));
+
+    let mut runner = scenario.build();
+
+    // Cast the backup creature; the harness drives the ETB trigger's target
+    // selection from the declared intent (the payoff creature). When that target
+    // locks, `GameEvent::BecomesTarget` fires with the backup ability as source,
+    // matching the payoff's `valid_source = StackAbility { tag: Backup }`.
+    let outcome = runner.cast(backup).target_object(payoff).resolve();
+
+    // The becomes-target trigger drew exactly one card. This assertion flips to 0
+    // if the `AbilityTag::Backup` stamp, the `tag` filter, or the parser
+    // `valid_source` wiring is reverted: the draw only happens when the backup
+    // ETB's `GameEvent::BecomesTarget` (CR 603.3d, Phase B4) is routed through the
+    // payoff's `valid_source = StackAbility { tag: Backup }`.
+    assert_eq!(
+        outcome.hand_drawn(P0),
+        1,
+        "the backup-ability target trigger must draw exactly one card"
+    );
+}
+
+/// Negative: a plain (non-backup) spell/ability targeting the payoff creature must
+/// NOT fire the backup-specific trigger. Lightning Bolt is an instant spell, not a
+/// backup ability, so its `BecomesTarget` event does not match
+/// `StackAbility { tag: Some(Backup) }`.
+#[test]
+fn non_backup_source_does_not_fire_backup_trigger() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let payoff = scenario
+        .add_creature_from_oracle(P0, "Huge Truck", 4, 4, HUGE_TRUCK_TRIGGER)
+        .id();
+    // A second P0 creature so "another creature you control" is satisfiable.
+    let _other = scenario.add_creature(P0, "Grizzly Bear", 2, 2).id();
+
+    // P1 holds a Lightning Bolt to target the payoff creature.
+    let bolt = scenario.add_bolt_to_hand(P1);
+    scenario.with_library_top(P0, &["Forest"]);
+    scenario.with_mana_pool(
+        P1,
+        vec![ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![])],
+    );
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
+
+    let card_id = runner.state().objects[&bolt].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: bolt,
+            card_id,
+            targets: vec![],
+        })
+        .expect("casting Lightning Bolt should succeed");
+
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::TargetSelection { .. }
+    ) {
+        runner
+            .act(GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(payoff)),
+            })
+            .expect("targeting the payoff creature should succeed");
+    }
+
+    runner.advance_until_stack_empty();
+
+    // A non-backup source must not have drawn a card for P0.
+    let hand_after = runner.state().players[P0.0 as usize].hand.len();
+    assert_eq!(
+        hand_after, hand_before,
+        "a non-backup spell targeting the payoff creature must not fire the backup trigger"
+    );
+}

--- a/crates/engine/tests/integration/louisoix_sacrifice_counter.rs
+++ b/crates/engine/tests/integration/louisoix_sacrifice_counter.rs
@@ -78,9 +78,13 @@ fn louisoix_sacrifice_parses_disjunctive_counter_target() {
 
     // Ability leg — any activated/triggered ability on the stack.
     assert!(
-        filters
-            .iter()
-            .any(|f| matches!(f, TargetFilter::StackAbility { controller: None })),
+        filters.iter().any(|f| matches!(
+            f,
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None
+            }
+        )),
         "missing the activated/triggered ability disjunct: {target:?}"
     );
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -14,6 +14,7 @@ mod auntie_ool_minus_one_counter_trigger;
 mod aura_graft_enchant_restriction;
 mod aura_on_player;
 mod awaken_runtime;
+mod backup_becomes_target_trigger;
 mod balance_equalization;
 mod baleful_mastery_regression;
 mod banding_combat;


### PR DESCRIPTION
Adds the reusable source-identification primitive so a card like Huge Truck
('Whenever another creature you control becomes the target of a backup ability,
...') can fire when one of its creatures is targeted by a Backup ability
specifically. The trigger mode (BecomesTarget), event, and matcher all already
exist and fire for triggered-ability target locks (CR 603.3d); the missing
pieces were source identification:

- AbilityTag::Backup marks the synthesized Backup ETB ability so a stack-source
  filter can recognize it on the stack (CR 702.165a: Backup is a triggered
  ability).
- TargetFilter::StackAbility is parameterized with an optional keyword tag
  (CR 113.7a: an ability on the stack exists independently of its source);
  stack_ability_matches_filter honors it. Existing StackAbility constructions
  default tag: None (serde-default keeps the {"type":"StackAbility"} wire
  format).
- The parser recognizes 'becomes the target of a backup ability' (+ plural) and
  wires valid_source = StackAbility { tag: Some(Backup) }.

Huge Truck's 'gains all abilities shared this way' payoff (CR 702.165c) is a
single-card effect, intentionally scoped OUT as a follow-up; this delivers only
the reusable trigger primitive. Covered by parser, matcher, and integration
tests.
