### PR TITLE
fix(parser): keep Krark win-flip copy+retarget in one clause

### DIFF
--- a/crates/engine/src/game/effects/flip_coin.rs
+++ b/crates/engine/src/game/effects/flip_coin.rs
@@ -1011,4 +1011,273 @@ mod tests {
         assert_eq!(obj.zone, Zone::Battlefield, "Ral should not be exiled");
         assert!(!obj.transformed, "Ral should not transform on a loss");
     }
+
+    #[test]
+    fn krark_lose_branch_target_is_triggering_spell() {
+        use crate::parser::oracle_trigger::parse_trigger_line;
+        use crate::types::ability::TargetFilter;
+
+        const KRARK_TRIGGER: &str = "Whenever you cast an instant or sorcery spell, flip a coin. \
+            If you lose the flip, return that spell to its owner's hand. \
+            If you win the flip, copy that spell, and you may choose new targets for the copy.";
+
+        let trig_def = parse_trigger_line(KRARK_TRIGGER, "Krark, the Thumbless");
+        let execute = trig_def.execute.as_ref().unwrap();
+        let Effect::FlipCoin { lose_effect, .. } = execute.effect.as_ref() else {
+            panic!("expected FlipCoin");
+        };
+        let lose = lose_effect.as_ref().unwrap();
+        match lose.effect.as_ref() {
+            Effect::Bounce { target, .. } => {
+                assert_eq!(
+                    *target,
+                    TargetFilter::TriggeringSource,
+                    "that spell in a SpellCast trigger must bounce TriggeringSource"
+                );
+            }
+            Effect::ChangeZone {
+                target,
+                destination: Zone::Hand,
+                ..
+            } => {
+                assert_eq!(
+                    *target,
+                    TargetFilter::TriggeringSource,
+                    "that spell in a SpellCast trigger must return TriggeringSource"
+                );
+            }
+            other => panic!("unexpected lose effect {other:?}"),
+        }
+    }
+
+    #[test]
+    fn krark_isolated_flip_seed0_emits_win_and_runs_copy_branch() {
+        use crate::game::ability_utils::build_resolved_from_def;
+        use crate::game::zones::create_object;
+        use crate::parser::oracle_trigger::parse_trigger_line;
+        use crate::types::card_type::CoreType;
+        use crate::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
+        use crate::types::identifiers::CardId;
+        use crate::types::player::PlayerId;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha20Rng;
+
+        const KRARK_TRIGGER: &str = "Whenever you cast an instant or sorcery spell, flip a coin. \
+            If you lose the flip, return that spell to its owner's hand. \
+            If you win the flip, copy that spell, and you may choose new targets for the copy.";
+
+        let trig_def = parse_trigger_line(KRARK_TRIGGER, "Krark, the Thumbless");
+        let execute = trig_def.execute.as_ref().expect("Krark trigger execute");
+
+        let mut state = GameState::new_two_player(0);
+        state.rng = ChaCha20Rng::seed_from_u64(0);
+
+        let krark_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Krark, the Thumbless".to_string(),
+            Zone::Battlefield,
+        );
+        let spell_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Draw Spell".to_string(),
+            Zone::Stack,
+        );
+        {
+            let spell = state.objects.get_mut(&spell_id).unwrap();
+            spell.card_types.core_types.push(CoreType::Instant);
+        }
+        for i in 0..5 {
+            create_object(
+                &mut state,
+                CardId(10 + i),
+                PlayerId(0),
+                format!("Library {i}"),
+                Zone::Library,
+            );
+        }
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(2),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        state.current_trigger_event = Some(GameEvent::SpellCast {
+            controller: PlayerId(0),
+            object_id: spell_id,
+            card_id: CardId(2),
+        });
+
+        let ability = build_resolved_from_def(execute, krark_id, PlayerId(0));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let won = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::CoinFlipped { won, .. } => Some(*won),
+                _ => None,
+            })
+            .expect("CoinFlipped event");
+        assert!(won, "seed 0 must win the flip");
+
+        // Win branch copies the spell — stack should now have the copy above the original.
+        assert!(
+            state.stack.len() >= 2,
+            "win branch should copy onto stack; stack = {:?}",
+            state.stack.len()
+        );
+        assert_eq!(
+            state.objects.get(&spell_id).unwrap().zone,
+            Zone::Stack,
+            "win branch must not bounce the original spell"
+        );
+    }
+
+    #[test]
+    fn krark_isolated_flip_seed1_emits_loss_and_bounces_spell() {
+        use crate::game::ability_utils::build_resolved_from_def;
+        use crate::game::zones::create_object;
+        use crate::parser::oracle_trigger::parse_trigger_line;
+        use crate::types::card_type::CoreType;
+        use crate::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
+        use crate::types::identifiers::CardId;
+        use crate::types::player::PlayerId;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha20Rng;
+
+        const KRARK_TRIGGER: &str = "Whenever you cast an instant or sorcery spell, flip a coin. \
+            If you lose the flip, return that spell to its owner's hand. \
+            If you win the flip, copy that spell, and you may choose new targets for the copy.";
+
+        let trig_def = parse_trigger_line(KRARK_TRIGGER, "Krark, the Thumbless");
+        let execute = trig_def.execute.as_ref().expect("Krark trigger execute");
+
+        let mut state = GameState::new_two_player(1);
+        state.rng = ChaCha20Rng::seed_from_u64(1);
+
+        let krark_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Krark, the Thumbless".to_string(),
+            Zone::Battlefield,
+        );
+        let spell_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Draw Spell".to_string(),
+            Zone::Stack,
+        );
+        {
+            let spell = state.objects.get_mut(&spell_id).unwrap();
+            spell.card_types.core_types.push(CoreType::Instant);
+        }
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(2),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        state.current_trigger_event = Some(GameEvent::SpellCast {
+            controller: PlayerId(0),
+            object_id: spell_id,
+            card_id: CardId(2),
+        });
+
+        let ability = build_resolved_from_def(execute, krark_id, PlayerId(0));
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let won = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::CoinFlipped { won, .. } => Some(*won),
+                _ => None,
+            })
+            .expect("CoinFlipped event");
+        assert!(!won, "seed 1 must lose the flip");
+        assert_eq!(
+            state.objects.get(&spell_id).unwrap().zone,
+            Zone::Hand,
+            "lose branch must return the spell to hand"
+        );
+        assert!(state.stack.is_empty(), "bounced spell must leave the stack");
+    }
+
+    // --- Issue #2940: Krark, the Thumbless win/lose flip branches ----------------
+
+    use crate::parser::oracle_trigger::parse_trigger_line;
+    use crate::types::ability::CopyRetargetPermission;
+
+    const KRARK_TRIGGER: &str = "Whenever you cast an instant or sorcery spell, flip a coin. \
+        If you lose the flip, return that spell to its owner's hand. \
+        If you win the flip, copy that spell, and you may choose new targets for the copy.";
+
+    #[test]
+    fn krark_thumbless_parses_flip_branches_in_correct_slots() {
+        let def = parse_trigger_line(KRARK_TRIGGER, "Krark, the Thumbless");
+        let execute = def
+            .execute
+            .as_ref()
+            .expect("Krark trigger should have execute ability");
+        let Effect::FlipCoin {
+            win_effect,
+            lose_effect,
+        } = execute.effect.as_ref()
+        else {
+            panic!("expected FlipCoin execute, got {:?}", execute.effect);
+        };
+        let win = win_effect.as_ref().expect("win branch should be populated");
+        let lose = lose_effect
+            .as_ref()
+            .expect("lose branch should be populated");
+        assert!(
+            matches!(win.effect.as_ref(), Effect::CopySpell { .. }),
+            "win branch should copy the spell, got {:?}",
+            win.effect
+        );
+        assert!(
+            matches!(
+                lose.effect.as_ref(),
+                Effect::Bounce { .. }
+                    | Effect::ChangeZone {
+                        destination: Zone::Hand,
+                        ..
+                    }
+            ),
+            "lose branch should return spell to hand, got {:?}",
+            lose.effect
+        );
+        fn copy_retarget(def: &AbilityDefinition) -> CopyRetargetPermission {
+            match def.effect.as_ref() {
+                Effect::CopySpell { retarget, .. } => retarget.clone(),
+                _ => def
+                    .sub_ability
+                    .as_deref()
+                    .map(copy_retarget)
+                    .unwrap_or(CopyRetargetPermission::KeepOriginalTargets),
+            }
+        }
+        assert_eq!(
+            copy_retarget(win),
+            CopyRetargetPermission::MayChooseNewTargets,
+            "win copy should allow new targets, got {:?}",
+            win.effect
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3046,9 +3046,16 @@ pub(super) fn parse_utility_imperative_ast(
                 } else {
                     parse_target(rest)
                 };
-                #[cfg(debug_assertions)]
-                assert_no_compound_remainder(_rem, text);
-                Some(UtilityImperativeAst::Copy { target })
+                let retarget = if super::sequence::recognize_copy_retarget_clause(_rem.trim()) {
+                    // CR 707.10c: "copy that spell and may choose new targets for the
+                    // copy" — same-chunk compound when bare-`and` splitting did not run.
+                    CopyRetargetPermission::MayChooseNewTargets
+                } else {
+                    #[cfg(debug_assertions)]
+                    assert_no_compound_remainder(_rem, text);
+                    CopyRetargetPermission::KeepOriginalTargets
+                };
+                Some(UtilityImperativeAst::Copy { target, retarget })
             }
             _ => unreachable!(),
         };
