### PR TITLE
fix(lobby): improve mobile format filter and server chip layout

### DIFF
--- a/client/src/components/lobby/LobbyView.tsx
+++ b/client/src/components/lobby/LobbyView.tsx
@@ -11,7 +11,7 @@ import { GameListItem } from "./GameListItem";
 import type { LobbyGame } from "./GameListItem";
 import { ServerFlag } from "./ServerFlag";
 import { ServerPicker } from "./ServerPicker";
-import { SelectField } from "../ui/SelectField";
+import { MenuSelect } from "../ui/MenuSelect";
 
 interface LobbyViewProps {
   onHostGame: () => void;
@@ -264,27 +264,42 @@ export function LobbyView({
     });
   }, [games, formatFilter, roomTypeFilter]);
 
+  const formatMenuGroups = useMemo(
+    () =>
+      FORMAT_FILTER_GROUPS.map(({ group, items }) => ({
+        label: group,
+        items: items.map((m) => ({ value: m.format, label: m.label })),
+      })),
+    [],
+  );
+
+  const formatMenuLabel = formatFilter
+    ? (FORMAT_REGISTRY.find((m) => m.format === formatFilter)?.label ?? formatFilter)
+    : t("lobbyView.allFormats");
+
+  const serverHost = serverAddress.replace(/^wss?:\/\//, "").split("/")[0];
+
   return (
     <MenuPanel className="relative z-10 flex w-full max-w-3xl flex-col gap-6 px-5 py-6">
-      <div className="flex w-full items-center justify-between gap-3">
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">
           {isP2P ? t("lobbyView.directConnection") : t("lobbyView.onlineLobby")}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2 sm:justify-end">
           {isServer && (
             <button
               type="button"
               onClick={() => setServerPickerOpen(true)}
               title={serverAddress}
-              className="flex items-center gap-1.5 rounded-full border border-white/10 bg-black/18 px-2.5 py-0.5 font-mono text-[10px] text-slate-300 transition-colors hover:border-white/18 hover:bg-white/6"
+              className="flex min-w-0 max-w-full items-center gap-1.5 rounded-full border border-white/10 bg-black/18 px-2.5 py-0.5 font-mono text-[10px] text-slate-300 transition-colors hover:border-white/18 hover:bg-white/6"
             >
               {serverFlag && (
                 <ServerFlag
                   flag={serverFlag}
-                  className="h-2.5 w-auto rounded-[1px] ring-1 ring-black/20"
+                  className="h-2.5 w-auto shrink-0 rounded-[1px] ring-1 ring-black/20"
                 />
               )}
-              {serverAddress.replace(/^wss?:\/\//, "").split("/")[0]}
+              <span className="truncate whitespace-nowrap">{serverHost}</span>
             </button>
           )}
           {/* In P2P mode the user has no other path back to ServerPicker —
@@ -309,43 +324,30 @@ export function LobbyView({
         </div>
       </div>
 
-      {/* Format filter -- grouped native <select>. Native is the
-          mobile/tablet UX win: a 14-chip segmented control overflows
-          horizontally on phone/tablet, while native <select> opens an
-          OS-level full-screen picker that's already touch-optimized.
-          Trigger is sized to the 44px touch-target rule. */}
+      {/* Format filter — MenuSelect opens a bottom sheet below 820px (shell tab
+          bar width) so the long format roster never covers the lobby form.
+          Desktop keeps the anchored dropdown. min-h-44px + text-base meet the
+          44/48px touch-target rule and prevent iOS focus-zoom. */}
       {isServer && (
-        <label
-          htmlFor="lobby-format-filter"
-          className="flex min-h-[44px] items-center gap-2 self-start rounded-[16px] bg-black/18 px-3 py-1 ring-1 ring-white/10"
-        >
-          <span className="text-[0.62rem] font-medium uppercase tracking-[0.18em] text-gray-500">
+        <div className="flex min-h-[44px] w-full items-center gap-2 self-stretch rounded-[16px] bg-black/18 px-3 py-1 ring-1 ring-white/10 sm:w-auto sm:self-start">
+          <span className="shrink-0 text-[0.62rem] font-medium uppercase tracking-[0.18em] text-gray-500">
             {t("lobbyView.format")}
           </span>
-          <SelectField
-            id="lobby-format-filter"
-            value={formatFilter ?? FILTER_ALL_SENTINEL}
-            onChange={(e) =>
+          <MenuSelect
+            ariaLabel={t("lobbyView.format")}
+            label={formatMenuLabel}
+            selectedValue={formatFilter ?? FILTER_ALL_SENTINEL}
+            items={[{ value: FILTER_ALL_SENTINEL, label: t("lobbyView.allFormats") }]}
+            groups={formatMenuGroups}
+            onSelect={(value) =>
               setFormatFilter(
-                e.target.value === FILTER_ALL_SENTINEL ? null : (e.target.value as GameFormat),
+                value === FILTER_ALL_SENTINEL ? null : (value as GameFormat),
               )
             }
-            className="bg-transparent py-1.5 text-base font-medium text-white outline-none"
-          >
-            <option value={FILTER_ALL_SENTINEL} className="bg-[#0a0f1b] text-slate-100">
-              {t("lobbyView.allFormats")}
-            </option>
-            {FORMAT_FILTER_GROUPS.map(({ group, items }) => (
-              <optgroup key={group} label={group} className="bg-[#0a0f1b] text-slate-100">
-                {items.map((m) => (
-                  <option key={m.format} value={m.format} className="bg-[#0a0f1b] text-slate-100">
-                    {m.label}
-                  </option>
-                ))}
-              </optgroup>
-            ))}
-          </SelectField>
-        </label>
+            wrapperClassName="min-w-0 flex-1 sm:min-w-[10rem]"
+            className="min-h-[44px] rounded-none border-0 bg-transparent px-0 py-1.5 text-base font-medium text-white shadow-none hover:bg-transparent focus-visible:ring-white/20"
+          />
+        </div>
       )}
 
       {isServer && showRoomTypeFilter && (

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -19,7 +19,6 @@ function useMobileSheetLayout(): boolean {
   useEffect(() => {
     const mediaQuery = window.matchMedia(MOBILE_SHEET_MEDIA_QUERY);
     const handleChange = () => setMobileSheet(mediaQuery.matches);
-    handleChange();
     mediaQuery.addEventListener("change", handleChange);
     return () => mediaQuery.removeEventListener("change", handleChange);
   }, []);

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 const MENU_GAP_PX = 4;
@@ -130,8 +130,7 @@ export function MenuSelect({
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLSpanElement>(null);
-  const allItems = flattenMenuItems(items, groups);
-  const itemsKey = allItems.map((item) => item.label).join("\0");
+  const allItems = useMemo(() => flattenMenuItems(items, groups), [items, groups]);
   const [menuStyle, setMenuStyle] = useState<{
     top: number | "auto";
     bottom: number | "auto";
@@ -158,7 +157,7 @@ export function MenuSelect({
 
     // px-3 padding + chevron + gap between label and icon.
     setMinWidthPx(Math.min(contentWidth + 48, TRIGGER_MAX_WIDTH_PX));
-  }, [label, itemsKey]);
+  }, [label, allItems]);
 
   const updatePosition = useCallback(() => {
     if (mobileSheet) return;

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -6,6 +6,26 @@ const MENU_VIEWPORT_PADDING_PX = 8;
 const MENU_MAX_HEIGHT_PX = 280;
 /** Matches AppShell `pb-[76px]` tab-bar reserve on viewports below 820px. */
 const MOBILE_TAB_BAR_RESERVE_PX = 76;
+/** Shell tab bar appears below this width — menus become bottom sheets. */
+const MOBILE_SHEET_MEDIA_QUERY = "(max-width: 819px)";
+
+function useMobileSheetLayout(): boolean {
+  const [mobileSheet, setMobileSheet] = useState(() =>
+    typeof window !== "undefined"
+      ? window.matchMedia(MOBILE_SHEET_MEDIA_QUERY).matches
+      : false,
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(MOBILE_SHEET_MEDIA_QUERY);
+    const handleChange = () => setMobileSheet(mediaQuery.matches);
+    handleChange();
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  return mobileSheet;
+}
 
 function getViewportBottomInset(): number {
   if (window.matchMedia("(min-width: 820px)").matches) {
@@ -35,10 +55,18 @@ export interface MenuSelectItem {
   label: string;
 }
 
+export interface MenuSelectGroup {
+  label: string;
+  items: MenuSelectItem[];
+}
+
 export interface MenuSelectProps {
   /** Visible trigger label (e.g. placeholder text). */
   label: string;
-  items: MenuSelectItem[];
+  /** Ungrouped options rendered before any `groups` sections. */
+  items?: MenuSelectItem[];
+  /** Grouped sections (e.g. Constructed / Commander format families). */
+  groups?: MenuSelectGroup[];
   onSelect: (value: string) => void;
   disabled?: boolean;
   /** Accessible name when `label` shows the current value instead of the control name. */
@@ -75,9 +103,20 @@ function getScrollParents(element: HTMLElement | null): (HTMLElement | Window)[]
   return parents;
 }
 
+function flattenMenuItems(
+  items: MenuSelectItem[] | undefined,
+  groups: MenuSelectGroup[] | undefined,
+): MenuSelectItem[] {
+  return [
+    ...(items ?? []),
+    ...(groups ?? []).flatMap((group) => group.items),
+  ];
+}
+
 export function MenuSelect({
   label,
   items,
+  groups,
   onSelect,
   disabled = false,
   ariaLabel,
@@ -86,12 +125,14 @@ export function MenuSelect({
   className = "",
 }: MenuSelectProps) {
   const listboxId = useId();
+  const mobileSheet = useMobileSheetLayout();
   const [open, setOpen] = useState(false);
   const [minWidthPx, setMinWidthPx] = useState<number | undefined>(undefined);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLSpanElement>(null);
-  const itemsKey = items.map((item) => item.label).join("\0");
+  const allItems = flattenMenuItems(items, groups);
+  const itemsKey = allItems.map((item) => item.label).join("\0");
   const [menuStyle, setMenuStyle] = useState<{
     top: number | "auto";
     bottom: number | "auto";
@@ -111,7 +152,7 @@ export function MenuSelect({
     if (!measure) return;
 
     let contentWidth = 0;
-    for (const sample of [label, ...items.map((item) => item.label)]) {
+    for (const sample of [label, ...allItems.map((item) => item.label)]) {
       measure.textContent = sample;
       contentWidth = Math.max(contentWidth, measure.offsetWidth);
     }
@@ -121,6 +162,7 @@ export function MenuSelect({
   }, [label, itemsKey]);
 
   const updatePosition = useCallback(() => {
+    if (mobileSheet) return;
     const trigger = triggerRef.current;
     if (!trigger) return;
 
@@ -148,7 +190,7 @@ export function MenuSelect({
       top: openUp ? "auto" : rect.bottom + MENU_GAP_PX,
       bottom: openUp ? window.innerHeight - rect.top + MENU_GAP_PX : "auto",
     });
-  }, []);
+  }, [mobileSheet]);
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -162,7 +204,7 @@ export function MenuSelect({
         : null;
     (selectedOption ?? menu?.querySelector<HTMLButtonElement>('[role="option"]'))?.focus();
     selectedOption?.scrollIntoView({ block: "nearest" });
-  }, [open, selectedValue, updatePosition]);
+  }, [open, selectedValue, updatePosition, mobileSheet]);
 
   useEffect(() => {
     if (!open) return;
@@ -218,7 +260,27 @@ export function MenuSelect({
         parent.removeEventListener("scroll", handleScroll);
       });
     };
-  }, [open, updatePosition]);
+  }, [open, updatePosition, mobileSheet]);
+
+  const renderOption = (item: MenuSelectItem) => (
+    <button
+      key={item.value}
+      type="button"
+      role="option"
+      onClick={() => {
+        onSelect(item.value);
+        setOpen(false);
+      }}
+      aria-selected={selectedValue === item.value}
+      className={[
+        "flex w-full min-w-0 items-center px-3 py-2 text-left text-sm transition-colors hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-none",
+        selectedValue === item.value ? "bg-white/10 text-white" : "text-slate-200",
+      ].join(" ")}
+      title={item.label}
+    >
+      <span className="min-w-0 truncate">{item.label}</span>
+    </button>
+  );
 
   const triggerClassName = [
     "flex w-full items-center justify-between gap-2 rounded-xl border border-white/10 bg-black/18 px-3 py-1.5 text-left text-sm text-white transition-colors",
@@ -259,41 +321,53 @@ export function MenuSelect({
 
       {open &&
         createPortal(
-          <div
-            ref={menuRef}
-            id={listboxId}
-            role="listbox"
-            aria-label={ariaLabel ?? label}
-            className="fixed z-[120] flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain rounded-xl border border-white/10 bg-[#0a0f1b]/98 py-1 shadow-xl backdrop-blur-md thin-scrollbar"
-            onWheel={(event) => event.stopPropagation()}
-            style={{
-              top: menuStyle.top,
-              bottom: menuStyle.bottom,
-              left: menuStyle.left,
-              width: menuStyle.width,
-              maxHeight: menuStyle.maxHeight,
-            }}
-          >
-            {items.map((item) => (
+          <>
+            {mobileSheet && (
               <button
-                key={item.value}
                 type="button"
-                role="option"
-                onClick={() => {
-                  onSelect(item.value);
-                  setOpen(false);
-                }}
-                aria-selected={selectedValue === item.value}
-                className={[
-                  "flex w-full min-w-0 items-center px-3 py-2 text-left text-sm transition-colors hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-none",
-                  selectedValue === item.value ? "bg-white/10 text-white" : "text-slate-200",
-                ].join(" ")}
-                title={item.label}
-              >
-                <span className="min-w-0 truncate">{item.label}</span>
-              </button>
-            ))}
-          </div>,
+                aria-label={ariaLabel ?? label}
+                className="fixed inset-0 z-[119] bg-black/60"
+                onClick={() => setOpen(false)}
+              />
+            )}
+            <div
+              ref={menuRef}
+              id={listboxId}
+              role="listbox"
+              aria-label={ariaLabel ?? label}
+              className={[
+                "fixed z-[120] flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain border border-white/10 bg-[#0a0f1b]/98 py-1 shadow-xl backdrop-blur-md thin-scrollbar",
+                mobileSheet
+                  ? "inset-x-0 bottom-[calc(76px+env(safe-area-inset-bottom))] max-h-[min(70dvh,calc(100dvh-76px-env(safe-area-inset-bottom)-1rem))] rounded-t-2xl rounded-b-none border-b-0"
+                  : "rounded-xl",
+              ].join(" ")}
+              onWheel={(event) => event.stopPropagation()}
+              style={
+                mobileSheet
+                  ? undefined
+                  : {
+                      top: menuStyle.top,
+                      bottom: menuStyle.bottom,
+                      left: menuStyle.left,
+                      width: menuStyle.width,
+                      maxHeight: menuStyle.maxHeight,
+                    }
+              }
+            >
+              {items?.map((item) => renderOption(item))}
+              {groups?.map((group) => (
+                <div key={group.label}>
+                  <div
+                    role="presentation"
+                    className="px-3 py-1.5 text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-slate-500"
+                  >
+                    {group.label}
+                  </div>
+                  {group.items.map((item) => renderOption(item))}
+                </div>
+              ))}
+            </div>
+          </>,
           document.body,
         )}
     </div>


### PR DESCRIPTION
## Summary

* Prevent the online lobby server address chip from wrapping awkwardly on mobile viewports
* Replace the format filter's native `<select>` with `MenuSelect`
* Show format options in a mobile-friendly bottom sheet on narrow screens
* Add grouped section support to `MenuSelect`
* Preserve the existing anchored dropdown experience on desktop

## Screenshots

### Before

<img width="356" height="760" alt="image" src="https://github.com/user-attachments/assets/d2855931-54c0-44a8-923f-14cf1a40a2c6" />
<img width="375" height="758" alt="image" src="https://github.com/user-attachments/assets/8093ac64-7382-4d05-b98d-e3dcbe3310dc" />

### After
<img width="396" height="760" alt="image" src="https://github.com/user-attachments/assets/e8faf990-670c-4363-abca-e66125e2d608" />
<img width="396" height="760" alt="image" src="https://github.com/user-attachments/assets/837a292f-f31b-49a8-b15a-7aec3914ea87" />

## Test Plan

* [ ] On a mobile viewport (<820px), open **Online** and verify the server chip stays on one line and truncates cleanly if necessary
* [ ] Open the **Format** filter and confirm a bottom sheet appears above the tab bar
* [ ] Verify format options are grouped correctly (Constructed, Commander, etc.)
* [ ] Verify tapping outside the sheet dismisses it
* [ ] Select a format and confirm the filter updates correctly
* [ ] Select **All formats** and confirm the filter is cleared
* [ ] On desktop (≥820px), verify the format menu still opens as an anchored dropdown
