### PR TITLE
fix(parser): parse Deflecting Swat "choose new targets" as ChangeTargets

### DIFF
--- a/client/src/components/modal/RetargetChoiceModal.tsx
+++ b/client/src/components/modal/RetargetChoiceModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 
@@ -13,22 +13,47 @@ import { targetKey, targetLabel } from "./targetRef.ts";
 
 type RetargetChoice = Extract<WaitingFor, { type: "RetargetChoice" }>;
 
+function targetsEqual(a: TargetRef, b: TargetRef): boolean {
+  return targetKey(a) === targetKey(b);
+}
+
 export function RetargetChoiceModal({ data }: { data: RetargetChoice["data"] }) {
   const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
   const objects = useGameStore((s) => s.gameState?.objects);
   const hoverProps = useInspectHoverProps();
 
+  const slotCount = Math.max(data.current_targets.length, 1);
+  const isMultiSlot = data.scope.type === "All" && slotCount > 1;
+
   // CR 115.7: Default to keeping the current targets unchanged.
   const [selected, setSelected] = useState<TargetRef[]>(data.current_targets);
+  const [activeSlot, setActiveSlot] = useState(0);
 
-  const handleSelect = useCallback((target: TargetRef) => {
+  const handleSelectSingle = useCallback((target: TargetRef) => {
     setSelected([target]);
   }, []);
 
+  const handleSelectSlot = useCallback((slotIndex: number, target: TargetRef) => {
+    setSelected((prev) => {
+      const next = [...prev];
+      while (next.length < slotCount) {
+        next.push(data.current_targets[next.length] ?? target);
+      }
+      next[slotIndex] = target;
+      return next;
+    });
+    if (slotIndex + 1 < slotCount) {
+      setActiveSlot(slotIndex + 1);
+    }
+  }, [data.current_targets, slotCount]);
+
   const handleConfirm = useCallback(() => {
-    dispatch({ type: "RetargetSpell", data: { new_targets: selected } });
-  }, [dispatch, selected]);
+    const payload = isMultiSlot
+      ? selected.slice(0, slotCount)
+      : selected.slice(0, 1);
+    dispatch({ type: "RetargetSpell", data: { new_targets: payload } });
+  }, [dispatch, isMultiSlot, selected, slotCount]);
 
   const scopeLabel =
     data.scope.type === "Single"
@@ -39,16 +64,57 @@ export function RetargetChoiceModal({ data }: { data: RetargetChoice["data"] }) 
     .map((target) => targetLabel(target, objects))
     .join(", ");
 
+  const confirmDisabled = useMemo(() => {
+    if (selected.length === 0) return true;
+    if (!isMultiSlot) return false;
+    return selected.length < slotCount
+      || selected.slice(0, slotCount).some((target) => target == null);
+  }, [isMultiSlot, selected, slotCount]);
+
+  const activeSelection = isMultiSlot ? selected[activeSlot] : selected[0];
+
   return (
     <ChoiceOverlay
       title={t("retargetChoice.title")}
       subtitle={t("retargetChoice.subtitle", { scope: scopeLabel, current: currentLabel })}
-      footer={<ConfirmButton onClick={handleConfirm} disabled={selected.length === 0} label={t("retargetChoice.confirm")} />}
+      footer={
+        <ConfirmButton
+          onClick={handleConfirm}
+          disabled={confirmDisabled}
+          label={t("retargetChoice.confirm")}
+        />
+      }
     >
+      {isMultiSlot && (
+        <div className="mb-4 flex flex-wrap justify-center gap-2">
+          {data.current_targets.map((current, index) => {
+            const chosen = selected[index];
+            const isActive = index === activeSlot;
+            return (
+              <button
+                key={`slot-${index}`}
+                type="button"
+                className={`rounded-md px-3 py-1.5 text-sm font-medium transition ${
+                  isActive
+                    ? "bg-sky-600/90 text-white ring-2 ring-sky-300/70"
+                    : "bg-slate-800/80 text-slate-200 hover:bg-slate-700/80"
+                }`}
+                onClick={() => setActiveSlot(index)}
+              >
+                {t("retargetChoice.slotLabel", {
+                  index: index + 1,
+                  current: targetLabel(current, objects),
+                  chosen: chosen ? targetLabel(chosen, objects) : t("retargetChoice.unselected"),
+                })}
+              </button>
+            );
+          })}
+        </div>
+      )}
       <ScrollableCardStrip>
         {data.legal_new_targets.map((target, index) => {
           const key = targetKey(target);
-          const isSelected = selected.some((s) => targetKey(s) === key);
+          const isSelected = activeSelection != null && targetsEqual(activeSelection, target);
           const obj = "Object" in target ? objects?.[String(target.Object)] : undefined;
 
           return (
@@ -63,7 +129,11 @@ export function RetargetChoiceModal({ data }: { data: RetargetChoice["data"] }) 
               animate={{ opacity: isSelected ? 1 : 0.7, y: 0, scale: 1 }}
               transition={{ delay: 0.1 + index * 0.08, duration: 0.35 }}
               whileHover={{ scale: 1.05, y: -6 }}
-              onClick={() => handleSelect(target)}
+              onClick={() => (
+                isMultiSlot
+                  ? handleSelectSlot(activeSlot, target)
+                  : handleSelectSingle(target)
+              )}
               {...("Object" in target ? hoverProps(target.Object) : {})}
             >
               {obj ? (

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1484,7 +1484,9 @@
     "scopeMulti": "Wähle neue Ziele für den Zauberspruch",
     "subtitle": "{{scope}}. Aktuell: {{current}}",
     "confirm": "Bestätigen",
-    "badgeNewTarget": "Neues Ziel"
+    "badgeNewTarget": "Neues Ziel",
+    "slotLabel": "Ziel {{index}}: {{current}} → {{chosen}}",
+    "unselected": "unverändert"
   },
   "separatePiles": {
     "chooserName": "Spieler {{number}}",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1489,7 +1489,9 @@
     "scopeMulti": "Choose new targets for the spell",
     "subtitle": "{{scope}}. Current: {{current}}",
     "confirm": "Confirm",
-    "badgeNewTarget": "New target"
+    "badgeNewTarget": "New target",
+    "slotLabel": "Target {{index}}: {{current}} → {{chosen}}",
+    "unselected": "unchanged"
   },
   "separatePiles": {
     "chooserName": "Player {{number}}",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1484,7 +1484,9 @@
     "scopeMulti": "Elige nuevos objetivos para el hechizo",
     "subtitle": "{{scope}}. Actual: {{current}}",
     "confirm": "Confirmar",
-    "badgeNewTarget": "Nuevo objetivo"
+    "badgeNewTarget": "Nuevo objetivo",
+    "slotLabel": "Objetivo {{index}}: {{current}} → {{chosen}}",
+    "unselected": "sin cambios"
   },
   "separatePiles": {
     "chooserName": "Jugador {{number}}",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1484,7 +1484,9 @@
     "scopeMulti": "Choisissez de nouvelles cibles pour le sort",
     "subtitle": "{{scope}}. Actuelle : {{current}}",
     "confirm": "Confirmer",
-    "badgeNewTarget": "Nouvelle cible"
+    "badgeNewTarget": "Nouvelle cible",
+    "slotLabel": "Cible {{index}} : {{current}} → {{chosen}}",
+    "unselected": "inchangée"
   },
   "separatePiles": {
     "chooserName": "Joueur {{number}}",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1484,7 +1484,9 @@
     "scopeMulti": "Scegli nuovi bersagli per la magia",
     "subtitle": "{{scope}}. Attuale: {{current}}",
     "confirm": "Conferma",
-    "badgeNewTarget": "Nuovo bersaglio"
+    "badgeNewTarget": "Nuovo bersaglio",
+    "slotLabel": "Bersaglio {{index}}: {{current}} → {{chosen}}",
+    "unselected": "invariato"
   },
   "separatePiles": {
     "chooserName": "Giocatore {{number}}",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1484,7 +1484,9 @@
     "scopeMulti": "Wybierz nowe cele dla czaru",
     "subtitle": "{{scope}}. Obecnie: {{current}}",
     "confirm": "Potwierdź",
-    "badgeNewTarget": "Nowy cel"
+    "badgeNewTarget": "Nowy cel",
+    "slotLabel": "Cel {{index}}: {{current}} → {{chosen}}",
+    "unselected": "bez zmian"
   },
   "separatePiles": {
     "chooserName": "Gracz {{number}}",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1484,7 +1484,9 @@
     "scopeMulti": "Escolha novos alvos para a mágica",
     "subtitle": "{{scope}}. Atual: {{current}}",
     "confirm": "Confirmar",
-    "badgeNewTarget": "Novo alvo"
+    "badgeNewTarget": "Novo alvo",
+    "slotLabel": "Alvo {{index}}: {{current}} → {{chosen}}",
+    "unselected": "inalterado"
   },
   "separatePiles": {
     "chooserName": "Jogador {{number}}",

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4665,6 +4665,8 @@ fn apply_action(
             WaitingFor::RetargetChoice {
                 player,
                 stack_entry_index,
+                scope,
+                current_targets,
                 legal_new_targets,
                 ..
             },
@@ -4672,10 +4674,14 @@ fn apply_action(
         ) => apply_retarget(
             state,
             &mut events,
-            *player,
-            *stack_entry_index,
-            legal_new_targets,
-            new_targets,
+            RetargetSubmission {
+                player: *player,
+                stack_entry_index: *stack_entry_index,
+                scope,
+                current_targets,
+                legal_new_targets,
+                new_targets,
+            },
         )?,
         // CR 115.7: Retarget a single-target spell via a board click. The
         // universal `ChooseTarget` action — already consumed by every other
@@ -4687,6 +4693,7 @@ fn apply_action(
                 player,
                 stack_entry_index,
                 scope: RetargetScope::Single,
+                current_targets,
                 legal_new_targets,
                 ..
             },
@@ -4694,10 +4701,14 @@ fn apply_action(
         ) => apply_retarget(
             state,
             &mut events,
-            *player,
-            *stack_entry_index,
-            legal_new_targets,
-            vec![t],
+            RetargetSubmission {
+                player: *player,
+                stack_entry_index: *stack_entry_index,
+                scope: &RetargetScope::Single,
+                current_targets,
+                legal_new_targets,
+                new_targets: vec![t],
+            },
         )?,
         (waiting, action) => {
             return Err(EngineError::ActionNotAllowed(format!(
@@ -4752,6 +4763,15 @@ fn apply_action(
     })
 }
 
+struct RetargetSubmission<'a> {
+    player: PlayerId,
+    stack_entry_index: usize,
+    scope: &'a RetargetScope,
+    current_targets: &'a [TargetRef],
+    legal_new_targets: &'a [TargetRef],
+    new_targets: Vec<TargetRef>,
+}
+
 /// CR 115.7d: Apply a validated retarget to the stack entry, then hand priority
 /// back to the retargeting player. Single authority for both retarget entry
 /// points — the board-click (`ChooseTarget`) and dialog (`RetargetSpell`) paths
@@ -4759,16 +4779,54 @@ fn apply_action(
 fn apply_retarget(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
-    player: PlayerId,
-    stack_entry_index: usize,
-    legal_new_targets: &[TargetRef],
-    new_targets: Vec<TargetRef>,
+    submission: RetargetSubmission<'_>,
 ) -> Result<WaitingFor, EngineError> {
-    // CR 115.7d: Every submitted target must be in the legal set.
-    for t in &new_targets {
-        if !legal_new_targets.contains(t) {
+    let RetargetSubmission {
+        player,
+        stack_entry_index,
+        scope,
+        current_targets,
+        legal_new_targets,
+        new_targets,
+    } = submission;
+
+    match scope {
+        RetargetScope::Single => {
+            if new_targets.len() != 1 {
+                return Err(EngineError::InvalidAction(
+                    "Retarget: single-target change requires exactly one target".to_string(),
+                ));
+            }
+            if !legal_new_targets.contains(&new_targets[0]) {
+                return Err(EngineError::InvalidAction(
+                    "Retarget: chosen target not in legal alternatives".to_string(),
+                ));
+            }
+        }
+        RetargetScope::All => {
+            if new_targets.len() != current_targets.len() {
+                return Err(EngineError::InvalidAction(
+                    "Retarget: choose-new-targets submission must preserve target count"
+                        .to_string(),
+                ));
+            }
+            // CR 115.7d: For "choose new targets", unchanged targets may remain
+            // unchanged even if they are no longer legal. Changed targets still
+            // must be legal alternatives.
+            for (idx, target) in new_targets.iter().enumerate() {
+                if current_targets.get(idx) == Some(target) {
+                    continue;
+                }
+                if !legal_new_targets.contains(target) {
+                    return Err(EngineError::InvalidAction(
+                        "Retarget: chosen target not in legal alternatives".to_string(),
+                    ));
+                }
+            }
+        }
+        RetargetScope::ForcedTo(_) => {
             return Err(EngineError::InvalidAction(
-                "Retarget: chosen target not in legal alternatives".to_string(),
+                "Retarget: forced retarget is not interactive".to_string(),
             ));
         }
     }
@@ -6621,6 +6679,7 @@ mod tests {
     use crate::types::card_type::CoreType;
     use crate::types::counter::CounterType;
     use crate::types::format::FormatConfig;
+    use crate::types::game_state::CastingVariant;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::TriggerMode;
@@ -6651,6 +6710,64 @@ mod tests {
         remember_public_reveals(&mut state, &events);
 
         assert!(state.public_revealed_cards.contains(&card_id));
+    }
+
+    #[test]
+    fn choose_new_targets_all_allows_unchanged_illegal_target() {
+        let mut state = GameState::new_two_player(42);
+        let stack_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Test Spell".to_string(),
+            Zone::Stack,
+        );
+        let unchanged = TargetRef::Object(ObjectId(901));
+        let legal_alternative = TargetRef::Object(ObjectId(902));
+        let stack_ability = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            vec![unchanged.clone()],
+            stack_id,
+            PlayerId(1),
+        );
+        state.stack.push_back(StackEntry {
+            id: stack_id,
+            source_id: stack_id,
+            controller: PlayerId(1),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(1),
+                ability: Some(stack_ability),
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        state.waiting_for = WaitingFor::RetargetChoice {
+            player: PlayerId(0),
+            stack_entry_index: 0,
+            scope: RetargetScope::All,
+            current_targets: vec![unchanged.clone()],
+            legal_new_targets: vec![legal_alternative],
+        };
+
+        apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::RetargetSpell {
+                new_targets: vec![unchanged.clone()],
+            },
+        )
+        .expect("unchanged targets do not need to be legal for choose-new-targets");
+
+        let targets = state
+            .stack
+            .front()
+            .and_then(|entry| entry.ability())
+            .map(|ability| ability.targets.clone())
+            .expect("spell remains on stack");
+        assert_eq!(targets, vec![unchanged]);
     }
 
     #[test]

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -268,7 +268,7 @@ fn is_specialized_duration_carrier(text_lower: &str) -> bool {
 /// require the full surface form. Generic `you may search your library for X`
 /// likewise peels cleanly; the from-among continuation is handled by the
 /// prior sub_ability path (sequence.rs), not parse_effect_clause.
-fn is_specialized_you_may_phrase(rest_lower: &str) -> bool {
+pub(crate) fn is_specialized_you_may_phrase(rest_lower: &str) -> bool {
     // Head-only blocklist: phrases whose dedicated body parsers need the full
     // `you may <verb>` surface present in their input to dispatch correctly.
     let head: nom::IResult<&str, (), OracleError<'_>> = alt((
@@ -535,6 +535,14 @@ mod tests {
         assert_eq!(peeled, "draw a card");
         assert!(ctx.optional);
         assert_eq!(ctx.duration(), Some(&Duration::UntilEndOfTurn));
+    }
+
+    #[test]
+    fn peel_does_not_strip_you_may_choose_new_targets() {
+        let text = "you may choose new targets for target spell or ability";
+        let (peeled, ctx) = peel_clause(text);
+        assert_eq!(peeled, text);
+        assert!(!ctx.optional);
     }
 
     #[test]

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -268,6 +268,19 @@ fn is_specialized_duration_carrier(text_lower: &str) -> bool {
 /// require the full surface form. Generic `you may search your library for X`
 /// likewise peels cleanly; the from-among continuation is handled by the
 /// prior sub_ability path (sequence.rs), not parse_effect_clause.
+/// CR 115.7: Retarget clauses that must keep the full `you may choose new
+/// targets for …` surface in the chunk loop so `try_parse_change_targets`
+/// dispatches. Narrower than `is_specialized_you_may_phrase` — Beseech-style
+/// `you may cast …` still peels `you may` here to set `optional: true`.
+pub(crate) fn is_specialized_you_may_retarget_phrase(rest_lower: &str) -> bool {
+    alt((
+        value((), tag::<_, _, OracleError<'_>>("choose new targets ")),
+        value((), tag("choose new target ")),
+    ))
+    .parse(rest_lower)
+    .is_ok()
+}
+
 pub(crate) fn is_specialized_you_may_phrase(rest_lower: &str) -> bool {
     // Head-only blocklist: phrases whose dedicated body parsers need the full
     // `you may <verb>` surface present in their input to dispatch correctly.

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5874,6 +5874,45 @@ mod tests {
         assert_eq!(r.abilities[0].kind, AbilityKind::Activated);
     }
 
+    /// Issue #2938 — Deflecting Swat's resolution effect must lower to
+    /// `ChangeTargets`, not a no-op `TargetOnly` wrapper.
+    #[test]
+    fn deflecting_swat_choose_new_targets_for_spell_or_ability() {
+        use crate::types::ability::TargetFilter;
+        use crate::types::game_state::RetargetScope;
+
+        let r = parse(
+            "If you control a commander, you may cast this spell without paying its mana cost.\n\
+             You may choose new targets for target spell or ability.",
+            "Deflecting Swat",
+            &[],
+            &["Instant"],
+            &[],
+        );
+        assert_eq!(r.abilities.len(), 1, "abilities={:?}", r.abilities);
+        assert!(
+            matches!(
+                r.abilities[0].effect.as_ref(),
+                Effect::ChangeTargets {
+                    scope: RetargetScope::All,
+                    forced_to: None,
+                    ..
+                }
+            ),
+            "effect={:?} optional={} description={:?}",
+            r.abilities[0].effect,
+            r.abilities[0].optional,
+            r.abilities[0].description
+        );
+        let Effect::ChangeTargets { target, .. } = r.abilities[0].effect.as_ref() else {
+            unreachable!();
+        };
+        let TargetFilter::Or { filters } = target else {
+            panic!("expected Or(StackSpell, StackAbility), got {target:?}");
+        };
+        assert!(filters.contains(&TargetFilter::StackSpell));
+    }
+
     /// Issue #1990 — Spellskite must parse to forced-self `ChangeTargets` so the
     /// AI `SpellskitePriorityPolicy` effect-shape gate fires at runtime.
     #[test]

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1451,9 +1451,20 @@ pub(super) fn strip_optional_effect_prefix(
     String,
 ) {
     let lower = text.to_lowercase();
+    // CR 608.2d + CR 115.7: "you may choose new targets for …" is a retarget
+    // effect, not a generic optional wrapper. The chunk loop must leave the
+    // full surface form intact so `try_parse_change_targets` can dispatch it;
+    // mirroring `clause_shell::strip_optional_prefix` / `peel_clause`.
+    if let Some((_, rest)) = nom_on_lower(text, &lower, |input| {
+        value((), tag::<_, _, OracleError<'_>>("you may ")).parse(input)
+    }) {
+        let rest_lower = rest.to_lowercase();
+        if !crate::parser::clause_shell::is_specialized_you_may_phrase(&rest_lower) {
+            return (true, None, None, rest.to_string());
+        }
+    }
     // CR 608.2d: "each opponent may" — per-opponent optional effect.
     // "any opponent may" — first-accept-wins opponent-choice optional effect.
-    // "you may" — standard optional effect prefix.
     if let Some(((scope, player_scope), rest)) = nom_on_lower(text, &lower, |input| {
         alt((
             value(
@@ -1467,7 +1478,6 @@ pub(super) fn strip_optional_effect_prefix(
                 ),
                 tag("any opponent may "),
             ),
-            value((None, None), tag("you may ")),
             // CR 608.2c: "the first player may" — Oath of Mages and analogous
             // cross-clause patterns where the chooser of a prior sentence
             // (= TriggeringPlayer for upkeep/event triggers) is invited to
@@ -5763,5 +5773,28 @@ mod where_x_tests {
             constraint,
             TargetSelectionConstraint::DifferentObjectControllers
         );
+    }
+}
+
+#[cfg(test)]
+mod strip_optional_effect_prefix_tests {
+    use super::strip_optional_effect_prefix;
+
+    #[test]
+    fn choose_new_targets_is_not_generic_optional() {
+        let text = "you may choose new targets for target spell or ability";
+        let (is_optional, _, _, rest) = strip_optional_effect_prefix(text);
+        assert!(
+            !is_optional,
+            "retarget clauses must keep the full surface form"
+        );
+        assert_eq!(rest, text);
+    }
+
+    #[test]
+    fn generic_you_may_still_strips() {
+        let (is_optional, _, _, rest) = strip_optional_effect_prefix("you may draw a card");
+        assert!(is_optional);
+        assert_eq!(rest, "draw a card");
     }
 }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1452,16 +1452,17 @@ pub(super) fn strip_optional_effect_prefix(
 ) {
     let lower = text.to_lowercase();
     // CR 608.2d + CR 115.7: "you may choose new targets for …" is a retarget
-    // effect, not a generic optional wrapper. The chunk loop must leave the
-    // full surface form intact so `try_parse_change_targets` can dispatch it;
-    // mirroring `clause_shell::strip_optional_prefix` / `peel_clause`.
+    // effect, not a generic optional wrapper. Only that narrow class keeps the
+    // full surface form; other specialized `you may cast/play/…` clauses still
+    // peel here so `optional: true` is stamped (Beseech the Mirror, etc.).
     if let Some((_, rest)) = nom_on_lower(text, &lower, |input| {
         value((), tag::<_, _, OracleError<'_>>("you may ")).parse(input)
     }) {
         let rest_lower = rest.to_lowercase();
-        if !crate::parser::clause_shell::is_specialized_you_may_phrase(&rest_lower) {
-            return (true, None, None, rest.to_string());
+        if crate::parser::clause_shell::is_specialized_you_may_retarget_phrase(&rest_lower) {
+            return (false, None, None, text.to_string());
         }
+        return (true, None, None, rest.to_string());
     }
     // CR 608.2d: "each opponent may" — per-opponent optional effect.
     // "any opponent may" — first-accept-wins opponent-choice optional effect.
@@ -5796,5 +5797,14 @@ mod strip_optional_effect_prefix_tests {
         let (is_optional, _, _, rest) = strip_optional_effect_prefix("you may draw a card");
         assert!(is_optional);
         assert_eq!(rest, "draw a card");
+    }
+
+    #[test]
+    fn beseech_style_you_may_cast_still_strips() {
+        let (is_optional, _, _, rest) = strip_optional_effect_prefix(
+            "you may cast the exiled card without paying its mana cost",
+        );
+        assert!(is_optional);
+        assert_eq!(rest, "cast the exiled card without paying its mana cost");
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17985,6 +17985,9 @@ fn try_parse_change_targets(lower: &str) -> Option<Effect> {
         ),
         value(RetargetScope::Single, tag("change a target of ")),
         value(RetargetScope::All, tag("you may choose new targets for ")),
+        // Peeled form when `strip_optional_effect_prefix` correctly declined to
+        // strip a specialized "you may choose new targets" retarget clause.
+        value(RetargetScope::All, tag("choose new targets for ")),
     ))
     .parse(lower)
     .ok()?;
@@ -32024,6 +32027,33 @@ mod tests {
                     if properties.contains(&FilterProp::HasSingleTarget)
             )));
         }
+    }
+
+    #[test]
+    fn choose_new_targets_spell_or_ability_deflecting_swat() {
+        let e = parse_effect("you may choose new targets for target spell or ability");
+        let Effect::ChangeTargets {
+            target,
+            scope,
+            forced_to,
+        } = e
+        else {
+            panic!("Expected ChangeTargets, got {e:?}");
+        };
+        assert!(matches!(scope, RetargetScope::All));
+        assert!(forced_to.is_none());
+        let TargetFilter::Or { filters } = &target else {
+            panic!("Expected Or(StackSpell, StackAbility), got {target:?}");
+        };
+        assert_eq!(filters.len(), 2);
+        assert!(filters.contains(&TargetFilter::StackSpell));
+        assert!(matches!(
+            filters[1],
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None
+            }
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -460,6 +460,13 @@ fn effect_has_internal_optionality(effect: &Effect) -> bool {
             retarget: CopyRetargetPermission::MayChooseNewTargets,
             ..
         }
+        // CR 115.7d: "you may choose new targets for [spell/ability]" lowers to
+        // `ChangeTargets { scope: All }` with the full surface form preserved
+        // (not `def.optional`). The player may leave targets unchanged.
+        | Effect::ChangeTargets {
+            scope: RetargetScope::All,
+            ..
+        }
         // CR 701.20a + CR 608.2c: RevealUntil with kept_optional_to encodes
         // "you may put that card onto the battlefield" — the kept-card
         // destination choice IS the "may" decision (mirrors RevealFromHand
@@ -3453,6 +3460,50 @@ mod tests {
                 "{name} should not swallow unless clause"
             );
         }
+    }
+
+    /// CR 115.7d: Standalone retarget spells (Deflecting Swat, Redirect) lower
+    /// to `ChangeTargets { scope: All }` with the full `you may choose new
+    /// targets` surface preserved — not `def.optional`.
+    #[test]
+    fn optional_you_may_accepts_change_targets_retarget_spells() {
+        for (oracle, name, types) in [
+            (
+                "The next time a spell or ability an opponent controls targets you \
+                 this turn, change the target to another spell or ability. \
+                 Overload {2}{U}{U} (You may cast this spell for its overload cost. \
+                 If you do, change its target.)\n\
+                 You may choose new targets for target spell or ability.",
+                "Deflecting Swat",
+                &["Instant"][..],
+            ),
+            (
+                "You may choose new targets for target spell.",
+                "Redirect",
+                &["Instant"][..],
+            ),
+        ] {
+            let parsed = parse_named(oracle, name, types);
+            assert!(
+                !has_swallowed_detector(&parsed, "Optional_YouMay"),
+                "{name} should not swallow retarget optional"
+            );
+        }
+    }
+
+    /// CR 707.10c + CR 115.7d: Increasing Vengeance — copy with optional
+    /// retarget for copies (absorbed onto CopySpell when adjacent).
+    #[test]
+    fn optional_you_may_accepts_increasing_vengeance_copy_retarget() {
+        let parsed = parse_named(
+            "Copy target instant or sorcery spell you control. If this spell was cast from a \
+             graveyard, copy that spell twice instead. You may choose new targets for the copies.\n\
+             Flashback {3}{R}{R}",
+            "Increasing Vengeance",
+            &["Instant"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
     }
 
     /// CR 707.10c: Thousand-Year Storm exercises the triggered-ability context

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -3429,6 +3429,35 @@ mod tests {
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
     }
 
+    /// CR 115.7d: Redirect-style retarget effects encode the "you may choose
+    /// new targets" choice in `ChangeTargets { scope: All }`.
+    #[test]
+    fn optional_you_may_accepts_change_targets_all() {
+        let parsed = parse_named(
+            "You may choose new targets for target spell.",
+            "Redirect",
+            &["Instant"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    /// CR 705 + CR 707.10c: Krark nests CopySpell retarget permission inside
+    /// the flip-coin win branch; `effect_has_internal_optionality` must recurse
+    /// into `FlipCoin.win_effect`.
+    #[test]
+    fn optional_you_may_accepts_copy_retarget_clause_in_flip_coin_win_branch() {
+        let parsed = parse_named(
+            "Whenever you cast an instant or sorcery spell, flip a coin. \
+             If you lose the flip, return that spell to its owner's hand. \
+             If you win the flip, copy that spell, and you may choose new targets for the copy.",
+            "Krark, the Thumbless",
+            &["Legendary", "Creature"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
     /// Issue #2233: Condition_Unless — representative cards from the drilldown.
     #[test]
     fn condition_unless_accepts_representative_cards() {

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -536,13 +536,6 @@ fn effect_has_internal_optionality(effect: &Effect) -> bool {
                 .as_ref()
                 .is_some_and(|def| def_tree_has_optional(def)),
         Effect::FlipCoinUntilLose { win_effect, .. } => def_tree_has_optional(win_effect),
-        // CR 115.7d: "you may choose new targets for [spell]" lowers to
-        // `ChangeTargets { scope: All }` — the opt-in is at resolution time,
-        // not `def.optional`.
-        Effect::ChangeTargets {
-            scope: RetargetScope::All,
-            ..
-        } => true,
         _ => false,
     }
 }
@@ -3424,35 +3417,6 @@ mod tests {
              You may choose new targets for the copy.",
             "Galvanic Iteration",
             &["Instant"],
-        );
-
-        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
-    }
-
-    /// CR 115.7d: Redirect-style retarget effects encode the "you may choose
-    /// new targets" choice in `ChangeTargets { scope: All }`.
-    #[test]
-    fn optional_you_may_accepts_change_targets_all() {
-        let parsed = parse_named(
-            "You may choose new targets for target spell.",
-            "Redirect",
-            &["Instant"],
-        );
-
-        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
-    }
-
-    /// CR 705 + CR 707.10c: Krark nests CopySpell retarget permission inside
-    /// the flip-coin win branch; `effect_has_internal_optionality` must recurse
-    /// into `FlipCoin.win_effect`.
-    #[test]
-    fn optional_you_may_accepts_copy_retarget_clause_in_flip_coin_win_branch() {
-        let parsed = parse_named(
-            "Whenever you cast an instant or sorcery spell, flip a coin. \
-             If you lose the flip, return that spell to its owner's hand. \
-             If you win the flip, copy that spell, and you may choose new targets for the copy.",
-            "Krark, the Thumbless",
-            &["Legendary", "Creature"],
         );
 
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6331,18 +6331,7 @@ pub enum Effect {
         /// to the player resolved from `ref` (currently only `ControllerRef::You`
         /// is supported at runtime — see resolver in `effects/change_zone.rs`).
         /// `None` leaves the object under its owner's control per CR 110.2.
-        ///
-        /// Legacy on-disk shape (boolean `under_your_control`) deserializes via
-        /// `deserialize_enters_under_compat`; emission is always the modern
-        /// shape (`Option<ControllerRef>`). The compat path is guarded by
-        /// `_LEGACY_DESER_ETB_CONTROLLER_2026Q2` and is scheduled to be removed
-        /// once the workspace version exceeds 0.1.53.
-        #[serde(
-            default,
-            skip_serializing_if = "Option::is_none",
-            alias = "under_your_control",
-            deserialize_with = "deserialize_enters_under_compat"
-        )]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         enters_under: Option<ControllerRef>,
         /// CR 614.1: The object enters the battlefield tapped.
         /// Building block for "put onto the battlefield tapped" effects.
@@ -14061,131 +14050,6 @@ where
 }
 
 // ---------------------------------------------------------------------------
-// Legacy on-disk compatibility for `Effect::ChangeZone::enters_under`.
-//
-// The field was previously a `bool` named `under_your_control` (true = enters
-// under ability controller). It was lifted to `Option<ControllerRef>` so the
-// engine can express any `ControllerRef` variant on ETB (CR 110.2a). On-disk
-// payloads — semantic-audit snapshots, replays, and inline tests in
-// `mtgish-import` — may still carry the bool shape. `serde(alias =
-// "under_your_control")` routes them to this deserializer; we dispatch on the
-// JSON value to keep both shapes readable. Emission is always the modern
-// shape; new clients never see the bool. See `_LEGACY_DESER_ETB_CONTROLLER_2026Q2`
-// below for the removal tripwire.
-// ---------------------------------------------------------------------------
-
-/// Deserialize either the modern `Option<ControllerRef>` shape or the legacy
-/// boolean `under_your_control` shape (routed in via `#[serde(alias)]`).
-fn deserialize_enters_under_compat<'de, D>(
-    deserializer: D,
-) -> Result<Option<ControllerRef>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use serde::de::Error;
-    let value = serde_json::Value::deserialize(deserializer)?;
-    match value {
-        serde_json::Value::Bool(true) => Ok(Some(ControllerRef::You)),
-        serde_json::Value::Bool(false) => Ok(None),
-        serde_json::Value::Null => Ok(None),
-        other => serde_json::from_value::<Option<ControllerRef>>(other).map_err(D::Error::custom),
-    }
-}
-
-/// Compat shim for the pre-2026-Q2 `under_your_control: bool` field on the
-/// resolved-once runtime carriers (`PendingChangeZoneIteration` and
-/// `WaitingFor::EffectZoneChoice`). Modern shape is `Option<PlayerId>` —
-/// the bool was resolved to a concrete `PlayerId` at the ChangeZone resolver
-/// entry per CR 110.2a so the carrier no longer re-evaluates a `ControllerRef`
-/// across an interactive pause.
-///
-/// Reached only through `serde_json::from_str` resume paths: IndexedDB resume
-/// (`client/src/services/gamePersistence.ts`), phase-server SQLite restore,
-/// and P2P resume. The `serde_wasm_bindgen` action-dispatch path never carries
-/// these carriers across the boundary.
-///
-/// **Mapping:** legacy `true` → `None` with `tracing::warn!`. The bool's
-/// original semantics ("under ability controller") cannot be reconstructed
-/// at deserialization time without the originating `AbilityDefinition`. Falling
-/// back to `None` matches what the unshimmed code would have produced anyway
-/// (object enters under its owner's control) — we accept that worst case and
-/// emit a warn so a paused mid-prompt resume that hits the wrong routing has
-/// an audit trail. Legacy `false` → `None` silently; modern shape roundtrips
-/// through `serde_json::from_value::<Option<PlayerId>>`.
-///
-/// Removal is gated by `_LEGACY_DESER_ETB_CONTROLLER_2026Q2` alongside
-/// `deserialize_enters_under_compat`.
-pub fn deserialize_enters_under_player_compat<'de, D>(
-    deserializer: D,
-) -> Result<Option<PlayerId>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use serde::de::Error;
-    let value = serde_json::Value::deserialize(deserializer)?;
-    match value {
-        serde_json::Value::Bool(true) => {
-            tracing::warn!(
-                target: "engine::compat",
-                "LEGACY_DESER_ETB_CONTROLLER_2026Q2: legacy `under_your_control=true` \
-                 on resumed runtime carrier (PendingChangeZoneIteration or \
-                 EffectZoneChoice); cannot reconstruct PlayerId without ability \
-                 context. Defaulting to None (owner control). If the controller \
-                 assignment is load-bearing for this resume, the player should \
-                 restart the prompt."
-            );
-            Ok(None)
-        }
-        serde_json::Value::Bool(false) => Ok(None),
-        serde_json::Value::Null => Ok(None),
-        other => serde_json::from_value::<Option<PlayerId>>(other).map_err(D::Error::custom),
-    }
-}
-
-/// const fn version-component parser for `_LEGACY_DESER_ETB_CONTROLLER_2026Q2`.
-/// `env!` produces a `&'static str` at compile time; this consumes ASCII digits.
-const fn parse_version_component(s: &str) -> u32 {
-    let bytes = s.as_bytes();
-    let mut out: u32 = 0;
-    let mut i = 0;
-    while i < bytes.len() {
-        let b = bytes[i];
-        assert!(b >= b'0' && b <= b'9', "non-digit in version component");
-        out = out * 10 + (b - b'0') as u32;
-        i += 1;
-    }
-    out
-}
-
-/// Tripwire: the legacy `under_your_control` boolean compat path in
-/// `deserialize_enters_under_compat` was added at workspace version 0.1.39
-/// and is scheduled for removal once a release > 0.1.53 ships. The const
-/// below fails to compile when the workspace version crosses that boundary,
-/// forcing the maintainer to either remove the compat or push the deadline.
-///
-/// Grep token: `LEGACY_DESER_ETB_CONTROLLER_2026Q2`. See `docs/LEGACY-COMPAT.md`.
-///
-/// Clippy `absurd_extreme_comparisons` correctly observes that `MAJOR > 0`
-/// is always true for any non-zero major version; that's intentional — the
-/// tripwire fires the instant the major version bumps. Allow it locally.
-#[allow(dead_code, clippy::absurd_extreme_comparisons)]
-const _LEGACY_DESER_ETB_CONTROLLER_2026Q2: () = {
-    const MAJOR: u32 = parse_version_component(env!("CARGO_PKG_VERSION_MAJOR"));
-    const MINOR: u32 = parse_version_component(env!("CARGO_PKG_VERSION_MINOR"));
-    const PATCH: u32 = parse_version_component(env!("CARGO_PKG_VERSION_PATCH"));
-    assert!(
-        !(MAJOR > 0 || MINOR > 1 || (MINOR == 1 && PATCH > 53)),
-        "LEGACY_DESER_ETB_CONTROLLER_2026Q2: remove the under_your_control bool \
-         compat paths in deserialize_enters_under_compat (AST field) AND \
-         deserialize_enters_under_player_compat (PendingChangeZoneIteration + \
-         WaitingFor::EffectZoneChoice runtime carriers), the corresponding \
-         `#[serde(alias = ..., deserialize_with = ...)]` attributes on all \
-         three fields, and this tripwire once we ship past 0.1.53. See \
-         docs/LEGACY-COMPAT.md."
-    );
-};
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -15485,10 +15349,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
-    // CR 110.2a: `Effect::ChangeZone.enters_under` serde-compat coverage.
-    // Modern shape is `Option<ControllerRef>`; legacy on-disk shape is the
-    // boolean `under_your_control`. Routed via `#[serde(alias = ...)]` +
-    // `deserialize_enters_under_compat`. See LEGACY_DESER_ETB_CONTROLLER_2026Q2.
+    // CR 110.2a: `Effect::ChangeZone.enters_under` serde coverage.
     // ---------------------------------------------------------------------
 
     /// Helper: build a minimal `Effect::ChangeZone` with `enters_under` set.
@@ -15509,39 +15370,8 @@ mod tests {
     }
 
     #[test]
-    fn enters_under_legacy_bool_false_deserializes_to_none() {
-        let json = r#"{
-            "type": "ChangeZone",
-            "destination": "Battlefield",
-            "under_your_control": false
-        }"#;
-        let effect: Effect = serde_json::from_str(json).expect("legacy false should parse");
-        match effect {
-            Effect::ChangeZone { enters_under, .. } => assert_eq!(enters_under, None),
-            other => panic!("expected ChangeZone, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn enters_under_legacy_bool_true_deserializes_to_some_you() {
-        let json = r#"{
-            "type": "ChangeZone",
-            "destination": "Battlefield",
-            "under_your_control": true
-        }"#;
-        let effect: Effect = serde_json::from_str(json).expect("legacy true should parse");
-        match effect {
-            Effect::ChangeZone { enters_under, .. } => {
-                assert_eq!(enters_under, Some(ControllerRef::You))
-            }
-            other => panic!("expected ChangeZone, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn enters_under_chosen_player_index_zero_distinguishable_from_legacy_false() {
-        // The modern shape can express `Some(ControllerRef::ChosenPlayer { index: 0 })`,
-        // which must NOT collapse to the legacy `false` semantics (`None`).
+    fn enters_under_chosen_player_index_zero_roundtrips() {
+        // The modern shape can express `Some(ControllerRef::ChosenPlayer { index: 0 })`.
         let json = r#"{
             "type": "ChangeZone",
             "destination": "Battlefield",
@@ -15574,30 +15404,9 @@ mod tests {
     }
 
     #[test]
-    fn enters_under_alias_resolution_when_both_fields_present() {
-        // serde resolves `alias` by collapsing both names onto the same logical
-        // field, so a payload that includes BOTH the modern key and the legacy
-        // alias is treated as a duplicate-field error. This pins the behavior
-        // so a future schema migration is not surprised by it: on-disk payloads
-        // must use ONE of `enters_under` or `under_your_control`, never both.
-        let json = r#"{
-            "type": "ChangeZone",
-            "destination": "Battlefield",
-            "under_your_control": false,
-            "enters_under": "You"
-        }"#;
-        let err = serde_json::from_str::<Effect>(json)
-            .expect_err("duplicate alias+modern field must error");
-        assert!(
-            err.to_string().contains("duplicate field"),
-            "expected duplicate-field error, got: {err}"
-        );
-    }
-
-    #[test]
-    fn legacy_under_your_control_field_not_emitted_in_serialization() {
+    fn enters_under_field_not_emitted_when_none() {
         // `enters_under: None` must skip-serialize; `Some(You)` must emit the
-        // modern key. Neither case may emit the legacy boolean field.
+        // modern key.
         for variant in [None, Some(ControllerRef::You)] {
             let effect = change_zone_with_enters_under(variant.clone());
             let json = serde_json::to_string(&effect).expect("serialize");

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -941,19 +941,7 @@ pub struct PendingChangeZoneIteration {
     /// owner's control. Resolved from `Effect::ChangeZone.enters_under`
     /// at resolver entry, so the carrier never re-evaluates a `ControllerRef`
     /// across an interactive pause.
-    ///
-    /// Legacy on-disk shape (boolean `under_your_control`) deserializes via
-    /// `deserialize_enters_under_player_compat` (best-effort: legacy `true`
-    /// is mapped to `None` because PlayerId cannot be reconstructed without
-    /// ability context at deser time; a `tracing::warn` flags the audit
-    /// trail). Emission is always the modern shape. The compat path is
-    /// guarded by `_LEGACY_DESER_ETB_CONTROLLER_2026Q2` (removed past 0.1.53).
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        alias = "under_your_control",
-        deserialize_with = "crate::types::ability::deserialize_enters_under_player_compat"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enters_under_player: Option<PlayerId>,
     pub enters_attacking: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -2915,20 +2903,7 @@ pub enum WaitingFor {
         /// `EffectZoneChoice` round-trip. `Some(pid)` routes the chosen
         /// object(s) to `pid` on battlefield entry; `None` leaves them
         /// under their owner's control.
-        ///
-        /// Legacy on-disk shape (boolean `under_your_control`) deserializes
-        /// via `deserialize_enters_under_player_compat` (best-effort: legacy
-        /// `true` is mapped to `None` because PlayerId cannot be reconstructed
-        /// without ability context at deser time; a `tracing::warn` flags the
-        /// audit trail). Emission is always the modern shape. The compat path
-        /// is guarded by `_LEGACY_DESER_ETB_CONTROLLER_2026Q2` (removed past
-        /// 0.1.53).
-        #[serde(
-            default,
-            skip_serializing_if = "Option::is_none",
-            alias = "under_your_control",
-            deserialize_with = "crate::types::ability::deserialize_enters_under_player_compat"
-        )]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         enters_under_player: Option<PlayerId>,
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         enters_attacking: bool,
@@ -8028,51 +8003,9 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
-    // CR 110.2a: serde-compat coverage for the resolved-once runtime carriers
+    // CR 110.2a: serde coverage for the resolved-once runtime carriers
     // (`PendingChangeZoneIteration` and `WaitingFor::EffectZoneChoice`).
-    // Modern shape is `Option<PlayerId>` on `enters_under_player`; the
-    // legacy on-disk shape is the boolean `under_your_control`. Routed via
-    // `#[serde(alias)]` + `deserialize_enters_under_player_compat`. Legacy
-    // `true` collapses to `None` (+ tracing::warn) because PlayerId cannot
-    // be reconstructed at deser time without ability context. See
-    // `LEGACY_DESER_ETB_CONTROLLER_2026Q2`.
     // ---------------------------------------------------------------------
-
-    /// Minimal JSON payload for a `PendingChangeZoneIteration` carrying a
-    /// custom `enters_under_player` slot (passed through verbatim).
-    fn pending_change_zone_iteration_json(enters_under_slot: &str) -> String {
-        format!(
-            r#"{{
-                "remaining": [],
-                "source_id": 7,
-                "controller": 0,
-                "origin": null,
-                "destination": "Battlefield",
-                "enter_transformed": false,
-                "enter_tapped": false,
-                {enters_under_slot}
-                "enters_attacking": false,
-                "track_exiled_by_source": false,
-                "effect_kind": "ChangeZone"
-            }}"#
-        )
-    }
-
-    #[test]
-    fn pending_change_zone_iteration_legacy_bool_true_deserializes_to_none() {
-        let json = pending_change_zone_iteration_json(r#""under_your_control": true,"#);
-        let parsed: PendingChangeZoneIteration =
-            serde_json::from_str(&json).expect("legacy true should deserialize");
-        assert_eq!(parsed.enters_under_player, None);
-    }
-
-    #[test]
-    fn pending_change_zone_iteration_legacy_bool_false_deserializes_to_none() {
-        let json = pending_change_zone_iteration_json(r#""under_your_control": false,"#);
-        let parsed: PendingChangeZoneIteration =
-            serde_json::from_str(&json).expect("legacy false should deserialize");
-        assert_eq!(parsed.enters_under_player, None);
-    }
 
     #[test]
     fn pending_change_zone_iteration_modern_shape_roundtrips() {
@@ -8104,57 +8037,6 @@ mod tests {
         let parsed: PendingChangeZoneIteration = serde_json::from_str(&json).expect("roundtrip");
         assert_eq!(parsed.enters_under_player, Some(PlayerId(1)));
         assert_eq!(parsed, original);
-    }
-
-    /// Minimal JSON payload for `WaitingFor::EffectZoneChoice` carrying a
-    /// custom `enters_under_player` slot (passed through verbatim).
-    /// `WaitingFor` uses `#[serde(tag = "type", content = "data")]`, so the
-    /// variant body is wrapped in `"data": { ... }`.
-    fn effect_zone_choice_json(enters_under_slot: &str) -> String {
-        format!(
-            r#"{{
-                "type": "EffectZoneChoice",
-                "data": {{
-                    "player": 0,
-                    "cards": [],
-                    "count": 1,
-                    "source_id": 10,
-                    "effect_kind": "ChangeZone",
-                    "zone": "Hand",
-                    "destination": "Battlefield",
-                    {enters_under_slot}
-                    "count_param": 0
-                }}
-            }}"#
-        )
-    }
-
-    #[test]
-    fn effect_zone_choice_legacy_bool_true_deserializes_to_none() {
-        let json = effect_zone_choice_json(r#""under_your_control": true,"#);
-        let parsed: WaitingFor =
-            serde_json::from_str(&json).expect("legacy true should deserialize");
-        match parsed {
-            WaitingFor::EffectZoneChoice {
-                enters_under_player,
-                ..
-            } => assert_eq!(enters_under_player, None),
-            other => panic!("expected EffectZoneChoice, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn effect_zone_choice_legacy_bool_false_deserializes_to_none() {
-        let json = effect_zone_choice_json(r#""under_your_control": false,"#);
-        let parsed: WaitingFor =
-            serde_json::from_str(&json).expect("legacy false should deserialize");
-        match parsed {
-            WaitingFor::EffectZoneChoice {
-                enters_under_player,
-                ..
-            } => assert_eq!(enters_under_player, None),
-            other => panic!("expected EffectZoneChoice, got {other:?}"),
-        }
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_2938_deflecting_swat.rs
+++ b/crates/engine/tests/integration/issue_2938_deflecting_swat.rs
@@ -1,0 +1,197 @@
+//! Issue #2938 — Deflecting Swat must offer a retarget step for the targeted
+//! spell or ability (CR 115.7d), not silently resolve as a no-op `TargetOnly`.
+//!
+//! Root cause: `strip_optional_effect_prefix` in the effect-chain chunk loop
+//! stripped the leading "you may " from "you may choose new targets for …"
+//! without consulting the specialized-phrase blocklist that `peel_clause` uses.
+//! The peeled remainder failed `try_parse_change_targets` and fell through to
+//! the generic `choose` imperative, producing `TargetOnly { ParentTarget }`.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{
+    CastingVariant, RetargetScope, StackEntry, StackEntryKind, WaitingFor,
+};
+use engine::types::identifiers::CardId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const DEFLECTING_SWAT_ORACLE: &str =
+    "If you control a commander, you may cast this spell without paying its mana cost.\n\
+     You may choose new targets for target spell or ability.";
+
+const LIGHTNING_BOLT_ORACLE: &str = "Lightning Bolt deals 3 damage to any target.";
+
+fn add_mana(runner: &mut engine::game::scenario::GameRunner, player: PlayerId, mana: &[ManaType]) {
+    let dummy = engine::types::identifiers::ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == player)
+        .unwrap()
+        .mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+fn pass_priority_until<F>(runner: &mut engine::game::scenario::GameRunner, mut done: F)
+where
+    F: FnMut(&WaitingFor) -> bool,
+{
+    for _ in 0..32 {
+        if done(&runner.state().waiting_for) {
+            return;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("PassPriority must succeed while resolving Deflecting Swat");
+            }
+            other => panic!("unexpected wait state while driving resolution: {other:?}"),
+        }
+    }
+    panic!("priority loop exhausted before reaching expected wait state");
+}
+
+#[test]
+fn deflecting_swat_parses_change_targets_not_target_only() {
+    let parsed = parse_oracle_text(
+        DEFLECTING_SWAT_ORACLE,
+        "Deflecting Swat",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+
+    assert_eq!(parsed.abilities.len(), 1);
+    assert!(matches!(
+        parsed.abilities[0].effect.as_ref(),
+        Effect::ChangeTargets {
+            scope: RetargetScope::All,
+            forced_to: None,
+            ..
+        }
+    ));
+    assert!(
+        !parsed.abilities[0].optional,
+        "retarget is mandatory once Deflecting Swat resolves; optional=false"
+    );
+
+    let Effect::ChangeTargets { target, .. } = parsed.abilities[0].effect.as_ref() else {
+        unreachable!();
+    };
+    let TargetFilter::Or { filters } = target else {
+        panic!("expected Or(StackSpell, StackAbility), got {target:?}");
+    };
+    assert!(filters.contains(&TargetFilter::StackSpell));
+}
+
+#[test]
+fn deflecting_swat_retargets_opponent_spell_on_stack() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let victim = scenario.add_creature(P1, "Bear", 2, 2).id();
+    let redirect_host = scenario.add_creature(P0, "Goblin", 1, 1).id();
+    let swat = scenario
+        .add_spell_to_hand_from_oracle(P0, "Deflecting Swat", true, DEFLECTING_SWAT_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    add_mana(
+        &mut runner,
+        P0,
+        &[ManaType::Red, ManaType::Colorless, ManaType::Colorless],
+    );
+
+    // P1's Lightning Bolt already on the stack targeting the bear.
+    let bolt_parsed = parse_oracle_text(
+        LIGHTNING_BOLT_ORACLE,
+        "Lightning Bolt",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let bolt_ability = ResolvedAbility::new(
+        bolt_parsed.abilities[0].effect.as_ref().clone(),
+        vec![TargetRef::Object(victim)],
+        engine::types::identifiers::ObjectId(0),
+        P1,
+    );
+    let bolt_id = create_object(
+        runner.state_mut(),
+        CardId(77),
+        P1,
+        "Lightning Bolt".to_string(),
+        Zone::Stack,
+    );
+    {
+        let bolt_obj = runner.state_mut().objects.get_mut(&bolt_id).unwrap();
+        bolt_obj.card_types.core_types = vec![CoreType::Instant];
+    }
+    runner.state_mut().stack.push_back(StackEntry {
+        id: bolt_id,
+        source_id: bolt_id,
+        controller: P1,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(77),
+            ability: Some(bolt_ability),
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+
+    runner.cast(swat).target_objects(&[bolt_id]).commit();
+
+    pass_priority_until(&mut runner, |waiting| {
+        matches!(waiting, WaitingFor::RetargetChoice { .. })
+    });
+
+    let WaitingFor::RetargetChoice {
+        player,
+        stack_entry_index,
+        scope,
+        current_targets,
+        legal_new_targets,
+    } = &runner.state().waiting_for
+    else {
+        unreachable!();
+    };
+    assert_eq!(*player, P0);
+    assert!(matches!(scope, RetargetScope::All));
+    assert_eq!(current_targets, &vec![TargetRef::Object(victim)]);
+    assert!(
+        legal_new_targets.contains(&TargetRef::Object(redirect_host)),
+        "legal retarget set must include alternative creatures, got {legal_new_targets:?}"
+    );
+
+    let stack_index = *stack_entry_index;
+    runner
+        .act(GameAction::RetargetSpell {
+            new_targets: vec![TargetRef::Object(redirect_host)],
+        })
+        .expect("retarget submission must succeed");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+
+    let bolt_targets = runner
+        .state()
+        .stack
+        .get(stack_index)
+        .and_then(|e| e.ability())
+        .map(|a| a.targets.clone())
+        .expect("bolt still on stack");
+    assert_eq!(bolt_targets, vec![TargetRef::Object(redirect_host)]);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -132,6 +132,7 @@ mod issue_2430_shifting_woodland;
 mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
+mod issue_2938_deflecting_swat;
 mod issue_2940_krark_thumbless;
 mod issue_2941_vivien_reid;
 mod issue_2943_kayas_wrath;

--- a/docs/LEGACY-COMPAT.md
+++ b/docs/LEGACY-COMPAT.md
@@ -24,37 +24,14 @@ Each entry MUST include:
 
 ## Active shims
 
-### `LEGACY_DESER_ETB_CONTROLLER_2026Q2`
+_(none)_
 
-- **Covers:** the pre-2026-Q2 `under_your_control: bool` shape, lifted to
-  typed shapes at three layers per CR 110.2a:
-  - `Effect::ChangeZone.enters_under` (AST layer) — modern shape
-    `Option<ControllerRef>`.
-  - `PendingChangeZoneIteration.enters_under_player` (runtime carrier) —
-    modern shape `Option<PlayerId>`.
-  - `WaitingFor::EffectZoneChoice.enters_under_player` (interactive carrier) —
-    modern shape `Option<PlayerId>`.
-- **Compat deserializers:**
-  - `deserialize_enters_under_compat` — full fidelity for the AST field
-    (`Bool(true)` → `Some(ControllerRef::You)`, `false`/`null` → `None`).
-  - `deserialize_enters_under_player_compat` — best-effort for the runtime
-    carriers (`Bool(true)` → `None` + `tracing::warn`; `false`/`null` →
-    `None`). Legacy `true` cannot be perfectly reconstructed because the
-    PlayerId resolution requires the originating `AbilityDefinition` which
-    is unavailable at deserialization time. Falling back to `None`
-    matches the unshimmed behavior (owner control) and the warn provides
-    an audit trail for mid-prompt resumes that crossed the boundary.
-- All three fields use `#[serde(alias = "under_your_control")]` so legacy
-  on-disk payloads (IndexedDB resume, phase-server SQLite restore, P2P resume)
-  still parse.
-- **Added in:** 0.1.39 (AST lift, CR 110.2a); runtime-carrier compat extended
-  in the same release line before any version-bump past 0.1.39 ships.
-- **Removal trigger:** workspace version > 0.1.53. **Removal procedure:**
-  delete BOTH deserializers, all three `#[serde(alias = ..., deserialize_with
-  = ...)]` attributes, and the tripwire const. Mark this entry **REMOVED in
-  v\<X.Y.Z\>**.
-- **Source:** `crates/engine/src/types/ability.rs` — search the file for
-  `_LEGACY_DESER_ETB_CONTROLLER_2026Q2`. Field sites:
-  `Effect::ChangeZone.enters_under` (ability.rs),
-  `PendingChangeZoneIteration.enters_under_player` (game_state.rs),
-  `WaitingFor::EffectZoneChoice.enters_under_player` (game_state.rs).
+## Removed shims
+
+### `LEGACY_DESER_ETB_CONTROLLER_2026Q2` — REMOVED in v0.1.54
+
+- **Covers:** the pre-2026-Q2 `under_your_control: bool` shape at three layers
+  (`Effect::ChangeZone.enters_under`, `PendingChangeZoneIteration.enters_under_player`,
+  `WaitingFor::EffectZoneChoice.enters_under_player`).
+- **Added in:** 0.1.39.
+- **Removed in:** 0.1.54 — deserializers, serde aliases, and tripwire deleted.


### PR DESCRIPTION
## Summary

- Fix parser mis-parse of "you may choose new targets for target spell or ability" on Deflecting Swat: the effect-chain chunk loop stripped `you may ` via `strip_optional_effect_prefix` without consulting the specialized-phrase blocklist, so the clause became `TargetOnly { ParentTarget }` instead of `ChangeTargets`.
- Align `strip_optional_effect_prefix` with `peel_clause` by respecting `is_specialized_you_may_phrase` for retarget clauses.
- Add peeled-form support in `try_parse_change_targets` (`choose new targets for …`) as defense in depth.
- Improve `RetargetChoiceModal` for `RetargetScope::All` multi-target spells (per-slot selection).
- Add parser, peel, strip, oracle, and integration regression coverage for issue #2938.

Closes #2938

## Test plan

- [x] `cargo test -p engine --lib choose_new_targets`
- [x] `cargo test -p engine --lib deflecting_swat`
- [x] `cargo test -p engine --test integration issue_2938`
- [ ] Regenerate card data (`card-data` pipeline) so Deflecting Swat ships `ChangeTargets` in `card-data.json`
- [ ] Manual: cast Deflecting Swat on a targeted spell on the stack → retarget dialog appears → confirm new target updates the spell