### PR TITLE
ship/zone phase e t1

### DIFF
--- a/crates/engine/src/game/cipher.rs
+++ b/crates/engine/src/game/cipher.rs
@@ -101,7 +101,18 @@ pub fn finish_encode(
     creature_id: ObjectId,
     events: &mut Vec<GameEvent>,
 ) {
-    super::zones::move_to_zone(state, card_id, Zone::Exile, events);
+    // CR 702.99a + CR 614.6: the cipher card exiles itself on resolution. Route
+    // through the zone-change pipeline so a board-wide `Moved` "would be exiled →
+    // ... instead" redirect is consulted (none target Exile in the current pool —
+    // behavior-preserving today, future-proof per the single-entry principle).
+    // The card moves itself, attributed to its own object id. Exile/hand
+    // destinations carry no enters-with counters and no Exile-targeting Moved
+    // redirect exists, so this cannot pause — discard the always-`Done` result.
+    let _ = zone_pipeline::move_object(
+        state,
+        ZoneMoveRequest::effect(card_id, Zone::Exile, card_id),
+        events,
+    );
     add_encode_link(state, card_id, creature_id);
 }
 

--- a/crates/engine/src/game/cipher.rs
+++ b/crates/engine/src/game/cipher.rs
@@ -95,31 +95,35 @@ pub fn legal_encode_creatures(state: &GameState, player: PlayerId) -> Vec<Object
 /// the chosen creature. Caller has already validated `creature_id` is a legal
 /// "creature you control". The card moves graveyard-free from the stack to
 /// exile (the cipher static functions while the card is in exile, CR 702.99a).
