### PR TITLE
fix(engine): resolve enters_under for any player ControllerRef (CR 110.2a)

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -57,20 +57,34 @@ fn tracked_set_member_zones(state: &GameState, filter: &TargetFilter) -> Option<
 }
 
 fn resolve_enters_under_player(
+    state: &GameState,
+    ability: &ResolvedAbility,
     effect_name: &str,
     enters_under: Option<&ControllerRef>,
-    controller: PlayerId,
 ) -> Result<Option<PlayerId>, EffectError> {
-    // CR 110.2a: Resolve controller-override references exactly once at the
-    // resolver boundary, then carry a concrete PlayerId through zone movement.
+    // CR 110.2a: Resolve the controller-override reference to a concrete
+    // `PlayerId` exactly once at the resolver boundary, then carry it through
+    // zone movement. Delegates to the canonical `ControllerRef` resolver so
+    // every player reference resolves consistently: `You` (and the per-iteration
+    // controller under `player_scope`), `ScopedPlayer` ("each player … under
+    // their control"), `TargetPlayer` ("under target player's control"),
+    // `ParentTargetController`, etc. `None` keeps the default (owner's control).
     match enters_under {
         None => Ok(None),
-        Some(ControllerRef::You) => Ok(Some(controller)),
-        Some(other) => Err(EffectError::InvalidParam(format!(
-            "CR 110.2a: {effect_name}.enters_under = {other:?} is not yet \
-             supported by the resolver; only ControllerRef::You maps to a \
-             concrete PlayerId today"
-        ))),
+        Some(cref) => crate::game::filter::controller_ref_player(
+            state,
+            ability.source_id,
+            Some(ability.controller),
+            Some(ability),
+            cref,
+        )
+        .map(Some)
+        .ok_or_else(|| {
+            EffectError::InvalidParam(format!(
+                "CR 110.2a: {effect_name}.enters_under = {cref:?} could not be \
+                 resolved to a concrete controller in this context"
+            ))
+        }),
     }
 }
 
