### PR TITLE
Add regression tests for issue #861 (Tree of Perdition, First Sliver)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -13895,6 +13895,65 @@ pub mod tests {
     }
 
     #[test]
+    fn first_sliver_granted_cascade_triggers_for_sliver_spell() {
+        let mut state = setup();
+        let caster = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "The First Sliver".to_string(),
+            Zone::Battlefield,
+        );
+        let grant = StaticDefinition::new(StaticMode::CastWithKeyword {
+            keyword: Keyword::Cascade,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Subtype("Sliver".into())).controller(ControllerRef::You),
+        ));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        let spell = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Cheap Sliver".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Sliver".into());
+            obj.cast_from_zone = Some(Zone::Hand);
+        }
+
+        process_triggers(
+            &mut state,
+            &[GameEvent::SpellCast {
+                object_id: spell,
+                controller: caster,
+                card_id: CardId(2),
+            }],
+        );
+
+        assert!(
+            state.stack.iter().any(|entry| {
+                matches!(
+                    &entry.kind,
+                    StackEntryKind::TriggeredAbility { ability, .. }
+                        if matches!(ability.effect, Effect::Cascade)
+                )
+            }),
+            "Sliver spells cast with The First Sliver on the battlefield should trigger cascade"
+        );
+    }
+
+    #[test]
     fn granted_casualty_triggers_copy_when_paid() {
         let mut state = setup();
         let caster = PlayerId(0);

--- a/crates/engine/tests/integration/issue_861_first_sliver_cascade.rs
+++ b/crates/engine/tests/integration/issue_861_first_sliver_cascade.rs
@@ -1,0 +1,132 @@
+//! Regression for issue #861: The First Sliver must grant cascade to Sliver
+//! spells you cast while it is on the battlefield.
+//!
+//! https://github.com/phase-rs/phase/issues/861
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::Effect;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, StackEntryKind};
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+use engine::types::zones::Zone;
+
+const FIRST_SLIVER_ORACLE: &str = "Cascade (When you cast this spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom in a random order.)\nSliver spells you cast have cascade.";
+
+fn add_mana(runner: &mut GameRunner, mana: &[ManaType]) {
+    let dummy = engine::types::identifiers::ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+fn exile_count(
+    state: &engine::types::game_state::GameState,
+    player: engine::types::player::PlayerId,
+) -> usize {
+    state
+        .objects
+        .values()
+        .filter(|obj| obj.controller == player && obj.zone == Zone::Exile)
+        .count()
+}
+
+#[test]
+fn first_sliver_oracle_parses_sliver_spell_cascade_grant() {
+    let mut scenario = GameScenario::new();
+    let first_sliver = scenario
+        .add_creature_from_oracle(P0, "The First Sliver", 7, 7, FIRST_SLIVER_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let obj = &runner.state().objects[&first_sliver];
+    assert!(
+        obj.static_definitions.iter_unchecked().any(|def| {
+            matches!(
+                def.mode,
+                StaticMode::CastWithKeyword {
+                    keyword: engine::types::keywords::Keyword::Cascade
+                }
+            )
+        }),
+        "The First Sliver must grant cascade to Sliver spells, statics={:?}",
+        obj.static_definitions
+    );
+}
+
+#[test]
+fn first_sliver_grants_cascade_to_sliver_spells_cast_from_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Forest", "Forest", "Island"]);
+    let first_sliver = scenario
+        .add_creature_from_oracle(P0, "The First Sliver", 7, 7, FIRST_SLIVER_ORACLE)
+        .id();
+
+    let sliver_spell = scenario
+        .add_creature_to_hand(P0, "Cheap Sliver", 1, 1)
+        .with_subtypes(vec!["Sliver"])
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 1,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    assert_eq!(
+        runner.state().objects[&first_sliver].zone,
+        Zone::Battlefield
+    );
+    assert!(runner.state().objects[&sliver_spell]
+        .card_types
+        .subtypes
+        .iter()
+        .any(|s| s == "Sliver"));
+
+    let exile_before = exile_count(runner.state(), P0);
+    add_mana(&mut runner, &[ManaType::Colorless, ManaType::Red]);
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: sliver_spell,
+            card_id: runner.state().objects[&sliver_spell].card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Cheap Sliver");
+
+    for _ in 0..24 {
+        match &runner.state().waiting_for {
+            engine::types::game_state::WaitingFor::ManaPayment { .. } => {
+                runner.act(GameAction::PassPriority).expect("pay mana");
+            }
+            engine::types::game_state::WaitingFor::Priority { .. } => break,
+            other => panic!("unexpected cast prompt: {other:?}"),
+        }
+    }
+
+    runner.advance_until_stack_empty();
+
+    let saw_cascade_trigger = runner.state().stack.iter().any(|entry| {
+        matches!(
+            &entry.kind,
+            StackEntryKind::TriggeredAbility { ability, .. }
+                if matches!(ability.effect, Effect::Cascade)
+        )
+    });
+    let exile_after = exile_count(runner.state(), P0);
+
+    assert!(
+        saw_cascade_trigger || exile_after > exile_before,
+        "casting a Sliver spell with The First Sliver on the battlefield must trigger cascade \
+         (exile before={exile_before}, after={exile_after}, stack={:?})",
+        runner.state().stack
+    );
+}

--- a/crates/engine/tests/integration/issue_861_first_sliver_cascade.rs
+++ b/crates/engine/tests/integration/issue_861_first_sliver_cascade.rs
@@ -112,21 +112,23 @@ fn first_sliver_grants_cascade_to_sliver_spells_cast_from_hand() {
         }
     }
 
