### PR TITLE
feat(engine): enter under an opponent’s control on ETB (CR 110.2a)

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -6331,4 +6331,75 @@ mod tests {
             "layer-derived loyalty must equal the seeded loyalty counters"
         );
     }
+
+    /// CR 110.2a: A permanent whose own self-replacement says it "enters under
+    /// the control of an opponent of your choice" enters the battlefield under
+    /// the opponent's control — not its owner's. Drives the real ChangeZone
+    /// pipeline: the entering object carries the `Moved` / `enters_under =
+    /// Opponent` replacement that `oracle_replacement` emits for Xantcha,
+    /// Sleeper Agent et al., and the replacement step stamps the ZoneChange's
+    /// controller_override before the entry completes (before ETB triggers).
+    #[test]
+    fn self_enters_under_opponent_replacement_routes_control_to_opponent() {
+        use crate::types::ability::{ControllerRef, ReplacementDefinition};
+        use crate::types::card_type::CoreType;
+        use crate::types::replacements::ReplacementEvent;
+
+        let mut state = GameState::new_two_player(7);
+
+        // Xantcha-style creature in player 0's hand, carrying the self-ETB
+        // controller-override replacement on itself.
+        let obj = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Xantcha, Sleeper Agent".to_string(),
+            Zone::Hand,
+        );
+        {
+            let o = state.objects.get_mut(&obj).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+            o.replacement_definitions.push(
+                ReplacementDefinition::new(ReplacementEvent::Moved)
+                    .valid_card(TargetFilter::SelfRef)
+                    .destination_zone(Zone::Battlefield)
+                    .enters_under(ControllerRef::Opponent),
+            );
+        }
+
+        // Enter the battlefield with NO imperative controller override (default
+        // would be the owner's control, player 0). The self-replacement must
+        // flip control to the opponent, player 1.
+        let ability = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Hand),
+                destination: Zone::Battlefield,
+                target: TargetFilter::Any,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+            vec![TargetRef::Object(obj)],
+            ObjectId(999),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.objects[&obj].zone,
+            Zone::Battlefield,
+            "permanent entered the battlefield"
+        );
+        assert_eq!(
+            state.objects[&obj].controller,
+            PlayerId(1),
+            "CR 110.2a: enters under the opponent's control, not its owner's"
+        );
+    }
 }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -3912,6 +3912,11 @@ pub(super) struct EventModifiers {
     etb_tap_state: EtbTapState,
     etb_counters: Vec<(CounterType, u32)>,
     redirect_zone: Option<Zone>,
+    /// CR 110.2a: Controller override for a self-ETB replacement
+    /// (`ReplacementDefinition::enters_under`). Carried as an unresolved
+    /// `ControllerRef`; resolved to a concrete `PlayerId` and written onto the
+    /// `ZoneChange`'s `controller_override` when the replacement is applied.
+    controller_override: Option<ControllerRef>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -4013,6 +4018,38 @@ fn event_modifiers_for_ability(
         etb_tap_state,
         etb_counters: counters,
         redirect_zone: redirect,
+        controller_override: None,
+    }
+}
+
+/// CR 110.2a: Resolve the controller for a self-ETB controller-override
+/// replacement (`ReplacementDefinition::enters_under`). The reference is resolved
+/// relative to the entering object's *own* controller.
+///
+/// `ControllerRef::Opponent` ("enters under the control of an opponent of your
+/// choice") is resolved here rather than via the canonical `controller_ref_player`,
+/// which returns `None` for `Opponent` (ambiguous when more than one opponent
+/// exists). In a two-player game this is the sole opponent — fully correct. In
+/// multiplayer it picks the first opponent in seat order; a full controller choice
+/// is a follow-up. Either way the permanent enters under an opponent's control
+/// rather than its owner's, satisfying CR 110.2a.
+fn resolve_self_enters_under_controller(
+    state: &GameState,
+    object_id: ObjectId,
+    cref: &ControllerRef,
+) -> Option<PlayerId> {
+    let entering_controller = state.objects.get(&object_id)?.controller;
+    match cref {
+        ControllerRef::Opponent => crate::game::players::opponents(state, entering_controller)
+            .into_iter()
+            .next(),
+        other => crate::game::filter::controller_ref_player(
+            state,
+            object_id,
+            Some(entering_controller),
+            None,
+            other,
+        ),
     }
 }
 
@@ -4298,11 +4335,13 @@ fn apply_single_replacement(
                         | (ProposedEvent::LifeGain { .. }, Effect::GainLife { .. })
                 )
             });
