### PR TITLE
style(client): theme native number input steppers for dark UI

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -193,13 +193,17 @@ body {
   -webkit-touch-callout: default;
 }
 
-/* Number input steppers — replace default light-grey Chrome/Edge spin buttons with
-   hairline-dark chrome consistent with .thin-scrollbar and form fields.
+/* Number input steppers — deliberately global (unlike class-scoped .thin-scrollbar)
+   so every number field app-wide gets consistent chrome without per-component classes.
+   Replaces default light-grey Chrome/Edge spin buttons with hairline-dark styling.
    Custom hover-reveal steppers are pointer-fine only: the 16px control is below
    the 44pt touch-target rule and :hover is unreliable on coarse pointers. Touch
-   devices keep native steppers tinted via html { color-scheme: dark }. */
+   devices keep native steppers tinted via html { color-scheme: dark }.
+   Firefox: appearance:textfield removes native spinners (no ::-webkit-* equivalent);
+   keyboard arrows and direct typing still work — intentional tradeoff. */
 input[type="number"] {
   -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 @media (pointer: fine) {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -152,6 +152,10 @@
   }
 }
 
+html {
+  color-scheme: dark;
+}
+
 body {
   background:
     radial-gradient(circle at top, rgba(251, 146, 60, 0.12), transparent 30%),
@@ -187,6 +191,46 @@ body {
   -webkit-user-select: text;
   user-select: text;
   -webkit-touch-callout: default;
+}
+
+/* Number input steppers — replace default light-grey Chrome/Edge spin buttons with
+   hairline-dark chrome consistent with .thin-scrollbar and form fields. */
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  opacity: 0;
+  width: 0;
+  height: 1.25rem;
+  margin-left: 0;
+  pointer-events: none;
+  cursor: pointer;
+  background-color: rgba(255, 255, 255, 0.08);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 10'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M4 0 8 4H0zM0 6h8l-4 4z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 0.5rem 0.625rem;
+  border-radius: 4px;
+  transition:
+    opacity 150ms ease,
+    width 150ms ease,
+    margin-left 150ms ease,
+    background-color 150ms ease;
+}
+
+input[type="number"]:hover::-webkit-inner-spin-button,
+input[type="number"]:focus::-webkit-inner-spin-button {
+  opacity: 1;
+  width: 1rem;
+  margin-left: 0.125rem;
+  pointer-events: auto;
+}
+
+input[type="number"]:hover::-webkit-inner-spin-button:hover,
+input[type="number"]:focus::-webkit-inner-spin-button:hover {
+  background-color: rgba(255, 255, 255, 0.14);
 }
 
 .menu-display {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -194,43 +194,48 @@ body {
 }
 
 /* Number input steppers — replace default light-grey Chrome/Edge spin buttons with
-   hairline-dark chrome consistent with .thin-scrollbar and form fields. */
+   hairline-dark chrome consistent with .thin-scrollbar and form fields.
+   Custom hover-reveal steppers are pointer-fine only: the 16px control is below
+   the 44pt touch-target rule and :hover is unreliable on coarse pointers. Touch
+   devices keep native steppers tinted via html { color-scheme: dark }. */
 input[type="number"] {
   -moz-appearance: textfield;
 }
 
-input[type="number"]::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  opacity: 0;
-  width: 0;
-  height: 1.25rem;
-  margin-left: 0;
-  pointer-events: none;
-  cursor: pointer;
-  background-color: rgba(255, 255, 255, 0.08);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 10'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M4 0 8 4H0zM0 6h8l-4 4z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 0.5rem 0.625rem;
-  border-radius: 4px;
-  transition:
-    opacity 150ms ease,
-    width 150ms ease,
-    margin-left 150ms ease,
-    background-color 150ms ease;
-}
+@media (pointer: fine) {
+  input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    opacity: 0;
+    width: 0;
+    height: 1.25rem;
+    margin-left: 0;
+    pointer-events: none;
+    cursor: pointer;
+    background-color: rgba(255, 255, 255, 0.08);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 10'%3E%3Cpath fill='rgba(255,255,255,0.55)' d='M4 0 8 4H0zM0 6h8l-4 4z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 0.5rem 0.625rem;
+    border-radius: 4px;
+    transition:
+      opacity 150ms ease,
+      width 150ms ease,
+      margin-left 150ms ease,
+      background-color 150ms ease;
+  }
 
-input[type="number"]:hover::-webkit-inner-spin-button,
-input[type="number"]:focus::-webkit-inner-spin-button {
-  opacity: 1;
-  width: 1rem;
-  margin-left: 0.125rem;
-  pointer-events: auto;
-}
+  input[type="number"]:hover::-webkit-inner-spin-button,
+  input[type="number"]:focus::-webkit-inner-spin-button {
+    opacity: 1;
+    width: 1rem;
+    margin-left: 0.125rem;
+    pointer-events: auto;
+  }
 
-input[type="number"]:hover::-webkit-inner-spin-button:hover,
-input[type="number"]:focus::-webkit-inner-spin-button:hover {
-  background-color: rgba(255, 255, 255, 0.14);
+  input[type="number"]:hover::-webkit-inner-spin-button:hover,
+  input[type="number"]:focus::-webkit-inner-spin-button:hover {
+    background-color: rgba(255, 255, 255, 0.14);
+  }
 }
 
 .menu-display {


### PR DESCRIPTION
## Summary

Improves the appearance of native number input controls across the application by aligning browser-provided steppers with the existing dark theme.

### Changes

* Enable `color-scheme: dark` on the root document so native form controls adopt dark-mode styling where supported
* Add global number-input stepper styling in `index.css`
* Replace bright browser-default spinner chrome with subtle dark-theme styling consistent with existing scrollbar controls
* Hide steppers by default and reveal them on hover or focus for a cleaner UI
* Apply the behavior consistently across all number inputs without requiring per-component overrides

## Motivation

Several number inputs throughout the application displayed bright grey browser-default steppers that contrasted with the dark interface. Examples include:

* Play setup → Starting Life
* Cube Draft setup → Seats, Packs, Pack Size, Min Deck

This change provides a single global solution that keeps number inputs visually consistent with the rest of the application's dark UI while preserving native increment/decrement functionality.

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/d74130a8-b5f2-4511-bb85-1007b3e1831d" />

### After

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/bcca0756-00b9-4c71-b53b-f6c323afd3e0" />

## Checklist

* [x] Responsive/mobile checked
* [x] Uses existing theme styling patterns
* [x] No component-specific overrides required
* [x] Tested across affected number-input controls

## Test Plan

* [ ] Open **Play Setup** and verify the **Starting Life** input displays themed steppers on hover/focus
* [ ] Open **Draft → Cube** setup and verify **Seats**, **Packs**, **Pack Size**, and **Min Deck** inputs behave consistently
* [ ] Confirm steppers remain hidden when the input is idle
* [ ] Confirm steppers appear on hover
* [ ] Confirm steppers remain visible while the input is focused
* [ ] Verify increment/decrement functionality still works correctly
* [ ] Spot-check other number inputs (Lobby Host Setup, Deck Builder, etc.) for consistent styling
