### PR TITLE
fix(parser): split scoped "can't attack you" from compound static lines (closes #2874)

### DIFF
--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -830,11 +830,11 @@ pub(crate) fn try_split_and_cant_attack(text: &str) -> Option<Vec<StaticDefiniti
     Some(defs)
 }
 
-/// CR 508.1d: Decompose `"<grant or restriction>[,] and can't attack you [or
-/// planeswalkers you control]"` (the Vow cycle — Vow of Lightning, Duty,
-/// Flight, Torment, Wildness) into the first conjunct's static(s) plus a
-/// companion `CantAttack` static scoped to the Aura controller's side of
-/// the board, sharing the same `affected` set.
+/// CR 508.1b + CR 508.1c: Decompose `"<grant or restriction>[,] and can't
+/// attack you [or planeswalkers you control]"` (the Vow cycle — Vow of
+/// Lightning, Duty, Flight, Torment, Wildness) into the first conjunct's
+/// static(s) plus a companion `CantAttack` static scoped to the Aura
+/// controller's side of the board, sharing the same `affected` set.
 ///
 /// Without this split the trailing attack restriction was silently dropped:
 /// Vow of Lightning ("Enchanted creature gets +2/+2, has first strike, and
@@ -852,7 +852,6 @@ pub(crate) fn try_split_and_cant_attack(text: &str) -> Option<Vec<StaticDefiniti
 /// - `"and can't attack you or planeswalkers you control"` → `CantAttack`
 ///   with `defended = PlayerOrPlaneswalker`
 pub(crate) fn try_split_and_cant_attack_scoped(text: &str) -> Option<Vec<StaticDefinition>> {
-    use crate::types::triggers::AttackTargetFilter;
     type VE<'a> = OracleError<'a>;
     let lower = text.to_ascii_lowercase();
 
@@ -862,16 +861,13 @@ pub(crate) fn try_split_and_cant_attack_scoped(text: &str) -> Option<Vec<StaticD
             tag::<_, _, VE>("and can\u{2019}t attack"),
         ))
         .parse(i)?;
