### PR TITLE
fix(parser+runtime): handle 'N fewer [type] counter' pattern in enter_with_counters

### DIFF
--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -293,7 +293,8 @@ fn snapshot_parent_dependent_quantities(
         // frozen at delayed trigger creation time (before step transition
         // clears the LKI cache).
         Effect::ChangeZone {
-            enter_with_counters, ..
+            enter_with_counters,
+            ..
         } => {
             for (_, qty) in enter_with_counters.iter_mut() {
                 snapshot_quantity_expr(qty, state, ability);
@@ -447,10 +448,7 @@ fn snapshot_quantity_ref(
                 }
             }
             live.map(|obj| {
-                crate::game::quantity::counter_count_from_map(
-                    &obj.counters,
-                    counter_type.as_ref(),
-                )
+                crate::game::quantity::counter_count_from_map(&obj.counters, counter_type.as_ref())
             })
         }
         _ => None,

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -368,6 +368,32 @@ fn snapshot_quantity_ref(
     ability: &ResolvedAbility,
 ) -> Option<i32> {
     use crate::types::ability::ObjectScope;
+    // CR 603.7c + CR 400.7: CountersOn { Source } uses ability.source_id,
+    // not targets — handle it before the target_object_id extraction which
+    // early-returns None when targets is empty (common for dies triggers).
+    if let QuantityRef::CountersOn {
+        scope: ObjectScope::Source,
+        counter_type,
+    } = qty
+    {
+        let source_id = ability.source_id;
+        // Mirrors resolve_counters_on_scope (quantity.rs:2778): live first,
+        // LKI fallback.
+        let live = state.objects.get(&source_id);
+        let on_battlefield =
+            live.is_some_and(|obj| obj.zone == crate::types::zones::Zone::Battlefield);
+        if !on_battlefield {
+            if let Some(lki) = state.lki_cache.get(&source_id) {
+                return Some(crate::game::quantity::counter_count_from_map(
+                    &lki.counters,
+                    counter_type.as_ref(),
+                ));
+            }
+        }
+        return live.map(|obj| {
+            crate::game::quantity::counter_count_from_map(&obj.counters, counter_type.as_ref())
+        });
+    }
     let target_object_id = ability.targets.iter().find_map(|t| match t {
         TargetRef::Object(id) => Some(*id),
         _ => None,
@@ -423,33 +449,6 @@ fn snapshot_quantity_ref(
                 &filter_ctx,
             )
             .or(Some(0))
-        }
-        // CR 603.7c + CR 400.7: Snapshot the source object's counter count from
-        // LKI at delayed trigger creation time. At resolution time (next end
-        // step), the LKI cache will have been cleared by step transition
-        // (turns.rs:417). `ability.source_id` is the parent dies trigger's
-        // source = the dying creature.
-        QuantityRef::CountersOn {
-            scope: ObjectScope::Source,
-            counter_type,
-        } => {
-            let source_id = ability.source_id;
-            // Mirrors resolve_counters_on_scope (quantity.rs:2778): live first,
-            // LKI fallback.
-            let live = state.objects.get(&source_id);
-            let on_battlefield =
-                live.is_some_and(|obj| obj.zone == crate::types::zones::Zone::Battlefield);
-            if !on_battlefield {
-                if let Some(lki) = state.lki_cache.get(&source_id) {
-                    return Some(crate::game::quantity::counter_count_from_map(
-                        &lki.counters,
-                        counter_type.as_ref(),
-                    ));
-                }
-            }
-            live.map(|obj| {
-                crate::game::quantity::counter_count_from_map(&obj.counters, counter_type.as_ref())
-            })
         }
         _ => None,
     }

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -288,6 +288,17 @@ fn snapshot_parent_dependent_quantities(
             snapshot_pt_value(power, state, ability);
             snapshot_pt_value(toughness, state, ability);
         }
+        // CR 603.7c + CR 122.2: Snapshot counter-relative quantities inside
+        // ChangeZone.enter_with_counters so the LKI-based counter count is
+        // frozen at delayed trigger creation time (before step transition
+        // clears the LKI cache).
+        Effect::ChangeZone {
+            enter_with_counters, ..
+        } => {
+            for (_, qty) in enter_with_counters.iter_mut() {
+                snapshot_quantity_expr(qty, state, ability);
+            }
+        }
         _ => {}
     }
 }
