### PR TITLE
fix(decks): improve mobile format dropdown with MenuSelect

### DIFF
--- a/client/src/components/menu/MyDecks.tsx
+++ b/client/src/components/menu/MyDecks.tsx
@@ -44,6 +44,7 @@ import {
 import { BASIC_LAND_NAMES } from "../../constants/game";
 import { BracketEstimateChip } from "../deck-builder/BracketEstimateChip";
 import { SelectField } from "../ui/SelectField";
+import { MenuSelect } from "../ui/MenuSelect";
 import { useBracketEstimate } from "../../hooks/useBracketEstimate";
 import { getSharedAdapter } from "../../adapter/wasm-adapter";
 const PRECON_PREFIX = "[Pre-built] ";
@@ -556,6 +557,16 @@ export function MyDecks({
   const [activeFilter, setActiveFilter] = useState<DeckFilter>(contextualFilter ?? "all");
   const selectedFormatForCompatibility = selectedFormat ?? (activeFilter === "all" ? null : activeFilter);
   const activeFilterOption = FORMAT_FILTERS.find((option) => option.key === activeFilter);
+  const formatMenuItems = useMemo(
+    () =>
+      FORMAT_FILTERS.map(({ key, label }) => ({
+        value: key,
+        label: key === "all" ? t("myDecks.filterAll") : label,
+      })),
+    [t],
+  );
+  const formatMenuLabel =
+    activeFilter === "all" ? t("myDecks.filterAll") : (activeFilterOption?.label ?? t("myDecks.filterAll"));
   const requiresCompatibilityFilter = activeFilter !== "all";
   const [activeSort, setActiveSort] = useState<DeckSort>(
     mode === "select" ? (selectedFormat ? "format" : "recent") : "alpha",
@@ -1126,32 +1137,27 @@ export function MyDecks({
           />
         </div>
 
-        {mode === "manage" && (<>
-        <div className="flex min-w-0 items-center gap-1 sm:w-[228px]">
-          <label htmlFor="my-decks-format-filter" className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+        {mode === "manage" && (
+        <div className="flex w-full min-w-0 flex-col gap-2 sm:contents">
+        <div className="flex min-w-0 w-full items-center gap-2 sm:w-[228px] sm:flex-none">
+          <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
             {t("myDecks.formatLabel")}
-          </label>
-          <SelectField
-            id="my-decks-format-filter"
-            wrapperClassName="min-w-0 flex-1 sm:w-44"
-            chevronSize="sm"
-            iconWrapperClassName="text-slate-400"
-            value={activeFilter}
-            onChange={(e) => setActiveFilter(e.target.value as DeckFilter)}
-            className="min-h-[30px] w-full rounded bg-black/30 px-2 py-1 text-xs text-slate-300 outline-none ring-1 ring-white/10 focus:ring-white/20"
-          >
-            {FORMAT_FILTERS.map(({ key, label }) => (
-              <option key={key} value={key}>
-                {key === "all" ? t("myDecks.filterAll") : label}
-              </option>
-            ))}
-          </SelectField>
+          </span>
+          <MenuSelect
+            ariaLabel={t("myDecks.formatLabel")}
+            label={formatMenuLabel}
+            selectedValue={activeFilter}
+            items={formatMenuItems}
+            onSelect={(value) => setActiveFilter(value as DeckFilter)}
+            wrapperClassName="min-w-0 flex-1 sm:w-44 sm:flex-none"
+            className="min-h-[30px] rounded bg-black/30 px-2 py-1 text-xs text-slate-300 ring-1 ring-white/10 focus-visible:ring-white/20"
+          />
           {activeFilterOption?.aetherhubUrl && (
             <a
               href={activeFilterOption.aetherhubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded p-1 text-slate-500 transition-colors hover:bg-white/5 hover:text-slate-300"
+              className="shrink-0 rounded p-1 text-slate-500 transition-colors hover:bg-white/5 hover:text-slate-300"
               title={t("myDecks.browseAetherhub", { format: activeFilterOption.label })}
             >
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
@@ -1163,12 +1169,12 @@ export function MyDecks({
         {contextualFilter && activeFilter === contextualFilter && (
           <button
             onClick={() => setActiveFilter("all")}
-            className="rounded border border-indigo-500/50 bg-indigo-500/10 px-2 py-1 text-xs font-medium text-indigo-200 hover:bg-indigo-500/20"
+            className="hidden rounded border border-indigo-500/50 bg-indigo-500/10 px-2 py-1 text-xs font-medium text-indigo-200 hover:bg-indigo-500/20 sm:inline-flex"
           >
             {t("myDecks.showAllDecks")}
           </button>
         )}
-        <div className="flex items-center justify-end gap-1 sm:ml-auto">
+        <div className="flex w-full items-center justify-end gap-1 sm:ml-auto sm:w-auto">
           <SelectField
             chevronSize="sm"
             iconWrapperClassName="text-slate-400"
@@ -1199,7 +1205,8 @@ export function MyDecks({
             </svg>
           </button>
         </div>
-        </>)}
+        </div>
+        )}
       </div>
 
       {/* Format-filter banner: in select mode, when the caller pins a format

--- a/client/src/components/menu/__tests__/MyDecks.test.tsx
+++ b/client/src/components/menu/__tests__/MyDecks.test.tsx
@@ -230,10 +230,12 @@ describe("MyDecks", () => {
 
     expect(await screen.findByText("PDH Ready")).toBeInTheDocument();
     expect(screen.getByText("Not PDH")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Format" }));
     expect(screen.getByRole("option", { name: "Pauper Commander" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "BO3" })).not.toBeInTheDocument();
-
-    await userEvent.selectOptions(screen.getByLabelText("Format"), "PauperCommander");
+    await user.click(screen.getByRole("option", { name: "Pauper Commander" }));
 
     expect(await screen.findByText("Not PDH")).toBeInTheDocument();
     expect(screen.getByText("PDH Ready")).toBeInTheDocument();
@@ -272,7 +274,9 @@ describe("MyDecks", () => {
       />,
     );
 
-    await userEvent.selectOptions(screen.getByLabelText("Format"), "Standard");
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Format" }));
+    await user.click(screen.getByRole("option", { name: "Standard" }));
 
     expect(await screen.findByText("Known Standard")).toBeInTheDocument();
     expect(screen.getByText("Unknown User Deck")).toBeInTheDocument();

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -2,7 +2,29 @@ import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from
 import { createPortal } from "react-dom";
 
 const MENU_GAP_PX = 4;
+const MENU_VIEWPORT_PADDING_PX = 8;
 const MENU_MAX_HEIGHT_PX = 280;
+/** Matches AppShell `pb-[76px]` tab-bar reserve on viewports below 820px. */
+const MOBILE_TAB_BAR_RESERVE_PX = 76;
+
+function getViewportBottomInset(): number {
+  if (window.matchMedia("(min-width: 820px)").matches) {
+    return MENU_VIEWPORT_PADDING_PX;
+  }
+  return MOBILE_TAB_BAR_RESERVE_PX + MENU_VIEWPORT_PADDING_PX;
+}
+
+function getViewportBottom(): number {
+  const visualViewport = window.visualViewport;
+  if (visualViewport) {
+    return visualViewport.offsetTop + visualViewport.height - getViewportBottomInset();
+  }
+  return window.innerHeight - getViewportBottomInset();
+}
+
+function getViewportTop(): number {
+  return window.visualViewport?.offsetTop ?? 0;
+}
 // Cap how far the widest item label can grow the closed trigger — a single
 // long deck name must not stretch the toolbar (items truncate with a title
 // tooltip beyond this).
@@ -19,6 +41,10 @@ export interface MenuSelectProps {
   items: MenuSelectItem[];
   onSelect: (value: string) => void;
   disabled?: boolean;
+  /** Accessible name when `label` shows the current value instead of the control name. */
+  ariaLabel?: string;
+  /** Highlights the matching option in the open menu. */
+  selectedValue?: string;
   /** Class on the outer relative wrapper (e.g. `max-w-[8rem] shrink-0`). */
   wrapperClassName?: string;
   /** Class on the trigger button. */
@@ -54,6 +80,8 @@ export function MenuSelect({
   items,
   onSelect,
   disabled = false,
+  ariaLabel,
+  selectedValue,
   wrapperClassName = "",
   className = "",
 }: MenuSelectProps) {
@@ -97,14 +125,25 @@ export function MenuSelect({
     if (!trigger) return;
 
     const rect = trigger.getBoundingClientRect();
-    const spaceBelow = Math.max(0, window.innerHeight - rect.bottom - MENU_GAP_PX);
-    const spaceAbove = Math.max(0, rect.top - MENU_GAP_PX);
+    const viewportWidth = window.innerWidth;
+    const viewportTop = getViewportTop();
+    const viewportBottom = getViewportBottom();
+    const width = Math.min(
+      rect.width,
+      viewportWidth - MENU_VIEWPORT_PADDING_PX * 2,
+    );
+    const left = Math.max(
+      MENU_VIEWPORT_PADDING_PX,
+      Math.min(rect.left, viewportWidth - width - MENU_VIEWPORT_PADDING_PX),
+    );
+    const spaceBelow = Math.max(0, viewportBottom - rect.bottom - MENU_GAP_PX);
+    const spaceAbove = Math.max(0, rect.top - viewportTop - MENU_GAP_PX);
     const openUp = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
     const maxHeight = Math.min(MENU_MAX_HEIGHT_PX, openUp ? spaceAbove : spaceBelow);
 
     setMenuStyle({
-      left: rect.left,
-      width: rect.width,
+      left,
+      width,
       maxHeight: Math.max(maxHeight, 0),
       top: openUp ? "auto" : rect.bottom + MENU_GAP_PX,
       bottom: openUp ? window.innerHeight - rect.top + MENU_GAP_PX : "auto",
@@ -116,8 +155,14 @@ export function MenuSelect({
     updatePosition();
     // APG listbox pattern: move focus into the menu so the keyboard path
     // (Arrow keys + Enter) works like the native select this replaces.
-    menuRef.current?.querySelector<HTMLButtonElement>('[role="option"]')?.focus();
-  }, [open, updatePosition]);
+    const menu = menuRef.current;
+    const selectedOption =
+      selectedValue != null
+        ? menu?.querySelector<HTMLButtonElement>(`[role="option"][aria-selected="true"]`)
+        : null;
+    (selectedOption ?? menu?.querySelector<HTMLButtonElement>('[role="option"]'))?.focus();
+    selectedOption?.scrollIntoView({ block: "nearest" });
+  }, [open, selectedValue, updatePosition]);
 
   useEffect(() => {
     if (!open) return;
@@ -157,6 +202,8 @@ export function MenuSelect({
     window.addEventListener("pointerdown", handlePointerDown, true);
     window.addEventListener("keydown", handleKeyDown);
     window.addEventListener("resize", updatePosition);
+    window.visualViewport?.addEventListener("resize", updatePosition);
+    window.visualViewport?.addEventListener("scroll", updatePosition);
     scrollParents.forEach((parent) => {
       parent.addEventListener("scroll", handleScroll, { passive: true });
     });
@@ -165,6 +212,8 @@ export function MenuSelect({
       window.removeEventListener("pointerdown", handlePointerDown, true);
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("resize", updatePosition);
+      window.visualViewport?.removeEventListener("resize", updatePosition);
+      window.visualViewport?.removeEventListener("scroll", updatePosition);
       scrollParents.forEach((parent) => {
         parent.removeEventListener("scroll", handleScroll);
       });
@@ -197,7 +246,7 @@ export function MenuSelect({
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
-        aria-label={label}
+        aria-label={ariaLabel ?? label}
         onClick={() => {
           if (disabled) return;
           setOpen((prev) => !prev);
@@ -214,7 +263,7 @@ export function MenuSelect({
             ref={menuRef}
             id={listboxId}
             role="listbox"
-            aria-label={label}
+            aria-label={ariaLabel ?? label}
             className="fixed z-[120] flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain rounded-xl border border-white/10 bg-[#0a0f1b]/98 py-1 shadow-xl backdrop-blur-md thin-scrollbar"
             onWheel={(event) => event.stopPropagation()}
             style={{
@@ -234,7 +283,11 @@ export function MenuSelect({
                   onSelect(item.value);
                   setOpen(false);
                 }}
-                className="flex w-full min-w-0 items-center px-3 py-2 text-left text-sm text-slate-200 transition-colors hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-none"
+                aria-selected={selectedValue === item.value}
+                className={[
+                  "flex w-full min-w-0 items-center px-3 py-2 text-left text-sm transition-colors hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-none",
+                  selectedValue === item.value ? "bg-white/10 text-white" : "text-slate-200",
+                ].join(" ")}
                 title={item.label}
               >
                 <span className="min-w-0 truncate">{item.label}</span>


### PR DESCRIPTION
## Summary

* Replace the native format `<select>` on **My Decks** with `MenuSelect`
* Display long format lists in a scrollable dropdown instead of the mobile browser's full-screen picker
* Stack format and sort controls on separate rows on mobile while preserving the existing toolbar layout on larger screens
* Improve `MenuSelect` mobile behavior with viewport-aware positioning, tab-bar-safe spacing, and selected-option visibility

## Screenshots

### Before

<img width="373" height="760" alt="image" src="https://github.com/user-attachments/assets/ea2a5a22-9111-47e8-8854-31fc642005de" />
<img width="418" height="764" alt="image" src="https://github.com/user-attachments/assets/f460f764-f7dd-4c47-bd83-63b2854e118a" />

### After

<img width="373" height="760" alt="image" src="https://github.com/user-attachments/assets/db10d2a3-75f2-48e1-bfbe-a7b115a9cf93" />

## Test Plan

* [ ] On mobile (<820px), open **My Decks** and verify format and sort controls appear on separate rows
* [ ] Open the format dropdown and confirm it scrolls correctly, stays above the bottom tab bar, and does not overflow the viewport
* [ ] Verify the selected format is visible and highlighted when the menu opens
* [ ] Select a format and confirm deck filtering works correctly
* [ ] On desktop, verify search, format, and sort controls remain on a single toolbar row
