### PR TITLE
fix(parser): Weathered Wayfarer activation when opponent has more lands

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -5018,9 +5018,10 @@ fn parse_opponent_comparison_conditions(input: &str) -> OracleResult<'_, StaticC
         }
     }
 
-    // CR 109.4: "an opponent controls more [type] than you" — existential over
-    // opponents (at least one opponent strictly exceeds your count), not an
-    // aggregate of all opponent permanents. Weathered Wayfarer, Tithe, etc.
+    // CR 109.4 + CR 109.5: "an opponent controls more [type] than you" —
+    // existential over opponents (at least one opponent strictly exceeds your
+    // count; "you" = the ability's controller), not an aggregate of all
+    // opponent permanents. Weathered Wayfarer, Land Tax.
     if let Ok((rest2, _)) = tag::<_, _, OracleError<'_>>("controls more ").parse(rest) {
         if let Ok((rest3, type_text)) =
             take_until::<_, _, OracleError<'_>>(" than you").parse(rest2)

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -25,8 +25,9 @@ use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
     AbilityCondition, AggregateFunction, CastManaObjectScope, CastManaSpentMetric,
     CommanderOwnership, Comparator, ControllerRef, CountScope, DamageGroupKey, DamageKindFilter,
-    FilterProp, ObjectProperty, ObjectScope, PlayerScope, QuantityExpr, QuantityRef, SharedQuality,
-    StaticCondition, TargetFilter, TypeFilter, TypedFilter, ZoneRef,
+    FilterProp, ObjectProperty, ObjectScope, PlayerFilter, PlayerRelation, PlayerScope,
+    QuantityExpr, QuantityRef, SharedQuality, StaticCondition, TargetFilter, TypeFilter,
+    TypedFilter, ZoneRef,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::events::PlayerActionKind;
@@ -5017,35 +5018,38 @@ fn parse_opponent_comparison_conditions(input: &str) -> OracleResult<'_, StaticC
         }
     }
 
