### PR TITLE
fix(engine): publish RevealTop cards for ChooseFromZone picks

### DIFF
--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -85,15 +85,14 @@ pub fn resolve(
     Ok(())
 }
 
-/// CR 700.2 + CR 603.7: Resolve the candidate card pool for a tracked-set pick.
+/// CR 608.2c + CR 608.2d + CR 603.7: Resolve the candidate card pool for a
+/// tracked-set pick.
 ///
 /// Priority order:
 /// 1. The current resolution chain's tracked set (if non-empty).
-/// 2. `last_revealed_ids` from a preceding reveal in this resolution — must
-///    beat stale global tracked sets from earlier resolutions (issue #1374).
-/// 3. The latest non-empty tracked set from any prior publish in this game.
-/// 4. Explicit `TargetRef::Object` targets on the ability.
-/// 5. Direct zone scan (`zone` + `additional_zones`).
+/// 2. The latest non-empty tracked set from any prior publish in this game.
+/// 3. Explicit `TargetRef::Object` targets on the ability.
+/// 4. Direct zone scan (`zone` + `additional_zones`).
 fn resolve_candidate_cards(
     state: &GameState,
     ability: &ResolvedAbility,
@@ -104,22 +103,6 @@ fn resolve_candidate_cards(
 ) -> Result<Vec<ObjectId>, EffectError> {
     if let Some(cards) = chain_tracked_set_cards(state) {
         return Ok(cards);
-    }
-
-    if !state.last_revealed_ids.is_empty() {
-        // CR 701.20b: RevealTop/Dig reveal-only parents write here but do not
-        // emit ZoneChanged, so the tracked-set publish depends on
-        // `affected_objects_from_events` reading `CardsRevealed`.
-        let filter_ctx = FilterContext::from_ability(ability);
-        let cards: Vec<_> = state
-            .last_revealed_ids
-            .iter()
-            .copied()
-            .filter(|id| filter.is_none_or(|f| matches_target_filter(state, *id, f, &filter_ctx)))
-            .collect();
-        if !cards.is_empty() {
-            return Ok(cards);
-        }
     }
 
     let cards = crate::game::targeting::latest_tracked_set_id(state)
@@ -798,93 +781,6 @@ mod tests {
                 categories: vec![CoreType::Artifact, CoreType::Creature],
             }),
         ));