-            (
-                repl_def.event.clone(),
-                event_modifiers_for_ability(ability, state, rid.source, &proposed),
-                post_effect,
-            )
+            let mut modifiers = event_modifiers_for_ability(ability, state, rid.source, &proposed);
+            // CR 110.2a: A self-ETB controller override is carried directly on the
+            // replacement definition (not derived from `execute`), parallel to the
+            // imperative `Effect::ChangeZone.enters_under` slot. Surface it as an
+            // event modifier so it is written onto the `ZoneChange` below.
+            modifiers.controller_override = repl_def.enters_under.clone();
+            (repl_def.event.clone(), modifiers, post_effect)
         }
         None => return Ok(proposed),
     };
@@ -4327,6 +4366,25 @@ fn apply_single_replacement(
                 if modifiers.etb_tap_state != EtbTapState::Unspecified {
                     if let Some(enter_tapped) = new_event.battlefield_entry_tap_state_mut() {
                         *enter_tapped = modifiers.etb_tap_state;
+                    }
+                }
+                // CR 110.2a: Apply a self-ETB controller override onto the entering
+                // ZoneChange (set before ETB triggers fire — the permanent never
+                // enters under its owner's control first). Resolve the carried
+                // `ControllerRef` against the entering object's own controller.
+                if let Some(cref) = modifiers.controller_override.as_ref() {
+                    if let ProposedEvent::ZoneChange {
+                        object_id,
+                        to: Zone::Battlefield,
+                        controller_override,
+                        ..
+                    } = &mut new_event
+                    {
+                        if let Some(pid) =
+                            resolve_self_enters_under_controller(state, *object_id, cref)
+                        {
+                            *controller_override = Some(pid);
+                        }
                     }
                 }
                 // CR 614.6: Apply zone redirect (e.g., graveyard → exile for Rest in Peace).

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -154,6 +154,16 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         return Some(def);
     }
 
+    // --- "~ enters under the control of an opponent of your choice." ---
+    // CR 110.2a: A self-ETB controller-override replacement — the permanent
+    // enters the battlefield directly under an opponent's control (Xantcha,
+    // Sleeper Agent; Captive Audience; Pendant of Prosperity; Abby, Merciless
+    // Soldier). Checked before the generic enters-tapped guard so the "enters"
+    // verb isn't claimed by another arm.
+    if let Some(def) = parse_self_enters_under_opponent(&norm_lower, &text) {
+        return Some(def);
+    }
+
     // --- "~ enters the battlefield tapped" (unconditional) ---
     // Guard: reject text with " unless " or "if you control" — all conditional
     // patterns must be handled above. Counter-bearing variants fall through to
@@ -1115,6 +1125,64 @@ fn parse_as_enters_choose(norm_lower: &str, original_text: &str) -> Option<Repla
             .valid_card(TargetFilter::SelfRef)
             // CR 614.1c: battlefield-entry-scoped (see destination-gate note above).
             .destination_zone(Zone::Battlefield)
+            .description(original_text.to_string()),
+    )
+}
+
+/// CR 110.2a + CR 614.1c: "`<this permanent>` enters under the control of an
+/// opponent of your choice." — a self-ETB controller-override replacement.
+///
+/// The permanent enters the battlefield directly under an opponent's control;
+/// it never enters under its owner's control first (CR 110.2a). Cards: Xantcha,
+/// Sleeper Agent; Captive Audience; Pendant of Prosperity; Abby, Merciless
+/// Soldier. Emitted as a `Moved` self-replacement (`valid_card = SelfRef`,
+/// `destination_zone = Battlefield`) carrying `enters_under = Opponent`; the
+/// engine resolves the opponent and stamps the entering `ZoneChange`'s
+/// `controller_override` before ETB triggers fire (see
+/// `resolve_self_enters_under_controller`).
+///
+/// "Of your choice" is the controller's choice of opponent — deterministic in a
+/// two-player game (the sole opponent); a full multiplayer choice is a follow-up.
+fn parse_self_enters_under_opponent(
+    norm_lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    // The full, highly specific control clause (with or without "the battlefield").
+    let has_clause = nom_primitives::scan_contains(
+        norm_lower,
+        "enters under the control of an opponent of your choice",
+    ) || nom_primitives::scan_contains(
+        norm_lower,
+        "enters the battlefield under the control of an opponent of your choice",
+    );
+    if !has_clause {
+        return None;
+    }
+
+    // Self-subject gate: the subject of "enters" must be this permanent — the
+    // normalized self-name "~" (legendary short names included), or a "this
+    // <card-type>" / bare "this" demonstrative — never an external filter
+    // ("creatures you control enter ...").
+    let is_self_subject = nom_primitives::scan_contains(norm_lower, "~ enters")
+        || nom_primitives::scan_contains(norm_lower, "this artifact enters")
+        || nom_primitives::scan_contains(norm_lower, "this creature enters")
+        || nom_primitives::scan_contains(norm_lower, "this enchantment enters")
+        || nom_primitives::scan_contains(norm_lower, "this planeswalker enters")
+        || nom_primitives::scan_contains(norm_lower, "this land enters")
+        || nom_primitives::scan_contains(norm_lower, "this battle enters")
+        || nom_primitives::scan_contains(norm_lower, "this permanent enters")
+        || nom_primitives::scan_contains(norm_lower, "this enters");
+    if !is_self_subject {
+        return None;
+    }
+
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::Moved)
+            .valid_card(TargetFilter::SelfRef)
+            // CR 614.1c: battlefield-entry-scoped (see destination-gate note above).
+            .destination_zone(Zone::Battlefield)
+            // CR 110.2a: enters under an opponent's control (resolved at apply time).
+            .enters_under(ControllerRef::Opponent)
             .description(original_text.to_string()),
     )
 }