-    // "an opponent controls more [type] than you"
+    // CR 109.4: "an opponent controls more [type] than you" — existential over
+    // opponents (at least one opponent strictly exceeds your count), not an
+    // aggregate of all opponent permanents. Weathered Wayfarer, Tithe, etc.
     if let Ok((rest2, _)) = tag::<_, _, OracleError<'_>>("controls more ").parse(rest) {
         if let Ok((rest3, type_text)) =
             take_until::<_, _, OracleError<'_>>(" than you").parse(rest2)
         {
             let (rest3, _) = tag(" than you").parse(rest3)?;
-            let (filter, _) = parse_type_phrase(type_text.trim());
-            let opp_filter = match filter {
+            let (type_filter, _) = parse_type_phrase(type_text.trim());
+            let you_filter = match &type_filter {
                 TargetFilter::Typed(tf) => {
-                    TargetFilter::Typed(tf.controller(ControllerRef::Opponent))
+                    TargetFilter::Typed(tf.clone().controller(ControllerRef::You))
                 }
-                other => other,
-            };
-            let you_filter = match parse_type_phrase(type_text.trim()) {
-                (TargetFilter::Typed(tf), _) => {
-                    TargetFilter::Typed(tf.controller(ControllerRef::You))
-                }
-                (other, _) => other,
+                other => other.clone(),
             };
             return Ok((
                 rest3,
                 StaticCondition::QuantityComparison {
                     lhs: QuantityExpr::Ref {
-                        qty: QuantityRef::ObjectCount { filter: opp_filter },
+                        qty: QuantityRef::PlayerCount {
+                            filter: PlayerFilter::ControlsCount {
+                                relation: PlayerRelation::Opponent,
+                                filter: type_filter,
+                                comparator: Comparator::GT,
+                                count: Box::new(QuantityExpr::Ref {
+                                    qty: QuantityRef::ObjectCount { filter: you_filter },
+                                }),
+                            },
+                        },
                     },
-                    comparator: Comparator::GT,
-                    rhs: QuantityExpr::Ref {
-                        qty: QuantityRef::ObjectCount { filter: you_filter },
-                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 1 },
                 },
             ));
         }
@@ -8212,15 +8216,50 @@ mod tests {
             StaticCondition::QuantityComparison {
                 lhs:
                     QuantityExpr::Ref {
-                        qty: QuantityRef::ObjectCount { .. },
+                        qty:
+                            QuantityRef::PlayerCount {
+                                filter:
+                                    PlayerFilter::ControlsCount {
+                                        relation: PlayerRelation::Opponent,
+                                        comparator: Comparator::GT,
+                                        ..
+                                    },
+                            },
                     },
-                comparator: Comparator::GT,
-                rhs:
-                    QuantityExpr::Ref {
-                        qty: QuantityRef::ObjectCount { .. },
-                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
             } => {}
-            other => panic!("expected ObjectCount GT ObjectCount, got {other:?}"),
+            other => panic!("expected existential opponent ControlsCount GE 1, got {other:?}"),
+        }
+    }
+
+    /// Issue #859: Weathered Wayfarer — "Activate only if an opponent controls
+    /// more lands than you."
+    #[test]
+    fn test_opponent_controls_more_lands_than_you() {
+        let (rest, c) = parse_inner_condition("an opponent controls more lands than you").unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::PlayerCount {
+                                filter:
+                                    PlayerFilter::ControlsCount {
+                                        relation: PlayerRelation::Opponent,
+                                        filter: TargetFilter::Typed(tf),
+                                        comparator: Comparator::GT,
+                                        ..
+                                    },
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            } => {
+                assert_eq!(tf.type_filters, vec![TypeFilter::Land]);
+            }
+            other => panic!("expected existential opponent land count GE 1, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -5028,12 +5028,7 @@ fn parse_opponent_comparison_conditions(input: &str) -> OracleResult<'_, StaticC
         {
             let (rest3, _) = tag(" than you").parse(rest3)?;
             let (type_filter, _) = parse_type_phrase(type_text.trim());
-            let you_filter = match &type_filter {
-                TargetFilter::Typed(tf) => {
-                    TargetFilter::Typed(tf.clone().controller(ControllerRef::You))
-                }
-                other => other.clone(),
-            };
+            let you_filter = inject_controller_you(type_filter.clone());
             return Ok((
                 rest3,
                 StaticCondition::QuantityComparison {

--- a/crates/engine/tests/integration/issue_859_weathered_wayfarer.rs
+++ b/crates/engine/tests/integration/issue_859_weathered_wayfarer.rs
@@ -1,0 +1,61 @@
+//! Issue #859: Weathered Wayfarer cannot activate when an opponent controls
+//! more lands. Regression for existential "an opponent controls more [type]
+//! than you" activation restrictions (CR 109.4).
+
+use engine::ai_support::legal_actions;
+use engine::game::casting::can_activate_ability_now;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+
+const WEATHERED_WAYFARER: &str = "\
+{W}, {T}: Search your library for a land card, reveal it, put it into your hand, \
+then shuffle. Activate only if an opponent controls more lands than you.";
+
+#[test]
+fn weathered_wayfarer_activates_when_opponent_has_more_lands() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let wayfarer = scenario
+        .add_creature_from_oracle(P0, "Weathered Wayfarer", 1, 1, WEATHERED_WAYFARER)
+        .id();
+    scenario.add_basic_land(P0, ManaColor::White);
+    scenario.add_basic_land(P1, ManaColor::Blue);
+    scenario.add_basic_land(P1, ManaColor::Green);
+    scenario.add_basic_land(P1, ManaColor::Red);
+
+    let runner = scenario.build();
+    assert!(
+        can_activate_ability_now(runner.state(), P0, wayfarer, 0),
+        "opponent controls three lands vs controller's one"
+    );
+
+    let actions = legal_actions(runner.state());
+    assert!(
+        actions.iter().any(|a| matches!(
+            a,
+            GameAction::ActivateAbility { source_id, .. } if *source_id == wayfarer
+        )),
+        "legal_actions must offer Weathered Wayfarer's search ability"
+    );
+}
+
+#[test]
+fn weathered_wayfarer_blocked_when_land_counts_tied() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let wayfarer = scenario
+        .add_creature_from_oracle(P0, "Weathered Wayfarer", 1, 1, WEATHERED_WAYFARER)
+        .id();
+    scenario.add_basic_land(P0, ManaColor::White);
+    scenario.add_basic_land(P1, ManaColor::Blue);
+
+    let runner = scenario.build();
+    assert!(
+        !can_activate_ability_now(runner.state(), P0, wayfarer, 0),
+        "equal land counts must block activation"
+    );
+}

--- a/crates/engine/tests/integration/issue_859_weathered_wayfarer.rs
+++ b/crates/engine/tests/integration/issue_859_weathered_wayfarer.rs
@@ -8,6 +8,9 @@ use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::actions::GameAction;
 use engine::types::mana::ManaColor;
 use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P2: PlayerId = PlayerId(2);
 
 const WEATHERED_WAYFARER: &str = "\
 {W}, {T}: Search your library for a land card, reveal it, put it into your hand, \
@@ -57,5 +60,30 @@ fn weathered_wayfarer_blocked_when_land_counts_tied() {
     assert!(
         !can_activate_ability_now(runner.state(), P0, wayfarer, 0),
         "equal land counts must block activation"
+    );
+}
+
+/// "An opponent" is existential — a single opponent must individually control
+/// more lands than you. Two opponents with one land each (combined 2 > your 1)
+/// must NOT satisfy the restriction. This is the only scenario where the
+/// existential parse diverges from the old aggregate-opponent-count parse, so
+/// this test is the discriminating regression pin for this fix.
+#[test]
+fn weathered_wayfarer_blocked_when_only_combined_opponents_exceed() {
+    let mut scenario = GameScenario::new_n_player(3, 99);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let wayfarer = scenario
+        .add_creature_from_oracle(P0, "Weathered Wayfarer", 1, 1, WEATHERED_WAYFARER)
+        .id();
+    scenario.add_basic_land(P0, ManaColor::White);
+    scenario.add_basic_land(P1, ManaColor::Blue);
+    scenario.add_basic_land(P2, ManaColor::Green);
+
+    let runner = scenario.build();
+    assert!(
+        !can_activate_ability_now(runner.state(), P0, wayfarer, 0),
+        "no single opponent controls more lands than the controller; \
+         combined opponent land counts must not satisfy the restriction"
     );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -135,6 +135,7 @@ mod issue_566_ragavan_dash_cast;
 mod issue_580_solitude_evoke_prompt;
 mod issue_583_vivi_ornitier_mana_source;
 mod issue_709_regression;
+mod issue_859_weathered_wayfarer;
 mod issue_860_luminarch_aspirant;
 mod issue_879_obsessive_pursuit;
 mod issue_924_offspring;


### PR DESCRIPTION
## Summary
- Parse "an opponent controls more [type] than you" as an existential opponent check (at least one opponent strictly exceeds your count) instead of comparing aggregate opponent permanents to yours.
- Add integration tests covering Weathered Wayfarer activation when land counts differ and when they are tied.

## Test plan
- [ ] Activate Weathered Wayfarer when you control one land and an opponent controls three.
- [ ] Confirm activation is blocked when each player controls the same number of lands.
- [ ] In a three-player game, verify activation requires a single opponent with more lands, not a combined opponent total.

Fixes #859

Made with [Cursor](https://cursor.com)