-    }
-
-    /// CR 701.20b + CR 700.2: Issue #1374 — when RevealTop did not publish a
-    /// tracked set, `ChooseFromZone` must bind to `last_revealed_ids`, not a
-    /// stale graveyard set from an earlier resolution.
-    #[test]
-    fn resolve_prefers_last_revealed_ids_over_stale_tracked_set() {
-        let mut state = GameState::new_two_player(42);
-        let revealed_creature = create_object(
-            &mut state,
-            CardId(1),
-            PlayerId(0),
-            "Revealed Creature".to_string(),
-            Zone::Library,
-        );
-        state
-            .objects
-            .get_mut(&revealed_creature)
-            .unwrap()
-            .card_types
-            .core_types = vec![CoreType::Creature];
-        let revealed_instant = create_object(
-            &mut state,
-            CardId(2),
-            PlayerId(0),
-            "Revealed Instant".to_string(),
-            Zone::Library,
-        );
-        state
-            .objects
-            .get_mut(&revealed_instant)
-            .unwrap()
-            .card_types
-            .core_types = vec![CoreType::Instant];
-        let stale_graveyard_card = create_object(
-            &mut state,
-            CardId(3),
-            PlayerId(0),
-            "Stale Graveyard Card".to_string(),
-            Zone::Graveyard,
-        );
-        state
-            .tracked_object_sets
-            .insert(TrackedSetId(9), vec![stale_graveyard_card]);
-        state.next_tracked_set_id = 10;
-        state.last_revealed_ids = vec![revealed_creature, revealed_instant];
-
-        let categories = vec![
-            CoreType::Artifact,
-            CoreType::Battle,
-            CoreType::Creature,
-            CoreType::Enchantment,
-            CoreType::Instant,
-            CoreType::Land,
-            CoreType::Planeswalker,
-            CoreType::Sorcery,
-        ];
-        let ability = ResolvedAbility::new(
-            Effect::ChooseFromZone {
-                count: categories.len() as u32,
-                zone: Zone::Library,
-                additional_zones: Vec::new(),
-                zone_owner: ZoneOwner::Controller,
-                filter: None,
-                chooser: Chooser::Controller,
-                up_to: true,
-                constraint: Some(ChooseFromZoneConstraint::DistinctCardTypes { categories }),
-            },
-            vec![],
-            ObjectId(100),
-            PlayerId(0),
-        );
-        let mut events = Vec::new();
-
-        resolve(&mut state, &ability, &mut events).unwrap();
-
-        match &state.waiting_for {
-            WaitingFor::ChooseFromZoneChoice { cards, .. } => {
-                assert!(cards.contains(&revealed_creature));
-                assert!(cards.contains(&revealed_instant));
-                assert!(
-                    !cards.contains(&stale_graveyard_card),
-                    "stale graveyard tracked set must not shadow revealed library cards"
-                );
-            }
-            other => panic!("Expected ChooseFromZoneChoice, got {:?}", other),
-        }
     }
 
     /// End-to-end regression for Atraxa, Grand Unifier's ETB chain:

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -45,38 +45,14 @@ pub fn resolve(
             _ => return Err(EffectError::MissingParam("ChooseFromZone".to_string())),
         };
 
-    // Read available cards from the most recent tracked set (same pattern as delayed_trigger.rs).
-    // The tracked set was recorded by the preceding ChangeZone effect via next_sub_needs_tracked_set.
-    let cards: Vec<ObjectId> = crate::game::targeting::latest_tracked_set_id(state)
-        .and_then(|id| state.tracked_object_sets.get(&id).cloned())
-        .unwrap_or_default();
-
-    // Fallback: if tracked set is empty, try ability targets filtered to objects.
-    let cards = if cards.is_empty() {
-        ability
-            .targets
-            .iter()
-            .filter_map(|t| match t {
-                TargetRef::Object(id) => Some(*id),
-                _ => None,
-            })
-            .collect()
-    } else {
-        cards
-    };
-
-    let cards = if cards.is_empty() {
-        collect_direct_zone_cards(
-            state,
-            ability,
-            zone,
-            &additional_zones,
-            zone_owner,
-            filter.as_ref(),
-        )?
-    } else {
-        cards
-    };
+    let cards = resolve_candidate_cards(
+        state,
+        ability,
+        zone,
+        &additional_zones,
+        zone_owner,
+        filter.as_ref(),
+    )?;
 
     // CR 700.2: If there are no objects to choose from, skip the choice.
     if cards.is_empty() || count == 0 {
@@ -107,6 +83,71 @@ pub fn resolve(
     });
 
     Ok(())
