### PR TITLE
fix(engine): keep keyword suffixes on final Or disjunct for comma-OR targets

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2596,13 +2596,19 @@ fn distribute_shared_properties(filter: TargetFilter, shared_props: &[FilterProp
 }
 
 /// Returns true when the given property is leg-local (produced by an adjective
-/// prefix during `parse_type_phrase` scanning) and must NOT distribute back
-/// across earlier legs of a comma-OR list. Every other property is assumed to
+/// prefix during `parse_type_phrase` scanning, or by a type-scoped keyword
+/// suffix on only the final disjunct) and must NOT distribute back across
+/// earlier legs of a comma-OR list. Every other property is assumed to
 /// originate from a trailing-suffix parser and is eligible for distribution —
 /// e.g., "artifacts and creatures with mana value 2 or less" distributes
 /// `CmcLE` back onto the artifact leg, while "Auras, Equipment, and modified
 /// creatures you control" must NOT propagate `FilterProp::Modified` to the
 /// Aura/Equipment legs.
+///
+/// CR 115.1: "artifact, enchantment, or creature with flying" binds flying
+/// only to the creature disjunct. Spreading `WithKeyword(Flying)` onto the
+/// artifact/enchantment legs would require those permanents to have flying and
+/// would block activation when only a legal enchantment is present (#2941).
 fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
     matches!(
         prop,
@@ -2636,6 +2642,12 @@ fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
             // Token qualifier ("creature tokens").
             | FilterProp::Token
             | FilterProp::NonToken
+            // CR 702.9: "<type> with [keyword]" suffixes bind to the type
+            // phrase that parsed them — never retroactively onto earlier Or
+            // disjuncts ("artifact, enchantment, or creature with flying").
+            | FilterProp::WithKeyword { .. }
+            | FilterProp::WithoutKeyword { .. }
+            | FilterProp::WithoutKeywordKind { .. }
     )
 }
 
@@ -8962,6 +8974,95 @@ mod tests {
         let (f, rest) = parse_type_phrase("creature and draw a card");
         assert_eq!(f, TargetFilter::Typed(TypedFilter::creature()));
         assert!(rest.contains("and draw"), "rest = {:?}", rest);
+    }
+
+    #[test]
+    fn comma_or_keyword_suffix_stays_on_final_disjunct_only() {
+        // Issue #2941 (Vivien Reid): "artifact, enchantment, or creature with
+        // flying" — flying applies only to the creature leg.
+        let (f, rest) = parse_target("target artifact, enchantment, or creature with flying");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        let TargetFilter::Or { filters } = &f else {
+            panic!("expected Or filter, got {f:?}");
+        };
+        assert_eq!(
+            filters.len(),
+            3,
+            "expected three disjuncts, got {filters:?}"
+        );
+
+        let artifact = &filters[0];
+        let enchantment = &filters[1];
+        let creature = &filters[2];
+
+        let TargetFilter::Typed(artifact_typed) = artifact else {
+            panic!("artifact leg should be Typed, got {artifact:?}");
+        };
+        assert!(has_type(artifact_typed, TypeFilter::Artifact));
+        assert!(
+            !artifact_typed
+                .properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::WithKeyword { .. })),
+            "flying must not distribute onto artifact leg: {artifact_typed:?}"
+        );
+
+        let TargetFilter::Typed(enchantment_typed) = enchantment else {
+            panic!("enchantment leg should be Typed, got {enchantment:?}");
+        };
+        assert!(has_type(enchantment_typed, TypeFilter::Enchantment));
+        assert!(
+            !enchantment_typed
+                .properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::WithKeyword { .. })),
+            "flying must not distribute onto enchantment leg: {enchantment_typed:?}"
+        );
+
+        let TargetFilter::Typed(creature_typed) = creature else {
+            panic!("creature leg should be Typed, got {creature:?}");
+        };
+        assert!(has_type(creature_typed, TypeFilter::Creature));
+        assert!(
+            creature_typed
+                .properties
+                .contains(&FilterProp::WithKeyword {
+                    value: Keyword::Flying
+                }),
+            "creature leg must retain flying: {creature_typed:?}"
+        );
+    }
+
+    #[test]
+    fn comma_or_without_keyword_suffix_stays_on_final_disjunct_only() {
+        let (f, rest) = parse_target("target artifact or creature without flying");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        let TargetFilter::Or { filters } = &f else {
+            panic!("expected Or filter, got {f:?}");
+        };
+        assert_eq!(filters.len(), 2);
+
+        let TargetFilter::Typed(artifact_typed) = &filters[0] else {
+            panic!("expected artifact Typed");
+        };
+        assert!(
+            !artifact_typed
+                .properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::WithoutKeyword { .. })),
+            "without-flying must not distribute onto artifact leg: {artifact_typed:?}"
+        );
+
+        let TargetFilter::Typed(creature_typed) = &filters[1] else {
+            panic!("expected creature Typed");
+        };
+        assert!(
+            creature_typed
+                .properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::WithoutKeyword { .. })),
+            "creature leg must retain without-flying: {creature_typed:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2642,7 +2642,7 @@ fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
             // Token qualifier ("creature tokens").
             | FilterProp::Token
             | FilterProp::NonToken
