### PR TITLE
fix(parser): passive "spells with the chosen name can’t be cast" (Meddling Mage, CR 101.2)

### DIFF
--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -992,6 +992,24 @@ pub(crate) fn parse_passive_cant_be_cast(tp: &str, text: &str) -> Option<StaticD
         );
     }
 
+    // --- "Spells with the chosen name can't be cast" (passive voice) ---
+    // CR 101.2 + CR 201.2: the name-lock hatebears — Meddling Mage, Nevermore,
+    // Voidstone Gargoyle. The active-voice equivalent ("[subject] can't cast
+    // spells with the chosen name") is handled in `parse_cant_cast_type_spells`;
+    // mirror it here for the passive form. `HasChosenName` is resolved at cast
+    // time by `cant_cast_filter_matches` against the source's chosen card name.
+    if let Some(rest) = nom_tag_lower(before_cant, before_cant, "spells with the chosen name") {
+        if rest.trim().is_empty() {
+            return Some(
+                StaticDefinition::new(StaticMode::CantBeCast {
+                    who: ProhibitionScope::AllPlayers,
+                })
+                .affected(TargetFilter::HasChosenName)
+                .description(text.to_string()),
+            );
+        }
+    }
+
     // Require " spells" at the end of the subject
     let type_text = before_cant.strip_suffix(" spells")?; // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10308,6 +10308,28 @@ fn cant_cast_spells_with_chosen_name() {
 }
 
 #[test]
+fn passive_spells_with_chosen_name_cant_be_cast() {
+    // CR 101.2 + CR 201.2: passive-voice name-lock — Meddling Mage, Nevermore,
+    // Voidstone Gargoyle. "All players" scope (no subject). The active-voice
+    // form ("[subject] can't cast spells with the chosen name") is covered above.
+    for text in [
+        "Spells with the chosen name can't be cast.",
+        "Spells with the chosen name can't be cast",
+    ] {
+        let def = parse_static_line(text)
+            .unwrap_or_else(|| panic!("should parse passive name-lock: {text:?}"));
+        assert_eq!(
+            def.mode,
+            StaticMode::CantBeCast {
+                who: ProhibitionScope::AllPlayers,
+            },
+            "{text:?}"
+        );
+        assert_eq!(def.affected, Some(TargetFilter::HasChosenName), "{text:?}");
+    }
+}
+
+#[test]
 fn cant_cast_spells_with_chosen_name_parenthetical() {
     // Alhammarret full text with parenthetical condition
     let def = parse_static_line(


### PR DESCRIPTION
## Summary
The name-lock hatebears — **Meddling Mage**, **Nevermore**, **Voidstone Gargoyle** — read "As ~ enters, choose a nonland card name. **Spells with the chosen name can’t be cast.**" The choose-name half parsed (persisted as `ChosenAttribute::CardName`), but the **passive** "Spells with the chosen name can’t be cast" line was dropped (`Effect:unknown`), so the lock never applied — the named spell could still be cast.

The runtime is **already fully wired**: `StaticMode::CantBeCast` + the `cant_cast_filter_matches` enforcement already resolves `TargetFilter::HasChosenName` against the source’s chosen card name (CR 201.2). The **active-voice** form ("[subject] can’t cast spells with the chosen name", Alhammarret) was already parsed; only the **passive** form was missing.

## Change (one parser arm — no engine/type/runtime change)
- **`parser/oracle_static/restriction.rs`** — `parse_passive_cant_be_cast` gains the "spells with the chosen name" subject → `CantBeCast { who: AllPlayers }.affected(HasChosenName)`, mirroring the active-voice arm in `parse_cant_cast_type_spells`. Uses the approved `nom_tag_lower` combinator.

## Tests
- `passive_spells_with_chosen_name_cant_be_cast` — "Spells with the chosen name can’t be cast." (with/without trailing period) → `CantBeCast { who: AllPlayers }`, `affected = HasChosenName`.
- Existing active-voice tests (`cant_cast_spells_with_chosen_name` + parenthetical) still pass — no regression.

Parser-combinator gate, `rustfmt --check`, and clippy `-D warnings` all clean.

CR 101.2 (a spell can’t be cast if an effect says it can’t), CR 201.2 (matching by name).

Fixes #2981