+}
+
+/// CR 700.2 + CR 603.7: Resolve the candidate card pool for a tracked-set pick.
+///
+/// Priority order:
+/// 1. The current resolution chain's tracked set (if non-empty).
+/// 2. `last_revealed_ids` from a preceding reveal in this resolution — must
+///    beat stale global tracked sets from earlier resolutions (issue #1374).
+/// 3. The latest non-empty tracked set from any prior publish in this game.
+/// 4. Explicit `TargetRef::Object` targets on the ability.
+/// 5. Direct zone scan (`zone` + `additional_zones`).
+fn resolve_candidate_cards(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    zone: Zone,
+    additional_zones: &[Zone],
+    zone_owner: ZoneOwner,
+    filter: Option<&TargetFilter>,
+) -> Result<Vec<ObjectId>, EffectError> {
+    if let Some(cards) = chain_tracked_set_cards(state) {
+        return Ok(cards);
+    }
+
+    if !state.last_revealed_ids.is_empty() {
+        // CR 701.20b: RevealTop/Dig reveal-only parents write here but do not
+        // emit ZoneChanged, so the tracked-set publish depends on
+        // `affected_objects_from_events` reading `CardsRevealed`.
+        let filter_ctx = FilterContext::from_ability(ability);
+        let cards: Vec<_> = state
+            .last_revealed_ids
+            .iter()
+            .copied()
+            .filter(|id| filter.is_none_or(|f| matches_target_filter(state, *id, f, &filter_ctx)))
+            .collect();
+        if !cards.is_empty() {
+            return Ok(cards);
+        }
+    }
+
+    let cards = crate::game::targeting::latest_tracked_set_id(state)
+        .and_then(|id| state.tracked_object_sets.get(&id).cloned())
+        .unwrap_or_else(|| {
+            ability
+                .targets
+                .iter()
+                .filter_map(|t| match t {
+                    TargetRef::Object(id) => Some(*id),
+                    _ => None,
+                })
+                .collect()
+        });
+
+    let cards = if cards.is_empty() {
+        collect_direct_zone_cards(state, ability, zone, additional_zones, zone_owner, filter)?
+    } else {
+        cards
+    };
+
+    Ok(cards)
+}
+
+fn chain_tracked_set_cards(state: &GameState) -> Option<Vec<ObjectId>> {
+    let chain_id = state.chain_tracked_set_id?;
+    let cards = state.tracked_object_sets.get(&chain_id)?;
+    (!cards.is_empty()).then(|| cards.clone())
 }
 
 fn collect_direct_zone_cards(
@@ -757,5 +798,231 @@ mod tests {
                 categories: vec![CoreType::Artifact, CoreType::Creature],
             }),
         ));
