### PR TITLE
Cost-payment unification Phase 3: route handle_unless_payment through the authority

### DIFF
--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -16,13 +16,13 @@ use crate::types::proposed_event::ProposedEvent;
 use crate::types::zones::Zone;
 
 use super::casting;
+use super::costs::{self, PaymentOutcome};
 use super::effects;
 use super::engine::{
     handle_tap_land_for_mana, handle_untap_land_for_mana, resume_pending_continuation_if_priority,
     EngineError,
 };
 use super::engine_priority;
-use super::life_costs::{pay_life_as_cost, PayLifeCostResult};
 use super::mana_abilities;
 use super::zones;
 
@@ -488,9 +488,26 @@ pub(super) fn handle_unless_payment(
     let mut post_action_event_start = None;
     if pay {
         match cost {
-            // CR 118.12: Pay the static mana component of the unless cost.
-            AbilityCost::Mana { cost: mana_cost } => {
-                casting::pay_unless_cost(state, player, &mana_cost, events)?;
+            // CR 118.12: Pay the static mana component of the unless cost
+            // through the single payment authority (cost-payment unification,
+            // Phase 3). Resolution scope auto-taps via `pay_effect_mana_cost`
+            // — the same final mana path the old `pay_unless_cost` shim used —
+            // and maps an unpayable cost to the "unless" branch fall-through.
+            AbilityCost::Mana { .. } => {
+                match costs::pay_ability_cost_for_resolution(
+                    state,
+                    player,
+                    &cost,
+                    pending_effect.as_ref(),
+                    events,
+                )? {
+                    PaymentOutcome::Paid => {}
+                    PaymentOutcome::Failed { .. } => payment_failed = true,
+                    // CR 616.1: an atomic Mana cost cannot surface a
+                    // replacement pause; the authority never returns `Paused`
+                    // for it. Treat any pause defensively as not-paid.
+                    PaymentOutcome::Paused { .. } => payment_failed = true,
+                }
             }
             // CR 118.4 + CR 107.3c: A dynamic generic cost should have been
             // resolved into a fixed `Mana { cost }` upstream (in the
@@ -500,57 +517,47 @@ pub(super) fn handle_unless_payment(
             AbilityCost::ManaDynamic { .. } => {
                 unreachable!("ManaDynamic should be resolved before payment");
             }
-            // CR 118.12 + CR 118.3 + CR 119.4 + CR 119.8: Unless-pay life
-            // routes through the single-authority helper. An unpayable cost
-            // (insufficient life, or CantLoseLife lock) causes the "unless"
-            // branch to fall through to the effect still happening.
-            AbilityCost::PayLife { amount } => {
-                // CR 107.3c: Resolve the `QuantityExpr` against game state so
-                // dynamic life amounts (e.g., "pay X life where X is your
-                // opponents' life total") read the chosen X at payment time.
-                let life_amount = crate::game::quantity::resolve_quantity_with_targets(
+            // CR 118.12 + CR 118.3 + CR 119.4: Unless-pay life routes through
+            // the single payment authority (cost-payment unification, Phase 3).
+            // The authority resolves the `QuantityExpr` against the payer-
+            // adjusted ability (dynamic life amounts read the chosen X /
+            // event-context object at payment time, CR 608.2k) and routes
+            // through `pay_life_as_cost`; an unpayable cost (insufficient life,
+            // or a CantLoseLife lock) makes the "unless" branch fall through to
+            // the effect still happening.
+            AbilityCost::PayLife { .. } => {
+                match costs::pay_ability_cost_for_resolution(
                     state,
-                    &amount,
+                    player,
+                    &cost,
                     pending_effect.as_ref(),
-                );
-                let life_amount = u32::try_from(life_amount.max(0)).unwrap_or(0);
-                match pay_life_as_cost(state, player, life_amount, events) {
-                    PayLifeCostResult::Paid { .. } => {}
-                    PayLifeCostResult::InsufficientLife | PayLifeCostResult::Prohibited => {
+                    events,
+                )? {
+                    PaymentOutcome::Paid => {}
+                    PaymentOutcome::Failed { .. } | PaymentOutcome::Paused { .. } => {
                         payment_failed = true;
                     }
                 }
             }
-            // CR 118.12 + CR 118.12a: "[Effect] unless [player] pays [cost]"
-            // — the player chose to pay; deduct the cost and skip the effect.
-            // CR 107.14: Paying {E} removes one energy counter from the
-            // paying player per `{E}` symbol in the cost. Energy counters
-            // are tracked on `Player.energy` (no zone), so the deduction is
-            // a direct counter-state mutation.
-            AbilityCost::PayEnergy { amount } => {
-                // CR 107.3c: Resolve the `QuantityExpr` against game state
-                // before the mutable borrow below so dynamic amounts (e.g.
-                // "an amount of {E} equal to its mana value") read the parent
-                // target at payment time.
-                let energy_amount = crate::game::quantity::resolve_quantity_with_targets(
+            // CR 118.12 + CR 118.12a + CR 107.14: "[Effect] unless [player]
+            // pays [cost]" — paying {E} removes one energy counter per `{E}`
+            // symbol. Routed through the single payment authority (cost-payment
+            // unification, Phase 3); the authority resolves the dynamic
+            // `QuantityExpr` against the payer-adjusted ability (CR 107.3c) and
+            // performs the energy deduction. Insufficient energy makes the
+            // "unless" branch fall through to the effect happening.
+            AbilityCost::PayEnergy { .. } => {
+                match costs::pay_ability_cost_for_resolution(
                     state,
-                    &amount,
+                    player,
+                    &cost,
                     pending_effect.as_ref(),
-                );
-                let energy_amount = u32::try_from(energy_amount.max(0)).unwrap_or(0);
-                let Some(player_state) = state.players.iter_mut().find(|p| p.id == player) else {
-                    return Err(EngineError::InvalidAction(
-                        "Unless payment player not found".to_string(),
-                    ));
-                };
-                if player_state.energy < energy_amount {
-                    payment_failed = true;
-                } else {
-                    player_state.energy -= energy_amount;
-                    events.push(GameEvent::EnergyChanged {
-                        player,
-                        delta: -(energy_amount as i32),
-                    });
+                    events,
+                )? {
+                    PaymentOutcome::Paid => {}
+                    PaymentOutcome::Failed { .. } | PaymentOutcome::Paused { .. } => {
+                        payment_failed = true;
+                    }
                 }
             }
             // CR 118.12a + CR 701.9 + CR 702.24a: Unless-discard. Resolve the

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -518,13 +518,18 @@ pub(super) fn handle_unless_payment(
                 unreachable!("ManaDynamic should be resolved before payment");
             }
             // CR 118.12 + CR 118.3 + CR 119.4: Unless-pay life routes through
-            // the single payment authority (cost-payment unification, Phase 3).
-            // The authority resolves the `QuantityExpr` against the payer-
-            // adjusted ability (dynamic life amounts read the chosen X /
-            // event-context object at payment time, CR 608.2k) and routes
-            // through `pay_life_as_cost`; an unpayable cost (insufficient life,
-            // or a CantLoseLife lock) makes the "unless" branch fall through to
-            // the effect still happening.
+            // the single payment authority (cost-payment unification, Phase 3),
+            // which routes it through `pay_life_as_cost`; an unpayable cost
+            // (insufficient life, or a CantLoseLife lock) makes the "unless"
+            // branch fall through to the effect still happening.
+            // Deviation from the authority's stated Resolution precondition:
+            // `pending_effect` is passed RAW — controller NOT swapped to the
+            // payer (unlike the `effects/pay.rs` payer-adjusted clone) — and
+            // the unless-payer goes in separately as `player`. This preserves
+            // the pre-Phase-3 inline behavior: unless-cost dynamic quantities
+            // can be controller-relative by card text, so a blanket controller
+            // swap is not obviously correct here. The PAYER's life is still
+            // what gets deducted (the authority pays `player`).
             AbilityCost::PayLife { .. } => {
                 match costs::pay_ability_cost_for_resolution(
                     state,
@@ -534,6 +539,13 @@ pub(super) fn handle_unless_payment(
                     events,
                 )? {
                     PaymentOutcome::Paid => {}
+                    // CR 616.1: the authority's Resolution PayLife arm has no
+                    // `Paused` return path today (`pay_life_as_cost` returns
+                    // only Paid/InsufficientLife/Prohibited); lumped with
+                    // `Failed` defensively. If a future authority change makes
+                    // a pause reachable here, this arm must hold the unless-
+                    // prompt instead of resolving the punishment effect over a
+                    // live replacement choice.
                     PaymentOutcome::Failed { .. } | PaymentOutcome::Paused { .. } => {
                         payment_failed = true;
                     }
@@ -542,10 +554,12 @@ pub(super) fn handle_unless_payment(
             // CR 118.12 + CR 118.12a + CR 107.14: "[Effect] unless [player]
             // pays [cost]" — paying {E} removes one energy counter per `{E}`
             // symbol. Routed through the single payment authority (cost-payment
-            // unification, Phase 3); the authority resolves the dynamic
-            // `QuantityExpr` against the payer-adjusted ability (CR 107.3c) and
-            // performs the energy deduction. Insufficient energy makes the
-            // "unless" branch fall through to the effect happening.
+            // unification, Phase 3), which resolves the dynamic `QuantityExpr`
+            // (CR 107.3c) and performs the energy deduction. Insufficient
+            // energy makes the "unless" branch fall through to the effect
+            // happening. Same precondition deviation as the PayLife arm above:
+            // `pending_effect` is passed RAW (no payer-adjusted clone); the
+            // PAYER's energy is what gets deducted.
             AbilityCost::PayEnergy { .. } => {
                 match costs::pay_ability_cost_for_resolution(
                     state,
@@ -555,6 +569,8 @@ pub(super) fn handle_unless_payment(
                     events,
                 )? {
                     PaymentOutcome::Paid => {}
+                    // CR 616.1: no `Paused` path exists for PayEnergy today;
+                    // lumped with `Failed` defensively (see PayLife arm note).
                     PaymentOutcome::Failed { .. } | PaymentOutcome::Paused { .. } => {
                         payment_failed = true;
                     }

--- a/crates/engine/tests/unless_pay_life_routes_through_authority.rs
+++ b/crates/engine/tests/unless_pay_life_routes_through_authority.rs
@@ -1,0 +1,136 @@
+//! Discriminating coverage for **unless-pay-life routing through the single
+//! payment authority** (cost-payment unification, Phase 3).
+//!
+//! Phase 3 routes the deterministic `handle_unless_payment` arms (Mana,
+//! PayLife, PayEnergy) through `game::costs::pay_ability_cost_for_resolution`
+//! at `PaymentScope::Resolution`, replacing the bespoke inline life deduction
+//! that used to live in `engine_payment_choices.rs`. The interactive arms
+//! (Discard/Sacrifice/ReturnToHand/library-exile) stay adapter-side because
+//! their resources are acquired via WaitingFor round-trips before payment.
+//!
+//! These tests drive the REAL pipeline: a Sangrophage built from its
+//! authoritative Oracle text through `GameScenario::add_creature_from_oracle`
+//! (which runs `synthesize_all`), advanced through the upkeep step so the
+//! "tap this creature unless you pay 2 life" trigger fires and surfaces the
+//! `WaitingFor::UnlessPayment { cost: PayLife { 2 } }` prompt, then
+//! `GameAction::PayUnlessCost { pay: true }`.
+//!
+//! The DISCRIMINATION POINT is the authority's life-insufficiency failure
+//! path: with only 1 life and a 2-life cost, the authority returns
+//! `PaymentOutcome::Failed`, the adapter maps it to the "unless" branch
+//! (CR 118.12a: an unpayable cost ≡ the effect happens), and the creature is
+//! tapped without any life being deducted (CR 118.3 / CR 601.2h: partial
+//! payments are not allowed). With sufficient life, the authority pays
+//! (life deducted, creature untapped).
+//!
+//! CR ANCHORS (verified against docs/MagicCompRules.txt):
+//!   * CR 118.3   — "A player can't pay a cost without having the necessary resources to pay it fully."
+//!   * CR 118.12  — "[Do something]. If [a player] [does/doesn't/can't] …"
+//!   * CR 118.12a — "[Do something] unless [a player does something else]."
+//!   * CR 119.4   — "If a player pays life … the player loses that much life."
+//!   * CR 601.2h  — "Partial payments are not allowed. Unpayable costs can't be paid."
+//!
+//! CARD TEXT (verified from this engine's card-data for Sangrophage):
+//!   "At the beginning of your upkeep, tap this creature unless you pay 2 life."
+
+use engine::game::scenario::GameScenario;
+use engine::types::ability::AbilityCost;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+const SANGROPHAGE_ORACLE: &str =
+    "At the beginning of your upkeep, tap this creature unless you pay 2 life.";
+
+/// Build a Sangrophage on PlayerId(0)'s battlefield with `life` life, then
+/// advance to the controller's upkeep and resolve the upkeep trigger so the
+/// engine pauses at the PayLife `UnlessPayment` prompt.
+///
+/// Returns `(runner, sangrophage_id)` paused at `WaitingFor::UnlessPayment`.
+fn setup_at_unless_prompt(life: i32) -> (engine::game::scenario::GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    // Start at Untap so a single `auto_advance` (driven by `advance_to_upkeep`)
+    // ticks into Upkeep and fires the synthesized upkeep trigger (CR 503.1a).
+    scenario.at_phase(Phase::Untap);
+    scenario.with_life(P0, life);
+
+    let sangrophage = scenario
+        .add_creature_from_oracle(P0, "Sangrophage", 2, 2, SANGROPHAGE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.advance_to_upkeep();
+    runner.resolve_top();
+
+    // The trigger surfaced a PayLife { 2 } unless-cost prompt.
+    match &runner.state().waiting_for {
+        WaitingFor::UnlessPayment { player, cost, .. } => {
+            assert_eq!(*player, P0, "controller is the unless-payer");
+            assert!(
+                matches!(
+                    cost,
+                    AbilityCost::PayLife {
+                        amount: engine::types::ability::QuantityExpr::Fixed { value: 2 }
+                    }
+                ),
+                "expected a PayLife {{ 2 }} unless-cost, got {cost:?}"
+            );
+        }
+        other => panic!("expected UnlessPayment prompt, got {other:?}"),
+    }
+
+    (runner, sangrophage)
+}
+
+/// CR 118.3 + CR 118.12a + CR 601.2h: with only 1 life, the 2-life unless-cost
+/// is unpayable — the authority returns `Failed`, so the effect (tap) happens
+/// and NO life is deducted (no partial payment). This is the discrimination
+/// point: a bespoke inline deduction that ignored insufficiency would either
+/// panic or drive life negative; routing through the authority fails cleanly.
+#[test]
+fn unless_pay_life_insufficient_routes_through_authority_failure_path() {
+    let (mut runner, sangrophage) = setup_at_unless_prompt(1);
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("attempting to pay an unpayable life cost must be accepted");
+
+    // CR 118.12a: the unless-cost was unpayable, so the effect happened.
+    assert!(
+        runner.state().objects[&sangrophage].tapped,
+        "an unpayable life cost must let the tap effect happen"
+    );
+    // CR 601.2h: partial payments are not allowed — life is untouched.
+    assert_eq!(
+        runner.life(P0),
+        1,
+        "no life may be deducted when the cost is unpayable"
+    );
+}
+
+/// CR 119.4 + CR 118.12: with enough life, the authority pays — life is
+/// deducted by exactly the cost and the effect (tap) is suppressed.
+#[test]
+fn unless_pay_life_sufficient_routes_through_authority_paid_path() {
+    let (mut runner, sangrophage) = setup_at_unless_prompt(20);
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("paying the life cost must be accepted");
+
+    // CR 118.12a: paying the unless-cost suppresses the effect.
+    assert!(
+        !runner.state().objects[&sangrophage].tapped,
+        "paying the life cost must suppress the tap effect"
+    );
+    // CR 119.4: paying 2 life loses exactly 2 life.
+    assert_eq!(
+        runner.life(P0),
+        18,
+        "paying the unless-cost must deduct exactly 2 life"
+    );
+}

--- a/crates/engine/tests/unless_pay_routes_through_authority.rs
+++ b/crates/engine/tests/unless_pay_routes_through_authority.rs
@@ -1,27 +1,30 @@
-//! Discriminating coverage for **unless-pay-life routing through the single
-//! payment authority** (cost-payment unification, Phase 3).
+//! Coverage for **unless-pay routing through the single payment authority**
+//! (cost-payment unification, Phase 3).
 //!
 //! Phase 3 routes the deterministic `handle_unless_payment` arms (Mana,
 //! PayLife, PayEnergy) through `game::costs::pay_ability_cost_for_resolution`
-//! at `PaymentScope::Resolution`, replacing the bespoke inline life deduction
+//! at `PaymentScope::Resolution`, replacing the bespoke inline payment code
 //! that used to live in `engine_payment_choices.rs`. The interactive arms
 //! (Discard/Sacrifice/ReturnToHand/library-exile) stay adapter-side because
 //! their resources are acquired via WaitingFor round-trips before payment.
 //!
-//! These tests drive the REAL pipeline: a Sangrophage built from its
-//! authoritative Oracle text through `GameScenario::add_creature_from_oracle`
-//! (which runs `synthesize_all`), advanced through the upkeep step so the
-//! "tap this creature unless you pay 2 life" trigger fires and surfaces the
-//! `WaitingFor::UnlessPayment { cost: PayLife { 2 } }` prompt, then
+//! These tests drive the REAL pipeline: a creature built from authoritative
+//! Oracle text through `GameScenario::add_creature_from_oracle` (which runs
+//! `synthesize_all`), advanced through the upkeep step so the "tap this
+//! creature unless you pay [cost]" trigger fires and surfaces the
+//! `WaitingFor::UnlessPayment` prompt, then
 //! `GameAction::PayUnlessCost { pay: true }`.
 //!
-//! The DISCRIMINATION POINT is the authority's life-insufficiency failure
-//! path: with only 1 life and a 2-life cost, the authority returns
-//! `PaymentOutcome::Failed`, the adapter maps it to the "unless" branch
-//! (CR 118.12a: an unpayable cost ≡ the effect happens), and the creature is
-//! tapped without any life being deducted (CR 118.3 / CR 601.2h: partial
-//! payments are not allowed). With sufficient life, the authority pays
-//! (life deducted, creature untapped).
+//! Test character (honest labeling): the two PayLife tests are real-pipeline
+//! BEHAVIOR-PRESERVATION tests — the pre-Phase-3 inline arm used the same
+//! `pay_life_as_cost` with identical insufficiency handling, so they pin the
+//! routed path's equivalence rather than discriminating routing. The Mana
+//! test IS discriminating: Phase 3 changed the Mana arm's failure semantics
+//! (old: auto-tap mutated live state then returned `ActionNotAllowed`,
+//! rejecting the action and retaining the prompt; new: the authority
+//! pre-flights affordability on a clone and maps unaffordable to `Failed` →
+//! the "unless" branch — CR 118.12 can't-pay ≡ didn't-pay), so the old code
+//! fails that test.
 //!
 //! CR ANCHORS (verified against docs/MagicCompRules.txt):
 //!   * CR 118.3   — "A player can't pay a cost without having the necessary resources to pay it fully."
@@ -88,9 +91,9 @@ fn setup_at_unless_prompt(life: i32) -> (engine::game::scenario::GameRunner, Obj
 
 /// CR 118.3 + CR 118.12a + CR 601.2h: with only 1 life, the 2-life unless-cost
 /// is unpayable — the authority returns `Failed`, so the effect (tap) happens
-/// and NO life is deducted (no partial payment). This is the discrimination
-/// point: a bespoke inline deduction that ignored insufficiency would either
-/// panic or drive life negative; routing through the authority fails cleanly.
+/// and NO life is deducted (no partial payment). Behavior-preservation pin:
+/// the pre-Phase-3 inline arm handled insufficiency identically via
+/// `pay_life_as_cost`; this pins the routed path's equivalence.
 #[test]
 fn unless_pay_life_insufficient_routes_through_authority_failure_path() {
     let (mut runner, sangrophage) = setup_at_unless_prompt(1);
@@ -109,6 +112,61 @@ fn unless_pay_life_insufficient_routes_through_authority_failure_path() {
         runner.life(P0),
         1,
         "no life may be deducted when the cost is unpayable"
+    );
+}
+
+/// CR 118.3 + CR 118.12: DISCRIMINATING test for the Phase 3 Mana-arm change.
+/// With no mana available, `PayUnlessCost { pay: true }` on a "{2}" unless-cost
+/// must be ACCEPTED and fall through to the "unless" branch (can't-pay ≡
+/// didn't-pay): the effect (tap) happens, the prompt clears, and no live state
+/// was mutated by a failed payment attempt. The pre-Phase-3 inline arm instead
+/// auto-tapped live state and returned `EngineError::ActionNotAllowed`,
+/// rejecting the action and leaving the prompt stuck — the old code fails
+/// every assertion below.
+#[test]
+fn unless_pay_mana_unaffordable_falls_through_to_effect() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+
+    let creature = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Test Tithe Beast",
+            2,
+            2,
+            "At the beginning of your upkeep, tap this creature unless you pay {2}.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    runner.advance_to_upkeep();
+    runner.resolve_top();
+
+    match &runner.state().waiting_for {
+        WaitingFor::UnlessPayment { player, cost, .. } => {
+            assert_eq!(*player, P0, "controller is the unless-payer");
+            assert!(
+                matches!(cost, AbilityCost::Mana { .. }),
+                "expected a Mana unless-cost, got {cost:?}"
+            );
+        }
+        other => panic!("expected UnlessPayment prompt, got {other:?}"),
+    }
+
+    // No lands, no pool: the {2} cost is unaffordable. The pay attempt must
+    // be accepted (not rejected with ActionNotAllowed) and resolve the
+    // punishment effect.
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("attempting to pay an unaffordable mana unless-cost must be accepted");
+
+    assert!(
+        runner.state().objects[&creature].tapped,
+        "an unaffordable mana cost must let the tap effect happen (CR 118.12 can't-pay)"
+    );
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+        "the unless-prompt must clear instead of sticking on a rejected action"
     );
 }
 


### PR DESCRIPTION
## Summary

Phase 3 of the cost-payment unification plan (Phases 1–2 = #2946/#2951):

- `handle_unless_payment`'s deterministic arms (**Mana / PayLife / PayEnergy**) now route through the costs.rs authority (`pay_ability_cost_for_resolution`, `PaymentScope::Resolution`), deleting their inline payment duplicates.
- Interactive arms stay adapter-side per the L3 layering: ward discard/sacrifice/bounce round-trips, top-library exile, and the all-Mana Composite aggregation (cumulative upkeep) — the `WaitingFor` plumbing, `ManaAbilityResume::UnlessPayment`, and multi-player poll logic are untouched (plan risk R7).
- **Deliberate behavior fix (CR 118.12):** an unaffordable Mana unless-cost with `pay: true` now falls through to the didn't-pay branch (punishment resolves, prompt clears) instead of the old auto-tap-then-`ActionNotAllowed` rejection that mutated tap state and left the prompt stuck.
- Review round: payer-adjustment comments made truthful (raw `pending_effect`, documented precondition deviation), honest test relabeling, Paused-lumping trap documented.

## Testing
- Tilt gate green: clippy + test-engine (12177 passed, 0 failed)
- New runtime tests (real pipeline: oracle-synthesized upkeep trigger → UnlessPayment prompt → GameAction): 2 PayLife behavior-preservation pins + 1 Mana-arm discriminator (`unless_pay_mana_unaffordable_falls_through_to_effect` — fails on the pre-Phase-3 code)
- Isolated review: arm-by-arm preservation diff, R7 plumbing byte-comparison, all 11 CR annotations grep-verified
- `cargo check -p engine` green in this worktree