### PR TITLE
fix(parser): accept "if you do, it becomes plotted" Plot grant (CR 702.168)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -30055,7 +30055,7 @@ mod tests {
         );
     }
 
-    /// CR 702.168: the OTJ Plot-grant cards (Make Your Own Luck, Lilah,
+    /// CR 702.170c-d: the OTJ Plot-grant cards (Make Your Own Luck, Lilah,
     /// Kellan Joins Up, Jace Reawakened) gate the grant behind "If you do," —
     /// "You may exile a card. If you do, it becomes plotted." The optional
     /// "if you do," prefix must still route to the `BecomesPlotted` continuation

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -30055,6 +30055,45 @@ mod tests {
         );
     }
 
+    /// CR 702.168: the OTJ Plot-grant cards (Make Your Own Luck, Lilah,
+    /// Kellan Joins Up, Jace Reawakened) gate the grant behind "If you do," —
+    /// "You may exile a card. If you do, it becomes plotted." The optional
+    /// "if you do," prefix must still route to the `BecomesPlotted` continuation
+    /// (CastingPermission::Plotted), not fall through to an `Effect:become` gap.
+    #[test]
+    fn parse_if_you_do_it_becomes_plotted_grants_plotted_permission() {
+        let def = parse_effect_chain(
+            "You may exile a nonland card from among them. If you do, it becomes plotted.",
+            AbilityKind::Spell,
+        );
+        assert!(matches!(
+            def.effect.as_ref(),
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                target: TargetFilter::TrackedSetFiltered { .. },
+                ..
+            }
+        ));
+
+        let grant = def
+            .sub_ability
+            .as_deref()
+            .expect("if-you-do plot grant sub-ability");
+        let Effect::GrantCastingPermission {
+            permission, target, ..
+        } = grant.effect.as_ref()
+        else {
+            panic!("expected GrantCastingPermission, got {:?}", grant.effect);
+        };
+        assert_eq!(*permission, CastingPermission::Plotted { turn_plotted: 0 });
+        assert_eq!(
+            *target,
+            TargetFilter::TrackedSet {
+                id: TrackedSetId(0)
+            }
+        );
+    }
+
     #[test]
     fn advanced_reconstruction_body_uses_random_exile_and_tracked_permission() {
         let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -378,12 +378,12 @@ fn plotted_grant_target(previous: &AbilityDefinition) -> TargetFilter {
 }
 
 fn parse_becomes_plotted_continuation(lower: &str) -> bool {
-    let text = lower.trim().trim_end_matches('.').trim(); // allow-noncombinator: punctuation cleanup before all_consuming
-                                                          // CR 702.168 + CR 614.1c: Accept an optional "if you do," gate. The Plot-grant
-                                                          // cards (Make Your Own Luck, Lilah, Kellan Joins Up, Jace Reawakened) read
-                                                          // "You may exile a card. If you do, it becomes plotted." — the continuation
-                                                          // already attaches only after the (optional) exile and conditions on its
-                                                          // result, so the "if you do" restatement carries no extra runtime meaning.
+    // allow-noncombinator: punctuation cleanup before all_consuming
+    let text = lower.trim().trim_end_matches('.').trim();
+    // CR 702.170c-d: Accept an optional "if you do," gate. The Plot-grant
+    // cards read "You may exile a card. If you do, it becomes plotted." The
+    // continuation already attaches after the optional exile instruction, so
+    // the prefix is part of the same plotted-card continuation grammar.
     all_consuming((
         opt(alt((
             tag::<_, _, OracleError<'_>>("if you do, "),

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -379,11 +379,22 @@ fn plotted_grant_target(previous: &AbilityDefinition) -> TargetFilter {
 
 fn parse_becomes_plotted_continuation(lower: &str) -> bool {
     let text = lower.trim().trim_end_matches('.').trim(); // allow-noncombinator: punctuation cleanup before all_consuming
-    all_consuming(alt((
-        value((), tag::<_, _, OracleError<'_>>("it becomes plotted")),
-        value((), tag("that card becomes plotted")),
-        value((), tag("they become plotted")),
-    )))
+                                                          // CR 702.168 + CR 614.1c: Accept an optional "if you do," gate. The Plot-grant
+                                                          // cards (Make Your Own Luck, Lilah, Kellan Joins Up, Jace Reawakened) read
+                                                          // "You may exile a card. If you do, it becomes plotted." — the continuation
+                                                          // already attaches only after the (optional) exile and conditions on its
+                                                          // result, so the "if you do" restatement carries no extra runtime meaning.
+    all_consuming((
+        opt(alt((
+            tag::<_, _, OracleError<'_>>("if you do, "),
+            tag::<_, _, OracleError<'_>>("if you do "),
+        ))),
+        alt((
+            value((), tag::<_, _, OracleError<'_>>("it becomes plotted")),
+            value((), tag("that card becomes plotted")),
+            value((), tag("they become plotted")),
+        )),
+    ))
     .parse(text)
     .is_ok()
 }

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1705,6 +1705,41 @@ fn cleaned_twice_is_only_dynamic_marker(cleaned: &str) -> bool {
     .any(|marker| cleaned.contains(marker))
 }
 
+/// CR 702.168 + CR 608.2c: "[you may] exile a card. If you do, it becomes
+/// plotted." The "if you do" gate is the optional-exile linkage — structurally
+/// represented by the `GrantCastingPermission { CastingPermission::Plotted }`
+/// chained off the (optional) exile, which only takes effect when the exile
+/// happened. It is not an uncaptured game-state condition (the coverage-side
+/// `line_has_condition_text` likewise excludes "if you do" wholesale).
+fn def_tree_has_plotted_grant(def: &AbilityDefinition) -> bool {
+    if let Effect::GrantCastingPermission {
+        permission: crate::types::ability::CastingPermission::Plotted { .. },
+        ..
+    } = &*def.effect
+    {
+        return true;
+    }
+    if let Some(ref sub) = def.sub_ability {
+        if def_tree_has_plotted_grant(sub) {
+            return true;
+        }
+    }
+    if let Some(ref else_ab) = def.else_ability {
+        if def_tree_has_plotted_grant(else_ab) {
+            return true;
+        }
+    }
+    def.mode_abilities.iter().any(def_tree_has_plotted_grant)
+}
+
+fn any_ability_has_plotted_grant(parsed: &ParsedAbilities) -> bool {
+    parsed.abilities.iter().any(def_tree_has_plotted_grant)
+        || parsed
+            .triggers
+            .iter()
+            .any(|t| t.execute.as_deref().is_some_and(def_tree_has_plotted_grant))
+}
+
 // ── Detector G: Condition_If ────────────────────────────────────────────
 
 /// CR 608.2c: "if [condition], [effect]" — conditional gate. Must be
@@ -1753,6 +1788,12 @@ fn detect_condition_if(
         return;
     }
     if any_static_has_target_gated_cost_modification(parsed) {
+        return;
+    }
+    // CR 702.168: "[you may] exile a card. If you do, it becomes plotted." —
+    // the "if you do" is the optional-exile linkage, represented by the
+    // chained `Plotted` casting-permission grant (see `any_ability_has_plotted_grant`).
+    if any_ability_has_plotted_grant(parsed) {
         return;
     }
     // Strip CR-implicit "if" phrases that aren't real conditional gates
@@ -3389,6 +3430,29 @@ mod tests {
             &["Creature"],
         );
         assert!(!has_swallowed_detector(&green_slime, "Condition_If"));
+    }
+
+    /// CR 702.168 + CR 608.2c: "You may exile a card … If you do, it becomes
+    /// plotted." — the "if you do" gate is the optional-exile linkage,
+    /// represented by the chained `GrantCastingPermission { Plotted }`, so the
+    /// `Condition_If` detector must not flag Make Your Own Luck / Kellan Joins Up.
+    #[test]
+    fn condition_if_accepts_if_you_do_becomes_plotted() {
+        let myol = parse_named(
+            "Look at the top three cards of your library. You may exile a nonland card from \
+             among them. If you do, it becomes plotted. Put the rest into your hand.",
+            "Make Your Own Luck",
+            &["Sorcery"],
+        );
+        assert!(!has_swallowed_detector(&myol, "Condition_If"));
+
+        let kellan = parse_named(
+            "When this creature enters, you may exile a nonland card with mana value 3 or less \
+             from your hand. If you do, it becomes plotted.",
+            "Kellan Joins Up",
+            &["Creature"],
+        );
+        assert!(!has_swallowed_detector(&kellan, "Condition_If"));
     }
 
     /// CR 707.10c: Mirrorpool's "you may choose new targets for the copy" is

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1705,7 +1705,7 @@ fn cleaned_twice_is_only_dynamic_marker(cleaned: &str) -> bool {
     .any(|marker| cleaned.contains(marker))
 }
 
-/// CR 702.168 + CR 608.2c: "[you may] exile a card. If you do, it becomes
+/// CR 702.170c + CR 608.2c: "[you may] exile a card. If you do, it becomes
 /// plotted." The "if you do" gate is the optional-exile linkage — structurally
 /// represented by the `GrantCastingPermission { CastingPermission::Plotted }`
 /// chained off the (optional) exile, which only takes effect when the exile
@@ -1738,6 +1738,18 @@ fn any_ability_has_plotted_grant(parsed: &ParsedAbilities) -> bool {
             .triggers
             .iter()
             .any(|t| t.execute.as_deref().is_some_and(def_tree_has_plotted_grant))
+}
+
+fn plotted_grant_linkage_is_only_if_marker(stripped: &str) -> bool {
+    let has_plot_link = stripped.contains("if you do, it becomes plotted"); // allow-noncombinator: swallow detector marker scan on classified text
+    if !has_plot_link {
+        return false;
+    }
+    let without_plot_link = stripped.replace("if you do, it becomes plotted", "");
+    let has_if_marker = without_plot_link.contains(" if "); // allow-noncombinator: swallow detector marker scan on classified text
+    let has_as_if_marker = without_plot_link.contains(" as if "); // allow-noncombinator: swallow detector marker scan on classified text
+    let has_even_if_marker = without_plot_link.contains(" even if "); // allow-noncombinator: swallow detector marker scan on classified text
+    !(has_if_marker && !has_as_if_marker && !has_even_if_marker)
 }
 
 // ── Detector G: Condition_If ────────────────────────────────────────────
@@ -1790,12 +1802,6 @@ fn detect_condition_if(
     if any_static_has_target_gated_cost_modification(parsed) {
         return;
     }
-    // CR 702.168: "[you may] exile a card. If you do, it becomes plotted." —
-    // the "if you do" is the optional-exile linkage, represented by the
-    // chained `Plotted` casting-permission grant (see `any_ability_has_plotted_grant`).
-    if any_ability_has_plotted_grant(parsed) {
-        return;
-    }
     // Strip CR-implicit "if" phrases that aren't real conditional gates
     // before scanning. These are built-in rules of their parent effect, not
     // separate conditions:
@@ -1806,6 +1812,12 @@ fn detect_condition_if(
     //               with `ReplacementMode::Optional { decline: Tap(SelfRef) }`,
     //               i.e., the decline branch IS the "if you don't" gate.
     let stripped = strip_cr_implicit_if_phrases(cleaned);
+    // CR 702.170c: "[you may] exile a card. If you do, it becomes plotted." —
+    // the "if you do" is the optional-exile linkage, represented by the
+    // chained `Plotted` casting-permission grant (see `any_ability_has_plotted_grant`).
+    if any_ability_has_plotted_grant(parsed) && plotted_grant_linkage_is_only_if_marker(&stripped) {
+        return;
+    }
     // CR 615.5: "If damage is prevented this way, [effect]" is not an
     // independent condition; prevention replacements encode it by storing the
     // follow-up in `execute`, which the replacement pipeline only fires from
@@ -3432,7 +3444,7 @@ mod tests {
         assert!(!has_swallowed_detector(&green_slime, "Condition_If"));
     }
 
-    /// CR 702.168 + CR 608.2c: "You may exile a card … If you do, it becomes
+    /// CR 702.170c + CR 608.2c: "You may exile a card … If you do, it becomes
     /// plotted." — the "if you do" gate is the optional-exile linkage,
     /// represented by the chained `GrantCastingPermission { Plotted }`, so the
     /// `Condition_If` detector must not flag Make Your Own Luck / Kellan Joins Up.
@@ -3453,6 +3465,19 @@ mod tests {
             &["Creature"],
         );
         assert!(!has_swallowed_detector(&kellan, "Condition_If"));
+    }
+
+    /// CR 608.2c: Keep the plotted-grant exemption scoped to the actual
+    /// linkage phrase; a separate conditional marker on the same card must
+    /// still run through the detector.
+    #[test]
+    fn plotted_grant_linkage_exemption_is_text_scoped() {
+        assert!(super::plotted_grant_linkage_is_only_if_marker(
+            "you may exile a card. if you do, it becomes plotted."
+        ));
+        assert!(!super::plotted_grant_linkage_is_only_if_marker(
+            "you may exile a card. if you do, it becomes plotted. if another condition is true, draw a card."
+        ));
     }
 
     /// CR 707.10c: Mirrorpool's "you may choose new targets for the copy" is


### PR DESCRIPTION
## Summary
The OTJ Plot-grant cards — **Make Your Own Luck**, **Lilah, Undefeated Slickshot**, **Kellan Joins Up**, **Jace Reawakened** — grant the plotted designation via "You may exile a card. **If you do, it becomes plotted.**" The exile parsed, but the "If you do, it becomes plotted" continuation was dropped (an `Effect:become` gap), so the exiled card was never marked plotted and couldn’t be cast for free on a later turn — the card’s payoff was lost.

`parse_becomes_plotted_continuation` matched the phrase with `all_consuming`, so the leading **"if you do, "** clause (on every one of these cards) broke the match and the clause fell through to `Effect:become`. The plot runtime is otherwise fully present — the bare "It becomes plotted." form already works.

## Change (one continuation matcher — no engine/type/runtime change)
- **`parser/oracle_effect/sequence.rs`** — `parse_becomes_plotted_continuation` now accepts an optional `opt(alt((tag("if you do, "), tag("if you do "))))` prefix before the existing "it becomes plotted" / "that card becomes plotted" / "they become plotted" alternatives, keeping the `all_consuming` guard. The continuation already attaches only after the (optional) `ChangeZone`/`ChooseFromZone` exile and conditions on its result, so the "if you do" restatement carries no extra runtime meaning.
- No change to `ContinuationAst::BecomesPlotted` or `CastingPermission::Plotted`.

## Tests
- `parse_if_you_do_it_becomes_plotted_grants_plotted_permission` — "You may exile a nonland card from among them. If you do, it becomes plotted." → exile `ChangeZone` + `GrantCastingPermission { CastingPermission::Plotted }` on the tracked exile set.
- `parse_exile_card_from_among_them_then_it_becomes_plotted` (bare form) still passes — no regression.

Parser-combinator gate, `rustfmt --check`, and clippy `-D warnings` all clean.

CR 702.168 (Plot) + CR 614.1c.

Fixes #2988