+    }
+
+    /// CR 701.20b + CR 700.2: Issue #1374 — when RevealTop did not publish a
+    /// tracked set, `ChooseFromZone` must bind to `last_revealed_ids`, not a
+    /// stale graveyard set from an earlier resolution.
+    #[test]
+    fn resolve_prefers_last_revealed_ids_over_stale_tracked_set() {
+        let mut state = GameState::new_two_player(42);
+        let revealed_creature = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Revealed Creature".to_string(),
+            Zone::Library,
+        );
+        state
+            .objects
+            .get_mut(&revealed_creature)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Creature];
+        let revealed_instant = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Revealed Instant".to_string(),
+            Zone::Library,
+        );
+        state
+            .objects
+            .get_mut(&revealed_instant)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Instant];
+        let stale_graveyard_card = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Stale Graveyard Card".to_string(),
+            Zone::Graveyard,
+        );
+        state
+            .tracked_object_sets
+            .insert(TrackedSetId(9), vec![stale_graveyard_card]);
+        state.next_tracked_set_id = 10;
+        state.last_revealed_ids = vec![revealed_creature, revealed_instant];
+
+        let categories = vec![
+            CoreType::Artifact,
+            CoreType::Battle,
+            CoreType::Creature,
+            CoreType::Enchantment,
+            CoreType::Instant,
+            CoreType::Land,
+            CoreType::Planeswalker,
+            CoreType::Sorcery,
+        ];
+        let ability = ResolvedAbility::new(
+            Effect::ChooseFromZone {
+                count: categories.len() as u32,
+                zone: Zone::Library,
+                additional_zones: Vec::new(),
+                zone_owner: ZoneOwner::Controller,
+                filter: None,
+                chooser: Chooser::Controller,
+                up_to: true,
+                constraint: Some(ChooseFromZoneConstraint::DistinctCardTypes { categories }),
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice { cards, .. } => {
+                assert!(cards.contains(&revealed_creature));
+                assert!(cards.contains(&revealed_instant));
+                assert!(
+                    !cards.contains(&stale_graveyard_card),
+                    "stale graveyard tracked set must not shadow revealed library cards"
+                );
+            }
+            other => panic!("Expected ChooseFromZoneChoice, got {:?}", other),
+        }
+    }
+
+    /// End-to-end regression for Atraxa, Grand Unifier's ETB chain:
+    /// RevealTop(10) → ChooseFromZone(DistinctCardTypes) must offer only the
+    /// revealed library cards.
+    #[test]
+    fn atraxa_style_reveal_top_chain_offers_revealed_library_cards() {
+        use super::super::resolve_ability_chain;
+        use crate::types::ability::TargetFilter;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(900),
+            PlayerId(0),
+            "Atraxa, Grand Unifier".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut library_top = Vec::new();
+        for i in 0..10 {
+            let core_type = if i % 2 == 0 {
+                CoreType::Creature
+            } else {
+                CoreType::Instant
+            };
+            let id = create_object(
+                &mut state,
+                CardId(i + 1),
+                PlayerId(0),
+                format!("Library Card {i}"),
+                Zone::Library,
+            );
+            state.objects.get_mut(&id).unwrap().card_types.core_types = vec![core_type];
+            library_top.push(id);
+        }
+        let _library_padding = create_object(
+            &mut state,
+            CardId(50),
+            PlayerId(0),
+            "Library Padding".to_string(),
+            Zone::Library,
+        );
+
+        let stale_graveyard_card = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Stale Graveyard Card".to_string(),
+            Zone::Graveyard,
+        );
+        state
+            .tracked_object_sets
+            .insert(TrackedSetId(5), vec![stale_graveyard_card]);
+        state.next_tracked_set_id = 6;
+
+        let categories = vec![
+            CoreType::Artifact,
+            CoreType::Battle,
+            CoreType::Creature,
+            CoreType::Enchantment,
+            CoreType::Instant,
+            CoreType::Land,
+            CoreType::Planeswalker,
+            CoreType::Sorcery,
+        ];
+        let change_zone = Box::new(ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Library),
+                destination: Zone::Hand,
+                target: TargetFilter::Any,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        ));
+        let choose = ResolvedAbility {
+            sub_ability: Some(change_zone),
+            ..ResolvedAbility::new(
+                Effect::ChooseFromZone {
+                    count: categories.len() as u32,
+                    zone: Zone::Library,
+                    additional_zones: Vec::new(),
+                    zone_owner: ZoneOwner::Controller,
+                    filter: None,
+                    chooser: Chooser::Controller,
+                    up_to: true,
+                    constraint: Some(ChooseFromZoneConstraint::DistinctCardTypes { categories }),
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            )
+        };
+        let reveal = ResolvedAbility {
+            sub_ability: Some(Box::new(choose)),
+            ..ResolvedAbility::new(
+                Effect::RevealTop {
+                    player: TargetFilter::Controller,
+                    count: 10,
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            )
+        };
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &reveal, &mut events, 0).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice { cards, up_to, .. } => {
+                assert!(up_to);
+                assert_eq!(cards.len(), 10, "must offer exactly the ten revealed cards");
+                for id in &library_top {
+                    assert!(cards.contains(id), "missing revealed library card {id:?}");
+                }
+                assert!(
+                    !cards.contains(&stale_graveyard_card),
+                    "graveyard cards must never appear in the reveal-and-choose pool"
+                );
+                assert!(
+                    !cards.contains(&_library_padding),
+                    "cards below the reveal window must not be offered"
+                );
+            }
+            other => panic!(
+                "Expected ChooseFromZoneChoice after RevealTop, got {:?}",
+                other
+            ),
+        }
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2351,6 +2351,18 @@ fn affected_objects_from_events(
                     .collect()
             }
         }
