### PR TITLE
ship/cost payment phase4 delete paymentcost

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -15,12 +15,11 @@ use crate::types::ability::{
     ControllerRef, CopyRetargetPermission, CounterTriggerFilter, DamageKindFilter,
     DamageModification, DelayedTriggerCondition, Duration, Effect, EffectScope, FilterProp,
     KickerVariant, ManaContribution, ManaProduction, ModalSelectionCondition,
-    ModalSelectionConstraint, NinjutsuVariant, ObjectScope, ParsedCondition, PaymentCost,
-    PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
-    RenownSubject, ReplacementCondition, ReplacementDefinition, RuntimeHandler,
-    SearchSelectionConstraint, StaticCondition, StaticDefinition, TapStateChange,
-    TargetChoiceTiming, TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
-    UnlessPayModifier,
+    ModalSelectionConstraint, NinjutsuVariant, ObjectScope, ParsedCondition, PlayerFilter,
+    PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, RenownSubject,
+    ReplacementCondition, ReplacementDefinition, RuntimeHandler, SearchSelectionConstraint,
+    StaticCondition, StaticDefinition, TapStateChange, TargetChoiceTiming, TargetFilter,
+    TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
 };
 use crate::types::card::{CardFace, CardLayout, CleaveVariant};
 use crate::types::card_type::{CardType, CoreType, Supertype};
