### PR TITLE
fix(deck-builder): honor Seven Dwarves copy-limit override

### DIFF
--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -190,15 +190,26 @@ export function useDeckBuilder({
     };
   }, [deck.main, format, isCommander]);
 
+  // Names whose copy-limit override has already been requested (in flight or
+  // resolved). A card's copy limit is static per name, so once queried it never
+  // needs re-querying — this keeps deck edits and repeated searches from
+  // re-issuing WASM calls for every card in the deck.
+  const queriedCopyLimitNamesRef = useRef<Set<string>>(new Set());
+
   const prefetchDeckCopyLimits = useCallback((names: string[]) => {
-    const unique = Array.from(new Set(names));
+    const unique = Array.from(new Set(names)).filter(
+      (name) => !queriedCopyLimitNamesRef.current.has(name),
+    );
     if (unique.length === 0) return;
-    let cancelled = false;
+    for (const name of unique) {
+      queriedCopyLimitNamesRef.current.add(name);
+    }
     Promise.all(
       unique.map(async (name) => [name, await deckCopyLimit(name)] as const),
     )
       .then((results) => {
-        if (cancelled) return;
+        // No cancellation guard: limits are static per name, so a resolved
+        // batch is never stale — merging is always safe.
         setDeckCopyLimits((prev) => {
           const next = new Map(prev);
           for (const [name, limit] of results) {
@@ -209,28 +220,24 @@ export function useDeckBuilder({
         });
       })
       .catch(() => {
-        // Retain previously resolved overrides on transient WASM failures.
+        // Retain previously resolved overrides and allow this batch to be
+        // retried after a transient WASM failure.
+        for (const name of unique) {
+          queriedCopyLimitNamesRef.current.delete(name);
+        }
       });
-    return () => {
-      cancelled = true;
-    };
   }, []);
 
   // CR 100.2a / CR 903.5b: resolve per-card copy-limit overrides for every card
   // referenced anywhere in the deck. The engine is the single authority — the
-  // frontend never re-parses Oracle text. Mirrors the commander-eligibility
-  // effect's union-of-names keying and cancellation guard.
+  // frontend never re-parses Oracle text. Limits are static per card name, so
+  // the resolved map is a monotonic cache: merged into, never cleared.
   useEffect(() => {
-    const names = [
+    prefetchDeckCopyLimits([
       ...deck.main.map((e) => e.name),
       ...deck.sideboard.map((e) => e.name),
       ...commanders,
-    ];
-    if (names.length === 0) {
-      setDeckCopyLimits(new Map());
-      return;
-    }
-    return prefetchDeckCopyLimits(names);
+    ]);
   }, [deck.main, deck.sideboard, commanders, prefetchDeckCopyLimits]);
 
   // Synchronous per-card effective copy cap: the override when present, else the

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -190,40 +190,48 @@ export function useDeckBuilder({
     };
   }, [deck.main, format, isCommander]);
 
+  const prefetchDeckCopyLimits = useCallback((names: string[]) => {
+    const unique = Array.from(new Set(names));
+    if (unique.length === 0) return;
+    let cancelled = false;
+    Promise.all(
+      unique.map(async (name) => [name, await deckCopyLimit(name)] as const),
+    )
+      .then((results) => {
+        if (cancelled) return;
+        setDeckCopyLimits((prev) => {
+          const next = new Map(prev);
+          for (const [name, limit] of results) {
+            if (!limit) continue;
+            next.set(name, limit.type === "Unlimited" ? Infinity : limit.data);
+          }
+          return next;
+        });
+      })
+      .catch(() => {
+        // Retain previously resolved overrides on transient WASM failures.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // CR 100.2a / CR 903.5b: resolve per-card copy-limit overrides for every card
   // referenced anywhere in the deck. The engine is the single authority — the
   // frontend never re-parses Oracle text. Mirrors the commander-eligibility
   // effect's union-of-names keying and cancellation guard.
   useEffect(() => {
-    const names = Array.from(
-      new Set([
-        ...deck.main.map((e) => e.name),
-        ...deck.sideboard.map((e) => e.name),
-        ...commanders,
-      ]),
-    );
+    const names = [
+      ...deck.main.map((e) => e.name),
+      ...deck.sideboard.map((e) => e.name),
+      ...commanders,
+    ];
     if (names.length === 0) {
       setDeckCopyLimits(new Map());
       return;
     }
-    let cancelled = false;
-    Promise.all(
-      names.map(async (name) => [name, await deckCopyLimit(name)] as const),
-    ).then((results) => {
-      if (cancelled) return;
-      const next = new Map<string, number>();
-      for (const [name, limit] of results) {
-        if (!limit) continue;
-        next.set(name, limit.type === "Unlimited" ? Infinity : limit.data);
-      }
-      setDeckCopyLimits(next);
-    }).catch(() => {
-      if (!cancelled) setDeckCopyLimits(new Map());
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [deck.main, deck.sideboard, commanders]);
+    return prefetchDeckCopyLimits(names);
+  }, [deck.main, deck.sideboard, commanders, prefetchDeckCopyLimits]);
 
   // Synchronous per-card effective copy cap: the override when present, else the
   // format default (4 constructed / 1 singleton).
@@ -274,8 +282,9 @@ export function useDeckBuilder({
       }
       setSearchResults(cards);
       cacheCards(cards);
+      prefetchDeckCopyLimits(cards.map((card) => card.name));
     },
-    [cacheCards, initialDeckName, searchFilters],
+    [cacheCards, initialDeckName, prefetchDeckCopyLimits, searchFilters],
   );
 
   const handleSearchTrigger = useCallback(() => {


### PR DESCRIPTION
## Summary
- Prefetch engine `deckCopyLimit` overrides for cards shown in search results so Seven Dwarves and similar cards are not capped at four copies while limits load.
- Merge resolved overrides into the existing map instead of replacing it, and retain prior entries when a WASM lookup fails.

## Test plan
- [ ] Search for Seven Dwarves in the deck builder and add seven copies without the + button disabling at four.
- [ ] Confirm a deck with seven Seven Dwarves passes engine deck compatibility checks.
- [ ] Verify Relentless Rats still allows unlimited copies and normal cards still cap at four.

Fixes #857
