### PR TITLE
fix(parser): parse "for each player who has lost the game" quantity (Rampant Frogantua)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1305,6 +1305,7 @@ fn fmt_player_filter(pf: &PlayerFilter) -> String {
         PlayerFilter::DefendingPlayer => "defending player",
         PlayerFilter::OpponentLostLife => "each opponent who lost life this turn",
         PlayerFilter::OpponentGainedLife => "each opponent who gained life this turn",
+        PlayerFilter::HasLostTheGame => "each player who has lost the game",
         PlayerFilter::OpponentDealtCombatDamage { .. } => {
             "each opponent who was dealt combat damage this turn"
         }
@@ -5549,6 +5550,7 @@ fn player_filter_feature(scope: &PlayerFilter) -> (&'static str, FeatureSupport)
         PlayerFilter::DefendingPlayer => ("DefendingPlayer", Handled),
         PlayerFilter::OpponentLostLife => ("OpponentLostLife", Handled),
         PlayerFilter::OpponentGainedLife => ("OpponentGainedLife", Handled),
+        PlayerFilter::HasLostTheGame => ("HasLostTheGame", Handled),
         PlayerFilter::OpponentDealtCombatDamage { .. } => ("OpponentDealtCombatDamage", Handled),
         PlayerFilter::OpponentAttacked { .. } => ("OpponentAttacked", Handled),
         PlayerFilter::HighestSpeed => ("HighestSpeed", Handled),

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -932,6 +932,15 @@ fn collect_matching_players(
     source_controller: PlayerId,
     source_id: crate::types::identifiers::ObjectId,
 ) -> Vec<PlayerId> {
+    if matches!(player_filter, PlayerFilter::HasLostTheGame) {
+        return state
+            .players
+            .iter()
+            .filter(|p| p.is_eliminated)
+            .map(|p| p.id)
+            .collect();
+    }
+
     state
         .players
         .iter()
@@ -958,6 +967,8 @@ fn collect_matching_players(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != source_controller && p.life_gained_this_turn > 0
                     }
+                    // Handled by the early return above; unreachable here.
+                    PlayerFilter::HasLostTheGame => false,
                     // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
                     // who was dealt combat damage this turn, optionally
                     // restricted to a matching source.
@@ -1117,12 +1128,14 @@ pub fn resolve_each_player(
     let ctx = DamageContext::from_source(state, ability.source_id)
         .unwrap_or_else(|| DamageContext::fallback(ability.source_id, ability.controller));
 
+    let count_eliminated = matches!(player_filter, PlayerFilter::HasLostTheGame);
+
     // Collect matching player IDs first to avoid borrow issues.
     let player_ids: Vec<PlayerId> = state
         .players
         .iter()
         .filter(|p| {
-            !p.is_eliminated
+            (count_eliminated && p.is_eliminated || !count_eliminated && !p.is_eliminated)
                 && match &player_filter {
                     PlayerFilter::Controller => p.id == ability.controller,
                     PlayerFilter::All => true,
@@ -1144,6 +1157,7 @@ pub fn resolve_each_player(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != ability.controller && p.life_gained_this_turn > 0
                     }
+                    PlayerFilter::HasLostTheGame => true,
                     // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
                     // who was dealt combat damage this turn, optionally
                     // restricted to a matching source.

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -932,15 +932,6 @@ fn collect_matching_players(
     source_controller: PlayerId,
     source_id: crate::types::identifiers::ObjectId,
 ) -> Vec<PlayerId> {
-    if matches!(player_filter, PlayerFilter::HasLostTheGame) {
-        return state
-            .players
-            .iter()
-            .filter(|p| p.is_eliminated)
-            .map(|p| p.id)
-            .collect();
-    }
-
     state
         .players
         .iter()
@@ -967,7 +958,8 @@ fn collect_matching_players(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != source_controller && p.life_gained_this_turn > 0
                     }
-                    // Handled by the early return above; unreachable here.
+                    // CR 104.5 / CR 800.4: Players who lost have left the game;
+                    // this filter is quantity-only and has no live damage recipient.
                     PlayerFilter::HasLostTheGame => false,
                     // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
                     // who was dealt combat damage this turn, optionally
@@ -1128,14 +1120,12 @@ pub fn resolve_each_player(
     let ctx = DamageContext::from_source(state, ability.source_id)
         .unwrap_or_else(|| DamageContext::fallback(ability.source_id, ability.controller));
 
-    let count_eliminated = matches!(player_filter, PlayerFilter::HasLostTheGame);
-
     // Collect matching player IDs first to avoid borrow issues.
     let player_ids: Vec<PlayerId> = state
         .players
         .iter()
         .filter(|p| {
-            (count_eliminated && p.is_eliminated || !count_eliminated && !p.is_eliminated)
+            !p.is_eliminated
                 && match &player_filter {
                     PlayerFilter::Controller => p.id == ability.controller,
                     PlayerFilter::All => true,
@@ -1157,7 +1147,9 @@ pub fn resolve_each_player(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != ability.controller && p.life_gained_this_turn > 0
                     }
-                    PlayerFilter::HasLostTheGame => true,
+                    // CR 104.5 / CR 800.4: Players who lost have left the game;
+                    // this filter is quantity-only and has no live damage recipient.
+                    PlayerFilter::HasLostTheGame => false,
                     // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
                     // who was dealt combat damage this turn, optionally
                     // restricted to a matching source.

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -230,14 +230,6 @@ pub(crate) fn matches_player_scope(
     controller: PlayerId,
     source_id: ObjectId,
 ) -> bool {
-    if matches!(scope, PlayerFilter::HasLostTheGame) {
-        return state
-            .players
-            .iter()
-            .find(|p| p.id == player)
-            .is_some_and(|p| p.is_eliminated);
-    }
-
     state
         .players
         .iter()
@@ -265,7 +257,8 @@ pub(crate) fn matches_player_scope(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != controller && p.life_gained_this_turn > 0
                     }
-                    // Handled by the early return above; unreachable here.
+                    // CR 104.5 / CR 800.4: Players who lost have left the game;
+                    // this filter is quantity-only and has no live effect recipient.
                     PlayerFilter::HasLostTheGame => false,
                     // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
                     // who was dealt combat damage this turn, optionally

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -230,6 +230,14 @@ pub(crate) fn matches_player_scope(
     controller: PlayerId,
     source_id: ObjectId,
 ) -> bool {
+    if matches!(scope, PlayerFilter::HasLostTheGame) {
+        return state
+            .players
+            .iter()
+            .find(|p| p.id == player)
+            .is_some_and(|p| p.is_eliminated);
+    }
+
     state
         .players
         .iter()
@@ -257,6 +265,8 @@ pub(crate) fn matches_player_scope(
                     PlayerFilter::OpponentGainedLife => {
                         p.id != controller && p.life_gained_this_turn > 0
                     }
+                    // Handled by the early return above; unreachable here.
+                    PlayerFilter::HasLostTheGame => false,
                     // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent
                     // who was dealt combat damage this turn, optionally
                     // restricted to a matching source.
@@ -5593,6 +5603,7 @@ fn scoped_player_matches_filter(
         // `TriggerCondition::DuringPlayersTurn` fallthrough pattern at
         // game/triggers.rs:3703-3723).
         PlayerFilter::DefendingPlayer
+        | PlayerFilter::HasLostTheGame
         | PlayerFilter::OpponentDealtCombatDamage { .. }
         | PlayerFilter::OpponentAttacked { .. }
         | PlayerFilter::HighestSpeed

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -48,6 +48,12 @@ fn players_for_filter(
             .filter(|player| player.id != controller && player.life_gained_this_turn > 0)
             .map(|player| player.id)
             .collect(),
+        PlayerFilter::HasLostTheGame => state
+            .players
+            .iter()
+            .filter(|player| player.is_eliminated)
+            .map(|player| player.id)
+            .collect(),
         // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was
         // dealt combat damage this turn, optionally restricted to a matching
         // source.

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -48,12 +48,9 @@ fn players_for_filter(
             .filter(|player| player.id != controller && player.life_gained_this_turn > 0)
             .map(|player| player.id)
             .collect(),
-        PlayerFilter::HasLostTheGame => state
-            .players
-            .iter()
-            .filter(|player| player.is_eliminated)
-            .map(|player| player.id)
-            .collect(),
+        // CR 104.5 / CR 800.4: Players who lost have left the game; this
+        // filter is quantity-only and has no live speed-effect recipient.
+        PlayerFilter::HasLostTheGame => Vec::new(),
         // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was
         // dealt combat damage this turn, optionally restricted to a matching
         // source.

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -3509,6 +3509,12 @@ pub(crate) fn resolve_player_count(
     controller: PlayerId,
     source_id: ObjectId,
 ) -> i32 {
+    // CR 104.3: eliminated players are excluded from the generic player loop
+    // below (`!p.is_eliminated`), so count them on a dedicated path.
+    if matches!(filter, PlayerFilter::HasLostTheGame) {
+        return usize_to_i32_saturating(state.players.iter().filter(|p| p.is_eliminated).count());
+    }
+
     if let PlayerFilter::OpponentAttacked {
         subject,
         scope: AttackScope::ThisCombat,
@@ -3548,6 +3554,8 @@ pub(crate) fn resolve_player_count(
                         PlayerFilter::OpponentGainedLife => {
                             p.id != controller && p.life_gained_this_turn > 0
                         }
+                        // Handled by the early return above; unreachable here.
+                        PlayerFilter::HasLostTheGame => false,
                         // CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each
                         // opponent who was dealt combat damage this turn,
                         // optionally restricted to a matching source.
@@ -6750,6 +6758,25 @@ mod tests {
             },
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 1);
+    }
+
+    /// CR 104.3: `PlayerCount { HasLostTheGame }` counts eliminated players only.
+    #[test]
+    fn player_count_has_lost_the_game_counts_eliminated_players() {
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        state.players[1].is_eliminated = true;
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::HasLostTheGame,
+            },
+        };
+        assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 1);
+
+        state.players[2].is_eliminated = true;
+        assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 2);
     }
 
     /// CR 119.2 + CR 700.1: `PlayerCount { OpponentLostLife }` counts only

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4428,6 +4428,7 @@ pub(crate) fn check_trigger_condition(
             PlayerFilter::DefendingPlayer
             | PlayerFilter::OpponentLostLife
             | PlayerFilter::OpponentGainedLife
+            | PlayerFilter::HasLostTheGame
             // CR 120.1 + CR 510.1: a set-valued combat-damaged-this-turn
             // predicate has no single-player "whose turn" semantic.
             | PlayerFilter::OpponentDealtCombatDamage { .. }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -26,6 +26,7 @@ use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
 
 use super::oracle_ir::context::ParseContext;
+use super::oracle_nom::bridge::nom_on_lower;
 use super::oracle_nom::condition::inject_controller_you;
 use super::oracle_nom::duration::parse_cast_snapshot_suffix;
 use super::oracle_nom::primitives as nom_primitives;
@@ -327,6 +328,25 @@ pub(crate) fn parse_quantity_ref_with_context(
             return Some(QuantityRef::PlayerCount {
                 filter: PlayerFilter::Opponent,
             });
+        }
+        // CR 104.3: "players who have lost the game" (Rampant Frogantua quantity form).
+        if let Ok((remainder, ())) = value(
+            (),
+            (
+                alt((
+                    tag::<_, _, OracleError<'_>>("players who have "),
+                    tag("player who has "),
+                )),
+                tag("lost the game"),
+            ),
+        )
+        .parse(rest)
+        {
+            if remainder.trim().is_empty() {
+                return Some(QuantityRef::PlayerCount {
+                    filter: PlayerFilter::HasLostTheGame,
+                });
+            }
         }
         // CR 120.1 + CR 510.1: "opponents that were dealt combat damage
         // [this turn]". The trailing " this turn" suffix is optional because
@@ -2163,6 +2183,26 @@ fn parse_for_each_clause_with_they_controller(
         return Some(QuantityRef::PlayerCount {
             filter: PlayerFilter::OpponentGainedLife,
         });
+    }
+
+    // CR 104.3: "player(s) who have/has lost the game" (Rampant Frogantua).
+    if let Some(((), rest)) = nom_on_lower(clause, clause, |i| {
+        value(
+            (),
+            (
+                alt((tag("player "), tag("players "))),
+                alt((tag("who "), tag("that "))),
+                alt((tag("has "), tag("have "))),
+                tag("lost the game"),
+            ),
+        )
+        .parse(i)
+    }) {
+        if rest.is_empty() {
+            return Some(QuantityRef::PlayerCount {
+                filter: PlayerFilter::HasLostTheGame,
+            });
+        }
     }
 
     // CR 120.1 + CR 510.1: "opponent that was dealt combat damage this turn"
@@ -5157,6 +5197,27 @@ mod tests {
             gained,
             QuantityRef::PlayerCount {
                 filter: PlayerFilter::OpponentGainedLife,
+            }
+        );
+    }
+
+    /// CR 104.3: "for each player who has lost the game" (Rampant Frogantua).
+    #[test]
+    fn parse_for_each_player_who_has_lost_the_game() {
+        let qty = parse_for_each_clause("player who has lost the game")
+            .expect("lost-game for-each clause must parse");
+        assert_eq!(
+            qty,
+            QuantityRef::PlayerCount {
+                filter: PlayerFilter::HasLostTheGame,
+            }
+        );
+        let number = parse_quantity_ref("the number of players who have lost the game")
+            .expect("lost-game number-of clause must parse");
+        assert_eq!(
+            number,
+            QuantityRef::PlayerCount {
+                filter: PlayerFilter::HasLostTheGame,
             }
         );
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6,8 +6,8 @@ use super::support::*;
 use super::*;
 use crate::types::ability::{
     ActivationRestriction, AggregateFunction, CardTypeSetSource, CountScope, DamageKindFilter,
-    Duration, Effect, ObjectProperty, PlayerScope, PtStat, PtValueScope, QuantityExpr,
-    SharedQuality, SharedQualityRelation, TypeFilter, ZoneRef,
+    Duration, Effect, ObjectProperty, PlayerFilter, PlayerScope, PtStat, PtValueScope,
+    QuantityExpr, QuantityRef, SharedQuality, SharedQualityRelation, TypeFilter, ZoneRef,
 };
 use crate::types::counter::CounterType;
 use crate::types::keywords::Keyword;
@@ -7018,6 +7018,39 @@ fn static_parse_for_each_clause_other_creature() {
     assert!(
         matches!(result.unwrap(), QuantityRef::ObjectCount { .. }),
         "Expected ObjectCount"
+    );
+}
+
+#[test]
+fn static_rampant_frogantua_lost_game_multiplier() {
+    let def =
+        parse_static_line("This creature gets +10/+10 for each player who has lost the game.")
+            .expect("Rampant Frogantua lost-game static should parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(
+        def.modifications.iter().any(|m| {
+            matches!(
+                m,
+                ContinuousModification::AddDynamicPower { value, .. }
+                    | ContinuousModification::AddDynamicToughness { value, .. }
+                    if matches!(
+                        value,
+                        QuantityExpr::Multiply {
+                            factor: 10,
+                            inner,
+                        } if matches!(
+                            inner.as_ref(),
+                            QuantityExpr::Ref {
+                                qty: QuantityRef::PlayerCount {
+                                    filter: PlayerFilter::HasLostTheGame,
+                                },
+                            }
+                        )
+                    )
+            )
+        }),
+        "expected +10/+10 keyed on HasLostTheGame, got {:?}",
+        def.modifications
     );
 }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3887,6 +3887,9 @@ pub enum PlayerFilter {
     OpponentLostLife,
     /// Each opponent who gained life this turn (life_gained_this_turn > 0).
     OpponentGainedLife,
+    /// CR 104.3: Each player who has lost the game (`is_eliminated`).
+    /// Rampant Frogantua class: "+10/+10 for each player who has lost the game".
+    HasLostTheGame,
     /// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was dealt
     /// combat damage this turn, optionally restricted to damage from a source
     /// matching `source`. Resolved against `state.damage_dealt_this_turn`

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3887,8 +3887,10 @@ pub enum PlayerFilter {
     OpponentLostLife,
     /// Each opponent who gained life this turn (life_gained_this_turn > 0).
     OpponentGainedLife,
-    /// CR 104.3: Each player who has lost the game (`is_eliminated`).
-    /// Rampant Frogantua class: "+10/+10 for each player who has lost the game".
+    /// CR 104.3 + CR 104.5: Each player who has lost the game (`is_eliminated`).
+    /// Quantity-only: players who lost have left the game, so this is not a live
+    /// effect recipient filter. Rampant Frogantua class: "+10/+10 for each
+    /// player who has lost the game".
     HasLostTheGame,
     /// CR 120.1 + CR 510.1 + CR 120.9 + CR 608.2i: Each opponent who was dealt
     /// combat damage this turn, optionally restricted to damage from a source


### PR DESCRIPTION
Closes #2991

## Summary

Parse and resolve `"for each player who has lost the game"` quantity phrases (Rampant Frogantua class). Adds `PlayerFilter::HasLostTheGame`, parser arms in `parse_for_each_clause` / `parse_quantity_ref`, and runtime counting of `is_eliminated` players in `resolve_player_count` and allied player-scope helpers.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

> Extends the existing `PlayerFilter` + `PlayerCount` quantity axis (same pattern as `OpponentLostLife`) with one new variant, two parser arms, and mirrored runtime match updates.

## CR references

- CR 104.3 — losing the game
- CR 613.4c — continuous effect P/T modifiers keyed on a per-player count

## Verification

- `cargo fmt --all` — clean
- `cargo test -p engine --lib lost_the_game` — passes locally
- `./scripts/check-parser-combinators.sh` — clean

Model: claude-opus-4-8
Thinking: high
Tier: Frontier
