### PR TITLE
Zone pipeline Phase B: bucket-A deliveries onto the ApprovedZoneChange proof token

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What this PR changes and why. One or two sentences. -->
+
+## Implementation method (required)
+
+How was the engine/parser logic in this PR produced? Check exactly one:
+
+- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
+- [ ] **Not** `/engine-implementer` — explain why below
+
+If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
+change, docs/CI/tooling change, release chore, or a fix too small to warrant
+the pipeline):
+
+> _your reason here_
+
+> [!NOTE]
+> Any change to `crates/engine/` game logic — parser, effects, resolver,
+> targeting, rules behavior — is expected to go through `/engine-implementer`.
+> The "not used" box is for changes that genuinely fall outside that scope.
+
+## CR references
+
+<!-- `CR XXX.Y` annotations added or touched, or "None" for non-rules changes. -->
+
+## Verification
+
+<!-- Commands run and their results, or a note on how CI covers this change. -->

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -554,6 +554,7 @@ fn apply_pending_counter_post_action(
             source_id,
             duration,
             exile_tracking,
+            drain,
         } => {
             // CR 614.12a: the delivery tail may surface a Devour as-enters
             // sacrifice `EffectZoneChoice`. On that pause, return `false` so the
@@ -569,6 +570,7 @@ fn apply_pending_counter_post_action(
                 source_id,
                 duration.as_ref(),
                 exile_tracking,
+                drain,
                 events,
             ) {
                 super::change_zone::ZoneDeliveryResult::Done => true,

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -93,6 +93,8 @@ fn deliver_destruction_zone_change(
     let ctx = DeliveryCtx {
         source_id: source,
         exile_links: ExileLinkSpec::default(),
+        played_from_zone: None,
+        drain: crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
     };
     !matches!(
         zone_pipeline::deliver(state, approved, ctx, events),

--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -63,7 +63,15 @@ pub(crate) fn complete_discard_to_graveyard(
     };
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(event) => {
-            change_zone::deliver_replaced_zone_change(state, event, source_id, None, false, events);
+            change_zone::deliver_replaced_zone_change(
+                state,
+                event,
+                source_id,
+                None,
+                false,
+                crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                events,
+            );
         }
         ReplacementResult::Prevented => {
             // CR 614.6: a prevented event never happens — the card never left
@@ -215,7 +223,13 @@ pub fn resolve(
                             // The lowered ZoneChange already re-looped through the
                             // pipeline (CR 616.1f), so `Moved` redirects were consulted.
                             change_zone::deliver_replaced_zone_change(
-                                state, zone_event, None, None, false, events,
+                                state,
+                                zone_event,
+                                None,
+                                None,
+                                false,
+                                crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                                events,
                             );
                             // CR 702.35: The card was still discarded — record and emit event
                             // so "whenever you discard" triggers fire.
@@ -379,7 +393,13 @@ pub(crate) fn discard_as_cost_with_source(
                 // CR 702.35: The card was still discarded — record and emit event
                 // so "whenever you discard" triggers fire.
                 change_zone::deliver_replaced_zone_change(
-                    state, zone_event, None, None, false, events,
+                    state,
+                    zone_event,
+                    None,
+                    None,
+                    false,
+                    crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                    events,
                 );
                 crate::game::restrictions::record_discard(state, player);
                 events.push(GameEvent::Discarded {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5281,14 +5281,17 @@ fn handle_play_land(
                     // early-return — then surface the parked prompt; the land
                     // epilogue must not run yet.
                     crate::game::zone_pipeline::ZoneDeliveryResult::NeedsChoice(_) => {
+                        // CR 305.1 + CR 400.7i: stamp land-play provenance so
+                        // effects can find the permanent the played land became.
                         mark_land_played_from_zone(state, object_id, origin_zone);
                         return Ok(state.waiting_for.clone());
                     }
                 }
-                // Stamp the play origin (engine bookkeeping for "where it was
-                // played from"). Set fresh AFTER delivery — the ctx re-stamp
-                // knob is for preserving a pre-move value, which this site does
-                // not have (it is recording a brand-new origin).
+                // CR 305.1 + CR 400.7i: stamp land-play provenance ("where it
+                // was played from") so effects can find the permanent the
+                // played land became. Set fresh AFTER delivery — the ctx
+                // re-stamp knob is for preserving a pre-move value, which this
+                // site does not have (it is recording a brand-new origin).
                 mark_land_played_from_zone(state, object_id, origin_zone);
             }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5236,52 +5236,60 @@ fn handle_play_land(
 
     match super::replacement::replace_event(state, proposed, events) {
         super::replacement::ReplacementResult::Execute(event) => {
-            if let crate::types::proposed_event::ProposedEvent::ZoneChange {
-                object_id,
-                to,
-                enter_tapped,
-                enter_with_counters,
-                controller_override,
-                ..
-            } = event
+            if let crate::types::proposed_event::ProposedEvent::ZoneChange { object_id, .. } = event
             {
-                zones::move_to_zone(state, object_id, to, events);
-                mark_land_played_from_zone(state, object_id, origin_zone);
-                // CR 400.7: reset_for_battlefield_entry (inside move_to_zone) sets
-                // defaults. Override only when the replacement pipeline changed them.
-                if let Some(obj) = state.objects.get_mut(&object_id) {
-                    if enter_tapped.resolve(false) {
-                        obj.tapped = true;
-                    }
-                    if let Some(new_controller) = controller_override {
-                        obj.controller = new_controller;
-                    }
-                }
-                // CR 614.1c: Apply counters from replacement pipeline.
-                if !engine_replacement::apply_etb_counters(
+                // Phase B (PLAN §6.2 / §7): the divergent partial copy of
+                // `deliver_replaced_zone_change` that used to live here is
+                // dissolved — the post-`replace_event` event is a
+                // `ReplacementResult::Execute` payload, sealed through the third
+                // mint path (`approve_post_replacement`) and delivered by the
+                // shared `zone_pipeline::deliver`. The land entry now gets the
+                // FULL delivery tail the copy skipped (CR 614.1c
+                // `EntersWithAdditionalCounters` statics snapshot, the CR 303.4f
+                // `attach_to` host, `entered_via_ability_source` provenance, the
+                // CR 701.24a library-shuffle arm). `drain = CallerEpilogue`: the
+                // land-play epilogue below owns the `post_replacement_continuation`
+                // drain (it clears `post_replacement_source` and runs the
+                // land-specific accounting), so the tail must not also drain it.
+                let Ok(approved) =
+                    crate::game::zone_pipeline::ApprovedZoneChange::approve_post_replacement(event)
+                else {
+                    unreachable!("`if let ZoneChange` guarantees a ZoneChange payload");
+                };
+                match crate::game::zone_pipeline::deliver(
                     state,
-                    object_id,
-                    &enter_with_counters,
+                    approved,
+                    crate::game::zone_pipeline::DeliveryCtx {
+                        source_id: None,
+                        exile_links: crate::game::zone_pipeline::ExileLinkSpec::default(),
+                        // `played_from_zone` is set FRESH after the move via
+                        // `mark_land_played_from_zone` (this site stamps the play
+                        // origin; it is not preserving a pre-move value), so the
+                        // ctx re-stamp knob stays `None`.
+                        played_from_zone: None,
+                        drain: crate::types::game_state::PostReplacementDrainOwner::CallerEpilogue,
+                    },
                     events,
                 ) {
-                    return Ok(state.waiting_for.clone());
-                }
-                // CR 614.1c: Apply pending ETB counters from delayed triggers
-                // (e.g., "that creature enters with an additional +1/+1 counter").
-                let pending: Vec<_> = state
-                    .pending_etb_counters
-                    .iter()
-                    .filter(|(oid, _, _)| *oid == object_id)
-                    .map(|(_, ct, n)| (ct.clone(), *n))
-                    .collect();
-                if !pending.is_empty() {
-                    if !engine_replacement::apply_etb_counters(state, object_id, &pending, events) {
+                    crate::game::zone_pipeline::ZoneDeliveryResult::Done => {}
+                    // CR 614.1c / CR 614.12a: the delivery tail parked a
+                    // counter-replacement prompt and stashed the remaining tail
+                    // (carrying `CallerEpilogue`). The land has already entered
+                    // the battlefield (the move precedes the counter pause in the
+                    // tail), so stamp the play origin now — matching the pre-token
+                    // arm, which stamped before the `apply_etb_counters`
+                    // early-return — then surface the parked prompt; the land
+                    // epilogue must not run yet.
+                    crate::game::zone_pipeline::ZoneDeliveryResult::NeedsChoice(_) => {
+                        mark_land_played_from_zone(state, object_id, origin_zone);
                         return Ok(state.waiting_for.clone());
                     }
-                    state
-                        .pending_etb_counters
-                        .retain(|(oid, _, _)| *oid != object_id);
                 }
+                // Stamp the play origin (engine bookkeeping for "where it was
+                // played from"). Set fresh AFTER delivery — the ctx re-stamp
+                // knob is for preserving a pre-move value, which this site does
+                // not have (it is recording a brand-new origin).
+                mark_land_played_from_zone(state, object_id, origin_zone);
             }
 
             // CR 614.12a: Drain post-replacement side effects (e.g., "As this land
@@ -8059,6 +8067,85 @@ mod tests {
             "result.waiting_for={:?}, stack={:?}",
             result.waiting_for,
             state.stack
+        );
+    }
+
+    /// CR 614.1c discriminating test (fail-first): a land played through the
+    /// real `PlayLand` action must receive the `EntersWithAdditionalCounters`
+    /// static snapshot ("permanents you control enter with an additional +1/+1
+    /// counter" class) that an active permanent contributes. Before Phase B,
+    /// the land-play `Execute` arm was a divergent partial copy of
+    /// `deliver_replaced_zone_change`: it applied only the event's own
+    /// `enter_with_counters` and SKIPPED the statics snapshot, so a played land
+    /// silently missed the static's counter while every other battlefield entry
+    /// (creatures via the shared tail) received it. Routing the land entry
+    /// through `zone_pipeline::deliver` runs the full tail.
+    #[test]
+    fn played_land_receives_enters_with_additional_counters_static() {
+        use std::sync::Arc;
+
+        use crate::types::ability::{ControllerRef, FilterProp, StaticDefinition, TypedFilter};
+        use crate::types::statics::StaticMode;
+
+        let mut state = setup_game_at_main_phase();
+
+        // CR 614.1c: a P0 permanent granting "other permanents you control enter
+        // with an additional +1/+1 counter" — must be functioning BEFORE the
+        // land enters.
+        let source = create_object(
+            &mut state,
+            CardId(7000),
+            PlayerId(0),
+            "Counter Source".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            let def = StaticDefinition::new(StaticMode::EntersWithAdditionalCounters {
+                counter_type: CounterType::Plus1Plus1,
+                count: 1,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .controller(ControllerRef::You)
+                    .properties(vec![FilterProp::Another]),
+            ));
+            obj.static_definitions.push(def.clone());
+            Arc::make_mut(&mut obj.base_static_definitions).push(def);
+        }
+
+        let land = create_object(
+            &mut state,
+            CardId(7001),
+            PlayerId(0),
+            "Forest".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&land)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+
+        apply_as_current(
+            &mut state,
+            GameAction::PlayLand {
+                object_id: land,
+                card_id: CardId(7001),
+            },
+        )
+        .unwrap();
+
+        let obj = &state.objects[&land];
+        assert_eq!(obj.zone, Zone::Battlefield, "land entered the battlefield");
+        assert_eq!(
+            *obj.counters.get(&CounterType::Plus1Plus1).unwrap_or(&0),
+            1,
+            "played land must receive the EntersWithAdditionalCounters static \
+             (CR 614.1c) — the divergent land-play Execute arm dropped the \
+             statics snapshot the shared delivery tail applies"
         );
     }
 

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -652,6 +652,7 @@ pub fn route_debug_create_to_battlefield(
                 None,
                 None,
                 false,
+                crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
                 &mut events,
             ) {
                 super::effects::change_zone::ZoneDeliveryResult::Done => {}

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -429,13 +429,15 @@ fn pay_top_library_exile_cost(
             // counter-replacement pause (no battlefield entry); the arm is
             // present for exhaustiveness. A redirect to the battlefield that
             // paused would have no continuation home in this synchronous cost
-            // path, so flag it loudly rather than silently dropping the tail.
+            // path, so fail the payment loudly — continuing would silently
+            // drop the parked tail and corrupt the cost state in release
+            // builds where a debug_assert is a no-op.
             crate::game::zone_pipeline::ZoneDeliveryResult::NeedsChoice(_) => {
-                debug_assert!(
-                    false,
+                return Err(EngineError::InvalidAction(
                     "top-library exile cost delivery surfaced a replacement pause; \
                      no continuation exists in this cost path"
-                );
+                        .to_string(),
+                ));
             }
         }
     }

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -372,14 +372,23 @@ fn pay_top_library_exile_cost(
                 .collect::<Vec<_>>()
         })
         .ok_or_else(|| EngineError::InvalidAction("Player not found".to_string()))?;
-    let mut zone_changes = Vec::with_capacity(top_cards.len());
+    // Phase B (PLAN §6.2): stash the FULL post-replacement `ProposedEvent`s,
+    // not degraded `(object_id, to)` pairs. The pairs discarded the event's
+    // `applied: HashSet<ReplacementId>` (CR 616.1: the set of replacements
+    // already applied this pass) plus every other field the delivery tail
+    // reads; delivering through the raw mover then bypassed the tail entirely.
+    // Each event already cleared the replacement consult above, so it is sealed
+    // through the third mint path (`approve_post_replacement`) — a consult-
+    // skipping approved delivery. Re-proposing through `move_object` would
+    // double-apply the Moved definitions already applied here.
+    let mut approved_changes = Vec::with_capacity(top_cards.len());
 
     for card_id in top_cards {
         let proposed =
             ProposedEvent::zone_change(card_id, Zone::Library, Zone::Exile, Some(source_id));
         match replacement::replace_event(state, proposed, events) {
-            ReplacementResult::Execute(ProposedEvent::ZoneChange { object_id, to, .. }) => {
-                zone_changes.push((object_id, to));
+            ReplacementResult::Execute(event @ ProposedEvent::ZoneChange { .. }) => {
+                approved_changes.push(event);
             }
             ReplacementResult::Execute(_) | ReplacementResult::Prevented => {
                 return Ok(false);
@@ -391,8 +400,44 @@ fn pay_top_library_exile_cost(
         }
     }
 
-    for (object_id, to) in zone_changes {
-        zones::move_to_zone(state, object_id, to, events);
+    for event in approved_changes {
+        // Attribute the move to the cost source (the event's `cause`),
+        // preserving the value the proposal carried (the proposal was built
+        // with `Some(source_id)`).
+        let source_id = match &event {
+            ProposedEvent::ZoneChange { cause, .. } => *cause,
+            _ => unreachable!("collected only ZoneChange events"),
+        };
+        let Ok(approved) =
+            crate::game::zone_pipeline::ApprovedZoneChange::approve_post_replacement(event)
+        else {
+            unreachable!("collected only ZoneChange events");
+        };
+        match crate::game::zone_pipeline::deliver(
+            state,
+            approved,
+            crate::game::zone_pipeline::DeliveryCtx {
+                source_id,
+                exile_links: crate::game::zone_pipeline::ExileLinkSpec::default(),
+                played_from_zone: None,
+                drain: crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+            },
+            events,
+        ) {
+            crate::game::zone_pipeline::ZoneDeliveryResult::Done => {}
+            // The Library → Exile destination cannot surface a CR 614.1c
+            // counter-replacement pause (no battlefield entry); the arm is
+            // present for exhaustiveness. A redirect to the battlefield that
+            // paused would have no continuation home in this synchronous cost
+            // path, so flag it loudly rather than silently dropping the tail.
+            crate::game::zone_pipeline::ZoneDeliveryResult::NeedsChoice(_) => {
+                debug_assert!(
+                    false,
+                    "top-library exile cost delivery surfaced a replacement pause; \
+                     no continuation exists in this cost path"
+                );
+            }
+        }
     }
 
     Ok(true)
@@ -2111,6 +2156,61 @@ mod tests {
                 target: TargetFilter::Any,
                 count: 2,
             }
+        );
+    }
+
+    /// CR 614.1 + CR 614.6 regression test for the Phase-B seal+deliver
+    /// migration of the top-library exile cost (`pay_top_library_exile_cost`,
+    /// Thought Lash class). The loop now stashes the FULL post-replacement
+    /// `ProposedEvent`s and delivers each through
+    /// `ApprovedZoneChange::approve_post_replacement` + `zone_pipeline::deliver`
+    /// (a consult-skipping approved delivery that preserves the event's
+    /// `applied: HashSet<ReplacementId>`), rather than degrading survivors to
+    /// `(object_id, to)` pairs delivered via raw `zones::move_to_zone`.
+    ///
+    /// This is a structural fix (consult-once/deliver-once), not a behavior
+    /// change: a plain Library → Exile cost has no battlefield-entry mods to
+    /// apply, and the delivery tail's continuation drain early-returns for the
+    /// Exile destination (zone_pipeline.rs `apply_zone_delivery_tail`: `to ==
+    /// Exile` with a source attribution and no exile-link returns `Done` before
+    /// the `post_replacement_continuation` drain). The redirected destination
+    /// was already honored pre-migration (the `to` field was captured from the
+    /// Execute event), so this test pins the observable outcome — the top card
+    /// is exiled — against both the old raw delivery and the new sealed one.
+    #[test]
+    fn top_library_exile_cost_exiles_top_card_through_sealed_delivery() {
+        let mut state = GameState::new_two_player(42);
+
+        let source = create_object(
+            &mut state,
+            CardId(8000),
+            PlayerId(0),
+            "Cost Source".to_string(),
+            Zone::Battlefield,
+        );
+
+        // One card on top of P0's library to pay the exile cost with.
+        let top = create_object(
+            &mut state,
+            CardId(8001),
+            PlayerId(0),
+            "Top Card".to_string(),
+            Zone::Library,
+        );
+
+        let mut events = Vec::new();
+        let paid = pay_top_library_exile_cost(&mut state, PlayerId(0), 1, source, &mut events)
+            .expect("cost resolves");
+
+        assert!(paid, "the single top-library card pays the exile cost");
+        assert_eq!(
+            state.objects[&top].zone,
+            Zone::Exile,
+            "the top library card is exiled through the sealed delivery path"
+        );
+        assert!(
+            !state.players[0].library.contains(&top),
+            "the exiled card has left the library"
         );
     }
 }

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -24,7 +24,6 @@ use super::effects::scry::apply_scry_after_replacement;
 use super::effects::token::apply_create_token_after_replacement;
 use super::engine::EngineError;
 use super::sacrifice::{apply_sacrifice_after_replacement, SacrificeApply};
-use super::zones;
 
 /// CR 614.13a + CR 702.82a/c: matches the broad as-enters shape of a Devour
 /// sacrifice replacement — a `Moved` (ETB-style) event whose post-effect is a
@@ -77,106 +76,75 @@ pub(super) fn handle_replacement_choice(
             let mut zone_change_object_id = None;
             let mut enters_battlefield = false;
             match event {
-                // TODO(zone-pipeline Phase B): this arm is a divergent partial
-                // copy of `zone_pipeline::deliver_replaced_zone_change` — it has
-                // now dropped two fields (`played_from_zone`, patched below;
-                // `face_down_profile`, patched via the shared CR 708.3 helper)
-                // and still skips the tail's devour snapshot,
-                // EntersWithAdditionalCounters statics, `attach_to`,
-                // `entered_via_ability_source`, exile-link tracking, and the
-                // CR 701.24a library-shuffle arms. Route it through
-                // `ApprovedZoneChange::approve_post_replacement` +
-                // `zone_pipeline::deliver` when the Phase-B token migration
-                // reconciles the divergences that block it this round: (1) the
-                // post-`Execute` epilogue below drains
-                // `post_replacement_continuation` with the spell-resolution ctx
-                // and clears `post_replacement_source` for zone changes, while
-                // the tail drains it ctx-less and without the clear; (2)
-                // `pending_spell_resolution` ordering (the tail's drain would run
-                // before `apply_pending_spell_resolution`); (3) the bespoke
-                // `played_from_zone` preservation (PLAN Open Question #3).
-                ProposedEvent::ZoneChange {
-                    object_id,
-                    to,
-                    from,
-                    enter_tapped,
-                    enter_with_counters,
-                    controller_override,
-                    enter_transformed,
-                    face_down_profile,
-                    ..
-                } => {
+                // Phase B (PLAN §6.2 / §7): the divergent partial copy of
+                // `deliver_replaced_zone_change` that used to live here is
+                // dissolved — the post-choice event is a
+                // `ReplacementResult::Execute` payload, so it is sealed through
+                // the third mint path (`approve_post_replacement`) and
+                // delivered by the shared `zone_pipeline::deliver` machinery.
+                // The resumed entry now gets the FULL delivery tail the copy
+                // skipped: the CR 614.12a devour snapshot, the CR 614.1c
+                // `EntersWithAdditionalCounters` statics snapshot, the
+                // CR 303.4f `attach_to` host, `entered_via_ability_source`
+                // provenance (CR 603.6a, from the event's `cause`), and the
+                // CR 701.24a library-shuffle arm.
+                //
+                // Divergence reconciliation (the three blockers, resolved by
+                // parameterizing the shared tail instead of keeping a copy):
+                // (1) `DeliveryCtx.drain = CallerEpilogue` — the tail skips the
+                //     `post_replacement_continuation` drain; the epilogue below
+                //     keeps draining WITH the spell-resolution ctx and with
+                //     `post_replacement_source` cleared for zone changes.
+                // (2) `pending_spell_resolution` ordering is therefore
+                //     untouched: `apply_pending_spell_resolution` still runs in
+                //     the epilogue before that drain.
+                // (3) `played_from_zone` (PLAN OQ#3, UNDECIDED): captured
+                //     pre-move and ridden on `DeliveryCtx` so the shared
+                //     machinery re-stamps it after `reset_for_battlefield_entry`
+                //     — behavior preserved exactly, no OQ#3 adjudication.
+                event @ ProposedEvent::ZoneChange { .. } => {
+                    let (object_id, to, cause) = match &event {
+                        ProposedEvent::ZoneChange {
+                            object_id,
+                            to,
+                            cause,
+                            ..
+                        } => (*object_id, *to, *cause),
+                        _ => unreachable!("arm pattern guarantees ZoneChange"),
+                    };
                     let played_from_zone = state
                         .objects
                         .get(&object_id)
                         .and_then(|obj| obj.played_from_zone);
-                    zones::move_to_zone(state, object_id, to, events);
-                    // CR 708.3 + CR 708.2a: a face-down entry (morph / manifest /
-                    // "put it onto the battlefield face down") that parked on a
-                    // CR 616.1 ordering prompt must still enter FACE DOWN —
-                    // shared single authority with the delivery tail. Applied
-                    // immediately after the move and before the tap-state /
-                    // controller-override / ETB-counter blocks, mirroring the
-                    // tail's ordering so any later-applied triggers see the
-                    // face-down state. Discarding this field delivered the
-                    // resumed morph face-up, leaking the hidden card.
-                    if to == Zone::Battlefield {
-                        if let Some(profile) = &face_down_profile {
-                            crate::game::zone_pipeline::apply_face_down_entry_profile(
-                                state, object_id, profile,
-                            );
-                        }
-                    }
-                    // CR 400.7: reset_for_battlefield_entry (inside move_to_zone) sets
-                    // defaults. Override only when the replacement pipeline changed them.
-                    if to == Zone::Battlefield {
-                        if let Some(obj) = state.objects.get_mut(&object_id) {
-                            obj.played_from_zone = played_from_zone;
-                            if enter_tapped.resolve(false) {
-                                obj.tapped = true;
-                            }
-                        }
-                        if let Some(new_controller) = controller_override {
-                            zones::apply_battlefield_entry_controller_override(
-                                state,
-                                events,
-                                object_id,
-                                new_controller,
-                            );
-                        }
-                        // CR 614.1c: Apply counters from replacement pipeline.
-                        if !apply_etb_counters(state, object_id, &enter_with_counters, events) {
+                    let Ok(approved) =
+                        crate::game::zone_pipeline::ApprovedZoneChange::approve_post_replacement(
+                            event,
+                        )
+                    else {
+                        unreachable!("arm pattern guarantees a ZoneChange payload");
+                    };
+                    match crate::game::zone_pipeline::deliver(
+                        state,
+                        approved,
+                        crate::game::zone_pipeline::DeliveryCtx {
+                            source_id: cause,
+                            exile_links: crate::game::zone_pipeline::ExileLinkSpec::default(),
+                            played_from_zone,
+                            drain:
+                                crate::types::game_state::PostReplacementDrainOwner::CallerEpilogue,
+                        },
+                        events,
+                    ) {
+                        crate::game::zone_pipeline::ZoneDeliveryResult::Done => {}
+                        // CR 614.1c / CR 614.12a: the delivery tail parked a
+                        // counter-replacement or devour prompt and stashed the
+                        // remaining tail as a `ContinueZoneDeliveryTail` record
+                        // (carrying `CallerEpilogue`, so the NEXT resume's
+                        // epilogue still owns the continuation drain). Surface
+                        // the parked prompt; the epilogue must not run yet.
+                        crate::game::zone_pipeline::ZoneDeliveryResult::NeedsChoice(_) => {
                             return Ok(state.waiting_for.clone());
                         }
-                        // CR 614.1c: Apply pending ETB counters from delayed triggers
-                        // (e.g., "that creature enters with an additional +1/+1 counter").
-                        let pending: Vec<_> = state
-                            .pending_etb_counters
-                            .iter()
-                            .filter(|(oid, _, _)| *oid == object_id)
-                            .map(|(_, ct, n)| (ct.clone(), *n))
-                            .collect();
-                        if !pending.is_empty() {
-                            if !apply_etb_counters(state, object_id, &pending, events) {
-                                return Ok(state.waiting_for.clone());
-                            }
-                            state
-                                .pending_etb_counters
-                                .retain(|(oid, _, _)| *oid != object_id);
-                        }
-                    }
-                    // CR 712.14a: Apply transformation if entering the battlefield transformed.
-                    if enter_transformed && to == Zone::Battlefield {
-                        if let Some(obj) = state.objects.get(&object_id) {
-                            if obj.back_face.is_some() && !obj.transformed {
-                                let _ = crate::game::transform::transform_permanent(
-                                    state, object_id, events,
-                                );
-                            }
-                        }
-                    }
-                    if to == Zone::Battlefield || from == Zone::Battlefield {
-                        crate::game::layers::mark_layers_full(state);
                     }
                     enters_battlefield = to == Zone::Battlefield;
                     zone_change_object_id = Some(object_id);
@@ -1353,6 +1321,128 @@ mod tests {
         assert!(
             state.objects[&target].tapped,
             "Tap accepted after replacement choice must tap the target"
+        );
+    }
+
+    /// CR 614.1c + CR 616.1 discriminating test (fail-first): a battlefield
+    /// entry that parks on a replacement-ordering prompt (two external
+    /// enter-tapped `Moved` defs — Authority of the Consuls + Imposing
+    /// Sovereign class) must, on resume, run the FULL shared delivery tail.
+    /// Here the missing piece is the `EntersWithAdditionalCounters` static
+    /// snapshot (Kalain / Counter Lord class — "other creatures you control
+    /// enter with an additional +1/+1 counter"): the divergent resume copy
+    /// applied only the event's own `enter_with_counters`, so a resumed entry
+    /// silently missed the static's counter while the never-paused path
+    /// granted it.
+    #[test]
+    fn resumed_entry_receives_enters_with_additional_counters_static() {
+        use std::sync::Arc;
+
+        use crate::game::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
+        use crate::types::ability::{
+            AbilityDefinition, ControllerRef, Effect, FilterProp, StaticDefinition, TargetFilter,
+            TypedFilter,
+        };
+        use crate::types::statics::StaticMode;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+
+        // CR 614.1c: P0 permanent granting "other creatures you control enter
+        // with an additional +1/+1 counter" — must be functioning BEFORE the
+        // entrant enters.
+        let lord = make_creature(&mut state, PlayerId(0), "Counter Lord");
+        {
+            let obj = state.objects.get_mut(&lord).unwrap();
+            let def = StaticDefinition::new(StaticMode::EntersWithAdditionalCounters {
+                counter_type: CounterType::Plus1Plus1,
+                count: 1,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature()
+                    .controller(ControllerRef::You)
+                    .properties(vec![FilterProp::Another]),
+            ));
+            obj.static_definitions.push(def.clone());
+            Arc::make_mut(&mut obj.base_static_definitions).push(def);
+        }
+
+        // Two external enter-tapped Moved replacements on the opponent's board
+        // — the same-field collision surfaces the CR 616.1 ordering prompt.
+        for (offset, name) in [
+            (0u64, "Authority of the Consuls"),
+            (1, "Imposing Sovereign"),
+        ] {
+            let oid = ObjectId(9000 + offset);
+            let mut src = GameObject::new(
+                oid,
+                CardId(900 + offset),
+                PlayerId(1),
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            src.replacement_definitions = vec![ReplacementDefinition::new(ReplacementEvent::Moved)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::Tap {
+                        target: TargetFilter::SelfRef,
+                    },
+                ))
+                .destination_zone(Zone::Battlefield)
+                .description(name.to_string())]
+            .into();
+            state.objects.insert(oid, src);
+            state.battlefield.push_back(oid);
+        }
+
+        // P0 creature entering from hand through the pipeline.
+        let entrant = create_object(
+            &mut state,
+            CardId(50),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&entrant)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let mut events = Vec::new();
+        let result = zone_pipeline::move_object(
+            &mut state,
+            ZoneMoveRequest::effect(entrant, Zone::Battlefield, entrant),
+            &mut events,
+        );
+        assert!(
+            matches!(result, ZoneMoveResult::NeedsChoice(_)),
+            "the enter-tapped collision must park the entry"
+        );
+        let WaitingFor::ReplacementChoice {
+            player: chooser, ..
+        } = state.waiting_for.clone()
+        else {
+            panic!(
+                "expected parked ReplacementChoice, got {:?}",
+                state.waiting_for
+            );
+        };
+        state.priority_player = chooser;
+
+        apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+            .expect("resume replacement choice");
+
+        let obj = &state.objects[&entrant];
+        assert_eq!(obj.zone, Zone::Battlefield, "entry delivered after resume");
+        assert!(obj.tapped, "both enter-tapped replacements applied");
+        assert_eq!(
+            *obj.counters.get(&CounterType::Plus1Plus1).unwrap_or(&0),
+            1,
+            "resumed entry must receive the EntersWithAdditionalCounters static \
+             (CR 614.1c) — the divergent resume copy dropped the statics snapshot"
         );
     }
 

--- a/crates/engine/src/game/sacrifice.rs
+++ b/crates/engine/src/game/sacrifice.rs
@@ -183,6 +183,8 @@ fn deliver_sacrifice_zone_change(
     let ctx = DeliveryCtx {
         source_id: None,
         exile_links: ExileLinkSpec::default(),
+        played_from_zone: None,
+        drain: crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
     };
     match zone_pipeline::deliver(state, approved, ctx, events) {
         ZoneDeliveryResult::Done => SacrificeApply::Complete,

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -584,6 +584,8 @@ fn check_lethal_damage(
                                 let ctx = DeliveryCtx {
                                     source_id: source,
                                     exile_links: ExileLinkSpec::default(),
+                                    played_from_zone: None,
+                                    drain: crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
                                 };
                                 // CR 704.3: completing all SBAs may require a
                                 // replacement choice surfaced by the delivery tail

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -18078,7 +18078,13 @@ pub mod tests {
         match crate::game::replacement::replace_event(state, proposed, events) {
             crate::game::replacement::ReplacementResult::Execute(event) => {
                 crate::game::effects::change_zone::deliver_replaced_zone_change(
-                    state, event, None, None, false, events,
+                    state,
+                    event,
+                    None,
+                    None,
+                    false,
+                    crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                    events,
                 );
             }
             crate::game::replacement::ReplacementResult::Prevented => {}

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -23,7 +23,7 @@ use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
     BatchCompletion, ExileLink, ExileLinkKind, GameState, PendingBatchDeliveries,
-    PendingCounterPostAction, WaitingFor, ZoneDeliveryExileTracking,
+    PendingCounterPostAction, PostReplacementDrainOwner, WaitingFor, ZoneDeliveryExileTracking,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -384,12 +384,25 @@ impl ApprovedZoneChange {
     }
 }
 
-/// Context threaded into `deliver`: the attributed source and exile-link spec.
-/// Consumed by the Phase B bucket-A `deliver(approved, ctx)` migrations.
-#[allow(dead_code)]
+/// Context threaded into `deliver`: the attributed source, exile-link spec,
+/// and the Phase-B resume-path reconciliation knobs. Consumed by the bucket-A
+/// `deliver(approved, ctx)` migrations.
 pub(crate) struct DeliveryCtx {
     pub source_id: Option<ObjectId>,
     pub exile_links: ExileLinkSpec,
+    /// CR 400.7 + PLAN Open Question #3 (UNDECIDED — current behavior
+    /// preserved exactly): `Some(zone)` re-stamps `played_from_zone` onto the
+    /// object after a battlefield delivery, because `reset_for_battlefield_entry`
+    /// (inside the raw mover) clears it. The replacement-choice resume path
+    /// captures the pre-move value and rides it here instead of re-deriving it
+    /// post-move; when OQ#3 is decided, either this field becomes universal
+    /// delivery-tail behavior or stays a resume/stack-only ctx knob — both
+    /// resolutions slot into this one site. `None` = no re-stamp (every
+    /// non-resume caller today).
+    pub played_from_zone: Option<Zone>,
+    /// CR 614.12a: who drains `post_replacement_continuation` after this
+    /// delivery (see [`PostReplacementDrainOwner`]).
+    pub drain: PostReplacementDrainOwner,
 }
 
 /// Result of a single zone-move attempt through the replacement pipeline.
@@ -555,6 +568,8 @@ pub(crate) fn move_object(
             DeliveryCtx {
                 source_id,
                 exile_links,
+                played_from_zone: None,
+                drain: PostReplacementDrainOwner::DeliveryTail,
             },
             events,
         ) {
@@ -851,10 +866,9 @@ pub(crate) fn drain_pending_batch_deliveries(state: &mut GameState, events: &mut
 }
 
 /// Deliver an event that already passed the replacement consult. Only callable
-/// with the `ApprovedZoneChange` proof token. This is the renamed
-/// `deliver_replaced_zone_change`; Phase A exposes it for the Phase B bucket-A
-/// migration (it is not yet called through the token by any production site).
-#[allow(dead_code)]
+/// with the `ApprovedZoneChange` proof token — the consult-once/deliver-once
+/// contract for every bucket-A post-replacement site (destroy/sacrifice/SBA
+/// lowering, the replacement-choice resume path, land play).
 pub(crate) fn deliver(
     state: &mut GameState,
     approved: ApprovedZoneChange,
@@ -865,14 +879,33 @@ pub(crate) fn deliver(
         ctx.exile_links.tracking,
         ZoneDeliveryExileTracking::TrackBySource
     );
-    deliver_replaced_zone_change(
+    let (object_id, to) = match &approved.event {
+        ProposedEvent::ZoneChange { object_id, to, .. } => (Some(*object_id), Some(*to)),
+        _ => (None, None),
+    };
+    let result = deliver_replaced_zone_change(
         state,
         approved.event,
         ctx.source_id,
         ctx.exile_links.duration.as_ref(),
         track_exiled_by_source,
+        ctx.drain,
         events,
-    )
+    );
+    // CR 400.7 + PLAN OQ#3 (undecided — behavior preserved): re-stamp the
+    // captured `played_from_zone` after a battlefield delivery, because
+    // `reset_for_battlefield_entry` cleared it. Runs on the counter-pause
+    // outcome too — the pre-token resume arm restored the field BEFORE the
+    // counter application, so the field must be live even when the delivery
+    // parks on a counter-replacement prompt.
+    if let (Some(zone), Some(object_id), Some(Zone::Battlefield)) =
+        (ctx.played_from_zone, object_id, to)
+    {
+        if let Some(obj) = state.objects.get_mut(&object_id) {
+            obj.played_from_zone = Some(zone);
+        }
+    }
+    result
 }
 
 /// CR 614.1c + CR 122.1: Collect the additional ETB counters that active
@@ -929,6 +962,7 @@ fn append_zone_delivery_tail_after_counter_pause(
     source_id: Option<ObjectId>,
     duration: Option<&Duration>,
     exile_tracking: ZoneDeliveryExileTracking,
+    drain: PostReplacementDrainOwner,
     clear_pending_etb_counters: Option<ObjectId>,
 ) -> ZoneDeliveryResult {
     let mut actions = Vec::new();
@@ -943,6 +977,7 @@ fn append_zone_delivery_tail_after_counter_pause(
         source_id,
         duration: duration.cloned(),
         exile_tracking,
+        drain,
     });
     crate::game::effects::counters::append_pending_counter_post_actions(state, actions);
     replacement_pause_delivery_result(state)
@@ -958,6 +993,7 @@ pub(crate) fn apply_zone_delivery_tail(
     source_id: Option<ObjectId>,
     duration: Option<&Duration>,
     exile_tracking: ZoneDeliveryExileTracking,
+    drain: PostReplacementDrainOwner,
     events: &mut Vec<GameEvent>,
 ) -> ZoneDeliveryResult {
     // CR 701.24a: To shuffle a library, randomize the cards within it so that
@@ -999,7 +1035,15 @@ pub(crate) fn apply_zone_delivery_tail(
     // `NeedsChoice` so the mass/single zone-change loop stashes the remaining
     // co-entering members and resumes after the choice (instead of dropping
     // them, issue #535 class).
-    if state.post_replacement_continuation.is_some() {
+    //
+    // `CallerEpilogue` (the replacement-choice resume path) skips this drain:
+    // its epilogue drains the continuation itself, WITH the spell-resolution
+    // ctx and with `post_replacement_source` cleared for zone changes, and
+    // only after `apply_pending_spell_resolution` (Phase-B divergence
+    // reconciliation — the tail is parameterized instead of copied).
+    if matches!(drain, PostReplacementDrainOwner::DeliveryTail)
+        && state.post_replacement_continuation.is_some()
+    {
         let waiting_for = crate::game::engine_replacement::apply_pending_post_replacement_effect(
             state,
             Some(object_id),
@@ -1110,6 +1154,7 @@ pub(crate) fn deliver_replaced_zone_change(
     source_id: Option<ObjectId>,
     duration: Option<&Duration>,
     track_exiled_by_source: bool,
+    drain: PostReplacementDrainOwner,
     events: &mut Vec<GameEvent>,
 ) -> ZoneDeliveryResult {
     if let ProposedEvent::ZoneChange {
@@ -1283,6 +1328,7 @@ pub(crate) fn deliver_replaced_zone_change(
                     source_id,
                     duration,
                     exile_tracking,
+                    drain,
                     pending_etb_cleanup,
                 );
             }
@@ -1313,6 +1359,7 @@ pub(crate) fn deliver_replaced_zone_change(
                     source_id,
                     duration,
                     exile_tracking,
+                    drain,
                     None,
                 );
             }
@@ -1326,6 +1373,7 @@ pub(crate) fn deliver_replaced_zone_change(
             source_id,
             duration,
             exile_tracking,
+            drain,
             events,
         );
     }
@@ -1543,6 +1591,7 @@ pub(crate) fn execute_zone_move(
                     Some(source_id),
                     duration,
                     track_exiled_by_source,
+                    PostReplacementDrainOwner::DeliveryTail,
                     events,
                 ) {
                     ZoneDeliveryResult::Done => {}
@@ -1573,6 +1622,7 @@ pub(crate) fn execute_zone_move(
                 Some(source_id),
                 duration,
                 track_exiled_by_source,
+                PostReplacementDrainOwner::DeliveryTail,
                 events,
             ) {
                 ZoneDeliveryResult::Done => {}

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1338,6 +1338,11 @@ pub enum PendingCounterPostAction {
         source_id: Option<ObjectId>,
         duration: Option<Duration>,
         exile_tracking: ZoneDeliveryExileTracking,
+        /// Who drains `post_replacement_continuation` when this deferred tail
+        /// finally runs (CR 614.12a). `#[serde(default)]` = `DeliveryTail`,
+        /// matching every record minted before the field existed.
+        #[serde(default)]
+        drain: PostReplacementDrainOwner,
     },
     RecordStationed {
         spacecraft_id: ObjectId,
@@ -1357,6 +1362,30 @@ pub enum ZoneDeliveryExileTracking {
     #[default]
     None,
     TrackBySource,
+}
+
+/// CR 614.12a + CR 616.1: Which layer drains `post_replacement_continuation`
+/// after a post-replacement zone delivery (Phase-B divergence reconciliation,
+/// PLAN §7). The replacement-choice resume path historically drained the
+/// continuation in its own epilogue — WITH the spell-resolution ctx and with
+/// `post_replacement_source` cleared for zone changes — while the shared
+/// delivery tail drains it ctx-less without the clear. Parameterizing the tail
+/// (instead of keeping two divergent delivery copies) lets the resume path
+/// route through the shared `deliver` machinery while its epilogue keeps
+/// exclusive ownership of the drain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum PostReplacementDrainOwner {
+    /// The shared delivery tail (`apply_zone_delivery_tail`) drains the
+    /// continuation ctx-less — every direct pipeline delivery (effect moves,
+    /// stack resolution, land play, destroy/sacrifice lowering).
+    #[default]
+    DeliveryTail,
+    /// The caller's epilogue owns the drain; the tail skips it. Used by
+    /// `engine_replacement::handle_replacement_choice`, whose post-`Execute`
+    /// epilogue drains with the spell-resolution ctx and clears
+    /// `post_replacement_source` for zone changes (CR 614.12a ordering:
+    /// `apply_pending_spell_resolution` runs before the drain there).
+    CallerEpilogue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/AI-CONTRIBUTOR.md
+++ b/docs/AI-CONTRIBUTOR.md
@@ -117,6 +117,21 @@ If the contributor lacks `gh`, fall back to a plain `git clone` and tell them (i
 
 ---
 
+## 2.1. Sync your fork with upstream — every run
+
+Run this on **every** invocation, not just the first clone. A fork's `main` goes stale the moment upstream advances; working from a stale base produces spurious diffs against `origin/main`, risks textual merge-queue conflicts, and can revert other contributors' landed work. Always start from an up-to-date codebase.
+
+```bash
+git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://github.com/phase-rs/phase.git
+git fetch upstream main
+git checkout main && git merge --ff-only upstream/main   # fast-forward fork main to upstream
+git push origin main                                     # keep the fork's main in sync (best-effort)
+```
+
+If `git merge --ff-only` fails, your fork's `main` has diverged from upstream — do **not** force it. Proceed to §4 regardless: that step cuts your working branch directly from `upstream/main`, so a diverged fork `main` never contaminates your change.
+
+---
+
 ## 2.5. Bootstrap the repo (Developer track only)
 
 Run **once per fresh clone** before invoking `$engine-implementer`. This downloads MTGJSON, generates `client/public/card-data.json`, fetches the local copy of the Comprehensive Rules, installs frontend deps, and configures git hooks:
@@ -369,11 +384,16 @@ you can invoke skills, run shell commands, and you will not pause for input.
 
 Steps:
 1. gh repo fork phase-rs/phase --clone --remote && cd phase
+1a. Sync your fork with upstream EVERY run (never work from a stale base):
+   git remote add upstream https://github.com/phase-rs/phase.git 2>/dev/null;
+   git fetch upstream main; git checkout main &&
+   git merge --ff-only upstream/main && git push origin main
 2. If I named a card, use it. Otherwise WebFetch
    https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/staging/coverage-data.json
    and pick a card with supported==false and small gap_count.
-3. git checkout -b card/<slug>  (if the branch already exists locally or on
-   origin, append "-2", "-3", etc. — see Step 4 in docs/AI-CONTRIBUTOR.md).
+3. git checkout -b card/<slug> upstream/main  (cut the branch from CURRENT
+   upstream/main, not stale fork main; if the branch already exists locally or
+   on origin, append "-2", "-3", etc. — see Step 4 in docs/AI-CONTRIBUTOR.md).
 4. Invoke the $engine-implementer skill to implement the card. Tell it: follow
    CLAUDE.md and AGENTS.md without exception, plan with engine-planner, review
    the plan with $review-engine-plan until clean, use nom combinators on first


### PR DESCRIPTION
## Summary

Zone-change pipeline Phase B: all production bucket-A post-replacement delivery sites now route through the `ApprovedZoneChange` proof token + shared `zone_pipeline::deliver` tail — consult-once/deliver-once is structural, not conventional. Follows #2824/#2829. Also adds the PR template mandating engine-implementer attestation.

### The centerpiece

`handle_replacement_choice`'s ZoneChange resume arm — previously a divergent partial copy of the delivery tail that had already silently dropped two fields (face-down profile, batch attribution) — is dissolved. It now seals the post-replacement event via `ApprovedZoneChange::approve_post_replacement` (private fields + `_seal`; re-consult impossible by construction) and delivers through the shared tail. Resumed entries now receive the full tail: devour snapshot, `EntersWithAdditionalCounters` statics (CR 614.1c), `attach_to`, `entered_via_ability_source`, exile-link tracking, library auto-shuffle (CR 701.24a).

New machinery: `PostReplacementDrainOwner` (`DeliveryTail` / `CallerEpilogue`) rides `DeliveryCtx` and the deferred-tail record, so resume-path callers keep their epilogue's ctx-ful continuation drain without duplicating the tail. The counter-pause double-resume semantic is preserved and regression-pinned.

### Site migrations

- **Land play** (`handle_play_land` Execute arm): raw delivery + hand-applied enter-mods → token delivery. Lands now receive enters-with-counters statics (fail-first test: counter 0 → 1). `mark_land_played_from_zone` stamps a fresh origin after delivery on both synchronous and counter-pause paths (CR 305.1).
- **Top-library exile cost** (`pay_top_library_exile_cost`): the `(object_id, zone)` degradation — which discarded post-replacement payloads and `applied` sets — replaced by sealing full `ProposedEvent`s. Verified purely structural (the Exile delivery tail early-return predates this change and is preserved exactly).

### Status

The sole remaining production bucket-A raw delivery is `stack.rs:757`, parked on a design decision (`played_from_zone` provenance, PLAN OQ#3). Independent post-rebase census: zero genuinely-unmigrated production sites with live replacement exposure remain; the residual ~36 raw callers are all documented deferral classes (hand/exile no-op-consult, library placements, merged-permanent routing).

## Verification

- Fail-first discriminating tests for both behavior deltas; regression net green (devour post-replacement tests from #2795, paused face-down morph / ninjutsu / attraction, mill/seek/bounce batch resumes).
- Tilt gates green per batch (clippy, test-engine 12134/12134, test-ai).
- Two independent opus reviews: the resume-arm centerpiece (approved with complete divergence-enumeration audit) and the two site migrations (approved, all exit paths traced, CR cites grep-verified).
- `cargo check --workspace --all-targets` green in the ship worktree against current origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
