### PR TITLE
fix(engine): strip cast-only copiables from copy tokens and resolve offspring token art

### DIFF
--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -18,7 +18,6 @@ use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::proposed_event::{
     CopyTokenSpec, EtbTapState, ProposedEvent, TokenCharacteristics,
 };
-use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -308,13 +307,15 @@ fn drain_copy_token_resolution(
     });
 }
 
-/// CR 601.2f + CR 603.4: Cast-time triggers copied onto a token permanent are
-/// inert — the token was created, not cast.
-fn is_spell_casting_only_trigger(trig: &TriggerDefinition) -> bool {
+/// CR 601.2f + CR 603.4: Triggers gated on a cast-time additional-cost payment
+/// ("if its offspring cost was paid", "if it was kicked") are inert on a token
+/// copy — the token was created, not cast, so the payment condition can never
+/// hold. Only the payment-gated condition is stripped: persistent battlefield
+/// abilities that *observe* spell casts (Magecraft's `SpellCastOrCopy`,
+/// "whenever you cast a [type] spell" `SpellCast`) are copiable text per
+/// CR 707.2 and must survive on the copy.
+fn is_cast_payment_gated_trigger(trig: &TriggerDefinition) -> bool {
     matches!(
-        trig.mode,
-        TriggerMode::SpellCast | TriggerMode::SpellCastOrCopy
-    ) || matches!(
         trig.condition,
         Some(TriggerCondition::AdditionalCostPaid { .. })
     )
@@ -327,9 +328,9 @@ fn strip_spell_casting_copiable_characteristics(obj: &mut GameObject) {
     obj.keywords.retain(|kw| !kw.is_spell_casting_only());
     obj.base_keywords.retain(|kw| !kw.is_spell_casting_only());
     obj.trigger_definitions
-        .retain(|trig| !is_spell_casting_only_trigger(trig));
+        .retain(|trig| !is_cast_payment_gated_trigger(trig));
     Arc::make_mut(&mut obj.base_trigger_definitions)
-        .retain(|trig| !is_spell_casting_only_trigger(trig));
+        .retain(|trig| !is_cast_payment_gated_trigger(trig));
 }
 
 /// CR 111.10 + CR 702.175a: When a card-related token preset exists (Offspring,
@@ -1077,10 +1078,10 @@ mod tests {
     use crate::game::game_object::DisplaySource;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, ContinuousModification, ControllerRef,
-        CostPaidObjectSnapshot, Effect, FilterProp, ObjectScope, PtValue, QuantityExpr,
-        QuantityModification, QuantityRef, ReplacementDefinition, RoundingMode, TargetFilter,
-        TargetRef, TypeFilter, TypedFilter,
+        AbilityDefinition, AbilityKind, AdditionalCostPaymentSource, ContinuousModification,
+        ControllerRef, CostPaidObjectSnapshot, Effect, FilterProp, ObjectScope, PtValue,
+        QuantityExpr, QuantityModification, QuantityRef, ReplacementDefinition, RoundingMode,
+        TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card::PrintedCardRef;
@@ -1091,6 +1092,7 @@ mod tests {
     use crate::types::mana::ManaColor;
     use crate::types::player::PlayerId;
     use crate::types::replacements::ReplacementEvent;
+    use crate::types::triggers::TriggerMode;
 
     /// CR 707.9b + CR 707.9d: a copy token whose exception sets P/T, replaces
     /// color, and replaces creature subtypes (The Scarab God shape) stamps each
@@ -3181,6 +3183,101 @@ mod tests {
                 Some(TriggerCondition::AdditionalCostPaid { .. })
             )),
             "offspring token must not retain AdditionalCostPaid ETB triggers"
+        );
+    }
+
+    /// CR 707.2 vs CR 601.2f + CR 603.4: copy-token finalization strips only
+    /// cast-payment-gated triggers ("if its offspring cost was paid" / "if it
+    /// was kicked"). Persistent spell-cast observers — Magecraft's
+    /// `SpellCastOrCopy`, generic "whenever you cast a [type] spell"
+    /// `SpellCast` — are copiable battlefield text and must survive on the
+    /// token copy.
+    #[test]
+    fn copy_token_keeps_spell_cast_triggers_strips_payment_gated_triggers() {
+        let mut state = GameState::new_two_player(42);
+
+        let parent_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Archmage Emeritus".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let parent = state.objects.get_mut(&parent_id).unwrap();
+            parent.base_power = Some(2);
+            parent.base_toughness = Some(2);
+            parent.power = Some(2);
+            parent.toughness = Some(2);
+            parent.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec!["Human".to_string(), "Wizard".to_string()],
+            };
+            parent.card_types = parent.base_card_types.clone();
+
+            // Magecraft-style persistent battlefield trigger (CR 707.10 note:
+            // observes casts/copies; it is not itself cast-time bookkeeping).
+            let magecraft = TriggerDefinition::new(TriggerMode::SpellCastOrCopy).description(
+                "Magecraft — Whenever you cast or copy an instant or sorcery spell, draw a card."
+                    .to_string(),
+            );
+            // Offspring-style ETB trigger gated on a cast-time payment.
+            let offspring_etb = TriggerDefinition::new(TriggerMode::ChangesZone)
+                .destination(Zone::Battlefield)
+                .valid_card(TargetFilter::SelfRef)
+                .condition(TriggerCondition::AdditionalCostPaid {
+                    source: AdditionalCostPaymentSource::Any,
+                    variant: None,
+                    kicker_cost: None,
+                    min_count: 1,
+                })
+                .description("offspring etb".to_string());
+            parent.base_trigger_definitions = Arc::new(vec![magecraft, offspring_etb]);
+            parent.trigger_definitions = Arc::clone(&parent.base_trigger_definitions).into();
+        }
+
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::SelfRef,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            },
+            vec![],
+            parent_id,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let token_id = ObjectId(state.next_object_id - 1);
+        let token = state.objects.get(&token_id).unwrap();
+        assert!(token.is_token);
+        assert!(
+            token
+                .trigger_definitions
+                .iter_all()
+                .any(|trig| matches!(trig.mode, TriggerMode::SpellCastOrCopy)),
+            "token copy must keep the persistent Magecraft SpellCastOrCopy trigger (CR 707.2)"
+        );
+        assert!(
+            token
+                .base_trigger_definitions
+                .iter()
+                .any(|trig| matches!(trig.mode, TriggerMode::SpellCastOrCopy)),
+            "copiable base triggers must also keep the SpellCastOrCopy trigger (CR 707.2)"
+        );
+        assert!(
+            !token.trigger_definitions.iter_all().any(|trig| matches!(
+                trig.condition,
+                Some(TriggerCondition::AdditionalCostPaid { .. })
+            )),
+            "token copy must strip cast-payment-gated triggers (CR 601.2f + CR 603.4)"
         );
     }
 

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1,10 +1,11 @@
 use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::game::game_object::{DisplaySource, GameObject};
 use crate::game::layers::compute_current_copiable_values;
 use crate::game::quantity::resolve_quantity;
 use crate::game::{targeting, zones};
 use crate::types::ability::{
     ContinuousModification, Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter,
-    TargetRef,
+    TargetRef, TriggerCondition, TriggerDefinition,
 };
 use crate::types::card_type::SubtypeSet;
 #[cfg(test)]
