### PR TITLE
ship/zone t3

### DIFF
--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -316,19 +316,21 @@ fn install_merge_layer_effect(
 /// NOT a token (its survivor is a card, so a card-scoped redirect matches it and
 /// redirects the leave event), ALL components — token components included — take
 /// `dest` (730.3e first clause: "applies to all components of the merged
-/// permanent if it's not a token, including components that are tokens"). The
-/// second clause (the merged permanent's survivor is itself a TOKEN, so a
-/// card-scoped redirect does NOT match the survivor and its CARD components must
-/// still be moved by the redirect while the token survivor + token components
-/// take the default zone) is NOT handled here: it requires the merged-permanent
-/// leave to be consulted as a single component-aware event so the card-scoped
-/// redirect can apply to the card components without matching the token survivor.
-/// That is a replacement-pipeline extension (component-aware single consult), not
-/// a per-component re-consult (which 730.3d forbids), and no current pool `Moved`
-/// definition is card-scoped (the RIP-class parser ignores the "a card" subject
-/// and leaves `valid_card == None`, so today every such redirect is token-
-/// inclusive and matches the survivor regardless of token-ness). Tracked as a
-/// follow-up; the Commander exemption (CR 903.9b–c) is separately out of scope.
+/// permanent if it's not a token, including components that are tokens").
+///
+/// CR 730.3e SECOND clause (the merged permanent's survivor is itself a TOKEN, so
+/// a card-scoped redirect does NOT match the survivor): the token survivor + its
+/// token components take the pre-replacement default zone (`dest`), while the
+/// CARD components are "moved by the replacement effect". This split is driven by
+/// `state.merged_card_component_route`, which the pipeline
+/// (`zone_pipeline::deliver_replaced_zone_change`) stashes from a SINGLE
+/// component-aware consult (one `replace_event` for the card partition — NOT a
+/// per-component re-consult, which CR 730.3d forbids, and which would re-burn
+/// CR 616.1 ordering). When that override is present, a card component routes to
+/// its `card_dest`; a token component routes to its `default_dest` (== `dest`).
+/// The override is absent (and every component follows `dest`) for non-token
+/// survivors and whenever no card-scoped redirect diverges from the survivor's
+/// destination. The Commander exemption (CR 903.9b–c) is separately out of scope.
 ///
 /// CR 730.3a deferred: the owner's arrange-order choice for graveyard/library
 /// destinations is not modeled — components are placed in their stored
@@ -347,6 +349,17 @@ pub fn split_merged_permanent_on_leave(
     }
     let components = survivor.merged_components.clone();
 
+    // CR 730.3e (second clause): a TOKEN merged permanent leaving under a
+    // card-scoped (`NonToken`) `Moved` redirect routes its CARD components to
+    // the redirect destination (`card_dest`) while the token survivor + token
+    // components take the pre-replacement default zone (`default_dest`). The
+    // pipeline (`deliver_replaced_zone_change`) stashes this from the single
+    // component-aware consult; absent it (non-token survivor / no card-scoped
+    // divergence — clause 1), every component follows the survivor's `dest`
+    // (CR 730.3d). The override only fires when the survivor itself is a token
+    // (it lands in `default_dest == dest` via `move_to_zone`).
+    let card_route = state.merged_card_component_route;
+
     // CR 730.3 + CR 400.7: before the surviving object changes zone, drop the
     // merge's layer-1 copy effect and flush layers so it leaves as its own card.
     remove_merge_layer_effect(state, merged_id);
@@ -358,9 +371,24 @@ pub fn split_merged_permanent_on_leave(
         if component_id == merged_id {
             continue;
         }
-        // CR 730.3 + S4: route each component to ITS OWN owner's destination zone
-        // as a NEW object that did not independently leave the battlefield.
-        put_component_into_zone(state, component_id, dest, events);
+        // CR 730.3 + S4 / CR 730.3e: route each component to ITS OWN owner's
+        // destination zone as a NEW object that did not independently leave the
+        // battlefield. Under the clause-2 override, a CARD component follows the
+        // card-scoped redirect (`card_dest`); a token component (and the default
+        // case) follows the survivor's `dest`.
+        let component_dest = match card_route {
+            Some(route)
+                if state
+                    .objects
+                    .get(&component_id)
+                    .is_some_and(|o| !o.is_token) =>
+            {
+                route.card_dest
+            }
+            Some(route) => route.default_dest,
+            None => dest,
+        };
+        put_component_into_zone(state, component_id, component_dest, events);
         // CR 730.3c: record which surviving object this component split from, so an
         // effect that later finds "the object the merged permanent became" (a
         // flicker/blink return) brings this component back too, not just the

--- a/crates/engine/src/game/merge_tests.rs
+++ b/crates/engine/src/game/merge_tests.rs
@@ -988,6 +988,180 @@ fn cr_730_3e_nontoken_merged_leave_carries_token_component_with_redirect() {
     );
 }
 
+/// CR 730.3e + CR 111.1: a CARD-SCOPED graveyard→exile `Moved` redirect,
+/// mirroring Leyline of the Void's "If a card would be put into [a] graveyard
+/// from anywhere, exile it instead" — `valid_card: NonToken`, so it does NOT
+/// match a token (a dying token reaches the graveyard; dies-triggers fire). This
+/// is the parser output (item 1) modeled directly for the clause-2 split tests.
+fn graveyard_exile_replacement_card_scoped() -> crate::types::ability::ReplacementDefinition {
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, Effect, FilterProp, TargetFilter, TypedFilter,
+    };
+    use crate::types::replacements::ReplacementEvent;
+    crate::types::ability::ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(Zone::Graveyard)
+        .valid_card(TargetFilter::Typed(
+            TypedFilter::default().properties(vec![FilterProp::NonToken]),
+        ))
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+        ))
+        .description(
+            "If a card would be put into a graveyard from anywhere, exile it instead.".to_string(),
+        )
+}
+
+/// CR 730.3e (SECOND clause): "If the merged permanent is a token but some of its
+/// components are cards, the merged permanent and its token components are put
+/// into the appropriate zone, and the components that are cards are moved by the
+/// replacement effect."
+///
+/// A TOKEN merged permanent (token topmost per CR 730.2d) with a CARD component
+/// leaves the battlefield under a CARD-SCOPED graveyard→exile redirect (Leyline
+/// class). The redirect does NOT match the token survivor, so the survivor + its
+/// token components take the graveyard default; the CARD component is moved by
+/// the redirect to EXILE. Drives the REAL pipeline so `replace_event` fires the
+/// single component-aware consult.
+#[test]
+fn cr_730_3e_token_survivor_card_component_split_routes_card_to_redirect() {
+    use crate::game::scenario::GameScenario;
+    use crate::game::zone_pipeline::{move_object, ZoneMoveRequest, ZoneMoveResult};
+
+    let mut sc = GameScenario::new();
+    let token_host = sc.add_creature(P0, "Token Host", 2, 2).id();
+    let card_rider = sc.add_creature(P0, "Card Rider", 4, 4).id();
+    let leyline = sc.add_creature(P0, "Leyline of the Void", 0, 0).id();
+    let mut state = sc.state;
+    // Survivor is the TOKEN host; the card rider is an absorbed CARD component.
+    state.objects.get_mut(&token_host).unwrap().is_token = true;
+    state
+        .objects
+        .get_mut(&leyline)
+        .unwrap()
+        .replacement_definitions
+        .push(graveyard_exile_replacement_card_scoped());
+
+    let mut events = Vec::new();
+    // CR 730.2d: merge the card rider UNDERNEATH so the token host stays topmost
+    // and the merged permanent is a TOKEN (the clause-2 premise).
+    merge_object_onto(
+        &mut state,
+        card_rider,
+        token_host,
+        MergeSide::Bottom,
+        &mut events,
+    );
+    state.battlefield.retain(|&id| id != card_rider);
+    assert!(
+        state.objects[&token_host].is_token,
+        "premise: the merged permanent must be a TOKEN for 730.3e clause 2"
+    );
+
+    let result = move_object(
+        &mut state,
+        ZoneMoveRequest::effect(token_host, Zone::Graveyard, token_host),
+        &mut events,
+    );
+    assert!(matches!(result, ZoneMoveResult::Done));
+
+    // CR 730.3e clause 2: the CARD component is moved by the card-scoped redirect.
+    assert_eq!(
+        state.objects[&card_rider].zone,
+        Zone::Exile,
+        "the CARD component of a TOKEN merged permanent is moved by the \
+         card-scoped redirect to exile (CR 730.3e clause 2)"
+    );
+    // The TOKEN survivor takes the pre-replacement graveyard default (the
+    // card-scoped redirect did not match it); it then ceases to exist via the
+    // CR 111.7 SBA, but lands in the graveyard zone first.
+    assert_eq!(
+        state.objects[&token_host].zone,
+        Zone::Graveyard,
+        "the token survivor takes the pre-replacement graveyard default, NOT the \
+         card-scoped redirect (which does not match a token)"
+    );
+    assert!(
+        !state
+            .players
+            .iter()
+            .find(|p| p.id == P0)
+            .unwrap()
+            .graveyard
+            .contains(&card_rider),
+        "the card component must not land in the graveyard default"
+    );
+}
+
+/// CR 730.3e clause-1 SIBLING assertion (token-INCLUSIVE redirect): the same
+/// token-survivor + card-component pile under a TOKEN-INCLUSIVE redirect (Rest in
+/// Peace, `valid_card: None`) sends EVERYTHING to exile — the redirect matches the
+/// token survivor too, so no clause-2 split occurs. Pins that the clause-2 split
+/// fires ONLY for a card-scoped redirect.
+#[test]
+fn cr_730_3e_token_inclusive_redirect_exiles_all_components() {
+    use crate::game::scenario::GameScenario;
+    use crate::game::zone_pipeline::{move_object, ZoneMoveRequest, ZoneMoveResult};
+
+    let mut sc = GameScenario::new();
+    let token_host = sc.add_creature(P0, "Token Host", 2, 2).id();
+    let card_rider = sc.add_creature(P0, "Card Rider", 4, 4).id();
+    let rip = sc.add_creature(P0, "Rest in Peace", 0, 0).id();
+    let mut state = sc.state;
+    state.objects.get_mut(&token_host).unwrap().is_token = true;
+    state
+        .objects
+        .get_mut(&rip)
+        .unwrap()
+        .replacement_definitions
+        .push(graveyard_exile_replacement());
+
+    let mut events = Vec::new();
+    merge_object_onto(
+        &mut state,
+        card_rider,
+        token_host,
+        MergeSide::Bottom,
+        &mut events,
+    );
+    state.battlefield.retain(|&id| id != card_rider);
+    assert!(
+        state.objects[&token_host].is_token,
+        "premise: token survivor"
+    );
+
+    let result = move_object(
+        &mut state,
+        ZoneMoveRequest::effect(token_host, Zone::Graveyard, token_host),
+        &mut events,
+    );
+    assert!(matches!(result, ZoneMoveResult::Done));
+
+    // Token-inclusive redirect matches the token survivor too — everything exiled.
+    assert_eq!(
+        state.objects[&token_host].zone,
+        Zone::Exile,
+        "token survivor exiled"
+    );
+    assert_eq!(
+        state.objects[&card_rider].zone,
+        Zone::Exile,
+        "card component exiled"
+    );
+}
+
 /// CR 608.2b + CR 702.140b: end-to-end / resolution-time coverage of the wired
 /// runtime path (the actual bug #2014 path), not just the merge primitive. These
 /// drive `stack::resolve_top` and the full `handle_cast_spell` pipeline.

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -1319,7 +1319,18 @@ fn compute_merged_card_component_route(
         ReplacementResult::Execute(ProposedEvent::ZoneChange { to, .. }) => to,
         // Prevented / NeedsChoice / non-ZoneChange: no usable redirect for the
         // card partition — fall back to the survivor's destination (no split).
-        _ => return None,
+        // strict-failure: a NeedsChoice here means the card partition matched an
+        // Optional-mode def or a CR 616.1 ordering choice between multiple Moved
+        // candidates; the fallback skips that genuine choice (rules-wrong for
+        // the rare multi-candidate case) as the safe floor versus pausing
+        // mid-delivery. `pipeline_loop` parks `pending_replacement` BEFORE
+        // returning NeedsChoice — clear it, or the stranded record silently
+        // truncates every SBA pass (sba.rs gates on `pending_replacement`) for
+        // the rest of the game and serializes as garbage into saves.
+        _ => {
+            state.pending_replacement = None;
+            return None;
+        }
     };
 
     (card_dest != survivor_dest).then_some(MergedCardComponentRoute {
@@ -2411,6 +2422,106 @@ mod w3_library_placement_tests {
             state.players[0].library.iter().copied().collect::<Vec<_>>(),
             vec![placed, a, b],
             "after two declined parks the placement must still honor LibraryPosition::Top"
+        );
+    }
+}
+
+#[cfg(test)]
+mod parsed_leyline_card_scoping_tests {
+    use super::*;
+    use crate::game::scenario::{GameScenario, P0, P1};
+    use crate::game::triggers::process_triggers;
+    use crate::parser::oracle_replacement::parse_replacement_line;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter, TriggerDefinition,
+        TriggerMode,
+    };
+
+    /// End-to-end pin of the live Leyline of the Void bug (zone pipeline
+    /// tranche 3, parser card-scoping): the def installed here is the REAL
+    /// PARSED output of Leyline's oracle line — not a hand-built mirror — so
+    /// any parser-shape drift that breaks the matcher path turns this red.
+    ///
+    /// CR 111.1: tokens are not cards, so Leyline's "a card" subject must NOT
+    /// match a dying token: the opponent's token reaches the GRAVEYARD (its
+    /// dies-trigger fires per CR 603.6c look-back, then CR 111.7 ceases it),
+    /// while an opponent's dying nontoken CARD is exiled instead (CR 614.6).
+    #[test]
+    fn parsed_leyline_token_dies_to_graveyard_card_is_exiled() {
+        let mut sc = GameScenario::new();
+        let leyline = sc.add_creature(P0, "Leyline of the Void", 0, 0).id();
+        let token = sc.add_creature(P1, "Zombie Token", 2, 2).id();
+        let card_creature = sc.add_creature(P1, "Zombie", 2, 2).id();
+        let mut state = sc.state;
+        state.objects.get_mut(&token).unwrap().is_token = true;
+
+        let def = parse_replacement_line(
+            "If a card would be put into an opponent's graveyard from anywhere, exile it instead.",
+            "Leyline of the Void",
+        )
+        .expect("Leyline of the Void's replacement line must parse");
+        state
+            .objects
+            .get_mut(&leyline)
+            .unwrap()
+            .replacement_definitions
+            .push(def);
+
+        // Blood Artist-class observable: a self-scoped dies trigger on the token.
+        state
+            .objects
+            .get_mut(&token)
+            .unwrap()
+            .trigger_definitions
+            .push(
+                TriggerDefinition::new(TriggerMode::ChangesZone)
+                    .valid_card(TargetFilter::SelfRef)
+                    .origin(Zone::Battlefield)
+                    .destination(Zone::Graveyard)
+                    .trigger_zones(vec![Zone::Battlefield])
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Spell,
+                        Effect::GainLife {
+                            amount: QuantityExpr::Fixed { value: 1 },
+                            player: TargetFilter::Controller,
+                        },
+                    ))
+                    .description("When this creature dies, you gain 1 life.".to_string()),
+            );
+
+        // The opponent's TOKEN dies through the real pipeline.
+        let mut events = Vec::new();
+        let result = move_object(
+            &mut state,
+            ZoneMoveRequest::effect(token, Zone::Graveyard, token),
+            &mut events,
+        );
+        assert!(matches!(result, ZoneMoveResult::Done));
+        assert_eq!(
+            state.objects[&token].zone,
+            Zone::Graveyard,
+            "CR 111.1: 'a card' excludes tokens — the dying token must reach the \
+             graveyard, not be exiled (the pre-tranche-3 live bug)"
+        );
+        process_triggers(&mut state, &events);
+        assert!(
+            !state.stack.is_empty(),
+            "the token's dies-trigger must fire (CR 603.6c look-back) — exiling \
+             it instead suppressed Blood Artist-class triggers"
+        );
+
+        // Contrast: the opponent's nontoken CARD is exiled by the same def.
+        let mut events = Vec::new();
+        let result = move_object(
+            &mut state,
+            ZoneMoveRequest::effect(card_creature, Zone::Graveyard, card_creature),
+            &mut events,
+        );
+        assert!(matches!(result, ZoneMoveResult::Done));
+        assert_eq!(
+            state.objects[&card_creature].zone,
+            Zone::Exile,
+            "CR 614.6: the opponent's dying nontoken card is exiled instead"
         );
     }
 }

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -23,8 +23,8 @@ use crate::types::ability::{
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    BatchCompletion, ExileLinkKind, GameState, PendingBatchDeliveries, PendingCounterPostAction,
-    PostReplacementDrainOwner, WaitingFor, ZoneDeliveryExileTracking,
+    BatchCompletion, ExileLinkKind, GameState, MergedCardComponentRoute, PendingBatchDeliveries,
+    PendingCounterPostAction, PostReplacementDrainOwner, WaitingFor, ZoneDeliveryExileTracking,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -1262,6 +1262,72 @@ pub(crate) fn apply_face_down_entry_profile(
     }
 }
 