@@ -411,6 +422,36 @@ fn snapshot_quantity_ref(
                 &filter_ctx,
             )
             .or(Some(0))
+        }
+        // CR 603.7c + CR 400.7: Snapshot the source object's counter count from
+        // LKI at delayed trigger creation time. At resolution time (next end
+        // step), the LKI cache will have been cleared by step transition
+        // (turns.rs:417). `ability.source_id` is the parent dies trigger's
+        // source = the dying creature.
+        QuantityRef::CountersOn {
+            scope: ObjectScope::Source,
+            counter_type,
+        } => {
+            let source_id = ability.source_id;
+            // Mirrors resolve_counters_on_scope (quantity.rs:2778): live first,
+            // LKI fallback.
+            let live = state.objects.get(&source_id);
+            let on_battlefield =
+                live.is_some_and(|obj| obj.zone == crate::types::zones::Zone::Battlefield);
+            if !on_battlefield {
+                if let Some(lki) = state.lki_cache.get(&source_id) {
+                    return Some(crate::game::quantity::counter_count_from_map(
+                        &lki.counters,
+                        counter_type.as_ref(),
+                    ));
+                }
+            }
+            live.map(|obj| {
+                crate::game::quantity::counter_count_from_map(
+                    &obj.counters,
+                    counter_type.as_ref(),
+                )
+            })
         }
         _ => None,
     }
@@ -1457,6 +1498,130 @@ mod tests {
                 );
             }
             other => panic!("expected Mana{{Colorless}}, got {other:?}"),
