### PR TITLE
fix(parser): parse exile X cards from graveyard additional cost (Harvest Pyre)

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2007,6 +2007,15 @@ fn concretize_x_counter_removal_cost(cost: &AbilityCost, chosen_x: u32) -> Abili
             target: target.clone(),
             selection: *selection,
         },
+        AbilityCost::Exile {
+            count: u32::MAX,
+            zone: Some(Zone::Graveyard),
+            filter,
+        } => AbilityCost::Exile {
+            count: chosen_x,
+            zone: Some(Zone::Graveyard),
+            filter: filter.clone(),
+        },
         AbilityCost::Composite { costs } => AbilityCost::Composite {
             costs: costs
                 .iter()
@@ -3108,6 +3117,12 @@ fn pay_additional_cost_with_source(
         }
     }
 
+    let cost = if let Some(chosen_x) = pending.ability.chosen_x {
+        concretize_x_counter_removal_cost(&cost, chosen_x)
+    } else {
+        cost
+    };
+
     match cost {
         AbilityCost::PayLife { amount } => {
             // CR 118.3 + CR 119.4 + CR 119.8: Pay life as an additional cost via
@@ -3600,6 +3615,27 @@ fn additional_cost_x_max(
                     .len()
                     .try_into()
                     .unwrap_or(u32::MAX),
+            )
+        }
+        AbilityCost::Exile {
+            count: u32::MAX,
+            zone: Some(Zone::Graveyard),
+            filter,
+            ..
+        } => {
+            // CR 601.2b: X in an additional graveyard-exile cost is announced
+            // before the exile payment (Harvest Pyre).
+            Some(
+                super::casting::find_eligible_exile_for_cost_targets(
+                    state,
+                    player,
+                    source_id,
+                    ExileCostSourceZone::Graveyard,
+                    filter.as_ref(),
+                )
+                .len()
+                .try_into()
+                .unwrap_or(u32::MAX),
             )
         }
         AbilityCost::RemoveCounter {
@@ -7189,6 +7225,114 @@ mod tests {
                     .description("Apply discard replacement".to_string()),
             );
         replacement_source
+    }
+
+    #[test]
+    fn graveyard_exile_additional_cost_x_max_is_eligible_graveyard_size() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(9_100),
+            PlayerId(0),
+            "Harvest Pyre".to_string(),
+            Zone::Hand,
+        );
+        for idx in 0..4 {
+            create_object(
+                &mut state,
+                CardId(9_110 + idx),
+                PlayerId(0),
+                format!("Graveyard filler {idx}"),
+                Zone::Graveyard,
+            );
+        }
+        let cost = AbilityCost::Exile {
+            count: u32::MAX,
+            zone: Some(Zone::Graveyard),
+            filter: None,
+        };
+        assert_eq!(
+            additional_cost_x_max(&state, PlayerId(0), source, &cost),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn graveyard_exile_additional_cost_concretizes_after_x_is_chosen() {
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(9_200),
+            caster,
+            "Harvest Pyre".to_string(),
+            Zone::Hand,
+        );
+        let gy_cards: Vec<ObjectId> = (0..5)
+            .map(|idx| {
+                create_object(
+                    &mut state,
+                    CardId(9_210 + idx),
+                    caster,
+                    format!("Graveyard filler {idx}"),
+                    Zone::Graveyard,
+                )
+            })
+            .collect();
+        let mut ability = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+                target: TargetFilter::Typed(TypedFilter::creature()),
+                damage_source: None,
+            },
+            Vec::new(),
+            source,
+            caster,
+        );
+        ability.chosen_x = Some(3);
+        let pending = PendingCast::new(
+            source,
+            CardId(9_200),
+            ability,
+            ManaCost::Cost {
+                generic: 1,
+                shards: vec![ManaCostShard::Red],
+            },
+        );
+        let mut events = Vec::new();
+        let waiting = pay_additional_cost(
+            &mut state,
+            caster,
+            AbilityCost::Exile {
+                count: u32::MAX,
+                zone: Some(Zone::Graveyard),
+                filter: None,
+            },
+            pending,
+            &mut events,
+        )
+        .expect("chosen X should route to graveyard exile payment");
+        match waiting {
+            WaitingFor::PayCost {
+                kind:
+                    PayCostKind::ExileFromZone {
+                        zone: ExileCostSourceZone::Graveyard,
+                    },
+                choices,
+                count,
+                ..
+            } => {
+                assert_eq!(count, 3);
+                for card in gy_cards {
+                    assert!(choices.contains(&card));
+                }
+            }
+            other => panic!("expected PayCost ExileFromZone, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5,6 +5,7 @@ use crate::types::ability::{
     AbilityKind, AdditionalCost, BeholdCostAction, CastTimingPermission, CostPaidObjectSnapshot,
     CounterCostSelection, Effect, KickerVariant, QuantityExpr, QuantityRef, ReplacementDefinition,
     ResolvedAbility, SpellCastingOptionKind, StaticCondition, TargetFilter, TypedFilter,
+    EXILE_COST_X,
 };
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
@@ -1888,7 +1889,7 @@ pub(super) fn push_activated_ability_to_stack(
             // CR 602.2b + CR 601.2f + CR 122.1: Once X is announced for an
             // activation cost, the symbolic counter-removal cost becomes a
             // concrete count before payment removes counters.
-            concretized_cost = concretize_x_counter_removal_cost(cost, chosen_x);
+            concretized_cost = concretize_chosen_x_cost(cost, chosen_x);
             &concretized_cost
         } else {
             cost
@@ -1994,7 +1995,7 @@ pub(super) fn push_activated_ability_to_stack(
     push_ability_entry(state, player, source_id, ability_index, resolved, events)
 }
 
-fn concretize_x_counter_removal_cost(cost: &AbilityCost, chosen_x: u32) -> AbilityCost {
+fn concretize_chosen_x_cost(cost: &AbilityCost, chosen_x: u32) -> AbilityCost {
     match cost {
         AbilityCost::RemoveCounter {
             count,
@@ -2008,7 +2009,7 @@ fn concretize_x_counter_removal_cost(cost: &AbilityCost, chosen_x: u32) -> Abili
             selection: *selection,
         },
         AbilityCost::Exile {
-            count: u32::MAX,
+            count: EXILE_COST_X,
             zone: Some(Zone::Graveyard),
             filter,
         } => AbilityCost::Exile {
@@ -2019,7 +2020,7 @@ fn concretize_x_counter_removal_cost(cost: &AbilityCost, chosen_x: u32) -> Abili
         AbilityCost::Composite { costs } => AbilityCost::Composite {
             costs: costs
                 .iter()
-                .map(|cost| concretize_x_counter_removal_cost(cost, chosen_x))
+                .map(|cost| concretize_chosen_x_cost(cost, chosen_x))
                 .collect(),
         },
         _ => cost.clone(),
@@ -3118,7 +3119,7 @@ fn pay_additional_cost_with_source(
     }
 
     let cost = if let Some(chosen_x) = pending.ability.chosen_x {
-        concretize_x_counter_removal_cost(&cost, chosen_x)
+        concretize_chosen_x_cost(&cost, chosen_x)
     } else {
         cost
     };
@@ -3618,7 +3619,7 @@ fn additional_cost_x_max(
             )
         }
         AbilityCost::Exile {
-            count: u32::MAX,
+            count: EXILE_COST_X,
             zone: Some(Zone::Graveyard),
             filter,
             ..
@@ -6205,7 +6206,7 @@ pub fn enter_payment_step(
                 .map(|cost| (pending.as_ref().clone(), cost, chosen_x))
         });
         if let Some((mut pending, cost, chosen_x)) = targeted_counter_resume {
-            let concretized_cost = concretize_x_counter_removal_cost(&cost, chosen_x);
+            let concretized_cost = concretize_chosen_x_cost(&cost, chosen_x);
             let prompt_cost = targeted_remove_counter_choice_cost(&concretized_cost)
                 .unwrap_or_else(|| concretized_cost.clone());
             pending.activation_cost = Some(concretized_cost);
@@ -7247,7 +7248,7 @@ mod tests {
             );
         }
         let cost = AbilityCost::Exile {
-            count: u32::MAX,
+            count: EXILE_COST_X,
             zone: Some(Zone::Graveyard),
             filter: None,
         };
@@ -7308,7 +7309,7 @@ mod tests {
             &mut state,
             caster,
             AbilityCost::Exile {
-                count: u32::MAX,
+                count: EXILE_COST_X,
                 zone: Some(Zone::Graveyard),
                 filter: None,
             },

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1128,6 +1128,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_additional_cost_exile_x_cards_from_graveyard() {
+        let lower = "as an additional cost to cast this spell, exile x cards from your graveyard.";
+        let raw = "As an additional cost to cast this spell, exile X cards from your graveyard.";
+        let result = parse_additional_cost_line(lower, raw);
+        assert_eq!(
+            result,
+            Some(AdditionalCost::Required(AbilityCost::Exile {
+                count: u32::MAX,
+                zone: Some(crate::types::zones::Zone::Graveyard),
+                filter: None,
+            }))
+        );
+    }
+
+    #[test]
     fn parse_additional_cost_optional_sacrifice() {
         let lower = "as an additional cost to cast this spell, you may sacrifice an artifact.";
         let raw = "As an additional cost to cast this spell, you may sacrifice an artifact.";

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1135,7 +1135,7 @@ mod tests {
         assert_eq!(
             result,
             Some(AdditionalCost::Required(AbilityCost::Exile {
-                count: u32::MAX,
+                count: crate::types::ability::EXILE_COST_X,
                 zone: Some(crate::types::zones::Zone::Graveyard),
                 filter: None,
             }))

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -19,7 +19,7 @@ use super::oracle_util::parse_number;
 use super::oracle_util::TextPair;
 use crate::types::ability::{
     AbilityCost, BeholdCostAction, CostReduction, CounterCostSelection, FilterProp, PlayerScope,
-    QuantityExpr, QuantityRef, TargetFilter, TypedFilter, REMOVE_COUNTER_COST_ALL,
+    QuantityExpr, QuantityRef, TargetFilter, TypedFilter, EXILE_COST_X, REMOVE_COUNTER_COST_ALL,
     REMOVE_COUNTER_COST_ANY_NUMBER, REMOVE_COUNTER_COST_X,
 };
 use crate::types::counter::parse_counter_match;
@@ -575,7 +575,7 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
                 filter: None,
             };
         }
-        // CR 107.3a + CR 118.9: "Exile X card(s) from your graveyard" — variable
+        // CR 107.3a + CR 118.8: "Exile X card(s) from your graveyard" — variable
         // count announced during casting (Harvest Pyre). Ordered before the typed
         // `parse_type_phrase` arm, which cannot represent a bare zone with no filter.
         if let Some(((), rest_after_x)) =
@@ -595,13 +595,13 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
             .is_some()
             {
                 return AbilityCost::Exile {
-                    count: u32::MAX,
+                    count: EXILE_COST_X,
                     zone: Some(Zone::Graveyard),
                     filter: None,
                 };
             }
         }
-        // CR 118.9: "Exile N card(s) from your graveyard" without a type filter.
+        // CR 118.8: "Exile N card(s) from your graveyard" without a type filter.
         if let Some((count, after_count)) = parse_number(&rest_lower) {
             let after_count_lower = after_count.trim_start().to_lowercase();
             if nom_on_lower(after_count.trim_start(), &after_count_lower, |i| {
@@ -1539,7 +1539,7 @@ mod tests {
         assert_eq!(
             parse_oracle_cost("Exile X cards from your graveyard"),
             AbilityCost::Exile {
-                count: u32::MAX,
+                count: EXILE_COST_X,
                 zone: Some(Zone::Graveyard),
                 filter: None,
             }

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -575,6 +575,54 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
                 filter: None,
             };
         }
+        // CR 107.3a + CR 118.9: "Exile X card(s) from your graveyard" — variable
+        // count announced during casting (Harvest Pyre). Ordered before the typed
+        // `parse_type_phrase` arm, which cannot represent a bare zone with no filter.
+        if let Some(((), rest_after_x)) =
+            nom_on_lower(rest, &rest_lower, |i| value((), tag("x ")).parse(i))
+        {
+            let after_lower = rest_after_x.to_lowercase();
+            if nom_on_lower(rest_after_x, &after_lower, |i| {
+                value(
+                    (),
+                    alt((
+                        tag("card from your graveyard"),
+                        tag("cards from your graveyard"),
+                    )),
+                )
+                .parse(i)
+            })
+            .is_some()
+            {
+                return AbilityCost::Exile {
+                    count: u32::MAX,
+                    zone: Some(Zone::Graveyard),
+                    filter: None,
+                };
+            }
+        }
+        // CR 118.9: "Exile N card(s) from your graveyard" without a type filter.
+        if let Some((count, after_count)) = parse_number(&rest_lower) {
+            let after_count_lower = after_count.trim_start().to_lowercase();
+            if nom_on_lower(after_count.trim_start(), &after_count_lower, |i| {
+                value(
+                    (),
+                    alt((
+                        tag("card from your graveyard"),
+                        tag("cards from your graveyard"),
+                    )),
+                )
+                .parse(i)
+            })
+            .is_some()
+            {
+                return AbilityCost::Exile {
+                    count,
+                    zone: Some(Zone::Graveyard),
+                    filter: None,
+                };
+            }
+        }
         let count = parse_number(&rest_lower).map(|(n, _)| n).unwrap_or(1);
         let filter_start = parse_number(rest)
             .map(|(_, remaining)| remaining)
@@ -1484,6 +1532,30 @@ mod tests {
             }
             other => panic!("Expected Sacrifice, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn cost_exile_x_cards_from_graveyard() {
+        assert_eq!(
+            parse_oracle_cost("Exile X cards from your graveyard"),
+            AbilityCost::Exile {
+                count: u32::MAX,
+                zone: Some(Zone::Graveyard),
+                filter: None,
+            }
+        );
+    }
+
+    #[test]
+    fn cost_exile_two_cards_from_graveyard() {
+        assert_eq!(
+            parse_oracle_cost("Exile two cards from your graveyard"),
+            AbilityCost::Exile {
+                count: 2,
+                zone: Some(Zone::Graveyard),
+                filter: None,
+            }
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5054,6 +5054,8 @@ pub const REMOVE_COUNTER_COST_ALL: u32 = u32::MAX - 1;
 /// Sentinel for "any number of" remove-counter costs. This still requires a
 /// count choice, but is distinct from literal `X` for parser/data clarity.
 pub const REMOVE_COUNTER_COST_ANY_NUMBER: u32 = u32::MAX - 2;
+/// Sentinel for literal `X` in exile costs that use the compact numeric count.
+pub const EXILE_COST_X: u32 = u32::MAX;
 
 pub fn is_x_remove_counter_cost_count(count: u32) -> bool {
     count == REMOVE_COUNTER_COST_X


### PR DESCRIPTION
Closes #2994

Fixes #2934

## Summary

Parse and pay Harvest Pyre's `"exile X cards from your graveyard"` additional casting cost. Adds a parser arm for bare graveyard exile costs (fixed and variable X), extends `additional_cost_x_max` for graveyard exile, and concretizes the exile count once X is chosen so `PayCost::ExileFromZone` prompts for the correct number of cards.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

> Single parser arm plus two small runtime hooks mirroring existing variable sacrifice / pay-X-life additional-cost patterns.

## CR references

- CR 107.3a — choosing X during casting
- CR 118.9 — additional costs to cast
- CR 601.2b / CR 601.2f — announce X, then pay costs

## Verification

- `cargo fmt --all` — clean
- `cargo test -p engine --lib cost_exile graveyard_exile_additional` — passes locally
- `./scripts/check-parser-combinators.sh` — clean

Model: claude-opus-4-8
Thinking: high
Tier: Frontier