+/// CR 730.3e (second clause) + CR 730.2d + CR 614.6: compute the card-component
+/// routing override for a merged permanent's leave.
+///
+/// `survivor_dest` is the merged permanent's already-consulted destination (the
+/// survivor's post-replacement `to`). For a NON-token survivor every component
+/// followed `survivor_dest` (clause 1, CR 730.3d) and this returns `None`. For a
+/// TOKEN survivor (CR 730.2d: token iff the topmost component is a token), a
+/// card-scoped (`NonToken`) `Moved` redirect did NOT match the survivor — so
+/// `survivor_dest` is the pre-replacement default zone — but it DOES move the
+/// merged permanent's CARD components. We discover where by running ONE
+/// component-aware consult for a representative card component: a single
+/// `replace_event` over a `ZoneChange { from: Battlefield, to: survivor_dest }`
+/// proposal for that card. This is NOT a per-component re-consult — CR 616.1
+/// ordering is resolved once for the card partition, never per card — and it
+/// only READS the resolved destination (replacement does not move the object).
+///
+/// Returns `Some` only when the card consult diverges from `survivor_dest`
+/// (i.e. a card-scoped redirect genuinely applies to cards but not the token
+/// survivor); otherwise `None` (no override — the existing single-`to` routing
+/// is already correct).
+///
+/// `// strict-failure: a one-shot ("the next time ... instead") leave redirect
+/// would be consumed by this extra read-only consult; no such depletion-style
+/// def is in the merged-leave class (the graveyard-redirect hosers are
+/// continuous statics), so the double-stamp is benign.`
+fn compute_merged_card_component_route(
+    state: &mut GameState,
+    survivor_id: ObjectId,
+    survivor_dest: Zone,
+    events: &mut Vec<GameEvent>,
+) -> Option<MergedCardComponentRoute> {
+    let survivor = state.objects.get(&survivor_id)?;
+    // Clause 1 (CR 730.3d) already routed every component to `survivor_dest`
+    // for a non-token survivor; only the token-survivor case needs the split.
+    if !survivor.is_token || survivor.merged_components.is_empty() {
+        return None;
+    }
+    // A representative CARD (non-token) component, excluding the survivor.
+    let card_component = survivor
+        .merged_components
+        .iter()
+        .copied()
+        .find(|&id| id != survivor_id && state.objects.get(&id).is_some_and(|o| !o.is_token))?;
+
+    // Single component-aware consult for the card partition. The card component
+    // is still absorbed (on the battlefield via the survivor), so its leave
+    // origin is the battlefield.
+    let proposed = ProposedEvent::zone_change(
+        card_component,
+        Zone::Battlefield,
+        survivor_dest,
+        Some(survivor_id),
+    );
+    let card_dest = match replacement::replace_event(state, proposed, events) {
+        ReplacementResult::Execute(ProposedEvent::ZoneChange { to, .. }) => to,
+        // Prevented / NeedsChoice / non-ZoneChange: no usable redirect for the
+        // card partition — fall back to the survivor's destination (no split).
+        _ => return None,
+    };
+
+    (card_dest != survivor_dest).then_some(MergedCardComponentRoute {
+        default_dest: survivor_dest,
+        card_dest,
+    })
+}
+
 /// Deliver a zone-change event that has already passed through replacement.
 ///
 /// `library_placement` (CR 701.24a): when the event's delivered destination is
