### PR TITLE
fix(parser): unconditional life-floor replacement (Ali from Cairo, CR 614.1a)

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -524,6 +524,14 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         return Some(def);
     }
 
+    // --- Unconditional life-floor: "damage that would reduce your life total to
+    // less than N reduces it to N instead" (Ali from Cairo, Fortune Thief,
+    // Sustaining Spirit). CR 614.1a. Tried after the conditional Worship arm,
+    // which claims the "if you control …" prefix. ---
+    if let Some(def) = parse_unconditional_life_floor_damage_replacement(&norm_lower) {
+        return Some(def);
+    }
+
     None
 }
 
@@ -5879,6 +5887,50 @@ fn parse_life_floor_damage_replacement(norm_lower: &str) -> Option<ReplacementDe
     )
 }
 
+/// CR 614.1a: Parse the UNCONDITIONAL life-floor replacement — "damage that
+/// would reduce your life total to less than N reduces it to N instead."
+/// (Ali from Cairo, Fortune Thief, Sustaining Spirit). Identical to
+/// [`parse_life_floor_damage_replacement`] but without the Worship-class
+/// "if you control a [filter]," guard, so it carries no `IfControlsMatching`
+/// condition. Dispatched after the conditional arm, which claims the
+/// "if you control …" prefix first.
+fn parse_unconditional_life_floor_damage_replacement(
+    norm_lower: &str,
+) -> Option<ReplacementDefinition> {
+    let (after_threshold, _) =
+        tag::<_, _, OracleError<'_>>("damage that would reduce your life total to less than ")
+            .parse(norm_lower)
+            .ok()?;
+
+    let (tail, minimum) = nom_primitives::parse_number.parse(after_threshold).ok()?;
+    let (tail, floor_val) = preceded(
+        tag::<_, _, OracleError<'_>>(" reduces it to "),
+        nom_primitives::parse_number,
+    )
+    .parse(tail)
+    .ok()?;
+    if floor_val != minimum {
+        return None;
+    }
+    // Full-consumption guard: the line is exactly the life-floor clause.
+    all_consuming((
+        tag::<_, _, OracleError<'_>>(" instead"),
+        opt(tag::<_, _, OracleError<'_>>(".")),
+    ))
+    .parse(tail)
+    .ok()?;
+
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::DamageDone)
+            .damage_modification(DamageModification::LifeFloor {
+                minimum: minimum as i32,
+            })
+            .damage_target_filter(DamageTargetFilter::Player {
+                player: DamageTargetPlayerScope::Controller,
+            }),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -11063,6 +11115,59 @@ mod tests {
                 player: crate::types::ability::DamageTargetPlayerScope::Controller
             }),
             "damage target should be Controller"
+        );
+    }
+
+    /// CR 614.1a: the UNCONDITIONAL life-floor (Ali from Cairo, Fortune Thief,
+    /// Sustaining Spirit) parses to the same `DamageDone` + `LifeFloor` +
+    /// Controller-target replacement as Worship, but with NO condition — the
+    /// previously-dropped `Effect:replacement_structure` gap.
+    #[test]
+    fn parses_unconditional_life_floor_replacement() {
+        for card in ["Ali from Cairo", "Fortune Thief", "Sustaining Spirit"] {
+            let def = parse_replacement_line(
+                "Damage that would reduce your life total to less than 1 reduces it to 1 instead.",
+                card,
+            )
+            .unwrap_or_else(|| panic!("{card}: unconditional life-floor should parse"));
+
+            assert_eq!(def.event, ReplacementEvent::DamageDone, "{card}");
+            assert_eq!(
+                def.condition, None,
+                "{card}: unconditional form must carry NO condition (cf. Worship's IfControlsMatching)"
+            );
+            assert_eq!(
+                def.damage_modification,
+                Some(crate::types::ability::DamageModification::LifeFloor { minimum: 1 }),
+                "{card}: damage modification should be LifeFloor(1)"
+            );
+            assert_eq!(
+                def.damage_target_filter,
+                Some(crate::types::ability::DamageTargetFilter::Player {
+                    player: crate::types::ability::DamageTargetPlayerScope::Controller
+                }),
+                "{card}: damage target should be Controller"
+            );
+        }
+    }
+
+    /// Guard: the conditional Worship form still routes to the conditional arm
+    /// (keeps its `IfControlsMatching` condition) — the unconditional arm must
+    /// not swallow it.
+    #[test]
+    fn conditional_worship_life_floor_still_carries_condition() {
+        let def = parse_replacement_line(
+            "If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead.",
+            "Worship",
+        )
+        .expect("Worship should still parse");
+        assert!(
+            matches!(
+                def.condition,
+                Some(ReplacementCondition::IfControlsMatching { .. })
+            ),
+            "Worship must keep its IfControlsMatching condition, got {:?}",
+            def.condition
         );
     }
 }


### PR DESCRIPTION
## Summary
The unconditional life-floor replacement — **Ali from Cairo**, **Fortune Thief**, **Sustaining Spirit** — reads:

> "Damage that would reduce your life total to less than 1 reduces it to 1 instead."

This was dropped (an `Effect:replacement_structure` gap), so the cards did **nothing** — damage reduced the controller below 1 life and they lost normally, defeating the card.

Purely a **parser** gap. The engine fully supports it: `DamageModification::LifeFloor { minimum }` exists and is resolved in the damage pipeline (`game/replacement.rs`), and the parser already emits it — but only via the Worship-class arm `parse_life_floor_damage_replacement`, which **hard-requires** an "if you control a [filter]," prefix (`ReplacementCondition::IfControlsMatching`). The unconditional form matched no arm.

## Change
- **`parser/oracle_replacement.rs`** — add `parse_unconditional_life_floor_damage_replacement`, a sibling of the conditional arm that builds the same replacement (`event: DamageDone`, `damage_modification: LifeFloor { minimum: N }`, `damage_target_filter: Player(Controller)`) **minus** the `IfControlsMatching` condition, with a full-consumption guard on " instead[.]". Dispatched **after** the conditional arm, so the "if you control …" prefix still routes to Worship handling. **No engine/type change; no new variant.**

## Tests
- `parses_unconditional_life_floor_replacement` — build-the-class (Ali from Cairo / Fortune Thief / Sustaining Spirit) → `DamageDone` + `LifeFloor(1)` + Controller target, **no** condition.
- `conditional_worship_life_floor_still_carries_condition` — regression guard: Worship still keeps its `IfControlsMatching` condition.
- Existing Worship + LifeFloor-runtime tests still pass (6 total).

Parser-combinator gate, `rustfmt --check`, and clippy `-D warnings` all clean.

CR 614.1a (damage replacement effects).

Fixes #2969