### PR TITLE
fix(engine): Pest token attack life gain from catalog

### DIFF
--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -405,7 +405,7 @@ fn apply_pending_counter_post_action(
             // complete token entry exactly as the uninterrupted token path
             // does: abilities/bookkeeping, attachment, ETB events, and any
             // delayed sacrifice trigger.
-            super::token::inject_predefined_token_abilities(state, object_id);
+            super::token::inject_resolved_token_abilities(state, object_id);
             crate::game::layers::mark_layers_entered(state, object_id);
             crate::game::restrictions::record_battlefield_entry(state, object_id);
             crate::game::restrictions::record_token_created(state, object_id);

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -771,9 +771,9 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
             }
         }
 
-        // CR 111.10: Inject predefined abilities for known token subtypes.
-        inject_predefined_token_abilities(state, obj_id);
-        inject_catalog_token_abilities(state, obj_id);
+        // CR 111.4 + CR 707.2a: Predefined abilities first; catalog rules_text
+        // only when the predefined path contributed nothing.
+        inject_resolved_token_abilities(state, obj_id);
         // Battlefield entry: request an incremental layer re-derive for just this
         // token. `flush_layers` escalates to a full pass if the token sources a
         // continuous effect / carries counters / etc., or if any active effect
@@ -2377,6 +2377,19 @@ fn predefined_role_token_spec(name: &str) -> Option<RoleSpec> {
 /// the layer pass rebuilds live from base on each pass, but several code
 /// paths (SBAs, action enumeration) consult the live set directly between
 /// passes so keeping them in sync here avoids a one-frame lag.
+/// CR 111.4 + CR 707.2a: Apply predefined token abilities first; fall back to
+/// catalog `rules_text` only when the predefined path contributed nothing
+/// (artifacts, Roles, Incubator, …).
+pub(super) fn inject_resolved_token_abilities(
+    state: &mut GameState,
+    obj_id: crate::types::identifiers::ObjectId,
+) {
+    let predefined_injected = inject_predefined_token_abilities(state, obj_id);
+    if !predefined_injected {
+        inject_catalog_token_abilities(state, obj_id);
+    }
+}
+
 /// CR 111.4 + CR 707.2a: Grant catalog `rules_text` when token creation resolved
 /// a `token_image_ref` preset whose abilities are not already covered by the
 /// predefined path (e.g. SOS Pest attack life gain).
@@ -2392,15 +2405,6 @@ pub(super) fn inject_catalog_token_abilities(
     }) else {
         return;
     };
-    // CR 111.10 + CR 707.2a: Predefined-artifact presets already receive their
-    // abilities from `inject_predefined_token_abilities`; re-deriving from
-    // rules_text would double-grant the same sacrifice/mana ability.
-    if matches!(
-        preset.category,
-        crate::game::token_presets::TokenCategory::PredefinedArtifact { .. }
-    ) {
-        return;
-    }
     let Some(rules_text) = preset.rules_text.as_deref().filter(|text| !text.is_empty()) else {
         return;
     };