+        }
+    }
+
+    /// Issue #528: Nine-Lives Familiar — snapshot_parent_dependent_quantities must
+    /// freeze CountersOn { Source } inside ChangeZone.enter_with_counters to a Fixed
+    /// value from LKI at delayed trigger creation time (before step transition clears
+    /// the LKI cache).
+    #[test]
+    fn snapshot_counters_on_source_in_change_zone_enter_with_counters() {
+        use crate::types::game_state::LKISnapshot;
+        use std::collections::HashMap;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = ObjectId(7); // Nine-Lives Familiar that just died
+
+        // Populate LKI cache as if the source died with 5 revival counters
+        let mut lki_counters = HashMap::new();
+        lki_counters.insert(CounterType::Generic("revival".to_string()), 5);
+        state.lki_cache.insert(
+            source_id,
+            LKISnapshot {
+                name: "Nine-Lives Familiar".to_string(),
+                power: Some(3),
+                toughness: Some(3),
+                base_power: Some(3),
+                base_toughness: Some(3),
+                mana_value: 4,
+                controller: PlayerId(0),
+                owner: PlayerId(0),
+                card_types: vec![],
+                subtypes: vec![],
+                supertypes: vec![],
+                keywords: vec![],
+                colors: vec![],
+                chosen_attributes: Vec::new(),
+                counters: lki_counters,
+            },
+        );
+
+        // Set up the trigger event (dies = zone change to graveyard)
+        state.current_trigger_event = Some(GameEvent::ZoneChanged {
+            object_id: source_id,
+            from: Some(Zone::Battlefield),
+            to: Zone::Graveyard,
+            record: Box::new(crate::types::game_state::ZoneChangeRecord::test_minimal(
+                source_id,
+                Some(Zone::Battlefield),
+                Zone::Graveyard,
+            )),
+        });
+
+        // Build the delayed trigger inner effect: ChangeZone with enter_with_counters
+        // containing ClampMin { Offset { CountersOn { Source, revival }, -1 }, 0 }
+        let revival_type = CounterType::Generic("revival".to_string());
+        let counter_qty = QuantityExpr::ClampMin {
+            inner: Box::new(QuantityExpr::Offset {
+                inner: Box::new(QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Source,
+                        counter_type: Some(revival_type.clone()),
+                    },
+                }),
+                offset: -1,
+            }),
+            minimum: 0,
+        };
+
+        let delayed_inner = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Battlefield,
+                target: TargetFilter::ParentTarget,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![(revival_type.clone(), counter_qty)],
+                face_down_profile: None,
+            },
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::CreateDelayedTrigger {
+                condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+                effect: Box::new(delayed_inner),
+                uses_tracked_set: false,
+            },
+            vec![],
+            source_id, // source_id = the dying creature
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).expect("resolve must succeed");
+
+        // Verify the delayed trigger's enter_with_counters was snapshotted:
+        // CountersOn(Source) resolved to Fixed(5) from LKI. The outer Offset and
+        // ClampMin wrappers are preserved (snapshot only freezes Ref leaves).
+        let delayed = &state.delayed_triggers[0];
+        match &delayed.ability.effect {
+            Effect::ChangeZone {
+                enter_with_counters,
+                ..
+            } => {
+                assert_eq!(enter_with_counters.len(), 1);
+                let (ct, qty) = &enter_with_counters[0];
+                assert_eq!(*ct, revival_type);
+                assert_eq!(
+                    *qty,
+                    QuantityExpr::ClampMin {
+                        inner: Box::new(QuantityExpr::Offset {
+                            inner: Box::new(QuantityExpr::Fixed { value: 5 }),
+                            offset: -1,
+                        }),
+                        minimum: 0,
+                    },
+                    "CountersOn(Source) with 5 revival counters in LKI must snapshot to \
+                     ClampMin {{ Offset {{ Fixed(5), -1 }}, 0 }}"
+                );
+            }
+            other => panic!("expected ChangeZone, got {other:?}"),
         }
     }
 }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5057,7 +5057,36 @@ pub(crate) fn parse_counter_suffix_body_combinator(
     // Count: digits, English word, or article ("a"/"an").
     let (rest, count) = nom_primitives::parse_number.parse(input)?;
     let (rest, _) = tag(" ").parse(rest)?;
-
+    // "N fewer [type] counter(s)" — counter-relative-to-LKI pattern (Nine-Lives Familiar class).
+    // CR 603.7c + CR 107.1b: The delayed trigger reads the source's pre-death counter count
+    // via LKI and subtracts N, clamped to zero.
+    if let Ok((fewer_rest, _)) = tag::<_, _, OracleError<'_>>("fewer ").parse(rest) {
+        let (fewer_rest, type_token) = take_until(" counter").parse(fewer_rest)?;
+        let counter_type = crate::types::counter::parse_counter_type(type_token);
+        let (fewer_rest, _) = tag(" counter").parse(fewer_rest)?;
+        let (fewer_rest, _) =
+            nom::combinator::opt(tag::<_, _, OracleError<'_>>("s")).parse(fewer_rest)?;
+        let (fewer_rest, _) =
+            nom::combinator::opt(tag::<_, _, OracleError<'_>>(" on it")).parse(fewer_rest)?;
+        return Ok((
+            fewer_rest,
+            (
+                counter_type.clone(),
+                QuantityExpr::ClampMin {
+                    inner: Box::new(QuantityExpr::Offset {
+                        inner: Box::new(QuantityExpr::Ref {
+                            qty: QuantityRef::CountersOn {
+                                scope: ObjectScope::Source,
+                                counter_type: Some(counter_type),
+                            },
+                        }),
+                        offset: -(count as i32),
+                    }),
+                    minimum: 0,
+                },
+            ),
+        ));
+    }
     // Optional "additional " — a synonym in this grammatical position.
     let (rest, _) =
         nom::combinator::opt(tag::<_, _, OracleError<'_>>("additional ")).parse(rest)?;
@@ -5124,8 +5153,8 @@ mod tests {
     };
     use crate::parser::oracle_util::TextPair;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, DelayedTriggerCondition, Effect, PtValue, QuantityExpr,
-        QuantityRef, TargetFilter, TriggerDefinition,
+        AbilityDefinition, AbilityKind, DelayedTriggerCondition, Effect, ObjectScope, PtValue,
+        QuantityExpr, QuantityRef, TargetFilter, TriggerDefinition,
     };
     use crate::types::counter::CounterType;
     use crate::types::phase::Phase;
@@ -5373,11 +5402,56 @@ mod tests {
             assert!(
                 delayed_lose,
                 "expected a delayed LoseTheGame at the extra turn's end step in {text:?}, got {effects:?}"
-            );
+                        );
         }
     }
-}
 
