### PR TITLE
fix(parser): recognize "that turn’s end step" delayed loss (Final Fortune family, CR 603.7a)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2522,7 +2522,7 @@ pub(super) fn strip_temporal_suffix(text: &str) -> (&str, Option<DelayedTriggerC
                 player: crate::types::player::PlayerId(0),
             },
         ),
-        // CR 603.7a + CR 104.3a: anaphoric "that turn's end step" — the extra
+        // CR 603.7a + CR 104.3e: anaphoric "that turn's end step" — the extra
         // turn granted by the parent clause (the controller's next turn), so
         // the controller's next end step. Suffix companion of the prefix arm
         // in `strip_temporal_prefix`. Used by Final Fortune / Last Chance /
@@ -2584,7 +2584,7 @@ pub(super) fn strip_temporal_prefix(text: &str) -> (&str, Option<DelayedTriggerC
                 },
                 tag("at the beginning of your next end step, "),
             ),
-            // CR 603.7a + CR 104.3a: "at the beginning of that turn's end step"
+            // CR 603.7a + CR 104.3e: "at the beginning of that turn's end step"
             // is the anaphoric form used by the extra-turn-with-a-cost cards
             // (Final Fortune, Last Chance, Warrior's Oath, Chance for Glory):
             // "Take an extra turn after this one. At the beginning of that
@@ -5298,7 +5298,7 @@ mod tests {
         );
     }
 
-    /// CR 603.7a + CR 104.3a: the anaphoric "at the beginning of that turn's end
+    /// CR 603.7a + CR 104.3e: the anaphoric "at the beginning of that turn's end
     /// step" (extra-turn-with-a-cost cards) is recognized by both temporal
     /// recognizers, mapping to the controller's next end step — identical to the
     /// existing "your next end step" arm.

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2522,6 +2522,18 @@ pub(super) fn strip_temporal_suffix(text: &str) -> (&str, Option<DelayedTriggerC
                 player: crate::types::player::PlayerId(0),
             },
         ),