@@ -1354,6 +1420,22 @@ pub(crate) fn deliver_replaced_zone_change(
             })
             .flatten();
 
+        // CR 730.3e (second clause): if a TOKEN merged permanent leaves the
+        // battlefield while a card-scoped (`NonToken`) `Moved` redirect is
+        // active, the redirect did NOT match the token survivor (so `to` above
+        // is the pre-replacement default zone for the survivor + its token
+        // components), but it DOES move the merged permanent's CARD components.
+        // Run ONE additional component-aware consult here (NOT per component —
+        // a single `replace_event` for the card-component partition, so CR 616.1
+        // ordering is computed once for the partition, not re-burned per card),
+        // and stash the resulting `card_dest` so the survivor split routes card
+        // components there while the token survivor + token components take the
+        // default zone. A no-op (no route stashed) for non-token survivors
+        // (clause 1, already handled — every component followed the survivor's
+        // redirected `to`) and when no card-scoped redirect diverges.
+        state.merged_card_component_route =
+            compute_merged_card_component_route(state, object_id, to, events);
+
         // CR 701.24a: deliver to a specific library index when the event's
         // destination is the library and a position was requested (a placement is
         // not a shuffle); otherwise the zone-default `move_to_zone` (which the
@@ -1376,6 +1458,11 @@ pub(crate) fn deliver_replaced_zone_change(
             }
             _ => zones::move_to_zone(state, object_id, to, events),
         }