@@ -14,7 +15,10 @@ use crate::types::game_state::{
     GameState, PendingCopyTokenBatch, PendingCopyTokenResolution, PendingCounterPostAction,
 };
 use crate::types::identifiers::{CardId, ObjectId};
-use crate::types::proposed_event::{CopyTokenSpec, EtbTapState, ProposedEvent};
+use crate::types::proposed_event::{
+    CopyTokenSpec, EtbTapState, ProposedEvent, TokenCharacteristics,
+};
+use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -304,6 +308,73 @@ fn drain_copy_token_resolution(
     });
 }
 
+/// CR 601.2f + CR 603.4: Cast-time triggers copied onto a token permanent are
+/// inert — the token was created, not cast.
+fn is_spell_casting_only_trigger(trig: &TriggerDefinition) -> bool {
+    matches!(
+        trig.mode,
+        TriggerMode::SpellCast | TriggerMode::SpellCastOrCopy
+    ) || matches!(
+        trig.condition,
+        Some(TriggerCondition::AdditionalCostPaid { .. })
+    )
+}
+
+/// CR 601.2f + CR 707.2: Remove spell-casting-only copiable characteristics
+/// from a freshly created copy token (Offspring/Kicker keywords, "if it was
+/// kicked" / "if offspring was paid" ETB triggers, etc.).
+fn strip_spell_casting_copiable_characteristics(obj: &mut GameObject) {
+    obj.keywords.retain(|kw| !kw.is_spell_casting_only());
+    obj.base_keywords.retain(|kw| !kw.is_spell_casting_only());
+    obj.trigger_definitions
+        .retain(|trig| !is_spell_casting_only_trigger(trig));
+    Arc::make_mut(&mut obj.base_trigger_definitions)
+        .retain(|trig| !is_spell_casting_only_trigger(trig));
+}
+
+/// CR 111.10 + CR 702.175a: When a card-related token preset exists (Offspring,
+/// set-specific copy tokens), route the copy through the token art database
+/// instead of rendering as a card-copy with a "Copy" badge.
+fn resolve_predefined_token_display(
+    state: &mut GameState,
+    copy_source_id: ObjectId,
+    token_id: ObjectId,
+) {
+    let body = {
+        let token = match state.objects.get(&token_id) {
+            Some(token) if token.display_source == DisplaySource::Card => token,
+            _ => return,
+        };
+        TokenCharacteristics {
+            display_name: token.name.clone(),
+            power: token.power,
+            toughness: token.toughness,
+            core_types: token.card_types.core_types.clone(),
+            subtypes: token.card_types.subtypes.clone(),
+            supertypes: token.card_types.supertypes.clone(),
+            colors: token.color.clone(),
+            keywords: token.keywords.clone(),
+        }
+    };
+    let Some(image_ref) =
+        crate::game::token_presets::find_card_linked_copy_token_ref(state, copy_source_id, &body)
+    else {
+        return;
+    };
+    if let Some(token) = state.objects.get_mut(&token_id) {
+        token.display_source = DisplaySource::Token;
+        token.token_image_ref = Some(image_ref);
+    }
+}
+
+/// CR 707.2: Finalize a copy token after P/T exceptions and cast-only stripping.
+fn finalize_copied_token(state: &mut GameState, copy_source_id: ObjectId, token_id: ObjectId) {
+    if let Some(token) = state.objects.get_mut(&token_id) {
+        strip_spell_casting_copiable_characteristics(token);
+    }
+    resolve_predefined_token_display(state, copy_source_id, token_id);
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn apply_copy_token_after_replacement(
     state: &mut GameState,
@@ -452,6 +523,8 @@ pub(crate) fn apply_copy_token_after_replacement(
                 completion: CopyTokenApplyCompletion::Paused,
             };
         }
+
+        finalize_copied_token(state, source_id, token_id);
 
         // CR 614.1c + CR 122.6a: ETB-counter replacement mutations are carried
         // on the accepted CreateToken spec, even for copy tokens whose full
@@ -608,6 +681,7 @@ pub(crate) fn apply_remaining_token_modifications_after_counter_pause(
     ) {
         return false;
     }
+    finalize_copied_token(state, source_id, token_id);
     if enters_attacking {
         crate::game::combat::enter_attacking(state, token_id, source_id, controller);
     }
@@ -3094,6 +3168,20 @@ mod tests {
         assert_eq!(token.name, "Coruscation Mage");
         assert!(token.card_types.subtypes.contains(&"Wizard".to_string()));
         assert!(token.is_token);
+        assert!(
+            !token
+                .keywords
+                .iter()
+                .any(|kw| matches!(kw, crate::types::keywords::Keyword::Offspring(_))),
+            "offspring token must not retain the cast-only Offspring keyword"
+        );
+        assert!(
+            !token.trigger_definitions.iter_all().any(|trig| matches!(
+                trig.condition,
+                Some(TriggerCondition::AdditionalCostPaid { .. })
+            )),
+            "offspring token must not retain AdditionalCostPaid ETB triggers"
+        );
     }
 
     /// CR 707.9b: dynamic copy exceptions are resolved after the copied values

--- a/crates/engine/src/game/token_presets.rs
+++ b/crates/engine/src/game/token_presets.rs
@@ -171,6 +171,38 @@ pub fn find_exact_token_ref(
     source_id: ObjectId,
     body: &TokenCharacteristics,
 ) -> Option<TokenImageRef> {
+    find_token_ref_with_mode(state, source_id, body, TokenRefMatchMode::Exact)
+}
+
+/// CR 111.10 + CR 702.175a: Resolve a card-linked token preset for a copy
+/// token when the copied body exactly matches a catalog entry. Unlike
+/// [`find_exact_token_ref`], never skips body matching for a sole
+/// `source_related_token_ids` link — Twinflame-style copies keep source P/T and
+/// must not route through an offspring 1/1 preset.
+pub fn find_card_linked_copy_token_ref(
+    state: &GameState,
+    source_id: ObjectId,
+    body: &TokenCharacteristics,
+) -> Option<TokenImageRef> {
+    find_token_ref_with_mode(state, source_id, body, TokenRefMatchMode::CardLinkedCopy)
+}
+
+#[derive(Clone, Copy)]
+enum TokenRefMatchMode {
+    /// `CreateToken` path: a unique `source_related_token_ids` link may resolve
+    /// without a body match when the card names exactly one preset.
+    Exact,
+    /// `CopyTokenOf` path: always require an exact body match so copies that
+    /// keep source P/T (Twinflame, Populate) do not inherit offspring presets.
+    CardLinkedCopy,
+}
+
+fn find_token_ref_with_mode(
+    state: &GameState,
+    source_id: ObjectId,
+    body: &TokenCharacteristics,
+    mode: TokenRefMatchMode,
+) -> Option<TokenImageRef> {
     let source = state.objects.get(&source_id);
     let related_ids = source
         .map(|obj| obj.source_related_token_ids.as_slice())
@@ -191,9 +223,11 @@ pub fn find_exact_token_ref(
             .iter()
             .filter(|preset| related_ids.iter().any(|id| id == &preset.id));
 
-        let first = matches.next()?;
-        if matches.next().is_none() {
-            return first.token_image_ref.clone();
+        if matches!(mode, TokenRefMatchMode::Exact) {
+            let first = matches.next()?;
+            if matches.next().is_none() {
+                return first.token_image_ref.clone();
+            }
         }
 
         let mut matches = known_token_presets().iter().filter(|preset| {

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1206,6 +1206,15 @@ impl Keyword {
     /// casting a spell. A token created by `CopyTokenOf` was not cast, so these
     /// keywords are inert on the copy and are stripped at creation time so the
     /// token does not display cast-only reminders (Offspring, Kicker, etc.).
+    ///
+    /// Maintenance note: every new alternative-cost or additional-cost casting
+    /// keyword added to `Keyword` must also be added here, or token copies of
+    /// permanents carrying it re-introduce the inert-reminder display bug.
+    ///
+    /// Deliberately excluded: `Prototype` — CR 718.2a makes the alternative
+    /// characteristics part of the object's copiable values and CR 718.3d
+    /// treats a copy of a prototyped permanent as itself prototyped, so the
+    /// keyword must survive copying.
     pub fn is_spell_casting_only(&self) -> bool {
         matches!(
             self,
@@ -1241,7 +1250,13 @@ impl Keyword {
                 | Keyword::Suspend { .. }
                 | Keyword::Morph(_)
                 | Keyword::Megamorph(_)
-                | Keyword::Prototype { .. }
+                | Keyword::Disguise(_)
+                | Keyword::Spectacle(_)
+                | Keyword::Surge(_)
+                | Keyword::Overload(_)
+                | Keyword::Splice { .. }
+                | Keyword::Escalate(_)
+                | Keyword::Prowl(_)
                 | Keyword::Impending { .. }
                 | Keyword::MoreThanMeetsTheEye(_)
                 | Keyword::Freerunning(_)

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1202,6 +1202,52 @@ impl Keyword {
         }
     }
 
+    /// CR 601.2f + CR 707.2: Keywords that only function while a player is
+    /// casting a spell. A token created by `CopyTokenOf` was not cast, so these
+    /// keywords are inert on the copy and are stripped at creation time so the
+    /// token does not display cast-only reminders (Offspring, Kicker, etc.).
+    pub fn is_spell_casting_only(&self) -> bool {
+        matches!(
+            self,
+            Keyword::Offspring(_)
+                | Keyword::Kicker(_)
+                | Keyword::Buyback(_)
+                | Keyword::Flashback(_)
+                | Keyword::Retrace
+                | Keyword::Blitz(_)
+                | Keyword::Dash(_)
+                | Keyword::Sneak(_)
+                | Keyword::Ninjutsu(_)
+                | Keyword::Mutate(_)
+                | Keyword::Escape { .. }
+                | Keyword::Foretell(_)
+                | Keyword::Plot(_)
+                | Keyword::Miracle(_)
+                | Keyword::Gift(_)
+                | Keyword::Bargain
+                | Keyword::Replicate(_)
+                | Keyword::Squad(_)
+                | Keyword::Conspire
+                | Keyword::Harmonize(_)
+                | Keyword::Casualty(_)
+                | Keyword::Aftermath
+                | Keyword::Disturb(_)
+                | Keyword::JumpStart
+                | Keyword::Cipher
+                | Keyword::Evoke(_)
+                | Keyword::Emerge(_)
+                | Keyword::Bestow(_)
+                | Keyword::Madness(_)
+                | Keyword::Suspend { .. }
+                | Keyword::Morph(_)
+                | Keyword::Megamorph(_)
+                | Keyword::Prototype { .. }
+                | Keyword::Impending { .. }
+                | Keyword::MoreThanMeetsTheEye(_)
+                | Keyword::Freerunning(_)
+        )
+    }
+
     /// CR 113.2c: keywords whose multiple instances each function separately AND
     /// are printed in Oracle text as repeated bare words, so every printed
     /// occurrence must survive as a distinct `Keyword` on the card face (MTGJSON

--- a/crates/engine/tests/integration/issue_924_offspring.rs
+++ b/crates/engine/tests/integration/issue_924_offspring.rs
@@ -1,0 +1,178 @@
+//! Issue #924: Iridescent Vinelasher — Offspring creates the token but also
+//! incorrectly labels the original creature as a copy/offspring.
+
+use engine::game::game_object::DisplaySource;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::TriggerCondition;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaColor, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const VINELASHER_ORACLE: &str = "\
+Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\n\
+Landfall — Whenever a land you control enters, this creature deals 1 damage to target opponent.";
+
+fn fund_mana(runner: &mut GameRunner, count: usize) {
+    let p0 = runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap();
+    for _ in 0..count {
+        p0.mana_pool.add(ManaUnit {
+            color: ManaType::Colorless,
+            source_id: engine::types::identifiers::ObjectId(0),
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: Vec::new(),
+            grants: vec![],
+            expiry: None,
+        });
+    }
+}
+
+fn pass_until_priority(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        if matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+            && runner.state().stack.is_empty()
+        {
+            break;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+}
+
+#[test]
+fn offspring_cast_creates_token_without_labeling_original_as_copy() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::Black);
+
+    let spell_id = scenario
+        .add_creature_to_hand_from_oracle(P0, "Iridescent Vinelasher", 1, 2, VINELASHER_ORACLE)
+        .with_subtypes(vec!["Lizard", "Assassin"])
+        .id();
+
+    let mut runner = scenario.build();
+    {
+        let obj = runner.state_mut().objects.get_mut(&spell_id).unwrap();
+        obj.color = vec![ManaColor::Black];
+        obj.base_color = vec![ManaColor::Black];
+    }
+    let card_id = runner.state().objects[&spell_id].card_id;
+    fund_mana(&mut runner, 5);
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+        })
+        .expect("cast should start");
+
+    // Pay offspring optional cost during casting (CR 601.2f).
+    loop {
+        match &runner.state().waiting_for {
+            WaitingFor::OptionalCostChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalCost { pay: true })
+                    .expect("pay offspring");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner.act(GameAction::PassPriority).expect("pay mana");
+            }
+            WaitingFor::Priority { .. } => break,
+            other => panic!("unexpected waiting_for during cast: {other:?}"),
+        }
+    }
+
+    // Resolve the spell and offspring ETB trigger.
+    pass_until_priority(&mut runner);
+
+    let battlefield: Vec<_> = runner
+        .state()
+        .battlefield
+        .iter()
+        .filter_map(|id| runner.state().objects.get(id).map(|o| (*id, o)))
+        .filter(|(_, o)| o.card_types.core_types.contains(&CoreType::Creature))
+        .collect();
+
+    assert_eq!(
+        battlefield.len(),
+        2,
+        "expected parent + offspring token creatures on battlefield, got {battlefield:?}"
+    );
+
+    let (parent_id, parent) = battlefield
+        .iter()
+        .find(|(_, o)| !o.is_token)
+        .map(|(id, o)| (*id, o))
+        .expect("parent creature");
+    let (token_id, token) = battlefield
+        .iter()
+        .find(|(_, o)| o.is_token)
+        .map(|(id, o)| (*id, o))
+        .expect("offspring token");
+
+    assert_ne!(parent_id, token_id);
+
+    // Original must remain a real card, not a token/copy.
+    assert!(!parent.is_token, "parent must not be marked is_token");
+    assert_eq!(parent.display_source, DisplaySource::Card);
+    assert_eq!(parent.power, Some(1), "parent keeps printed power");
+    assert_eq!(parent.toughness, Some(2), "parent keeps printed toughness");
+    assert!(
+        parent
+            .keywords
+            .iter()
+            .any(|kw| matches!(kw, Keyword::Offspring(_))),
+        "parent retains printed Offspring keyword"
+    );
+
+    // Offspring token is 1/1 per CR 702.175a and uses predefined token art.
+    assert!(token.is_token);
+    assert_eq!(token.power, Some(1));
+    assert_eq!(token.toughness, Some(1));
+    assert_eq!(
+        token.display_source,
+        DisplaySource::Token,
+        "offspring token must use token art, not card-copy display"
+    );
+    assert!(
+        token.token_image_ref.is_some(),
+        "offspring token must carry a resolved token_image_ref"
+    );
+    assert!(
+        !token
+            .keywords
+            .iter()
+            .any(|kw| matches!(kw, Keyword::Offspring(_))),
+        "offspring token must not display cast-only Offspring keyword"
+    );
+    assert!(
+        !token
+            .trigger_definitions
+            .iter_unchecked()
+            .any(|trig| matches!(
+                trig.condition,
+                Some(TriggerCondition::AdditionalCostPaid { .. })
+            )),
+        "offspring token must not retain offspring ETB trigger"
+    );
+    assert!(
+        token.trigger_definitions.iter_unchecked().any(|trig| trig
+            .description
+            .as_deref()
+            .is_some_and(|d| d.contains("land you control enters"))),
+        "offspring token keeps copied landfall trigger"
+    );
+
+    // Token should not inherit cast-time payment metadata (would re-fire offspring).
+    assert_eq!(token.additional_cost_payment_count, 0);
+}

--- a/crates/engine/tests/integration/issue_924_offspring.rs
+++ b/crates/engine/tests/integration/issue_924_offspring.rs
@@ -173,6 +173,8 @@ fn offspring_cast_creates_token_without_labeling_original_as_copy() {
         "offspring token keeps copied landfall trigger"
     );
 
-    // Token should not inherit cast-time payment metadata (would re-fire offspring).
+    // Sanity invariant (not new behavior in this fix): `reset_for_battlefield_entry`
+    // already zeroes cast-time payment metadata at token creation; the
+    // discriminating assertion for this fix is the trigger strip above.
     assert_eq!(token.additional_cost_payment_count, 0);
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -128,6 +128,7 @@ mod issue_580_solitude_evoke_prompt;
 mod issue_709_regression;
 mod issue_860_luminarch_aspirant;
 mod issue_879_obsessive_pursuit;
+mod issue_924_offspring;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;
 mod kaito_integration;


### PR DESCRIPTION
## Summary

Fixes [#924](https://github.com/phase-rs/phase/issues/924) — when Offspring is paid on cards like Iridescent Vinelasher, the offspring token was created correctly but both the token and the original looked wrong:

- The **token** kept cast-only copiable characteristics (`Offspring` keyword, `AdditionalCostPaid` ETB trigger) copied from the parent.
- The **token** used `display_source = Card`, so the frontend showed the **"Copy"** badge instead of the predefined offspring token art from `known-tokens.toml`.

This change finalizes copy tokens after P/T exceptions by:

1. **Stripping spell-casting-only copiables** — cast-only keywords (`Offspring`, `Kicker`, etc.) and triggers (`AdditionalCostPaid`, spell-cast triggers) are removed from the token copy (CR 601.2f / CR 707.2).
2. **Resolving card-linked token presets** — when a copy token's body exactly matches a catalog entry (e.g. Iridescent Vinelasher 1/1), set `display_source = Token` and `token_image_ref` so the UI uses token art, not a card-copy badge (CR 111.10 / CR 702.175a).
3. **Strict body matching for copy tokens** — new `find_card_linked_copy_token_ref` requires an exact body match so Twinflame-style copies (same P/T as source) don't accidentally pick up offspring 1/1 presets.

The original creature is unchanged: it remains a normal card with printed Offspring and cast-time payment metadata.

## Test plan

- [x] `cargo test -p engine offspring`
- [x] `cargo test -p engine token_copy::tests`
- [x] New integration test: `issue_924_offspring::offspring_cast_creates_token_without_labeling_original_as_copy`
- [ ] Manual: cast Iridescent Vinelasher with offspring paid — parent shows Offspring keyword, token shows token art (no "Copy" badge), token has landfall but no offspring ETB trigger