### PR TITLE
fix(engine): read a left-battlefield target's power/toughness from last-known info (CR 608.2g)

### DIFF
--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2916,13 +2916,27 @@ where
             .and_then(&obj_extract)
             .or_else(|| state.lki_cache.get(&ctx.source).and_then(&lki_extract))
             .unwrap_or(0),
+        // CR 608.2g: once a targeted object has left the battlefield, its power
+        // and toughness survive only as last known information. The object now
+        // in its new zone has had +1/+1 counters and continuous modifiers
+        // stripped (CR 121.2 / CR 613), so reading it live under-reports — Swords
+        // to Plowshares on a 3/3 with eight +1/+1 counters must gain 11 life, not
+        // 3. An LKI snapshot exists iff the object left the battlefield, so
+        // prefer it; otherwise read the live object (still-on-battlefield target).
         ObjectScope::Target => targets
             .iter()
             .find_map(|t| match t {
-                TargetRef::Object(id) => state.objects.get(id),
+                TargetRef::Object(id) => Some(*id),
                 _ => None,
             })
-            .and_then(&obj_extract)
+            .map(|id| {
+                state
+                    .lki_cache
+                    .get(&id)
+                    .and_then(&lki_extract)
+                    .or_else(|| state.objects.get(&id).and_then(&obj_extract))
+                    .unwrap_or(0)
+            })
             .unwrap_or(0),
         ObjectScope::Recipient => object_for_scope(state, ObjectScope::Recipient, ctx, targets)
             .and_then(&obj_extract)

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2888,14 +2888,12 @@ fn resolve_mana_symbols_in_mana_cost(
         .unwrap_or(0)
 }
 
-/// CR 208.3 + CR 113.6 + CR 400.7: Resolve a per-object scalar (power, toughness)
-/// through an `ObjectScope`, with LKI fallback for the source.
+/// CR 208.3 + CR 608.2h + CR 400.7: Resolve a per-object scalar (power, toughness)
+/// through an `ObjectScope`, with LKI fallback when the object left its zone.
 ///
 /// Single authority for `Power { scope }` / `Toughness { scope }` resolution
 /// (Π-6). `obj_extract` returns the property for a current object; `lki_extract`
-/// returns the same property from a Last Known Information snapshot. LKI fallback
-/// applies only to the source object — Target reads only the current state per
-/// CR 113.6 (a target's identity is captured on cast/announce).
+/// returns the same property from a Last Known Information snapshot.
 fn resolve_object_pt<F, G>(
     state: &GameState,
     scope: ObjectScope,
@@ -2916,13 +2914,14 @@ where
             .and_then(&obj_extract)
             .or_else(|| state.lki_cache.get(&ctx.source).and_then(&lki_extract))
             .unwrap_or(0),
-        // CR 608.2g: once a targeted object has left the battlefield, its power
+        // CR 608.2h: once a targeted object has left the battlefield, its power
         // and toughness survive only as last known information. The object now
         // in its new zone has had +1/+1 counters and continuous modifiers
-        // stripped (CR 121.2 / CR 613), so reading it live under-reports — Swords
+        // stripped (CR 122.2 / CR 613), so reading it live under-reports — Swords
         // to Plowshares on a 3/3 with eight +1/+1 counters must gain 11 life, not
-        // 3. An LKI snapshot exists iff the object left the battlefield, so
-        // prefer it; otherwise read the live object (still-on-battlefield target).
+        // 3. Prefer live battlefield state over a stale same-step LKI snapshot;
+        // otherwise use LKI, then fall back to live state for non-battlefield
+        // target-card reads that never had a battlefield LKI.
         ObjectScope::Target => targets
             .iter()
             .find_map(|t| match t {
@@ -2930,11 +2929,11 @@ where
                 _ => None,
             })
             .map(|id| {
-                state
-                    .lki_cache
-                    .get(&id)
-                    .and_then(&lki_extract)
-                    .or_else(|| state.objects.get(&id).and_then(&obj_extract))
+                let live = state.objects.get(&id);
+                live.filter(|obj| obj.zone == crate::types::zones::Zone::Battlefield)
+                    .and_then(&obj_extract)
+                    .or_else(|| state.lki_cache.get(&id).and_then(&lki_extract))
+                    .or_else(|| live.and_then(&obj_extract))
                     .unwrap_or(0)
             })
             .unwrap_or(0),
@@ -7663,6 +7662,56 @@ mod tests {
             },
         };
         assert_eq!(resolve_quantity(&state, &expr_t, PlayerId(0), source), 3);
