### PR TITLE
fix(parser): evaluate combat-damage-by-type intervening-if

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -148,10 +148,64 @@ fn parse_event_history_conditions(input: &str) -> OracleResult<'_, StaticConditi
 
 fn parse_damage_dealt_this_turn_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
     alt((
+        parse_player_dealt_combat_damage_by_source_this_turn,
         parse_source_dealt_damage_to_opponent_this_turn,
         parse_source_was_dealt_damage_this_turn,
     ))
     .parse(input)
+}
+
+/// CR 603.4 + CR 120.2a + CR 608.2i: Parse the intervening-`if` predicate
+/// "a player/an opponent was dealt combat damage by a <source> this turn".
+///
+/// Lost Monarch of Ifnir: "At the beginning of your second main phase, if a
+/// player was dealt combat damage by a Zombie this turn, …". The predicate is
+/// satisfied when at least one recipient matching the subject was dealt combat
+/// damage this turn by a source matching the `by` filter.
+///
+/// Builds for the class — the source is parsed by `parse_type_phrase`, so any
+/// "by a <creature type / creature / permanent>" qualifier is covered, and the
+/// subject covers both "a player" and "an opponent" recipients. The resulting
+/// `QuantityRef::DamageDealtThisTurn` carries `damage_kind: CombatOnly`
+/// (CR 120.2a) and resolves against `state.damage_dealt_this_turn`, matching
+/// the source's CR 608.2i look-back type snapshot recorded at damage time, so a
+/// later type change or the source leaving the battlefield still answers the
+/// rules-correct question.
+fn parse_player_dealt_combat_damage_by_source_this_turn(
+    input: &str,
+) -> OracleResult<'_, StaticCondition> {
+    // Recipient subject: "a player" (any player) or "an opponent".
+    let (rest, recipient) = alt((
+        value(
+            TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+            tag("an opponent"),
+        ),
+        value(TargetFilter::Player, tag("a player")),
+    ))
+    .parse(input)?;
+    let (rest, _) = tag(" was dealt combat damage by ").parse(rest)?;
+    // CR 608.2i: the `by` source qualifier — "a Zombie", "a creature", etc.
+    let (source, after_source) = parse_type_phrase(rest);
+    if matches!(source, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let (rest, _) = tag(" this turn").parse(after_source)?;
+    Ok((
+        rest,
+        make_quantity_ge(
+            QuantityRef::DamageDealtThisTurn {
+                source: Box::new(source),
+                target: Box::new(recipient),
+                aggregate: AggregateFunction::Sum,
+                group_by: None,
+                damage_kind: DamageKindFilter::CombatOnly,
+            },
+            1,
+        ),
+    ))
 }
 
 fn parse_source_dealt_damage_to_opponent_this_turn(
@@ -9732,6 +9786,73 @@ mod tests {
                 rhs: QuantityExpr::Fixed { value: 1 },
             } if source == Box::new(TargetFilter::Any)
                 && target == Box::new(TargetFilter::SelfRef)
+        ));
+    }
+
+    /// Issue #1347 — CR 603.4 + CR 120.2a + CR 608.2i: "a player was dealt
+    /// combat damage by a Zombie this turn" (Lost Monarch of Ifnir's
+    /// intervening-if) parses to a combat-only `DamageDealtThisTurn` keyed on a
+    /// Zombie source and any-player recipient.
+    #[test]
+    fn test_player_dealt_combat_damage_by_creature_type_this_turn() {
+        let (rest, c) =
+            parse_inner_condition("a player was dealt combat damage by a Zombie this turn")
+                .unwrap();
+        assert_eq!(rest, "");
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::DamageDealtThisTurn {
+                            source,
+                            target,
+                            aggregate: AggregateFunction::Sum,
+                            group_by: None,
+                            damage_kind: DamageKindFilter::CombatOnly,
+                        },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 1 },
+        } = c
+        else {
+            panic!("expected combat-only DamageDealtThisTurn GE 1, got {c:?}");
+        };
+        // CR 120.1: any-player recipient (Lost Monarch reads "a player").
+        assert_eq!(*target, TargetFilter::Player);
+        // CR 608.2i: the source qualifier carries the Zombie subtype.
+        let TargetFilter::Typed(tf) = source.as_ref() else {
+            panic!("expected typed source filter, got {source:?}");
+        };
+        assert!(
+            tf.type_filters
+                .contains(&TypeFilter::Subtype("Zombie".to_string())),
+            "source must be keyed on the Zombie subtype, got {:?}",
+            tf.type_filters
+        );
+    }
+
+    /// Issue #1347 — class coverage: the same predicate with an "an opponent"
+    /// recipient and a bare-creature source ("by a creature") still parses,
+    /// proving the combinator is parameterized over subject and source rather
+    /// than special-cased to "a player … Zombie".
+    #[test]
+    fn test_opponent_dealt_combat_damage_by_creature_this_turn() {
+        let (rest, c) =
+            parse_inner_condition("an opponent was dealt combat damage by a creature this turn")
+                .unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(
+            c,
+            StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::DamageDealtThisTurn {
+                        damage_kind: DamageKindFilter::CombatOnly,
+                        ..
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            }
         ));
     }
 

