### PR TITLE
fix(engine): Gate lands offer fixed color and chosen color when tapped

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8211,6 +8211,79 @@ mod tests {
         );
     }
 
+    /// Issue #2933: Black Dragon Gate must offer {B} and the as-enters chosen
+    /// color when tapped — not only the chosen color.
+    #[test]
+    fn black_dragon_gate_tap_offers_fixed_black_or_chosen_color() {
+        use crate::game::mana_sources::activatable_land_mana_options;
+        use crate::types::ability::ChosenAttribute;
+        use crate::types::mana::ManaType;
+
+        let mut state = setup_game_at_main_phase();
+        let gate = create_object(
+            &mut state,
+            CardId(347),
+            PlayerId(0),
+            "Black Dragon Gate".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&gate).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Gate".to_string());
+        }
+        apply_oracle_to_object(
+            &mut state,
+            gate,
+            "Black Dragon Gate",
+            "This land enters tapped.\nAs this land enters, choose a color other than black.\n{T}: Add {B} or one mana of the chosen color.",
+        );
+        state
+            .objects
+            .get_mut(&gate)
+            .unwrap()
+            .chosen_attributes
+            .push(ChosenAttribute::Color(ManaColor::Red));
+
+        let options = activatable_land_mana_options(&state, gate, PlayerId(0));
+        let types: Vec<ManaType> = options.iter().map(|o| o.mana_type).collect();
+        assert!(
+            types.contains(&ManaType::Black),
+            "Black Dragon Gate must offer {{B}}, got {types:?}"
+        );
+        assert!(
+            types.contains(&ManaType::Red),
+            "Black Dragon Gate must offer chosen Red, got {types:?}"
+        );
+        assert_eq!(types.len(), 2);
+
+        let tap_black = apply_as_current(
+            &mut state,
+            GameAction::ActivateAbility {
+                source_id: gate,
+                ability_index: 0,
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(tap_black.waiting_for, WaitingFor::ChooseManaColor { .. }),
+            "two-color Gate must prompt before producing mana, got {:?}",
+            tap_black.waiting_for
+        );
+
+        let resolved = apply_as_current(
+            &mut state,
+            GameAction::ChooseManaColor {
+                choice: crate::types::game_state::ManaChoice::SingleColor(ManaType::Black),
+                count: 1,
+            },
+        )
+        .unwrap();
+        assert!(matches!(resolved.waiting_for, WaitingFor::Priority { .. }));
+        assert!(state.objects[&gate].tapped);
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Black), 1);
+    }
+
     #[test]
     fn thriving_grove_play_land_stays_tapped_after_color_choice() {
         let mut state = setup_game_at_main_phase();

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -524,18 +524,20 @@ pub fn display_land_mana_pips(
             // chosen color"), show both available mana choices.
             ManaProduction::ChosenColor {
                 fixed_alternative, ..
-            } => {
-                if let Some(color) = fixed_alternative {
-                    push(&mut pips, ManaPip::Color(*color));
+            } => match (fixed_alternative, obj.chosen_color()) {
+                (None, None) => {
+                    push(&mut pips, ManaPip::OneOfColors(ManaColor::ALL.to_vec()));
                 }
-                match obj.chosen_color() {
-                    Some(color) => push(&mut pips, ManaPip::Color(color)),
-                    None if fixed_alternative.is_none() => {
-                        push(&mut pips, ManaPip::OneOfColors(ManaColor::ALL.to_vec()));
+                _ => {
+                    for mana_type in
+                        chosen_color_mana_type_options(state, object_id, *fixed_alternative)
+                    {
+                        if let Some(color) = mana_type_to_color(mana_type) {
+                            push(&mut pips, ManaPip::Color(color));
+                        }
                     }
-                    None => {}
                 }
-            }
+            },
             // CR 106.7: Dynamically computed from opponent lands.
             ManaProduction::OpponentLandColors { .. } => {
                 let colors: Vec<ManaColor> = opponent_land_color_options(state, controller)
@@ -925,20 +927,9 @@ fn profile_kind_from_production(
             fixed_alternative, ..
         } => {
             let count = resolved_production_count(produced, state, resolved);
-            let mut options = state
-                .objects
-                .get(&object_id)
-                .and_then(|obj| obj.chosen_color())
-                .map(|color| vec![mana_color_to_type(&color)])
-                .unwrap_or_default();
+            let options = chosen_color_mana_type_options(state, object_id, *fixed_alternative);
             if options.is_empty() {
                 return None;
-            }
-            if let Some(alt) = fixed_alternative {
-                let alt_type = mana_color_to_type(alt);
-                if !options.contains(&alt_type) {
-                    options.push(alt_type);
-                }
             }
             if count <= 1 && options.len() == 1 {
                 Some(ActivatableManaProfileKind::Exact(options))
@@ -1432,6 +1423,37 @@ pub(crate) fn activation_condition_satisfied(
     .is_ok()
 }
 
+/// CR 106.1: Resolve the mana-type option set for `ChosenColor` production.
+///
+/// Gate lands ("Add {B} or one mana of the chosen color") carry a
+/// `fixed_alternative` alongside the as-enters chosen color — both are legal
+/// outputs once the color is chosen. Pure chosen-color producers (Utopia Sprawl)
+/// with no color chosen yet fall back to all five colors so preview and
+/// mana-source analysis paths surface a non-empty set.
+pub(crate) fn chosen_color_mana_type_options(
+    state: &GameState,
+    object_id: ObjectId,
+    fixed_alternative: Option<ManaColor>,
+) -> Vec<ManaType> {
+    let mut options = Vec::new();
+    if let Some(fixed) = fixed_alternative {
+        options.push(mana_color_to_type(&fixed));
+    }
+    if let Some(chosen) = state
+        .objects
+        .get(&object_id)
+        .and_then(|obj| obj.chosen_color())
+    {
+        let chosen_type = mana_color_to_type(&chosen);
+        if !options.contains(&chosen_type) {
+            options.push(chosen_type);
+        }
+    } else if fixed_alternative.is_none() {
+        return ManaColor::ALL.iter().map(mana_color_to_type).collect();
+    }
+    options
+}
+
 fn mana_options_from_production(
     state: &GameState,
     controller: PlayerId,
@@ -1461,15 +1483,11 @@ fn mana_options_from_production(
             }
             options
         }
-        // CR 106.1a: Resolve the source permanent's chosen color. If the
-        // permanent has no chosen color yet (e.g., still in library / sideboard
-        // preview), return empty so it isn't offered as a mana source.
-        ManaProduction::ChosenColor { .. } => state
-            .objects
-            .get(&object_id)
-            .and_then(|obj| obj.chosen_color())
-            .map(|color| vec![mana_color_to_type(&color)])
-            .unwrap_or_default(),
+        // CR 106.1: Resolve chosen-color production, including the fixed-color
+        // alternative on Gate lands ("Add {B} or one mana of the chosen color").
+        ManaProduction::ChosenColor {
+            fixed_alternative, ..
+        } => chosen_color_mana_type_options(state, object_id, *fixed_alternative),
         // CR 106.7: Compute colors dynamically from opponent-controlled lands.
         ManaProduction::OpponentLandColors { .. } => opponent_land_color_options(state, controller),
         // CR 106.7 + CR 106.1b: Compute the full type set (incl. Colorless)
@@ -2244,6 +2262,68 @@ mod tests {
         // nothing pre-resolution.
         let trigger_only = pips_for_production(ManaProduction::TriggerEventManaType);
         assert!(trigger_only.is_empty());
+    }
+
+    #[test]
+    fn gate_land_fixed_or_chosen_exposes_both_mana_options() {
+        // Issue #2933: Black Dragon Gate — `{T}: Add {B} or one mana of the
+        // chosen color` must surface both Black and the as-enters chosen color
+        // in activatable land mana options (not just the chosen color).
+        use crate::types::ability::ChosenAttribute;
+
+        let mut state = GameState::new_two_player(42);
+        let gate = create_object(
+            &mut state,
+            CardId(347),
+            PlayerId(0),
+            "Black Dragon Gate".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&gate).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.chosen_attributes
+                .push(ChosenAttribute::Color(ManaColor::Red));
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::ChosenColor {
+                            count: QuantityExpr::Fixed { value: 1 },
+                            contribution: ManaContribution::Base,
+                            fixed_alternative: Some(ManaColor::Black),
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            );
+        }
+
+        let options = activatable_land_mana_options(&state, gate, PlayerId(0));
+        let types: Vec<_> = options.iter().map(|o| o.mana_type).collect();
+        assert!(
+            types.contains(&ManaType::Black),
+            "Gate land must offer printed {{B}}, got {types:?}"
+        );
+        assert!(
+            types.contains(&ManaType::Red),
+            "Gate land must offer chosen color Red, got {types:?}"
+        );
+        assert_eq!(types.len(), 2, "expected exactly two distinct options");
+
+        assert_eq!(
+            chosen_color_mana_type_options(&state, gate, Some(ManaColor::Black)),
+            vec![ManaType::Black, ManaType::Red]
+        );
+        assert!(source_could_produce_two_or_more_colors(
+            &state,
+            gate,
+            PlayerId(0)
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -429,6 +429,29 @@ pub(super) fn try_parse_add_mana_effect(text: &str) -> Option<Effect> {
             });
         }
 
+        // CR 106.1: "{fixed} or one mana of the chosen color" after a count
+        // prefix must retain the fixed-color alternative. Scan `rest` before
+        // the bare chosen-color arm so a leading count token does not drop the
+        // `{B}`/`{G}` branch (Gate lands with a count-qualified tail).
+        if let Some(produced) = scan_mana_production_type(&rest_lower, count.clone(), contribution)
+        {
+            if matches!(
+                produced,
+                ManaProduction::ChosenColor {
+                    fixed_alternative: Some(_),
+                    ..
+                }
+            ) {
+                return Some(Effect::Mana {
+                    produced,
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: where_x_target,
+                });
+            }
+        }
+
         if let Some((_, after_color)) = nom_on_lower(rest, &rest_lower, |i| {
             alt((
                 value((), tag("mana of the chosen color")),
@@ -2499,5 +2522,26 @@ mod tests {
             ),
             other => panic!("expected colorless Mana, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_black_dragon_gate_mana_ability() {
+        // Issue #2933: "Add {B} or one mana of the chosen color" must retain
+        // the fixed Black alternative through `try_parse_add_mana_effect`.
+        let effect = try_parse_add_mana_effect("Add {B} or one mana of the chosen color.")
+            .expect("Black Dragon Gate mana line must parse");
+        assert!(
+            matches!(
+                effect,
+                Effect::Mana {
+                    produced: ManaProduction::ChosenColor {
+                        fixed_alternative: Some(ManaColor::Black),
+                        ..
+                    },
+                    ..
+                }
+            ),
+            "expected ChosenColor with fixed_alternative Black, got {effect:?}"
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26769,6 +26769,52 @@ mod tests {
     }
 
     #[test]
+    fn effect_add_fixed_or_chosen_color_gate_land_black() {
+        // Issue #2933: Black Dragon Gate — same pattern with {B}.
+        let e = parse_effect("add {b} or one mana of the chosen color");
+        assert!(
+            matches!(
+                &e,
+                Effect::Mana {
+                    produced: ManaProduction::ChosenColor {
+                        fixed_alternative: Some(crate::types::mana::ManaColor::Black),
+                        ..
+                    },
+                    ..
+                }
+            ),
+            "expected ChosenColor with fixed_alternative Some(Black), got {e:?}"
+        );
+    }
+
+    #[test]
+    fn effect_add_fixed_or_chosen_color_gate_land_all_colors() {
+        // Building-block: every Gate land fixed color must survive parsing.
+        for (symbol, color) in [
+            ("w", crate::types::mana::ManaColor::White),
+            ("u", crate::types::mana::ManaColor::Blue),
+            ("b", crate::types::mana::ManaColor::Black),
+            ("r", crate::types::mana::ManaColor::Red),
+            ("g", crate::types::mana::ManaColor::Green),
+        ] {
+            let e = parse_effect(&format!("add {{{symbol}}} or one mana of the chosen color"));
+            assert!(
+                matches!(
+                    &e,
+                    Effect::Mana {
+                        produced: ManaProduction::ChosenColor {
+                            fixed_alternative: Some(parsed),
+                            ..
+                        },
+                        ..
+                    } if *parsed == color
+                ),
+                "expected fixed_alternative {color:?} for {{{symbol}}}, got {e:?}"
+            );
+        }
+    }
+
+    #[test]
     fn effect_add_additional_mana_any_color_fertile_ground() {
         // CR 605.1a: Fertile Ground's "adds an additional one mana of any color"
         // carries the additive role on `AnyOneColor`.


### PR DESCRIPTION
## Summary

- Fixes Black Dragon Gate (and the full Gate land cycle) so tapping offers **both** the printed fixed color (e.g. {B}) **and** the color chosen as the land entered, per Oracle text: "Add {B} or one mana of the chosen color."
- Root cause: `mana_options_from_production` only returned the as-enters chosen color for `ChosenColor` production and ignored `fixed_alternative`. That made `activatable_land_mana_options` report a single color, which routed taps through `TapLandForMana` and auto-produced the chosen color with no {B} option.
- Introduces `chosen_color_mana_type_options` as the shared building block and uses it in mana source enumeration, display pips, and activatable profile resolution. Adds parser hardening and tests across parser, mana-sources, and full activation flow.

## Test plan

- [x] `cargo test -p engine --lib black_dragon_gate_tap_offers_fixed_black_or_chosen_color`
- [x] `cargo test -p engine --lib gate_land_fixed_or_chosen_exposes_both_mana_options`
- [x] `cargo test -p engine --lib effect_add_fixed_or_chosen_color_gate_land`
- [x] `cargo test -p engine --lib effect_add_fixed_or_chosen_color_gate_land_black`
- [x] `cargo test -p engine --lib effect_add_fixed_or_chosen_color_gate_land_all_colors`
- [x] `cargo test -p engine --lib parse_black_dragon_gate_mana_ability`
- [x] `cargo test -p engine --lib display_pips_cover_every_mana_production_variant` (regression)
- [ ] Manual: play Black Dragon Gate, choose a non-black color on ETB, tap it, confirm color prompt offers {B} and the chosen color

Fixes #2933