### PR TITLE
fix(parser): parse Astarion modal "life they lost this turn" amount (closes #2927)

### DIFF
--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -606,6 +606,42 @@ mod tests {
         assert_eq!(state.players[1].life, 17);
     }
 
+    /// CR 115.1 + CR 119.3: Astarion, the Decadent (Feed mode) — "Target
+    /// opponent loses life equal to the amount of life they lost this turn."
+    /// The third-person "they" anaphor is the effect's player target, so the
+    /// amount resolves through `PlayerScope::Target` (the target's *own*
+    /// `life_lost_this_turn`), NOT the controller's. The controller's count is
+    /// seeded high as a trap: a `Controller`-scoped resolution would drain the
+    /// target by 99 instead of 3.
+    #[test]
+    fn lose_life_amount_target_relative_life_lost_this_turn() {
+        use crate::types::ability::PlayerScope;
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life_lost_this_turn = 99; // controller — must be ignored
+        state.players[1].life_lost_this_turn = 3; // target opponent
+        let ability = ResolvedAbility::new(
+            Effect::LoseLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::LifeLostThisTurn {
+                        player: PlayerScope::Target,
+                    },
+                },
+                target: None,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_lose(&mut state, &ability, &mut events).unwrap();
+
+        // Target opponent (20 starting) loses 3 — their own life lost this turn.
+        assert_eq!(state.players[1].life, 17);
+        // Controller is untouched (it is the source, not a target/recipient).
+        assert_eq!(state.players[0].life, 20);
+    }
+
     #[test]
     fn lose_life_parent_target_controller_uses_attack_event_source() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -10038,6 +10038,65 @@ mod tests {
     }
 
     #[test]
+    fn astarion_end_step_modal_target_relative_life_modes() {
+        // CR 603.1 + CR 700.2 + CR 115.1: Astarion, the Decadent — an end-step
+        // "choose one" modal trigger whose two named modes each reference a
+        // life-this-turn quantity. Previously the Feed mode dropped to
+        // `Unimplemented` (the third-person "the amount of life they lost this
+        // turn" anaphor never reached a recognizer), leaving the whole modal
+        // trigger inert. Both modes must now parse, and the Feed mode's amount
+        // must resolve through `PlayerScope::Target` (the target opponent's own
+        // life lost), not the controller's.
+        use crate::types::ability::{Effect, PlayerScope, QuantityExpr, QuantityRef};
+        let r = parse(
+            "Deathtouch, lifelink\nAt the beginning of your end step, choose one —\n• Feed — Target opponent loses life equal to the amount of life they lost this turn.\n• Friends — You gain life equal to the amount of life you gained this turn.",
+            "Astarion, the Decadent",
+            &[],
+            &["Creature"],
+            &["Vampire", "Noble"],
+        );
+        assert_eq!(r.triggers.len(), 1);
+        let execute = r.triggers[0]
+            .execute
+            .as_ref()
+            .expect("end-step trigger should have execute");
+        let modal = execute.modal.as_ref().expect("execute should be modal");
+        assert_eq!(modal.mode_count, 2);
+        assert_eq!(execute.mode_abilities.len(), 2);
+
+        // Feed: target opponent loses life equal to *their own* life lost this
+        // turn — the amount resolves through `PlayerScope::Target`, and a target
+        // filter is present (it is no longer an `Unimplemented` drop).
+        match execute.mode_abilities[0].effect.as_ref() {
+            Effect::LoseLife { amount, target } => {
+                assert_eq!(
+                    *amount,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::LifeLostThisTurn {
+                            player: PlayerScope::Target,
+                        },
+                    },
+                );
+                assert!(target.is_some(), "Feed mode targets the opponent");
+            }
+            other => panic!("Feed mode must be LoseLife, got {other:?}"),
+        }
+
+        // Friends: you gain life equal to the life you gained this turn.
+        match execute.mode_abilities[1].effect.as_ref() {
+            Effect::GainLife { amount, .. } => assert_eq!(
+                *amount,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::LifeGainedThisTurn {
+                        player: PlayerScope::Controller,
+                    },
+                },
+            ),
+            other => panic!("Friends mode must be GainLife, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn non_modal_spell_has_no_modal_metadata() {
         let r = parse(
             "Deal 3 damage to any target.",

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -328,11 +328,68 @@ fn parse_life_verb_remainder<'a>(
     .map(|(_, rest)| rest)
 }
 
+/// CR 119.3 + CR 115.1: "the amount of life [they|that player] [lost|gained]
+/// this turn" in a *targeted* life-change context ("Target opponent loses life
+/// equal to the amount of life they lost this turn" — Astarion, the Decadent's
+/// Feed/Friends modes). The third-person "they"/"that player" anaphor refers to
+/// the effect's player target, so it resolves through `PlayerScope::Target`
+/// (read from `ability.targets` by `resolve_quantity_with_targets`) — the same
+/// player the surrounding LoseLife/GainLife affects, so a target opponent loses
+/// life equal to *their own* life lost this turn.
+///
+/// Kept distinct from the shared `parse_life_lost_ref` "they lost" arms (which
+/// map to `Controller` for the per-iteration rebind of "each opponent" effects
+/// and to which Astarion's phrase never reaches because that combinator's
+/// `opt("the amount of ")` strip makes its "amount of …" tag unreachable). This
+/// recognizer requires the "amount of" gloss, so the article-only each-opponent
+/// phrasing ("the life they lost this turn", Archfiend of Despair) is untouched.
+fn parse_target_relative_life_change_this_turn(qty_text: &str) -> Option<QuantityExpr> {
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>("the "))
+        .parse(qty_text)
+        .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("amount of life ")
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = alt((tag::<_, _, OracleError<'_>>("they "), tag("that player ")))
+        .parse(rest)
+        .ok()?;
+    let (rest, gained) = alt((
+        value(false, tag::<_, _, OracleError<'_>>("lost")),
+        value(true, tag("gained")),
+    ))
+    .parse(rest)
+    .ok()?;
+    // "this turn" is the canonical duration; tolerate its absence for callers
+    // that strip trailing durations before this point.
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>(" this turn"))
+        .parse(rest)
+        .ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    let qty = if gained {
+        QuantityRef::LifeGainedThisTurn {
+            player: PlayerScope::Target,
+        }
+    } else {
+        QuantityRef::LifeLostThisTurn {
+            player: PlayerScope::Target,
+        }
+    };
+    Some(QuantityExpr::Ref { qty })
+}
+
 fn parse_life_equal_quantity(after_verb_lower: &str) -> Option<QuantityExpr> {
     let (qty_text, _) = tag::<_, _, OracleError<'_>>("life equal to ")
         .parse(after_verb_lower)
         .ok()?;
     let qty_text = qty_text.trim_end_matches('.').trim();
+    // CR 115.1: target-relative "they/that player lost/gained this turn" → Target
+    // scope. Tried before the generic delegation, which would otherwise map the
+    // third-person anaphor to the controller (see helper doc).
+    if let Some(qty) = parse_target_relative_life_change_this_turn(qty_text) {
+        return Some(qty);
+    }
     if let Some(qty) = crate::parser::oracle_quantity::parse_event_context_quantity(qty_text) {
         return Some(qty);
     }
@@ -9356,6 +9413,37 @@ mod tests {
                 );
             }
             other => panic!("Expected LoseLife, got {other:?}"),
+        }
+    }
+
+    /// CR 115.1 + CR 119.3: Astarion (Feed mode) — "loses life equal to the
+    /// amount of life they lost this turn." The third-person "they" anaphor in a
+    /// targeted life-change refers to the effect's player target, so it maps to
+    /// `LifeLostThisTurn { Target }` (NOT `Controller` like the "you" form). The
+    /// maintainer's shared `parse_life_lost_ref` "amount of … they lost" tag is
+    /// unreachable behind its own prefix strip, so this targeted-context
+    /// recognizer is what resurrects the Feed mode.
+    #[test]
+    fn parse_lose_life_equal_to_life_they_lost_this_turn_is_target_scoped() {
+        for text in [
+            "loses life equal to the amount of life they lost this turn",
+            "loses life equal to the amount of life that player lost this turn",
+        ] {
+            let lower = text.to_lowercase();
+            let result = parse_numeric_imperative_ast(text, &lower)
+                .unwrap_or_else(|| panic!("should parse {text:?}"));
+            match result {
+                NumericImperativeAst::LoseLife { amount } => assert_eq!(
+                    amount,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::LifeLostThisTurn {
+                            player: PlayerScope::Target,
+                        },
+                    },
+                    "{text:?} must be Target-scoped",
+                ),
+                other => panic!("Expected LoseLife, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Astarion, the Decadent's end-step modal trigger was completely inert. The trigger parsed, but its **Feed** mode — *"Target opponent loses life equal to the amount of life they lost this turn"* — dropped to `Effect::Unimplemented`, which left the whole `choose one` trigger with a null effect (the **Friends** gain mode parsed fine on its own).

## Root cause

The third-person `they` / `that player` life-this-turn anaphor in a **targeted** life-change had no recognizer. `parse_life_lost_ref` does carry an `"the amount of life they lost this turn"` arm, but its own `opt("the amount of ")` prefix strip runs first, making that arm unreachable — so the phrase fell through to `Unimplemented`.

## Fix

Add `parse_target_relative_life_change_this_turn`, tried at the top of `parse_life_equal_quantity` (the shared `"X loses/gains life equal to …"` path used by both `LoseLife` and `GainLife`). It maps `"[the] amount of life {they|that player} {lost|gained} this turn"` → `Life{Lost,Gained}ThisTurn { player: Target }`.

Per **CR 115.1** the `they` anaphor is the effect's player target, and `resolve_lose` reads the same player from `ability.targets`, so a target opponent loses life equal to **their own** life lost this turn — not the controller's.

Deliberately scoped to the `"amount of"` gloss, so the article-only each-opponent phrasing (`"the life they lost this turn"`, Archfiend of Despair) keeps its existing `Controller` mapping. No existing life-this-turn test changes.

## Tests

- **`parser::oracle`** — Astarion's full modal trigger parses both modes: Feed → `LoseLife { LifeLostThisTurn { Target } }`, Friends → `GainLife { LifeGainedThisTurn { Controller } }`.
- **`parser::oracle_effect::imperative`** — building-block: `"they"` / `"that player"` lost → `Target`.
- **`game::effects::life`** — runtime resolve: a target opponent who lost 3 life loses exactly 3 more, with the controller's count seeded to 99 as a trap that proves `Target` (not `Controller`) scope.

Closes #2927
