### PR TITLE
fix(parser): parse unconditional life-floor damage replacements (Ali from Cairo)

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5898,46 +5898,13 @@ fn parse_life_floor_damage_replacement(norm_lower: &str) -> Option<ReplacementDe
 fn parse_unconditional_life_floor_damage_replacement(
     norm_lower: &str,
 ) -> Option<ReplacementDefinition> {
-    let tail = norm_lower.strip_prefix("damage that would reduce your life total to ")?;
-
-    let floor_minimum = if let Ok((rest, minimum)) = preceded(
-        tag::<_, _, OracleError<'_>>("less than "),
-        nom_primitives::parse_number,
-    )
-    .parse(tail)
-    {
-        let (rest, floor_val) = preceded(
-            tag::<_, _, OracleError<'_>>(" reduces it to "),
-            nom_primitives::parse_number,
-        )
-        .parse(rest)
-        .ok()?;
-        if floor_val != minimum {
-            return None;
-        }
-        all_consuming((
-            tag::<_, _, OracleError<'_>>(" instead"),
-            opt(tag::<_, _, OracleError<'_>>(".")),
-        ))
-        .parse(rest)
-        .ok()?;
-        minimum as i32
-    } else if let Ok((rest, floor_val)) = preceded(
-        tag::<_, _, OracleError<'_>>("0 reduces it to "),
-        nom_primitives::parse_number,
-    )
-    .parse(tail)
-    {
-        all_consuming((
-            tag::<_, _, OracleError<'_>>(" instead"),
-            opt(tag::<_, _, OracleError<'_>>(".")),
-        ))
-        .parse(rest)
-        .ok()?;
-        floor_val as i32
-    } else {
-        return None;
-    };
+    let floor_minimum = alt((
+        parse_unconditional_life_floor_less_than_form,
+        parse_unconditional_life_floor_to_zero_form,
+    ))
+    .parse(norm_lower)
+    .ok()
+    .map(|(_, minimum)| minimum)?;
 
     Some(
         ReplacementDefinition::new(ReplacementEvent::DamageDone)
@@ -5948,6 +5915,49 @@ fn parse_unconditional_life_floor_damage_replacement(
                 player: DamageTargetPlayerScope::Controller,
             }),
     )
+}
+
+/// "damage that would reduce your life total to less than N reduces it to N instead."
+fn parse_unconditional_life_floor_less_than_form(input: &str) -> OracleResult<'_, i32> {
+    let (rest, minimum) = preceded(
+        tag::<_, _, OracleError<'_>>("damage that would reduce your life total to less than "),
+        nom_primitives::parse_number,
+    )
+    .parse(input)?;
+    let (rest, floor_val) = preceded(
+        tag::<_, _, OracleError<'_>>(" reduces it to "),
+        nom_primitives::parse_number,
+    )
+    .parse(rest)?;
+    if floor_val != minimum {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+    all_consuming((
+        tag::<_, _, OracleError<'_>>(" instead"),
+        opt(tag::<_, _, OracleError<'_>>(".")),
+    ))
+    .parse(rest)?;
+    Ok((rest, minimum as i32))
+}
+
+/// Ali from Cairo printed wording: "…to 0 reduces it to M instead."
+fn parse_unconditional_life_floor_to_zero_form(input: &str) -> OracleResult<'_, i32> {
+    let (rest, floor_val) = preceded(
+        tag::<_, _, OracleError<'_>>(
+            "damage that would reduce your life total to 0 reduces it to ",
+        ),
+        nom_primitives::parse_number,
+    )
+    .parse(input)?;
+    all_consuming((
+        tag::<_, _, OracleError<'_>>(" instead"),
+        opt(tag::<_, _, OracleError<'_>>(".")),
+    ))
+    .parse(rest)?;
+    Ok((rest, floor_val as i32))
 }
 
 #[cfg(test)]

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5935,7 +5935,7 @@ fn parse_unconditional_life_floor_less_than_form(input: &str) -> OracleResult<'_
             nom::error::ErrorKind::Verify,
         )));
     }