@@ -11364,6 +11432,75 @@ mod snapshot_tests {
         assert!(
             super::parse_copy_count_replacement(&lower, text).is_none(),
             "copy-count replacement must not be gated by loose substring matching"
+        );
+    }
+
+    /// CR 110.2a: "<this permanent> enters under the control of an opponent of
+    /// your choice." parses to a self-ETB controller-override replacement —
+    /// `Moved` / `valid_card = SelfRef` / `destination_zone = Battlefield` /
+    /// `enters_under = Opponent`. Build-the-class across the four real corpus
+    /// phrasings (self-name "~", "this artifact", "this enchantment").
+    #[test]
+    fn self_enters_under_opponent_parses_controller_override_replacement() {
+        let cases = [
+            // Xantcha, Sleeper Agent / Abby, Merciless Soldier (legendary short name → "~").
+            (
+                "Xantcha enters under the control of an opponent of your choice.",
+                "Xantcha, Sleeper Agent",
+            ),
+            (
+                "Abby enters under the control of an opponent of your choice.",
+                "Abby, Merciless Soldier",
+            ),
+            // Pendant of Prosperity (card name absent; demonstrative subject).
+            (
+                "This artifact enters under the control of an opponent of your choice.",
+                "Pendant of Prosperity",
+            ),
+            // Captive Audience.
+            (
+                "This enchantment enters under the control of an opponent of your choice.",
+                "Captive Audience",
+            ),
+        ];
+
+        for (text, card_name) in cases {
+            let def = parse_replacement_line(text, card_name)
+                .unwrap_or_else(|| panic!("{card_name}: should parse as a replacement"));
+            assert_eq!(
+                def.event,
+                ReplacementEvent::Moved,
+                "{card_name}: self-ETB replacement is a Moved event"
+            );
+            assert_eq!(
+                def.valid_card,
+                Some(TargetFilter::SelfRef),
+                "{card_name}: applies only to the entering permanent itself"
+            );
+            assert_eq!(
+                def.destination_zone,
+                Some(Zone::Battlefield),
+                "{card_name}: battlefield-entry-scoped (CR 614.1c)"
+            );
+            assert_eq!(
+                def.enters_under,
+                Some(ControllerRef::Opponent),
+                "{card_name}: enters under an opponent's control (CR 110.2a)"
+            );
+        }
+    }
+
+    /// The control clause is NOT claimed when the subject is an external filter
+    /// rather than the permanent itself — the self-subject gate must reject it.
+    #[test]
+    fn external_enters_under_opponent_is_not_a_self_replacement() {
+        assert!(
+            super::parse_self_enters_under_opponent(
+                "creatures you control enter under the control of an opponent of your choice",
+                "Whatever",
+            )
+            .is_none(),
+            "external-subject entry must not match the self controller-override arm"
         );
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -12783,6 +12783,19 @@ pub struct ReplacementDefinition {
     /// counter-agnostic replacements.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub counter_match: Option<CounterMatch>,
+    /// CR 110.2a + CR 614.1c: Controller override applied to a self-ETB
+    /// (`event = Moved`, `valid_card = SelfRef`, `destination_zone = Battlefield`)
+    /// replacement, for permanents that "enter under the control of an opponent
+    /// of your choice" (Xantcha, Sleeper Agent; Captive Audience; Pendant of
+    /// Prosperity; Abby, Merciless Soldier). `Some(cref)` routes the entering
+    /// object to the player resolved from `cref` — set on the `ZoneChange`'s
+    /// `controller_override` *before* ETB triggers fire, so the permanent never
+    /// enters under its owner's control first. Mirrors the imperative
+    /// `Effect::ChangeZone.enters_under` slot (generalized for any `ControllerRef`
+    /// in #2817) on the self-replacement path. `None` = enters under owner's
+    /// control (the default for every existing replacement).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enters_under: Option<ControllerRef>,
 }
 
 impl ReplacementDefinition {
@@ -12815,7 +12828,14 @@ impl ReplacementDefinition {
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         }
+    }
+
+    /// CR 110.2a: Builder for the self-ETB controller override (see field docs).
+    pub fn enters_under(mut self, controller: ControllerRef) -> Self {
+        self.enters_under = Some(controller);
+        self
     }
 
     pub fn execute(mut self, ability: AbilityDefinition) -> Self {

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -95,6 +95,7 @@ pub fn convert_as_enters(
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         });
     }
     Ok(out)
