### PR TITLE
ship/zone phase e t2

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -162,16 +162,29 @@ fn route_rest_partition(
             // DigChoice) and the reveal-until rest pile (effects::reveal_until::
             // move_rest_then) ARE migrated; this shared partition helper is not,
             // because it has three callers — two synchronous (search-split at
-            // :279, dig at the kept block) and ONE inside `run_batch_completion`'s
-            // RevealRestPile arm. Routing it through `move_objects_simultaneously`
-            // makes a CR 616.1 pause possible from inside a completion, which
-            // requires a re-pause-from-completion contract (the completion returns
-            // `()` and cannot signal a fresh park to its caller) plus pause
-            // handling threaded through both synchronous callers. That is a
-            // cross-cutting state-machine change; tracked for a follow-up so it
-            // lands as one reviewable unit rather than a partial migration here.
-            // (Practical exposure: a graveyard-redirect on a dig REST pile — the
-            // non-kept cards — with RIP/Leyline on the battlefield.)
+            // `apply_search_partition`, dig at the kept block) and ONE inside
+            // `run_batch_completion`'s RevealRestPile arm.
+            //
+            // RE-PAUSE CONTRACT STATUS (updated): the "pause from inside a
+            // completion" blocker named here previously is RESOLVED — the
+            // re-pause contract documented on
+            // `zone_pipeline::drain_pending_batch_deliveries` now covers a fresh
+            // park raised FROM a completion (the drain `.take()`s the old record
+            // BEFORE invoking the completion, so a completion that re-enters the
+            // batch machinery installs a clean record; see the
+            // `AttractionOpenRemainder` arm, which already pauses + re-defers
+            // through this exact path). The ONLY remaining work to migrate this
+            // helper onto `move_objects_simultaneously` is threading the
+            // `BatchMoveResult::NeedsChoice` return through the two SYNCHRONOUS
+            // callers (`apply_search_partition` and the dig kept-block), each of
+            // which currently returns `Result<(), _>` / `()` and would need to
+            // surface a parked prompt the same way the migrated DigChoice
+            // unkept-loop does (`defer_completion_on_pause` + early return). That
+            // is a cross-cutting signature change across both callers; tracked for
+            // a follow-up so it lands as one reviewable unit rather than a partial
+            // migration here. (Practical exposure: a graveyard-redirect on a dig
+            // REST pile — the non-kept cards — with RIP/Leyline on the
+            // battlefield.)
             for &obj_id in rest_ids {
                 zones::move_to_zone(state, obj_id, zone, events);
             }

--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -299,6 +299,37 @@ fn install_merge_layer_effect(
 /// Called from the battlefield-exit seam in `zones::move_to_zone` BEFORE the
 /// surviving object is moved. Returns immediately for non-merged objects.
 ///
+/// CR 730.3d (replacement propagation): `dest` is the merged permanent's
+/// *resolved* destination — the merged-permanent leave is a single ZoneChange
+/// event consulted ONCE through `replace_event` (on the survivor) before
+/// `zones::move_to_zone` reaches this seam, so `dest` already reflects any
+/// applied `Moved` redirect (Rest in Peace / Leyline of the Void:
+/// graveyard → exile). Routing every component to that same resolved `dest`
+/// "applies one replacement effect to the object [and thereby] to all components
+/// of the object" — exactly CR 730.3d. Components are explicitly NOT re-consulted
+/// per component here (`put_component_into_zone` routes raw); re-consulting would
+/// double-apply ordering and is rules-wrong per 730.3d.
+///
+/// CR 730.3e (card-vs-token scope): a "card"-scoped redirect (one that applies to
+/// a card being put into a zone without also including tokens) follows the
+/// survivor's resolved destination through `dest`. When the merged permanent is
+/// NOT a token (its survivor is a card, so a card-scoped redirect matches it and
+/// redirects the leave event), ALL components — token components included — take
+/// `dest` (730.3e first clause: "applies to all components of the merged
+/// permanent if it's not a token, including components that are tokens"). The
+/// second clause (the merged permanent's survivor is itself a TOKEN, so a
+/// card-scoped redirect does NOT match the survivor and its CARD components must
+/// still be moved by the redirect while the token survivor + token components
+/// take the default zone) is NOT handled here: it requires the merged-permanent
+/// leave to be consulted as a single component-aware event so the card-scoped
+/// redirect can apply to the card components without matching the token survivor.
+/// That is a replacement-pipeline extension (component-aware single consult), not
+/// a per-component re-consult (which 730.3d forbids), and no current pool `Moved`
+/// definition is card-scoped (the RIP-class parser ignores the "a card" subject
+/// and leaves `valid_card == None`, so today every such redirect is token-
+/// inclusive and matches the survivor regardless of token-ness). Tracked as a
+/// follow-up; the Commander exemption (CR 903.9b–c) is separately out of scope.
+///
 /// CR 730.3a deferred: the owner's arrange-order choice for graveyard/library
 /// destinations is not modeled — components are placed in their stored
 /// (topmost-first) order.

--- a/crates/engine/src/game/merge_tests.rs
+++ b/crates/engine/src/game/merge_tests.rs
@@ -814,10 +814,12 @@ fn merge_stacking_leave_routes_all_components_and_restores_survivor() {
     assert!(survivor.merge_layer_effect_id.is_none());
 }
 
-/// CR 614.6: "If a card would be put into a graveyard from anywhere, exile it
-/// instead." (Rest in Peace / Leyline of the Void class.) A graveyard→exile
-/// `Moved` redirect scoped to its own source, installed on a battlefield object
-/// so the merged-permanent leave event consults it.
+/// CR 614.6: a token-INCLUSIVE graveyard→exile `Moved` redirect, mirroring the
+/// actual Rest in Peace text "If a card or token would be put into a graveyard
+/// from anywhere, exile it instead" (`valid_card: None` — no card/token
+/// scoping; Leyline of the Void's card-only subject is a different, card-scoped
+/// class). Installed on a battlefield object so the merged-permanent leave
+/// event consults it.
 fn graveyard_exile_replacement() -> crate::types::ability::ReplacementDefinition {
     use crate::types::ability::{AbilityDefinition, AbilityKind, Effect, TargetFilter};
     use crate::types::replacements::ReplacementEvent;
@@ -870,7 +872,7 @@ fn cr_730_3d_redirect_on_merged_leave_propagates_to_all_components() {
     let host = sc.add_creature(P0, "Host", 2, 2).id();
     let rider = sc.add_creature(P0, "Rider", 4, 4).id();
     // Install a global graveyard→exile redirect on a separate battlefield object
-    // (an opponent's Rest in Peace) so the merged-permanent leave consults it.
+    // (a Rest in Peace–class permanent) so the merged-permanent leave consults it.
     let rip = sc.add_creature(P0, "Rest in Peace", 0, 0).id();
     let mut state = sc.state;
     state
@@ -949,8 +951,21 @@ fn cr_730_3e_nontoken_merged_leave_carries_token_component_with_redirect() {
         .push(graveyard_exile_replacement());
 
     let mut events = Vec::new();
-    merge_object_onto(&mut state, token_rider, host, MergeSide::Top, &mut events);
+    // CR 730.2d: the merged permanent is a token only if the TOPMOST component
+    // is a token — merge the token rider underneath so the card host stays
+    // topmost and the survivor remains a non-token (the clause-1 premise).
+    merge_object_onto(
+        &mut state,
+        token_rider,
+        host,
+        MergeSide::Bottom,
+        &mut events,
+    );
     state.battlefield.retain(|&id| id != token_rider);
+    assert!(
+        !state.objects[&host].is_token,
+        "premise: the merged permanent must be NON-token for 730.3e clause 1"
+    );
 
     let result = move_object(
         &mut state,

--- a/crates/engine/src/game/merge_tests.rs
+++ b/crates/engine/src/game/merge_tests.rs
@@ -814,6 +814,165 @@ fn merge_stacking_leave_routes_all_components_and_restores_survivor() {
     assert!(survivor.merge_layer_effect_id.is_none());
 }
 
+/// CR 614.6: "If a card would be put into a graveyard from anywhere, exile it
+/// instead." (Rest in Peace / Leyline of the Void class.) A graveyard→exile
+/// `Moved` redirect scoped to its own source, installed on a battlefield object
+/// so the merged-permanent leave event consults it.
+fn graveyard_exile_replacement() -> crate::types::ability::ReplacementDefinition {
+    use crate::types::ability::{AbilityDefinition, AbilityKind, Effect, TargetFilter};
+    use crate::types::replacements::ReplacementEvent;
+    crate::types::ability::ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(Zone::Graveyard)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+        ))
+        .description(
+            "If a card would be put into a graveyard from anywhere, exile it instead.".to_string(),
+        )
+}
+
+/// CR 730.3d: "If multiple replacement effects could be applied to the event of a
+/// merged permanent leaving the battlefield or being put into the new zone,
+/// applying one of those replacement effects to the object applies it to all
+/// components of the object."
+///
+/// A non-token merged permanent (two cards) leaves the battlefield while a global
+/// graveyard→exile redirect (Rest in Peace) is active. The redirect is consulted
+/// ONCE on the merged-permanent leave event (the survivor's ZoneChange) and its
+/// chosen destination — Exile — must propagate to EVERY component, NOT just the
+/// survivor. The redirect is explicitly NOT re-consulted per component
+/// (CR 730.3d): the survivor's resolved destination is what every component
+/// follows.
+///
+/// Drives the REAL pipeline (`zone_pipeline::move_object`), so `replace_event`
+/// actually fires the redirect — a bare `zones::move_to_zone` would skip the
+/// consult and send everything to the graveyard, which is exactly the
+/// pre-pipeline bug this pins against.
+#[test]
+fn cr_730_3d_redirect_on_merged_leave_propagates_to_all_components() {
+    use crate::game::scenario::GameScenario;
+    use crate::game::zone_pipeline::{move_object, ZoneMoveRequest, ZoneMoveResult};
+
+    let mut sc = GameScenario::new();
+    let host = sc.add_creature(P0, "Host", 2, 2).id();
+    let rider = sc.add_creature(P0, "Rider", 4, 4).id();
+    // Install a global graveyard→exile redirect on a separate battlefield object
+    // (an opponent's Rest in Peace) so the merged-permanent leave consults it.
+    let rip = sc.add_creature(P0, "Rest in Peace", 0, 0).id();
+    let mut state = sc.state;
+    state
+        .objects
+        .get_mut(&rip)
+        .unwrap()
+        .replacement_definitions
+        .push(graveyard_exile_replacement());
+
+    let mut events = Vec::new();
+    merge_object_onto(&mut state, rider, host, MergeSide::Top, &mut events);
+    // Runtime invariant: the mutating spell resolved off the stack, never listed.
+    state.battlefield.retain(|&id| id != rider);
+
+    // Route the survivor's leave THROUGH the pipeline so the redirect fires. The
+    // merged permanent "leaves the battlefield" → its event is a single ZoneChange
+    // (CR 730.3 — one permanent leaves), which RIP redirects to exile.
+    let result = move_object(
+        &mut state,
+        ZoneMoveRequest::effect(host, Zone::Graveyard, host),
+        &mut events,
+    );
+    assert!(
+        matches!(result, ZoneMoveResult::Done),
+        "the merged-permanent leave with a single applicable redirect resolves synchronously"
+    );
+
+    // CR 730.3d: BOTH components honor the survivor's redirected destination.
+    assert_eq!(
+        state.objects[&host].zone,
+        Zone::Exile,
+        "survivor follows the graveyard->exile redirect"
+    );
+    assert_eq!(
+        state.objects[&rider].zone,
+        Zone::Exile,
+        "absorbed component follows the SAME redirect applied to the merged \
+         permanent (CR 730.3d) — not the pre-replacement graveyard default"
+    );
+    let gy = &state.players.iter().find(|p| p.id == P0).unwrap().graveyard;
+    assert!(
+        !gy.contains(&host) && !gy.contains(&rider),
+        "no component may land in the pre-replacement graveyard default"
+    );
+}
+
+/// CR 730.3e (first clause): "If a replacement effect applies to a 'card' being
+/// put into a zone without also including tokens, that effect applies to all
+/// components of the merged permanent if it's not a token, including components
+/// that are tokens."
+///
+/// A NON-TOKEN merged permanent whose pile includes a TOKEN component leaves the
+/// battlefield under the graveyard→exile redirect. Because the merged permanent
+/// (its survivor) is not a token, the redirect carries ALL components to exile —
+/// including the token component, which would otherwise have gone to the
+/// graveyard (then ceased to exist). This is the merged-permanent destination
+/// following the survivor's resolved outcome regardless of per-component
+/// token-ness (CR 730.3e first clause + CR 730.3d).
+#[test]
+fn cr_730_3e_nontoken_merged_leave_carries_token_component_with_redirect() {
+    use crate::game::scenario::GameScenario;
+    use crate::game::zone_pipeline::{move_object, ZoneMoveRequest, ZoneMoveResult};
+
+    let mut sc = GameScenario::new();
+    let host = sc.add_creature(P0, "Host", 2, 2).id();
+    let token_rider = sc.add_creature(P0, "Token Rider", 4, 4).id();
+    let rip = sc.add_creature(P0, "Rest in Peace", 0, 0).id();
+    let mut state = sc.state;
+    // Make the rider a TOKEN component; the survivor (host) is a card.
+    state.objects.get_mut(&token_rider).unwrap().is_token = true;
+    state
+        .objects
+        .get_mut(&rip)
+        .unwrap()
+        .replacement_definitions
+        .push(graveyard_exile_replacement());
+
+    let mut events = Vec::new();
+    merge_object_onto(&mut state, token_rider, host, MergeSide::Top, &mut events);
+    state.battlefield.retain(|&id| id != token_rider);
+
+    let result = move_object(
+        &mut state,
+        ZoneMoveRequest::effect(host, Zone::Graveyard, host),
+        &mut events,
+    );
+    assert!(matches!(result, ZoneMoveResult::Done));
+
+    assert_eq!(
+        state.objects[&host].zone,
+        Zone::Exile,
+        "non-token survivor follows the redirect to exile"
+    );
+    assert_eq!(
+        state.objects[&token_rider].zone,
+        Zone::Exile,
+        "the TOKEN component of a NON-TOKEN merged permanent follows the redirect \
+         too (CR 730.3e first clause: applies to all components if the merged \
+         permanent is not a token, including token components)"
+    );
+}
+
 /// CR 608.2b + CR 702.140b: end-to-end / resolution-time coverage of the wired
 /// runtime path (the actual bug #2014 path), not just the merge primitive. These
 /// drive `stack::resolve_top` and the full `handle_cast_spell` pipeline.

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -911,6 +911,28 @@ fn stash_batch_tail(state: &mut GameState, tail: Vec<ZoneMoveRequest>, destinati
 /// the next object surfaces its own prompt. Rebuilds each tail request with the
 /// stashed batch-uniform context (attribution source, tap-state, exile
 /// tracking) so the resumed deliveries match the originals.
+///
+/// RE-PAUSE CONTRACT (the explicit guarantee for "a LATER item in the same batch
+/// parks after the first one already parked and was resumed"): everything a batch
+/// needs to finish identically across an arbitrary number of sequential parks is
+/// held in `state.pending_batch_deliveries` — NOT on the stack and NOT in the
+/// resuming caller — so each park can re-stash it for the next one:
+///   * the **undelivered tail** (`remaining`) — `deliver_batch` re-stashes the
+///     still-undelivered suffix on every re-park, so no object is ever dropped;
+///   * the **batch-uniform request context** (`destination`, `source_id`,
+///     `enter_tapped`, `exile_tracking`) — re-applied to every rebuilt request so
+///     the second-park resume produces requests equivalent to the originals
+///     (e.g. seek's `enter_tapped`, mill's self-anchored attribution);
+///   * the **post-loop `completion`** — taken out here, then re-attached via
+///     `ensure_batch_record` on the `NeedsChoice` arm so it survives the second
+///     pause boundary and still runs EXACTLY ONCE, the moment the final tail
+///     empties (never early, never twice).
+/// Because all of this lives on the parked record (not in `route_rest_partition`
+/// or any synchronous caller frame), a second, third, … park is just another
+/// `deliver_batch` → re-stash cycle. The contract is pinned by
+/// `mill_double_redirect_choice_continuation` (two sequential parks, no
+/// completion) and `surveil_rest_pile_redirect_continuation` (two sequential
+/// parks WITH a completion that must fire once after the second park drains).
 pub(crate) fn drain_pending_batch_deliveries(state: &mut GameState, events: &mut Vec<GameEvent>) {
     if let Some(pending) = state.pending_batch_deliveries.take() {
         let completion = pending.completion;

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -927,6 +927,7 @@ fn stash_batch_tail(state: &mut GameState, tail: Vec<ZoneMoveRequest>, destinati
 ///     `ensure_batch_record` on the `NeedsChoice` arm so it survives the second
 ///     pause boundary and still runs EXACTLY ONCE, the moment the final tail
 ///     empties (never early, never twice).
+///
 /// Because all of this lives on the parked record (not in `route_rest_partition`
 /// or any synchronous caller frame), a second, third, … park is just another
 /// `deliver_batch` → re-stash cycle. The contract is pinned by


### PR DESCRIPTION
- **feat(engine): pin CR 730.3d replacement propagation across merged-permanent components + document 730.3e scope (zone pipeline Phase E)**
- **docs(engine): make the batch re-pause contract explicit + correct route_rest_partition deferral note (zone pipeline Phase E)**
- **style(engine): satisfy clippy doc_lazy_continuation on the re-pause contract doc**
- **fix(engine): correct 730.3e clause-1 test premise — MergeSide::Bottom keeps survivor non-token (CR 730.2d)**
