### PR TITLE
fix(parser): parse "equal to the number of … destroyed this way" quantities

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -11884,4 +11884,31 @@ mod tests {
             "recipient prevent must not carry a source filter"
         );
     }
+
+    /// CR 119.3 + CR 608.2c: Kaya's Wrath lifegain (issue #2943) must parse
+    /// through the imperative GainLife path with a FilteredTrackedSetSize
+    /// amount, not fall through to Unimplemented.
+    #[test]
+    fn gain_life_equal_to_destroyed_creatures_you_controlled_this_way() {
+        use crate::types::ability::{ControllerRef, QuantityExpr, QuantityRef};
+
+        let text = "You gain life equal to the number of creatures you controlled that were \
+                    destroyed this way.";
+        let lower = text.to_ascii_lowercase();
+        let ast = parse_numeric_imperative_ast(text, &lower)
+            .expect("Kaya's Wrath lifegain clause must parse");
+        match ast {
+            NumericImperativeAst::GainLife { amount } => match amount {
+                QuantityExpr::Ref {
+                    qty: QuantityRef::FilteredTrackedSetSize { filter },
+                } => {
+                    let tf = typed_leg(&filter).expect("filter must be Typed");
+                    assert!(has_type(tf, TypeFilter::Creature));
+                    assert_eq!(tf.controller, Some(ControllerRef::You));
+                }
+                other => panic!("expected FilteredTrackedSetSize, got {other:?}"),
+            },
+            other => panic!("expected GainLife imperative, got {other:?}"),
+        }
+    }
 }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -420,14 +420,10 @@ pub(crate) fn parse_quantity_ref_with_context(
         // and leave an unresolved "that were destroyed this way" tail.
         // Class: Kaya's Wrath (issue #2943), Ceaseless Conflict, and any
         // "equal to the number of … destroyed this way" lifegain phrasing.
+        if let Some(qty) =
+            parse_destroyed_or_sacrificed_this_way_quantity(&rest.to_ascii_lowercase())
         {
-            let lower = rest.to_ascii_lowercase();
-            if lower.contains("destroyed this way") || lower.contains("sacrificed this way") {
-                if let Some(qty) = parse_filtered_destroyed_this_way(&lower) {
-                    return Some(qty);
-                }
-                return Some(QuantityRef::TrackedSetSize);
-            }
+            return Some(qty);
         }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
         // CR 109.1: `parse_type_phrase_with_ctx` always returns `TargetFilter::Typed`,
@@ -1759,7 +1755,7 @@ fn filter_is_nontrivial_for_tracked_set(filter: &crate::types::ability::TargetFi
 ///
 /// Uses `terminated(take_until(suffix), tag(suffix))` to split at each
 /// recognized suffix, then delegates the prefix to `parse_type_phrase`.
-fn parse_filtered_destroyed_this_way(lower: &str) -> Option<QuantityRef> {
+fn parse_destroyed_or_sacrificed_this_way_filter(lower: &str) -> Option<Option<TargetFilter>> {
     // Each suffix is tried in order; the first complete match wins.
     // Longer/more-specific suffixes must come before shorter ones so
     // "that was destroyed this way" is preferred over "destroyed this way".
@@ -1767,9 +1763,11 @@ fn parse_filtered_destroyed_this_way(lower: &str) -> Option<QuantityRef> {
         " that was destroyed this way",
         " that were destroyed this way",
         " destroyed this way",
+        "destroyed this way",
         " that was sacrificed this way",
         " that were sacrificed this way",
         " sacrificed this way",
+        "sacrificed this way",
     ];
     for &suffix in suffixes {
         // terminated(take_until(suffix), tag(suffix)) parses the noun-phrase
@@ -1779,17 +1777,37 @@ fn parse_filtered_destroyed_this_way(lower: &str) -> Option<QuantityRef> {
         if let Ok(("", filter_phrase)) = result {
             let (filter, remainder) =
                 crate::parser::oracle_target::parse_type_phrase(filter_phrase.trim());
-            if remainder.trim().is_empty() && filter_is_nontrivial_for_tracked_set(&filter) {
-                return Some(QuantityRef::FilteredTrackedSetSize {
-                    filter: Box::new(filter),
-                });
+            if remainder.trim().is_empty() {
+                return Some(Some(filter));
             }
             // A suffix matched but the filter is trivial or the phrase
             // didn't fully consume — fall through to TrackedSetSize.
-            return None;
+            return Some(None);
         }
     }
     None
+}
+
+fn parse_filtered_destroyed_this_way(lower: &str) -> Option<QuantityRef> {
+    match parse_destroyed_or_sacrificed_this_way_filter(lower)? {
+        Some(filter) if filter_is_nontrivial_for_tracked_set(&filter) => {
+            Some(QuantityRef::FilteredTrackedSetSize {
+                filter: Box::new(filter),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn parse_destroyed_or_sacrificed_this_way_quantity(lower: &str) -> Option<QuantityRef> {
+    match parse_destroyed_or_sacrificed_this_way_filter(lower)? {
+        Some(filter) if filter_is_nontrivial_for_tracked_set(&filter) => {
+            Some(QuantityRef::FilteredTrackedSetSize {
+                filter: Box::new(filter),
+            })
+        }
+        _ => Some(QuantityRef::TrackedSetSize),
+    }
 }
 
 fn try_parse_counters_removed_this_way(lower: &str) -> bool {

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -413,6 +413,22 @@ pub(crate) fn parse_quantity_ref_with_context(
                 });
             }
         }
+        // CR 608.2c + CR 400.7: "the number of [filter] destroyed/sacrificed
+        // this way" — count from the tracked set populated by the preceding
+        // destroy/sacrifice in the sub_ability chain. Must run BEFORE
+        // `parse_type_phrase`, which would consume "creatures you controlled"
+        // and leave an unresolved "that were destroyed this way" tail.
+        // Class: Kaya's Wrath (issue #2943), Ceaseless Conflict, and any
+        // "equal to the number of … destroyed this way" lifegain phrasing.
+        {
+            let lower = rest.to_ascii_lowercase();
+            if lower.contains("destroyed this way") || lower.contains("sacrificed this way") {
+                if let Some(qty) = parse_filtered_destroyed_this_way(&lower) {
+                    return Some(qty);
+                }
+                return Some(QuantityRef::TrackedSetSize);
+            }
+        }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
         // CR 109.1: `parse_type_phrase_with_ctx` always returns `TargetFilter::Typed`,
         // including the empty-shaped form (no `type_filters`, no `controller`, no
@@ -5347,6 +5363,55 @@ mod tests {
             },
         };
         assert_eq!(qty, expected);
+    }
+
+    /// CR 608.2c + CR 400.7: "the number of creatures you controlled that were
+    /// destroyed this way" (Kaya's Wrath, issue #2943) must lower to
+    /// `FilteredTrackedSetSize`, not `Effect::Unimplemented`. The for-each
+    /// path already handled this shape; the `parse_quantity_ref` "the number
+    /// of …" path must mirror it before `parse_type_phrase` strips the tail.
+    #[test]
+    fn parse_quantity_ref_creatures_you_controlled_destroyed_this_way() {
+        let qty = parse_quantity_ref(
+            "the number of creatures you controlled that were destroyed this way",
+        )
+        .expect("must parse");
+        match qty {
+            QuantityRef::FilteredTrackedSetSize { filter } => match *filter {
+                TargetFilter::Typed(ref tf) => {
+                    assert!(
+                        tf.type_filters.contains(&TypeFilter::Creature),
+                        "filter must require Creature"
+                    );
+                    assert!(
+                        tf.controller
+                            .as_ref()
+                            .is_some_and(|c| matches!(c, ControllerRef::You)),
+                        "filter must require controller=You"
+                    );
+                }
+                other => panic!("expected Typed filter, got {other:?}"),
+            },
+            other => panic!("expected FilteredTrackedSetSize, got {other:?}"),
+        }
+    }
+
+    /// Type-qualified "the number of … destroyed this way" via
+    /// `parse_quantity_ref` emits `FilteredTrackedSetSize` when the type
+    /// phrase restricts the tracked set.
+    #[test]
+    fn parse_quantity_ref_permanents_destroyed_this_way_uses_filtered_tracked_set() {
+        let qty =
+            parse_quantity_ref("the number of permanents destroyed this way").expect("must parse");
+        match qty {
+            QuantityRef::FilteredTrackedSetSize { filter } => {
+                assert!(
+                    matches!(filter.as_ref(), TargetFilter::Typed(_)),
+                    "expected typed permanent filter, got {filter:?}"
+                );
+            }
+            other => panic!("expected FilteredTrackedSetSize, got {other:?}"),
+        }
     }
 
     /// Same composite shape with "you controlled" — verifies the controller

--- a/crates/engine/tests/integration/issue_2943_kayas_wrath.rs
+++ b/crates/engine/tests/integration/issue_2943_kayas_wrath.rs
@@ -1,0 +1,204 @@
+//! Integration test for issue #2943 — Kaya's Wrath lifegain from destroyed creatures.
+//!
+//! Oracle:
+//!   "Destroy all creatures. You gain life equal to the number of creatures
+//!    you controlled that were destroyed this way."
+//!
+//! Before the fix the lifegain clause lowered to `Effect::Unimplemented` because
+//! `parse_quantity_ref` let `parse_type_phrase` consume "creatures you controlled"
+//! and leave an unresolved "that were destroyed this way" tail. The fix routes
+//! "the number of … destroyed/sacrificed this way" through
+//! `FilteredTrackedSetSize` before the generic object-count fall-through.
+//!
+//! CR 701.8a: Destroy moves battlefield permanents to the graveyard.
+//! CR 608.2c + CR 400.7: Downstream sub-abilities count only objects actually
+//!   moved by the preceding destroy, optionally filtered by controller/type.
+//! CR 119.3: Gain life equal to that filtered count.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityKind, ControllerRef, Effect, QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter,
+    TypeFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const KAYAS_WRATH_ORACLE: &str = "Destroy all creatures. You gain life equal to the number of \
+creatures you controlled that were destroyed this way.";
+
+fn kayas_wrath_ability(controller: PlayerId, source_id: ObjectId) -> ResolvedAbility {
+    let def = parse_effect_chain(KAYAS_WRATH_ORACLE, AbilityKind::Spell);
+    build_resolved_from_def(&def, source_id, controller)
+}
+
+fn spawn_creature(state: &mut GameState, card_id: CardId, owner: PlayerId, name: &str) -> ObjectId {
+    let id = create_object(state, card_id, owner, name.to_string(), Zone::Battlefield);
+    state
+        .objects
+        .get_mut(&id)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+    id
+}
+
+/// Parse-shape contract: DestroyAll(creatures) chained to GainLife whose amount
+/// reads the filtered tracked set of controller-owned creatures destroyed.
+#[test]
+fn kayas_wrath_lowers_to_destroy_all_plus_filtered_tracked_set_gain_life() {
+    let def = parse_effect_chain(KAYAS_WRATH_ORACLE, AbilityKind::Spell);
+    match def.effect.as_ref() {
+        Effect::DestroyAll {
+            target: TargetFilter::Typed(tf),
+            ..
+        } => {
+            assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+        }
+        other => panic!("expected DestroyAll{{creatures}}, got {other:?}"),
+    }
+
+    let gain_life = def
+        .sub_ability
+        .as_ref()
+        .expect("lifegain must be a sub_ability of DestroyAll");
+    match gain_life.effect.as_ref() {
+        Effect::GainLife {
+            amount:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::FilteredTrackedSetSize { filter },
+                },
+            player: TargetFilter::Controller,
+        } => match filter.as_ref() {
+            TargetFilter::Typed(tf) => {
+                assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+                assert!(
+                    tf.controller
+                        .as_ref()
+                        .is_some_and(|c| matches!(c, ControllerRef::You)),
+                    "lifegain count must be restricted to creatures you controlled"
+                );
+            }
+            other => panic!("expected Typed creature-you filter, got {other:?}"),
+        },
+        other => panic!("expected FilteredTrackedSetSize GainLife sub_ability, got {other:?}"),
+    }
+}
+
+/// CR 608.2c: Only the controller's destroyed creatures contribute to lifegain,
+/// even when the wrath destroys the whole battlefield.
+#[test]
+fn kayas_wrath_gains_life_only_for_controller_creatures_destroyed() {
+    let mut state = GameState::new_two_player(42);
+    for i in 0..3 {
+        spawn_creature(&mut state, CardId(i + 1), PlayerId(0), "Yours");
+    }
+    for i in 0..2 {
+        spawn_creature(&mut state, CardId(i + 10), PlayerId(1), "Theirs");
+    }
+    let starting_life = state.players[0].life;
+
+    let ability = kayas_wrath_ability(PlayerId(0), ObjectId(100));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        state.players[0].life,
+        starting_life + 3,
+        "controller must gain life equal to their own destroyed creatures only"
+    );
+    assert_eq!(
+        state.battlefield.len(),
+        0,
+        "all creatures must leave the battlefield"
+    );
+}
+
+/// CR 702.12b + CR 608.2c: Indestructible creatures are excluded from both
+/// destruction and the filtered tracked-set count.
+#[test]
+fn kayas_wrath_excludes_indestructible_from_life_gained() {
+    let mut state = GameState::new_two_player(42);
+    let god = spawn_creature(&mut state, CardId(1), PlayerId(0), "Indestructible");
+    state
+        .objects
+        .get_mut(&god)
+        .unwrap()
+        .keywords
+        .push(engine::types::keywords::Keyword::Indestructible);
+    spawn_creature(&mut state, CardId(2), PlayerId(0), "Mortal");
+    spawn_creature(&mut state, CardId(3), PlayerId(1), "Opponent");
+    let starting_life = state.players[0].life;
+
+    let ability = kayas_wrath_ability(PlayerId(0), ObjectId(100));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        state.players[0].life,
+        starting_life + 1,
+        "only the mortal creature you controlled should count toward lifegain"
+    );
+    assert!(
+        state.battlefield.contains(&god),
+        "indestructible creature must survive"
+    );
+}
+
+/// CR 701.8c: Regenerated creatures are not destroyed and must not count.
+#[test]
+fn kayas_wrath_excludes_regenerated_creature_from_life_gained() {
+    use engine::types::ability::ReplacementDefinition;
+    use engine::types::replacements::ReplacementEvent;
+
+    let mut state = GameState::new_two_player(42);
+    let shielded = spawn_creature(&mut state, CardId(1), PlayerId(0), "Shielded");
+    let shield = ReplacementDefinition::new(ReplacementEvent::Destroy)
+        .valid_card(TargetFilter::SelfRef)
+        .description("Regenerate".to_string())
+        .regeneration_shield();
+    state
+        .objects
+        .get_mut(&shielded)
+        .unwrap()
+        .replacement_definitions
+        .push(shield);
+    spawn_creature(&mut state, CardId(2), PlayerId(0), "Unshielded");
+    let starting_life = state.players[0].life;
+
+    let ability = kayas_wrath_ability(PlayerId(0), ObjectId(100));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        state.players[0].life,
+        starting_life + 1,
+        "regenerated creature must not increment the destroyed-this-way count"
+    );
+    assert!(
+        state.battlefield.contains(&shielded),
+        "regenerated creature must remain on the battlefield"
+    );
+}
+
+/// Zero controlled creatures destroyed → zero life gained, but the chain still
+/// records an empty tracked set so stale prior sets are not reused.
+#[test]
+fn kayas_wrath_gains_zero_when_controller_had_no_creatures() {
+    let mut state = GameState::new_two_player(42);
+    spawn_creature(&mut state, CardId(1), PlayerId(1), "Opponent only");
+    let starting_life = state.players[0].life;
+
+    let ability = kayas_wrath_ability(PlayerId(0), ObjectId(100));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(state.players[0].life, starting_life);
+    assert_eq!(state.battlefield.len(), 0);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -130,6 +130,7 @@ mod issue_2430_shifting_woodland;
 mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
+mod issue_2943_kayas_wrath;
 mod issue_564_wishclaw_talisman_control;
 mod issue_565_birthing_ritual_end_step_trigger;
 mod issue_566_ragavan_dash_cast;


### PR DESCRIPTION
## Summary

- Fixes [#2943](https://github.com/phase-rs/phase/issues/2943): Kaya's Wrath's lifegain clause (`You gain life equal to the number of creatures you controlled that were destroyed this way`) was lowering to `Effect::Unimplemented`.
- The `"for each … destroyed this way"` path already emitted `FilteredTrackedSetSize`; the `"equal to the number of …"` path did not — `parse_type_phrase` consumed `"creatures you controlled"` and left an unresolved tail.
- Wires the existing `parse_filtered_destroyed_this_way` combinator into `parse_quantity_ref` before the generic object-count fall-through. Runtime (`DestroyAll` tracked set + `FilteredTrackedSetSize` resolution) was already correct.

## Test plan

- [x] `parse_quantity_ref_creatures_you_controlled_destroyed_this_way`
- [x] `parse_quantity_ref_permanents_destroyed_this_way_uses_filtered_tracked_set`
- [x] `gain_life_equal_to_destroyed_creatures_you_controlled_this_way`
- [x] `issue_2943_kayas_wrath::*` (5 integration tests: parse shape, controller-only count, indestructible/regen exclusion, zero creatures)