-            // CR 702.9: "<type> with [keyword]" suffixes bind to the type
+            // CR 702: "<type> with [keyword]" suffixes bind to the type
             // phrase that parsed them — never retroactively onto earlier Or
             // disjuncts ("artifact, enchantment, or creature with flying").
             | FilterProp::WithKeyword { .. }

--- a/crates/engine/tests/integration/issue_2941_vivien_reid.rs
+++ b/crates/engine/tests/integration/issue_2941_vivien_reid.rs
@@ -1,0 +1,237 @@
+//! Issue #2941: Vivien Reid's -3 loyalty ("Destroy target artifact, enchantment,
+//! or creature with flying") must be activatable whenever any artifact,
+//! enchantment, or flying creature is a legal target. A prior parser bug spread
+//! `WithKeyword(Flying)` onto every Or disjunct, so a lone enchantment did not
+//! satisfy the activation gate.
+
+use std::sync::Arc;
+
+use engine::game::casting::can_activate_ability_now;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, Effect, TargetFilter,
+    TypeFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::CounterType;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const MINUS_THREE_ORACLE: &str = "Destroy target artifact, enchantment, or creature with flying.";
+
+fn vivien_minus_three_destroy_effect() -> Effect {
+    match parse_effect(MINUS_THREE_ORACLE) {
+        Effect::Destroy { target, .. } => Effect::Destroy {
+            target,
+            cant_regenerate: false,
+        },
+        other => panic!("expected Destroy effect, got {other:?}"),
+    }
+}
+
+fn add_battlefield_permanent(
+    state: &mut engine::types::game_state::GameState,
+    card_id: u64,
+    player: engine::types::player::PlayerId,
+    name: &str,
+    core_type: CoreType,
+) -> ObjectId {
+    let oid = create_object(
+        state,
+        CardId(card_id),
+        player,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&oid).expect("just created");
+    obj.card_types.core_types.push(core_type);
+    obj.base_card_types = obj.card_types.clone();
+    oid
+}
+
+fn setup_vivien_with_minus_three() -> (engine::game::scenario::GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let vivien_id = scenario.add_creature(P0, "Vivien Reid", 0, 0).id();
+    let mut runner = scenario.build();
+
+    {
+        let state = runner.state_mut();
+        let obj = state.objects.get_mut(&vivien_id).unwrap();
+        obj.card_types.core_types.clear();
+        obj.card_types.core_types.push(CoreType::Planeswalker);
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = None;
+        obj.toughness = None;
+        obj.base_power = None;
+        obj.base_toughness = None;
+        obj.loyalty = Some(5);
+        obj.counters
+            .insert(CounterType::Loyalty, 5);
+
+        let minus_three =
+            AbilityDefinition::new(AbilityKind::Activated, vivien_minus_three_destroy_effect())
+                .cost(AbilityCost::Loyalty { amount: -3 })
+                .activation_restrictions(vec![ActivationRestriction::AsSorcery]);
+
+        Arc::make_mut(&mut obj.abilities).push(minus_three.clone());
+        Arc::make_mut(&mut obj.base_abilities).push(minus_three);
+    }
+
+    (runner, vivien_id)
+}
+
+fn minus_three_ability_index(
+    state: &engine::types::game_state::GameState,
+    vivien: ObjectId,
+) -> usize {
+    state
+        .objects
+        .get(&vivien)
+        .unwrap()
+        .abilities
+        .iter()
+        .position(|ability| matches!(ability.cost, Some(AbilityCost::Loyalty { amount: -3 })))
+        .expect("Vivien -3 loyalty ability")
+}
+
+#[test]
+fn vivien_minus_three_parser_binds_flying_only_to_creature_leg() {
+    let Effect::Destroy { target, .. } = vivien_minus_three_destroy_effect() else {
+        panic!("expected Destroy");
+    };
+    let TargetFilter::Or { filters } = target else {
+        panic!("expected Or destroy target, got {target:?}");
+    };
+    assert_eq!(filters.len(), 3);
+
+    let artifact_leg = &filters[0];
+    let enchantment_leg = &filters[1];
+    let creature_leg = &filters[2];
+
+    let TargetFilter::Typed(artifact) = artifact_leg else {
+        panic!("artifact leg should be Typed");
+    };
+    assert!(artifact.type_filters.contains(&TypeFilter::Artifact));
+    assert!(!artifact
+        .properties
+        .iter()
+        .any(|p| matches!(p, engine::types::ability::FilterProp::WithKeyword { .. })));
+
+    let TargetFilter::Typed(enchantment) = enchantment_leg else {
+        panic!("enchantment leg should be Typed");
+    };
+    assert!(enchantment.type_filters.contains(&TypeFilter::Enchantment));
+    assert!(!enchantment
+        .properties
+        .iter()
+        .any(|p| matches!(p, engine::types::ability::FilterProp::WithKeyword { .. })));
+
+    let TargetFilter::Typed(creature) = creature_leg else {
+        panic!("creature leg should be Typed");
+    };
+    assert!(creature.type_filters.contains(&TypeFilter::Creature));
+    assert!(creature.properties.iter().any(|p| matches!(
+        p,
+        engine::types::ability::FilterProp::WithKeyword {
+            value: Keyword::Flying
+        }
+    )));
+}
+
+#[test]
+fn vivien_minus_three_activates_with_only_enchantment_on_battlefield() {
+    let (mut runner, vivien) = setup_vivien_with_minus_three();
+    let ability_index = minus_three_ability_index(runner.state(), vivien);
+
+    add_battlefield_permanent(
+        runner.state_mut(),
+        201,
+        P1,
+        "Opp Enchantment",
+        CoreType::Enchantment,
+    );
+
+    assert!(
+        can_activate_ability_now(runner.state(), P0, vivien, ability_index),
+        "lone opponent enchantment must make -3 activatable"
+    );
+}
+
+#[test]
+fn vivien_minus_three_activates_with_only_artifact_on_battlefield() {
+    let (mut runner, vivien) = setup_vivien_with_minus_three();
+    let ability_index = minus_three_ability_index(runner.state(), vivien);
+
+    add_battlefield_permanent(
+        runner.state_mut(),
+        202,
+        P1,
+        "Opp Artifact",
+        CoreType::Artifact,
+    );
+
+    assert!(
+        can_activate_ability_now(runner.state(), P0, vivien, ability_index),
+        "lone opponent artifact must make -3 activatable"
+    );
+}
+
+#[test]
+fn vivien_minus_three_activates_with_only_flying_creature_on_battlefield() {
+    let (mut runner, vivien) = setup_vivien_with_minus_three();
+    let ability_index = minus_three_ability_index(runner.state(), vivien);
+
+    let flyer = add_battlefield_permanent(
+        runner.state_mut(),
+        203,
+        P1,
+        "Flying Creature",
+        CoreType::Creature,
+    );
+    {
+        let obj = runner.state_mut().objects.get_mut(&flyer).unwrap();
+        obj.power = Some(2);
+        obj.toughness = Some(2);
+        obj.base_power = Some(2);
+        obj.base_toughness = Some(2);
+        obj.keywords.push(Keyword::Flying);
+        obj.base_keywords.push(Keyword::Flying);
+    }
+
+    assert!(
+        can_activate_ability_now(runner.state(), P0, vivien, ability_index),
+        "flying creature must make -3 activatable"
+    );
+}
+
+#[test]
+fn vivien_minus_three_not_activatable_with_only_nonflying_creature() {
+    let (mut runner, vivien) = setup_vivien_with_minus_three();
+    let ability_index = minus_three_ability_index(runner.state(), vivien);
+
+    let walker = add_battlefield_permanent(
+        runner.state_mut(),
+        204,
+        P1,
+        "Ground Creature",
+        CoreType::Creature,
+    );
+    {
+        let obj = runner.state_mut().objects.get_mut(&walker).unwrap();
+        obj.power = Some(3);
+        obj.toughness = Some(3);
+        obj.base_power = Some(3);
+        obj.base_toughness = Some(3);
+    }
+
+    assert!(
+        !can_activate_ability_now(runner.state(), P0, vivien, ability_index),
+        "non-flying creature alone must not enable -3"
+    );
+}