+        // CR 730.3e: the survivor split (inside `move_to_zone` above) has consumed
+        // any clause-2 routing override; clear it so it never leaks into a later
+        // unrelated move. Purely synchronous lifetime (set → consumed → cleared in
+        // this one delivery), so it never crosses a pause.
+        state.merged_card_component_route = None;
         // CR 400.7d: restore the cast link immediately after the entry reset —
         // BEFORE the face-down / counter blocks, so a counter-replacement pause
         // (CR 616.1) cannot strand the resumed permanent without its kicker /

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -1283,6 +1283,23 @@ pub(crate) fn apply_face_down_entry_profile(
 /// survivor); otherwise `None` (no override — the existing single-`to` routing
 /// is already correct).
 ///
+/// LIMITATION (homogeneous card partition): the representative-component consult
+/// applies one card component's resolved destination to the ENTIRE card
+/// partition. This is exact when every card component matches the card-scoped
+/// redirect identically — true for the common case (RIP/Leyline "a card …"
+/// matches every non-token) and for Mutate piles versus type-level filters (all
+/// components are creatures). It can misroute only a heterogeneous partition
+/// under a subtype/color-scoped card redirect (e.g. a green creature card merged
+/// with a red creature card under a TOKEN survivor, versus "if a green creature
+/// card would be put into a graveyard"): the off-filter card component would
+/// follow the representative's redirect instead of its own default. Fully
+/// correct per-component routing would evaluate each card component's filter
+/// individually while resolving CR 616.1 ordering only once — deferred, because
+/// per-component re-consults re-burn that ordering choice (the OQ#5
+/// single-consult mandate) and the misroute requires a token-survivor Mutate
+/// pile with mixed card characteristics under a scoped graveyard-redirect, which
+/// no current card produces.
+///
 /// `// strict-failure: a one-shot ("the next time ... instead") leave redirect
 /// would be consumed by this extra read-only consult; no such depletion-style
 /// def is in the merged-leave class (the graveyard-redirect hosers are
@@ -2434,8 +2451,8 @@ mod parsed_leyline_card_scoping_tests {
     use crate::parser::oracle_replacement::parse_replacement_line;
     use crate::types::ability::{
         AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter, TriggerDefinition,
-        TriggerMode,
     };
+    use crate::types::triggers::TriggerMode;
 
     /// End-to-end pin of the live Leyline of the Void bug (zone pipeline
     /// tranche 3, parser card-scoping): the def installed here is the REAL

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3260,11 +3260,27 @@ fn parse_graveyard_exile_replacement(
         // is token-excluding (Leyline of the Void: "a card"). The inclusive RIP
         // phrasing ("a card or token") names tokens explicitly and stays
         // unscoped. The token-rider check wins over the bare-card check, so
-        // "a card or token" is never misread as token-excluding. These are
-        // terminal noun-phrase tail checks on the slice the combinator already
-        // tokenized off `take_until` — not parsing dispatch.
-        let names_token = subject.ends_with(" or token") || subject.ends_with(" or tokens"); // allow-noncombinator: noun-phrase tail check on pre-tokenized slice
-        let names_card = subject.ends_with(" card") || subject.ends_with(" cards"); // allow-noncombinator: noun-phrase tail check on pre-tokenized slice
+        // "a card or token" is never misread as token-excluding.
+        //
+        // The token axis is a terminal-noun classification of the noun phrase
+        // `take_until` already tokenized off. "Ends with <noun>" is expressed as
+        // a forward combinator — `take_until(noun) + tag(noun) + eof` — so the
+        // classification stays combinator-pure (no raw tail string-ops) and is
+        // correct for arbitrarily long subjects ("a nontoken creature card",
+        // "a creature an opponent controls") where a first-word split would not
+        // be.
+        fn subject_ends_with<'a>(subject: &'a str, noun: &'static str) -> bool {
+            terminated(
+                (take_until(noun), tag(noun)),
+                eof::<&'a str, OracleError<'a>>,
+            )
+            .parse(subject)
+            .is_ok()
+        }
+        let names_token =
+            subject_ends_with(subject, " or token") || subject_ends_with(subject, " or tokens");
+        let names_card =
+            subject_ends_with(subject, " card") || subject_ends_with(subject, " cards");
         let token_scope = if names_card && !names_token {
             TokenScope::NonToken
         } else {

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3236,12 +3236,40 @@ fn parse_graveyard_exile_replacement(
         ShuffleBack { reveal: bool },
     }
 
-    let ((scope, outcome), _rest) = nom_on_lower(original_text, norm_lower, |i| {
+    // CR 730.3e + CR 111.1: the subject's token axis. "a card or token" is
+    // token-INCLUSIVE (Rest in Peace) and adds no constraint; "a card" is
+    // token-EXCLUDING (Leyline of the Void) and adds a `NonToken` filter so
+    // a dying token reaches the graveyard (and dies-triggers fire) instead of
+    // being wrongly redirected. Any other subject (`~`, "that spell", "a
+    // permanent", a counter condition) leaves the axis `Unscoped` — the
+    // pre-existing token-inclusive behavior, preserved.
+    #[derive(Clone, Copy)]
+    enum TokenScope {
+        Unscoped,
+        NonToken,
+    }
+
+    let ((scope, token_scope, outcome), _rest) = nom_on_lower(original_text, norm_lower, |i| {
         // Prefix: "if <subject> would be put into <scope> graveyard[ from anywhere], "
         let (i, _) = tag::<_, _, OracleError<'_>>("if ").parse(i)?;
         // Subject: accept any phrase up to " would be put into " — covers
         // "a card", "a nontoken creature", "~", "a creature an opponent controls", …
-        let (i, _) = take_until::<_, _, OracleError<'_>>(" would be put into ").parse(i)?;
+        // — and classify its token axis (CR 730.3e) from the captured slice.
+        let (i, subject) = take_until::<_, _, OracleError<'_>>(" would be put into ").parse(i)?;
+        // CR 730.3e + CR 111.1: a card-noun subject WITHOUT an "or token" rider
+        // is token-excluding (Leyline of the Void: "a card"). The inclusive RIP
+        // phrasing ("a card or token") names tokens explicitly and stays
+        // unscoped. The token-rider check wins over the bare-card check, so
+        // "a card or token" is never misread as token-excluding. These are
+        // terminal noun-phrase tail checks on the slice the combinator already
+        // tokenized off `take_until` — not parsing dispatch.
+        let names_token = subject.ends_with(" or token") || subject.ends_with(" or tokens"); // allow-noncombinator: noun-phrase tail check on pre-tokenized slice
+        let names_card = subject.ends_with(" card") || subject.ends_with(" cards"); // allow-noncombinator: noun-phrase tail check on pre-tokenized slice
+        let token_scope = if names_card && !names_token {
+            TokenScope::NonToken
+        } else {
+            TokenScope::Unscoped
+        };
         let (i, _) = tag::<_, _, OracleError<'_>>(" would be put into ").parse(i)?;
         let (i, scope) = alt((
             value(Scope::Opponent, tag("an opponent's graveyard")),
@@ -3271,7 +3299,7 @@ fn parse_graveyard_exile_replacement(
         ))
         .parse(i)?;
 
-        Ok((i, (scope, outcome)))
+        Ok((i, (scope, token_scope, outcome)))
     })?;
 
     // Destination routing is determined by the outcome branch.
@@ -3282,14 +3310,21 @@ fn parse_graveyard_exile_replacement(
 
     // CR 400.3 + CR 108.3: "opponent's graveyard" means cards owned by an opponent
     // (cards go to owner's graveyard, so ownership is the stable discriminant).
-    let valid_card = match scope {
-        Scope::Opponent => Some(TargetFilter::Typed(TypedFilter::default().properties(
-            vec![FilterProp::Owned {
-                controller: ControllerRef::Opponent,
-            }],
-        ))),
-        Scope::Any => None,
-    };
+    // CR 730.3e + CR 111.1: a token-excluding subject ("a card") adds `NonToken`
+    // so a dying token is NOT redirected (Leyline of the Void must let an
+    // opponent's token reach the graveyard so dies-triggers fire — Blood Artist
+    // class). Both axes are leaf `FilterProp`s on one `TypedFilter`.
+    let mut props = Vec::new();
+    if let Scope::Opponent = scope {
+        props.push(FilterProp::Owned {
+            controller: ControllerRef::Opponent,
+        });
+    }
+    if let TokenScope::NonToken = token_scope {
+        props.push(FilterProp::NonToken);
+    }
+    let valid_card =
+        (!props.is_empty()).then(|| TargetFilter::Typed(TypedFilter::default().properties(props)));
 
     // Build the ChangeZone redirect. `event_modifiers_for_ability` extracts only
     // the `destination` field from this top-level ChangeZone — other fields here
@@ -8530,7 +8565,9 @@ mod tests {
         .unwrap();
         assert_eq!(def.event, ReplacementEvent::Moved);
         assert_eq!(def.destination_zone, Some(Zone::Graveyard));
-        assert!(def.valid_card.is_none()); // matches all objects
+        // CR 730.3e: "a card or token" names tokens explicitly — token-inclusive,
+        // so NO `NonToken` constraint and (with `Any` scope) no `valid_card` at all.
+        assert!(def.valid_card.is_none()); // matches all objects, tokens included
         assert!(matches!(
             *def.execute.as_ref().unwrap().effect,
             Effect::ChangeZone {
@@ -8550,14 +8587,21 @@ mod tests {
         .unwrap();
         assert_eq!(def.event, ReplacementEvent::Moved);
         assert_eq!(def.destination_zone, Some(Zone::Graveyard));
-        // valid_card should scope to opponent-owned cards
+        // valid_card should scope to opponent-owned cards AND exclude tokens:
+        // CR 730.3e + CR 111.1 — "a card" (no "or token") is token-excluding, so a
+        // dying token reaches the graveyard (dies-triggers fire — Blood Artist
+        // class) instead of being wrongly exiled.
         match &def.valid_card {
             Some(TargetFilter::Typed(TypedFilter { properties, .. })) => {
                 assert!(properties.contains(&FilterProp::Owned {
                     controller: ControllerRef::Opponent,
                 }));
+                assert!(
+                    properties.contains(&FilterProp::NonToken),
+                    "'a card' subject must exclude tokens (CR 730.3e)"
+                );
             }
-            other => panic!("Expected Typed filter with Owned, got {other:?}"),
+            other => panic!("Expected Typed filter with Owned + NonToken, got {other:?}"),
         }
         assert!(matches!(
             *def.execute.as_ref().unwrap().effect,
@@ -8567,6 +8611,37 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// CR 730.3e + CR 111.1: a card-only subject targeting ANY graveyard ("a
+    /// card would be put into a graveyard") is token-EXCLUDING with no
+    /// controller scope — `valid_card` is `NonToken` alone. This is the live
+    /// Leyline-class bug fix: without the `NonToken` axis a dying token was
+    /// wrongly redirected (exiled), suppressing dies-triggers.
+    #[test]
+    fn card_only_any_graveyard_excludes_tokens() {
+        let def = parse_replacement_line(
+            "If a card would be put into a graveyard from anywhere, exile it instead.",
+            "Some Card-Scoped Hoser",
+        )
+        .unwrap();
+        assert_eq!(def.event, ReplacementEvent::Moved);
+        assert_eq!(def.destination_zone, Some(Zone::Graveyard));
+        match &def.valid_card {
+            Some(TargetFilter::Typed(TypedFilter { properties, .. })) => {
+                assert!(
+                    properties.contains(&FilterProp::NonToken),
+                    "'a card' subject must exclude tokens (CR 730.3e)"
+                );
+                assert!(
+                    !properties.contains(&FilterProp::Owned {
+                        controller: ControllerRef::Opponent,
+                    }),
+                    "any-graveyard scope must not add an owner constraint"
+                );
+            }
+            other => panic!("Expected Typed filter with NonToken, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1373,6 +1373,22 @@ pub enum ZoneDeliveryExileTracking {
 /// (instead of keeping two divergent delivery copies) lets the resume path
 /// route through the shared `deliver` machinery while its epilogue keeps
 /// exclusive ownership of the drain.
+/// CR 730.3e (second clause): the card-component routing override for a TOKEN
+/// merged permanent leaving the battlefield under a card-scoped (`NonToken`)
+/// `Moved` redirect. The token survivor and token components are put into
+/// `default_dest` (the pre-replacement appropriate zone); the card components
+/// are "moved by the replacement effect" to `card_dest`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergedCardComponentRoute {
+    /// Where the token survivor + token components go — the pre-replacement
+    /// appropriate zone (a card-scoped redirect did not match the token
+    /// survivor, so its own move is unredirected).
+    pub default_dest: Zone,
+    /// Where the card components go — the destination the card-scoped redirect
+    /// resolved to in the single component-aware consult.
+    pub card_dest: Zone,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum PostReplacementDrainOwner {
     /// The shared delivery tail (`apply_zone_delivery_tail`) drains the
@@ -5852,6 +5868,23 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub devour_eligible_snapshot: Option<HashSet<ObjectId>>,
 
+    /// CR 730.3e (second clause): routing override for the card components of a
+    /// TOKEN merged permanent leaving the battlefield under a card-scoped
+    /// (`NonToken`) `Moved` redirect. "If the merged permanent is a token but
+    /// some of its components are cards, the merged permanent and its token
+    /// components are put into the appropriate [default] zone, and the
+    /// components that are cards are moved by the replacement effect."
+    ///
+    /// Set by `zone_pipeline::deliver_replaced_zone_change` from the single
+    /// component-aware consult immediately before the survivor's
+    /// `zones::move_to_zone`, read by `merge::split_merged_permanent_on_leave`
+    /// to route CARD components to `card_dest` while token components follow the
+    /// survivor's `default_dest`, then cleared. Purely synchronous (set →
+    /// `move_to_zone` split consumes → cleared in the same delivery), so it
+    /// never survives a pause; the serde guard is belt-and-suspenders.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merged_card_component_route: Option<MergedCardComponentRoute>,
+
     /// CR 707.2 + CR 614.1a + CR 616.1: Pending `CopyTokenOf` source loop
     /// paused by an interactive token-creation replacement. Drained by
     /// `token_copy::drain_pending_copy_token_resolution` after the current
@@ -6693,6 +6726,7 @@ impl GameState {
             pending_repeat_iteration: None,
             pending_change_zone_iteration: None,
             devour_eligible_snapshot: None,
+            merged_card_component_route: None,
             pending_copy_token_resolution: None,
             pending_coin_flip: None,
             pending_repeat_until: None,


### PR DESCRIPTION
- **fix(engine): card-scope graveyard-redirect subjects so dying tokens reach the graveyard (CR 730.3e / CR 111.1)**
- **feat(engine): CR 730.3e clause 2 — token-survivor merged leave splits card components to the card-scoped redirect (zone pipeline tranche 3)**
- **fix(engine): t3 review round — clear stranded pending_replacement in card-partition consult fallback + end-to-end parsed-Leyline pin**