-        // Match the scoped suffix — "you or planeswalkers you control" must be
-        // tried before bare "you" so the longer form wins.
-        let (i, defended) = alt((
-            value(
-                AttackTargetFilter::PlayerOrPlaneswalker,
-                tag::<_, _, VE>(" you or planeswalkers you control"),
-            ),
-            value(AttackTargetFilter::Player, tag::<_, _, VE>(" you")),
-        ))
-        .parse(i)?;
+        let (i, defended) = parse_cant_attack_defended_scope_nom(i)?;
+        let Some(defended) = defended else {
+            return Err(nom::Err::Error(OracleError::new(
+                i,
+                nom::error::ErrorKind::Tag,
+            )));
+        };
         // Optional trailing duration phrase.
         let (i, _) = opt(alt((
             tag::<_, _, VE>(" each combat"),

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -854,7 +854,7 @@ pub(crate) fn try_split_and_cant_attack(text: &str) -> Option<Vec<StaticDefiniti
 pub(crate) fn try_split_and_cant_attack_scoped(text: &str) -> Option<Vec<StaticDefinition>> {
     use crate::types::triggers::AttackTargetFilter;
     type VE<'a> = OracleError<'a>;
-    let lower = text.to_lowercase();
+    let lower = text.to_ascii_lowercase();
 
     let (before, defended, rest) = nom_primitives::scan_preceded(&lower, |i: &str| {
         let (i, _) = alt((

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -830,6 +830,88 @@ pub(crate) fn try_split_and_cant_attack(text: &str) -> Option<Vec<StaticDefiniti
     Some(defs)
 }
 
+/// CR 508.1d: Decompose `"<grant or restriction>[,] and can't attack you [or
+/// planeswalkers you control]"` (the Vow cycle — Vow of Lightning, Duty,
+/// Flight, Torment, Wildness) into the first conjunct's static(s) plus a
+/// companion `CantAttack` static scoped to the Aura controller's side of
+/// the board, sharing the same `affected` set.
+///
+/// Without this split the trailing attack restriction was silently dropped:
+/// Vow of Lightning ("Enchanted creature gets +2/+2, has first strike, and
+/// can't attack you or planeswalkers you control.") parsed to only the +2/+2
+/// grant and first-strike keyword — the lockout that defines the Vow cycle
+/// was completely inert and the enchanted creature could freely attack its
+/// Aura's controller.
+///
+/// Registered before `try_split_and_cant_attack` so the more specific scoped
+/// phrase is consumed first; the bare-attack splitter's terminal guard would
+/// decline the " you …" tail anyway, but ordering is belt-and-suspenders.
+///
+/// Handles two scoped forms:
+/// - `"and can't attack you"` → `CantAttack` with `defended = Player`
+/// - `"and can't attack you or planeswalkers you control"` → `CantAttack`
+///   with `defended = PlayerOrPlaneswalker`
+pub(crate) fn try_split_and_cant_attack_scoped(text: &str) -> Option<Vec<StaticDefinition>> {
+    use crate::types::triggers::AttackTargetFilter;
+    type VE<'a> = OracleError<'a>;
+    let lower = text.to_lowercase();
+
+    let (before, defended, rest) = nom_primitives::scan_preceded(&lower, |i: &str| {
+        let (i, _) = alt((
+            tag::<_, _, VE>("and can't attack"),
+            tag::<_, _, VE>("and can\u{2019}t attack"),
+        ))
+        .parse(i)?;
+        // Match the scoped suffix — "you or planeswalkers you control" must be
+        // tried before bare "you" so the longer form wins.
+        let (i, defended) = alt((
+            value(
+                AttackTargetFilter::PlayerOrPlaneswalker,
+                tag::<_, _, VE>(" you or planeswalkers you control"),
+            ),
+            value(AttackTargetFilter::Player, tag::<_, _, VE>(" you")),
+        ))
+        .parse(i)?;
+        // Optional trailing duration phrase.
+        let (i, _) = opt(alt((
+            tag::<_, _, VE>(" each combat"),
+            tag::<_, _, VE>(" this combat"),
+            tag::<_, _, VE>(" this turn"),
+        )))
+        .parse(i)?;
+        Ok((i, defended))
+    })?;
+
+    // Terminal guard: decline unless the tail is empty (punctuation only).
+    if !rest.trim_start().trim_end_matches('.').trim().is_empty() {
+        return None;
+    }
+
+    let cut_end = before
+        .trim_end_matches(|ch: char| ch == ',' || ch.is_whitespace())
+        .len();
+    let line_a = format!("{}.", text[..cut_end].trim_end_matches('.'));
+    let mut defs = parse_static_line_multi(&line_a);
+    if defs.is_empty() {
+        return None;
+    }
+    for def in &mut defs {
+        def.description = Some(text.to_string());
+    }
+
+    let affected = defs[0].affected.clone()?;
+    let condition = defs[0].condition.clone();
+    let mut companion = StaticDefinition::new(StaticMode::CantAttack)
+        .affected(affected)
+        .attack_defended(Some(defended))
+        .description(text.to_string());
+    if let Some(condition) = condition {
+        companion = companion.condition(condition);
+    }
+    defs.push(companion);
+    Some(defs)
+}
+
 /// CR 702.5 / CR 702.6: Decompose `"<grant or restriction> and can't be
 /// enchanted [or equipped] [by other Auras]"` (and the "equipped" lead-in) into
 /// the first conjunct's static(s) plus the matching attach-prohibition

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -104,9 +104,10 @@ mod support {
         try_parse_scoped_must_attack_block, try_split_and_can_attack_despite_defender,
         try_split_and_can_block_additional, try_split_and_cant_activate_abilities,
         try_split_and_cant_attack, try_split_and_cant_attack_or_block,
-        try_split_and_cant_be_attached, try_split_and_cant_be_blocked,
-        try_split_and_cant_be_sacrificed, try_split_and_cant_be_targeted, try_split_and_cant_block,
-        try_split_and_doesnt_untap, try_split_and_must_attack_block,
+        try_split_and_cant_attack_scoped, try_split_and_cant_be_attached,
+        try_split_and_cant_be_blocked, try_split_and_cant_be_sacrificed,
+        try_split_and_cant_be_targeted, try_split_and_cant_block, try_split_and_doesnt_untap,
+        try_split_and_must_attack_block,
     };
     pub(super) use super::grammar::*;
     pub(super) use super::keyword_grant::{

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2307,7 +2307,8 @@ pub(crate) fn parse_rule_static_predicate_nom(
     Ok((rest, predicate))
 }
 
-/// Combat-rule predicate plus optional CR 508.1d defended scope (`CantAttack` only).
+/// Combat-rule predicate plus optional CR 508.1b + CR 508.1c defended scope
+/// (`CantAttack` only).
 pub(crate) fn parse_combat_rule_static_predicate_with_defended_nom(
     input: &str,
 ) -> OracleResult<
@@ -2405,7 +2406,7 @@ pub(crate) fn parse_rule_static_tail_predicates(rest: &str) -> Option<Vec<RuleSt
     }
 }
 
-/// Optional attack-target scope after "can't attack" (CR 508.1d).
+/// Optional attack-target scope after "can't attack" (CR 508.1b + CR 508.1c).
 pub(crate) fn parse_cant_attack_defended_scope_nom(
     input: &str,
 ) -> OracleResult<'_, Option<crate::types::triggers::AttackTargetFilter>> {

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -635,6 +635,14 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         return defs;
     }
 
+    // CR 508.1d: "<grant or restriction> and can't attack you [or planeswalkers
+    // you control]" — the Vow cycle (Vow of Lightning / Duty / Flight / Torment
+    // / Wildness). Registered before the bare-attack splitter so the more
+    // specific scoped phrase is consumed first.
+    if let Some(defs) = try_split_and_cant_attack_scoped(&stripped) {
+        return defs;
+    }
+
     // CR 508.1c: "<grant> and can't attack" pairs a P/T (or keyword) grant with an
     // attacking restriction under one subject (Cagemail). Split so the CantAttack
     // clause is not dropped. The terminal-phrase guard keeps the scoped

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -390,7 +390,7 @@ fn cant_attack_scoped_splits_from_pt_and_keyword_grant() {
     let lockout = defs
         .iter()
         .find(|d| d.mode == StaticMode::CantAttack)
-        .expect("expected a CantAttack companion, got {:?}");
+        .unwrap_or_else(|| panic!("expected a CantAttack companion, got {:?}", defs));
     assert_eq!(
         lockout.attack_defended,
         Some(crate::types::triggers::AttackTargetFilter::PlayerOrPlaneswalker),

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -282,9 +282,9 @@ fn cant_attack_static_splits_self_reference() {
 }
 
 /// CR 508.1c: The terminal-phrase guard must NOT mis-split scoped attack
-/// restrictions. "can't attack alone" (Sightless Brawler) and the Vow cycle's
-/// "can't attack you or planeswalkers you control" are different restrictions
-/// owned by other branches — the plain-`CantAttack` splitter must decline.
+/// restrictions. "can't attack alone" (Sightless Brawler) is owned by a
+/// different branch; the Vow cycle's "can't attack you or planeswalkers you
+/// control" must be parsed as a defended-scope `CantAttack`, not a blanket one.
 #[test]
 fn cant_attack_split_declines_scoped_restrictions() {
     let alone = parse_static_line_multi("Enchanted creature gets +3/+2 and can't attack alone.");
@@ -297,10 +297,14 @@ fn cant_attack_split_declines_scoped_restrictions() {
     let scoped = parse_static_line_multi(
         "Enchanted creature gets +2/+2, has vigilance, and can't attack you or planeswalkers you control.",
     );
-    assert!(
-        !scoped.iter().any(|d| d.mode == StaticMode::CantAttack),
-        "scoped \"can't attack you …\" must not become a plain CantAttack, got {:?}",
-        scoped.iter().map(|d| &d.mode).collect::<Vec<_>>()
+    let scoped_lockout = scoped
+        .iter()
+        .find(|d| d.mode == StaticMode::CantAttack)
+        .unwrap_or_else(|| panic!("expected scoped CantAttack, got {:?}", scoped));
+    assert_eq!(
+        scoped_lockout.attack_defended,
+        Some(crate::types::triggers::AttackTargetFilter::PlayerOrPlaneswalker),
+        "scoped \"can't attack you ...\" must not become a blanket CantAttack"
     );
 }
 
@@ -377,7 +381,7 @@ fn cant_attack_or_block_split_does_not_suppress_siblings() {
     );
 }
 
-/// CR 508.1d: Vow of Lightning — "Enchanted creature gets +2/+2, has first
+/// CR 508.1b + CR 508.1c: Vow of Lightning — "Enchanted creature gets +2/+2, has first
 /// strike, and can't attack you or planeswalkers you control." must produce the
 /// +2/+2 and first-strike grant AND a companion `CantAttack` scoped to
 /// `PlayerOrPlaneswalker`. Previously the attack restriction was silently
@@ -408,8 +412,8 @@ fn cant_attack_scoped_splits_from_pt_and_keyword_grant() {
     );
 }
 
-/// CR 508.1d: "and can't attack you" (Player scope only, without planeswalkers)
-/// also splits into a `CantAttack` with `defended = Player`.
+/// CR 508.1b + CR 508.1c: "and can't attack you" (Player scope only, without
+/// planeswalkers) also splits into a `CantAttack` with `defended = Player`.
 #[test]
 fn cant_attack_scoped_player_only_variant() {
     let defs = parse_static_line_multi("Enchanted creature gets +0/+3 and can't attack you.");
@@ -425,8 +429,8 @@ fn cant_attack_scoped_player_only_variant() {
     );
 }
 
-/// CR 508.1d: The scoped-attack splitter must not suppress the existing
-/// bare-attack and cant-attack-or-block splitters.
+/// CR 508.1b + CR 508.1c: The scoped-attack splitter must not suppress the
+/// existing bare-attack and cant-attack-or-block splitters.
 #[test]
 fn cant_attack_scoped_split_does_not_suppress_siblings() {
     // Bare "can't attack" must still route to plain CantAttack with no defended scope.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -377,6 +377,79 @@ fn cant_attack_or_block_split_does_not_suppress_siblings() {
     );
 }
 
+/// CR 508.1d: Vow of Lightning — "Enchanted creature gets +2/+2, has first
+/// strike, and can't attack you or planeswalkers you control." must produce the
+/// +2/+2 and first-strike grant AND a companion `CantAttack` scoped to
+/// `PlayerOrPlaneswalker`. Previously the attack restriction was silently
+/// dropped, so the enchanted creature could freely attack the Aura controller.
+#[test]
+fn cant_attack_scoped_splits_from_pt_and_keyword_grant() {
+    let defs = parse_static_line_multi(
+        "Enchanted creature gets +2/+2, has first strike, and can't attack you or planeswalkers you control.",
+    );
+    let lockout = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantAttack)
+        .expect("expected a CantAttack companion, got {:?}");
+    assert_eq!(
+        lockout.attack_defended,
+        Some(crate::types::triggers::AttackTargetFilter::PlayerOrPlaneswalker),
+        "companion must be scoped to PlayerOrPlaneswalker, got {:?}",
+        lockout.attack_defended
+    );
+    assert!(
+        lockout.affected.is_some(),
+        "CantAttack companion must carry an affected filter"
+    );
+    // The leading grant must also be preserved.
+    assert!(
+        defs.iter().any(|d| d.mode == StaticMode::Continuous),
+        "leading +2/+2 and first-strike grant must be preserved"
+    );
+}
+
+/// CR 508.1d: "and can't attack you" (Player scope only, without planeswalkers)
+/// also splits into a `CantAttack` with `defended = Player`.
+#[test]
+fn cant_attack_scoped_player_only_variant() {
+    let defs = parse_static_line_multi("Enchanted creature gets +0/+3 and can't attack you.");
+    let lockout = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantAttack)
+        .expect("expected a CantAttack companion for 'can't attack you'");
+    assert_eq!(
+        lockout.attack_defended,
+        Some(crate::types::triggers::AttackTargetFilter::Player),
+        "companion must be scoped to Player, got {:?}",
+        lockout.attack_defended
+    );
+}
+
+/// CR 508.1d: The scoped-attack splitter must not suppress the existing
+/// bare-attack and cant-attack-or-block splitters.
+#[test]
+fn cant_attack_scoped_split_does_not_suppress_siblings() {
+    // Bare "can't attack" must still route to plain CantAttack with no defended scope.
+    let bare = parse_static_line_multi("Enchanted creature gets +2/+2 and can't attack.");
+    let bare_lockout = bare
+        .iter()
+        .find(|d| d.mode == StaticMode::CantAttack)
+        .expect("bare cant-attack splitter must still produce CantAttack");
+    assert_eq!(
+        bare_lockout.attack_defended, None,
+        "bare CantAttack must have no defended scope"
+    );
+
+    // "can't attack or block" must still route to CantAttackOrBlock.
+    let aob = parse_static_line_multi(
+        "Enchanted creature loses all abilities and can't attack or block.",
+    );
+    assert!(
+        aob.iter().any(|d| d.mode == StaticMode::CantAttackOrBlock),
+        "cant-attack-or-block splitter must still produce CantAttackOrBlock"
+    );
+}
+
 /// CR 701.21: Assault Suit — "Equipped creature gets +2/+2, has haste, can't
 /// attack you or planeswalkers you control, and can't be sacrificed." must
 /// include an `Other("CantBeSacrificed")` static alongside the +2/+2 grant.


### PR DESCRIPTION
## Summary

Close: https://github.com/phase-rs/phase/issues/2874

- Adds `try_split_and_cant_attack_scoped` in `evasion.rs` to handle compound Oracle lines of the form `"<grant or restriction> and can't attack you [or planeswalkers you control]"`
- The function uses `scan_preceded` to locate the scoped attack restriction, captures the `AttackTargetFilter` value inline, and emits both the leading static(s) and a trailing `CantAttack` + `attack_defended` definition
- Registered in `shared.rs` before the bare-attack splitter so the more specific scoped phrase is consumed first (CR 508.1d)
- Covers the entire Vow cycle (Vow of Lightning, Vow of Duty, Vow of Flight, Vow of Torment, Vow of Wildness) and any future card with the same clause shape

## Test plan

- [ ] `cant_attack_scoped_splits_from_pt_and_keyword_grant` — Vow of Lightning full line produces `AddPower`, `AddToughness`, `AddKeyword(FirstStrike)`, and `CantAttack` with `attack_defended = PlayerOrPlaneswalker`
- [ ] `cant_attack_scoped_player_only_variant` — bare "can't attack you" variant produces `attack_defended = Player`
- [ ] `cant_attack_scoped_split_does_not_suppress_siblings` — validates no other statics are dropped
- [ ] Manually verify `jq '.["vow of lightning"]'` in card-data shows the scoped attack restriction