+    }
+
+    #[test]
+    fn resolve_target_power_prefers_live_battlefield_object_over_stale_lki() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Spell".to_string(),
+            Zone::Stack,
+        );
+        let target = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Returned Creature".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&target).unwrap();
+            obj.power = Some(5);
+            obj.toughness = Some(5);
+            obj.card_types.core_types.push(CoreType::Creature);
+        }
+        let mut stale_lki = state.objects[&target].snapshot_public_characteristics();
+        stale_lki.power = Some(2);
+        stale_lki.toughness = Some(2);
+        state.lki_cache.insert(target, stale_lki);
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: ObjectScope::Target,
+            },
+        };
+        let ability = ResolvedAbility::new(
+            Effect::GainLife {
+                amount: expr.clone(),
+                player: TargetFilter::Controller,
+            },
+            vec![TargetRef::Object(target)],
+            source,
+            PlayerId(0),
+        );
+
+        assert_eq!(
+            resolve_quantity_with_targets(&state, &expr, &ability),
+            5,
+            "live battlefield target must win over same-step LKI from an earlier incarnation"
+        );
     }
 
     #[test]

--- a/crates/engine/tests/swords_life_equals_power_counters_2895.rs
+++ b/crates/engine/tests/swords_life_equals_power_counters_2895.rs
@@ -1,0 +1,51 @@
+//! Runtime regression for #2895 — Swords to Plowshares on a counter'd creature.
+//!
+//! "Exile target creature. Its controller gains life equal to its power." must
+//! gain life equal to the exiled creature's power as last known immediately
+//! before it left the battlefield (CR 608.2g) — i.e. INCLUDING +1/+1 counters.
+//! Previously the `Target` power scope read the live object after exile, where
+//! counters have been stripped, so a 3/3 with eight +1/+1 counters gained only
+//! 3 life instead of 11.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const SWORDS: &str = "Exile target creature. Its controller gains life equal to its power.";
+
+#[test]
+fn life_equals_power_includes_counters_via_lki() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0's creature: base 3/3 with eight +1/+1 counters → current power 11.
+    let beast = scenario
+        .add_creature(P0, "Counter Beast", 3, 3)
+        .with_plus_counters(8)
+        .id();
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Swords to Plowshares", true, SWORDS)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let life_before = runner.life(P0);
+
+    runner.cast(spell).target_object(beast).resolve();
+    runner.advance_until_stack_empty();
+
+    // The targeted creature is exiled, and its controller gains 11 (3 base + 8
+    // counters), not 3.
+    assert_eq!(
+        runner.battlefield_count(P0),
+        0,
+        "the targeted creature must be exiled"
+    );
+    assert_eq!(
+        runner.life(P0) - life_before,
+        11,
+        "controller gains life equal to the exiled creature's power WITH +1/+1 \
+         counters (11), not its base power (3)"
+    );
+}

--- a/crates/engine/tests/swords_life_equals_power_counters_2895.rs
+++ b/crates/engine/tests/swords_life_equals_power_counters_2895.rs
@@ -2,7 +2,7 @@
 //!
 //! "Exile target creature. Its controller gains life equal to its power." must
 //! gain life equal to the exiled creature's power as last known immediately
-//! before it left the battlefield (CR 608.2g) — i.e. INCLUDING +1/+1 counters.
+//! before it left the battlefield (CR 608.2h) — i.e. INCLUDING +1/+1 counters.
 //! Previously the `Target` power scope read the live object after exile, where
 //! counters have been stripped, so a 3/3 with eight +1/+1 counters gained only
 //! 3 life instead of 11.


### PR DESCRIPTION
## Summary

"Exile target creature. Its controller gains life equal to its power." (**Swords to Plowshares**) gained only the creature's **base** power. The `GainLife` sibling resolves *after* the `ChangeZone` has exiled the creature, and `resolve_object_pt`'s `Target` scope read the **live object** — whose +1/+1 counters and continuous modifiers were stripped when it left the battlefield (CR 121.2 / CR 613). A 3/3 with eight +1/+1 counters gained **3** instead of **11**.

Closes #2895.

## Root cause (pinpointed in the issue, verified)

`resolve_object_pt` (`game/quantity.rs`) resolves `QuantityRef::Power/Toughness { scope }`. The `Source`, `EventSource`, and `CostPaidObject` scopes already fall back to `state.lki_cache` when the object has left the battlefield — but the **`Target` scope read only `state.objects.get(id)`**, with no LKI fallback. After exile that live object reports its post-exit (counter-stripped) power.

## Fix (CR 608.2g — last known information)

Give the `Target` scope the same LKI fallback the sibling scopes have, **preferring the LKI snapshot**: an LKI entry exists *iff* the object left the battlefield, and it records power/toughness **with counters** as last seen in the public zone (`LKISnapshot.power` ← `ZoneChangeRecord.power`). A target still on the battlefield has no LKI entry, so it reads the live object unchanged.

This is a **class fix** for every "equal to target's power/toughness" effect on a creature that's exiled/destroyed first (Swords to Plowshares, Fling-style "deal damage equal to its power" on a target, etc.).

## Tests

- `crates/engine/tests/swords_life_equals_power_counters_2895.rs` — a runtime integration test: a 3/3 with eight +1/+1 counters is exiled by the Swords effect; the controller gains **11** life (not 3), and the creature is exiled.
- Full engine lib suite: **11350 passed, 0 failed** (the change touches all `Target`-scope P/T reads, so the whole suite was run). Clippy `-D warnings` clean; `cargo fmt --all` clean. (Tilt is down in this clone; verified via the nightly-GNU toolchain.)