--- a/crates/engine/tests/integration/issue_2941_vivien_reid.rs
+++ b/crates/engine/tests/integration/issue_2941_vivien_reid.rs
@@ -16,10 +16,10 @@ use engine::types::ability::{
 };
 use engine::types::card_type::CoreType;
 use engine::types::identifiers::{CardId, ObjectId};
-use engine::types::CounterType;
 use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
+use engine::types::CounterType;
 
 const MINUS_THREE_ORACLE: &str = "Destroy target artifact, enchantment, or creature with flying.";
 
@@ -71,8 +71,7 @@ fn setup_vivien_with_minus_three() -> (engine::game::scenario::GameRunner, Objec
         obj.base_power = None;
         obj.base_toughness = None;
         obj.loyalty = Some(5);
-        obj.counters
-            .insert(CounterType::Loyalty, 5);
+        obj.counters.insert(CounterType::Loyalty, 5);
 
         let minus_three =
             AbilityDefinition::new(AbilityKind::Activated, vivien_minus_three_destroy_effect())

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -132,6 +132,7 @@ mod issue_2430_shifting_woodland;
 mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
+mod issue_2941_vivien_reid;
 mod issue_2943_kayas_wrath;
 mod issue_564_wishclaw_talisman_control;
 mod issue_565_birthing_ritual_end_step_trigger;


### PR DESCRIPTION
## Summary

- Fixes [#2941](https://github.com/phase-rs/phase/issues/2941): Vivien Reid's -3 loyalty ability ("Destroy target artifact, enchantment, or creature with flying") could not be activated when only an artifact or enchantment was on the battlefield.
- Root cause: `distribute_properties_to_or` copied `WithKeyword(Flying)` from the final disjunct onto every earlier `Or` branch, so non-flying artifacts/enchantments were never legal targets and the activation gate reported no legal targets.
- Fix: treat `WithKeyword`, `WithoutKeyword`, and `WithoutKeywordKind` as leg-local properties (like `Modified`, `Attacking`, etc.) so keyword suffixes stay on the type phrase that parsed them.
- Also fixes the same misparsing class on ~10 other cards (e.g. Broken Wings, Carnivorous Canopy).

## Test plan

- [x] `cargo test -p engine --lib comma_or_keyword_suffix`
- [x] `cargo test -p engine --lib comma_or_without_keyword`
- [x] `cargo test -p engine issue_2941`
- [ ] Regenerate card data (`./scripts/gen-card-data.sh`) so baked exports pick up the parser fix — `client/public/card-data.json` is gitignored and updated locally
- [ ] Manual: Vivien Reid -3 activatable with only an opponent enchantment on board; can target and destroy it