+        // CR 701.20b + CR 608.2c: Reveal instructions do not move cards, so they
+        // emit `CardsRevealed` rather than `ZoneChanged`. Publish the revealed
+        // card ids for downstream "from among the revealed cards"
+        // `ChooseFromZone` continuations (Atraxa, Grand Unifier class).
+        Effect::RevealTop { .. } | Effect::RevealHand { .. } | Effect::Clash => events
+            .iter()
+            .filter_map(|event| match event {
+                GameEvent::CardsRevealed { card_ids, .. } => Some(card_ids.as_slice()),
+                _ => None,
+            })
+            .flat_map(|ids| ids.iter().copied())
+            .collect(),
         _ => {
             let dest_zone = match effect {
                 Effect::ChangeZone { destination, .. }
@@ -8881,6 +8893,43 @@ mod tests {
             .filter(|o| o.name == "Treasure")
             .count();
         assert_eq!(treasures0, 0, "Empty chain must mint zero tokens");
+    }
+
+    /// CR 701.20b + CR 608.2c: `RevealTop` publishes `CardsRevealed`, not
+    /// `ZoneChanged`. Without a dedicated arm in `affected_objects_from_events`,
+    /// the tracked-set publish is empty and `ChooseFromZone` falls back to a
+    /// stale graveyard set from an earlier resolution (issue #1374).
+    #[test]
+    fn reveal_top_publishes_cards_revealed_for_tracked_set() {
+        let mut state = GameState::new_two_player(42);
+        let top = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Top Card".to_string(),
+            Zone::Library,
+        );
+        let second = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Second Card".to_string(),
+            Zone::Library,
+        );
+        let events = vec![GameEvent::CardsRevealed {
+            player: PlayerId(0),
+            card_ids: vec![top, second],
+            card_names: vec!["Top Card".to_string(), "Second Card".to_string()],
+        }];
+        let effect = Effect::RevealTop {
+            player: TargetFilter::Controller,
+            count: 2,
+        };
+
+        assert_eq!(
+            affected_objects_from_events(&effect, &events, &[]),
+            vec![top, second]
+        );
     }
 
     /// CR 701.20a + CR 608.2f: an Indomitable Creativity-style

