### PR TITLE
fix(deck-builder): replace Load deck select with MenuSelect

### DIFF
--- a/client/src/components/deck-builder/DeckBuilderToolbar.tsx
+++ b/client/src/components/deck-builder/DeckBuilderToolbar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { GameFormat } from "../../adapter/types";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import { FormatFilter } from "./FormatFilter";
+import { MenuSelect } from "../ui/MenuSelect";
 import { SelectField } from "../ui/SelectField";
 
 function PencilIcon({ className }: { className?: string }) {
@@ -119,19 +120,12 @@ export function DeckBuilderToolbar({
           {t("toolbar.clone")}
         </button>
         {savedDecks.length > 0 && (
-          <SelectField
-            onChange={(e) => e.target.value && onLoad(e.target.value)}
-            value=""
+          <MenuSelect
+            label={t("toolbar.loadDeck")}
+            items={savedDecks.map((name) => ({ value: name, label: name }))}
+            onSelect={onLoad}
             wrapperClassName="max-w-[8rem] shrink-0 sm:max-w-none"
-            className="rounded-xl border border-white/10 bg-black/18 px-3 py-1.5 text-sm text-white focus:outline-none"
-          >
-            <option value="">{t("toolbar.loadDeck")}</option>
-            {savedDecks.map((name) => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ))}
-          </SelectField>
+          />
         )}
       </div>
     </div>

--- a/client/src/components/deck-builder/DeckBuilderToolbar.tsx
+++ b/client/src/components/deck-builder/DeckBuilderToolbar.tsx
@@ -124,7 +124,7 @@ export function DeckBuilderToolbar({
             label={t("toolbar.loadDeck")}
             items={savedDecks.map((name) => ({ value: name, label: name }))}
             onSelect={onLoad}
-            wrapperClassName="max-w-[8rem] shrink-0 sm:max-w-none"
+            wrapperClassName="shrink-0"
           />
         )}
       </div>

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -3,6 +3,10 @@ import { createPortal } from "react-dom";
 
 const MENU_GAP_PX = 4;
 const MENU_MAX_HEIGHT_PX = 280;
+// Cap how far the widest item label can grow the closed trigger — a single
+// long deck name must not stretch the toolbar (items truncate with a title
+// tooltip beyond this).
+const TRIGGER_MAX_WIDTH_PX = 320;
 
 export interface MenuSelectItem {
   value: string;
@@ -85,7 +89,7 @@ export function MenuSelect({
     }
 
     // px-3 padding + chevron + gap between label and icon.
-    setMinWidthPx(contentWidth + 48);
+    setMinWidthPx(Math.min(contentWidth + 48, TRIGGER_MAX_WIDTH_PX));
   }, [label, itemsKey]);
 
   const updatePosition = useCallback(() => {
@@ -110,6 +114,9 @@ export function MenuSelect({
   useLayoutEffect(() => {
     if (!open) return;
     updatePosition();
+    // APG listbox pattern: move focus into the menu so the keyboard path
+    // (Arrow keys + Enter) works like the native select this replaces.
+    menuRef.current?.querySelector<HTMLButtonElement>('[role="option"]')?.focus();
   }, [open, updatePosition]);
 
   useEffect(() => {
@@ -121,7 +128,23 @@ export function MenuSelect({
       setOpen(false);
     };
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+        return;
+      }
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      const options = menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]');
+      if (!options || options.length === 0) return;
+      event.preventDefault();
+      const current = Array.prototype.indexOf.call(options, document.activeElement);
+      const next =
+        current < 0
+          ? event.key === "ArrowDown"
+            ? 0
+            : options.length - 1
+          : (current + (event.key === "ArrowDown" ? 1 : -1) + options.length) % options.length;
+      options[next].focus();
     };
     const handleScroll = (event: Event) => {
       const target = event.target as Node | null;

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -59,13 +59,16 @@ export function MenuSelect({
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLSpanElement>(null);
+  const itemsKey = items.map((item) => item.label).join("\0");
   const [menuStyle, setMenuStyle] = useState<{
-    top: number;
+    top: number | "auto";
+    bottom: number | "auto";
     left: number;
     width: number;
     maxHeight: number;
   }>({
     top: 0,
+    bottom: "auto",
     left: 0,
     width: 0,
     maxHeight: MENU_MAX_HEIGHT_PX,
@@ -83,7 +86,7 @@ export function MenuSelect({
 
     // px-3 padding + chevron + gap between label and icon.
     setMinWidthPx(contentWidth + 48);
-  }, [label, items]);
+  }, [label, itemsKey]);
 
   const updatePosition = useCallback(() => {
     const trigger = triggerRef.current;
@@ -94,23 +97,20 @@ export function MenuSelect({
     const spaceAbove = Math.max(0, rect.top - MENU_GAP_PX);
     const openUp = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
     const maxHeight = Math.min(MENU_MAX_HEIGHT_PX, openUp ? spaceAbove : spaceBelow);
-    const renderedHeight = Math.min(menuRef.current?.offsetHeight ?? maxHeight, maxHeight);
 
     setMenuStyle({
       left: rect.left,
       width: rect.width,
       maxHeight: Math.max(maxHeight, 0),
-      top: openUp ? rect.top - renderedHeight - MENU_GAP_PX : rect.bottom + MENU_GAP_PX,
+      top: openUp ? "auto" : rect.bottom + MENU_GAP_PX,
+      bottom: openUp ? window.innerHeight - rect.top + MENU_GAP_PX : "auto",
     });
   }, []);
 
   useLayoutEffect(() => {
     if (!open) return;
     updatePosition();
-    // Re-measure once the portaled menu has layout for open-up placement.
-    const frame = requestAnimationFrame(updatePosition);
-    return () => cancelAnimationFrame(frame);
-  }, [open, items.length, minWidthPx, updatePosition]);
+  }, [open, updatePosition]);
 
   useEffect(() => {
     if (!open) return;
@@ -196,6 +196,7 @@ export function MenuSelect({
             onWheel={(event) => event.stopPropagation()}
             style={{
               top: menuStyle.top,
+              bottom: menuStyle.bottom,
               left: menuStyle.left,
               width: menuStyle.width,
               maxHeight: menuStyle.maxHeight,

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const MENU_GAP_PX = 4;
+const MENU_MAX_HEIGHT_PX = 280;
+
+export interface MenuSelectItem {
+  value: string;
+  label: string;
+}
+
+export interface MenuSelectProps {
+  /** Visible trigger label (e.g. placeholder text). */
+  label: string;
+  items: MenuSelectItem[];
+  onSelect: (value: string) => void;
+  disabled?: boolean;
+  /** Class on the outer relative wrapper (e.g. `max-w-[8rem] shrink-0`). */
+  wrapperClassName?: string;
+  /** Class on the trigger button. */
+  className?: string;
+}
+
+function ChevronDownIcon({ className }: { className: string }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 20 20" className={`fill-current ${className}`}>
+      <path d="M5.47 7.97a.75.75 0 0 1 1.06 0L10 11.44l3.47-3.47a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 0 1-1.06 0l-4-4a.75.75 0 0 1 0-1.06Z" />
+    </svg>
+  );
+}
+
+function getScrollParents(element: HTMLElement | null): (HTMLElement | Window)[] {
+  const parents: (HTMLElement | Window)[] = [window];
+  let node = element?.parentElement ?? null;
+
+  while (node) {
+    const { overflow, overflowY, overflowX } = getComputedStyle(node);
+    const scrollable = [overflow, overflowY, overflowX].some(
+      (value) => value === "auto" || value === "scroll" || value === "overlay",
+    );
+    if (scrollable) parents.push(node);
+    node = node.parentElement;
+  }
+
+  return parents;
+}
+
+export function MenuSelect({
+  label,
+  items,
+  onSelect,
+  disabled = false,
+  wrapperClassName = "",
+  className = "",
+}: MenuSelectProps) {
+  const listboxId = useId();
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuStyle, setMenuStyle] = useState<{
+    top: number;
+    left: number;
+    width: number;
+    minWidth: number;
+    maxHeight: number;
+  }>({
+    top: 0,
+    left: 0,
+    width: 0,
+    minWidth: 0,
+    maxHeight: MENU_MAX_HEIGHT_PX,
+  });
+
+  const updatePosition = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+
+    const rect = trigger.getBoundingClientRect();
+    const spaceBelow = Math.max(0, window.innerHeight - rect.bottom - MENU_GAP_PX);
+    const spaceAbove = Math.max(0, rect.top - MENU_GAP_PX);
+    const openUp = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
+    const maxHeight = Math.min(MENU_MAX_HEIGHT_PX, openUp ? spaceAbove : spaceBelow);
+    const renderedHeight = Math.min(menuRef.current?.offsetHeight ?? maxHeight, maxHeight);
+
+    const viewportMargin = 8;
+    const naturalWidth = Math.max(rect.width, menuRef.current?.scrollWidth ?? rect.width);
+    const spaceRight = window.innerWidth - rect.left - viewportMargin;
+    const spaceLeft = rect.right - viewportMargin;
+
+    let width = Math.min(naturalWidth, window.innerWidth - viewportMargin * 2);
+    let left = rect.left;
+
+    if (width > spaceRight && spaceLeft >= width) {
+      left = rect.right - width;
+    } else {
+      width = Math.min(width, spaceRight);
+      left = Math.max(viewportMargin, Math.min(left, window.innerWidth - width - viewportMargin));
+    }
+
+    setMenuStyle({
+      left,
+      width,
+      minWidth: rect.width,
+      maxHeight: Math.max(maxHeight, 0),
+      top: openUp ? rect.top - renderedHeight - MENU_GAP_PX : rect.bottom + MENU_GAP_PX,
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updatePosition();
+    // Re-measure once the portaled menu has layout for open-up placement.
+    const frame = requestAnimationFrame(updatePosition);
+    return () => cancelAnimationFrame(frame);
+  }, [open, items.length, updatePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    const handleScroll = (event: Event) => {
+      const target = event.target as Node | null;
+      if (menuRef.current && target && menuRef.current.contains(target)) return;
+      updatePosition();
+    };
+
+    const scrollParents = getScrollParents(triggerRef.current);
+
+    window.addEventListener("pointerdown", handlePointerDown, true);
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", updatePosition);
+    scrollParents.forEach((parent) => {
+      parent.addEventListener("scroll", handleScroll, { passive: true });
+    });
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", updatePosition);
+      scrollParents.forEach((parent) => {
+        parent.removeEventListener("scroll", handleScroll);
+      });
+    };
+  }, [open, updatePosition]);
+
+  const triggerClassName = [
+    "flex w-full items-center justify-between gap-2 rounded-xl border border-white/10 bg-black/18 px-3 py-1.5 text-left text-sm text-white transition-colors",
+    "hover:bg-white/6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20",
+    disabled ? "cursor-not-allowed opacity-40" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={`relative ${wrapperClassName}`.trim()}>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-label={label}
+        onClick={() => {
+          if (disabled) return;
+          setOpen((prev) => !prev);
+        }}
+        className={triggerClassName}
+      >
+        <span className="truncate">{label}</span>
+        <ChevronDownIcon className="h-4 w-4 shrink-0 text-white/70" />
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            id={listboxId}
+            role="listbox"
+            aria-label={label}
+            className="fixed z-[120] w-max overflow-y-auto overscroll-contain rounded-xl border border-white/10 bg-[#0a0f1b]/98 py-1 shadow-xl backdrop-blur-md thin-scrollbar"
+            onWheel={(event) => event.stopPropagation()}
+            style={{
+              top: menuStyle.top,
+              left: menuStyle.left,
+              width: menuStyle.width > 0 ? menuStyle.width : undefined,
+              minWidth: menuStyle.minWidth,
+              maxHeight: menuStyle.maxHeight,
+            }}
+          >
+            {items.map((item) => (
+              <button
+                key={item.value}
+                type="button"
+                role="option"
+                onClick={() => {
+                  onSelect(item.value);
+                  setOpen(false);
+                }}
+                className="flex w-full min-w-0 items-center px-3 py-2 text-left text-sm text-slate-200 transition-colors hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-none"
+              >
+                <span className="min-w-0 whitespace-nowrap">{item.label}</span>
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -55,21 +55,35 @@ export function MenuSelect({
 }: MenuSelectProps) {
   const listboxId = useId();
   const [open, setOpen] = useState(false);
+  const [minWidthPx, setMinWidthPx] = useState<number | undefined>(undefined);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
   const [menuStyle, setMenuStyle] = useState<{
     top: number;
     left: number;
     width: number;
-    minWidth: number;
     maxHeight: number;
   }>({
     top: 0,
     left: 0,
     width: 0,
-    minWidth: 0,
     maxHeight: MENU_MAX_HEIGHT_PX,
   });
+
+  useLayoutEffect(() => {
+    const measure = measureRef.current;
+    if (!measure) return;
+
+    let contentWidth = 0;
+    for (const sample of [label, ...items.map((item) => item.label)]) {
+      measure.textContent = sample;
+      contentWidth = Math.max(contentWidth, measure.offsetWidth);
+    }
+
+    // px-3 padding + chevron + gap between label and icon.
+    setMinWidthPx(contentWidth + 48);
+  }, [label, items]);
 
   const updatePosition = useCallback(() => {
     const trigger = triggerRef.current;
@@ -82,25 +96,9 @@ export function MenuSelect({
     const maxHeight = Math.min(MENU_MAX_HEIGHT_PX, openUp ? spaceAbove : spaceBelow);
     const renderedHeight = Math.min(menuRef.current?.offsetHeight ?? maxHeight, maxHeight);
 
-    const viewportMargin = 8;
-    const naturalWidth = Math.max(rect.width, menuRef.current?.scrollWidth ?? rect.width);
-    const spaceRight = window.innerWidth - rect.left - viewportMargin;
-    const spaceLeft = rect.right - viewportMargin;
-
-    let width = Math.min(naturalWidth, window.innerWidth - viewportMargin * 2);
-    let left = rect.left;
-
-    if (width > spaceRight && spaceLeft >= width) {
-      left = rect.right - width;
-    } else {
-      width = Math.min(width, spaceRight);
-      left = Math.max(viewportMargin, Math.min(left, window.innerWidth - width - viewportMargin));
-    }
-
     setMenuStyle({
-      left,
-      width,
-      minWidth: rect.width,
+      left: rect.left,
+      width: rect.width,
       maxHeight: Math.max(maxHeight, 0),
       top: openUp ? rect.top - renderedHeight - MENU_GAP_PX : rect.bottom + MENU_GAP_PX,
     });
@@ -112,7 +110,7 @@ export function MenuSelect({
     // Re-measure once the portaled menu has layout for open-up placement.
     const frame = requestAnimationFrame(updatePosition);
     return () => cancelAnimationFrame(frame);
-  }, [open, items.length, updatePosition]);
+  }, [open, items.length, minWidthPx, updatePosition]);
 
   useEffect(() => {
     if (!open) return;
@@ -160,7 +158,15 @@ export function MenuSelect({
     .join(" ");
 
   return (
-    <div className={`relative ${wrapperClassName}`.trim()}>
+    <div
+      className={`relative ${wrapperClassName}`.trim()}
+      style={minWidthPx ? { minWidth: minWidthPx } : undefined}
+    >
+      <span
+        ref={measureRef}
+        aria-hidden="true"
+        className="pointer-events-none invisible absolute text-sm whitespace-nowrap"
+      />
       <button
         ref={triggerRef}
         type="button"
@@ -186,13 +192,12 @@ export function MenuSelect({
             id={listboxId}
             role="listbox"
             aria-label={label}
-            className="fixed z-[120] w-max overflow-y-auto overscroll-contain rounded-xl border border-white/10 bg-[#0a0f1b]/98 py-1 shadow-xl backdrop-blur-md thin-scrollbar"
+            className="fixed z-[120] flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain rounded-xl border border-white/10 bg-[#0a0f1b]/98 py-1 shadow-xl backdrop-blur-md thin-scrollbar"
             onWheel={(event) => event.stopPropagation()}
             style={{
               top: menuStyle.top,
               left: menuStyle.left,
-              width: menuStyle.width > 0 ? menuStyle.width : undefined,
-              minWidth: menuStyle.minWidth,
+              width: menuStyle.width,
               maxHeight: menuStyle.maxHeight,
             }}
           >
@@ -206,8 +211,9 @@ export function MenuSelect({
                   setOpen(false);
                 }}
                 className="flex w-full min-w-0 items-center px-3 py-2 text-left text-sm text-slate-200 transition-colors hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-none"
+                title={item.label}
               >
-                <span className="min-w-0 whitespace-nowrap">{item.label}</span>
+                <span className="min-w-0 truncate">{item.label}</span>
               </button>
             ))}
           </div>,

--- a/client/src/components/ui/SelectField.tsx
+++ b/client/src/components/ui/SelectField.tsx
@@ -46,7 +46,9 @@ export function SelectField({
       <select
         {...props}
         disabled={disabled}
-        className={["appearance-none", sizeStyle.select, className].filter(Boolean).join(" ")}
+        className={["appearance-none", "select-dark", sizeStyle.select, className]
+          .filter(Boolean)
+          .join(" ")}
       >
         {children}
       </select>

--- a/client/src/components/ui/__tests__/MenuSelect.test.tsx
+++ b/client/src/components/ui/__tests__/MenuSelect.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MenuSelect } from "../MenuSelect";
+
+afterEach(cleanup);
+
+const items = [
+  { value: "Mono Red", label: "Mono Red" },
+  { value: "Azorius Control", label: "Azorius Control" },
+];
+
+function renderMenu(onSelect = vi.fn()) {
+  render(<MenuSelect label="Load deck..." items={items} onSelect={onSelect} />);
+  return onSelect;
+}
+
+describe("MenuSelect", () => {
+  it("renders a closed trigger with no menu", () => {
+    renderMenu();
+    expect(screen.getByRole("button", { name: "Load deck..." })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("opens on click, lists every item, and focuses the first option", () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Load deck..." }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    const options = screen.getAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual(["Mono Red", "Azorius Control"]);
+    expect(options[0]).toHaveFocus();
+  });
+
+  it("fires onSelect with the item value and closes", () => {
+    const onSelect = renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Load deck..." }));
+    fireEvent.click(screen.getByRole("option", { name: "Azorius Control" }));
+    expect(onSelect).toHaveBeenCalledWith("Azorius Control");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("moves focus with arrow keys, wrapping at the ends", () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole("button", { name: "Load deck..." }));
+    const options = screen.getAllByRole("option");
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    expect(options[1]).toHaveFocus();
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    expect(options[0]).toHaveFocus();
+    fireEvent.keyDown(window, { key: "ArrowUp" });
+    expect(options[1]).toHaveFocus();
+  });
+
+  it("closes on Escape and restores focus to the trigger", () => {
+    renderMenu();
+    const trigger = screen.getByRole("button", { name: "Load deck..." });
+    fireEvent.click(trigger);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("does not open when disabled", () => {
+    render(
+      <MenuSelect label="Load deck..." items={items} onSelect={vi.fn()} disabled />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Load deck..." }));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -206,6 +206,18 @@ input[type="number"] {
   appearance: textfield;
 }
 
+/* Native select option tint — applied via SelectField's select-dark class so
+   browsers that honor option styling get the same dark surface as the app shell.
+   Long action menus (e.g. Load deck) use MenuSelect instead of native popups. */
+select.select-dark {
+  color-scheme: dark;
+}
+
+select.select-dark option {
+  background-color: #0a0f1b;
+  color: #e2e8f0;
+}
+
 @media (pointer: fine) {
   input[type="number"]::-webkit-inner-spin-button {
     -webkit-appearance: none;


### PR DESCRIPTION
## Summary

* Replace the Deck Builder **Load deck...** native select with a custom `MenuSelect`
* Use a dark-themed dropdown that matches the rest of the application
* Remove the width limit that caused long deck names to be truncated
* Add dark styling for remaining native selects where supported

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/5cffec4a-bb8b-4465-b145-57a5bc3c6a57" />

### After

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/3876ef32-77e6-4f06-829d-2b5feb012f06" />

## Test Plan

* [ ] Open Deck Builder and verify the **Load deck...** control matches the toolbar styling
* [ ] Open the dropdown and confirm it uses a dark-themed menu
* [ ] Verify long deck names are displayed correctly
* [ ] Verify the dropdown scrolls correctly with many saved decks
* [ ] Select a deck and confirm it loads successfully
* [ ] Verify other native selects still render correctly