@@ -5645,9 +5644,8 @@ fn is_extort_trigger(t: &TriggerDefinition) -> bool {
                 && matches!(
                     &*a.effect,
                     Effect::PayCost {
-                        cost: PaymentCost::AbilityCost {
-                            cost: AbilityCost::Mana { cost },
-                        },
+                        cost: AbilityCost::Mana { cost },
+                        scale: None,
                         payer: TargetFilter::Controller,
                     } if is_extort_mana_cost(cost)
                 )
@@ -5789,11 +5787,10 @@ fn build_extort_trigger() -> TriggerDefinition {
     let execute = AbilityDefinition::new(
         AbilityKind::Spell,
         Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::Mana {
-                    cost: wb_mana.clone(),
-                },
+            cost: AbilityCost::Mana {
+                cost: wb_mana.clone(),
             },
+            scale: None,
             payer: TargetFilter::Controller,
         },
     )
@@ -13992,11 +13989,9 @@ mod extort_synthesis_tests {
         };
         assert!(execute.optional, "extort must be optional (may pay)");
         let Effect::PayCost {
-            cost:
-                PaymentCost::AbilityCost {
-                    cost: AbilityCost::Mana { cost },
-                },
+            cost: AbilityCost::Mana { cost },
             payer,
+            ..
         } = &*execute.effect
         else {
             panic!("extort must pay W/B via PayCost before draining");
@@ -14120,11 +14115,10 @@ mod extort_synthesis_tests {
         let execute = AbilityDefinition::new(
             AbilityKind::Spell,
             Effect::PayCost {
-                cost: PaymentCost::AbilityCost {
-                    cost: AbilityCost::Mana {
-                        cost: ManaCost::generic(1),
-                    },
+                cost: AbilityCost::Mana {
+                    cost: ManaCost::generic(1),
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
         )

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -8433,9 +8433,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         let mut ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: crate::types::ability::PaymentCost::Life {
+                cost: AbilityCost::PayLife {
                     amount: crate::types::ability::QuantityExpr::Fixed { value: 1 },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -8503,9 +8504,10 @@ mod tests {
 
         let ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: crate::types::ability::PaymentCost::Energy {
+                cost: AbilityCost::PayEnergy {
                     amount: QuantityExpr::Fixed { value: 3 },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -8562,9 +8564,10 @@ mod tests {
 
         let ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: crate::types::ability::PaymentCost::Energy {
+                cost: AbilityCost::PayEnergy {
                     amount: QuantityExpr::Fixed { value: 3 },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -8637,9 +8640,10 @@ mod tests {
         // Sanity check: the same flag DOES gate a PayCost parent.
         let pay_cost_parent = ResolvedAbility::new(
             Effect::PayCost {
-                cost: crate::types::ability::PaymentCost::Energy {
+                cost: AbilityCost::PayEnergy {
                     amount: QuantityExpr::Fixed { value: 3 },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -14928,18 +14932,17 @@ mod tests {
         .condition(AbilityCondition::effect_performed());
         let mut ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: crate::types::ability::PaymentCost::AbilityCost {
-                    cost: crate::types::ability::AbilityCost::Composite {
-                        costs: vec![
-                            crate::types::ability::AbilityCost::Mana {
-                                cost: ManaCost::generic(1),
-                            },
-                            crate::types::ability::AbilityCost::PayLife {
-                                amount: QuantityExpr::Fixed { value: 1 },
-                            },
-                        ],
-                    },
+                cost: crate::types::ability::AbilityCost::Composite {
+                    costs: vec![
+                        crate::types::ability::AbilityCost::Mana {
+                            cost: ManaCost::generic(1),
+                        },
+                        crate::types::ability::AbilityCost::PayLife {
+                            amount: QuantityExpr::Fixed { value: 1 },
+                        },
+                    ],
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -15017,9 +15020,10 @@ mod tests {
         .condition(AbilityCondition::effect_performed());
         let mut ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: crate::types::ability::PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: ManaCost::generic(1),
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -1,10 +1,9 @@
 use crate::game::costs::{self, PaymentOutcome};
-use crate::game::life_costs::{can_pay_life_cost, pay_life_as_cost, PayLifeCostResult};
+use crate::game::life_costs::can_pay_life_cost;
 use crate::game::quantity::resolve_quantity_with_targets;
-use crate::game::speed::{effective_speed, set_speed};
 use crate::game::targeting::resolve_effect_player_ref;
 use crate::game::{casting, casting_costs};
-use crate::types::ability::{AbilityCost, Effect, PaymentCost, QuantityExpr, QuantityRef};
+use crate::types::ability::{AbilityCost, Effect, QuantityExpr, QuantityRef};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, PayableResource, WaitingFor};
 use crate::types::mana::{ManaCost, ManaCostShard};
@@ -34,8 +33,8 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (cost, payer_filter) = match &ability.effect {
-        Effect::PayCost { cost, payer } => (cost, payer),
+    let (cost, scale, payer_filter) = match &ability.effect {
+        Effect::PayCost { cost, scale, payer } => (cost, scale, payer),
         _ => return Err(EffectError::MissingParam("PayCost".to_string())),
     };
     let Some(payer) = resolve_effect_player_ref(state, ability, payer_filter) else {
@@ -45,145 +44,101 @@ pub fn resolve(
     let mut payment_ability = ability.clone();
     payment_ability.controller = payer;
 
+    // CR 118.1 + CR 118.5: Per-object scaled mana cost (was
+    // `PaymentCost::ScaledMana`). `scale` is resolution-only metadata: the mana
+    // `cost` base (which may carry colored pips) is multiplied by `times`; when
+    // `times` resolves to 0 the scaled cost is `{0}` — paid trivially as a no-op
+    // SUCCESS (the empty selection IS the acknowledgment), never a payment
+    // failure. The concrete scaled `Mana` cost routes through the authority.
+    if let Some(times) = scale {
+        let AbilityCost::Mana { cost: base } = cost else {
+            return Err(EffectError::InvalidParam(
+                "PayCost.scale requires a Mana cost base".to_string(),
+            ));
+        };
+        let times = resolve_quantity_with_targets(state, times, &payment_ability).max(0);
+        let times = u32::try_from(times).unwrap_or(0);
+        let scaled = scale_mana_cost(base, times);
+        resolve_ability_cost_payment(
+            state,
+            &payment_ability,
+            payer,
+            &AbilityCost::Mana { cost: scaled },
+            events,
+        )?;
+        return Ok(());
+    }
+
     match cost {
-        PaymentCost::Mana { cost: mana_cost } => {
-            if payment_ability.chosen_x.is_none() && casting_costs::cost_has_x(mana_cost) {
-                let per_x = mana_x_shard_count(mana_cost);
-                let max = max_resolution_mana_x_value(state, payer, ability.source_id, mana_cost);
-                let max = trigger_event_amount(state).map_or(max, |amount| max.min(amount));
-                state.waiting_for = WaitingFor::PayAmountChoice {
-                    player: payer,
-                    resource: PayableResource::ManaGeneric { per_x },
-                    min: 0,
-                    max,
-                    accumulated: 0,
-                    source_id: ability.source_id,
-                    pending_mana_ability: None,
-                };
-                return Ok(());
-            }
-            if !casting::can_pay_effect_mana_cost_after_auto_tap(
-                state,
-                payer,
-                ability.source_id,
-                mana_cost,
-            ) {
-                state.cost_payment_failed_flag = true;
-                return Ok(());
-            }
-            if casting::pay_effect_mana_cost(state, payer, ability.source_id, mana_cost, events)
-                .is_err()
-            {
-                state.cost_payment_failed_flag = true;
-            }
+        // CR 107.3a + CR 601.2b: A resolution-time mana cost with an unannounced
+        // X (e.g. Well of Lost Dreams) prompts the payer for an amount before
+        // payment. This X-prompt stays adapter-side — the authority pays a
+        // concrete `Mana` cost only.
+        AbilityCost::Mana { cost: mana_cost }
+            if payment_ability.chosen_x.is_none() && casting_costs::cost_has_x(mana_cost) =>
+        {
+            let per_x = mana_x_shard_count(mana_cost);
+            let max = max_resolution_mana_x_value(state, payer, ability.source_id, mana_cost);
+            let max = trigger_event_amount(state).map_or(max, |amount| max.min(amount));
+            state.waiting_for = WaitingFor::PayAmountChoice {
+                player: payer,
+                resource: PayableResource::ManaGeneric { per_x },
+                min: 0,
+                max,
+                accumulated: 0,
+                source_id: ability.source_id,
+                pending_mana_ability: None,
+            };
         }
-        PaymentCost::Life { amount } => {
-            // CR 118.8 + CR 119.4 + CR 119.8: Paying life as an effect-embedded
-            // cost routes through the single-authority helper. Per CR 119.4 this
-            // IS a life-loss event, so the replacement pipeline fires and a
-            // CantLoseLife lock blocks the payment (cost unpayable). The amount
-            // is a `QuantityExpr` resolved here — dynamic refs like
-            // `Power { CostPaidObject }` resolve against the cost-paid /
-            // trigger-referenced object per CR 608.2k.
-            let amount = resolve_quantity_with_targets(state, amount, &payment_ability);
-            let amount = u32::try_from(amount.max(0)).unwrap_or(0);
-            match pay_life_as_cost(state, payer, amount, events) {
-                PayLifeCostResult::Paid { .. } => {}
-                PayLifeCostResult::InsufficientLife | PayLifeCostResult::Prohibited => {
-                    state.cost_payment_failed_flag = true;
-                }
-            }
-        }
-        PaymentCost::Speed { amount } => {
-            let amount = resolve_quantity_with_targets(state, amount, &payment_ability);
-            let amount = u8::try_from(amount.max(0)).unwrap_or(u8::MAX);
-            let current_speed = effective_speed(state, payer);
-            if amount <= current_speed {
-                set_speed(state, payer, Some(current_speed - amount), events);
-            } else {
-                state.cost_payment_failed_flag = true;
-            }
-        }
-        // CR 107.14: A player can pay {E} only if they have enough energy counters.
-        PaymentCost::Energy { amount } => {
-            // CR 107.1c + CR 107.14: "Pay any amount of {E}" — suspend the chain
-            // and surface a `PayAmountChoice` prompt. The sub-ability continuation
-            // machinery in `effects::mod` stashes the remainder of the chain;
-            // when the player submits the chosen amount (see
-            // `engine_resolution_choices::handle_resolution_choice`), the engine
-            // deducts energy, records the paid amount on `last_effect_count`
-            // (the fallback for `QuantityRef::EventContextAmount`), and drains
-            // the continuation so the subsequent "that much damage" effect
-            // reads the player's chosen value.
-            if is_pay_any_amount(amount) {
-                let max = state
-                    .players
-                    .iter()
-                    .find(|p| p.id == payer)
-                    .map(|p| p.energy)
-                    .unwrap_or(0);
-                state.waiting_for = WaitingFor::PayAmountChoice {
-                    player: payer,
-                    resource: PayableResource::Energy,
-                    min: 0,
-                    max,
-                    accumulated: 0,
-                    source_id: ability.source_id,
-                    pending_mana_ability: None,
-                };
-                return Ok(());
-            }
-            let amount = resolve_quantity_with_targets(state, amount, &payment_ability);
-            let amount = u32::try_from(amount.max(0)).unwrap_or(0);
-            let can_pay = state
+        // CR 107.1c + CR 107.14: "Pay any amount of {E}" — suspend the chain and
+        // surface a `PayAmountChoice` prompt. The sub-ability continuation
+        // machinery in `effects::mod` stashes the remainder of the chain; when
+        // the player submits the chosen amount (see
+        // `engine_resolution_choices::handle_resolution_choice`), the engine
+        // deducts energy, records the paid amount on `last_effect_count` (the
+        // fallback for `QuantityRef::EventContextAmount`), and drains the
+        // continuation so the subsequent "that much damage" effect reads the
+        // player's chosen value. This X-prompt stays adapter-side; the authority
+        // pays a concrete `PayEnergy` amount only.
+        AbilityCost::PayEnergy { amount } if is_pay_any_amount(amount) => {
+            let max = state
                 .players
                 .iter()
                 .find(|p| p.id == payer)
-                .is_some_and(|p| p.energy >= amount);
-            if can_pay {
-                if let Some(p) = state.players.iter_mut().find(|p| p.id == payer) {
-                    p.energy -= amount;
-                    events.push(GameEvent::EnergyChanged {
-                        player: payer,
-                        delta: -(amount as i32),
-                    });
-                }
-                // CR 107.1c: Record the paid amount for downstream chain steps
-                // that reference `QuantityRef::EventContextAmount` (e.g.
-                // "that much damage"). Uses the same fallback slot populated
-                // for "pay any amount of X" so fixed and variable pays are
-                // observationally uniform downstream.
-                state.last_effect_count = Some(amount as i32);
-            } else {
-                state.cost_payment_failed_flag = true;
-            }
+                .map(|p| p.energy)
+                .unwrap_or(0);
+            state.waiting_for = WaitingFor::PayAmountChoice {
+                player: payer,
+                resource: PayableResource::Energy,
+                min: 0,
+                max,
+                accumulated: 0,
+                source_id: ability.source_id,
+                pending_mana_ability: None,
+            };
         }
-        PaymentCost::AbilityCost { cost } => {
+        // CR 107.1c + CR 107.14: A fixed-amount energy payment routes through the
+        // authority, then stamps `last_effect_count` so downstream chain steps
+        // that reference `QuantityRef::EventContextAmount` (e.g. "deals that much
+        // damage") read the paid value. The stamping is resolution-scope adapter
+        // behavior the authority's `PayEnergy` arm does not carry.
+        AbilityCost::PayEnergy { amount } => {
+            let resolved = u32::try_from(
+                resolve_quantity_with_targets(state, amount, &payment_ability).max(0),
+            )
+            .unwrap_or(0);
             resolve_ability_cost_payment(state, &payment_ability, payer, cost, events)?;
+            if !state.cost_payment_failed_flag {
+                state.last_effect_count = Some(resolved as i32);
+            }
         }
-        // CR 118.1 + CR 118.5: Per-object scaled mana cost. The `base` cost
-        // (which may carry colored pips) is multiplied by `times`; when
-        // `times` resolves to 0 the scaled cost is `{0}` — paid trivially as a
-        // no-op SUCCESS (the empty selection IS the acknowledgment), never a
-        // payment failure.
-        PaymentCost::ScaledMana { base, times } => {
-            let times = resolve_quantity_with_targets(state, times, &payment_ability).max(0);
-            let times = u32::try_from(times).unwrap_or(0);
-            let scaled = scale_mana_cost(base, times);
-            if !casting::can_pay_effect_mana_cost_after_auto_tap(
-                state,
-                payer,
-                ability.source_id,
-                &scaled,
-            ) {
-                state.cost_payment_failed_flag = true;
-                return Ok(());
-            }
-            if casting::pay_effect_mana_cost(state, payer, ability.source_id, &scaled, events)
-                .is_err()
-            {
-                state.cost_payment_failed_flag = true;
-            }
+        // All other resolution-time cost shapes (Mana without X, PayLife,
+        // PaySpeed, Composite, Discard, …) route through the single payment
+        // authority. CR 119.4: paying life IS losing life (the replacement
+        // pipeline + CantLoseLife lock apply inside the authority's
+        // `pay_life_as_cost`).
+        _ => {
+            resolve_ability_cost_payment(state, &payment_ability, payer, cost, events)?;
         }
     }
     Ok(())
@@ -481,7 +436,8 @@ mod tests {
             generic: 2,
         };
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Mana { cost },
+            cost: AbilityCost::Mana { cost },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -499,7 +455,8 @@ mod tests {
             generic: 2,
         };
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Mana { cost },
+            cost: AbilityCost::Mana { cost },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -521,9 +478,10 @@ mod tests {
             expiry: None,
         });
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Mana {
+            cost: AbilityCost::Mana {
                 cost: ManaCost::generic(1),
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -546,9 +504,10 @@ mod tests {
         let unrestricted =
             create_colorless_source(&mut state, CardId(11), "Unrestricted Source", Vec::new());
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Mana {
+            cost: AbilityCost::Mana {
                 cost: ManaCost::generic(1),
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -571,12 +530,13 @@ mod tests {
             vec![ManaSpendRestriction::ActivateOnly],
         );
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Mana {
+            cost: AbilityCost::Mana {
                 cost: ManaCost::Cost {
                     shards: vec![ManaCostShard::X],
                     generic: 0,
                 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -595,9 +555,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].life = 20;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Life {
+            cost: AbilityCost::PayLife {
                 amount: crate::types::ability::QuantityExpr::Fixed { value: 3 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -617,9 +578,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].life = 2;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Life {
+            cost: AbilityCost::PayLife {
                 amount: crate::types::ability::QuantityExpr::Fixed { value: 3 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -639,11 +601,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].life = 20;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::PayLife {
-                    amount: QuantityExpr::Fixed { value: 4 },
-                },
+            cost: AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 4 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -666,11 +627,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].life = 3;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::PayLife {
-                    amount: QuantityExpr::Fixed { value: 4 },
-                },
+            cost: AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 4 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -693,21 +653,20 @@ mod tests {
             expiry: None,
         });
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::Composite {
-                    costs: vec![
-                        AbilityCost::Mana {
-                            cost: ManaCost::Cost {
-                                shards: vec![],
-                                generic: 1,
-                            },
+            cost: AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![],
+                            generic: 1,
                         },
-                        AbilityCost::PayLife {
-                            amount: QuantityExpr::Fixed { value: 3 },
-                        },
-                    ],
-                },
+                    },
+                    AbilityCost::PayLife {
+                        amount: QuantityExpr::Fixed { value: 3 },
+                    },
+                ],
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -731,11 +690,10 @@ mod tests {
             expiry: None,
         });
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::Mana {
-                    cost: ManaCost::generic(1),
-                },
+            cost: AbilityCost::Mana {
+                cost: ManaCost::generic(1),
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -761,11 +719,10 @@ mod tests {
             });
         }
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::ManaDynamic {
-                    quantity: QuantityExpr::Fixed { value: 2 },
-                },
+            cost: AbilityCost::ManaDynamic {
+                quantity: QuantityExpr::Fixed { value: 2 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -790,21 +747,20 @@ mod tests {
             expiry: None,
         });
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::Composite {
-                    costs: vec![
-                        AbilityCost::Mana {
-                            cost: ManaCost::Cost {
-                                shards: vec![],
-                                generic: 1,
-                            },
+            cost: AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![],
+                            generic: 1,
                         },
-                        AbilityCost::PayLife {
-                            amount: QuantityExpr::Fixed { value: 3 },
-                        },
-                    ],
-                },
+                    },
+                    AbilityCost::PayLife {
+                        amount: QuantityExpr::Fixed { value: 3 },
+                    },
+                ],
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -825,18 +781,17 @@ mod tests {
         state.players[0].life = 5;
         state.players[0].energy = 3;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::Composite {
-                    costs: vec![
-                        AbilityCost::PayLife {
-                            amount: QuantityExpr::Fixed { value: 1 },
-                        },
-                        AbilityCost::PayEnergy {
-                            amount: QuantityExpr::Fixed { value: 1 },
-                        },
-                    ],
-                },
+            cost: AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::PayLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                    },
+                    AbilityCost::PayEnergy {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                    },
+                ],
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -855,18 +810,17 @@ mod tests {
         state.players[0].life = 5;
         state.players[0].energy = 0;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::Composite {
-                    costs: vec![
-                        AbilityCost::PayLife {
-                            amount: QuantityExpr::Fixed { value: 1 },
-                        },
-                        AbilityCost::PayEnergy {
-                            amount: QuantityExpr::Fixed { value: 1 },
-                        },
-                    ],
-                },
+            cost: AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::PayLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                    },
+                    AbilityCost::PayEnergy {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                    },
+                ],
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -886,11 +840,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].energy = 5;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::PayEnergy {
-                    amount: QuantityExpr::Fixed { value: 5 },
-                },
+            cost: AbilityCost::PayEnergy {
+                amount: QuantityExpr::Fixed { value: 5 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -904,11 +857,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].energy = 4;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::AbilityCost {
-                cost: AbilityCost::PayEnergy {
-                    amount: QuantityExpr::Fixed { value: 5 },
-                },
+            cost: AbilityCost::PayEnergy {
+                amount: QuantityExpr::Fixed { value: 5 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -923,9 +875,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].energy = 3;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Energy {
+            cost: AbilityCost::PayEnergy {
                 amount: crate::types::ability::QuantityExpr::Fixed { value: 2 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -945,9 +898,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].energy = 1;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Energy {
+            cost: AbilityCost::PayEnergy {
                 amount: crate::types::ability::QuantityExpr::Fixed { value: 2 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -968,14 +922,13 @@ mod tests {
         let second = create_object(&mut state, CardId(11), PlayerId(0), "B".into(), Zone::Hand);
         let ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::AbilityCost {
-                    cost: AbilityCost::Discard {
-                        count: QuantityExpr::Fixed { value: 1 },
-                        filter: None,
-                        selection: crate::types::ability::CardSelectionMode::Chosen,
-                        self_scope: crate::types::ability::DiscardSelfScope::FromHand,
-                    },
+                cost: AbilityCost::Discard {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    filter: None,
+                    selection: crate::types::ability::CardSelectionMode::Chosen,
+                    self_scope: crate::types::ability::DiscardSelfScope::FromHand,
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -1021,14 +974,13 @@ mod tests {
         let second = create_object(&mut state, CardId(11), PlayerId(0), "B".into(), Zone::Hand);
         let ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::AbilityCost {
-                    cost: AbilityCost::Discard {
-                        count: QuantityExpr::Fixed { value: 1 },
-                        filter: None,
-                        selection: crate::types::ability::CardSelectionMode::Random,
-                        self_scope: crate::types::ability::DiscardSelfScope::FromHand,
-                    },
+                cost: AbilityCost::Discard {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    filter: None,
+                    selection: crate::types::ability::CardSelectionMode::Random,
+                    self_scope: crate::types::ability::DiscardSelfScope::FromHand,
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -1078,14 +1030,13 @@ mod tests {
         );
         let mut pay_ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::AbilityCost {
-                    cost: AbilityCost::Discard {
-                        count: QuantityExpr::Fixed { value: 1 },
-                        filter: None,
-                        selection: crate::types::ability::CardSelectionMode::Chosen,
-                        self_scope: crate::types::ability::DiscardSelfScope::FromHand,
-                    },
+                cost: AbilityCost::Discard {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    filter: None,
+                    selection: crate::types::ability::CardSelectionMode::Chosen,
+                    self_scope: crate::types::ability::DiscardSelfScope::FromHand,
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -1128,9 +1079,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].energy = 5;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Energy {
+            cost: AbilityCost::PayEnergy {
                 amount: crate::types::ability::QuantityExpr::Fixed { value: 3 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -1146,13 +1098,14 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].energy = 3;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Energy {
+            cost: AbilityCost::PayEnergy {
                 amount: crate::types::ability::QuantityExpr::Ref {
                     qty: crate::types::ability::QuantityRef::Variable {
                         name: "X".to_string(),
                     },
                 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -1231,13 +1184,14 @@ mod tests {
         );
         let mut pay_ability = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Energy {
+                cost: AbilityCost::PayEnergy {
                     amount: QuantityExpr::Ref {
                         qty: QuantityRef::Variable {
                             name: "X".to_string(),
                         },
                     },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![TargetRef::Object(target_id)],
@@ -1339,12 +1293,13 @@ mod tests {
         );
         let mut pay = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: ManaCost::Cost {
                         shards: vec![ManaCostShard::X],
                         generic: 0,
                     },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -1464,12 +1419,13 @@ mod tests {
         // IfYouDo Draw attached as `sub_ability`.
         let mut pay = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: ManaCost::Cost {
                         shards: vec![ManaCostShard::X],
                         generic: 0,
                     },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -1620,12 +1576,13 @@ mod tests {
 
         let mut pay = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: ManaCost::Cost {
                         shards: vec![ManaCostShard::X],
                         generic: 0,
                     },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -1726,12 +1683,13 @@ mod tests {
 
         let mut pay = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: ManaCost::Cost {
                         shards: vec![ManaCostShard::X],
                         generic: 0,
                     },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -1834,12 +1792,13 @@ mod tests {
 
         let mut pay = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: ManaCost::Cost {
                         shards: vec![ManaCostShard::X],
                         generic: 0,
                     },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -1927,12 +1886,13 @@ mod tests {
         );
         let mut pay = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: ManaCost::Cost {
                         shards: vec![ManaCostShard::X],
                         generic: 0,
                     },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],
@@ -2000,13 +1960,14 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.players[0].energy = 0;
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Energy {
+            cost: AbilityCost::PayEnergy {
                 amount: crate::types::ability::QuantityExpr::Ref {
                     qty: crate::types::ability::QuantityRef::Variable {
                         name: "X".to_string(),
                     },
                 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -2042,9 +2003,10 @@ mod tests {
         );
 
         let ability = make_ability(Effect::PayCost {
-            cost: PaymentCost::Life {
+            cost: AbilityCost::PayLife {
                 amount: crate::types::ability::QuantityExpr::Fixed { value: 3 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         });
         let mut events = Vec::new();
@@ -2095,12 +2057,13 @@ mod tests {
         );
         let mut pay = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: ManaCost::Cost {
                         shards: vec![ManaCostShard::X],
                         generic: 0,
                     },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -1,4 +1,4 @@
-use crate::game::costs::{self, PaymentOutcome};
+use crate::game::costs::{self, PaymentFailure, PaymentOutcome};
 use crate::game::life_costs::can_pay_life_cost;
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::game::targeting::resolve_effect_player_ref;
@@ -127,15 +127,20 @@ pub fn resolve(
                 resolve_quantity_with_targets(state, amount, &payment_ability).max(0),
             )
             .unwrap_or(0);
-            resolve_ability_cost_payment(state, &payment_ability, payer, cost, events)?;
-            if !state.cost_payment_failed_flag {
+            let outcome =
+                resolve_ability_cost_payment(state, &payment_ability, payer, cost, events)?;
+            // Gate the stamp on THIS payment's outcome, not the global
+            // `cost_payment_failed_flag` — a stale flag from an earlier effect
+            // must not suppress the stamp for a payment that succeeded.
+            if outcome == PaymentOutcome::Paid {
                 state.last_effect_count = Some(resolved as i32);
             }
         }
         // All other resolution-time cost shapes (Mana without X, PayLife,
         // PaySpeed, Composite, Discard, …) route through the single payment
-        // authority. CR 119.4: paying life IS losing life (the replacement
-        // pipeline + CantLoseLife lock apply inside the authority's
+        // authority. CR 119.4: paying life IS losing life; CR 119.8: a
+        // CantLoseLife lock therefore blocks the payment (the replacement
+        // pipeline + lock both apply inside the authority's
         // `pay_life_as_cost`).
         _ => {
             resolve_ability_cost_payment(state, &payment_ability, payer, cost, events)?;
@@ -177,33 +182,35 @@ fn resolve_ability_cost_payment(
     payer: PlayerId,
     cost: &AbilityCost,
     events: &mut Vec<GameEvent>,
-) -> Result<(), EffectError> {
+) -> Result<PaymentOutcome, EffectError> {
     // CR 601.2h: pre-gate the whole cost so a `Composite` never commits a
     // sub-cost before discovering a later sub-cost is unpayable. The
     // authority's `Failed` is the secondary guard for any drift between
     // affordability and payment.
     if !can_pay_resolution_ability_cost(state, ability, payer, cost) {
         state.cost_payment_failed_flag = true;
-        return Ok(());
+        return Ok(PaymentOutcome::Failed {
+            reason: PaymentFailure {
+                reason: "resolution-time cost not affordable (pre-gate)".to_string(),
+            },
+        });
     }
     match costs::pay_ability_cost_for_resolution(state, payer, cost, ability, events) {
-        Ok(PaymentOutcome::Paid) => {}
+        Ok(outcome @ PaymentOutcome::Paid) => Ok(outcome),
         // CR 616.1: a replacement-effect choice — or an interactive
         // `DiscardChoice` — interrupted payment. `state.waiting_for` is already
         // set by the authority; the resolution chain resumes from there.
-        Ok(PaymentOutcome::Paused { .. }) => {}
-        Ok(PaymentOutcome::Failed { .. }) => {
+        Ok(outcome @ PaymentOutcome::Paused { .. }) => Ok(outcome),
+        Ok(outcome @ PaymentOutcome::Failed { .. }) => {
             state.cost_payment_failed_flag = true;
+            Ok(outcome)
         }
         // An engine invariant violation (e.g. missing source object) surfaces
         // as an effect error rather than a silent payment failure.
-        Err(e) => {
-            return Err(EffectError::InvalidParam(format!(
-                "resolution-time cost payment failed: {e:?}"
-            )));
-        }
+        Err(e) => Err(EffectError::InvalidParam(format!(
+            "resolution-time cost payment failed: {e:?}"
+        ))),
     }
-    Ok(())
 }
 
 /// CR 118.3: A player can't pay a cost without having the necessary resources
@@ -852,6 +859,28 @@ mod tests {
         assert_eq!(state.players[0].energy, 0);
     }
 
+    /// A stale `cost_payment_failed_flag` left by an EARLIER effect must not
+    /// suppress the `last_effect_count` stamp for an energy payment that
+    /// succeeds — the stamp is gated on this payment's own `PaymentOutcome`,
+    /// not the global flag.
+    #[test]
+    fn resolution_pay_energy_stamps_count_despite_stale_failed_flag() {
+        let mut state = GameState::new_two_player(42);
+        state.players[0].energy = 5;
+        state.cost_payment_failed_flag = true;
+        let ability = make_ability(Effect::PayCost {
+            cost: AbilityCost::PayEnergy {
+                amount: QuantityExpr::Fixed { value: 5 },
+            },
+            scale: None,
+            payer: TargetFilter::Controller,
+        });
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert_eq!(state.players[0].energy, 0);
+        assert_eq!(state.last_effect_count, Some(5));
+    }
+
     #[test]
     fn resolution_pay_energy_fixed_amount_fails_when_insufficient() {
         let mut state = GameState::new_two_player(42);
@@ -868,6 +897,8 @@ mod tests {
         assert!(state.cost_payment_failed_flag);
         // No partial payment — energy unchanged.
         assert_eq!(state.players[0].energy, 4);
+        // CR 118.12: an unpaid cost must not feed "that much" downstream.
+        assert_eq!(state.last_effect_count, None);
     }
 
     #[test]

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::types::ability::{
-    ChoiceType, ChoiceValue, ChosenAttribute, Effect, EffectKind, PaymentCost, QuantityExpr,
+    AbilityCost, ChoiceType, ChoiceValue, ChosenAttribute, Effect, EffectKind, QuantityExpr,
     QuantityRef, ResolvedAbility, TargetRef,
 };
 use crate::types::actions::{GameAction, LearnOption, OutsideGameSelection};
@@ -3327,11 +3327,12 @@ fn route_kept_card_or_defer(
 fn starts_with_pay_amount_prompt(ability: &ResolvedAbility) -> bool {
     match &ability.effect {
         Effect::PayCost {
-            cost: PaymentCost::Mana { cost },
+            cost: AbilityCost::Mana { cost },
+            scale: None,
             ..
         } => casting_costs::cost_has_x(cost),
         Effect::PayCost {
-            cost: PaymentCost::Energy { amount },
+            cost: AbilityCost::PayEnergy { amount },
             ..
         } => matches!(
             amount,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5168,8 +5168,8 @@ pub mod tests {
         AggregateFunction, AttackersDeclaredCountSubject, CardSelectionMode, ChosenAttribute,
         ChosenSubtypeKind, CommanderOwnership, Comparator, ContinuousModification, ControllerRef,
         DelayedTriggerCondition, DiscardSelfScope, Duration, Effect, FilterProp, KickerVariant,
-        MultiTargetSpec, PaymentCost, PlayerFilter, PlayerScope, PtStat, PtValueScope,
-        QuantityExpr, QuantityRef, ResolvedAbility, SearchSelectionConstraint, SharedQuality,
+        MultiTargetSpec, PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr,
+        QuantityRef, ResolvedAbility, SearchSelectionConstraint, SharedQuality,
         SharedQualityRelation, StaticCondition, StaticDefinition, TargetFilter, TargetRef,
         TriggerCondition, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
     };
@@ -5767,18 +5767,17 @@ pub mod tests {
         let pay_then_draw = AbilityDefinition::new(
             AbilityKind::Spell,
             Effect::PayCost {
-                cost: PaymentCost::AbilityCost {
-                    cost: AbilityCost::Composite {
-                        costs: vec![
-                            AbilityCost::Mana {
-                                cost: ManaCost::generic(1),
-                            },
-                            AbilityCost::PayLife {
-                                amount: QuantityExpr::Fixed { value: 1 },
-                            },
-                        ],
-                    },
+                cost: AbilityCost::Composite {
+                    costs: vec![
+                        AbilityCost::Mana {
+                            cost: ManaCost::generic(1),
+                        },
+                        AbilityCost::PayLife {
+                            amount: QuantityExpr::Fixed { value: 1 },
+                        },
+                    ],
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
         )
@@ -21446,7 +21445,7 @@ mod push_first_contract_tests {
     use crate::game::effects::resolve_ability_chain;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityCondition, AbilityDefinition, AbilityKind, ControllerRef, Effect, PaymentCost,
+        AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, Effect,
         QuantityExpr, ResolvedAbility, TargetFilter, TargetRef, TriggerDefinition, TypedFilter,
     };
     use crate::types::actions::GameAction;
@@ -21730,9 +21729,10 @@ mod push_first_contract_tests {
         // Parent: pay {E}{E}{E}. On success the reflexive `WhenYouDo` fires.
         let parent = ResolvedAbility::new(
             Effect::PayCost {
-                cost: PaymentCost::Energy {
+                cost: AbilityCost::PayEnergy {
                     amount: QuantityExpr::Fixed { value: 3 },
                 },
+                scale: None,
                 payer: TargetFilter::Controller,
             },
             vec![],

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -26,8 +26,8 @@ use crate::parser::oracle_static::{
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, CategoryChooserScope, ChoiceType,
     Chooser, ContinuousModification, ControllerRef, CopyRetargetPermission, Duration, Effect,
-    EffectScope, FilterProp, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool, PaymentCost,
-    PlayerScope, PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
+    EffectScope, FilterProp, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool, PlayerScope,
+    PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
     SearchSelectionConstraint, StaticDefinition, TapStateChange, TargetFilter, TypeFilter,
     TypedFilter, ZoneOwner,
 };
@@ -5176,7 +5176,7 @@ fn parse_pay_life_amount(rest: &str) -> Option<QuantityExpr> {
     None
 }
 
-fn parse_mana_and_life_payment(rest_orig: &str) -> Option<PaymentCost> {
+fn parse_mana_and_life_payment(rest_orig: &str) -> Option<AbilityCost> {
     let (mana_cost, after_mana) = parse_mana_symbols(rest_orig.trim())?;
     let after_mana_lower = after_mana.to_lowercase();
     let (_, after_and) = nom_on_lower(after_mana, &after_mana_lower, |input| {
@@ -5187,13 +5187,11 @@ fn parse_mana_and_life_payment(rest_orig: &str) -> Option<PaymentCost> {
         .parse(input)
     })?;
     let amount = parse_pay_life_amount(after_and.trim_start())?;
-    Some(PaymentCost::AbilityCost {
-        cost: AbilityCost::Composite {
-            costs: vec![
-                AbilityCost::Mana { cost: mana_cost },
-                AbilityCost::PayLife { amount },
-            ],
-        },
+    Some(AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana { cost: mana_cost },
+            AbilityCost::PayLife { amount },
+        ],
     })
 }
 
@@ -5227,13 +5225,13 @@ pub(super) fn parse_cost_resource_ast(
         // nom combinators over the post-"pay " remainder.
         if let Some(amount) = parse_pay_life_amount(rest) {
             return Some(CostResourceImperativeAst::Pay {
-                cost: PaymentCost::Life { amount },
+                cost: AbilityCost::PayLife { amount },
             });
         }
         // CR 107.14: "pay any amount of {E}" → variable energy payment
         if let Ok((_, _)) = tag::<_, _, OracleError<'_>>("any amount of {e}").parse(rest) {
             return Some(CostResourceImperativeAst::Pay {
-                cost: PaymentCost::Energy {
+                cost: AbilityCost::PayEnergy {
                     amount: QuantityExpr::Ref {
                         qty: QuantityRef::Variable {
                             name: "X".to_string(),
@@ -5247,7 +5245,7 @@ pub(super) fn parse_cost_resource_ast(
         // following effect chain.
         if let Ok((_, _)) = tag::<_, _, OracleError<'_>>("any amount of mana").parse(rest) {
             return Some(CostResourceImperativeAst::Pay {
-                cost: PaymentCost::Mana {
+                cost: AbilityCost::Mana {
                     cost: crate::types::mana::ManaCost::Cost {
                         shards: vec![crate::types::mana::ManaCostShard::X],
                         generic: 0,
@@ -5265,12 +5263,12 @@ pub(super) fn parse_cost_resource_ast(
         {
             if let Some(amount) = super::parse_dynamic_energy_unless_cost(rest) {
                 return Some(CostResourceImperativeAst::Pay {
-                    cost: PaymentCost::Energy { amount },
+                    cost: AbilityCost::PayEnergy { amount },
                 });
             }
             // Fallback: variable energy payment
             return Some(CostResourceImperativeAst::Pay {
-                cost: PaymentCost::Energy {
+                cost: AbilityCost::PayEnergy {
                     amount: QuantityExpr::Ref {
                         qty: QuantityRef::Variable {
                             name: "X".to_string(),
@@ -5279,14 +5277,14 @@ pub(super) fn parse_cost_resource_ast(
                 },
             });
         }
-        // CR 107.14: "pay {E}", "pay {E}{E}", "pay N {E}" → PaymentCost::Energy
+        // CR 107.14: "pay {E}", "pay {E}{E}", "pay N {E}" → AbilityCost::PayEnergy
         if rest.contains("{e}") {
             let energy_count = rest.matches("{e}").count() as u32;
             let cleaned = rest.replace("{e}", "").replace(' ', "");
             if cleaned.is_empty() {
                 // Pure {E} symbols: "pay {e}{e}"
                 return Some(CostResourceImperativeAst::Pay {
-                    cost: PaymentCost::Energy {
+                    cost: AbilityCost::PayEnergy {
                         amount: QuantityExpr::Fixed {
                             value: energy_count as i32,
                         },
@@ -5298,17 +5296,17 @@ pub(super) fn parse_cost_resource_ast(
                 let prefix = rest.trim_end_matches("{e}").trim();
                 if let Ok((_, n)) = nom_primitives::parse_number.parse(prefix) {
                     return Some(CostResourceImperativeAst::Pay {
-                        cost: PaymentCost::Energy {
+                        cost: AbilityCost::PayEnergy {
                             amount: QuantityExpr::Fixed { value: n as i32 },
                         },
                     });
                 }
             }
         }
-        // "pay {2}{B}" → PaymentCost::Mana (CR 117.1)
+        // "pay {2}{B}" → AbilityCost::Mana (CR 117.1)
         if let Some((mana_cost, _)) = parse_mana_symbols(rest_orig.trim()) {
             return Some(CostResourceImperativeAst::Pay {
-                cost: PaymentCost::Mana { cost: mana_cost },
+                cost: AbilityCost::Mana { cost: mana_cost },
             });
         }
     }
@@ -5414,6 +5412,7 @@ pub(super) fn lower_cost_resource_ast(ast: CostResourceImperativeAst) -> Effect 
         }
         CostResourceImperativeAst::Pay { cost } => Effect::PayCost {
             cost,
+            scale: None,
             payer: TargetFilter::Controller,
         },
         CostResourceImperativeAst::DamageEffect(effect) => *effect,
@@ -9672,7 +9671,7 @@ mod tests {
         let text = "pay any amount of mana";
         let lower = text.to_lowercase();
         let Some(CostResourceImperativeAst::Pay {
-            cost: PaymentCost::Mana { cost },
+            cost: AbilityCost::Mana { cost },
         }) = parse_cost_resource_ast(text, &lower, &mut ParseContext::default())
         else {
             panic!("expected variable mana PayCost");

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -23,9 +23,9 @@ use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::effect_chain::{ClauseIr, EffectChainIr, SpecialClause};
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, AbilityKind, AttackScope, AttackSubject, Comparator,
-    ControllerRef, DamageSource, DelayedTriggerCondition, Duration, Effect, EffectScope,
-    FilterProp, MultiTargetSpec, ObjectScope, PaymentCost, PlayerFilter, PtValue, QuantityExpr,
+    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AttackScope, AttackSubject,
+    Comparator, ControllerRef, DamageSource, DelayedTriggerCondition, Duration, Effect,
+    EffectScope, FilterProp, MultiTargetSpec, ObjectScope, PlayerFilter, PtValue, QuantityExpr,
     QuantityRef, RoundingMode, StaticCondition, StaticDefinition, SubAbilityLink,
     TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
 };
@@ -4757,17 +4757,22 @@ pub(super) fn apply_where_x_effect_expression(
         // the sub-ability's "draw X cards"; without this arm the cost amount
         // stayed as the bare `Variable("X")` and decoupled from the resolved
         // expression.
-        Effect::PayCost { cost, .. } => match cost {
-            PaymentCost::Life { amount }
-            | PaymentCost::Speed { amount }
-            | PaymentCost::Energy { amount } => {
-                *amount = apply_where_x_quantity_expression(amount.clone(), where_x_expression);
-            }
-            PaymentCost::ScaledMana { times, .. } => {
+        Effect::PayCost { cost, scale, .. } => {
+            // CR 118.1 + CR 118.5: per-object scaled mana (`scale`) tracks the
+            // surrounding where-X binding before the cost amount itself.
+            if let Some(times) = scale {
                 *times = apply_where_x_quantity_expression(times.clone(), where_x_expression);
             }
-            PaymentCost::Mana { .. } | PaymentCost::AbilityCost { .. } => {}
-        },
+            match cost {
+                AbilityCost::PayLife { amount }
+                | AbilityCost::PaySpeed { amount }
+                | AbilityCost::PayEnergy { amount }
+                | AbilityCost::ManaDynamic { quantity: amount } => {
+                    *amount = apply_where_x_quantity_expression(amount.clone(), where_x_expression);
+                }
+                _ => {}
+            }
+        }
         Effect::GenericEffect {
             static_abilities, ..
         } => {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -92,9 +92,9 @@ use crate::types::ability::{
     ContinuousModification, ControllerRef, DamageModification, DamageSource,
     DelayedTriggerCondition, DoubleTarget, Duration, Effect, EffectScope, FilterProp,
     GameRestriction, IntensityScope, IterationKindBinding, ManaProduction, ManaSpendPermission,
-    MultiTargetSpec, ObjectProperty, ObjectScope, PaymentCost, PlayerFilter, PlayerRelation,
-    PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue, QuantityExpr,
-    QuantityRef, ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RoundingMode,
+    MultiTargetSpec, ObjectProperty, ObjectScope, PlayerFilter, PlayerRelation, PlayerScope,
+    PreventionAmount, PreventionScope, ProhibitedActivity, PtValue, QuantityExpr, QuantityRef,
+    ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RoundingMode,
     StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink, TapStateChange,
     TargetFilter, TargetSelectionMode, TriggerCondition, TriggerDefinition, TypeFilter,
     TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
@@ -3422,12 +3422,10 @@ fn try_parse_choose_and_pay_per_object(
     let pay_ability = AbilityDefinition::new(
         AbilityKind::Spell,
         Effect::PayCost {
-            cost: PaymentCost::ScaledMana {
-                base,
-                times: QuantityExpr::Ref {
-                    qty: QuantityRef::TrackedSetSize,
-                },
-            },
+            cost: AbilityCost::Mana { cost: base },
+            scale: Some(QuantityExpr::Ref {
+                qty: QuantityRef::TrackedSetSize,
+            }),
             payer: chooser.clone(),
         },
     );
@@ -18107,11 +18105,11 @@ mod tests {
     use super::*;
     use crate::parser::parse_oracle_text;
     use crate::types::ability::{
-        AbilityCondition, AggregateFunction, BounceSelection, CardTypeSetSource, CastVariantPaid,
-        ChoiceType, ChosenSubtypeKind, CombatRelation, CombatRelationSubject, Comparator,
-        ContinuousModification, ControllerRef, CopyRetargetPermission, CountScope, DoublePTMode,
-        Duration, FilterProp, LibraryPosition, LinkedExileScope, ManaContribution, ManaProduction,
-        ObjectProperty, ObjectScope, PaymentCost, PermissionGrantee, PlayerRelation,
+        AbilityCondition, AbilityCost, AggregateFunction, BounceSelection, CardTypeSetSource,
+        CastVariantPaid, ChoiceType, ChosenSubtypeKind, CombatRelation, CombatRelationSubject,
+        Comparator, ContinuousModification, ControllerRef, CopyRetargetPermission, CountScope,
+        DoublePTMode, Duration, FilterProp, LibraryPosition, LinkedExileScope, ManaContribution,
+        ManaProduction, ObjectProperty, ObjectScope, PermissionGrantee, PlayerRelation,
         PreventionScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
         SearchSelectionConstraint, SharedQuality, TargetChoiceTiming, TypeFilter, TypedFilter,
         ZoneRef,
@@ -18412,19 +18410,19 @@ mod tests {
         );
         // sub_ability: PayCost { ScaledMana { base: {4}, times: TrackedSetSize } }.
         let pay = clause.sub_ability.as_ref().expect("PayCost sub_ability");
-        let Effect::PayCost { cost, payer } = pay.effect.as_ref() else {
+        let Effect::PayCost { cost, scale, payer } = pay.effect.as_ref() else {
             panic!("expected PayCost, got {:?}", pay.effect);
         };
         assert_eq!(*payer, TargetFilter::TriggeringPlayer);
-        let PaymentCost::ScaledMana { base, times } = cost else {
-            panic!("expected ScaledMana, got {cost:?}");
+        let AbilityCost::Mana { cost: base } = cost else {
+            panic!("expected Mana base, got {cost:?}");
         };
         assert_eq!(*base, crate::types::mana::ManaCost::generic(4));
         assert_eq!(
-            *times,
-            QuantityExpr::Ref {
+            *scale,
+            Some(QuantityExpr::Ref {
                 qty: QuantityRef::TrackedSetSize
-            }
+            })
         );
     }
 
@@ -18440,11 +18438,12 @@ mod tests {
             .expect("Thelon's Curse main clause must parse");
         let pay = clause.sub_ability.as_ref().expect("PayCost sub_ability");
         let Effect::PayCost {
-            cost: PaymentCost::ScaledMana { base, .. },
+            cost: AbilityCost::Mana { cost: base },
+            scale: Some(_),
             ..
         } = pay.effect.as_ref()
         else {
-            panic!("expected PayCost {{ ScaledMana }}, got {:?}", pay.effect);
+            panic!("expected PayCost {{ Mana, scale }}, got {:?}", pay.effect);
         };
         assert_eq!(
             *base,
@@ -26942,7 +26941,7 @@ mod tests {
         assert!(matches!(
             e,
             Effect::PayCost {
-                cost: PaymentCost::Life {
+                cost: AbilityCost::PayLife {
                     amount: crate::types::ability::QuantityExpr::Fixed { value: 3 },
                 },
                 ..
@@ -26955,10 +26954,7 @@ mod tests {
         let e = parse_effect("pay {1} and 3 life");
         match e {
             Effect::PayCost {
-                cost:
-                    PaymentCost::AbilityCost {
-                        cost: crate::types::ability::AbilityCost::Composite { costs },
-                    },
+                cost: crate::types::ability::AbilityCost::Composite { costs },
                 ..
             } => {
                 assert_eq!(costs.len(), 2);
@@ -26993,7 +26989,7 @@ mod tests {
             matches!(
                 &e,
                 Effect::PayCost {
-                    cost: PaymentCost::Life {
+                    cost: AbilityCost::PayLife {
                         amount: crate::types::ability::QuantityExpr::Ref {
                             qty: crate::types::ability::QuantityRef::Power {
                                 scope: crate::types::ability::ObjectScope::Anaphoric,
@@ -27014,7 +27010,7 @@ mod tests {
         match &e {
             Effect::PayCost {
                 cost:
-                    PaymentCost::Life {
+                    AbilityCost::PayLife {
                         amount:
                             crate::types::ability::QuantityExpr::Ref {
                                 qty: crate::types::ability::QuantityRef::Variable { name },
@@ -37684,7 +37680,7 @@ mod tests {
             matches!(
                 e,
                 Effect::PayCost {
-                    cost: PaymentCost::Energy {
+                    cost: AbilityCost::PayEnergy {
                         amount: QuantityExpr::Fixed { value: 2 },
                     },
                     ..
@@ -37701,7 +37697,7 @@ mod tests {
             matches!(
                 e,
                 Effect::PayCost {
-                    cost: PaymentCost::Energy {
+                    cost: AbilityCost::PayEnergy {
                         amount: QuantityExpr::Fixed { value: 3 },
                     },
                     ..
@@ -43709,8 +43705,9 @@ mod tests {
             matches!(
                 &*def.effect,
                 Effect::PayCost {
-                    cost: PaymentCost::Mana { .. },
+                    cost: AbilityCost::Mana { .. },
                     payer: TargetFilter::Controller,
+                    ..
                 }
             ),
             "Outer effect must be PayCost {{ Mana, Controller }}, got {:?}",
@@ -43850,8 +43847,9 @@ mod tests {
             matches!(
                 &*def.effect,
                 Effect::PayCost {
-                    cost: PaymentCost::Mana { .. },
+                    cost: AbilityCost::Mana { .. },
                     payer: TargetFilter::Controller,
+                    ..
                 }
             ),
             "Outer effect must be PayCost {{ Mana, Controller }}, got {:?}",
@@ -43904,8 +43902,9 @@ mod tests {
         assert!(matches!(
             &*def.effect,
             Effect::PayCost {
-                cost: PaymentCost::Mana { .. },
+                cost: AbilityCost::Mana { .. },
                 payer: TargetFilter::Controller,
+                ..
             }
         ));
         assert_eq!(def.player_scope, Some(PlayerFilter::All));
@@ -43937,8 +43936,9 @@ mod tests {
         assert!(matches!(
             &*def.effect,
             Effect::PayCost {
-                cost: PaymentCost::Mana { .. },
+                cost: AbilityCost::Mana { .. },
                 payer: TargetFilter::Controller,
+                ..
             }
         ));
         assert_eq!(def.player_scope, Some(PlayerFilter::All));

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -2,10 +2,10 @@ use serde::Serialize;
 
 use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, ActivationRestriction, BounceSelection, CastingPermission,
-    ControllerRef, CounterSourceRider, Duration, Effect, FaceDownProfile, LibraryPosition,
-    ManaProduction, ManaSpendRestriction, ModalSelectionConstraint, OutsideGameSourcePool,
-    PaymentCost, PlayerFilter, PtStat, PtValue, QuantityExpr, SearchDestinationSplit,
+    AbilityCondition, AbilityCost, AbilityDefinition, ActivationRestriction, BounceSelection,
+    CastingPermission, ControllerRef, CounterSourceRider, Duration, Effect, FaceDownProfile,
+    LibraryPosition, ManaProduction, ManaSpendRestriction, ModalSelectionConstraint,
+    OutsideGameSourcePool, PlayerFilter, PtStat, PtValue, QuantityExpr, SearchDestinationSplit,
     SearchSelectionConstraint, StaticDefinition, TargetFilter,
 };
 use crate::types::card_type::Supertype;
@@ -1089,9 +1089,12 @@ pub(crate) enum CostResourceImperativeAst {
     /// in the CostResource AST (DamageSource, DamageEachPlayer, etc.).
     /// The Effect is already fully constructed by try_parse_damage.
     DamageEffect(Box<Effect>),
-    /// CR 118.1: "pay {cost}" as an effect verb (mana or life).
+    /// CR 118.1: "pay {cost}" as an effect verb (mana, life, energy, …).
+    /// Carries the unified `AbilityCost` taxonomy directly (lowered to
+    /// `Effect::PayCost { cost, scale: None, .. }`); this IR path never emits a
+    /// per-object scaled mana cost.
     Pay {
-        cost: PaymentCost,
+        cost: AbilityCost,
     },
 }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -13902,7 +13902,7 @@ mod tests {
     #[test]
     fn parse_ezio_damage_trigger_full_structure() {
         use crate::types::ability::{
-            AbilityCondition, Effect, PaymentCost, PlayerScope, QuantityExpr, QuantityRef,
+            AbilityCondition, AbilityCost, Effect, PlayerScope, QuantityExpr, QuantityRef,
         };
         use crate::types::mana::{ManaCost, ManaCostShard};
 
@@ -13955,9 +13955,9 @@ mod tests {
 
         // (d) Cost effect — PayCost { Mana { WUBRG }, payer: Controller }.
         match &*execute.effect {
-            Effect::PayCost { cost, payer } => {
+            Effect::PayCost { cost, payer, .. } => {
                 match cost {
-                    PaymentCost::Mana {
+                    AbilityCost::Mana {
                         cost: ManaCost::Cost { shards, generic },
                     } => {
                         assert_eq!(*generic, 0, "WUBRG cost has no generic component");
@@ -14037,7 +14037,7 @@ mod tests {
     #[test]
     fn parse_ezio_damage_trigger_verbatim_oracle_text() {
         use crate::types::ability::{
-            AbilityCondition, Effect, PaymentCost, PlayerScope, QuantityExpr, QuantityRef,
+            AbilityCondition, AbilityCost, Effect, PlayerScope, QuantityExpr, QuantityRef,
         };
         use crate::types::mana::{ManaCost, ManaCostShard};
 
@@ -14077,9 +14077,9 @@ mod tests {
         // (c) Cost effect — PayCost { Mana { WUBRG }, payer: Controller }.
         // The cost shape must be identical to the normalized form.
         match &*execute.effect {
-            Effect::PayCost { cost, payer } => {
+            Effect::PayCost { cost, payer, .. } => {
                 match cost {
-                    PaymentCost::Mana {
+                    AbilityCost::Mana {
                         cost: ManaCost::Cost { shards, generic },
                     } => {
                         assert_eq!(*generic, 0, "WUBRG cost has no generic component");
@@ -22394,7 +22394,7 @@ mod tests {
     /// and made Tymna draw all 12 of the player's permanents instead of 1).
     #[test]
     fn trigger_tymna_the_weaver_pays_and_draws_bound_x() {
-        use crate::types::ability::{Effect, PaymentCost, PlayerFilter, QuantityExpr, QuantityRef};
+        use crate::types::ability::{AbilityCost, Effect, PlayerFilter, QuantityExpr, QuantityRef};
 
         let def = parse_trigger_line(
             "At the beginning of each of your postcombat main phases, you may pay X life, \
@@ -22421,7 +22421,7 @@ mod tests {
         // CR 118.8 + CR 107.3i: pay-life cost amount carries the bound X.
         match execute.effect.as_ref() {
             Effect::PayCost {
-                cost: PaymentCost::Life { amount },
+                cost: AbilityCost::PayLife { amount },
                 ..
             } => assert_eq!(*amount, bound_qty, "pay-life cost amount must be bound X"),
             other => panic!("expected PayCost::Life, got {:?}", other),
@@ -25013,7 +25013,8 @@ mod tests {
         match &*execute.effect {
             Effect::PayCost {
                 payer,
-                cost: crate::types::ability::PaymentCost::Mana { cost },
+                cost: AbilityCost::Mana { cost },
+                ..
             } => {
                 assert_eq!(payer, &TargetFilter::TriggeringPlayer);
                 assert_eq!(cost, &crate::types::mana::ManaCost::generic(2));
@@ -25338,7 +25339,8 @@ mod tests {
         match &*execute.effect {
             Effect::PayCost {
                 payer,
-                cost: crate::types::ability::PaymentCost::Mana { cost },
+                cost: AbilityCost::Mana { cost },
+                ..
             } => {
                 assert_eq!(payer, &TargetFilter::Controller);
                 assert_eq!(cost, &crate::types::mana::ManaCost::generic(2));
@@ -25368,7 +25370,8 @@ mod tests {
         match &*execute.effect {
             Effect::PayCost {
                 payer,
-                cost: crate::types::ability::PaymentCost::Mana { cost },
+                cost: AbilityCost::Mana { cost },
+                ..
             } => {
                 assert_eq!(payer, &TargetFilter::Controller);
                 assert_eq!(cost, &crate::types::mana::ManaCost::generic(1));

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5747,14 +5747,19 @@ impl LegacyUnlessCost {
 /// - `Speed { amount }` → `PaySpeed { amount }`
 /// - `Energy { amount }` → `PayEnergy { amount }`
 /// - `AbilityCost { cost }` → `cost` (unwrap)
-/// - `ScaledMana { base, .. }` → `Mana { cost: base }` — the per-object `times`
-///   multiplier moved to the sibling `Effect::PayCost::scale` field, which a
-///   field-level deserializer cannot populate. `ScaledMana` is emitted only as
-///   a `Spell`-kind sub-ability that resolves in a single pass (it never pauses
-///   on a `PayAmountChoice`), so it is never persisted mid-resolution; the only
-///   legacy surface is `card-data.json`, which is regenerated in this phase and
-///   carries the modern `(Mana, scale)` shape. Mapping the base alone here is a
-///   safe best-effort for any stale artifact.
+/// - `ScaledMana { base, times }` → `Unimplemented` (deny, don't undercharge).
+///   The per-object `times` multiplier moved to the sibling
+///   `Effect::PayCost::scale` field, which a field-level deserializer cannot
+///   populate, so the multiplier is unrecoverable here. Mapping the base alone
+///   would silently undercharge (CR 118.1): a pre-Phase-4 save captured at a
+///   `ChooseObjectsSelection` prompt persists the stashed
+///   `PayCost { ScaledMana }` sub-ability inside
+///   `GameState::pending_continuation` (Magnetic Mountain–class, ~2 cards).
+///   Mapping to `Unimplemented` makes the authority fail the payment, so the
+///   CR 118.12 didn't-pay branch applies — rules-safer than charging `base`
+///   for an N-object effect. `card-data.json` is regenerated with the modern
+///   `(Mana, scale)` shape, so this fires only for saves crossing the
+///   pre→post-Phase-4 upgrade boundary.
 pub fn deserialize_pay_cost_compat<'de, D>(d: D) -> Result<AbilityCost, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -5786,7 +5791,8 @@ enum LegacyPaymentCost {
     // The legacy `times` field is intentionally omitted: serde ignores the
     // extra JSON key, and the per-object multiplier moved to the sibling
     // `Effect::PayCost::scale` field which a field-level deserializer cannot
-    // reach (see `deserialize_pay_cost_compat`). Only the mana `base` survives.
+    // reach (see `deserialize_pay_cost_compat`). The unrecoverable multiplier
+    // means this maps to `Unimplemented` (deny, don't undercharge).
     ScaledMana { base: ManaCost },
 }
 
@@ -5798,9 +5804,17 @@ impl LegacyPaymentCost {
             LegacyPaymentCost::Speed { amount } => AbilityCost::PaySpeed { amount },
             LegacyPaymentCost::Energy { amount } => AbilityCost::PayEnergy { amount },
             LegacyPaymentCost::AbilityCost { cost } => cost,
-            // The per-object `times` lives on the sibling `scale` field, which a
-            // field-level deserializer cannot reach; map the base alone.
-            LegacyPaymentCost::ScaledMana { base } => AbilityCost::Mana { cost: base },
+            // CR 118.1 + CR 118.12: the per-object `times` lives on the sibling
+            // `scale` field, which a field-level deserializer cannot reach.
+            // Deny rather than undercharge: `Unimplemented` fails the payment
+            // in the authority, taking the didn't-pay branch instead of
+            // charging `base` once for an N-object effect.
+            LegacyPaymentCost::ScaledMana { base } => AbilityCost::Unimplemented {
+                description: format!(
+                    "legacy ScaledMana PayCost from a pre-Phase-4 save (base {base:?}; \
+                     per-object multiplier unrecoverable)"
+                ),
+            },
         }
     }
 }
@@ -15942,6 +15956,45 @@ mod modal_ability_tests {
                 amount: QuantityExpr::Fixed { value: 1 }
             }
         );
+
+        // Legacy PaymentCost::Speed → AbilityCost::PaySpeed.
+        let legacy_speed = r#"{
+            "type": "PayCost",
+            "cost": { "type": "Speed", "amount": { "type": "Fixed", "value": 1 } }
+        }"#;
+        let effect: Effect = serde_json::from_str(legacy_speed).expect("legacy Speed must load");
+        let Effect::PayCost { cost, .. } = effect else {
+            panic!("expected PayCost");
+        };
+        assert_eq!(
+            cost,
+            AbilityCost::PaySpeed {
+                amount: QuantityExpr::Fixed { value: 1 }
+            }
+        );
+
+        // Legacy PaymentCost::ScaledMana (with the legacy `times` key present) →
+        // AbilityCost::Unimplemented: the per-object multiplier is unrecoverable
+        // by a field-level deserializer, so the mapping denies the payment
+        // (CR 118.12 didn't-pay branch) rather than undercharging `base` alone.
+        let legacy_scaled = r#"{
+            "type": "PayCost",
+            "cost": {
+                "type": "ScaledMana",
+                "base": { "type": "Cost", "shards": [], "generic": 4 },
+                "times": { "type": "Ref", "qty": { "type": "TrackedSetSize" } }
+            }
+        }"#;
+        let effect: Effect =
+            serde_json::from_str(legacy_scaled).expect("legacy ScaledMana must load");
+        let Effect::PayCost { cost, scale, .. } = effect else {
+            panic!("expected PayCost");
+        };
+        assert!(
+            matches!(cost, AbilityCost::Unimplemented { .. }),
+            "legacy ScaledMana must map to Unimplemented (deny, don't undercharge), got {cost:?}"
+        );
+        assert_eq!(scale, None);
 
         // Modern shape (unwrapped AbilityCost + explicit scale) still round-trips.
         let modern = Effect::PayCost {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4883,55 +4883,6 @@ pub enum ParsedCondition {
 }
 
 // ---------------------------------------------------------------------------
-// PaymentCost — cost paid during effect resolution (not activation)
-// ---------------------------------------------------------------------------
-
-/// CR 118.1: A cost paid as part of an effect's resolution.
-/// Distinct from AbilityCost (which gates activation before the colon).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum PaymentCost {
-    Mana {
-        cost: ManaCost,
-    },
-    /// CR 118.8 + CR 119.4: Pay life during effect resolution. Paying life IS losing
-    /// life — the replacement pipeline and `CantLoseLife` locks apply. `amount` is a
-    /// `QuantityExpr` so dynamic references (`"life equal to its power"`, `"X life"`,
-    /// `"life equal to the number of ..."`) compose through the same cost resolver
-    /// as a literal `"pay 2 life"`.
-    Life {
-        amount: QuantityExpr,
-    },
-    /// CR 118.3 + CR 702.179f: Pay speed during effect resolution.
-    Speed {
-        amount: QuantityExpr,
-    },
-    /// CR 107.14: Pay energy counters during effect resolution.
-    /// Distinct from `AbilityCost::PayEnergy` (activation cost before the colon).
-    Energy {
-        amount: QuantityExpr,
-    },
-    /// CR 118.1 + CR 118.12: Non-resource cost instructions paid while a spell or
-    /// ability resolves. Reuses the engine's existing `AbilityCost` taxonomy so
-    /// resolution-time costs such as "discard a card" do not grow a parallel
-    /// payment hierarchy.
-    AbilityCost {
-        cost: AbilityCost,
-    },
-    /// CR 118.1: Per-object scaled mana cost. The `base` `ManaCost` (which may
-    /// carry colored pips, e.g. `{U}`) is multiplied by `times` at payment
-    /// resolution — every pip is repeated and the generic component scaled.
-    /// Models "pay {N} for each [object] chosen this way" uniformly across
-    /// generic ({4}×N) and colored ({U}×N) bases.
-    /// CR 118.5: when `times` resolves to 0 the scaled cost is `{0}`, paid by
-    /// the player's acknowledgment (the empty selection) — a no-op SUCCESS.
-    ScaledMana {
-        base: ManaCost,
-        times: QuantityExpr,
-    },
-}
-
-// ---------------------------------------------------------------------------
 // AbilityCost -- expanded typed variants
 // ---------------------------------------------------------------------------
 
@@ -5779,6 +5730,77 @@ impl LegacyUnlessCost {
                 filter: Some(filter),
                 from_zone,
             },
+        }
+    }
+}
+
+/// Forward-compatible deserializer for `Effect::PayCost::cost` (cost-payment
+/// unification Phase 4). First tries the unified `AbilityCost` JSON shape, then
+/// falls back to the legacy `PaymentCost` wrapper shape so saved-game JSON /
+/// persisted continuations keep loading after `PaymentCost` was deleted.
+///
+/// Legacy `PaymentCost` → modern `AbilityCost` mapping (§4 of the unification
+/// plan; field types already align — the fold is lossless except `ScaledMana`,
+/// see below):
+/// - `Mana { cost }` → `Mana { cost }`
+/// - `Life { amount }` → `PayLife { amount }`
+/// - `Speed { amount }` → `PaySpeed { amount }`
+/// - `Energy { amount }` → `PayEnergy { amount }`
+/// - `AbilityCost { cost }` → `cost` (unwrap)
+/// - `ScaledMana { base, .. }` → `Mana { cost: base }` — the per-object `times`
+///   multiplier moved to the sibling `Effect::PayCost::scale` field, which a
+///   field-level deserializer cannot populate. `ScaledMana` is emitted only as
+///   a `Spell`-kind sub-ability that resolves in a single pass (it never pauses
+///   on a `PayAmountChoice`), so it is never persisted mid-resolution; the only
+///   legacy surface is `card-data.json`, which is regenerated in this phase and
+///   carries the modern `(Mana, scale)` shape. Mapping the base alone here is a
+///   safe best-effort for any stale artifact.
+pub fn deserialize_pay_cost_compat<'de, D>(d: D) -> Result<AbilityCost, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize as _;
+    let raw: serde_json::Value = serde_json::Value::deserialize(d)?;
+    // Try the modern AbilityCost shape first.
+    if let Ok(cost) = serde_json::from_value::<AbilityCost>(raw.clone()) {
+        return Ok(cost);
+    }
+    // Fall back to the legacy `PaymentCost` wrapper shape and translate.
+    let legacy: LegacyPaymentCost =
+        serde_json::from_value(raw).map_err(serde::de::Error::custom)?;
+    Ok(legacy.into_ability_cost())
+}
+
+/// CR 118.1: Legacy shadow type used ONLY by `deserialize_pay_cost_compat` to
+/// accept pre-Phase-4 serialized JSON. The variants and field names mirror the
+/// deleted `PaymentCost` enum exactly. New code must NOT construct this type —
+/// it exists solely as a deserialization staging area.
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum LegacyPaymentCost {
+    Mana { cost: ManaCost },
+    Life { amount: QuantityExpr },
+    Speed { amount: QuantityExpr },
+    Energy { amount: QuantityExpr },
+    AbilityCost { cost: AbilityCost },
+    // The legacy `times` field is intentionally omitted: serde ignores the
+    // extra JSON key, and the per-object multiplier moved to the sibling
+    // `Effect::PayCost::scale` field which a field-level deserializer cannot
+    // reach (see `deserialize_pay_cost_compat`). Only the mana `base` survives.
+    ScaledMana { base: ManaCost },
+}
+
+impl LegacyPaymentCost {
+    fn into_ability_cost(self) -> AbilityCost {
+        match self {
+            LegacyPaymentCost::Mana { cost } => AbilityCost::Mana { cost },
+            LegacyPaymentCost::Life { amount } => AbilityCost::PayLife { amount },
+            LegacyPaymentCost::Speed { amount } => AbilityCost::PaySpeed { amount },
+            LegacyPaymentCost::Energy { amount } => AbilityCost::PayEnergy { amount },
+            LegacyPaymentCost::AbilityCost { cost } => cost,
+            // The per-object `times` lives on the sibling `scale` field, which a
+            // field-level deserializer cannot reach; map the base alone.
+            LegacyPaymentCost::ScaledMana { base } => AbilityCost::Mana { cost: base },
         }
     }
 }
@@ -7257,9 +7279,21 @@ pub enum Effect {
         #[serde(default)]
         triggers: Vec<TriggerDefinition>,
     },
-    /// CR 118.1: Pay a cost during effect resolution (mana or life).
+    /// CR 118.1: Pay a cost during effect resolution. Carries the unified
+    /// `AbilityCost` taxonomy directly (no parallel `PaymentCost` hierarchy) so
+    /// resolution-time costs route through the single payment authority
+    /// (`game::costs`). Forward-compatible deserialization (`deserialize_pay_cost_compat`)
+    /// accepts the legacy `PaymentCost`-wrapped JSON shape so saved games /
+    /// persisted continuations keep loading after the fold.
     PayCost {
-        cost: PaymentCost,
+        #[serde(deserialize_with = "deserialize_pay_cost_compat")]
+        cost: AbilityCost,
+        /// CR 118.1 + CR 118.5: Resolution-only per-object scale (was
+        /// `PaymentCost::ScaledMana`). When `Some(times)` the mana `cost` base
+        /// is multiplied by `times` at payment ("pay {N} for each object chosen
+        /// this way"); `times == 0` yields `{0}`, a trivial no-op success.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scale: Option<QuantityExpr>,
         /// CR 608.2c: Player who pays the resolution-time cost. Defaults to
         /// the ability controller; target-derived refs such as
         /// `ParentTargetController` cover "that spell's controller may pay".
@@ -15826,5 +15860,101 @@ mod modal_ability_tests {
 
         assert!(def.modal.is_some());
         assert_eq!(def.mode_abilities.len(), 2);
+    }
+
+    /// CR 118.1 (cost-payment unification Phase 4, risk R2): a saved
+    /// `Effect::PayCost` persisted before `PaymentCost` was deleted still
+    /// deserializes. The legacy `cost` field carried a `PaymentCost`-tagged
+    /// object (`{"type":"Life",...}`, `{"type":"Energy",...}`, etc.);
+    /// `deserialize_pay_cost_compat` translates each into the unified
+    /// `AbilityCost` taxonomy. Mirrors the `deserialize_ability_cost_compat`
+    /// precedent for legacy `UnlessCost` saves.
+    #[test]
+    fn pay_cost_legacy_payment_cost_json_roundtrips() {
+        // Legacy PaymentCost::Life → AbilityCost::PayLife.
+        let legacy_life = r#"{
+            "type": "PayCost",
+            "cost": { "type": "Life", "amount": { "type": "Fixed", "value": 3 } },
+            "payer": { "type": "Controller" }
+        }"#;
+        let effect: Effect = serde_json::from_str(legacy_life).expect("legacy Life must load");
+        match effect {
+            Effect::PayCost { cost, scale, .. } => {
+                assert_eq!(
+                    cost,
+                    AbilityCost::PayLife {
+                        amount: QuantityExpr::Fixed { value: 3 }
+                    }
+                );
+                assert_eq!(scale, None);
+            }
+            other => panic!("expected PayCost, got {other:?}"),
+        }
+
+        // Legacy PaymentCost::Energy → AbilityCost::PayEnergy.
+        let legacy_energy = r#"{
+            "type": "PayCost",
+            "cost": { "type": "Energy", "amount": { "type": "Fixed", "value": 2 } }
+        }"#;
+        let effect: Effect = serde_json::from_str(legacy_energy).expect("legacy Energy must load");
+        let Effect::PayCost { cost, .. } = effect else {
+            panic!("expected PayCost");
+        };
+        assert_eq!(
+            cost,
+            AbilityCost::PayEnergy {
+                amount: QuantityExpr::Fixed { value: 2 }
+            }
+        );
+
+        // Legacy PaymentCost::Mana → AbilityCost::Mana.
+        let legacy_mana = r#"{
+            "type": "PayCost",
+            "cost": { "type": "Mana", "cost": { "type": "Cost", "shards": [], "generic": 2 } }
+        }"#;
+        let effect: Effect = serde_json::from_str(legacy_mana).expect("legacy Mana must load");
+        let Effect::PayCost { cost, .. } = effect else {
+            panic!("expected PayCost");
+        };
+        assert_eq!(
+            cost,
+            AbilityCost::Mana {
+                cost: ManaCost::generic(2)
+            }
+        );
+
+        // Legacy PaymentCost::AbilityCost wrapper → unwrapped AbilityCost.
+        let legacy_wrapper = r#"{
+            "type": "PayCost",
+            "cost": {
+                "type": "AbilityCost",
+                "cost": { "type": "PayLife", "amount": { "type": "Fixed", "value": 1 } }
+            }
+        }"#;
+        let effect: Effect =
+            serde_json::from_str(legacy_wrapper).expect("legacy AbilityCost wrapper must load");
+        let Effect::PayCost { cost, .. } = effect else {
+            panic!("expected PayCost");
+        };
+        assert_eq!(
+            cost,
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 1 }
+            }
+        );
+
+        // Modern shape (unwrapped AbilityCost + explicit scale) still round-trips.
+        let modern = Effect::PayCost {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::generic(4),
+            },
+            scale: Some(QuantityExpr::Ref {
+                qty: QuantityRef::TrackedSetSize,
+            }),
+            payer: TargetFilter::Controller,
+        };
+        let json = serde_json::to_string(&modern).expect("serialize modern PayCost");
+        let back: Effect = serde_json::from_str(&json).expect("modern PayCost must round-trip");
+        assert_eq!(back, modern);
     }
 }

--- a/crates/engine/tests/integration/madame_null_integration.rs
+++ b/crates/engine/tests/integration/madame_null_integration.rs
@@ -7,7 +7,7 @@
 //!
 //! These tests pin the
 //! `PayCost { Life(Ref(Power { scope: CostPaidObject })) }`
-//! resolution enabled by the PaymentCost::Life → QuantityExpr widening. The
+//! resolution enabled by the PayCost life-cost → QuantityExpr widening. The
 //! `CostPaidObject` scope resolves (CR 608.2k) via cost-paid object →
 //! trigger-event source → effect-context object; with no cost-paid object
 //! these tests exercise the trigger-event-source (slot 2) fallback:
@@ -27,7 +27,7 @@
 use engine::game::effects;
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    AbilityKind, Effect, ObjectScope, PaymentCost, QuantityExpr, QuantityRef, ResolvedAbility,
+    AbilityCost, AbilityKind, Effect, ObjectScope, QuantityExpr, QuantityRef, ResolvedAbility,
     TargetFilter,
 };
 use engine::types::card_type::CoreType;
@@ -57,13 +57,14 @@ use engine::types::zones::Zone;
 fn build_madame_null_pay_chain(source_id: ObjectId, controller: PlayerId) -> ResolvedAbility {
     let mut outer = ResolvedAbility::new(
         Effect::PayCost {
-            cost: PaymentCost::Life {
+            cost: AbilityCost::PayLife {
                 amount: QuantityExpr::Ref {
                     qty: QuantityRef::Power {
                         scope: ObjectScope::CostPaidObject,
                     },
                 },
             },
+            scale: None,
             payer: TargetFilter::Controller,
         },
         vec![],

--- a/crates/engine/tests/integration/magnetic_mountain_choose_and_pay.rs
+++ b/crates/engine/tests/integration/magnetic_mountain_choose_and_pay.rs
@@ -11,7 +11,7 @@
 //!
 //! This test drives the full pipeline through `apply`: the upkeep trigger
 //! fires, the engine raises `WaitingFor::ChooseObjectsSelection`, the player
-//! selects 2 tapped blue creatures, `PaymentCost::ScaledMana` charges
+//! selects 2 tapped blue creatures, the `PayCost` scaled mana charges
 //! {4}×2 = {8}, and the reused `IfYouDo`/`Untap{TrackedSet}` tail untaps
 //! exactly those 2 creatures. Every assertion fails against pre-07d behavior.
 
@@ -142,7 +142,7 @@ fn magnetic_mountain_choose_and_pay_per_creature_untaps_selection() {
     // Resolve the rest of the chain: PayCost { ScaledMana } then IfYouDo/Untap.
     runner.advance_until_stack_empty();
 
-    // DISCRIMINATING ASSERTION 2 — PaymentCost::ScaledMana charged {4} × 2 =
+    // DISCRIMINATING ASSERTION 2 — PayCost scaled mana charged {4} × 2 =
     // {8}, draining the whole pool. Pre-07d the fixed {4} would leave 4 behind.
     let mana_left = runner
         .state()

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -10,9 +10,9 @@ use engine::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, ChoiceType,
     ContinuousModification, ControllerRef, DamageSource, DelayedTriggerCondition, Duration, Effect,
     EffectScope, FilterProp, LibraryPosition, ManaProduction, ManaSpendRestriction,
-    ModalSelectionConstraint, MultiTargetSpec, PaymentCost, PlayerFilter, PlayerScope, PtValue,
-    QuantityExpr, QuantityRef, SearchSelectionConstraint, SharedQuality, StaticDefinition,
-    TapStateChange, TargetFilter, TriggerDefinition, TypedFilter,
+    ModalSelectionConstraint, MultiTargetSpec, PlayerFilter, PlayerScope, PtValue, QuantityExpr,
+    QuantityRef, SearchSelectionConstraint, SharedQuality, StaticDefinition, TapStateChange,
+    TargetFilter, TriggerDefinition, TypedFilter,
 };
 use engine::types::counter::{parse_counter_type, CounterType as EngineCounterType};
 use engine::types::game_state::DistributionUnit;
@@ -322,23 +322,29 @@ fn rewrite_bound_x_in_mana_production(
     }
 }
 
-fn rewrite_bound_x_in_payment_cost(cost: &mut PaymentCost, binding: &QuantityExpr) -> usize {
-    match cost {
-        PaymentCost::Life { amount }
-        | PaymentCost::Speed { amount }
-        | PaymentCost::Energy { amount } => rewrite_bound_x_in_quantity_expr(amount, binding),
-        PaymentCost::AbilityCost { cost } => rewrite_bound_x_in_ability_cost(cost, binding),
-        // CR 118.1: ScaledMana's `times` is a QuantityExpr that may carry a
-        // bound X — rewrite it like the other amount-bearing variants.
-        PaymentCost::ScaledMana { times, .. } => rewrite_bound_x_in_quantity_expr(times, binding),
-        PaymentCost::Mana { .. } => 0,
-    }
+/// CR 118.1: Rewrite a bound X inside an `Effect::PayCost`. The unified
+/// `AbilityCost` cost is rewritten via `rewrite_bound_x_in_ability_cost`; the
+/// resolution-only per-object `scale` (was `PaymentCost::ScaledMana::times`)
+/// carries a `QuantityExpr` that may also reference the bound X.
+fn rewrite_bound_x_in_payment_cost(
+    cost: &mut AbilityCost,
+    scale: &mut Option<QuantityExpr>,
+    binding: &QuantityExpr,
+) -> usize {
+    let cost_rewrites = rewrite_bound_x_in_ability_cost(cost, binding);
+    let scale_rewrites = scale
+        .as_mut()
+        .map_or(0, |times| rewrite_bound_x_in_quantity_expr(times, binding));
+    cost_rewrites + scale_rewrites
 }
 
 fn rewrite_bound_x_in_ability_cost(cost: &mut AbilityCost, binding: &QuantityExpr) -> usize {
     match cost {
         AbilityCost::PayLife { amount }
         | AbilityCost::PaySpeed { amount }
+        // CR 107.14: `PayEnergy` carries its (possibly X-bound) amount as a
+        // `QuantityExpr` — rewrite it like the other amount-bearing variants.
+        | AbilityCost::PayEnergy { amount }
         | AbilityCost::Discard { count: amount, .. } => {
             rewrite_bound_x_in_quantity_expr(amount, binding)
         }
@@ -376,7 +382,6 @@ fn rewrite_bound_x_in_ability_cost(cost: &mut AbilityCost, binding: &QuantityExp
         | AbilityCost::CollectEvidence { .. }
         | AbilityCost::TapCreatures { .. }
         | AbilityCost::RemoveCounter { .. }
-        | AbilityCost::PayEnergy { .. }
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Unattach
         | AbilityCost::Mill { .. }
@@ -536,7 +541,9 @@ fn rewrite_bound_x_in_effect(effect: &mut Effect, binding: &QuantityExpr) -> usi
                 .sum();
             static_count + trigger_count
         }
-        Effect::PayCost { cost, .. } => rewrite_bound_x_in_payment_cost(cost, binding),
+        Effect::PayCost { cost, scale, .. } => {
+            rewrite_bound_x_in_payment_cost(cost, scale, binding)
+        }
         Effect::CastFromZone {
             alt_ability_cost: Some(_),
             ..
@@ -6750,13 +6757,11 @@ mod tests {
         };
         assert!(matches!(
             cost,
-            PaymentCost::AbilityCost {
-                cost: AbilityCost::Discard {
-                    count: QuantityExpr::Fixed { value: 1 },
-                    filter: None,
-                    selection: engine::types::ability::CardSelectionMode::Chosen,
-                    self_scope: engine::types::ability::DiscardSelfScope::FromHand,
-                },
+            AbilityCost::Discard {
+                count: QuantityExpr::Fixed { value: 1 },
+                filter: None,
+                selection: engine::types::ability::CardSelectionMode::Chosen,
+                self_scope: engine::types::ability::DiscardSelfScope::FromHand,
             }
         ));
         let sub = ability.sub_ability.as_ref().expect("expected paid body");

--- a/crates/mtgish-import/src/convert/mod.rs
+++ b/crates/mtgish-import/src/convert/mod.rs
@@ -1225,6 +1225,7 @@ fn apply_segment_optionality(
                 ability.kind,
                 Effect::PayCost {
                     cost: payment_cost,
+                    scale: None,
                     payer,
                 },
             )
@@ -1373,6 +1374,7 @@ pub(crate) fn build_ability_from_actions(
                 kind,
                 Effect::PayCost {
                     cost: payment_cost,
+                    scale: None,
                     payer,
                 },
             )
@@ -1403,6 +1405,7 @@ pub(crate) fn build_ability_from_actions(
             sub.condition = Some(engine::types::ability::AbilityCondition::WhenYouDo);
             let parent_effect = engine::types::ability::Effect::PayCost {
                 cost: payment_cost,
+                scale: None,
                 payer,
             };
             // CR 117.6: `optional = true` on the parent gates `Effect::PayCost`
@@ -2223,41 +2226,31 @@ fn build_two_branch_spell(
     Ok(parent.sub_ability(paid))
 }
 
-/// CR 118.1: Map an activation-time `AbilityCost` to a resolution-time
-/// `PaymentCost`. Reflexive triggers ("you may pay X. when you do, Y")
-/// materialize the cost choice as `Effect::PayCost`. Resource costs map to
-/// dedicated `PaymentCost` leaves; supported non-resource resolution costs
-/// reuse the engine's `AbilityCost` taxonomy through `PaymentCost::AbilityCost`.
+/// CR 118.1: Validate that an activation-time `AbilityCost` is a shape the
+/// resolution-time `Effect::PayCost` authority can pay, returning a clone for
+/// the `cost` field. Reflexive triggers ("you may pay X. when you do, Y")
+/// materialize the cost choice as `Effect::PayCost`. The unified `AbilityCost`
+/// taxonomy is carried directly (cost-payment unification Phase 4 deleted the
+/// parallel `PaymentCost` hierarchy); the supported set is the resolution arms
+/// of the `game::costs` authority.
 fn ability_cost_to_payment_cost(
     cost: &engine::types::ability::AbilityCost,
-) -> ConvResult<engine::types::ability::PaymentCost> {
+) -> ConvResult<engine::types::ability::AbilityCost> {
     use engine::types::ability::AbilityCost as AC;
-    use engine::types::ability::PaymentCost as PC;
-    Ok(match cost {
-        AC::Mana { cost } => PC::Mana { cost: cost.clone() },
-        AC::PayLife { amount } => PC::Life {
-            amount: amount.clone(),
-        },
-        AC::PayEnergy { amount } => PC::Energy {
-            amount: amount.clone(),
-        },
-        AC::PaySpeed { amount } => PC::Speed {
-            amount: amount.clone(),
-        },
+    match cost {
+        AC::Mana { .. } | AC::PayLife { .. } | AC::PayEnergy { .. } | AC::PaySpeed { .. } => {
+            Ok(cost.clone())
+        }
         AC::Discard {
             selection: engine::types::ability::CardSelectionMode::Chosen,
             self_scope: engine::types::ability::DiscardSelfScope::FromHand,
             ..
-        } => PC::AbilityCost { cost: cost.clone() },
-        _ => {
-            return Err(ConversionGap::EnginePrerequisiteMissing {
-                engine_type: "PaymentCost",
-                needed_variant: format!(
-                    "AbilityCost not mappable to resolution-time PaymentCost: {cost:?}"
-                ),
-            });
-        }
-    })
+        } => Ok(cost.clone()),
+        _ => Err(ConversionGap::EnginePrerequisiteMissing {
+            engine_type: "Effect::PayCost",
+            needed_variant: format!("AbilityCost not payable as a resolution-time cost: {cost:?}"),
+        }),
+    }
 }
 
 /// Convert an mtgish `Cost` to a pure `ManaCost`, strict-failing for


### PR DESCRIPTION
- **refactor(engine): delete PaymentCost — Effect::PayCost carries AbilityCost directly (cost-payment unification Phase 4)**
- **fix(engine): Phase 4 review round — deny legacy ScaledMana saves, outcome-gated energy stamp, compat fixtures**