-    all_consuming((
+    let (rest, _) = all_consuming((
         tag::<_, _, OracleError<'_>>(" instead"),
         opt(tag::<_, _, OracleError<'_>>(".")),
     ))
@@ -5952,7 +5952,7 @@ fn parse_unconditional_life_floor_to_zero_form(input: &str) -> OracleResult<'_, 
         nom_primitives::parse_number,
     )
     .parse(input)?;
-    all_consuming((
+    let (rest, _) = all_consuming((
         tag::<_, _, OracleError<'_>>(" instead"),
         opt(tag::<_, _, OracleError<'_>>(".")),
     ))

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5887,43 +5887,62 @@ fn parse_life_floor_damage_replacement(norm_lower: &str) -> Option<ReplacementDe
     )
 }
 
-/// CR 614.1a: Parse the UNCONDITIONAL life-floor replacement — "damage that
-/// would reduce your life total to less than N reduces it to N instead."
-/// (Ali from Cairo, Fortune Thief, Sustaining Spirit). Identical to
-/// [`parse_life_floor_damage_replacement`] but without the Worship-class
-/// "if you control a [filter]," guard, so it carries no `IfControlsMatching`
-/// condition. Dispatched after the conditional arm, which claims the
-/// "if you control …" prefix first.
+/// CR 614.1a: Parse the UNCONDITIONAL life-floor replacement:
+/// - "damage that would reduce your life total to less than N reduces it to N instead"
+///   (Fortune Thief, Sustaining Spirit)
+/// - "damage that would reduce your life total to 0 reduces it to 1 instead"
+///   (Ali from Cairo printed wording — lethal threshold "to 0", floor M)
+///
+/// Identical to [`parse_life_floor_damage_replacement`] but without the Worship-class
+/// "if you control a [filter]," guard. Dispatched after the conditional arm.
 fn parse_unconditional_life_floor_damage_replacement(
     norm_lower: &str,
 ) -> Option<ReplacementDefinition> {
-    let (after_threshold, _) =
-        tag::<_, _, OracleError<'_>>("damage that would reduce your life total to less than ")
-            .parse(norm_lower)
-            .ok()?;
+    let tail = norm_lower.strip_prefix("damage that would reduce your life total to ")?;
 
-    let (tail, minimum) = nom_primitives::parse_number.parse(after_threshold).ok()?;
-    let (tail, floor_val) = preceded(
-        tag::<_, _, OracleError<'_>>(" reduces it to "),
+    let floor_minimum = if let Ok((rest, minimum)) = preceded(
+        tag::<_, _, OracleError<'_>>("less than "),
         nom_primitives::parse_number,
     )
     .parse(tail)
-    .ok()?;
-    if floor_val != minimum {
-        return None;
-    }
-    // Full-consumption guard: the line is exactly the life-floor clause.
-    all_consuming((
-        tag::<_, _, OracleError<'_>>(" instead"),
-        opt(tag::<_, _, OracleError<'_>>(".")),
-    ))
+    {
+        let (rest, floor_val) = preceded(
+            tag::<_, _, OracleError<'_>>(" reduces it to "),
+            nom_primitives::parse_number,
+        )
+        .parse(rest)
+        .ok()?;
+        if floor_val != minimum {
+            return None;
+        }
+        all_consuming((
+            tag::<_, _, OracleError<'_>>(" instead"),
+            opt(tag::<_, _, OracleError<'_>>(".")),
+        ))
+        .parse(rest)
+        .ok()?;
+        minimum as i32
+    } else if let Ok((rest, floor_val)) = preceded(
+        tag::<_, _, OracleError<'_>>("0 reduces it to "),
+        nom_primitives::parse_number,
+    )
     .parse(tail)
-    .ok()?;
+    {
+        all_consuming((
+            tag::<_, _, OracleError<'_>>(" instead"),
+            opt(tag::<_, _, OracleError<'_>>(".")),
+        ))
+        .parse(rest)
+        .ok()?;
+        floor_val as i32
+    } else {
+        return None;
+    };
 
     Some(
         ReplacementDefinition::new(ReplacementEvent::DamageDone)
             .damage_modification(DamageModification::LifeFloor {
-                minimum: minimum as i32,
+                minimum: floor_minimum,
             })
             .damage_target_filter(DamageTargetFilter::Player {
                 player: DamageTargetPlayerScope::Controller,
@@ -11124,6 +11143,18 @@ mod tests {
     /// previously-dropped `Effect:replacement_structure` gap.
     #[test]
     fn parses_unconditional_life_floor_replacement() {
+        let def = parse_replacement_line(
+            "Damage that would reduce your life total to 0 reduces it to 1 instead.",
+            "Ali from Cairo",
+        )
+        .expect("Ali from Cairo printed 'to 0' wording should parse");
+        assert_eq!(def.event, ReplacementEvent::DamageDone);
+        assert_eq!(def.condition, None);
+        assert_eq!(
+            def.damage_modification,
+            Some(crate::types::ability::DamageModification::LifeFloor { minimum: 1 })
+        );
+
         for card in ["Ali from Cairo", "Fortune Thief", "Sustaining Spirit"] {
             let def = parse_replacement_line(
                 "Damage that would reduce your life total to less than 1 reduces it to 1 instead.",


### PR DESCRIPTION
Closes #2977

## Summary

Parse unconditional life-floor damage replacements (`Ali from Cairo` class) before the Worship-gated `"if you control a [filter], …"` arm. Adds `parse_unconditional_life_floor_damage_replacement` for `"damage that would reduce your life total to 0 reduces it to 1 instead"` and the bare `"less than N reduces it to M instead"` tail.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

> Narrow parser addition on an existing `LifeFloor` runtime path. Reuses the Worship tail shape and `damage_target_controller()`; no new resolver behavior.

## CR references

- CR 614.1a — replacement effects modifying damage events

## Verification

- `cargo fmt --all` — clean
- `cargo test -p engine --lib parses_ali_from_cairo_unconditional_life_floor_replacement parses_worship_life_floor_replacement` — passes locally

Model: claude-opus-4-8
Thinking: high
Tier: Frontier
