### PR TITLE
fix(deck-builder): use MenuSelect for mobile format selector

### DIFF
--- a/client/src/components/deck-builder/DeckBuilderToolbar.tsx
+++ b/client/src/components/deck-builder/DeckBuilderToolbar.tsx
@@ -4,7 +4,6 @@ import type { GameFormat } from "../../adapter/types";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import { FormatFilter } from "./FormatFilter";
 import { MenuSelect } from "../ui/MenuSelect";
-import { SelectField } from "../ui/SelectField";
 
 function PencilIcon({ className }: { className?: string }) {
   return (
@@ -44,6 +43,13 @@ export function DeckBuilderToolbar({
   onFormatChange,
 }: DeckBuilderToolbarProps) {
   const { t } = useTranslation("deck-builder");
+  const formatLabel =
+    FORMAT_REGISTRY.find((entry) => entry.format === format)?.label ?? format;
+  const formatMenuItems = FORMAT_REGISTRY.map(({ format: value, label }) => ({
+    value,
+    label,
+  }));
+
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-white/8 bg-black/18 px-3 py-2 backdrop-blur-md lg:px-4">
       <div className="flex min-w-0 flex-1 items-center gap-3 lg:flex-none">
@@ -78,26 +84,22 @@ export function DeckBuilderToolbar({
       </div>
 
       <div className="order-3 flex w-full flex-col gap-2 lg:order-none lg:w-auto lg:flex-row lg:items-center">
-        {/* Format: compact native select up to tablet, full button row at lg+
-            (where there's horizontal room for the ~15-format wall). */}
-        <SelectField
-          value={format}
-          onChange={(e) => onFormatChange(e.target.value as GameFormat)}
-          aria-label={t("toolbar.format")}
-          className="rounded-xl border border-white/10 bg-black/18 px-3 py-1.5 text-sm text-white focus:outline-none lg:hidden"
-        >
-          {FORMAT_REGISTRY.map(({ format: value, label }) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </SelectField>
+        {/* Format: MenuSelect below lg (full-width trigger matches Load deck);
+            button row at lg+ where there's room for the ~15-format wall. */}
+        <MenuSelect
+          ariaLabel={t("toolbar.format")}
+          label={formatLabel}
+          selectedValue={format}
+          items={formatMenuItems}
+          onSelect={(value) => onFormatChange(value as GameFormat)}
+          wrapperClassName="w-full lg:hidden"
+        />
         <div className="hidden lg:block">
           <FormatFilter selected={format} onChange={onFormatChange} />
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex w-full flex-wrap items-center gap-2 max-lg:[&>*:last-child]:basis-full lg:w-auto lg:flex-nowrap">
         <button
           type="button"
           onClick={onSave}
@@ -124,7 +126,7 @@ export function DeckBuilderToolbar({
             label={t("toolbar.loadDeck")}
             items={savedDecks.map((name) => ({ value: name, label: name }))}
             onSelect={onLoad}
-            wrapperClassName="shrink-0"
+            wrapperClassName="min-w-0 w-full lg:w-auto lg:shrink-0"
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

* Replace the mobile format `<select>` with `MenuSelect`
* Make the format selector a full-width control on mobile with the format name on the left and chevron on the right
* Fix the mobile layout issue where the native select background only covered the selected value while the chevron appeared detached
* Make the **Load deck...** control full width on mobile for consistent toolbar alignment
* Preserve the existing desktop (`lg+`) format filter experience

## Screenshots

### Before

<img width="360" height="760" alt="image" src="https://github.com/user-attachments/assets/e3a9eced-b212-42b6-99f1-8f0f2f7082d8" />

### After

<img width="360" height="760" alt="image" src="https://github.com/user-attachments/assets/2f8ad9fb-e77e-449d-96ed-5b34dc327554" />

## Test Plan

* [ ] Open Deck Builder on a mobile viewport (<1024px)
* [ ] Verify the format selector appears as a single full-width control with proper label and chevron alignment
* [ ] Open the format menu and verify all formats can be selected
* [ ] Verify the selected format updates correctly
* [ ] With saved decks available, verify **Load deck...** is full width and visually matches the format selector
* [ ] On desktop (`lg+`), verify the existing format pill row (`FormatFilter`) remains unchanged