--- a/crates/engine/tests/integration/lost_monarch_combat_damage_by_type_intervening_if.rs
+++ b/crates/engine/tests/integration/lost_monarch_combat_damage_by_type_intervening_if.rs
@@ -1,0 +1,128 @@
+//! Runtime regression for issue #1347 (Lost Monarch of Ifnir).
+//!
+//! Lost Monarch of Ifnir: "At the beginning of your second main phase, if a
+//! player was dealt combat damage by a Zombie this turn, mill three cards,
+//! then you may return a creature card from your graveyard to your hand."
+//!
+//! Bug (pre-fix): the intervening-if condition "a player was dealt combat
+//! damage by a [creature type] this turn" (CR 603.4) did not parse in
+//! `parse_inner_condition`, so the trigger carried NO condition and the mill
+//! happened UNCONDITIONALLY at every second main phase — even when no Zombie
+//! dealt combat damage.
+//!
+//! Fix: parse the condition into
+//! `QuantityRef::DamageDealtThisTurn { source: <Zombie creature filter>,
+//! target: Player, damage_kind: CombatOnly } >= 1`, which the existing
+//! intervening-if bridge composes onto the trigger and the existing
+//! `resolve_damage_dealt_this_turn` resolver evaluates against the per-turn
+//! `state.damage_dealt_this_turn` ledger (matching the CR 608.2i look-back
+//! source-type snapshot recorded at damage time).
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 603.4: an intervening "if" is checked when the ability would trigger
+//!     and again when it resolves; if the condition is false at either point
+//!     the ability does nothing.
+//!   - CR 510.1c / CR 120.1: combat damage is dealt and recorded this turn.
+//!   - CR 608.2i: damage-source look-back uses the source's characteristics as
+//!     they were at the time it dealt damage.
+//!
+//! These tests drive the real pipeline (build → `from_oracle_text` parses the
+//! trigger + intervening-if → combat damage records the source-type snapshot →
+//! second main-phase trigger evaluates the condition → `Effect::Mill`). The
+//! discriminator is *whether any mill happens at all*: the trigger must mill
+//! when a Zombie dealt combat damage and must NOT mill otherwise. The exact
+//! milled count is deliberately not asserted (it is orthogonal to the
+//! intervening-if gate). Reverting the parser fix makes the condition parse to
+//! `None`, so the negative case (no Zombie damage) WOULD mill — failing
+//! `no_mill_when_no_zombie_combat_damage`.
+
+use super::rules::{run_combat, GameRunner, GameScenario, ObjectId, Phase, PlayerId, P0};
+
+const LOST_MONARCH_LIKE: &str =
+    "At the beginning of your second main phase, if a player was dealt combat \
+     damage by a Zombie this turn, mill three cards.";
+
+/// Count of cards in `player`'s library — the mill discriminator.
+fn library_len(runner: &GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .library
+        .len()
+}
+
+/// Build a Lost-Monarch-like Zombie on the battlefield plus a single attacker
+/// of the given subtype, seed P0's library, and return the assembled runner.
+fn build_scenario(attacker_subtype: &str) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0's trigger source carries the Lost-Monarch-like second-main mill.
+    scenario
+        .add_creature(P0, "Lost Monarch", 4, 4)
+        .as_creature()
+        .with_subtypes(vec!["Zombie", "Noble"])
+        .from_oracle_text(LOST_MONARCH_LIKE);
+
+    let attacker = scenario
+        .add_creature(P0, "Attacker", 2, 2)
+        .with_subtypes(vec![attacker_subtype])
+        .id();
+
+    // A library deep enough that an unconditional mill would visibly shrink it.
+    scenario.with_library_top(
+        P0,
+        &["L0", "L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9"],
+    );
+
+    (scenario.build(), attacker)
+}
+
+/// CR 603.4: When a Zombie dealt combat damage this turn, the intervening-if is
+/// satisfied and the trigger mills (library shrinks).
+#[test]
+fn mills_when_zombie_dealt_combat_damage() {
+    let (mut runner, zombie_attacker) = build_scenario("Zombie");
+    let lib_before = library_len(&runner, P0);
+
+    // Zombie deals combat damage to P1 during the combat phase.
+    run_combat(&mut runner, vec![zombie_attacker], vec![]);
+
+    // Advance to the second main phase, where the trigger fires + resolves.
+    runner.advance_to_phase(Phase::PostCombatMain);
+    runner.advance_until_stack_empty();
+
+    assert!(
+        library_len(&runner, P0) < lib_before,
+        "CR 603.4: a Zombie dealt combat damage this turn, so the intervening-if \
+         is satisfied and P0 mills (library must shrink): before={lib_before}, \
+         after={}",
+        library_len(&runner, P0)
+    );
+}
+
+/// CR 603.4: With no Zombie combat damage this turn, the intervening-if is
+/// FALSE and the trigger does nothing — no mill. Pre-fix (condition not
+/// parsed) this case milled unconditionally and the assert fails.
+#[test]
+fn no_mill_when_no_zombie_combat_damage() {
+    // The attacker is a Human, NOT a Zombie — its combat damage does NOT
+    // satisfy "dealt combat damage by a Zombie".
+    let (mut runner, human_attacker) = build_scenario("Human");
+    let lib_before = library_len(&runner, P0);
+
+    run_combat(&mut runner, vec![human_attacker], vec![]);
+
+    runner.advance_to_phase(Phase::PostCombatMain);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        library_len(&runner, P0),
+        lib_before,
+        "CR 603.4: no Zombie dealt combat damage this turn, so the intervening-if \
+         is FALSE and P0 must NOT mill (pre-fix this milled unconditionally)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -161,6 +161,7 @@ mod lathiel_end_step_counters_repro;
 mod leyline_taps_for_mana_repro;
 mod liliana_dreadhorde_multi_dies;
 mod liliana_waker_cross_scope_decline;
+mod lost_monarch_combat_damage_by_type_intervening_if;
 mod louisoix_sacrifice_counter;
 mod lurking_predators_1604_repro;
 mod madame_null_integration;


### PR DESCRIPTION
Closes #1347

## Problem
Lost Monarch of Ifnir: "At the beginning of your second main phase, if a player was dealt combat damage by a Zombie this turn, mill three cards, then you may return a creature card from your graveyard to your hand." The mill happened **unconditionally** â it fired at every second main phase regardless of whether a Zombie dealt combat damage (the reported bug).

## Root cause
The intervening-if condition "a player was dealt combat damage by a Zombie this turn" (CR 603.4) was not recognized by `parse_inner_condition`, so the trigger was built with no condition and resolved every turn.

## Fix
Added a parser combinator in `oracle_nom/condition.rs` for "a player/an opponent was dealt combat damage by a `<source>` this turn", mapping to `QuantityRef::DamageDealtThisTurn { source, target, damage_kind: CombatOnly } >= 1`. The existing intervening-if bridge composes this onto the trigger, and the existing `resolve_damage_dealt_this_turn` resolver evaluates it against `state.damage_dealt_this_turn`, matching the source's CR 608.2i look-back creature-type snapshot recorded at damage time. No new runtime subsystem was required.

Built for the class: the source is parsed via `parse_type_phrase` and the subject covers both "a player" and "an opponent", so this covers every "dealt combat damage by a `<creature type / creature / permanent>` this turn" intervening-if predicate â not just Lost Monarch.

## Tests
- Integration (`lost_monarch_combat_damage_by_type_intervening_if.rs`): drives the real pipeline; mills only when a Zombie dealt combat damage, does not mill otherwise. The negative case fails on the pre-fix code (unconditional mill).
- Parser unit tests: assert the typed AST for the "a player â¦ Zombie" and the "an opponent â¦ creature" class variants.

CR 603.4 (intervening if), CR 120.2a (combat damage), CR 608.2i (look-back source snapshot), verified against `docs/MagicCompRules.txt`. Full lib (11384) + integration (866) green; clippy `-D warnings` clean; parser-combinator gate clean.

## Scope note
This PR fixes the **reported** defect (the condition was never evaluated â unconditional mill). While building the discriminating test I noticed two *separate* parse issues on this same card that are independent of the condition gate and are deliberately left out of this focused change: (1) the mill count parses as 6 rather than 3, and (2) the trailing optional "you may return a creature card â¦" clause is dropped. The integration test is intentionally count-agnostic so it isolates the condition fix. Happy to follow up on those two in a separate PR if you'd prefer them folded in here.
