### PR TITLE
feat(engine): conditional activation cost reduction — "costs {N} less to activate if [condition]" (CR 601.2f)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11670,7 +11670,7 @@ fn apply_cost_reduction(
     source_id: ObjectId,
 ) {
     if let Some(ref reduction) = ability_def.cost_reduction {
-        // CR 601.2f: A conditional flat reduction ("costs {N} less … if [cond]")
+        // CR 602.2b + CR 601.2f: A conditional flat reduction ("costs {N} less … if [cond]")
         // applies only when its gate holds at cost-determination time. `None` =
         // unconditional (the "for each" scaling form and all legacy reductions).
         let condition_met = reduction.condition.as_ref().is_none_or(|cond| {
@@ -41505,7 +41505,7 @@ mod tests {
         );
     }
 
-    /// CR 601.2f: a conditional flat cost reduction ("costs {N} less to activate
+    /// CR 602.2b + CR 601.2f: a conditional flat cost reduction ("costs {N} less to activate
     /// if [condition]") reduces the activation cost only when the gate holds.
     /// Esquire of the King class: "{cost}: … This ability costs {2} less to
     /// activate if you control a legendary creature."

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11670,11 +11670,20 @@ fn apply_cost_reduction(
     source_id: ObjectId,
 ) {
     if let Some(ref reduction) = ability_def.cost_reduction {
-        let count = super::quantity::resolve_quantity(state, &reduction.count, player, source_id);
-        let reduce_by = (reduction.amount_per as i32 * count).max(0) as u32;
-        if reduce_by > 0 {
-            if let Some(ref mut cost) = ability_def.cost {
-                reduce_generic_in_cost(cost, reduce_by);
+        // CR 601.2f: A conditional flat reduction ("costs {N} less … if [cond]")
+        // applies only when its gate holds at cost-determination time. `None` =
+        // unconditional (the "for each" scaling form and all legacy reductions).
+        let condition_met = reduction.condition.as_ref().is_none_or(|cond| {
+            crate::game::restrictions::evaluate_condition(state, player, source_id, cond)
+        });
+        if condition_met {
+            let count =
+                super::quantity::resolve_quantity(state, &reduction.count, player, source_id);
+            let reduce_by = (reduction.amount_per as i32 * count).max(0) as u32;
+            if reduce_by > 0 {
+                if let Some(ref mut cost) = ability_def.cost {
+                    reduce_generic_in_cost(cost, reduce_by);
+                }
             }
         }
     }
@@ -41493,6 +41502,89 @@ mod tests {
         assert!(
             can_cast_object_now(&state, PlayerId(0), command),
             "can_cast_object_now must be true (issue #2011)"
+        );
+    }
+
+    /// CR 601.2f: a conditional flat cost reduction ("costs {N} less to activate
+    /// if [condition]") reduces the activation cost only when the gate holds.
+    /// Esquire of the King class: "{cost}: … This ability costs {2} less to
+    /// activate if you control a legendary creature."
+    #[test]
+    fn conditional_cost_reduction_applies_only_when_condition_met() {
+        use crate::parser::oracle_condition::parse_restriction_condition;
+        use crate::types::ability::{CostReduction, Effect, QuantityExpr};
+        use crate::types::card_type::{CoreType, Supertype};
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+
+        let condition = parse_restriction_condition("you control a legendary creature")
+            .expect("test condition must parse");
+
+        let make_def = || {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "test".to_string(),
+                    description: None,
+                },
+            );
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic: 6,
+                },
+            });
+            def.cost_reduction = Some(CostReduction {
+                amount_per: 3,
+                count: QuantityExpr::Fixed { value: 1 },
+                condition: Some(condition.clone()),
+            });
+            def
+        };
+        let generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => *generic,
+            other => panic!("expected Mana cost, got {other:?}"),
+        };
+
+        let mut state = GameState::new_two_player(1);
+        let src = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Esquire of the King".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Case A: controller has no legendary creature → no reduction.
+        let mut def_a = make_def();
+        apply_cost_reduction(&state, &mut def_a, PlayerId(0), src);
+        assert_eq!(
+            generic_of(&def_a),
+            6,
+            "no legendary creature → full {{6}} cost"
+        );
+
+        // Case B: a legendary creature on the battlefield → {3} reduction applies.
+        let leg = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Some Legend".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let o = state.objects.get_mut(&leg).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+            o.card_types.supertypes.push(Supertype::Legendary);
+        }
+        let mut def_b = make_def();
+        apply_cost_reduction(&state, &mut def_b, PlayerId(0), src);
+        assert_eq!(
+            generic_of(&def_b),
+            3,
+            "legendary creature present → cost reduced by {{3}}"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -902,7 +902,7 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
 
     let after_mana = after_mana.trim_start();
 
-    // CR 601.2f conditional flat form: "... less to activate if [condition]" /
+    // CR 602.2b + CR 601.2f conditional flat form: "... less to activate if [condition]" /
     // "... less to cast if [condition]". The reduction is a flat {amount_per}
     // (count = Fixed(1)) gated by `condition`. Checked before the "for each"
     // form; if the "if " marker is present but the condition does not parse,
@@ -2194,7 +2194,7 @@ mod tests {
         }
     }
 