--- a/crates/engine/tests/integration/issue_1374_atraxa_grand_unifier.rs
+++ b/crates/engine/tests/integration/issue_1374_atraxa_grand_unifier.rs
@@ -1,0 +1,215 @@
+//! Regression: GitHub issue #1374 — Atraxa, Grand Unifier ETB must let the
+//! controller choose from among the revealed library cards, not from the
+//! graveyard (or any other stale tracked set).
+//!
+//! Oracle (ETB half):
+//!   "When Atraxa enters, reveal the top ten cards of your library. For each
+//!    card type, you may put a card of that type from among the revealed cards
+//!    into your hand. Put the rest on the bottom of your library in a random
+//!    order."
+//!
+//! Bug: `RevealTop` emits `CardsRevealed`, not `ZoneChanged`, so
+//! `affected_objects_from_events` published an empty tracked set. `ChooseFromZone`
+//! then fell back to `latest_tracked_set_id`, which could return a stale
+//! graveyard/mill set from an earlier resolution — offering only graveyard cards.
+//!
+//! CR 701.20b: Revealing does not move cards; the choice pool is the revealed set.
+//! CR 700.2: "From among" restricts the pick to that set.
+
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::P0;
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    ChooseFromZoneConstraint, Chooser, Effect, ResolvedAbility, TargetFilter, ZoneOwner,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, TrackedSetId};
+use engine::types::zones::Zone;
+
+const ATRAXA_ETB: &str = "Flying, vigilance, deathtouch, lifelink\n\
+    When Atraxa enters, reveal the top ten cards of your library. For each card type, \
+    you may put a card of that type from among the revealed cards into your hand. \
+    Put the rest on the bottom of your library in a random order.";
+
+fn distinct_card_type_categories() -> Vec<CoreType> {
+    vec![
+        CoreType::Artifact,
+        CoreType::Battle,
+        CoreType::Creature,
+        CoreType::Enchantment,
+        CoreType::Instant,
+        CoreType::Land,
+        CoreType::Planeswalker,
+        CoreType::Sorcery,
+    ]
+}
+
+/// Parser precondition: the ETB trigger must lower to RevealTop → ChooseFromZone.
+#[test]
+fn atraxa_parser_wires_reveal_top_to_distinct_card_type_choose() {
+    let parsed = parse_oracle_text(
+        ATRAXA_ETB,
+        "Atraxa, Grand Unifier",
+        &[],
+        &["Creature".to_string()],
+        &["Phyrexian".to_string(), "Angel".to_string()],
+    );
+    assert_eq!(parsed.triggers.len(), 1);
+    let execute = parsed.triggers[0]
+        .execute
+        .as_ref()
+        .expect("ETB trigger must have execute");
+    assert!(
+        matches!(&*execute.effect, Effect::RevealTop { count: 10, .. }),
+        "top effect must be RevealTop(10), got {:?}",
+        execute.effect
+    );
+    let choose = execute
+        .sub_ability
+        .as_ref()
+        .expect("RevealTop must chain to ChooseFromZone");
+    assert!(
+        matches!(
+            &*choose.effect,
+            Effect::ChooseFromZone {
+                up_to: true,
+                constraint: Some(ChooseFromZoneConstraint::DistinctCardTypes { .. }),
+                ..
+            }
+        ),
+        "sub-ability must be ChooseFromZone with DistinctCardTypes, got {:?}",
+        choose.effect
+    );
+}
+
+/// Runtime regression: after RevealTop resolves, the choice modal must list the
+/// ten revealed library cards — never a stale graveyard tracked set.
+#[test]
+fn atraxa_etb_choice_offers_revealed_library_not_graveyard() {
+    let mut state = GameState::new_two_player(42);
+    let source = create_object(
+        &mut state,
+        CardId(900),
+        P0,
+        "Atraxa, Grand Unifier".to_string(),
+        Zone::Battlefield,
+    );
+
+    let mut library_top = Vec::new();
+    for i in 0..10 {
+        let id = create_object(
+            &mut state,
+            CardId(i + 1),
+            P0,
+            format!("Top Card {i}"),
+            Zone::Library,
+        );
+        let core_type = if i % 2 == 0 {
+            CoreType::Creature
+        } else {
+            CoreType::Instant
+        };
+        state.objects.get_mut(&id).unwrap().card_types.core_types = vec![core_type];
+        library_top.push(id);
+    }
+    let padding = create_object(
+        &mut state,
+        CardId(50),
+        P0,
+        "Library Bottom".to_string(),
+        Zone::Library,
+    );
+    let graveyard_trap = create_object(
+        &mut state,
+        CardId(99),
+        P0,
+        "Graveyard Trap".to_string(),
+        Zone::Graveyard,
+    );
+    state
+        .tracked_object_sets
+        .insert(TrackedSetId(7), vec![graveyard_trap]);
+    state.next_tracked_set_id = 8;
+
+    let categories = distinct_card_type_categories();
+    let change_zone = Box::new(ResolvedAbility::new(
+        Effect::ChangeZone {
+            origin: Some(Zone::Library),
+            destination: Zone::Hand,
+            target: TargetFilter::Any,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            face_down_profile: None,
+        },
+        vec![],
+        source,
+        P0,
+    ));
+    let choose = ResolvedAbility {
+        sub_ability: Some(change_zone),
+        ..ResolvedAbility::new(
+            Effect::ChooseFromZone {
+                count: categories.len() as u32,
+                zone: Zone::Library,
+                additional_zones: Vec::new(),
+                zone_owner: ZoneOwner::Controller,
+                filter: None,
+                chooser: Chooser::Controller,
+                up_to: true,
+                constraint: Some(ChooseFromZoneConstraint::DistinctCardTypes { categories }),
+            },
+            vec![],
+            source,
+            P0,
+        )
+    };
+    let reveal = ResolvedAbility {
+        sub_ability: Some(Box::new(choose)),
+        ..ResolvedAbility::new(
+            Effect::RevealTop {
+                player: TargetFilter::Controller,
+                count: 10,
+            },
+            vec![],
+            source,
+            P0,
+        )
+    };
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &reveal, &mut events, 0)
+        .expect("Atraxa ETB reveal/choose chain must resolve");
+
+    match state.waiting_for {
+        WaitingFor::ChooseFromZoneChoice { cards, up_to, .. } => {
+            assert!(up_to, "per-card-type picks are optional (up_to)");
+            assert_eq!(
+                cards.len(),
+                10,
+                "choice pool must be exactly the ten revealed cards; got {cards:?}"
+            );
+            for id in &library_top {
+                assert!(
+                    cards.contains(id),
+                    "revealed library card {id:?} must be choosable"
+                );
+            }
+            assert!(
+                !cards.contains(&graveyard_trap),
+                "graveyard cards must never be offered (issue #1374)"
+            );
+            assert!(
+                !cards.contains(&padding),
+                "unrevealed library cards must not be offered"
+            );
+        }
+        other => panic!("expected ChooseFromZoneChoice for Atraxa ETB, got {other:?}"),
+    }
+}