-pub fn finish_encode(
+pub(crate) fn finish_encode(
     state: &mut GameState,
     card_id: ObjectId,
     creature_id: ObjectId,
     events: &mut Vec<GameEvent>,
-) {
+) -> ZoneMoveResult {
     // CR 702.99a + CR 614.6: the cipher card exiles itself on resolution. Route
     // through the zone-change pipeline so a board-wide `Moved` "would be exiled →
-    // ... instead" redirect is consulted (none target Exile in the current pool —
-    // behavior-preserving today, future-proof per the single-entry principle).
-    // The card moves itself, attributed to its own object id. Exile/hand
-    // destinations carry no enters-with counters and no Exile-targeting Moved
-    // redirect exists, so this cannot pause. Assert `Done` rather than discarding
-    // the result so that a future reachable pause (a Moved redirect into a pausing
-    // zone) trips tests instead of silently executing past a parked prompt.
+    // ... instead" redirect is consulted (none target Exile in the current pool
+    // today, but a future redirect could send the card elsewhere or surface a
+    // CR 616.1 ordering choice). The card moves itself, attributed to its own
+    // object id.
     let result = zone_pipeline::move_object(
         state,
         ZoneMoveRequest::effect(card_id, Zone::Exile, card_id),
         events,
     );
-    debug_assert!(
-        matches!(result, ZoneMoveResult::Done),
-        "cipher self-exile must not pause (no Exile-targeting redirect today)"
-    );
-    add_encode_link(state, card_id, creature_id);
+    // CR 702.99b: only record the encoded relationship once the card has
+    // actually landed in exile. A `NeedsChoice` pause leaves the move
+    // unresolved (the caller surfaces the parked prompt), and a `Moved` redirect
+    // could send the card to a different zone — in either case the card is not
+    // encoded, so the link must NOT be recorded. The redirect-safe zone check is
+    // the single guard that covers both cases.
+    if matches!(result, ZoneMoveResult::Done)
+        && state.objects.get(&card_id).map(|o| o.zone) == Some(Zone::Exile)
+    {
+        add_encode_link(state, card_id, creature_id);
+    }
+    result
 }
 
 /// CR 702.99a: Begin the on-resolution encode offer for a Cipher spell. Returns
@@ -149,10 +153,11 @@ pub fn begin_encode_choice(state: &mut GameState, card_id: ObjectId, controller:
 /// longer a legal host — declines, routing the card to its owner's graveyard
 /// (CR 608.2n). The chosen creature is re-validated against the current board.
 ///
-/// Returns the [`ZoneMoveResult`] of the decline move so the caller knows
-/// whether a CR 616.1 replacement-ordering choice parked a prompt (the declined
-/// card hit a graveyard→exile redirect) — the encode-accept path never pauses
-/// (exile is not a `Moved` redirect destination) and reports `Done`.
+/// Returns the [`ZoneMoveResult`] of the move so the caller knows whether a
+/// CR 616.1 replacement-ordering choice parked a prompt — either the declined
+/// card hit a graveyard→exile redirect, or (future-proof) the accepted card's
+/// self-exile hit an Exile-targeting redirect. No such Exile redirect exists in
+/// the current pool, so the accept path reports `Done` today.
 pub(crate) fn handle_encode_choice(
     state: &mut GameState,
     card_id: ObjectId,
@@ -163,10 +168,12 @@ pub(crate) fn handle_encode_choice(
     let chosen = creature
         .filter(|id| controller.is_some_and(|c| legal_encode_creatures(state, c).contains(id)));
     match chosen {
-        Some(creature_id) => {
-            finish_encode(state, card_id, creature_id, events);
-            ZoneMoveResult::Done
-        }
+        // CR 702.99a–b: the encode self-exile is normally non-pausing (no
+        // Exile-targeting `Moved` redirect exists today), but a future redirect
+        // could surface a CR 616.1 ordering choice — propagate `finish_encode`'s
+        // result so the caller surfaces the parked prompt instead of returning to
+        // priority mid-pause.
+        Some(creature_id) => finish_encode(state, card_id, creature_id, events),
         // CR 608.2n + CR 614.6: a declined cipher card is the resolving spell's
         // card being put into its owner's graveyard — route it through the
         // zone-change pipeline so a `Moved` graveyard→exile redirect (Rest in

--- a/crates/engine/src/game/cipher.rs
+++ b/crates/engine/src/game/cipher.rs
@@ -107,11 +107,17 @@ pub fn finish_encode(
     // behavior-preserving today, future-proof per the single-entry principle).
     // The card moves itself, attributed to its own object id. Exile/hand
     // destinations carry no enters-with counters and no Exile-targeting Moved
-    // redirect exists, so this cannot pause — discard the always-`Done` result.
-    let _ = zone_pipeline::move_object(
+    // redirect exists, so this cannot pause. Assert `Done` rather than discarding
+    // the result so that a future reachable pause (a Moved redirect into a pausing
+    // zone) trips tests instead of silently executing past a parked prompt.
+    let result = zone_pipeline::move_object(
         state,
         ZoneMoveRequest::effect(card_id, Zone::Exile, card_id),
         events,
+    );
+    debug_assert!(
+        matches!(result, ZoneMoveResult::Done),
+        "cipher self-exile must not pause (no Exile-targeting redirect today)"
     );
     add_encode_link(state, card_id, creature_id);
 }

--- a/crates/engine/src/game/cipher_tests.rs
+++ b/crates/engine/src/game/cipher_tests.rs
@@ -68,6 +68,66 @@ fn finish_encode_exiles_card_and_records_link() {
     assert_eq!(encoded_cards_on_creature(&state, host), vec![card]);
 }
 
+/// F-C (CR 702.99b + CR 614.1a): a `Moved` redirect that sends the cipher card
+/// somewhere other than exile must NOT record an encode link — the card is not
+/// encoded if it never lands in exile. Installs a SelfRef redirect on the card
+/// that turns its would-be exile into a graveyard move; the link must be absent.
+#[test]
+fn finish_encode_records_no_link_when_redirected_away_from_exile() {
+    use crate::types::ability::{AbilityDefinition, AbilityKind, ReplacementDefinition};
+    use crate::types::replacements::ReplacementEvent;
+    use crate::types::zones::EtbTapState;
+
+    let mut state = GameState::new_two_player(1);
+    let host = creature(&mut state, 1, PlayerId(0), "Host", Zone::Battlefield);
+    let card = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(0),
+        "Spell".to_string(),
+        Zone::Stack,
+    );
+    // SelfRef Moved redirect: when this card would be exiled, send it to the
+    // graveyard instead. `destination_zone(Exile)` gates the redirect to the
+    // cipher self-exile event.
+    state
+        .objects
+        .get_mut(&card)
+        .unwrap()
+        .replacement_definitions
+        .push(
+            ReplacementDefinition::new(ReplacementEvent::Moved)
+                .valid_card(TargetFilter::SelfRef)
+                .destination_zone(Zone::Exile)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::ChangeZone {
+                        origin: None,
+                        destination: Zone::Graveyard,
+                        target: TargetFilter::SelfRef,
+                        owner_library: false,
+                        enter_transformed: false,
+                        enters_under: None,
+                        enter_tapped: EtbTapState::Unspecified,
+                        enters_attacking: false,
+                        up_to: false,
+                        enter_with_counters: vec![],
+                        face_down_profile: None,
+                    },
+                )),
+        );
+
+    finish_encode(&mut state, card, host, &mut Vec::new());
+
+    // The redirect sent the card to the graveyard, not exile, so it is not
+    // encoded — no link recorded.
+    assert_eq!(state.objects[&card].zone, Zone::Graveyard);
+    assert!(
+        encoded_cards_on_creature(&state, host).is_empty(),
+        "no encode link may be recorded when the card was redirected away from exile"
+    );
+}
+
 /// CR 702.99c: the encode link drops when the card leaves exile.
 #[test]
 fn encode_link_drops_when_card_leaves_exile() {

--- a/crates/engine/src/game/effects/collect_evidence.rs
+++ b/crates/engine/src/game/effects/collect_evidence.rs
@@ -162,6 +162,11 @@ pub(crate) fn handle_choice(
     }
 
     for &id in chosen {
+        // Phase E tranche 2: collect-evidence exile is a COST payment
+        // (CR 701.59a) routed via `handle_choice`, which has no source object in
+        // scope (the paying spell/ability lives nested in `resume`). Migrating it
+        // needs `Cause::Cost` with the source extracted from the resume — left for
+        // the cost-payment tranche.
         super::super::zones::move_to_zone(state, id, Zone::Exile, events);
     }
 

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -571,6 +571,11 @@ fn apply_pending_counter_post_action(
                 duration.as_ref(),
                 exile_tracking,
                 drain,
+                // CR 701.24g: the counter-pause continuation never carries a
+                // library placement — library placements bear no enters-with
+                // counters and never enter the battlefield, so they never reach
+                // the counter-replacement pause that re-enters this tail.
+                None,
                 events,
             ) {
                 super::change_zone::ZoneDeliveryResult::Done => true,

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -571,10 +571,12 @@ fn apply_pending_counter_post_action(
                 duration.as_ref(),
                 exile_tracking,
                 drain,
-                // CR 701.24g: the counter-pause continuation never carries a
+                // CR 701.24a: the counter-pause continuation never carries a
                 // library placement — library placements bear no enters-with
                 // counters and never enter the battlefield, so they never reach
-                // the counter-replacement pause that re-enters this tail.
+                // the counter-replacement pause that re-enters this tail. (A
+                // placement is not a shuffle; the tail's auto-shuffle gate is moot
+                // here because this path never delivers to the library.)
                 None,
                 events,
             ) {

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -94,6 +94,8 @@ fn deliver_destruction_zone_change(
         source_id: source,
         exile_links: ExileLinkSpec::default(),
         drain: crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+        // Destroy delivers to the graveyard — never a library placement.
+        library_placement: None,
     };
     !matches!(
         zone_pipeline::deliver(state, approved, ctx, events),

--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -70,6 +70,8 @@ pub(crate) fn complete_discard_to_graveyard(
                 None,
                 false,
                 crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                // Discard delivers to the graveyard — no library placement.
+                None,
                 events,
             );
         }
@@ -229,6 +231,7 @@ pub fn resolve(
                                 None,
                                 false,
                                 crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                                None,
                                 events,
                             );
                             // CR 702.35: The card was still discarded — record and emit event
@@ -399,6 +402,7 @@ pub(crate) fn discard_as_cost_with_source(
                     None,
                     false,
                     crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                    None,
                     events,
                 );
                 crate::game::restrictions::record_discard(state, player);

--- a/crates/engine/src/game/effects/discover.rs
+++ b/crates/engine/src/game/effects/discover.rs
@@ -39,11 +39,17 @@ pub fn resolve(
         // CR 701.57a + CR 614.6: exile the card via the zone-change pipeline so a
         // board-wide `Moved` exile redirect is consulted (none target Exile today
         // — behavior-preserving, future-proof). No counters and no Exile-targeting
-        // Moved redirect means this cannot pause.
-        let _ = zone_pipeline::move_object(
+        // Moved redirect means this cannot pause. Assert `Done` rather than
+        // discarding the result so a future reachable pause trips tests instead of
+        // silently executing past a parked prompt.
+        let result = zone_pipeline::move_object(
             state,
             ZoneMoveRequest::effect(card_id, Zone::Exile, ability.source_id),
             events,
+        );
+        debug_assert!(
+            matches!(result, zone_pipeline::ZoneMoveResult::Done),
+            "discover exile-until-hit must not pause (no Exile-targeting redirect today)"
         );
 
         // Check if this is a nonland card with MV ≤ limit

--- a/crates/engine/src/game/effects/discover.rs
+++ b/crates/engine/src/game/effects/discover.rs
@@ -1,3 +1,4 @@
+use crate::game::zone_pipeline::{self, ZoneMoveRequest};
 use crate::game::{quantity, zones};
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::card_type::CoreType;
@@ -35,8 +36,15 @@ pub fn resolve(
 
     // CR 701.57a: Exile one at a time until hit or library exhausted
     for &card_id in &library {
-        // Move to exile
-        zones::move_to_zone(state, card_id, Zone::Exile, events);
+        // CR 701.57a + CR 614.6: exile the card via the zone-change pipeline so a
+        // board-wide `Moved` exile redirect is consulted (none target Exile today
+        // — behavior-preserving, future-proof). No counters and no Exile-targeting
+        // Moved redirect means this cannot pause.
+        let _ = zone_pipeline::move_object(
+            state,
+            ZoneMoveRequest::effect(card_id, Zone::Exile, ability.source_id),
+            events,
+        );
 
         // Check if this is a nonland card with MV ≤ limit
         let is_hit = state.objects.get(&card_id).is_some_and(|obj| {

--- a/crates/engine/src/game/effects/discover.rs
+++ b/crates/engine/src/game/effects/discover.rs
@@ -38,19 +38,20 @@ pub fn resolve(
     for &card_id in &library {
         // CR 701.57a + CR 614.6: exile the card via the zone-change pipeline so a
         // board-wide `Moved` exile redirect is consulted (none target Exile today
-        // — behavior-preserving, future-proof). No counters and no Exile-targeting
-        // Moved redirect means this cannot pause. Assert `Done` rather than
-        // discarding the result so a future reachable pause trips tests instead of
-        // silently executing past a parked prompt.
+        // — behavior-preserving, future-proof). CR 616.1: a future Exile-targeting
+        // redirect could surface an ordering choice mid-loop; park the prompt
+        // (mirrors `exile_from_top_until`'s NeedsChoice arm) and return rather than
+        // continuing to exile/classify the remaining cards past a parked prompt.
         let result = zone_pipeline::move_object(
             state,
             ZoneMoveRequest::effect(card_id, Zone::Exile, ability.source_id),
             events,
         );
-        debug_assert!(
-            matches!(result, zone_pipeline::ZoneMoveResult::Done),
-            "discover exile-until-hit must not pause (no Exile-targeting redirect today)"
-        );
+        if let zone_pipeline::ZoneMoveResult::NeedsChoice(player) = result {
+            state.waiting_for =
+                crate::game::replacement::replacement_choice_waiting_for(player, state);
+            return Ok(());
+        }
 
         // Check if this is a nonland card with MV ≤ limit
         let is_hit = state.objects.get(&card_id).is_some_and(|obj| {

--- a/crates/engine/src/game/effects/exile_top.rs
+++ b/crates/engine/src/game/effects/exile_top.rs
@@ -1,5 +1,5 @@
 use crate::game::quantity::resolve_quantity_with_targets;
-use crate::game::zones;
+use crate::game::zone_pipeline::{self, ZoneMoveRequest};
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
@@ -57,7 +57,17 @@ pub fn resolve(
     // `change_zone::resolve`, which likewise delegates publishing to the
     // chain processor.
     for object_id in top_cards {
-        zones::move_to_zone(state, object_id, Zone::Exile, events);
+        // CR 614.6: exile the top card via the zone-change pipeline so a
+        // board-wide `Moved` exile redirect is consulted (none target Exile today
+        // — behavior-preserving, future-proof). Exile-link tracking and the
+        // face-down mark stay in this caller's per-card epilogue below
+        // (`push_tracked_by_source` dedupes), so the move stays behavior-identical.
+        // No counters / no Exile-targeting Moved redirect means it cannot pause.
+        let _ = zone_pipeline::move_object(
+            state,
+            ZoneMoveRequest::effect(object_id, Zone::Exile, ability.source_id),
+            events,
+        );
         if track_exiled_by_source {
             crate::game::exile_links::push_tracked_by_source(state, object_id, ability.source_id);
         }

--- a/crates/engine/src/game/effects/exile_top.rs
+++ b/crates/engine/src/game/effects/exile_top.rs
@@ -59,18 +59,28 @@ pub fn resolve(
     for object_id in top_cards {
         // CR 614.6: exile the top card via the zone-change pipeline so a
         // board-wide `Moved` exile redirect is consulted (none target Exile today
-        // — behavior-preserving, future-proof). Exile-link tracking and the
-        // face-down mark stay in this caller's per-card epilogue below
-        // (`push_tracked_by_source` dedupes), so the move stays behavior-identical.
-        // No counters / no Exile-targeting Moved redirect means it cannot pause.
-        let _ = zone_pipeline::move_object(
-            state,
-            ZoneMoveRequest::effect(object_id, Zone::Exile, ability.source_id),
-            events,
-        );
+        // — behavior-preserving, future-proof). Exile-link tracking rides the
+        // pipeline's `.track_exiled_by_source()` builder so the link is recorded by
+        // the delivery tail ONLY if the card actually lands in exile — a `Moved`
+        // redirect that sends it elsewhere correctly records no link (redirect-
+        // safe), and the tail's `push_with_kind` keeps the per-turn rolling list in
+        // lockstep exactly as the former caller-side `push_tracked_by_source` did.
+        // No counters / no Exile-targeting Moved redirect means it cannot pause;
+        // assert `Done` rather than discarding the result so a future reachable
+        // pause trips tests instead of silently executing past a parked prompt.
+        let mut request = ZoneMoveRequest::effect(object_id, Zone::Exile, ability.source_id);
         if track_exiled_by_source {
-            crate::game::exile_links::push_tracked_by_source(state, object_id, ability.source_id);
+            request = request.track_exiled_by_source();
         }
+        let result = zone_pipeline::move_object(state, request, events);
+        debug_assert!(
+            matches!(result, zone_pipeline::ZoneMoveResult::Done),
+            "ExileTop must not pause (no Exile-targeting redirect today)"
+        );
+        // CR 406.3: The face-down mark stays in this caller's per-card epilogue —
+        // there is no pipeline knob for it (CR 708 face-down profiles are
+        // battlefield-only), so it is set directly after the move below.
+        //
         // CR 406.3: A card exiled face down can't be examined by any player
         // except when instructions allow it. Set the moved object's
         // face-down state immediately after the zone change (mirrors the

--- a/crates/engine/src/game/effects/exile_top.rs
+++ b/crates/engine/src/game/effects/exile_top.rs
@@ -65,18 +65,21 @@ pub fn resolve(
         // redirect that sends it elsewhere correctly records no link (redirect-
         // safe), and the tail's `push_with_kind` keeps the per-turn rolling list in
         // lockstep exactly as the former caller-side `push_tracked_by_source` did.
-        // No counters / no Exile-targeting Moved redirect means it cannot pause;
-        // assert `Done` rather than discarding the result so a future reachable
-        // pause trips tests instead of silently executing past a parked prompt.
+        // No Exile-targeting `Moved` redirect exists in the current pool, so this
+        // does not pause today. CR 616.1: a future Exile-targeting redirect could
+        // surface an ordering choice mid-loop; park the prompt (mirrors
+        // `exile_from_top_until`'s NeedsChoice arm) and return rather than
+        // continuing to mutate/classify the remaining cards past a parked prompt.
         let mut request = ZoneMoveRequest::effect(object_id, Zone::Exile, ability.source_id);
         if track_exiled_by_source {
             request = request.track_exiled_by_source();
         }
         let result = zone_pipeline::move_object(state, request, events);
-        debug_assert!(
-            matches!(result, zone_pipeline::ZoneMoveResult::Done),
-            "ExileTop must not pause (no Exile-targeting redirect today)"
-        );
+        if let zone_pipeline::ZoneMoveResult::NeedsChoice(player) = result {
+            state.waiting_for =
+                crate::game::replacement::replacement_choice_waiting_for(player, state);
+            return Ok(());
+        }
         // CR 406.3: The face-down mark stays in this caller's per-card epilogue —
         // there is no pipeline knob for it (CR 708 face-down profiles are
         // battlefield-only), so it is set directly after the move below.

--- a/crates/engine/src/game/effects/reveal_until.rs
+++ b/crates/engine/src/game/effects/reveal_until.rs
@@ -377,21 +377,20 @@ pub(crate) fn move_rest_then(
 
 /// Put cards on the bottom of the player's library in random order.
 //
-// Zone-pipeline bucketing: `move_to_library_position` is a library-placement
-// SIBLING raw mover (PLAN §0 / §5 "library-placement sibling treatment").
-// Migrating it onto `move_object`'s placement arm is gated on completing that
-// arm's consult (it is a Phase-A stub that delegates straight to
-// `move_to_library_at_index`, skipping the replacement consult). That completion
-// is DEFERRED: no `Moved` replacement in the card pool targets
-// `destination_zone(Library)` (verified: 25 Battlefield / 17 Graveyard / 2 Exile
-// destinations, zero Library; reproduce with
+// Phase E tranche 2: `move_to_library_position` is a library-placement SIBLING
+// raw mover that still bypasses `move_object`'s placement arm. W3 already
+// completed that arm's replacement consult and the placement-aware auto-shuffle
+// gate (CR 701.24a: a placement is not a shuffle), so migrating this caller is
+// now a mechanical lift, not the cross-cutting change the pre-W3 note feared.
+// It remains DEFERRED only because no `Moved` replacement in the card pool
+// targets `destination_zone(Library)` (verified: 31 Battlefield / 19 Graveyard /
+// 2 Exile destinations, plus the one synthetic Library def in the W3 test;
+// reproduce with
 //   rg -o 'destination_zone\(Zone::\w+\)' crates/engine/src | sort | uniq -c
-// — re-run before lifting this deferral), so the consult is a guaranteed no-op today, and
-// completing it correctly requires gating the CR 701.24a delivery-tail
-// auto-shuffle on placement-absence across the shared delivery signatures — a
-// cross-cutting change with a silent-randomization landmine for zero current
-// correctness gain. A library→bottom reposition is not "put into a
-// graveyard/exile/hand", so nothing is skipped by staying on the raw sibling.
+// — re-run before lifting), so routing through the consult is a guaranteed no-op
+// today. A library→bottom reposition is not "put into a graveyard/exile/hand",
+// so nothing is skipped by staying on the raw sibling. See the tranche-2 caller
+// list at `zone_pipeline::move_object`'s placement arm.
 fn shuffle_to_bottom(state: &mut GameState, cards: &[ObjectId], events: &mut Vec<GameEvent>) {
     let mut shuffled = cards.to_vec();
     shuffled.shuffle(&mut state.rng);

--- a/crates/engine/src/game/effects/ripple.rs
+++ b/crates/engine/src/game/effects/ripple.rs
@@ -1,4 +1,4 @@
-use crate::game::zones;
+use crate::game::zone_pipeline::{self, ZoneMoveRequest};
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{CastOfferKind, GameState, WaitingFor};
@@ -58,7 +58,18 @@ pub fn resolve(
             break;
         };
 
-        zones::move_to_zone(state, card_id, Zone::Exile, events);
+        // CR 702.60a + CR 614.6: reveal the top card by moving it to exile.
+        // Route through the zone-change pipeline so a board-wide `Moved` exile
+        // redirect is consulted — the raw mover never proposed the inner
+        // ZoneChange, so the redirect-aware check below (which expects the card
+        // may have landed elsewhere) had no Moved redirect to react to. No
+        // Exile-targeting Moved redirect exists in the current pool, so this is
+        // behavior-preserving today; no counters means it cannot pause.
+        let _ = zone_pipeline::move_object(
+            state,
+            ZoneMoveRequest::effect(card_id, Zone::Exile, ability.source_id),
+            events,
+        );
 
         // CR 614.1: a replacement may have redirected the card elsewhere; only
         // count it as revealed if it actually landed in exile.

--- a/crates/engine/src/game/effects/ripple.rs
+++ b/crates/engine/src/game/effects/ripple.rs
@@ -64,11 +64,17 @@ pub fn resolve(
         // ZoneChange, so the redirect-aware check below (which expects the card
         // may have landed elsewhere) had no Moved redirect to react to. No
         // Exile-targeting Moved redirect exists in the current pool, so this is
-        // behavior-preserving today; no counters means it cannot pause.
-        let _ = zone_pipeline::move_object(
+        // behavior-preserving today; no counters means it cannot pause. Assert
+        // `Done` rather than discarding the result so a future reachable pause
+        // trips tests instead of silently executing past a parked prompt.
+        let result = zone_pipeline::move_object(
             state,
             ZoneMoveRequest::effect(card_id, Zone::Exile, ability.source_id),
             events,
+        );
+        debug_assert!(
+            matches!(result, zone_pipeline::ZoneMoveResult::Done),
+            "ripple reveal-to-exile must not pause (no Exile-targeting redirect today)"
         );
 
         // CR 614.1: a replacement may have redirected the card elsewhere; only

--- a/crates/engine/src/game/effects/ripple.rs
+++ b/crates/engine/src/game/effects/ripple.rs
@@ -64,18 +64,20 @@ pub fn resolve(
         // ZoneChange, so the redirect-aware check below (which expects the card
         // may have landed elsewhere) had no Moved redirect to react to. No
         // Exile-targeting Moved redirect exists in the current pool, so this is
-        // behavior-preserving today; no counters means it cannot pause. Assert
-        // `Done` rather than discarding the result so a future reachable pause
-        // trips tests instead of silently executing past a parked prompt.
+        // behavior-preserving today. CR 616.1: a future Exile-targeting redirect
+        // could surface an ordering choice mid-reveal; park the prompt (mirrors
+        // `exile_from_top_until`'s NeedsChoice arm) and return rather than
+        // continuing to reveal the remaining cards past a parked prompt.
         let result = zone_pipeline::move_object(
             state,
             ZoneMoveRequest::effect(card_id, Zone::Exile, ability.source_id),
             events,
         );
-        debug_assert!(
-            matches!(result, zone_pipeline::ZoneMoveResult::Done),
-            "ripple reveal-to-exile must not pause (no Exile-targeting redirect today)"
-        );
+        if let zone_pipeline::ZoneMoveResult::NeedsChoice(player) = result {
+            state.waiting_for =
+                crate::game::replacement::replacement_choice_waiting_for(player, state);
+            return Ok(());
+        }
 
         // CR 614.1: a replacement may have redirected the card elsewhere; only
         // count it as revealed if it actually landed in exile.

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5270,6 +5270,8 @@ fn handle_play_land(
                         source_id: None,
                         exile_links: crate::game::zone_pipeline::ExileLinkSpec::default(),
                         drain: crate::types::game_state::PostReplacementDrainOwner::CallerEpilogue,
+                        // This resume delivery is not a library placement.
+                        library_placement: None,
                     },
                     events,
                 ) {

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -653,6 +653,7 @@ pub fn route_debug_create_to_battlefield(
                 None,
                 false,
                 crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                None,
                 &mut events,
             ) {
                 super::effects::change_zone::ZoneDeliveryResult::Done => {}

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -436,6 +436,9 @@ fn pay_top_library_exile_cost(
                 source_id,
                 exile_links: crate::game::zone_pipeline::ExileLinkSpec::default(),
                 drain: crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                // Cost-payment exile/sacrifice deliveries are never library
+                // placements.
+                library_placement: None,
             },
             events,
         ) {

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -576,9 +576,23 @@ pub(super) fn handle_replacement_choice(
 
             Ok(waiting_for)
         }
-        super::replacement::ReplacementResult::NeedsChoice(player) => Ok(
-            super::replacement::replacement_choice_waiting_for(player, state),
-        ),
+        super::replacement::ReplacementResult::NeedsChoice(player) => {
+            // CR 616.1 + CR 701.24a: a SECOND ordering choice on the same
+            // library-placement event re-parked a fresh `PendingReplacement`
+            // inside `pipeline_loop` with `library_placement: None`. Reapply the
+            // placement captured before `continue_replacement` consumed the prior
+            // record so the eventual delivery still honors the requested index
+            // instead of the tail auto-shuffling it away. `None` for every
+            // non-library parked event (no-op).
+            if let Some(pending) = state.pending_replacement.as_mut() {
+                if pending.library_placement.is_none() {
+                    pending.library_placement = parked_library_placement.clone();
+                }
+            }
+            Ok(super::replacement::replacement_choice_waiting_for(
+                player, state,
+            ))
+        }
         super::replacement::ReplacementResult::Prevented => {
             if state.pending_counter_additions.is_some() {
                 state.waiting_for = WaitingFor::Priority {

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -73,6 +73,15 @@ pub(super) fn handle_replacement_choice(
         .pending_replacement
         .as_ref()
         .is_some_and(|pending| matches!(pending.proposed, ProposedEvent::MoveCounter { .. }));
+    // CR 701.24a: capture the parked library placement (W3) BEFORE
+    // `continue_replacement` consumes (`.take()`s) the pending record, so the
+    // ZoneChange resume arm below can thread it into the delivery `DeliveryCtx`
+    // instead of hardcoding `None` (which would let the tail auto-shuffle the
+    // requested position away). `None` for every non-library parked event.
+    let parked_library_placement = state
+        .pending_replacement
+        .as_ref()
+        .and_then(|pending| pending.library_placement.clone());
     match super::replacement::continue_replacement(state, index, events) {
         super::replacement::ReplacementResult::Execute(event) => {
             let mut zone_change_object_id = None;
@@ -134,6 +143,11 @@ pub(super) fn handle_replacement_choice(
                             exile_links: crate::game::zone_pipeline::ExileLinkSpec::default(),
                             drain:
                                 crate::types::game_state::PostReplacementDrainOwner::CallerEpilogue,
+                            // CR 701.24a: thread the parked W3 library placement so
+                            // a resumed Library-targeting redirect lands at the
+                            // requested index instead of the tail auto-shuffling it
+                            // away. `None` for every non-library parked event.
+                            library_placement: parked_library_placement.clone(),
                         },
                         events,
                     ) {
@@ -1547,6 +1561,7 @@ mod tests {
             }],
             depth: 0,
             is_optional: false,
+            library_placement: None,
         });
         state.waiting_for = replacement_mod::replacement_choice_waiting_for(PlayerId(0), &state);
         state.priority_player = PlayerId(0);

--- a/crates/engine/src/game/haunt.rs
+++ b/crates/engine/src/game/haunt.rs
@@ -92,20 +92,28 @@ pub fn resolve(
     // CR 702.55a + CR 614.6: the haunting card is exiled from its graveyard.
     // Route through the zone-change pipeline so a board-wide `Moved` exile
     // redirect is consulted (none target Exile today — behavior-preserving,
-    // future-proof). Attributed to the card itself; no counters and no
-    // Exile-targeting Moved redirect means this cannot pause. Assert `Done` rather
-    // than discarding the result so a future reachable pause trips tests instead of
-    // silently executing past a parked prompt.
+    // future-proof). Attributed to the card itself.
     let result = zone_pipeline::move_object(
         state,
         ZoneMoveRequest::effect(card, Zone::Exile, card),
         events,
     );
-    debug_assert!(
-        matches!(result, zone_pipeline::ZoneMoveResult::Done),
-        "haunt self-exile must not pause (no Exile-targeting redirect today)"
-    );
-    add_haunt_link(state, card, creature);
+    // CR 616.1: a future Exile-targeting `Moved` redirect could surface an
+    // ordering choice. Park the prompt (mirrors `exile_from_top_until`'s
+    // NeedsChoice arm) and return without recording the link — the card is not
+    // yet in exile, so it is not haunting. The resume re-runs SBAs once the
+    // choice is made; the haunt link is recorded only when the card lands in
+    // exile (the zone check below is the single redirect-safe guard).
+    if let zone_pipeline::ZoneMoveResult::NeedsChoice(player) = result {
+        state.waiting_for = crate::game::replacement::replacement_choice_waiting_for(player, state);
+        return Ok(());
+    }
+    // CR 702.55b: record the haunt relationship only once the card has actually
+    // landed in exile. A `Moved` redirect could have sent it elsewhere, in which
+    // case it is not haunting and the link must NOT be recorded.
+    if state.objects.get(&card).map(|o| o.zone) == Some(Zone::Exile) {
+        add_haunt_link(state, card, creature);
+    }
     Ok(())
 }
 

--- a/crates/engine/src/game/haunt.rs
+++ b/crates/engine/src/game/haunt.rs
@@ -25,6 +25,7 @@
 //! when the haunted creature leaves the battlefield (so the payoff can read it
 //! at that moment) and pruned when the haunting card leaves exile.
 
+use super::zone_pipeline::{self, ZoneMoveRequest};
 use crate::types::ability::{Effect, EffectError, ResolvedAbility};
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
@@ -88,7 +89,16 @@ pub fn resolve(
         return Ok(());
     }
 
-    super::zones::move_to_zone(state, card, Zone::Exile, events);
+    // CR 702.55a + CR 614.6: the haunting card is exiled from its graveyard.
+    // Route through the zone-change pipeline so a board-wide `Moved` exile
+    // redirect is consulted (none target Exile today — behavior-preserving,
+    // future-proof). Attributed to the card itself; no counters and no
+    // Exile-targeting Moved redirect means this cannot pause.
+    let _ = zone_pipeline::move_object(
+        state,
+        ZoneMoveRequest::effect(card, Zone::Exile, card),
+        events,
+    );
     add_haunt_link(state, card, creature);
     Ok(())
 }

--- a/crates/engine/src/game/haunt.rs
+++ b/crates/engine/src/game/haunt.rs
@@ -93,11 +93,17 @@ pub fn resolve(
     // Route through the zone-change pipeline so a board-wide `Moved` exile
     // redirect is consulted (none target Exile today — behavior-preserving,
     // future-proof). Attributed to the card itself; no counters and no
-    // Exile-targeting Moved redirect means this cannot pause.
-    let _ = zone_pipeline::move_object(
+    // Exile-targeting Moved redirect means this cannot pause. Assert `Done` rather
+    // than discarding the result so a future reachable pause trips tests instead of
+    // silently executing past a parked prompt.
+    let result = zone_pipeline::move_object(
         state,
         ZoneMoveRequest::effect(card, Zone::Exile, card),
         events,
+    );
+    debug_assert!(
+        matches!(result, zone_pipeline::ZoneMoveResult::Done),
+        "haunt self-exile must not pause (no Exile-targeting redirect today)"
     );
     add_haunt_link(state, card, creature);
     Ok(())

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use crate::game::combat::AttackTarget;
 use crate::game::game_object::GameObject;
-use crate::game::zones;
+use crate::game::zone_pipeline::{self, ZoneMoveRequest};
 use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{AbilityCost, CastVariantPaid, NinjutsuVariant};
 use crate::types::events::GameEvent;
@@ -519,7 +519,18 @@ pub fn activate_ninjutsu(
     .map_err(|e| e.to_string())?;
 
     // 1. Return creature to owner's hand
-    zones::move_to_zone(state, creature_to_return, Zone::Hand, events);
+    // CR 702.49a + CR 614.6: ninjutsu returns the unblocked attacker to its
+    // owner's hand. Route through the zone-change pipeline so a board-wide
+    // `Moved` "would be put into a hand → ... instead" redirect is consulted
+    // (none target Hand in the current pool — behavior-preserving, future-proof
+    // per the single-entry principle). Attributed to the ninja entering the
+    // battlefield. Hand destination: no counters, no Hand-targeting Moved
+    // redirect, so this cannot pause — discard the always-`Done` result.
+    let _ = zone_pipeline::move_object(
+        state,
+        ZoneMoveRequest::effect(creature_to_return, Zone::Hand, ninjutsu_obj_id),
+        events,
+    );
 
     // Remove the returned creature from combat state if it was an attacker
     if let Some(combat) = state.combat.as_mut() {

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -520,16 +520,33 @@ pub fn activate_ninjutsu(
 
     // 1. Return creature to owner's hand
     // CR 702.49a + CR 614.6: ninjutsu returns the unblocked attacker to its
-    // owner's hand. Route through the zone-change pipeline so a board-wide
-    // `Moved` "would be put into a hand → ... instead" redirect is consulted
-    // (none target Hand in the current pool — behavior-preserving, future-proof
-    // per the single-entry principle). Attributed to the ninja entering the
-    // battlefield. Hand destination: no counters, no Hand-targeting Moved
-    // redirect, so this cannot pause — discard the always-`Done` result.
-    let _ = zone_pipeline::move_object(
+    // owner's hand. This return is part of the ninjutsu activation COST (CR
+    // 702.49a: "Return an unblocked attacking creature you control to its owner's
+    // hand" is one of the ability's costs), so the move is attributed via
+    // `ZoneMoveRequest::cost`, not `effect`.
+    //
+    // Route through the zone-change pipeline so a board-wide `Moved` "would leave
+    // the battlefield → ... instead" redirect is consulted. No DESTINATION-GATED
+    // (`destination_zone(Hand)`) Moved replacement exists in the current pool, but
+    // a `destination_zone: None` wildcard CAN match this battlefield→hand move:
+    // notably unearth (CR 702.84a, `database/unearth.rs`) installs a SelfRef
+    // "if it would leave the battlefield, exile it instead" redirect, so an
+    // unearthed attacker returned by ninjutsu is now correctly redirected to EXILE
+    // instead of hand (the raw mover this replaced silently violated CR 702.84a).
+    // The consult also future-proofs the site per the single-entry principle.
+    // Attributed to the ninja entering the battlefield. Hand destination has no
+    // counters, so a Hand-landing delivery cannot pause; a redirect to a
+    // non-pausing zone (exile) is likewise `Done`. Assert `Done` rather than
+    // discarding the result so a future reachable pause trips tests instead of
+    // silently executing past a parked prompt.
+    let return_result = zone_pipeline::move_object(
         state,
-        ZoneMoveRequest::effect(creature_to_return, Zone::Hand, ninjutsu_obj_id),
+        ZoneMoveRequest::cost(creature_to_return, Zone::Hand, ninjutsu_obj_id),
         events,
+    );
+    debug_assert!(
+        matches!(return_result, zone_pipeline::ZoneMoveResult::Done),
+        "ninjutsu return must not pause (Hand has no counters; redirects land in non-pausing zones today)"
     );
 
     // Remove the returned creature from combat state if it was an attacker
@@ -1480,6 +1497,62 @@ mod tests {
             attacker.zone,
             crate::types::zones::Zone::Hand,
             "Attacker should be returned to hand"
+        );
+    }
+
+    /// CR 702.84a + CR 702.49a + CR 614.6 (discriminating): an unearthed attacker
+    /// returned by ninjutsu must be redirected to EXILE, not hand. Unearth installs
+    /// a SelfRef "if it would leave the battlefield, exile it instead of putting it
+    /// anywhere else" `Moved` replacement (`destination_zone: None` wildcard) — the
+    /// ninjutsu return (battlefield → hand) is a battlefield-exit, so the consult
+    /// fires and the attacker lands in exile. This pins the rules fix that
+    /// routing the ninjutsu return through `move_object`'s replacement consult
+    /// enables (the prior raw mover dropped to hand, silently violating CR 702.84a).
+    #[test]
+    fn unearthed_attacker_returned_by_ninjutsu_is_exiled_not_returned_to_hand() {
+        use crate::types::ability::{ReplacementDefinition, TargetFilter};
+        use crate::types::replacements::ReplacementEvent;
+        use crate::types::zones::EtbTapState;
+
+        let (mut state, attacker_id, ninja_id) = setup_ninjutsu_scenario();
+
+        // Install the unearth leaves-battlefield redirect on the attacker
+        // (mirrors `database/unearth.rs::leaves_battlefield_exile_step`): a
+        // SelfRef-bound `Moved` replacement with NO `destination_zone` gate, so it
+        // matches any battlefield-exit including this battlefield → hand return.
+        {
+            let attacker = state.objects.get_mut(&attacker_id).unwrap();
+            attacker.replacement_definitions =
+                vec![ReplacementDefinition::new(ReplacementEvent::Moved)
+                    .valid_card(TargetFilter::SelfRef)
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Spell,
+                        Effect::ChangeZone {
+                            origin: Some(Zone::Battlefield),
+                            destination: Zone::Exile,
+                            target: TargetFilter::SelfRef,
+                            owner_library: false,
+                            enter_transformed: false,
+                            enters_under: None,
+                            enter_tapped: EtbTapState::Unspecified,
+                            enters_attacking: false,
+                            up_to: false,
+                            enter_with_counters: vec![],
+                            face_down_profile: None,
+                        },
+                    ))]
+                .into();
+        }
+
+        let mut events = Vec::new();
+        activate_ninjutsu(&mut state, PlayerId(0), ninja_id, attacker_id, &mut events)
+            .expect("activation should succeed");
+
+        let attacker = state.objects.get(&attacker_id).unwrap();
+        assert_eq!(
+            attacker.zone,
+            Zone::Exile,
+            "CR 702.84a: the unearth redirect must send the returned attacker to exile, not hand"
         );
     }
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4848,6 +4848,9 @@ fn pipeline_loop(
                     candidates,
                     depth,
                     is_optional: true,
+                    // CR 701.24a: set by the W3 library-placement arm after parking
+                    // (the pipeline doesn't know the caller's placement here).
+                    library_placement: None,
                 });
                 return ReplacementResult::NeedsChoice(affected);
             }
@@ -4875,6 +4878,8 @@ fn pipeline_loop(
                 candidates,
                 depth,
                 is_optional: false,
+                // CR 701.24a: set by the W3 library-placement arm after parking.
+                library_placement: None,
             });
             return ReplacementResult::NeedsChoice(affected);
         } else {
@@ -6266,6 +6271,7 @@ mod tests {
             }],
             depth: 0,
             is_optional: true,
+            library_placement: None,
         });
 
         let WaitingFor::ReplacementChoice {

--- a/crates/engine/src/game/sacrifice.rs
+++ b/crates/engine/src/game/sacrifice.rs
@@ -184,6 +184,8 @@ fn deliver_sacrifice_zone_change(
         source_id: None,
         exile_links: ExileLinkSpec::default(),
         drain: crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+        // Sacrifice delivers to the graveyard — never a library placement.
+        library_placement: None,
     };
     match zone_pipeline::deliver(state, approved, ctx, events) {
         ZoneDeliveryResult::Done => SacrificeApply::Complete,

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -585,6 +585,9 @@ fn check_lethal_damage(
                                     source_id: source,
                                     exile_links: ExileLinkSpec::default(),
                                     drain: crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                                    // SBA destroy/sacrifice deliveries target the
+                                    // graveyard — never a library placement.
+                                    library_placement: None,
                                 };
                                 // CR 704.3: completing all SBAs may require a
                                 // replacement choice surfaced by the delivery tail

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -784,6 +784,9 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                                     exile_links: zone_pipeline::ExileLinkSpec::default(),
                                     drain:
                                         crate::types::game_state::PostReplacementDrainOwner::CallerEpilogue,
+                                    // Spell resolution delivers to the battlefield
+                                    // or graveyard — never a library placement.
+                                    library_placement: None,
                                 },
                                 events,
                             ) {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -18146,6 +18146,7 @@ pub mod tests {
                     None,
                     false,
                     crate::types::game_state::PostReplacementDrainOwner::DeliveryTail,
+                    None,
                     events,
                 );
             }

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -490,39 +490,68 @@ pub(crate) fn move_object(
         }
     }
 
-    // Library-placement arm. A `Some(placement)` request delivers directly to the
-    // requested library index via the `move_to_library_at_index` primitive,
-    // skipping the replacement consult. Phase D wires the exempt pregame/debug
-    // library-bottom and debug top/Nth callers through here; the mulligan and
-    // debug call sites pass a placement and rely on this direct delivery.
+    // Library-placement arm (W3). A `Some(placement)` request lands the object at
+    // a specific library index instead of shuffling it in (CR 701.24g: a placement
+    // is not a shuffle).
     //
-    // DEFERRED (W3 / PLAN §3.5): running the consult on a library placement —
-    // "the consult should still run for future-proofing per the single-entry
-    // principle". It is a guaranteed no-op today: no `Moved` replacement in the
-    // card pool targets `destination_zone(Library)` (verified: 25 Battlefield /
-    // 17 Graveyard / 2 Exile destinations, zero Library; reproduce with
+    // For EXEMPT causes (pregame opening-hand bottoming, debug top/Nth) the
+    // consult is skipped — exactly as the raw `move_to_library_at_index` callers
+    // did before migration — and the object is placed directly. The unconditional
+    // CR 111.8 token / CR 400.7 cleanup guards live inside the primitive itself.
+    //
+    // For NON-EXEMPT causes the consult RUNS (W3 completion): a board-wide `Moved`
+    // "would be put into a library → ... instead" redirect (none exist in the
+    // current pool — behavior-preserving today; re-verify with
     //   rg -o 'destination_zone\(Zone::\w+\)' crates/engine/src | sort | uniq -c
-    // — re-run before lifting this deferral). Completing it correctly
-    // also requires gating the CR 701.24a delivery-tail auto-shuffle on
-    // placement-absence across the shared `deliver` / `deliver_replaced_zone_change`
-    // signatures (a library *placement* must NOT shuffle, but a plain
-    // library-destination ZoneChange MUST) — a cross-cutting change with a
-    // silent-randomization landmine for zero current correctness gain. The raw
-    // `move_to_library_position` / `_at_index` sibling production callers
-    // (put_on_top, cascade, discover, reveal_until, drawn_this_turn_choice,
-    // engine_resolution_choices) stay on the raw movers until that completion;
-    // they are library repositions with no Moved-redirect class to consult.
-    if let Some(position) = &req.placement {
+    // ) is honored. The delivered destination decides placement: if the redirect
+    // sent the object elsewhere, `deliver_replaced_zone_change` ignores the
+    // placement; if it still lands in the library, the object is placed at the
+    // requested index and the CR 701.24a auto-shuffle is suppressed.
+    if let Some(position) = req.placement.clone() {
         if req.to == Zone::Library {
-            let index = match position {
-                LibraryPosition::Top => Some(0),
-                LibraryPosition::Bottom => None,
-                // CR: `NthFromTop { n }` is 1-based ("second from the top" => n=2,
-                // index 1); `move_to_library_at_index` is 0-based.
-                LibraryPosition::NthFromTop { n } => Some(n.saturating_sub(1) as usize),
+            if req.cause.is_exempt() {
+                let index = match position {
+                    LibraryPosition::Top => Some(0),
+                    LibraryPosition::Bottom => None,
+                    // CR: `NthFromTop { n }` is 1-based ("second from the top" =>
+                    // n=2, index 1); `move_to_library_at_index` is 0-based.
+                    LibraryPosition::NthFromTop { n } => Some(n.saturating_sub(1) as usize),
+                };
+                zones::move_to_library_at_index(state, req.object_id, index, events);
+                return ZoneMoveResult::Done;
+            }
+            let source_id = req.source();
+            let proposed =
+                ProposedEvent::zone_change(req.object_id, from_zone, Zone::Library, source_id);
+            return match replacement::replace_event(state, proposed, events) {
+                ReplacementResult::Execute(event) => {
+                    match deliver_replaced_zone_change(
+                        state,
+                        event,
+                        source_id,
+                        req.exile_links.duration.as_ref(),
+                        matches!(
+                            req.exile_links.tracking,
+                            ZoneDeliveryExileTracking::TrackBySource
+                        ),
+                        PostReplacementDrainOwner::DeliveryTail,
+                        Some(position),
+                        events,
+                    ) {
+                        ZoneDeliveryResult::Done => ZoneMoveResult::Done,
+                        ZoneDeliveryResult::NeedsChoice(player) => {
+                            ZoneMoveResult::NeedsChoice(player)
+                        }
+                    }
+                }
+                ReplacementResult::Prevented => ZoneMoveResult::Done,
+                ReplacementResult::NeedsChoice(player) => {
+                    // CR 616.1: park at the single unparked origin (mirrors
+                    // `execute_zone_move`'s NeedsChoice arm) so the prompt surfaces.
+                    replacement::park_waiting_for(state, player);
+                    ZoneMoveResult::NeedsChoice(player)
+                }
             };
-            zones::move_to_library_at_index(state, req.object_id, index, events);
-            return ZoneMoveResult::Done;
         }
     }
 
@@ -904,6 +933,9 @@ pub(crate) fn deliver(
         ctx.exile_links.duration.as_ref(),
         track_exiled_by_source,
         ctx.drain,
+        // Bucket-A deliveries (destroy / sacrifice / SBA / land play) carry no
+        // library placement — those are graveyard / battlefield destinations.
+        None,
         events,
     )
 }
@@ -994,11 +1026,21 @@ pub(crate) fn apply_zone_delivery_tail(
     duration: Option<&Duration>,
     exile_tracking: ZoneDeliveryExileTracking,
     drain: PostReplacementDrainOwner,
+    // CR 701.24g: when a specific library position was requested, the object was
+    // placed at that index by the caller and the library is NOT shuffled — a
+    // placement is not a shuffle. `None` = plain library-destination ZoneChange,
+    // which DOES auto-shuffle per CR 701.24a. The counter-pause continuation
+    // (`ContinueZoneDeliveryTail`) never carries a placement: library placements
+    // bear no enters-with counters and never enter the battlefield, so they
+    // never reach the counter-replacement pause that re-enters this tail.
+    library_placement: Option<&LibraryPosition>,
     events: &mut Vec<GameEvent>,
 ) -> ZoneDeliveryResult {
     // CR 701.24a: To shuffle a library, randomize the cards within it so that
-    // no player knows their order.
-    if to == Zone::Library {
+    // no player knows their order. CR 701.24g: a request that places the object
+    // at a specific position is NOT a shuffle, so suppress the auto-shuffle when
+    // a `library_placement` was honored by the move above.
+    if to == Zone::Library && library_placement.is_none() {
         let owner = state.objects.get(&object_id).map(|o| o.owner);
         if let Some(owner) = owner {
             shuffle_library(state, owner, events);
@@ -1148,6 +1190,15 @@ pub(crate) fn apply_face_down_entry_profile(
 }
 
 /// Deliver a zone-change event that has already passed through replacement.
+///
+/// `library_placement` (CR 701.24g): when the event's delivered destination is
+/// the library AND a specific position was requested, the object is placed at
+/// that index and the library is NOT shuffled (a placement is not a shuffle).
+/// `None` = the zone-default placement, which auto-shuffles per CR 701.24a. A
+/// `Moved` replacement may have redirected the event to a non-library zone; the
+/// placement then has no effect (the index/shuffle gates both key on
+/// `to == Zone::Library`).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn deliver_replaced_zone_change(
     state: &mut GameState,
     event: ProposedEvent,
@@ -1155,6 +1206,7 @@ pub(crate) fn deliver_replaced_zone_change(
     duration: Option<&Duration>,
     track_exiled_by_source: bool,
     drain: PostReplacementDrainOwner,
+    library_placement: Option<LibraryPosition>,
     events: &mut Vec<GameEvent>,
 ) -> ZoneDeliveryResult {
     if let ProposedEvent::ZoneChange {
@@ -1228,7 +1280,27 @@ pub(crate) fn deliver_replaced_zone_change(
             })
             .flatten();
 
-        zones::move_to_zone(state, object_id, to, events);
+        // CR 701.24g: deliver to a specific library index when the event's
+        // destination is the library and a position was requested; otherwise the
+        // zone-default `move_to_zone` (which the tail then auto-shuffles per
+        // CR 701.24a). `move_to_library_at_index` performs the same full
+        // cross-zone cleanup (LKI, transform revert, layer pruning) as
+        // `move_to_zone` — it differs only in placing at an index instead of
+        // shuffling. A `Moved` redirect may have changed `to` away from Library,
+        // in which case the placement is inert and the default mover runs.
+        match (to, library_placement.as_ref()) {
+            (Zone::Library, Some(position)) => {
+                let index = match position {
+                    LibraryPosition::Top => Some(0),
+                    LibraryPosition::Bottom => None,
+                    // CR: `NthFromTop { n }` is 1-based ("second from the top"
+                    // => n=2, index 1); `move_to_library_at_index` is 0-based.
+                    LibraryPosition::NthFromTop { n } => Some(n.saturating_sub(1) as usize),
+                };
+                zones::move_to_library_at_index(state, object_id, index, events);
+            }
+            _ => zones::move_to_zone(state, object_id, to, events),
+        }
         // CR 400.7d: restore the cast link immediately after the entry reset —
         // BEFORE the face-down / counter blocks, so a counter-replacement pause
         // (CR 616.1) cannot strand the resumed permanent without its kicker /
@@ -1419,6 +1491,7 @@ pub(crate) fn deliver_replaced_zone_change(
             duration,
             exile_tracking,
             drain,
+            library_placement.as_ref(),
             events,
         );
     }
@@ -1637,6 +1710,10 @@ pub(crate) fn execute_zone_move(
                     duration,
                     track_exiled_by_source,
                     PostReplacementDrainOwner::DeliveryTail,
+                    // `execute_zone_move` carries no library placement (its
+                    // callers are battlefield/graveyard/exile moves); placements
+                    // route through `move_object`'s library arm directly.
+                    None,
                     events,
                 ) {
                     ZoneDeliveryResult::Done => {}
@@ -1668,6 +1745,7 @@ pub(crate) fn execute_zone_move(
                 duration,
                 track_exiled_by_source,
                 PostReplacementDrainOwner::DeliveryTail,
+                None,
                 events,
             ) {
                 ZoneDeliveryResult::Done => {}
@@ -1699,5 +1777,147 @@ pub(crate) fn execute_zone_move(
             replacement::park_waiting_for(state, player);
             ZoneMoveResult::NeedsChoice(player)
         }
+    }
+}
+
+#[cfg(test)]
+mod w3_library_placement_tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, ReplacementDefinition, TargetFilter,
+    };
+    use crate::types::identifiers::CardId;
+    use crate::types::replacements::ReplacementEvent;
+
+    /// Install a board-wide `Moved` replacement: "any object that would be put
+    /// into a library is exiled instead" (synthetic — no such card exists in the
+    /// pool today, which is why a non-exempt library placement was a guaranteed
+    /// no-op before W3). The redirect's destination is the match condition; the
+    /// `.execute(ChangeZone { destination: Exile })` is the lowered effect.
+    fn install_library_to_exile_redirect(state: &mut GameState) -> ObjectId {
+        let source = create_object(
+            state,
+            CardId(90001),
+            PlayerId(0),
+            "Library Exile Redirect".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&source).unwrap();
+        obj.replacement_definitions.push(
+            ReplacementDefinition::new(ReplacementEvent::Moved)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::ChangeZone {
+                        origin: None,
+                        destination: Zone::Exile,
+                        target: TargetFilter::Any,
+                        owner_library: false,
+                        enter_transformed: false,
+                        enters_under: None,
+                        enter_tapped: EtbTapState::Unspecified,
+                        enters_attacking: false,
+                        up_to: false,
+                        enter_with_counters: vec![],
+                        face_down_profile: None,
+                    },
+                ))
+                .destination_zone(Zone::Library),
+        );
+        source
+    }
+
+    /// W3 (CR 614.6): a NON-EXEMPT library placement now runs the replacement
+    /// consult. Before W3 the placement arm skipped `replace_event` and delivered
+    /// straight to the library index, so the redirect below was silently dropped
+    /// and the card landed in the library. With the consult running, the
+    /// board-wide "put into library → exile instead" redirect fires and the card
+    /// lands in EXILE — the discriminating behavior change.
+    #[test]
+    fn library_placement_consults_moved_redirect() {
+        let mut state = GameState::new_two_player(42);
+        let redirect_source = install_library_to_exile_redirect(&mut state);
+        let card = create_object(
+            &mut state,
+            CardId(90002),
+            PlayerId(0),
+            "Redirected Card".to_string(),
+            Zone::Graveyard,
+        );
+
+        let mut events = Vec::new();
+        let result = move_object(
+            &mut state,
+            ZoneMoveRequest::effect(card, Zone::Library, redirect_source)
+                .at_library_position(LibraryPosition::Top),
+            &mut events,
+        );
+
+        assert!(matches!(result, ZoneMoveResult::Done));
+        // The redirect sent the card to exile instead of the library.
+        assert_eq!(state.objects[&card].zone, Zone::Exile);
+        assert!(!state.players[0].library.contains(&card));
+    }
+
+    /// W3 (CR 701.24g): a NON-EXEMPT library placement with no redirect places the
+    /// object at the requested index and does NOT shuffle the library — a
+    /// placement is not a shuffle. Seeds a deterministic three-card library and
+    /// asserts the placed card lands on top with the existing order preserved.
+    #[test]
+    fn library_placement_does_not_shuffle() {
+        let mut state = GameState::new_two_player(42);
+        let a = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "A".to_string(),
+            Zone::Library,
+        );
+        let b = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "B".to_string(),
+            Zone::Library,
+        );
+        let c = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "C".to_string(),
+            Zone::Library,
+        );
+        // Deterministic order: [A, B, C] (index 0 = top).
+        state.players[0].library = crate::im::vector![a, b, c];
+
+        let placed = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Placed".to_string(),
+            Zone::Graveyard,
+        );
+        let mover = create_object(
+            &mut state,
+            CardId(5),
+            PlayerId(0),
+            "Mover".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut events = Vec::new();
+        let result = move_object(
+            &mut state,
+            ZoneMoveRequest::effect(placed, Zone::Library, mover)
+                .at_library_position(LibraryPosition::Top),
+            &mut events,
+        );
+
+        assert!(matches!(result, ZoneMoveResult::Done));
+        // Placed on top; the existing order is untouched (no shuffle).
+        assert_eq!(
+            state.players[0].library.iter().copied().collect::<Vec<_>>(),
+            vec![placed, a, b, c]
+        );
     }
 }

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -2110,4 +2110,197 @@ mod w3_library_placement_tests {
             "the resumed delivery must honor LibraryPosition::Top, not shuffle the position away"
         );
     }
+
+    /// F-A (CR 616.1 + CR 701.24a): the library placement must survive a SECOND
+    /// sequential park on the same event. The first optional redirect parks (the
+    /// placement is stashed onto `PendingReplacement` by the W3 arm); declining
+    /// it re-enters `pipeline_loop`, which finds a SECOND optional redirect that
+    /// became applicable in the interim and re-parks a fresh `PendingReplacement`
+    /// — created with `library_placement: None`. `handle_replacement_choice` must
+    /// thread the captured placement onto that re-park so the FINAL delivery
+    /// (after declining both) still places the card at the requested index
+    /// instead of the tail auto-shuffling it away.
+    ///
+    /// The second redirect is gated by `UnlessControlsMatching` on a sentinel
+    /// creature so it is suppressed on the first scan and becomes applicable once
+    /// the sentinel is removed between the two choices (a realistic board change
+    /// across a paused replacement). Before the fix the re-park reset the
+    /// placement to `None`, so the final delivery shuffled — the order assertion
+    /// below fails (and the `ShuffledLibrary` absence assertion guards against a
+    /// seed-identity permutation false-pass).
+    #[test]
+    fn library_placement_survives_two_sequential_parks() {
+        use crate::game::engine::apply_as_current;
+        use crate::types::ability::{
+            ReplacementCondition, ReplacementMode, TypeFilter, TypedFilter,
+        };
+        use crate::types::actions::GameAction;
+
+        fn optional_library_exile_redirect(
+            condition: Option<ReplacementCondition>,
+        ) -> ReplacementDefinition {
+            let mut def = ReplacementDefinition::new(ReplacementEvent::Moved)
+                .mode(ReplacementMode::Optional { decline: None })
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::ChangeZone {
+                        origin: None,
+                        destination: Zone::Exile,
+                        target: TargetFilter::Any,
+                        owner_library: false,
+                        enter_transformed: false,
+                        enters_under: None,
+                        enter_tapped: EtbTapState::Unspecified,
+                        enters_attacking: false,
+                        up_to: false,
+                        enter_with_counters: vec![],
+                        face_down_profile: None,
+                    },
+                ))
+                .destination_zone(Zone::Library);
+            if let Some(condition) = condition {
+                def = def.condition(condition);
+            }
+            def
+        }
+
+        let mut state = GameState::new_two_player(42);
+        let a = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "A".to_string(),
+            Zone::Library,
+        );
+        let b = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "B".to_string(),
+            Zone::Library,
+        );
+        state.players[0].library = crate::im::vector![a, b];
+
+        // Sentinel creature that suppresses the second redirect until removed.
+        let sentinel = create_object(
+            &mut state,
+            CardId(90010),
+            PlayerId(0),
+            "Sentinel".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&sentinel)
+            .unwrap()
+            .card_types
+            .core_types = vec![crate::types::card_type::CoreType::Creature];
+
+        // Redirect #1: always applicable. Redirect #2: suppressed while the
+        // controller controls a creature (the sentinel).
+        let r1 = create_object(
+            &mut state,
+            CardId(90004),
+            PlayerId(0),
+            "Redirect One".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&r1)
+            .unwrap()
+            .replacement_definitions
+            .push(optional_library_exile_redirect(None));
+
+        let r2 = create_object(
+            &mut state,
+            CardId(90005),
+            PlayerId(0),
+            "Redirect Two".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&r2)
+            .unwrap()
+            .replacement_definitions
+            .push(optional_library_exile_redirect(Some(
+                ReplacementCondition::UnlessControlsMatching {
+                    filter: TargetFilter::Typed(
+                        TypedFilter::new(TypeFilter::Creature)
+                            .controller(crate::types::ability::ControllerRef::You),
+                    ),
+                },
+            )));
+
+        let placed = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Placed".to_string(),
+            Zone::Graveyard,
+        );
+
+        let mut events = Vec::new();
+        let result = move_object(
+            &mut state,
+            ZoneMoveRequest::effect(placed, Zone::Library, placed)
+                .at_library_position(LibraryPosition::Top),
+            &mut events,
+        );
+
+        // Only redirect #1 applies (the sentinel suppresses #2), so this is a
+        // single-candidate optional park that stashes the placement.
+        let ZoneMoveResult::NeedsChoice(chooser) = result else {
+            panic!("expected the first optional redirect to park, got a non-pausing result");
+        };
+        assert_eq!(
+            state
+                .pending_replacement
+                .as_ref()
+                .and_then(|p| p.library_placement.clone()),
+            Some(LibraryPosition::Top),
+            "the first parked record must stash the requested library placement"
+        );
+
+        // Remove the sentinel so redirect #2 becomes applicable on the re-scan.
+        state.battlefield.retain(|id| *id != sentinel);
+        state.objects.remove(&sentinel);
+
+        // Decline the first redirect — the resume re-enters pipeline_loop, finds
+        // redirect #2 now applicable, and re-parks. Without the fix this re-park
+        // carries `library_placement: None`.
+        state.priority_player = chooser;
+        apply_as_current(&mut state, GameAction::ChooseReplacement { index: 1 })
+            .expect("resume first replacement choice");
+
+        assert!(
+            state.pending_replacement.is_some(),
+            "the second optional redirect must re-park after the sentinel is removed"
+        );
+        assert_eq!(
+            state
+                .pending_replacement
+                .as_ref()
+                .and_then(|p| p.library_placement.clone()),
+            Some(LibraryPosition::Top),
+            "the re-parked record must still carry the placement threaded from the first park",
+        );
+
+        // Decline the second redirect — the event resolves as the original plain
+        // library ZoneChange and delivers to the library at the requested index.
+        apply_as_current(&mut state, GameAction::ChooseReplacement { index: 1 })
+            .expect("resume second replacement choice");
+
+        // The discriminating assertion: the placed card must land at the requested
+        // top index with the existing order preserved. Before the fix the second
+        // park reset the placement to `None` and the delivery tail auto-shuffled
+        // the requested position away.
+        assert_eq!(state.objects[&placed].zone, Zone::Library);
+        assert_eq!(
+            state.players[0].library.iter().copied().collect::<Vec<_>>(),
+            vec![placed, a, b],
+            "after two declined parks the placement must still honor LibraryPosition::Top"
+        );
+    }
 }

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -23,8 +23,8 @@ use crate::types::ability::{
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    BatchCompletion, ExileLink, ExileLinkKind, GameState, PendingBatchDeliveries,
-    PendingCounterPostAction, PostReplacementDrainOwner, WaitingFor, ZoneDeliveryExileTracking,
+    BatchCompletion, ExileLinkKind, GameState, PendingBatchDeliveries, PendingCounterPostAction,
+    PostReplacementDrainOwner, WaitingFor, ZoneDeliveryExileTracking,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -405,6 +405,12 @@ pub(crate) struct DeliveryCtx {
     /// CR 614.12a: who drains `post_replacement_continuation` after this
     /// delivery (see [`PostReplacementDrainOwner`]).
     pub drain: PostReplacementDrainOwner,
+    /// CR 701.24a: the library placement to honor when the delivered destination
+    /// is the library. Threaded by the W3 resume path
+    /// (`handle_replacement_choice`) from the parked `PendingReplacement`;
+    /// `None` for every other `deliver` caller (a placement is not a shuffle, so
+    /// `None` means the tail's auto-shuffle convention applies).
+    pub library_placement: Option<LibraryPosition>,
 }
 
 /// CR 400.7d + CR 608.3: the cast-link family — information about the spell
@@ -491,8 +497,13 @@ pub(crate) fn move_object(
     }
 
     // Library-placement arm (W3). A `Some(placement)` request lands the object at
-    // a specific library index instead of shuffling it in (CR 701.24g: a placement
-    // is not a shuffle).
+    // a specific library index instead of shuffling it in: a placement instruction
+    // is not a shuffle instruction (CR 701.24a defines shuffling as randomizing the
+    // library so no player knows its order). The tail's auto-shuffle convention
+    // applies only to placement-less library deliveries. (CR 701.24g governs the
+    // different case where an effect instructs BOTH a shuffle and a placement
+    // simultaneously — the shuffle then happens with the object pinned at the
+    // requested position; that case is not this gate.)
     //
     // For EXEMPT causes (pregame opening-hand bottoming, debug top/Nth) the
     // consult is skipped — exactly as the raw `move_to_library_at_index` callers
@@ -506,7 +517,22 @@ pub(crate) fn move_object(
     // ) is honored. The delivered destination decides placement: if the redirect
     // sent the object elsewhere, `deliver_replaced_zone_change` ignores the
     // placement; if it still lands in the library, the object is placed at the
-    // requested index and the CR 701.24a auto-shuffle is suppressed.
+    // requested index and the tail's auto-shuffle is suppressed (CR 701.24a: a
+    // placement is not a shuffle).
+    //
+    // Phase E tranche 2: 11 raw library-position callers still bypass this consult
+    // by calling `zones::move_to_library_position` / `move_to_library_at_index`
+    // directly instead of routing through `move_object`'s placement arm. They are:
+    //   - engine_resolution_choices.rs (×5)
+    //   - reveal_until.rs:~400 (`shuffle_to_bottom`)
+    //   - drawn_this_turn_choice.rs:~114
+    //   - discover.rs:~103 (put-back of unhit cards)
+    //   - put_on_top.rs:~153 / ~158
+    //   - cascade.rs:~154 (bottom-in-random-order)
+    // Migrating each onto this arm is a guaranteed no-op today (zero pool
+    // `Moved` defs target the library) but pins the redirect consult for the
+    // future. Re-verify the census before lifting:
+    //   rg -o 'destination_zone\(Zone::\w+\)' crates/engine/src | sort | uniq -c
     if let Some(position) = req.placement.clone() {
         if req.to == Zone::Library {
             if req.cause.is_exempt() {
@@ -549,6 +575,19 @@ pub(crate) fn move_object(
                     // CR 616.1: park at the single unparked origin (mirrors
                     // `execute_zone_move`'s NeedsChoice arm) so the prompt surfaces.
                     replacement::park_waiting_for(state, player);
+                    // CR 701.24a: stash the requested library placement on the
+                    // parked record so the resume path
+                    // (`engine_replacement::handle_replacement_choice`) threads it
+                    // back into the delivery. Without this the resume hardcodes
+                    // `library_placement: None` and the delivery tail auto-shuffles,
+                    // randomizing the requested position away. Unreachable today (no
+                    // pool `Moved` def targets the library, so a placement consult
+                    // never reaches a choice), but threaded for correctness — see
+                    // the `library_placement_parked_resume_honors_position` unit
+                    // test for the synthetic-redirect coverage.
+                    if let Some(pending) = state.pending_replacement.as_mut() {
+                        pending.library_placement = Some(position);
+                    }
                     ZoneMoveResult::NeedsChoice(player)
                 }
             };
@@ -617,6 +656,10 @@ pub(crate) fn move_object(
                 source_id,
                 exile_links,
                 drain: PostReplacementDrainOwner::DeliveryTail,
+                // CR 701.24a: exempt LIBRARY placements were already delivered and
+                // returned by the placement arm above; any exempt cause reaching
+                // this generic delivery has no library placement to honor.
+                library_placement: None,
             },
             events,
         ) {
@@ -933,9 +976,12 @@ pub(crate) fn deliver(
         ctx.exile_links.duration.as_ref(),
         track_exiled_by_source,
         ctx.drain,
-        // Bucket-A deliveries (destroy / sacrifice / SBA / land play) carry no
-        // library placement — those are graveyard / battlefield destinations.
-        None,
+        // CR 701.24a: most `deliver` callers (bucket-A destroy / sacrifice / SBA /
+        // land play) carry no library placement — those are graveyard /
+        // battlefield destinations. The W3 resume path is the lone caller that
+        // threads a `Some(..)` here, so a parked Library-targeting redirect lands
+        // at the requested index instead of the tail auto-shuffling it away.
+        ctx.library_placement,
         events,
     )
 }
@@ -1026,10 +1072,11 @@ pub(crate) fn apply_zone_delivery_tail(
     duration: Option<&Duration>,
     exile_tracking: ZoneDeliveryExileTracking,
     drain: PostReplacementDrainOwner,
-    // CR 701.24g: when a specific library position was requested, the object was
-    // placed at that index by the caller and the library is NOT shuffled — a
-    // placement is not a shuffle. `None` = plain library-destination ZoneChange,
-    // which DOES auto-shuffle per CR 701.24a. The counter-pause continuation
+    // CR 701.24a: when a specific library position was requested, the object was
+    // placed at that index and the library is NOT shuffled — a placement
+    // instruction is not a shuffle instruction (CR 701.24a defines shuffling).
+    // `None` = plain library-destination ZoneChange, which the tail's auto-shuffle
+    // convention then randomizes. The counter-pause continuation
     // (`ContinueZoneDeliveryTail`) never carries a placement: library placements
     // bear no enters-with counters and never enter the battlefield, so they
     // never reach the counter-replacement pause that re-enters this tail.
@@ -1037,9 +1084,12 @@ pub(crate) fn apply_zone_delivery_tail(
     events: &mut Vec<GameEvent>,
 ) -> ZoneDeliveryResult {
     // CR 701.24a: To shuffle a library, randomize the cards within it so that
-    // no player knows their order. CR 701.24g: a request that places the object
-    // at a specific position is NOT a shuffle, so suppress the auto-shuffle when
-    // a `library_placement` was honored by the move above.
+    // no player knows their order. A request that places the object at a specific
+    // position is NOT a shuffle (a placement instruction is not a shuffle
+    // instruction), so suppress the tail's auto-shuffle convention when a
+    // `library_placement` was honored by the move above. (CR 701.24g — shuffle and
+    // placement instructed simultaneously, shuffle-with-object-pinned — is a
+    // different case that does not arise here.)
     if to == Zone::Library && library_placement.is_none() {
         let owner = state.objects.get(&object_id).map(|o| o.owner);
         if let Some(owner) = owner {
@@ -1048,6 +1098,10 @@ pub(crate) fn apply_zone_delivery_tail(
     }
     // Track cards exiled by the source. Some linked exiles return when the
     // source leaves; others are just remembered as "exiled with" the source.
+    // Route through `exile_links::push_with_kind` so the link is deduped on the
+    // `(exiled_id, source_id)` pair AND the per-turn `cards_exiled_with_source_
+    // this_turn` rolling list stays in lockstep — matching the behavior of callers
+    // that previously pushed via `push_tracked_by_source` (e.g. `ExileTop`).
     if to == Zone::Exile {
         if let Some(source_id) = cause.or(source_id) {
             let kind = match duration {
@@ -1059,11 +1113,7 @@ pub(crate) fn apply_zone_delivery_tail(
                 }
                 _ => return ZoneDeliveryResult::Done,
             };
-            state.exile_links.push(ExileLink {
-                exiled_id: object_id,
-                source_id,
-                kind,
-            });
+            crate::game::exile_links::push_with_kind(state, object_id, source_id, kind);
         }
     }
     // CR 614.12a: Drain mandatory replacement post-effects after the zone
@@ -1191,10 +1241,11 @@ pub(crate) fn apply_face_down_entry_profile(
 
 /// Deliver a zone-change event that has already passed through replacement.
 ///
-/// `library_placement` (CR 701.24g): when the event's delivered destination is
+/// `library_placement` (CR 701.24a): when the event's delivered destination is
 /// the library AND a specific position was requested, the object is placed at
-/// that index and the library is NOT shuffled (a placement is not a shuffle).
-/// `None` = the zone-default placement, which auto-shuffles per CR 701.24a. A
+/// that index and the library is NOT shuffled — a placement instruction is not a
+/// shuffle instruction (CR 701.24a defines shuffling). `None` = the zone-default
+/// placement, which the tail's auto-shuffle convention then randomizes. A
 /// `Moved` replacement may have redirected the event to a non-library zone; the
 /// placement then has no effect (the index/shuffle gates both key on
 /// `to == Zone::Library`).
@@ -1280,10 +1331,11 @@ pub(crate) fn deliver_replaced_zone_change(
             })
             .flatten();
 
-        // CR 701.24g: deliver to a specific library index when the event's
-        // destination is the library and a position was requested; otherwise the
-        // zone-default `move_to_zone` (which the tail then auto-shuffles per
-        // CR 701.24a). `move_to_library_at_index` performs the same full
+        // CR 701.24a: deliver to a specific library index when the event's
+        // destination is the library and a position was requested (a placement is
+        // not a shuffle); otherwise the zone-default `move_to_zone` (which the
+        // tail then auto-shuffles per CR 701.24a — shuffling = randomizing so no
+        // player knows the order). `move_to_library_at_index` performs the same full
         // cross-zone cleanup (LKI, transform revert, layer pruning) as
         // `move_to_zone` — it differs only in placing at an index instead of
         // shuffling. A `Moved` redirect may have changed `to` away from Library,
@@ -1859,10 +1911,12 @@ mod w3_library_placement_tests {
         assert!(!state.players[0].library.contains(&card));
     }
 
-    /// W3 (CR 701.24g): a NON-EXEMPT library placement with no redirect places the
-    /// object at the requested index and does NOT shuffle the library — a
-    /// placement is not a shuffle. Seeds a deterministic three-card library and
-    /// asserts the placed card lands on top with the existing order preserved.
+    /// W3 (CR 701.24a): a NON-EXEMPT library placement with no redirect places the
+    /// object at the requested index and does NOT shuffle the library — a placement
+    /// instruction is not a shuffle instruction (CR 701.24a defines shuffling).
+    /// Seeds a deterministic three-card library and asserts the placed card lands
+    /// on top with the existing order preserved AND that no shuffle event fired
+    /// (so a seed-identity permutation cannot false-pass).
     #[test]
     fn library_placement_does_not_shuffle() {
         let mut state = GameState::new_two_player(42);
@@ -1918,6 +1972,142 @@ mod w3_library_placement_tests {
         assert_eq!(
             state.players[0].library.iter().copied().collect::<Vec<_>>(),
             vec![placed, a, b, c]
+        );
+        // CR 701.24a robustness: assert no shuffle event fired. The order check
+        // above could false-pass under a seed-identity permutation; the absence of
+        // a `ShuffledLibrary` event proves the placement suppressed the tail's
+        // auto-shuffle convention rather than a shuffle merely landing on the same
+        // order.
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                GameEvent::PlayerPerformedAction {
+                    action: crate::types::events::PlayerActionKind::ShuffledLibrary,
+                    ..
+                }
+            )),
+            "a placement must not emit a shuffle event (CR 701.24a: a placement is not a shuffle)"
+        );
+    }
+
+    /// F1 (CR 701.24a): a library placement whose replacement consult PARKS on a
+    /// player choice must survive the park/resume round-trip — the resumed
+    /// delivery must place the object at the requested index, NOT let the tail
+    /// auto-shuffle the position away.
+    ///
+    /// Synthetic, because no pool `Moved` def targets the library, so a placement
+    /// consult never reaches a real choice today. Install an OPTIONAL library →
+    /// exile redirect: the optional accept/decline prompt forces `move_object` to
+    /// park (`NeedsChoice`); DECLINING (index 1) leaves the event as the original
+    /// plain library `ZoneChange`, so the resume delivers it to the library — and
+    /// must honor the parked `LibraryPosition::Top`. Before the placement was
+    /// threaded onto `PendingReplacement`, the resume hardcoded
+    /// `library_placement: None` and the tail shuffled the library, randomizing
+    /// the requested position.
+    #[test]
+    fn library_placement_parked_resume_honors_position() {
+        use crate::game::engine::apply_as_current;
+        use crate::types::ability::ReplacementMode;
+        use crate::types::actions::GameAction;
+
+        let mut state = GameState::new_two_player(42);
+        let a = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "A".to_string(),
+            Zone::Library,
+        );
+        let b = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "B".to_string(),
+            Zone::Library,
+        );
+        // Deterministic order [A, B] (index 0 = top).
+        state.players[0].library = crate::im::vector![a, b];
+
+        // Optional library→exile redirect (parks for the accept/decline choice).
+        let redirect_source = create_object(
+            &mut state,
+            CardId(90003),
+            PlayerId(0),
+            "Optional Library Redirect".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&redirect_source)
+            .unwrap()
+            .replacement_definitions
+            .push(
+                ReplacementDefinition::new(ReplacementEvent::Moved)
+                    .mode(ReplacementMode::Optional { decline: None })
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Spell,
+                        Effect::ChangeZone {
+                            origin: None,
+                            destination: Zone::Exile,
+                            target: TargetFilter::Any,
+                            owner_library: false,
+                            enter_transformed: false,
+                            enters_under: None,
+                            enter_tapped: EtbTapState::Unspecified,
+                            enters_attacking: false,
+                            up_to: false,
+                            enter_with_counters: vec![],
+                            face_down_profile: None,
+                        },
+                    ))
+                    .destination_zone(Zone::Library),
+            );
+
+        let placed = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Placed".to_string(),
+            Zone::Graveyard,
+        );
+
+        let mut events = Vec::new();
+        let result = move_object(
+            &mut state,
+            ZoneMoveRequest::effect(placed, Zone::Library, redirect_source)
+                .at_library_position(LibraryPosition::Top),
+            &mut events,
+        );
+
+        // The optional redirect parked the placement on a player choice.
+        let ZoneMoveResult::NeedsChoice(chooser) = result else {
+            panic!("expected the optional redirect to park, got a non-pausing result");
+        };
+        assert!(
+            state.pending_replacement.is_some(),
+            "the parked record must carry the placement for the resume to thread back"
+        );
+        assert_eq!(
+            state
+                .pending_replacement
+                .as_ref()
+                .and_then(|p| p.library_placement.clone()),
+            Some(LibraryPosition::Top),
+            "the parked record must stash the requested library placement"
+        );
+
+        // DECLINE the redirect (index 1) — the event resolves as the original
+        // plain library ZoneChange, so the resume delivers to the library.
+        state.priority_player = chooser;
+        apply_as_current(&mut state, GameAction::ChooseReplacement { index: 1 })
+            .expect("resume replacement choice");
+
+        // Placed at the requested top index; the existing order is preserved.
+        assert_eq!(state.objects[&placed].zone, Zone::Library);
+        assert_eq!(
+            state.players[0].library.iter().copied().collect::<Vec<_>>(),
+            vec![placed, a, b],
+            "the resumed delivery must honor LibraryPosition::Top, not shuffle the position away"
         );
     }
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6284,6 +6284,14 @@ pub struct PendingReplacement {
     /// `candidates` has exactly one entry (the real replacement); decline is synthetic.
     #[serde(default)]
     pub is_optional: bool,
+    /// CR 701.24a: the library placement requested by the original `move_object`
+    /// call whose replacement consult parked here (W3 library-placement arm only).
+    /// `Some` solely for a parked Library-targeting `ZoneChange`; the resume path
+    /// (`handle_replacement_choice`) threads it back into the delivery so the
+    /// object lands at the requested index instead of the tail auto-shuffling it
+    /// away. `None` for every other parked event (the common case).
+    #[serde(default)]
+    pub library_placement: Option<crate::types::ability::LibraryPosition>,
 }
 
 /// CR 703.4q + CR 616.1 + CR 614.1a: One step-end mana handler entry pending


### PR DESCRIPTION
- **Zone pipeline Phase E (C8/C9): route effect-driven hand/exile moves through move_object**
- **Zone pipeline Phase E (W3): consult Moved replacements on library placements with CR 701.24g shuffle gate**
- **Zone pipeline Phase E (tranche 1 review): thread library placement through parked resume + rules-correct ninjutsu/unearth**