@@ -2451,10 +2455,10 @@ pub(super) fn inject_catalog_token_abilities(
 pub(super) fn inject_predefined_token_abilities(
     state: &mut GameState,
     obj_id: crate::types::identifiers::ObjectId,
-) {
+) -> bool {
     let (subtypes, name) = match state.objects.get(&obj_id) {
         Some(obj) => (obj.card_types.subtypes.clone(), obj.name.clone()),
-        None => return,
+        None => return false,
     };
     let mut abilities_to_add = Vec::new();
     for subtype in &subtypes {
@@ -2465,13 +2469,14 @@ pub(super) fn inject_predefined_token_abilities(
     } else {
         None
     };
+    let is_incubator = subtypes.iter().any(|s| s == "Incubator");
 
-    if abilities_to_add.is_empty() && role_spec.is_none() {
-        return;
+    if abilities_to_add.is_empty() && role_spec.is_none() && !is_incubator {
+        return false;
     }
 
     let Some(obj) = state.objects.get_mut(&obj_id) else {
-        return;
+        return false;
     };
 
     if !abilities_to_add.is_empty() {
@@ -2511,6 +2516,8 @@ pub(super) fn inject_predefined_token_abilities(
             }
         }
     }
+
+    true
 }
 
 #[cfg(test)]
@@ -3725,6 +3732,83 @@ mod tests {
         assert!(
             obj.trigger_definitions.is_empty(),
             "catalog injection must not double-grant predefined Treasure triggers"
+        );
+    }
+
+    #[test]
+    fn predefined_royal_role_create_token_pipeline_has_exactly_one_role_static() {
+        use crate::types::proposed_event::TokenCharacteristics;
+        use std::collections::HashSet;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Royal Treatment".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .source_related_token_ids
+            .push("48b5010a-9c00-5cc1-b5e1-f407670846ba".to_string());
+        let spec = TokenSpec {
+            characteristics: TokenCharacteristics {
+                display_name: "Royal".to_string(),
+                power: None,
+                toughness: None,
+                core_types: vec![CoreType::Enchantment],
+                subtypes: vec!["Aura".to_string(), "Role".to_string()],
+                supertypes: vec![],
+                colors: vec![],
+                keywords: vec![],
+            },
+            script_name: "Royal".to_string(),
+            static_abilities: vec![],
+            enter_with_counters: vec![],
+            tapped: false,
+            enters_attacking: false,
+            sacrifice_at: None,
+            source_id: source,
+            controller: PlayerId(0),
+            attach_to: None,
+        };
+        let event = ProposedEvent::CreateToken {
+            owner: PlayerId(0),
+            spec: Box::new(spec),
+            copy: None,
+            enter_tapped: crate::types::proposed_event::EtbTapState::Unspecified,
+            count: 1,
+            applied: HashSet::new(),
+        };
+        let mut events = vec![];
+        apply_create_token_after_replacement(&mut state, event, &mut events);
+
+        let role_id = state.last_created_token_ids[0];
+        let obj = &state.objects[&role_id];
+        assert!(
+            obj.token_image_ref.is_some(),
+            "Royal Role creation must resolve a catalog preset image ref"
+        );
+        assert_eq!(
+            obj.static_definitions.len(),
+            1,
+            "predefined Royal Role must carry exactly one enchanted-creature static"
+        );
+        assert_eq!(
+            obj.base_static_definitions.len(),
+            1,
+            "base_static_definitions must mirror the single role static"
+        );
+        assert!(
+            obj.abilities.is_empty(),
+            "Royal Role has no activated abilities from the predefined path"
+        );
+        assert!(
+            obj.trigger_definitions.is_empty(),
+            "catalog injection must not double-grant predefined Royal Role statics"
         );
     }
 

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -773,6 +773,7 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
 
         // CR 111.10: Inject predefined abilities for known token subtypes.
         inject_predefined_token_abilities(state, obj_id);
+        inject_catalog_token_abilities(state, obj_id);
         // Battlefield entry: request an incremental layer re-derive for just this
         // token. `flush_layers` escalates to a full pass if the token sources a
         // continuous effect / carries counters / etc., or if any active effect
@@ -2376,6 +2377,45 @@ fn predefined_role_token_spec(name: &str) -> Option<RoleSpec> {
 /// the layer pass rebuilds live from base on each pass, but several code
 /// paths (SBAs, action enumeration) consult the live set directly between
 /// passes so keeping them in sync here avoids a one-frame lag.
+/// CR 111.10: Grant catalog `rules_text` when token creation resolved a
+/// `token_image_ref` preset (e.g. SOS Pest attack life gain).
+pub(super) fn inject_catalog_token_abilities(
+    state: &mut GameState,
+    obj_id: crate::types::identifiers::ObjectId,
+) {
+    let Some(preset_id) = state
+        .objects
+        .get(&obj_id)
+        .and_then(|obj| obj.token_image_ref.as_ref())
+        .map(|image_ref| image_ref.preset_id.as_str())
+    else {
+        return;
+    };
+    let Some(preset) = crate::game::token_presets::known_token_preset_by_id(preset_id) else {
+        return;
+    };
+    let Some(rules_text) = preset.rules_text.as_deref().filter(|text| !text.is_empty()) else {
+        return;
+    };
+    let modifications =
+        crate::parser::oracle_static::classify_quoted_inner(rules_text);
+    if modifications.is_empty() {
+        return;
+    }
+    let static_def = crate::types::ability::StaticDefinition::continuous()
+        .affected(crate::types::ability::TargetFilter::SelfRef)
+        .modifications(modifications)
+        .description(rules_text.to_string());
+    let Some(obj) = state.objects.get_mut(&obj_id) else {
+        return;
+    };
+    Arc::make_mut(&mut obj.base_static_definitions).push(static_def.clone());
+    obj.static_definitions.push(static_def);
+    if obj.token_rules_text.is_none() {
+        obj.token_rules_text = Some(rules_text.to_string());
+    }
+}
+
 pub(super) fn inject_predefined_token_abilities(
     state: &mut GameState,
     obj_id: crate::types::identifiers::ObjectId,
@@ -3550,6 +3590,41 @@ mod tests {
                 .unwrap_or(0),
             1,
             "Writhing Chrysalis sacrifice trigger should resolve to a +1/+1 counter"
+        );
+    }
+
+    #[test]
+    fn catalog_pest_preset_grants_attack_life_trigger() {
+        let preset = crate::game::token_presets::known_token_preset_by_id(
+            "00a0801d-0212-5890-8957-3cde30f382f9",
+        )
+        .expect("SOS Pest preset");
+
+        let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 2, 42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Pest".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&obj_id).unwrap();
+            obj.is_token = true;
+            obj.token_image_ref = preset.token_image_ref.clone();
+        }
+        inject_catalog_token_abilities(&mut state, obj_id);
+        let obj = &state.objects[&obj_id];
+        assert!(
+            obj.static_definitions.iter_all().any(|s| s
+                .modifications
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::GrantTrigger { .. }))),
+            "catalog rules_text must grant the attacks life trigger"
+        );
+        assert_eq!(
+            obj.token_rules_text.as_deref(),
+            Some("Whenever this token attacks, you gain 1 life.")
         );
     }
 

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -2383,22 +2383,18 @@ pub(super) fn inject_catalog_token_abilities(
     state: &mut GameState,
     obj_id: crate::types::identifiers::ObjectId,
 ) {
-    let Some(preset_id) = state
-        .objects
-        .get(&obj_id)
-        .and_then(|obj| obj.token_image_ref.as_ref())
-        .map(|image_ref| image_ref.preset_id.as_str())
-    else {
+    let Some(obj) = state.objects.get_mut(&obj_id) else {
         return;
     };
-    let Some(preset) = crate::game::token_presets::known_token_preset_by_id(preset_id) else {
+    let Some(preset) = obj.token_image_ref.as_ref().and_then(|image_ref| {
+        crate::game::token_presets::known_token_preset_by_id(&image_ref.preset_id)
+    }) else {
         return;
     };
     let Some(rules_text) = preset.rules_text.as_deref().filter(|text| !text.is_empty()) else {
         return;
     };
-    let modifications =
-        crate::parser::oracle_static::classify_quoted_inner(rules_text);
+    let modifications = crate::parser::oracle_static::classify_quoted_inner(rules_text);
     if modifications.is_empty() {
         return;
     }
@@ -2406,9 +2402,6 @@ pub(super) fn inject_catalog_token_abilities(
         .affected(crate::types::ability::TargetFilter::SelfRef)
         .modifications(modifications)
         .description(rules_text.to_string());
-    let Some(obj) = state.objects.get_mut(&obj_id) else {
-        return;
-    };
     Arc::make_mut(&mut obj.base_static_definitions).push(static_def.clone());
     obj.static_definitions.push(static_def);
     if obj.token_rules_text.is_none() {

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -2377,8 +2377,9 @@ fn predefined_role_token_spec(name: &str) -> Option<RoleSpec> {
 /// the layer pass rebuilds live from base on each pass, but several code
 /// paths (SBAs, action enumeration) consult the live set directly between
 /// passes so keeping them in sync here avoids a one-frame lag.
-/// CR 111.10: Grant catalog `rules_text` when token creation resolved a
-/// `token_image_ref` preset (e.g. SOS Pest attack life gain).
+/// CR 111.4 + CR 707.2a: Grant catalog `rules_text` when token creation resolved
+/// a `token_image_ref` preset whose abilities are not already covered by the
+/// predefined path (e.g. SOS Pest attack life gain).
 pub(super) fn inject_catalog_token_abilities(
     state: &mut GameState,
     obj_id: crate::types::identifiers::ObjectId,
@@ -2391,6 +2392,15 @@ pub(super) fn inject_catalog_token_abilities(
     }) else {
         return;
     };
+    // CR 111.10 + CR 707.2a: Predefined-artifact presets already receive their
+    // abilities from `inject_predefined_token_abilities`; re-deriving from
+    // rules_text would double-grant the same sacrifice/mana ability.
+    if matches!(
+        preset.category,
+        crate::game::token_presets::TokenCategory::PredefinedArtifact { .. }
+    ) {
+        return;
+    }
     let Some(rules_text) = preset.rules_text.as_deref().filter(|text| !text.is_empty()) else {
         return;
     };
@@ -2398,12 +2408,41 @@ pub(super) fn inject_catalog_token_abilities(
     if modifications.is_empty() {
         return;
     }
-    let static_def = crate::types::ability::StaticDefinition::continuous()
-        .affected(crate::types::ability::TargetFilter::SelfRef)
-        .modifications(modifications)
-        .description(rules_text.to_string());
-    Arc::make_mut(&mut obj.base_static_definitions).push(static_def.clone());
-    obj.static_definitions.push(static_def);
+
+    let mut static_mods = Vec::new();
+    let mut triggers = Vec::new();
+    let mut abilities = Vec::new();
+    let mut keywords = Vec::new();
+    for modification in modifications {
+        match modification {
+            ContinuousModification::GrantTrigger { trigger } => triggers.push(*trigger),
+            ContinuousModification::AddKeyword { keyword } => keywords.push(keyword),
+            ContinuousModification::GrantAbility { definition } => abilities.push(*definition),
+            other => static_mods.push(other),
+        }
+    }
+
+    if !static_mods.is_empty() {
+        let static_def = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(static_mods)
+            .description(rules_text.to_string());
+        Arc::make_mut(&mut obj.base_static_definitions).push(static_def.clone());
+        obj.static_definitions.push(static_def);
+    }
+    if !triggers.is_empty() {
+        Arc::make_mut(&mut obj.base_trigger_definitions).extend(triggers.iter().cloned());
+        for trigger in triggers {
+            obj.trigger_definitions.push(trigger);
+        }
+    }
+    if !abilities.is_empty() {
+        Arc::make_mut(&mut obj.abilities).extend(abilities.iter().cloned());
+        Arc::make_mut(&mut obj.base_abilities).extend(abilities);
+    }
+    if !keywords.is_empty() {
+        obj.keywords.extend(keywords);
+    }
     if obj.token_rules_text.is_none() {
         obj.token_rules_text = Some(rules_text.to_string());
     }
@@ -3608,16 +3647,84 @@ mod tests {
         }
         inject_catalog_token_abilities(&mut state, obj_id);
         let obj = &state.objects[&obj_id];
-        assert!(
-            obj.static_definitions.iter_all().any(|s| s
-                .modifications
-                .iter()
-                .any(|m| matches!(m, ContinuousModification::GrantTrigger { .. }))),
-            "catalog rules_text must grant the attacks life trigger"
+        assert_eq!(
+            obj.trigger_definitions.len(),
+            1,
+            "catalog rules_text must install the attacks life trigger intrinsically"
         );
+        assert_eq!(obj.trigger_definitions[0].mode, TriggerMode::Attacks);
         assert_eq!(
             obj.token_rules_text.as_deref(),
             Some("Whenever this token attacks, you gain 1 life.")
+        );
+    }
+
+    #[test]
+    fn predefined_treasure_create_token_pipeline_has_exactly_one_mana_ability() {
+        use crate::types::proposed_event::TokenCharacteristics;
+        use std::collections::HashSet;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Rapacious Dragon".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .source_related_token_ids
+            .push("0060ce13-67e2-5607-a29b-721c743e6770".to_string());
+        let spec = TokenSpec {
+            characteristics: TokenCharacteristics {
+                display_name: "Treasure".to_string(),
+                power: None,
+                toughness: None,
+                core_types: vec![CoreType::Artifact],
+                subtypes: vec!["Treasure".to_string()],
+                supertypes: vec![],
+                colors: vec![],
+                keywords: vec![],
+            },
+            script_name: "Treasure".to_string(),
+            static_abilities: vec![],
+            enter_with_counters: vec![],
+            tapped: false,
+            enters_attacking: false,
+            sacrifice_at: None,
+            source_id: source,
+            controller: PlayerId(0),
+            attach_to: None,
+        };
+        let event = ProposedEvent::CreateToken {
+            owner: PlayerId(0),
+            spec: Box::new(spec),
+            copy: None,
+            enter_tapped: crate::types::proposed_event::EtbTapState::Unspecified,
+            count: 1,
+            applied: HashSet::new(),
+        };
+        let mut events = vec![];
+        apply_create_token_after_replacement(&mut state, event, &mut events);
+
+        let treasure_id = state.last_created_token_ids[0];
+        let obj = &state.objects[&treasure_id];
+        assert!(
+            obj.token_image_ref.is_some(),
+            "Treasure creation must resolve a catalog preset image ref"
+        );
+        assert_eq!(
+            obj.abilities.len(),
+            1,
+            "predefined Treasure must carry exactly one sacrifice-for-mana ability"
+        );
+        assert!(matches!(*obj.abilities[0].effect, Effect::Mana { .. }));
+        assert!(
+            obj.trigger_definitions.is_empty(),
+            "catalog injection must not double-grant predefined Treasure triggers"
         );
     }
 


### PR DESCRIPTION
## Summary
- After token creation, parse and grant abilities from the catalog preset linked via token_image_ref.
- Fixes SOS Pest tokens gaining life when attacking.

## Test plan
- [ ] Create a SOS-style Pest token and attack; confirm you gain 1 life.
- [ ] Confirm dies-trigger Pest tokens use their own preset unchanged.

Fixes #866

Made with [Cursor](https://cursor.com)