+    /// Issue #528: Nine-Lives Familiar — "return it to the battlefield with one
+    /// fewer revival counter on it" must produce a ClampMin(Offset(CountersOn))
+    /// quantity, not a bogus counter type "fewer revival".
+    #[test]
+    fn return_to_battlefield_with_one_fewer_counter_produces_offset_quantity() {
+        let (target, dest, remainder) = strip_return_destination_ext_with_remainder(
+            "it to the battlefield with one fewer revival counter on it",
+        );
+        assert_eq!(target, "it");
+        let dest = dest.expect("expected a battlefield return destination");
+        assert_eq!(dest.zone, Zone::Battlefield);
+        assert_eq!(dest.enter_with_counters.len(), 1);
+        let (ct, qty) = &dest.enter_with_counters[0];
+        assert_eq!(*ct, CounterType::Generic("revival".to_string()));
+        // ClampMin { Offset { Ref { CountersOn { Source, revival } }, -1 }, 0 }
+        match qty {
+            QuantityExpr::ClampMin { inner, minimum } => {
+                assert_eq!(*minimum, 0);
+                match inner.as_ref() {
+                    QuantityExpr::Offset { inner, offset } => {
+                        assert_eq!(*offset, -1);
+                        match inner.as_ref() {
+                            QuantityExpr::Ref {
+                                qty:
+                                    QuantityRef::CountersOn {
+                                        scope,
+                                        counter_type,
+                                    },
+                            } => {
+                                assert_eq!(*scope, ObjectScope::Source);
+                                assert_eq!(
+                                    *counter_type,
+                                    Some(CounterType::Generic("revival".to_string()))
+                                );
+                            }
+                            other => panic!("expected CountersOn ref, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected Offset, got {other:?}"),
+                }
+            }
+            other => panic!("expected ClampMin, got {other:?}"),
+        }
+        assert_eq!(remainder, "");
+    }
+}
 #[cfg(test)]
 mod where_x_tests {
     use super::parse_where_x_quantity_expression;


### PR DESCRIPTION
## Summary

Fixes #528 — Nine-Lives Familiar enters with one fewer revival counter.

Builds on #2471 which confirmed the engine pipeline is correct and identified the parser gap as the remaining defect.

## Root Cause

`parse_counter_suffix_body_combinator` in `oracle_effect/lower.rs` did not handle the "N fewer [type] counter(s)" grammar. When parsing "with one fewer revival counter on it":
1. `parse_number` consumed "one" → count = 1
2. `take_until(" counter")` consumed "fewer revival" as the counter type token
3. Result: `enter_with_counters = [(Generic("fewer revival"), Fixed(1))]` — a bogus counter type

## Fix

### Parser (`oracle_effect/lower.rs`)
New arm in `parse_counter_suffix_body_combinator` detects "N fewer [type] counter(s)" and produces:
ClampMin { Offset { Ref(CountersOn { Source, type }), -N }, 0 }

### Runtime (`delayed_trigger.rs`)
1. `snapshot_parent_dependent_quantities` gains a `ChangeZone` arm that iterates `enter_with_counters` and calls `snapshot_quantity_expr` on each quantity.
2. `snapshot_quantity_ref` gains a `CountersOn { scope: Source }` arm that reads the source object's counter count from LKI (mirroring `resolve_counters_on_scope`).

This ensures the counter count is frozen at delayed trigger creation time (when the dies trigger resolves and LKI is still populated), before step transition clears the LKI cache.

## CR Citations
- CR 603.7c: Delayed trigger creation-time binding
- CR 107.1b: Quantity clamping semantics
- CR 122.2: Counter placement
- CR 400.7: Last-known information

## Tests
- **Parser unit test:** Verifies `strip_return_destination_ext_with_remainder` produces the correct `ClampMin(Offset(CountersOn))` shape for "with one fewer revival counter on it"
- **Runtime snapshot test:** Constructs a delayed trigger with `ChangeZone.enter_with_counters` containing `CountersOn(Source)`, populates LKI with 5 revival counters, resolves, and asserts the quantity is snapshotted to `ClampMin { Offset { Fixed(5), -1 }, 0 }`

## Test plan
- [x] `cargo test -p engine --lib return_to_battlefield_with_one_fewer_counter`
- [x] `cargo test -p engine --lib snapshot_counters_on_source_in_change_zone`
