### PR TITLE
fix(match-setup): improve mobile format picker modal layout and stacking

### DIFF
--- a/client/src/components/menu/FormatPicker.tsx
+++ b/client/src/components/menu/FormatPicker.tsx
@@ -69,26 +69,26 @@ interface FormatPickerProps {
 
 export function FormatPicker({ onFormatSelect }: FormatPickerProps) {
   return (
-    <div className="flex w-full max-w-3xl flex-col gap-8 px-4">
+    <div className="flex w-full max-w-3xl flex-col gap-6 sm:gap-8">
       {FORMAT_GROUPS.map((group) => {
         const tone = GROUP_TONES[group.tone];
         return (
-          <div key={group.label} className="flex flex-col gap-3">
+          <div key={group.label} className="flex flex-col gap-2.5 sm:gap-3">
             <span className={`text-[0.68rem] uppercase tracking-[0.22em] ${tone.kicker}`}>
               {group.label}
             </span>
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:gap-3 lg:grid-cols-3 xl:grid-cols-4">
               {group.formats.map((opt) => (
                 <button
                   key={opt.format}
                   onClick={() => onFormatSelect(opt.format)}
-                  className={`group relative flex flex-col overflow-hidden rounded-[18px] border px-4 py-4 text-left transition-colors ${tone.border} ${tone.bg} ${tone.hover} cursor-pointer`}
+                  className={`group relative flex flex-col overflow-hidden rounded-[18px] border px-4 py-3.5 text-left transition-colors sm:py-4 ${tone.border} ${tone.bg} ${tone.hover} cursor-pointer`}
                 >
-                  <div className={`absolute inset-y-4 left-0 w-[3px] rounded-r ${tone.accent}`} />
-                  <div className="text-[1.05rem] font-semibold text-white">
+                  <div className={`absolute inset-y-3.5 left-0 w-[3px] rounded-r sm:inset-y-4 ${tone.accent}`} />
+                  <div className="text-base font-semibold text-white sm:text-[1.05rem]">
                     {opt.label}
                   </div>
-                  <p className="mt-1.5 text-[0.78rem] leading-5 text-slate-400">
+                  <p className="mt-1 text-[0.78rem] leading-5 text-slate-400">
                     {opt.description}
                   </p>
                 </button>

--- a/client/src/components/ui/ModalPanelShell.tsx
+++ b/client/src/components/ui/ModalPanelShell.tsx
@@ -1,4 +1,6 @@
 import { AnimatePresence, motion } from "framer-motion";
+import { useId } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 interface ModalPanelShellProps {
@@ -21,11 +23,12 @@ export function ModalPanelShell({
   bodyClassName = "",
 }: ModalPanelShellProps) {
   const { t } = useTranslation();
+  const titleId = useId();
   const resolvedEyebrow = eyebrow ?? t("modal.defaultEyebrow");
-  return (
+  return createPortal(
     <AnimatePresence>
       <motion.div
-        className="fixed inset-0 z-50 flex items-stretch px-0 py-0 lg:items-center lg:justify-center lg:px-4 lg:py-6"
+        className="fixed inset-0 z-[60] flex items-stretch px-0 py-0 lg:items-center lg:justify-center lg:px-4 lg:py-6"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
@@ -39,40 +42,49 @@ export function ModalPanelShell({
         />
 
         <motion.div
-          className={`card-scale-reset relative z-10 flex h-full w-full flex-col overflow-hidden border-white/10 bg-[#0b1020]/96 shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-md lg:h-auto lg:max-h-[calc(100vh_-_3rem_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] lg:rounded-[24px] lg:border ${maxWidthClassName}`}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          className={`card-scale-reset relative z-10 flex h-full w-full flex-col overflow-hidden border-white/10 bg-[#0b1020]/96 pt-[env(safe-area-inset-top)] shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-md lg:h-auto lg:max-h-[calc(100vh_-_3rem_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] lg:rounded-[24px] lg:border lg:pt-0 ${maxWidthClassName}`}
           initial={{ scale: 0.97, opacity: 0, y: 10 }}
           animate={{ scale: 1, opacity: 1, y: 0 }}
           exit={{ scale: 0.97, opacity: 0, y: 10 }}
           transition={{ duration: 0.2, ease: "easeOut" }}
+          onClick={(e) => e.stopPropagation()}
         >
-          <div className="flex items-start justify-between gap-2 border-b border-white/10 px-2 py-1.5 lg:gap-4 lg:px-6 lg:py-5">
+          <div className="flex items-start justify-between gap-3 border-b border-white/10 px-4 py-4 lg:gap-4 lg:px-6 lg:py-5">
             <div className="min-w-0">
               {resolvedEyebrow && (
-                <div className="text-[0.55rem] uppercase tracking-[0.22em] text-slate-500 lg:text-[0.68rem]">
+                <div className="text-[0.62rem] uppercase tracking-[0.22em] text-slate-500 lg:text-[0.68rem]">
                   {resolvedEyebrow}
                 </div>
               )}
-              <h2 className="mt-0.5 text-sm font-semibold text-white lg:mt-1 lg:text-xl">{title}</h2>
+              <h2 id={titleId} className="mt-1 text-lg font-semibold text-white lg:text-xl">
+                {title}
+              </h2>
               {subtitle && (
-                <p className="mt-1 text-xs text-slate-400 lg:text-sm">{subtitle}</p>
+                <p className="mt-1 text-sm text-slate-400">{subtitle}</p>
               )}
             </div>
             <button
               onClick={onClose}
-              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[10px] border border-white/10 bg-black/18 text-slate-400 transition hover:bg-white/6 hover:text-white lg:h-11 lg:w-11 lg:rounded-[16px]"
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border border-white/10 bg-black/18 text-slate-400 transition hover:bg-white/6 hover:text-white lg:h-11 lg:w-11 lg:rounded-[16px]"
               aria-label={t("actions.closeNamed", { name: title })}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5 lg:h-5 lg:w-5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 lg:h-5 lg:w-5">
                 <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
               </svg>
             </button>
           </div>
 
-          <div className={`thin-scrollbar min-h-0 flex-1 pb-[env(safe-area-inset-bottom)] ${bodyClassName}`}>
+          <div
+            className={`thin-scrollbar min-h-0 flex-1 pb-[calc(1rem+env(safe-area-inset-bottom))] lg:pb-[env(safe-area-inset-bottom)] ${bodyClassName}`}
+          >
             {children}
           </div>
         </motion.div>
       </motion.div>
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 }

--- a/client/src/components/ui/ModalPanelShell.tsx
+++ b/client/src/components/ui/ModalPanelShell.tsx
@@ -4,6 +4,8 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 interface ModalPanelShellProps {
+  /** When false, runs the exit animation before removing portal content. */
+  open?: boolean;
   title: string;
   subtitle?: string;
   onClose: () => void;
@@ -14,6 +16,7 @@ interface ModalPanelShellProps {
 }
 
 export function ModalPanelShell({
+  open = true,
   title,
   subtitle,
   onClose,
@@ -27,63 +30,66 @@ export function ModalPanelShell({
   const resolvedEyebrow = eyebrow ?? t("modal.defaultEyebrow");
   return createPortal(
     <AnimatePresence>
-      <motion.div
-        className="fixed inset-0 z-[60] flex items-stretch px-0 py-0 lg:items-center lg:justify-center lg:px-4 lg:py-6"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.18 }}
-      >
-        <button
-          type="button"
-          className="absolute inset-0 bg-black/68 backdrop-blur-[2px]"
-          onClick={onClose}
-          aria-label={t("actions.closeNamed", { name: title })}
-        />
-
+      {open && (
         <motion.div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby={titleId}
-          className={`card-scale-reset relative z-10 flex h-full w-full flex-col overflow-hidden border-white/10 bg-[#0b1020]/96 pt-[env(safe-area-inset-top)] shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-md lg:h-auto lg:max-h-[calc(100vh_-_3rem_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] lg:rounded-[24px] lg:border lg:pt-0 ${maxWidthClassName}`}
-          initial={{ scale: 0.97, opacity: 0, y: 10 }}
-          animate={{ scale: 1, opacity: 1, y: 0 }}
-          exit={{ scale: 0.97, opacity: 0, y: 10 }}
-          transition={{ duration: 0.2, ease: "easeOut" }}
-          onClick={(e) => e.stopPropagation()}
+          key="modal-panel-shell"
+          className="fixed inset-0 z-[60] flex items-stretch px-0 py-0 lg:items-center lg:justify-center lg:px-4 lg:py-6"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18 }}
         >
-          <div className="flex items-start justify-between gap-3 border-b border-white/10 px-4 py-4 lg:gap-4 lg:px-6 lg:py-5">
-            <div className="min-w-0">
-              {resolvedEyebrow && (
-                <div className="text-[0.62rem] uppercase tracking-[0.22em] text-slate-500 lg:text-[0.68rem]">
-                  {resolvedEyebrow}
-                </div>
-              )}
-              <h2 id={titleId} className="mt-1 text-lg font-semibold text-white lg:text-xl">
-                {title}
-              </h2>
-              {subtitle && (
-                <p className="mt-1 text-sm text-slate-400">{subtitle}</p>
-              )}
-            </div>
-            <button
-              onClick={onClose}
-              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border border-white/10 bg-black/18 text-slate-400 transition hover:bg-white/6 hover:text-white lg:h-11 lg:w-11 lg:rounded-[16px]"
-              aria-label={t("actions.closeNamed", { name: title })}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 lg:h-5 lg:w-5">
-                <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
-              </svg>
-            </button>
-          </div>
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/68 backdrop-blur-[2px]"
+            onClick={onClose}
+            aria-label={t("actions.closeNamed", { name: title })}
+          />
 
-          <div
-            className={`thin-scrollbar min-h-0 flex-1 pb-[calc(1rem+env(safe-area-inset-bottom))] lg:pb-[env(safe-area-inset-bottom)] ${bodyClassName}`}
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            className={`card-scale-reset relative z-10 flex h-full w-full flex-col overflow-hidden border-white/10 bg-[#0b1020]/96 pt-[env(safe-area-inset-top)] shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-md lg:h-auto lg:max-h-[calc(100vh_-_3rem_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] lg:rounded-[24px] lg:border lg:pt-0 ${maxWidthClassName}`}
+            initial={{ scale: 0.97, opacity: 0, y: 10 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.97, opacity: 0, y: 10 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            onClick={(e) => e.stopPropagation()}
           >
-            {children}
-          </div>
+            <div className="flex items-start justify-between gap-3 border-b border-white/10 px-4 py-4 lg:gap-4 lg:px-6 lg:py-5">
+              <div className="min-w-0">
+                {resolvedEyebrow && (
+                  <div className="text-[0.62rem] uppercase tracking-[0.22em] text-slate-500 lg:text-[0.68rem]">
+                    {resolvedEyebrow}
+                  </div>
+                )}
+                <h2 id={titleId} className="mt-1 text-lg font-semibold text-white lg:text-xl">
+                  {title}
+                </h2>
+                {subtitle && (
+                  <p className="mt-1 text-sm text-slate-400">{subtitle}</p>
+                )}
+              </div>
+              <button
+                onClick={onClose}
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border border-white/10 bg-black/18 text-slate-400 transition hover:bg-white/6 hover:text-white lg:h-11 lg:w-11 lg:rounded-[16px]"
+                aria-label={t("actions.closeNamed", { name: title })}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 lg:h-5 lg:w-5">
+                  <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+                </svg>
+              </button>
+            </div>
+
+            <div
+              className={`thin-scrollbar min-h-0 flex-1 pb-[calc(1rem_+_env(safe-area-inset-bottom))] lg:pb-[env(safe-area-inset-bottom)] ${bodyClassName}`}
+            >
+              {children}
+            </div>
+          </motion.div>
         </motion.div>
-      </motion.div>
+      )}
     </AnimatePresence>,
     document.body,
   );

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -539,7 +539,7 @@ export function GameSetupPage() {
           subtitle={t("gameSetup.formatPicker.subtitle")}
           onClose={() => setFormatPickerOpen(false)}
           maxWidthClassName="max-w-3xl"
-          bodyClassName="overflow-y-auto px-2 py-4 lg:px-6 lg:py-6"
+          bodyClassName="overflow-y-auto px-4 py-4 lg:px-6 lg:py-6"
         >
           <FormatPicker
             onFormatSelect={(format) => {

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -532,23 +532,22 @@ export function GameSetupPage() {
         </div>
       </MenuShell>
 
-      {formatPickerOpen && (
-        <ModalPanelShell
-          eyebrow={t("gameSetup.eyebrow")}
-          title={t("gameSetup.formatPicker.title")}
-          subtitle={t("gameSetup.formatPicker.subtitle")}
-          onClose={() => setFormatPickerOpen(false)}
-          maxWidthClassName="max-w-3xl"
-          bodyClassName="overflow-y-auto px-4 py-4 lg:px-6 lg:py-6"
-        >
-          <FormatPicker
-            onFormatSelect={(format) => {
-              applyFormat(format);
-              setFormatPickerOpen(false);
-            }}
-          />
-        </ModalPanelShell>
-      )}
+      <ModalPanelShell
+        open={formatPickerOpen}
+        eyebrow={t("gameSetup.eyebrow")}
+        title={t("gameSetup.formatPicker.title")}
+        subtitle={t("gameSetup.formatPicker.subtitle")}
+        onClose={() => setFormatPickerOpen(false)}
+        maxWidthClassName="max-w-3xl"
+        bodyClassName="overflow-y-auto px-4 py-4 lg:px-6 lg:py-6"
+      >
+        <FormatPicker
+          onFormatSelect={(format) => {
+            applyFormat(format);
+            setFormatPickerOpen(false);
+          }}
+        />
+      </ModalPanelShell>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes several mobile usability issues in the Match Setup format picker dialog, including modal stacking problems, cramped card layouts, and safe-area spacing.

### Changes

* Portal `ModalPanelShell` to `document.body` and increase its z-index to `z-[60]` so the modal consistently renders above the mobile tab bar and other application chrome
* Improve mobile modal presentation with:

  * Safe-area-aware top spacing
  * Larger title and close button targets
  * Additional bottom scroll padding
* Update `FormatPicker` to use a single-column layout on narrow screens for improved readability
* Preserve responsive scaling to 2/3/4 columns on larger breakpoints
* Align format picker body padding on `GameSetupPage` using `px-4`

## Motivation

On mobile devices, the format picker dialog could appear underneath parts of the application shell, allowing the tab bar, version badge, and other chrome elements to bleed through the modal. Additionally, the two-column grid made format cards feel cramped and reduced readability on smaller screens.

This update ensures the dialog behaves as a true fullscreen mobile modal while providing a more comfortable browsing experience for format selection.

## Screenshots

### Before

<img width="482" height="760" alt="image" src="https://github.com/user-attachments/assets/877cb88d-9714-4399-b6c1-b00f1e8d8237" />

### After

<img width="418" height="760" alt="image" src="https://github.com/user-attachments/assets/8dfce2db-cc8d-491f-848a-b8dc4b57260d" />

## Checklist

* [x] Responsive/mobile checked
* [x] Desktop layout verified
* [x] Uses existing theme and modal patterns
* [x] No API or data model changes

## Test Plan

* [ ] On mobile (<820px), open **Play → Match Setup → Choose a Format**
* [ ] Verify the dialog covers the full viewport and no tab bar, version badge, or app chrome is visible through the modal
* [ ] Confirm format cards render in a single-column layout and remain fully readable
* [ ] Verify long descriptions are not clipped
* [ ] Scroll to the bottom and confirm the final format group is fully visible above the safe area
* [ ] Select a format and verify the modal closes and the selected format updates correctly
* [ ] On desktop (≥1024px), verify the dialog remains centered with rounded corners and the responsive multi-column layout behaves as before
* [ ] Spot-check other `ModalPanelShell` consumers (Preferences, Printing Picker, Zone Viewer) for regressions related to the portal and z-index changes