@@ -169,13 +183,11 @@ pub fn resolve(
             // the `EffectZoneChoice` round-trip. This keeps the runtime
             // carrier immune to re-evaluation across an interactive pause
             // and concentrates the `ControllerRef` semantics in one place.
-            // Only `ControllerRef::You` is supported today — any other
-            // variant is a parser bug or an unimplemented engine extension.
-            let enters_under_player = resolve_enters_under_player(
-                "ChangeZone",
-                enters_under.as_ref(),
-                ability.controller,
-            )?;
+            // Resolved via the canonical `ControllerRef` resolver, so any
+            // player reference ("under their/that/target player's control")
+            // maps to a concrete controller (CR 110.2a).
+            let enters_under_player =
+                resolve_enters_under_player(state, ability, "ChangeZone", enters_under.as_ref())?;
             (
                 *origin,
                 *destination,
@@ -817,7 +829,7 @@ pub fn resolve_all(
 
     let enters_under_player: Option<PlayerId> = match &ability.effect {
         Effect::ChangeZoneAll { enters_under, .. } => {
-            resolve_enters_under_player("ChangeZoneAll", enters_under.as_ref(), ability.controller)?
+            resolve_enters_under_player(state, ability, "ChangeZoneAll", enters_under.as_ref())?
         }
         _ => None,
     };
@@ -1177,6 +1189,92 @@ mod tests {
 
         assert!(state.battlefield.contains(&obj_id));
         assert!(!state.players[0].hand.contains(&obj_id));
+    }
+
+    /// CR 110.2a + CR 109.4: "put ... onto the battlefield under target player's
+    /// control" enters the card under the chosen player, not the ability
+    /// controller. Before, any `enters_under` other than `You` errored at the
+    /// resolver; now it routes through the canonical `ControllerRef` resolver.
+    #[test]
+    fn enters_under_target_player_puts_card_under_chosen_player() {
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Card".to_string(),
+            Zone::Hand,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Hand),
+                destination: Zone::Battlefield,
+                target: TargetFilter::Any,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: Some(ControllerRef::TargetPlayer),
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+            vec![TargetRef::Object(obj_id), TargetRef::Player(PlayerId(1))],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(state.battlefield.contains(&obj_id));
+        assert_eq!(
+            state.objects[&obj_id].controller,
+            PlayerId(1),
+            "card must enter under target player's control (CR 110.2a), not the ability controller"
+        );
+    }
+
+    /// CR 110.2a + CR 115.10: "each player puts ... onto the battlefield under
+    /// their control" — under `player_scope` the entering card's controller is
+    /// the scoped (iterating) player, resolved via `ControllerRef::ScopedPlayer`.
+    #[test]
+    fn enters_under_scoped_player_uses_iterating_player() {
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Card".to_string(),
+            Zone::Hand,
+        );
+        let mut ability = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Hand),
+                destination: Zone::Battlefield,
+                target: TargetFilter::Any,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: Some(ControllerRef::ScopedPlayer),
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+            vec![TargetRef::Object(obj_id)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        ability.set_scoped_player_recursive(PlayerId(1));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(state.battlefield.contains(&obj_id));
+        assert_eq!(
+            state.objects[&obj_id].controller,
+            PlayerId(1),
+            "card must enter under the scoped (iterating) player's control"
+        );
     }
 
     /// CR 614.1c + CR 122.1: A creature entering under a controller who has an

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -647,7 +647,7 @@ fn effective_controller(
     obj.controller
 }
 
-fn controller_ref_player(
+pub(crate) fn controller_ref_player(
     state: &GameState,
     source_id: ObjectId,
     source_controller: Option<PlayerId>,


### PR DESCRIPTION
## Summary
Fixes the engine side of #2813 (CR 110.2a). `resolve_enters_under_player` (`game/effects/change_zone.rs`) only mapped `ControllerRef::You` to a concrete `PlayerId` and returned `Err("not yet supported")` for every other variant. So any effect that puts a card onto the battlefield **under a player other than the ability controller** — "under their control" (each-player), "under target player's control", "that permanent's controller puts ..." — failed mid-resolution. This is a silent class gap: the card parses (the `enters_under` carrier is produced), so coverage counted it "supported," but `Effect::ChangeZone` / `Effect::ChangeZoneAll` errored at runtime.

Affected class: each-player / target-player mass put-into-play and reanimation (Tempting Wurm, Show and Tell, Hypergenesis, Warp World, Scrambleverse, "under target player's control" reanimation, …).

## Change
- `game/filter.rs` — make `controller_ref_player` (the single authority for `ControllerRef -> PlayerId`) `pub(crate)`.
- `game/effects/change_zone.rs` — `resolve_enters_under_player` now delegates to `controller_ref_player`, threading `state` + `ability`, so every player reference resolves consistently: `You`, `ScopedPlayer` (CR 115.10 / 608.2c), `TargetPlayer` (CR 109.4), `ParentTargetController`, etc. Both call sites (`ChangeZone`, `ChangeZoneAll`) updated.
- `None` still means the owner's control. A `ControllerRef` that genuinely cannot resolve to a single player in this context (e.g. bare `Opponent` in multiplayer with no target) keeps the explicit `Err` — no silent guessing, exhaustive match, no new engine variant.

## Tests
- `enters_under_target_player_puts_card_under_chosen_player` — card enters under the chosen `TargetPlayer`, not the ability controller.
- `enters_under_scoped_player_uses_iterating_player` — under `player_scope`, the card enters under the scoped (iterating) player.
- The pre-existing `change_zone_all_strict_fails_on_unsupported_enters_under_controller_ref` still passes, confirming the strict-fail invariant is preserved for genuinely-unresolvable refs.
- Full engine suite green (11,234 passed); `clippy -D warnings` and `fmt` clean.

Fixes #2813