+        // CR 603.7a + CR 104.3a: anaphoric "that turn's end step" — the extra
+        // turn granted by the parent clause (the controller's next turn), so
+        // the controller's next end step. Suffix companion of the prefix arm
+        // in `strip_temporal_prefix`. Used by Final Fortune / Last Chance /
+        // Warrior's Oath / Chance for Glory.
+        (
+            " at the beginning of that turn's end step",
+            DelayedTriggerCondition::AtNextPhaseForPlayer {
+                phase: Phase::End,
+                player: crate::types::player::PlayerId(0),
+            },
+        ),
         (
             " at the beginning of your next upkeep",
             DelayedTriggerCondition::AtNextPhaseForPlayer {
@@ -2571,6 +2583,22 @@ pub(super) fn strip_temporal_prefix(text: &str) -> (&str, Option<DelayedTriggerC
                     player: crate::types::player::PlayerId(0),
                 },
                 tag("at the beginning of your next end step, "),
+            ),
+            // CR 603.7a + CR 104.3a: "at the beginning of that turn's end step"
+            // is the anaphoric form used by the extra-turn-with-a-cost cards
+            // (Final Fortune, Last Chance, Warrior's Oath, Chance for Glory):
+            // "Take an extra turn after this one. At the beginning of that
+            // turn's end step, you lose the game." "That turn" is the just-
+            // granted extra turn — the controller's next turn — so this is the
+            // controller's next end step, identical to the "your next end step"
+            // arm above. PlayerId(0) is rewritten to ability.controller at
+            // resolve time.
+            value(
+                DelayedTriggerCondition::AtNextPhaseForPlayer {
+                    phase: Phase::End,
+                    player: crate::types::player::PlayerId(0),
+                },
+                tag("at the beginning of that turn's end step, "),
             ),
             // CR 505.1 + CR 603.7a: "your next main phase" → PreCombatMain.
             // PlayerId(0) rewritten to ability.controller at resolve time
@@ -5086,7 +5114,8 @@ pub(crate) fn parse_dynamic_counter_suffix_body(
 mod tests {
     use super::{
         nest_whenever_this_turn_token_cleanup_delayed_trigger, parse_where_x_quantity_expression,
-        strip_return_destination_ext_with_remainder, strip_trailing_where_x,
+        strip_return_destination_ext_with_remainder, strip_temporal_prefix, strip_temporal_suffix,
+        strip_trailing_where_x,
     };
     use crate::parser::oracle_util::TextPair;
     use crate::types::ability::{
@@ -5267,6 +5296,80 @@ mod tests {
             ),
             "sibling effects after the cleanup must remain on the outer ability"
         );
+    }
+
+    /// CR 603.7a + CR 104.3a: the anaphoric "at the beginning of that turn's end
+    /// step" (extra-turn-with-a-cost cards) is recognized by both temporal
+    /// recognizers, mapping to the controller's next end step — identical to the
+    /// existing "your next end step" arm.
+    #[test]
+    fn that_turns_end_step_temporal_resolves_to_controller_next_end_step() {
+        let expected = DelayedTriggerCondition::AtNextPhaseForPlayer {
+            phase: Phase::End,
+            player: crate::types::player::PlayerId(0),
+        };
+
+        let (rest, cond) =
+            strip_temporal_prefix("at the beginning of that turn's end step, you lose the game");
+        assert_eq!(rest, "you lose the game");
+        assert_eq!(cond, Some(expected.clone()));
+
+        let (rest, cond) =
+            strip_temporal_suffix("you lose the game at the beginning of that turn's end step");
+        assert_eq!(rest, "you lose the game");
+        assert_eq!(cond, Some(expected));
+    }
+
+    /// Build-the-class: the extra-turn-with-a-cost family parses to BOTH an
+    /// `ExtraTurn` effect AND a delayed `LoseTheGame` trigger fired at the extra
+    /// turn's end step (CR 603.7a). Previously the second sentence was dropped as
+    /// an `Effect:at` gap, so these cards became a downside-free extra turn.
+    #[test]
+    fn extra_turn_then_lose_parses_delayed_lose_the_game() {
+        use crate::parser::oracle_effect::parse_effect_chain;
+
+        // Recursively collect every effect in the def + sub_ability chain,
+        // descending into CreateDelayedTrigger's inner effect.
+        fn collect<'a>(def: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+            out.push(&def.effect);
+            if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+                collect(effect, out);
+            }
+            if let Some(sub) = def.sub_ability.as_deref() {
+                collect(sub, out);
+            }
+        }
+
+        for text in [
+            "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
+            "Creatures you control gain indestructible. Take an extra turn after this one. At the beginning of that turn's end step, you lose the game.",
+        ] {
+            let def = parse_effect_chain(text, AbilityKind::Spell);
+            let mut effects = Vec::new();
+            collect(&def, &mut effects);
+
+            assert!(
+                effects.iter().any(|e| matches!(e, Effect::ExtraTurn { .. })),
+                "expected an ExtraTurn effect in {text:?}, got {effects:?}"
+            );
+            let delayed_lose = effects.iter().any(|e| {
+                matches!(
+                    e,
+                    Effect::CreateDelayedTrigger {
+                        condition: DelayedTriggerCondition::AtNextPhaseForPlayer {
+                            phase: Phase::End,
+                            ..
+                        },
+                        effect,
+                        ..
+                    } if matches!(&*effect.effect, Effect::LoseTheGame { .. })
+                )
+            });
+            assert!(
+                delayed_lose,
+                "expected a delayed LoseTheGame at the extra turn's end step in {text:?}, got {effects:?}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
The extra-turn-with-a-cost cards — **Final Fortune**, **Last Chance**, **Warrior’s Oath**, **Chance for Glory** — read:

> "Take an extra turn after this one. **At the beginning of that turn’s end step, you lose the game.**"

The extra-turn half parsed (`grant_extra_turn_after`), but the delayed **"you lose the game"** trigger was **dropped** (an `Effect:at` gap), so in play you took the extra turn and **never lost** — a strictly downside-free extra turn. All four are unsupported on this single gap.

This is purely a **parser** gap: the runtime already does this. **Glorious End is supported** with the structurally identical "At the beginning of your next end step, you lose the game" (`Effect::CreateDelayedTrigger` wrapping `Effect::LoseTheGame`). Only the anaphoric phrase "that turn’s end step" was unrecognized.

## Change
- **`parser/oracle_effect/lower.rs`** — teach `strip_temporal_prefix` (the card uses the prefix form) and, for symmetry, `strip_temporal_suffix` the phrase `"at the beginning of that turn’s end step"` → `DelayedTriggerCondition::AtNextPhaseForPlayer { phase: End, player: PlayerId(0) }`. "That turn" is the just-granted extra turn — the controller’s next turn — so it is the controller’s next end step, identical to the existing "your next end step" arm (the `PlayerId(0)` placeholder is rewritten to `ability.controller` at resolve time).
- The stripped clause "you lose the game" already lowers to `Effect::LoseTheGame`, wrapped in `CreateDelayedTrigger` by the existing CR 603.7 path. **No engine/type change; no new variant.**

## Tests
- `that_turns_end_step_temporal_resolves_to_controller_next_end_step` — both recognizers map the phrase to the controller’s next end step.
- `extra_turn_then_lose_parses_delayed_lose_the_game` — build-the-class: Last Chance and Chance for Glory each parse to an `ExtraTurn` effect **and** a delayed `LoseTheGame` fired at the extra turn’s end step; no `Effect:at` gap.

Parser-combinator gate and `rustfmt --check` clean.

CR 603.7a (delayed triggered abilities / temporal anchoring), CR 104.3a (a player loses the game).

Fixes #2949