-    /// CR 601.2f: the conditional flat form "costs {N} less to activate if
+    /// CR 602.2b + CR 601.2f: the conditional flat form "costs {N} less to activate if
     /// [condition]" parses to a `CostReduction` with `count = Fixed(1)` and a
     /// `condition` gate (Esquire of the King, Razorlash Transmogrant, …) — the
     /// previously-dropped `Effect:this` clause.

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -900,8 +900,31 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
         _ => return None, // Only generic mana reduction supported
     };
 
-    // Strip " less to activate for each " or " less to cast for each "
     let after_mana = after_mana.trim_start();
+
+    // CR 601.2f conditional flat form: "... less to activate if [condition]" /
+    // "... less to cast if [condition]". The reduction is a flat {amount_per}
+    // (count = Fixed(1)) gated by `condition`. Checked before the "for each"
+    // form; if the "if " marker is present but the condition does not parse,
+    // return None so the clause stays a loud gap (coverage honesty) rather than
+    // silently mis-parsing.
+    if let Some(((), cond_text)) = nom_on_lower(after_mana, after_mana, |i| {
+        value(
+            (),
+            alt((tag("less to activate if "), tag("less to cast if "))),
+        )
+        .parse(i)
+    }) {
+        let cond_text = cond_text.trim().trim_end_matches('.').trim();
+        let condition = super::oracle_condition::parse_restriction_condition(cond_text)?;
+        return Some(CostReduction {
+            amount_per,
+            count: QuantityExpr::Fixed { value: 1 },
+            condition: Some(condition),
+        });
+    }
+
+    // Strip " less to activate for each " or " less to cast for each "
     let ((), after_less) = nom_on_lower(after_mana, after_mana, |i| {
         value(
             (),
@@ -919,6 +942,7 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
         return Some(CostReduction {
             amount_per,
             count: QuantityExpr::Ref { qty },
+            condition: None,
         });
     }
 
@@ -933,6 +957,7 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
         count: QuantityExpr::Ref {
             qty: QuantityRef::ObjectCount { filter },
         },
+        condition: None,
     })
 }
 
@@ -2167,5 +2192,51 @@ mod tests {
             }
             other => panic!("Expected OneOf, got {:?}", other),
         }
+    }
+
+    /// CR 601.2f: the conditional flat form "costs {N} less to activate if
+    /// [condition]" parses to a `CostReduction` with `count = Fixed(1)` and a
+    /// `condition` gate (Esquire of the King, Razorlash Transmogrant, …) — the
+    /// previously-dropped `Effect:this` clause.
+    #[test]
+    fn cost_reduction_conditional_flat_form_carries_condition() {
+        let def = try_parse_cost_reduction(
+            "this ability costs {2} less to activate if you control a legendary creature",
+        )
+        .expect("conditional cost reduction should parse");
+        assert_eq!(def.amount_per, 2);
+        assert_eq!(def.count, QuantityExpr::Fixed { value: 1 });
+        assert!(
+            def.condition.is_some(),
+            "the 'if [condition]' gate must be captured, got {:?}",
+            def.condition
+        );
+
+        // "if you're <something the condition parser doesn't model>" must NOT
+        // silently mis-parse: an unrecognized condition yields no reduction
+        // (stays a loud gap) rather than an unconditional one.
+        assert!(
+            try_parse_cost_reduction(
+                "this ability costs {2} less to activate if the moon is gibbous"
+            )
+            .is_none(),
+            "unparseable condition must not produce an (unconditional) reduction"
+        );
+    }
+
+    /// Regression: the "for each" scaling form is unchanged and carries no
+    /// condition.
+    #[test]
+    fn cost_reduction_for_each_form_unconditional() {
+        let def = try_parse_cost_reduction(
+            "this ability costs {1} less to activate for each artifact you control",
+        )
+        .expect("for-each cost reduction should still parse");
+        assert_eq!(def.amount_per, 1);
+        assert_eq!(def.condition, None, "for-each form is unconditional");
+        assert!(
+            !matches!(def.count, QuantityExpr::Fixed { .. }),
+            "for-each count is a dynamic ref, not Fixed"
+        );
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -10330,13 +10330,24 @@ pub enum CastingRestriction {
 }
 
 /// CR 601.2f: Self-referential cost reduction on an activated ability.
-/// "This ability costs {N} less to activate for each [condition]"
+/// "This ability costs {N} less to activate for each [condition]" (scaling), or
+/// "This ability costs {N} less to activate if [condition]" (conditional flat:
+/// `count = Fixed(1)` gated by `condition`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CostReduction {
     /// Generic mana reduced per counted object (the {N} value).
     pub amount_per: u32,
     /// How many objects to count (e.g., legendary creatures you control).
+    /// For the conditional flat form this is `Fixed(1)`.
     pub count: QuantityExpr,
+    /// CR 601.2f: Optional gate for the conditional flat form — the reduction
+    /// applies only when this condition holds at cost-determination time
+    /// (Razorlash Transmogrant, Esquire of the King, …). `None` = unconditional
+    /// (the "for each" scaling form and all pre-existing reductions). Evaluated
+    /// at runtime via the shared `restrictions::evaluate_condition`, the same
+    /// path `ActivationRestriction::RequiresCondition` uses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub condition: Option<ParsedCondition>,
 }
 
 /// CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -10329,7 +10329,7 @@ pub enum CastingRestriction {
     RequiresCondition { condition: Option<ParsedCondition> },
 }
 