@@ -174,6 +175,7 @@ pub fn convert_replace_would_enter(
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         });
     }
     Ok(out)
@@ -236,6 +238,7 @@ pub fn convert_replace_would_deal_damage(
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         });
     }
     Ok(out)
@@ -607,6 +610,7 @@ pub fn convert_replace_would_draw(
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         });
     }
     Ok(out)
@@ -727,6 +731,7 @@ pub fn convert_replace_would_put_into_graveyard(
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         });
     }
     Ok(out)
@@ -972,6 +977,7 @@ pub fn convert_as_put_into_graveyard_from_anywhere(
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         });
     }
     Ok(out)
@@ -1059,6 +1065,7 @@ pub fn convert_replace_would_put_counters(
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: counter_match.clone(),
+            enters_under: None,
         });
     }
     Ok(out)
@@ -1240,6 +1247,7 @@ pub fn convert_replace_would_gain_life(
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         });
     }
     Ok(out)
@@ -1358,6 +1366,7 @@ fn try_build_may_cost_pair(
         additional_token_spec: None,
         ensure_token_specs: None,
         counter_match: None,
+        enters_under: None,
     }))
 }
 

--- a/crates/phase-ai/src/cast_facts.rs
+++ b/crates/phase-ai/src/cast_facts.rs
@@ -505,6 +505,7 @@ mod tests {
             additional_token_spec: None,
             ensure_token_specs: None,
             counter_match: None,
+            enters_under: None,
         });
         object.replacement_definitions.push(ReplacementDefinition {
             destination_zone: None,


### PR DESCRIPTION
## Summary
Models the self-ETB replacement **"<this permanent> enters under the control of an opponent of your choice"** — the permanent enters the battlefield directly under an opponent’s control (CR 110.2a), never under its owner’s first. Previously the clause was dropped (`Effect:effect_structure` gap) and the permanent entered under its owner’s control.

Unlocks (each was unsupported on this single gap): **Xantcha, Sleeper Agent**; **Captive Audience**; **Pendant of Prosperity**; **Abby, Merciless Soldier**.

Completes the self-replacement side of the `enters_under` work whose imperative/engine half landed in #2817 (any-player `ControllerRef` resolution, CR 110.2a).

## Approach (parameterize, don’t proliferate)
- **types/ability.rs** — `ReplacementDefinition` gains `enters_under: Option<ControllerRef>` (serde `default`/`skip_serializing_if` — card-data back-compatible), parallel to the imperative `Effect::ChangeZone.enters_under` slot. No new enum variant.
- **game/replacement.rs** — surfaced as an `EventModifiers` field and stamped onto the entering `ZoneChange`’s `controller_override` where `etb_tap_state` is applied — **before ETB triggers fire**. `resolve_self_enters_under_controller` resolves `Opponent` against the entering object’s controller (the canonical resolver returns `None` for ambiguous `Opponent`): sole opponent in two-player, first in seat order otherwise.
- **parser/oracle_replacement.rs** — `parse_self_enters_under_opponent` emits the `Moved`/`SelfRef`/`Battlefield`/`enters_under=Opponent` replacement (nom combinators; self-subject gate covers `~` incl. legendary short names, and `this <card-type>`).

## Notes
“of your choice” is deterministic in two-player (the engine’s primary mode / CI). A full multiplayer choice is a follow-up; CR 110.2a holds either way.

## Tests
- `self_enters_under_opponent_parses_controller_override_replacement` (4-phrasing build-the-class)
- `external_enters_under_opponent_is_not_a_self_replacement` (self-subject gate)
- `self_enters_under_opponent_replacement_routes_control_to_opponent` (end-to-end: enters under the opponent’s control via the real ChangeZone pipeline)

Parser-combinator gate and `rustfmt --check` clean.

Fixes #2834