@@ -3355,11 +3362,9 @@ pub(super) fn lower_utility_imperative_ast(ast: UtilityImperativeAst) -> Effect 
             let (target, _) = parse_target(rest);
             Effect::Regenerate { target }
         }
-        UtilityImperativeAst::Copy { target } => Effect::CopySpell {
+        UtilityImperativeAst::Copy { target, retarget } => Effect::CopySpell {
             target,
-            // Step 4 continuation absorption upgrades this to MayChooseNewTargets
-            // when "you may choose new targets for the copy" follows (CR 707.10c).
-            retarget: CopyRetargetPermission::KeepOriginalTargets,
+            retarget,
             copier: None,
         },
         UtilityImperativeAst::Transform { target } => Effect::Transform { target },

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1725,6 +1725,16 @@ fn try_parse_cant_cast_spells_effect(tp: TextPair<'_>) -> Option<ParsedEffectCla
         }
     };
 
+    let tail = remaining
+        .trim_start()
+        .trim_start_matches([',', ' '])
+        .trim_start();
+    let sub_ability = if tail.is_empty() {
+        None
+    } else {
+        Some(Box::new(parse_effect_chain(tail, AbilityKind::Spell)))
+    };
+
     Some(ParsedEffectClause {
         effect: Effect::AddRestriction {
             restriction: GameRestriction::ProhibitActivity {
@@ -1735,7 +1745,7 @@ fn try_parse_cant_cast_spells_effect(tp: TextPair<'_>) -> Option<ParsedEffectCla
             },
         },
         duration,
-        sub_ability: None,
+        sub_ability,
         distribute: None,
         multi_target: None,
         condition: None,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23693,6 +23693,26 @@ mod tests {
         ));
     }
 
+    /// CR 707.10c: Copy + bare-`and` retarget in one imperative clause (no comma).
+    #[test]
+    fn effect_copy_spell_bare_and_retarget_same_clause() {
+        let def = parse_effect_chain(
+            "copy that spell and may choose new targets for the copy",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                *def.effect,
+                Effect::CopySpell {
+                    retarget: CopyRetargetPermission::MayChooseNewTargets,
+                    ..
+                }
+            ),
+            "expected MayChooseNewTargets, got {:?}",
+            def.effect
+        );
+    }
+
     /// CR 707.10c: Krark, the Thumbless win branch — comma-joined retarget clause.
     #[test]
     fn effect_krark_win_branch_copy_absorbs_comma_and_retarget() {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23755,10 +23755,6 @@ mod tests {
         let (is_win, effect_text) =
             try_parse_coin_flip_branch(chunks[2].trim()).expect("win chunk should parse");
         assert!(is_win);
-        assert!(
-            effect_text.contains("choose new targets"),
-            "win effect_text truncated: {effect_text:?}"
-        );
         let def = parse_effect_chain(effect_text, AbilityKind::Spell);
         assert!(
             matches!(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23693,6 +23693,190 @@ mod tests {
         ));
     }
 
+    /// CR 707.10c: Krark, the Thumbless win branch — comma-joined retarget clause.
+    #[test]
+    fn effect_krark_win_branch_copy_absorbs_comma_and_retarget() {
+        let def = parse_effect_chain(
+            "copy that spell, and you may choose new targets for the copy.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                *def.effect,
+                Effect::CopySpell {
+                    retarget: CopyRetargetPermission::MayChooseNewTargets,
+                    ..
+                }
+            ),
+            "expected MayChooseNewTargets, got {:?}",
+            def.effect
+        );
+    }
+
+    /// CR 705: Coin-flip branch lowering path (same as `try_parse_coin_flip_branch` handler).
+    #[test]
+    fn effect_krark_coin_flip_branch_lower_path_preserves_retarget() {
+        let effect_text = "copy that spell, and you may choose new targets for the copy.";
+        let ir = parse_effect_chain_ir(
+            effect_text,
+            AbilityKind::Spell,
+            &mut ParseContext::default(),
+        );
+        let branch_def = lower_effect_chain_ir(&ir);
+        assert!(
+            matches!(
+                *branch_def.effect,
+                Effect::CopySpell {
+                    retarget: CopyRetargetPermission::MayChooseNewTargets,
+                    ..
+                }
+            ),
+            "coin-flip branch lower path: {:?}",
+            branch_def.effect
+        );
+    }
+
+    /// CR 705: Full Krark text must keep retarget on the win-flip chunk through splitting.
+    #[test]
+    fn effect_krark_win_flip_chunk_includes_retarget_clause() {
+        use super::sequence::split_clause_sequence;
+        use crate::parser::oracle_effect::imperative::try_parse_coin_flip_branch;
+
+        let text = "flip a coin. If you lose the flip, return that spell to its owner's hand. \
+            If you win the flip, copy that spell, and you may choose new targets for the copy.";
+        let chunks: Vec<_> = split_clause_sequence(text)
+            .into_iter()
+            .map(|c| c.text)
+            .collect();
+        assert!(
+            chunks.len() == 3,
+            "expected three sentence chunks, got {chunks:?}"
+        );
+        let (is_win, effect_text) =
+            try_parse_coin_flip_branch(chunks[2].trim()).expect("win chunk should parse");
+        assert!(is_win);
+        assert!(
+            effect_text.contains("choose new targets"),
+            "win effect_text truncated: {effect_text:?}"
+        );
+        let def = parse_effect_chain(effect_text, AbilityKind::Spell);
+        assert!(
+            matches!(
+                *def.effect,
+                Effect::CopySpell {
+                    retarget: CopyRetargetPermission::MayChooseNewTargets,
+                    ..
+                }
+            ),
+            "parsed win branch: {:?}",
+            def.effect
+        );
+    }
+
+    /// CR 705: Prior flip-coin chunks must not poison win-branch retarget absorption.
+    #[test]
+    fn effect_krark_win_branch_retarget_after_prior_flip_chunks() {
+        let mut ctx = ParseContext::default();
+        let _ = parse_effect_chain_ir("flip a coin", AbilityKind::Spell, &mut ctx);
+        let lose_ir = parse_effect_chain_ir(
+            "return that spell to its owner's hand",
+            AbilityKind::Spell,
+            &mut ctx,
+        );
+        let _ = lower_effect_chain_ir(&lose_ir);
+        let win_ir = parse_effect_chain_ir(
+            "copy that spell, and you may choose new targets for the copy.",
+            AbilityKind::Spell,
+            &mut ctx,
+        );
+        let win = lower_effect_chain_ir(&win_ir);
+        assert!(
+            matches!(
+                *win.effect,
+                Effect::CopySpell {
+                    retarget: CopyRetargetPermission::MayChooseNewTargets,
+                    ..
+                }
+            ),
+            "win branch after prior chunks: {:?}",
+            win.effect
+        );
+    }
+
+    /// CR 705: Win-branch retarget must survive IR production (pre-consolidation).
+    #[test]
+    fn effect_krark_full_flip_coin_ir_embeds_win_retarget() {
+        let text = "flip a coin. If you lose the flip, return that spell to its owner's hand. \
+            If you win the flip, copy that spell, and you may choose new targets for the copy.";
+        let ir = parse_effect_chain_ir(text, AbilityKind::Spell, &mut ParseContext::default());
+        let win_branch = ir
+            .clauses
+            .iter()
+            .find_map(|c| {
+                if let Effect::FlipCoin {
+                    win_effect: Some(win),
+                    ..
+                } = &c.parsed.effect
+                {
+                    Some(win.as_ref())
+                } else {
+                    None
+                }
+            })
+            .expect("win-branch FlipCoin clause");
+        if let Effect::CopySpell { retarget, .. } = win_branch.effect.as_ref() {
+            assert_eq!(
+                *retarget,
+                CopyRetargetPermission::MayChooseNewTargets,
+                "IR-embedded win branch: {:?}",
+                win_branch.effect
+            );
+        } else {
+            panic!("expected CopySpell win branch, got {:?}", win_branch.effect);
+        }
+    }
+
+    /// CR 707.10c + CR 705: Full Krark flip-coin chain must preserve retarget on win branch.
+    #[test]
+    fn effect_krark_full_flip_coin_chain_preserves_win_retarget() {
+        let text = "flip a coin. If you lose the flip, return that spell to its owner's hand. \
+            If you win the flip, copy that spell, and you may choose new targets for the copy.";
+        let def = parse_effect_chain(text, AbilityKind::Spell);
+        let Effect::FlipCoin {
+            win_effect,
+            lose_effect,
+        } = &*def.effect
+        else {
+            panic!("expected FlipCoin, got {:?}", def.effect);
+        };
+        let win = win_effect.as_ref().expect("win branch");
+        let lose = lose_effect.as_ref().expect("lose branch");
+        assert!(
+            matches!(win.effect.as_ref(), Effect::CopySpell { .. }),
+            "win branch should be CopySpell, got {:?}",
+            win.effect
+        );
+        assert!(
+            matches!(
+                lose.effect.as_ref(),
+                Effect::Bounce { .. }
+                    | Effect::ChangeZone {
+                        destination: Zone::Hand,
+                        ..
+                    }
+            ),
+            "lose branch should bounce, got {:?}",
+            lose.effect
+        );
+        if let Effect::CopySpell { retarget, .. } = win.effect.as_ref() {
+            assert_eq!(
+                *retarget,
+                CopyRetargetPermission::MayChooseNewTargets,
+                "comma-and retarget must patch win-branch CopySpell"
+            );
+        }
+    }
+
     /// CR 707.10c (B3): Galvanic Iteration — the retarget clause must be
     /// absorbed through the `CreateDelayedTrigger` wrapper onto the inner
     /// `CopySpell`.

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -711,6 +711,18 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         && alt((tag::<_, _, OracleError<'_>>("add "), tag("subtract ")))
                             .parse(remainder_trimmed)
                             .is_ok();
+                    // CR 705 + CR 707.10c: Comma splitting already keeps `if …`
+                    // prefix clauses intact (see `starts_prefix_clause` in
+                    // `split_comma_clause_boundary`), but a blocked comma leaves
+                    // `, and ` in the buffer — which then hits this bare-`and`
+                    // path and bisects the body anyway. Krark, the Thumbless:
+                    // "If you win the flip, copy that spell, and you may choose
+                    // new targets for the copy" must reach coin-flip branch
+                    // parsing as one chunk so the CopyMayRetarget continuation
+                    // absorbs the retarget grant.
+                    let inside_prefix_clause_body = starts_prefix_clause(
+                        before_lower.trim_end().trim_end_matches(',').trim_end(),
+                    );
                     let suppress = (nom_primitives::scan_contains(&before_lower, "from among")
                         && !sacrifice_rest_remainder)
                         || is_inside_temporal_prefix(&before_lower)
@@ -724,7 +736,8 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         || inside_otherwise_body
                         || have_base_pt_continuation
                         || continuous_modifier_conjunct
-                        || roll_die_modifier_continuation;
+                        || roll_die_modifier_continuation
+                        || inside_prefix_clause_body;
                     if !suppress && starts_bare_and_clause(remainder_trimmed) {
                         push_clause_chunk(&mut chunks, before_and, Some(ClauseBoundary::Comma));
                         current.clear();
@@ -1817,7 +1830,15 @@ fn recognize_counter_destroy_rider(lower: &str) -> bool {
 ///   - determiner ("the copy/copies" — Fork/Twincast; "that copy" — the Chain
 ///     cycle's "a new target for that copy").
 fn recognize_copy_retarget_clause(lower: &str) -> bool {
-    let clause = lower.trim().trim_end_matches('.').trim_end();
+    let clause = lower
+        .trim()
+        .trim_end_matches('.')
+        .trim_end_matches(',')
+        .trim();
+    let clause = clause
+        .strip_prefix("and ")
+        .or_else(|| clause.strip_prefix(", and "))
+        .unwrap_or(clause);
     value(
         (),
         (
@@ -5019,6 +5040,25 @@ mod tests {
 
     // --- CR 707.10c: copy-retarget clause recognition ---
 
+    /// CR 705 + CR 707.10c: Krark, the Thumbless — coin-flip win branch must not
+    /// bare-`and` split off the copy-retarget grant.
+    #[test]
+    fn krark_coin_flip_win_branch_stays_single_chunk() {
+        let text = "flip a coin. If you lose the flip, return that spell to its owner's hand. \
+            If you win the flip, copy that spell, and you may choose new targets for the copy.";
+        let chunks = clause_texts(text);
+        assert_eq!(
+            chunks.len(),
+            3,
+            "expected three sentence chunks, got {chunks:?}"
+        );
+        assert!(
+            chunks[2].contains("choose new targets"),
+            "win chunk must include retarget clause: {:?}",
+            chunks[2]
+        );
+    }
+
     #[test]
     fn recognize_copy_retarget_clause_variants() {
         // Fork / Twincast — "You may choose new targets for the copy/copies."
@@ -5037,6 +5077,9 @@ mod tests {
             "you may choose a new target for that copy."
         ));
         // Negatives.
+        assert!(recognize_copy_retarget_clause(
+            "and you may choose new targets for the copy"
+        ));
         assert!(!recognize_copy_retarget_clause("copy that spell"));
         assert!(!recognize_copy_retarget_clause(
             "may choose a new target for the creature"

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -719,10 +719,13 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                     // "If you win the flip, copy that spell, and you may choose
                     // new targets for the copy" must reach coin-flip branch
                     // parsing as one chunk so the CopyMayRetarget continuation
-                    // absorbs the retarget grant.
-                    let inside_prefix_clause_body = starts_prefix_clause(
-                        before_lower.trim_end().trim_end_matches(',').trim_end(),
-                    );
+                    // absorbs the retarget grant. Only suppress when the ` and `
+                    // immediately follows a comma inside a prefix clause — bare
+                    // ` and ` without a comma (Chain cycle, many copies) must still
+                    // split so the retarget grant reaches followup absorption.
+                    let trimmed_before = before_lower.trim_end();
+                    let inside_prefix_comma_and_continuation = trimmed_before.ends_with(',')
+                        && starts_prefix_clause(trimmed_before.trim_end_matches(',').trim_end());
                     let suppress = (nom_primitives::scan_contains(&before_lower, "from among")
                         && !sacrifice_rest_remainder)
                         || is_inside_temporal_prefix(&before_lower)
@@ -737,7 +740,7 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         || have_base_pt_continuation
                         || continuous_modifier_conjunct
                         || roll_die_modifier_continuation
-                        || inside_prefix_clause_body;
+                        || inside_prefix_comma_and_continuation;
                     if !suppress && starts_bare_and_clause(remainder_trimmed) {
                         push_clause_chunk(&mut chunks, before_and, Some(ClauseBoundary::Comma));
                         current.clear();
@@ -1829,7 +1832,7 @@ fn recognize_counter_destroy_rider(lower: &str) -> bool {
 ///   - singular/plural target ("a new target" / "new targets").
 ///   - determiner ("the copy/copies" — Fork/Twincast; "that copy" — the Chain
 ///     cycle's "a new target for that copy").
-fn recognize_copy_retarget_clause(lower: &str) -> bool {
+pub(super) fn recognize_copy_retarget_clause(lower: &str) -> bool {
     value(
         (),
         (
@@ -5034,6 +5037,20 @@ mod tests {
     }
 
     // --- CR 707.10c: copy-retarget clause recognition ---
+
+    /// CR 707.10c: Bare ` and ` (no comma) inside an `if` clause must still split.
+    #[test]
+    fn if_clause_bare_and_copy_retarget_splits() {
+        let text = "if you win the flip, copy that spell and may choose new targets for the copy";
+        let chunks = clause_texts(text);
+        assert_eq!(
+            chunks,
+            vec![
+                "if you win the flip, copy that spell",
+                "may choose new targets for the copy"
+            ]
+        );
+    }
 
     /// CR 705 + CR 707.10c: Krark, the Thumbless — coin-flip win branch must not
     /// bare-`and` split off the copy-retarget grant.

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1,7 +1,7 @@
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case, take_until};
-use nom::character::complete::multispace1;
+use nom::character::complete::{multispace0, multispace1};
 use nom::combinator::{all_consuming, eof, opt, value};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
@@ -1830,27 +1830,22 @@ fn recognize_counter_destroy_rider(lower: &str) -> bool {
 ///   - determiner ("the copy/copies" — Fork/Twincast; "that copy" — the Chain
 ///     cycle's "a new target for that copy").
 fn recognize_copy_retarget_clause(lower: &str) -> bool {
-    let clause = lower
-        .trim()
-        .trim_end_matches('.')
-        .trim_end_matches(',')
-        .trim();
-    let clause = clause
-        .strip_prefix("and ")
-        .or_else(|| clause.strip_prefix(", and "))
-        .unwrap_or(clause);
     value(
         (),
         (
-            opt(tag::<_, _, OracleError<'_>>("you ")),
+            multispace0,
+            opt(alt((tag::<_, _, OracleError<'_>>(", and "), tag("and ")))),
+            opt(tag("you ")),
             tag("may choose "),
             alt((tag("a new target "), tag("new targets "))),
             tag("for "),
             alt((tag("the copies"), tag("the copy"), tag("that copy"))),
+            opt(alt((tag("."), tag(",")))),
+            multispace0,
             eof,
         ),
     )
-    .parse(clause)
+    .parse(lower.trim())
     .is_ok()
 }
 
@@ -5053,7 +5048,7 @@ mod tests {
             "expected three sentence chunks, got {chunks:?}"
         );
         assert!(
-            chunks[2].contains("choose new targets"),
+            nom_primitives::scan_contains(&chunks[2].to_ascii_lowercase(), "choose new targets "),
             "win chunk must include retarget clause: {:?}",
             chunks[2]
         );

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -3,10 +3,10 @@ use serde::Serialize;
 use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, ActivationRestriction, BounceSelection,
-    CastingPermission, ControllerRef, CounterSourceRider, Duration, Effect, FaceDownProfile,
-    LibraryPosition, ManaProduction, ManaSpendRestriction, ModalSelectionConstraint,
-    OutsideGameSourcePool, PlayerFilter, PtStat, PtValue, QuantityExpr, SearchDestinationSplit,
-    SearchSelectionConstraint, StaticDefinition, TargetFilter,
+    CastingPermission, ControllerRef, CopyRetargetPermission, CounterSourceRider, Duration, Effect,
+    FaceDownProfile, LibraryPosition, ManaProduction, ManaSpendRestriction,
+    ModalSelectionConstraint, OutsideGameSourcePool, PlayerFilter, PtStat, PtValue, QuantityExpr,
+    SearchDestinationSplit, SearchSelectionConstraint, StaticDefinition, TargetFilter,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::CounterType;
@@ -882,6 +882,8 @@ pub(crate) enum UtilityImperativeAst {
     },
     Copy {
         target: TargetFilter,
+        /// CR 707.10c: set when the imperative remainder is a copy-retarget grant.
+        retarget: CopyRetargetPermission,
     },
     Transform {
         target: TargetFilter,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
@@ -12,7 +12,7 @@ expression: "&ir"
           "effect": {
             "type": "Counter",
             "target": {
-              "type": "ParentTarget"
+              "type": "TriggeringSource"
             }
           },
           "cost": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_lowered.snap
@@ -12,7 +12,7 @@ expression: "&lowered"
         "effect": {
           "type": "Counter",
           "target": {
-            "type": "ParentTarget"
+            "type": "TriggeringSource"
           }
         },
         "cost": null,

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -463,21 +463,19 @@ pub fn parse_target_with_syntax<'a>(
             return parse_target_with_syntax(original_rest, ctx);
         }
     }
-    // CR 608.2k: Bare "that spell" / "that card" refer to the triggering spell
-    // object (Krark, the Thumbless; Spellchain Scatter). Predicate continuations
-    // ("that spell is countered this way") keep flowing to the ParentTarget arm
-    // below because text remains after the noun.
+    // CR 608.2k: Bare "that spell" refers to the triggering spell object
+    // (Krark, the Thumbless; Spellchain Scatter). "that card" is NOT included —
+    // it stays on the ParentTarget arm below and is rewritten to TrackedSet when
+    // a prior sibling publishes an affected set (Sin, Spira's Punishment). Predicate
+    // continuations ("that spell is countered this way") keep ParentTarget because
+    // text remains after the noun; comma continuations ("copy that spell, and …")
+    // still name the triggering spell.
     if let Ok((rest_subject, _)) = tag::<_, _, OracleError<'_>>("that ").parse(lower.as_str()) {
         let original_rest = &text[lower.len() - rest_subject.len()..];
-        for noun in ["spell", "card"] {
-            if let Ok((after, _)) = parse_word_bounded(rest_subject, noun) {
-                // Predicate tails ("is countered") stay on the ParentTarget arm;
-                // comma continuations ("copy that spell, and …") still name the
-                // triggering spell as the target object.
-                if after.is_empty() || after.starts_with([',', ';']) {
-                    let orig_after = original_rest.get(noun.len()..).unwrap_or(original_rest);
-                    return (TargetFilter::TriggeringSource, orig_after, syntax);
-                }
+        if let Ok((after, _)) = parse_word_bounded(rest_subject, "spell") {
+            if after.is_empty() || after.starts_with([',', ';']) {
+                let orig_after = original_rest.get("spell".len()..).unwrap_or(original_rest);
+                return (TargetFilter::TriggeringSource, orig_after, syntax);
             }
         }
         let (filter, rem) = parse_type_phrase_with_ctx(original_rest, ctx);
@@ -7897,9 +7895,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_target_standalone_that_card_is_triggering_source() {
+    fn parse_target_standalone_that_card_is_parent_target() {
         let (filter, rest, _) = parse_target_with_syntax("that card", &mut ParseContext::default());
-        assert_eq!(filter, TargetFilter::TriggeringSource);
+        assert_eq!(filter, TargetFilter::ParentTarget);
         assert_eq!(rest, "");
     }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -463,9 +463,23 @@ pub fn parse_target_with_syntax<'a>(
             return parse_target_with_syntax(original_rest, ctx);
         }
     }
-    // "that [type phrase]" → anaphoric reference to a typed subject
+    // CR 608.2k: Bare "that spell" / "that card" refer to the triggering spell
+    // object (Krark, the Thumbless; Spellchain Scatter). Predicate continuations
+    // ("that spell is countered this way") keep flowing to the ParentTarget arm
+    // below because text remains after the noun.
     if let Ok((rest_subject, _)) = tag::<_, _, OracleError<'_>>("that ").parse(lower.as_str()) {
         let original_rest = &text[lower.len() - rest_subject.len()..];
+        for noun in ["spell", "card"] {
+            if let Ok((after, _)) = parse_word_bounded(rest_subject, noun) {
+                // Predicate tails ("is countered") stay on the ParentTarget arm;
+                // comma continuations ("copy that spell, and …") still name the
+                // triggering spell as the target object.
+                if after.is_empty() || after.starts_with([',', ';']) {
+                    let orig_after = original_rest.get(noun.len()..).unwrap_or(original_rest);
+                    return (TargetFilter::TriggeringSource, orig_after, syntax);
+                }
+            }
+        }
         let (filter, rem) = parse_type_phrase_with_ctx(original_rest, ctx);
         if !matches!(filter, TargetFilter::Any) {
             return (TargetFilter::ParentTarget, rem, syntax);
@@ -7871,6 +7885,21 @@ mod tests {
     fn parse_target_them_inherits_parent_target() {
         let (filter, rest) = parse_target("them");
         assert_eq!(filter, TargetFilter::ParentTarget);
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn parse_target_standalone_that_spell_is_triggering_source() {
+        let (filter, rest, _) =
+            parse_target_with_syntax("that spell", &mut ParseContext::default());
+        assert_eq!(filter, TargetFilter::TriggeringSource);
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn parse_target_standalone_that_card_is_triggering_source() {
+        let (filter, rest, _) = parse_target_with_syntax("that card", &mut ParseContext::default());
+        assert_eq!(filter, TargetFilter::TriggeringSource);
         assert_eq!(rest, "");
     }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -3487,8 +3487,8 @@ mod tests {
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
     }
 
-    /// CR 701.43 + CR 117.3a + CR 609.4b: Xanathar's upkeep bundles look/play/
-    /// spend-as-any-color permissions inside the trigger execute tree.
+    /// CR 603.2b + CR 611.2 + CR 609.4b: Xanathar's upkeep trigger bundles
+    /// look/play/spend-as-any-color permissions inside the execute tree.
     #[test]
     fn optional_you_may_accepts_xanathar_upkeep_permissions() {
         let parsed = parse_named(

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -29,6 +29,7 @@ use crate::types::ability::{
     PlayerFilter, QuantityExpr, ReplacementDefinition, ReplacementMode, StaticDefinition,
     TargetFilter, TriggerDefinition,
 };
+use crate::types::game_state::RetargetScope;
 use crate::types::keywords::Keyword;
 use crate::types::statics::StaticMode;
 use crate::types::triggers::TriggerMode;
@@ -504,6 +505,37 @@ fn effect_has_internal_optionality(effect: &Effect) -> bool {
             statics.iter().any(static_definition_has_optional)
                 || triggers.iter().any(trigger_tree_has_optional)
         }
+        // CR 705: Flip-coin branches carry win/lose payloads as nested defs;
+        // "you may choose new targets for the copy" on the win branch (Krark)
+        // lives in `win_effect`, not at `def.optional`.
+        Effect::FlipCoin {
+            win_effect,
+            lose_effect,
+            ..
+        } => win_effect
+            .as_ref()
+            .is_some_and(|def| def_tree_has_optional(def))
+            || lose_effect
+                .as_ref()
+                .is_some_and(|def| def_tree_has_optional(def)),
+        Effect::FlipCoins {
+            win_effect,
+            lose_effect,
+            ..
+        } => win_effect
+            .as_ref()
+            .is_some_and(|def| def_tree_has_optional(def))
+            || lose_effect
+                .as_ref()
+                .is_some_and(|def| def_tree_has_optional(def)),
+        Effect::FlipCoinUntilLose { win_effect, .. } => def_tree_has_optional(win_effect),
+        // CR 115.7d: "you may choose new targets for [spell]" lowers to
+        // `ChangeTargets { scope: All }` — the opt-in is at resolution time,
+        // not `def.optional`.
+        Effect::ChangeTargets {
+            scope: RetargetScope::All,
+            ..
+        } => true,
         _ => false,
     }
 }
@@ -3434,6 +3466,38 @@ mod tests {
              You may choose new targets for the copies.",
             "Thousand-Year Storm",
             &["Enchantment"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    /// CR 705 + CR 707.10c: Krark nests CopySpell retarget permission inside
+    /// the flip-coin win branch; `effect_has_internal_optionality` must recurse
+    /// into `FlipCoin.win_effect`.
+    #[test]
+    fn optional_you_may_accepts_copy_retarget_clause_in_flip_coin_win_branch() {
+        let parsed = parse_named(
+            "Whenever you cast an instant or sorcery spell, flip a coin. \
+             If you lose the flip, return that spell to its owner's hand. \
+             If you win the flip, copy that spell, and you may choose new targets for the copy.",
+            "Krark, the Thumbless",
+            &["Legendary", "Creature"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    /// CR 701.43 + CR 117.3a + CR 609.4b: Xanathar's upkeep bundles look/play/
+    /// spend-as-any-color permissions inside the trigger execute tree.
+    #[test]
+    fn optional_you_may_accepts_xanathar_upkeep_permissions() {
+        let parsed = parse_named(
+            "At the beginning of your upkeep, choose target opponent. Until end of turn, \
+             that player can't cast spells, you may look at the top card of their library \
+             any time, you may play the top card of their library, and you may spend mana \
+             as though it were mana of any color to cast spells this way.",
+            "Xanathar, Guild Kingpin",
+            &["Legendary", "Creature"],
         );
 
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));

--- a/crates/engine/tests/integration/issue_2940_krark_thumbless.rs
+++ b/crates/engine/tests/integration/issue_2940_krark_thumbless.rs
@@ -1,0 +1,187 @@
+//! Regression for issue #2940: Krark, the Thumbless must run the return-to-hand
+//! branch on a lost flip and the copy branch on a won flip — not the reverse.
+//!
+//! https://github.com/phase-rs/phase/issues/2940
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{CopyRetargetPermission, Effect};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const KRARK: &str = "Whenever you cast an instant or sorcery spell, flip a coin. \
+    If you lose the flip, return that spell to its owner's hand. \
+    If you win the flip, copy that spell, and you may choose new targets for the copy.";
+
+const DRAW_SPELL: &str = "Draw a card.";
+
+fn floating_colorless(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn library_len(
+    state: &engine::types::game_state::GameState,
+    player: engine::types::player::PlayerId,
+) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.library.len())
+        .unwrap_or(0)
+}
+
+fn setup_krark_and_draw_spell(seed: u64) -> (GameScenario, engine::types::identifiers::ObjectId) {
+    let mut scenario = GameScenario::new_n_player(2, seed);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Krark, the Thumbless", 2, 2, KRARK);
+    for i in 0..5 {
+        scenario.add_spell_to_library_top(P0, &format!("Library {i}"), true);
+    }
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Draw Spell", true, DRAW_SPELL)
+        .id();
+    scenario.with_mana_pool(P0, floating_colorless(10));
+    (scenario, spell)
+}
+
+#[test]
+fn krark_oracle_text_trigger_branches_match_direct_parse() {
+    let parsed = parse_oracle_text(
+        KRARK,
+        "Krark, the Thumbless",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("Krark should parse a trigger");
+    let execute = trigger
+        .execute
+        .as_ref()
+        .expect("trigger should have execute");
+    let Effect::FlipCoin {
+        win_effect,
+        lose_effect,
+    } = execute.effect.as_ref()
+    else {
+        panic!("expected FlipCoin, got {:?}", execute.effect);
+    };
+    let win = win_effect.as_ref().expect("win branch");
+    let lose = lose_effect.as_ref().expect("lose branch");
+    assert!(
+        matches!(win.effect.as_ref(), Effect::CopySpell { .. }),
+        "win branch should be CopySpell, got {:?}",
+        win.effect
+    );
+    assert!(
+        matches!(
+            lose.effect.as_ref(),
+            Effect::Bounce { .. }
+                | Effect::ChangeZone {
+                    destination: Zone::Hand,
+                    ..
+                }
+        ),
+        "lose branch should bounce, got {:?}",
+        lose.effect
+    );
+    if let Effect::CopySpell { retarget, .. } = win.effect.as_ref() {
+        assert_eq!(
+            *retarget,
+            CopyRetargetPermission::MayChooseNewTargets,
+            "comma-and retarget clause must patch the win-branch CopySpell"
+        );
+    }
+}
+
+#[test]
+fn krark_battlefield_trigger_has_correct_flip_branches() {
+    let (scenario, _) = setup_krark_and_draw_spell(0);
+    let runner = scenario.build();
+    let krark_id = runner
+        .state()
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            runner
+                .state()
+                .objects
+                .get(id)
+                .is_some_and(|o| o.name.contains("Krark"))
+        })
+        .expect("Krark on battlefield");
+    let execute = &runner.state().objects[&krark_id].trigger_definitions[0]
+        .execute
+        .as_ref()
+        .expect("execute");
+    let Effect::FlipCoin {
+        win_effect,
+        lose_effect,
+    } = execute.effect.as_ref()
+    else {
+        panic!("expected FlipCoin, got {:?}", execute.effect);
+    };
+    assert!(matches!(
+        win_effect.as_ref().unwrap().effect.as_ref(),
+        Effect::CopySpell { .. }
+    ));
+    assert!(matches!(
+        lose_effect.as_ref().unwrap().effect.as_ref(),
+        Effect::Bounce { .. }
+            | Effect::ChangeZone {
+                destination: Zone::Hand,
+                ..
+            }
+    ));
+}
+
+/// CR 705 + CR 707.10c: Win branch copies (same targets) and both spells resolve;
+/// lose branch bounces the spell before it resolves.
+#[test]
+fn krark_flip_branches_match_coin_outcome_in_cast_pipeline() {
+    let mut saw_win = false;
+    let mut saw_lose = false;
+
+    for seed in 0..64 {
+        let (scenario, spell) = setup_krark_and_draw_spell(seed);
+        let mut runner = scenario.build();
+        let lib_before = library_len(runner.state(), P0);
+        let outcome = runner.cast(spell).resolve();
+        let lib_after = library_len(outcome.state(), P0);
+        let spell_zone = outcome.zone_of(spell);
+
+        if spell_zone == Zone::Hand {
+            assert_eq!(
+                lib_before, lib_after,
+                "seed {seed}: lose branch must bounce before Draw resolves"
+            );
+            assert!(
+                outcome.stack_names().is_empty(),
+                "seed {seed}: bounced spell must leave the stack"
+            );
+            saw_lose = true;
+        } else {
+            assert_eq!(
+                lib_before.saturating_sub(lib_after),
+                2,
+                "seed {seed}: win branch must resolve original + copy (each draws)"
+            );
+            assert!(
+                outcome.stack_names().is_empty(),
+                "seed {seed}: stack should empty after both spells resolve"
+            );
+            saw_win = true;
+        }
+    }
+
+    assert!(saw_win, "scan must observe at least one won flip");
+    assert!(saw_lose, "scan must observe at least one lost flip");
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -132,6 +132,7 @@ mod issue_2430_shifting_woodland;
 mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
+mod issue_2940_krark_thumbless;
 mod issue_2941_vivien_reid;
 mod issue_2943_kayas_wrath;
 mod issue_564_wishclaw_talisman_control;


### PR DESCRIPTION
## Summary

Fixes [#2940](https://github.com/phase-rs/phase/issues/2940). Krark, the Thumbless appeared to have inverted coin-flip outcomes (win → bounce, lose → resolve). Runtime branch selection in `flip_coin::resolve` was already correct; the bug was parser-side.

- **Clause splitting:** `split_clause_sequence` blocked comma splits inside `if you win the flip, …` but still bare-`and` split at `, and `, orphaning `you may choose new targets for the copy` from the win branch. Win parsed as `CopySpell` with `KeepOriginalTargets`; lose targeted `ParentTarget` instead of the cast spell.
- **`that spell` anaphora:** Bare `"that spell"` / `"that card"` followed by `,` or `;` (e.g. `copy that spell, and …`) now resolve to `TriggeringSource` so the lose branch bounce hits the triggering spell.

No runtime flip-branch inversion — parser data is now aligned with Oracle text.

## Changes

| Area | What |
|------|------|
| `oracle_effect/sequence.rs` | Suppress bare-`and` splits inside prefix clauses (`if`/`when`/`until`/…) |
| `oracle_target.rs` | `TriggeringSource` for `"that spell"` / `"that card"` before comma continuations |
| `oracle_effect/mod.rs` | Parser regressions for full flip-coin chain + win-branch retarget |
| `flip_coin.rs` | Unit tests for branch slots + isolated flip resolve |
| `issue_2940_krark_thumbless.rs` | Integration: parsed AST + cast-pipeline (library delta per flip outcome) |

## Test plan

- [x] `cargo test -p engine --lib krark_`
- [x] `cargo test -p engine --test integration issue_2940`
- [x] `cargo fmt --all`