--- a/crates/engine/tests/integration/issue_1374_atraxa_grand_unifier.rs
+++ b/crates/engine/tests/integration/issue_1374_atraxa_grand_unifier.rs
@@ -14,7 +14,7 @@
 //! graveyard/mill set from an earlier resolution — offering only graveyard cards.
 //!
 //! CR 701.20b: Revealing does not move cards; the choice pool is the revealed set.
-//! CR 700.2: "From among" restricts the pick to that set.
+//! CR 608.2d: "From among" restricts the resolution-time choice to that set.
 
 use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::P0;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -92,6 +92,7 @@ mod issue_1302_final_parting;
 mod issue_1305_thalisse_tokens_created_this_turn;
 mod issue_1308_unstoppable_plan;
 mod issue_1312_prepared_spell_cast_triggers;
+mod issue_1374_atraxa_grand_unifier;
 mod issue_1499_arabella;
 mod issue_1509_sorcery_main_phase_cast;
 mod issue_1524_serpents_soul_jar;


### PR DESCRIPTION
## Summary

- Fix `RevealTop` → `ChooseFromZone` tracked-set wiring so "from among the revealed cards" binds to the revealed library cards, not a stale graveyard/mill set from an earlier resolution.
- Add `CardsRevealed` handling in `affected_objects_from_events` for `RevealTop`, `RevealHand`, and `Clash`.
- Refactor `ChooseFromZone` candidate resolution to prefer chain-local tracked sets and `last_revealed_ids` over global `latest_tracked_set_id`.

Fixes #1374

## Root cause

Atraxa, Grand Unifier parses correctly as `RevealTop(10)` → `ChooseFromZone(DistinctCardTypes)` → `ChangeZone(Library→Hand)`. At runtime, `RevealTop` does not move cards (CR 701.20b), so it emits `CardsRevealed` rather than `ZoneChanged`. The tracked-set publisher only scanned zone changes, published an empty set, and `ChooseFromZone` fell back to the highest non-empty tracked set — often graveyard cards from a prior mill/discard/exile effect.

## Test plan

- [x] `reveal_top_publishes_cards_revealed_for_tracked_set`
- [x] `resolve_prefers_last_revealed_ids_over_stale_tracked_set`
- [x] `atraxa_style_reveal_top_chain_offers_revealed_library_cards`
- [x] `issue_1374_atraxa_grand_unifier::atraxa_parser_wires_reveal_top_to_distinct_card_type_choose`
- [x] `issue_1374_atraxa_grand_unifier::atraxa_etb_choice_offers_revealed_library_not_graveyard`
- [ ] Manual: cast Atraxa with a populated library and confirm the choice modal shows the 10 revealed top cards (not graveyard)