+    assert!(
+        runner.state().stack.iter().any(|entry| {
+            matches!(
+                &entry.kind,
+                StackEntryKind::TriggeredAbility { ability, .. }
+                    if matches!(ability.effect, Effect::Cascade)
+            )
+        }),
+        "granted cascade must be on the stack before resolution (stack={:?})",
+        runner.state().stack
+    );
+
     runner.advance_until_stack_empty();
 
-    let saw_cascade_trigger = runner.state().stack.iter().any(|entry| {
-        matches!(
-            &entry.kind,
-            StackEntryKind::TriggeredAbility { ability, .. }
-                if matches!(ability.effect, Effect::Cascade)
-        )
-    });
     let exile_after = exile_count(runner.state(), P0);
-
     assert!(
-        saw_cascade_trigger || exile_after > exile_before,
-        "casting a Sliver spell with The First Sliver on the battlefield must trigger cascade \
-         (exile before={exile_before}, after={exile_after}, stack={:?})",
-        runner.state().stack
+        exile_after > exile_before,
+        "cascade must exile at least one library card (before={exile_before}, after={exile_after})"
     );
 }

--- a/crates/engine/tests/integration/issue_861_tree_of_perdition.rs
+++ b/crates/engine/tests/integration/issue_861_tree_of_perdition.rs
@@ -1,0 +1,62 @@
+//! Regression for issue #861: Tree of Perdition's activated ability must
+//! exchange target opponent's life with its toughness.
+//!
+//! https://github.com/phase-rs/phase/issues/861
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const TREE_OF_PERDITION_ORACLE: &str =
+    "Defender\n{T}: Exchange target opponent's life total with this creature's toughness.";
+
+#[test]
+fn tree_of_perdition_exchanges_opponent_life_with_its_toughness() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let tree = scenario
+        .add_creature_from_oracle(P0, "Tree of Perdition", 0, 13, TREE_OF_PERDITION_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[1].life = 25;
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: tree,
+            ability_index: 0,
+        })
+        .expect("begin Tree of Perdition activation");
+
+    for _ in 0..16 {
+        match &runner.state().waiting_for {
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .choose_first_legal_target()
+                    .expect("choose target opponent");
+            }
+            WaitingFor::Priority { .. } => break,
+            other => panic!("unexpected activation prompt: {other:?}"),
+        }
+    }
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[1].life,
+        13,
+        "opponent life should become Tree of Perdition's toughness"
+    );
+    assert_eq!(
+        runner.state().objects[&tree].zone,
+        Zone::Battlefield,
+        "Tree of Perdition should remain on the battlefield"
+    );
+    assert_eq!(
+        runner.state().objects[&tree].toughness,
+        Some(25),
+        "Tree of Perdition's toughness should become the opponent's former life total"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -138,6 +138,8 @@ mod issue_583_vivi_ornitier_mana_source;
 mod issue_709_regression;
 mod issue_859_weathered_wayfarer;
 mod issue_860_luminarch_aspirant;
+mod issue_861_first_sliver_cascade;
+mod issue_861_tree_of_perdition;
 mod issue_868_szarekh_attack_trigger;
 mod issue_874_nadiers_nightblade_token_leaves;
 mod issue_879_obsessive_pursuit;


### PR DESCRIPTION
## Summary
- Add integration coverage for Tree of Perdition exchanging a targeted opponent's life total with its toughness.
- Add integration and trigger-unit coverage for The First Sliver granting cascade to Sliver spells cast from hand while it is on the battlefield.
- Lock parser output for The First Sliver's `CastWithKeyword { Cascade }` static grant.

Fixes #861

## Test plan
- [x] `cargo test -p engine --test integration issue_861`
- [x] `cargo test -p engine first_sliver_granted_cascade_triggers_for_sliver_spell --lib`

Made with [Cursor](https://cursor.com)