-/// CR 601.2f: Self-referential cost reduction on an activated ability.
+/// CR 602.2b + CR 601.2f: Self-referential cost reduction on an activated ability.
 /// "This ability costs {N} less to activate for each [condition]" (scaling), or
 /// "This ability costs {N} less to activate if [condition]" (conditional flat:
 /// `count = Fixed(1)` gated by `condition`).
@@ -10340,7 +10340,7 @@ pub struct CostReduction {
     /// How many objects to count (e.g., legendary creatures you control).
     /// For the conditional flat form this is `Fixed(1)`.
     pub count: QuantityExpr,
-    /// CR 601.2f: Optional gate for the conditional flat form — the reduction
+    /// CR 602.2b + CR 601.2f: Optional gate for the conditional flat form — the reduction
     /// applies only when this condition holds at cost-determination time
     /// (Razorlash Transmogrant, Esquire of the King, …). `None` = unconditional
     /// (the "for each" scaling form and all pre-existing reductions). Evaluated


### PR DESCRIPTION
## Summary
"This ability costs {N} less to activate **if [condition]**" was dropped (an `Effect:this` gap), so the abilities always cost full price. Only the **"for each"** scaling form was parsed. Affected (recent + classic): **Razorlash Transmogrant**, **Esquire of the King**, **Starport Security**, **A-Sewer Crocodile**, **Imoen, Trickster Friend**, and others.

`CostReduction { amount_per, count }` (applied at `casting.rs` as `amount_per * count`) had no condition slot, and `try_parse_cost_reduction` hard-required the literal "for each".

## Change (parameterize + reuse existing condition machinery — no new variant)
- **types/ability.rs** — `CostReduction` gains `condition: Option<ParsedCondition>` (serde `default`/`skip_serializing_if` → card-data back-compatible; `None` = the unconditional "for each" form and all legacy reductions).
- **parser/oracle_cost.rs** — `try_parse_cost_reduction` recognizes the "… less to activate/cast **if** [condition]" branch, parsing the gate via the existing **ctx-free** `parse_restriction_condition` and emitting `CostReduction { amount_per, count: Fixed(1), condition }`. If the "if" marker is present but the condition doesn't parse, **no reduction is produced** (the clause stays a loud gap — coverage honesty preserved).
- **game/casting.rs** — `apply_cost_reduction` gates the reduction on the condition via the shared `restrictions::evaluate_condition` — the same path `ActivationRestriction::RequiresCondition` already uses.

Conditions already modeled by `parse_restriction_condition` (control-a-filter, graveyard counts, quantity comparisons, …) are unlocked; the rest stay loud for follow-up.

## Tests
- `cost_reduction_conditional_flat_form_carries_condition` — "if you control a legendary creature" → `CostReduction { amount_per: 2, count: Fixed(1), condition: Some }`; an unparseable condition yields **no** reduction (not an unconditional one).
- `cost_reduction_for_each_form_unconditional` — regression: the "for each" form is unchanged and condition-free.
- `conditional_cost_reduction_applies_only_when_condition_met` — end-to-end: `apply_cost_reduction` reduces `{6}`→`{3}` only when a legendary creature is on the battlefield.

Full **`--workspace`** check, parser-combinator gate, `rustfmt --check`, and clippy `-D warnings` all clean.

CR 601.2f (cost reductions on activated abilities).

Fixes #2976