### PR TITLE
fix(parser): split dual-subject anthem statics

### DIFF
--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -468,10 +468,125 @@ pub(crate) fn parse_static_line_multi_ir(text: &str) -> Vec<StaticIr> {
         .collect()
 }
 
+/// CR 611.3 + CR 613.1: Split a static line into its sentence segments, then
+/// parse each as an independent continuous static. Returns `Some(defs)` only
+/// when the line splits into 2+ segments and EVERY segment yields at least one
+/// `StaticDefinition` — i.e. the line is genuinely a sequence of sibling
+/// statics (dual-subject anthems and their relatives). When any segment is
+/// non-static prose (or there is only one sentence) this returns `None`, so the
+/// single-sentence pipeline keeps ownership of the line.
+///
+/// Each segment is re-entered through `parse_static_line_multi_inner` so that a
+/// sentence which itself decomposes (e.g. "<grant> and can't block") still
+/// emits all of its own statics. Recursion terminates because a single-sentence
+/// segment produces only one `split_static_sentences` segment, which fails the
+/// 2+ guard.
+fn parse_multi_sentence_statics(text: &str) -> Option<Vec<StaticDefinition>> {
+    let segments = split_static_sentences(text);
+    if segments.len() < 2 {
+        return None;
+    }
+    // CR 611.3a: A sentence that opens with a back-referential connector
+    // ("Otherwise", "Then", "Instead") is a continuation whose meaning depends
+    // on the prior clause's condition (Hunter's Blowgun's ". Otherwise, it has
+    // reach." gates on `Not(<head condition>)`; the same holds for "as long
+    // as"-gated alternatives). Splitting these into independent statics would
+    // drop the complement condition, so defer the whole line to the dedicated
+    // attached-subject / otherwise handlers downstream.
+    if segments
+        .iter()
+        .skip(1)
+        .any(|segment| segment_is_back_referential_continuation(segment))
+    {
+        return None;
+    }
+    let mut defs = Vec::new();
+    for segment in &segments {
+        let segment_defs = parse_static_line_multi_inner(segment);
+        if segment_defs.is_empty() {
+            // A non-static sentence (or one the static pipeline can't classify)
+            // means this isn't a pure sibling-static line — defer the whole
+            // line to the single-sentence fallback rather than emitting a
+            // partial result that silently drops the unparsed sentence.
+            return None;
+        }
+        defs.extend(segment_defs);
+    }
+    Some(defs)
+}
+
+/// CR 611.3a: Recognize a sentence whose leading connector binds it to the
+/// preceding clause's condition rather than standing on its own. Such a sentence
+/// must not be split off as an independent static.
+fn segment_is_back_referential_continuation(segment: &str) -> bool {
+    let lower = segment.to_lowercase();
+    let result: OracleResult<'_, &str> =
+        alt((tag("otherwise"), tag("instead"), tag("then "))).parse(lower.as_str());
+    result.is_ok()
+}
+
+/// Split a static line on sentence boundaries (`.` followed by whitespace or
+/// end-of-input), tracking `{…}` mana-symbol and quote nesting so a period
+/// inside a quoted granted ability or a mana symbol never ends a sentence. Each
+/// returned segment keeps its terminating period and is trimmed; empty segments
+/// are dropped.
+fn split_static_sentences(text: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut brace_depth = 0usize;
+    let mut in_double_quote = false;
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        current.push(ch);
+        match ch {
+            '{' if !in_double_quote => brace_depth += 1,
+            '}' if !in_double_quote => brace_depth = brace_depth.saturating_sub(1),
+            '"' => in_double_quote = !in_double_quote,
+            // A sentence ends at a period that is followed by whitespace or
+            // end-of-input. A period directly followed by a non-space (e.g. an
+            // ellipsis or a decimal that MTG static text never uses) is kept
+            // inside the current segment.
+            '.' if brace_depth == 0
+                && !in_double_quote
+                && chars.peek().is_none_or(|next| next.is_whitespace()) =>
+            {
+                let trimmed = current.trim();
+                if !trimmed.is_empty() {
+                    segments.push(trimmed.to_string());
+                }
+                current.clear();
+            }
+            _ => {}
+        }
+    }
+    let trailing = current.trim();
+    if !trailing.is_empty() {
+        segments.push(trailing.to_string());
+    }
+    segments
+}
+
 pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition> {
     let stripped = strip_reminder_text(text);
     let lower = stripped.to_lowercase();
     let tp = TextPair::new(&stripped, &lower);
+
+    // CR 611.3 + CR 613.1: A static ability whose Oracle text is several
+    // independent sentences (each a self-contained continuous effect) defines
+    // each sentence as its own continuous effect with its own affected set.
+    // Dual-subject anthems are the canonical class — e.g. Flowering of the
+    // White Tree ("Legendary creatures you control get +2/+1 and have ward {1}.
+    // Nonlegendary creatures you control get +1/+1."), Intangible Virtue
+    // siblings, Glorious Anthem variants, the *-Tribute supertype pairs. Without
+    // this split the single-sentence pipeline parses the first sentence,
+    // swallows the period, and drops every following sentence. Split into
+    // sentence segments and parse each independently; only adopt the split when
+    // there are 2+ segments and EVERY segment yields at least one static, which
+    // restricts the path to genuine sibling-static lines and leaves trailing
+    // non-static prose to the single-sentence fallback below.
+    if let Some(defs) = parse_multi_sentence_statics(&stripped) {
+        return defs;
+    }
 
     // CR 601.2 + CR 602.5: City of Solitude class — "can cast spells and
     // activate abilities only during {your | their own} turn(s)". Emits both

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15053,3 +15053,124 @@ fn crew_contribution_power_and_toughness_modifiers_parse() {
         defs[0].modifications
     );
 }
+
+/// CR 611.3 + CR 613.1 + CR 205.4a: A multi-sentence static ability whose
+/// sentences are independent continuous effects (the dual-subject anthem class)
+/// must emit one `StaticDefinition` per sentence, each carrying its own affected
+/// filter and modifications. Regression for Flowering of the White Tree, whose
+/// first-sentence parse previously swallowed the period, mangled the ward cost,
+/// and dropped the entire second sentence.
+///
+/// Discriminating: the legendary half gets +2/+1 AND `ward {1}` (generic 1, NOT
+/// the empty `ward {0}` the swallowed-period bug produced); the nonlegendary
+/// half gets +1/+1 with NO keyword; both halves are restricted to `You`-
+/// controlled creatures so an opponent's legendary creature is unaffected.
+#[test]
+fn multi_sentence_dual_subject_anthem_emits_both_statics() {
+    use crate::types::keywords::WardCost;
+    use crate::types::mana::ManaCost;
+
+    let defs = parse_static_line_multi(
+        "Legendary creatures you control get +2/+1 and have ward {1}. \
+         Nonlegendary creatures you control get +1/+1.",
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "dual-subject anthem must emit both sentences as separate statics, got {defs:?}"
+    );
+
+    // Legendary half: +2/+1, ward {1}, controller=You, supertype=Legendary.
+    let legendary = defs
+        .iter()
+        .find(|d| {
+            matches!(
+                &d.affected,
+                Some(TargetFilter::Typed(tf))
+                    if tf.properties.contains(&FilterProp::HasSupertype {
+                        value: Supertype::Legendary,
+                    })
+            )
+        })
+        .expect("must emit a Legendary-supertype static");
+    assert_eq!(legendary.mode, StaticMode::Continuous);
+    assert!(matches!(
+        &legendary.affected,
+        Some(TargetFilter::Typed(tf))
+            if tf.controller == Some(ControllerRef::You)
+                && tf.type_filters.contains(&TypeFilter::Creature)
+    ));
+    assert!(legendary
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 2 }));
+    assert!(legendary
+        .modifications
+        .contains(&ContinuousModification::AddToughness { value: 1 }));
+    // Ward cost must be {1} — the swallowed-period bug produced an empty {0}.
+    let ward = legendary
+        .modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Ward(WardCost::Mana(cost)),
+            } => Some(cost),
+            _ => None,
+        })
+        .expect("legendary half must grant a mana ward keyword");
+    assert_eq!(
+        ward.mana_value(),
+        1,
+        "ward cost must be {{1}}, got {ward:?}"
+    );
+    assert_ne!(*ward, ManaCost::zero(), "ward cost must not be empty {{0}}");
+
+    // Nonlegendary half: +1/+1, controller=You, NotSupertype(Legendary), no keyword.
+    let nonlegendary = defs
+        .iter()
+        .find(|d| {
+            matches!(
+                &d.affected,
+                Some(TargetFilter::Typed(tf))
+                    if tf.properties.contains(&FilterProp::NotSupertype {
+                        value: Supertype::Legendary,
+                    })
+            )
+        })
+        .expect("must emit a NotSupertype(Legendary) static");
+    assert_eq!(nonlegendary.mode, StaticMode::Continuous);
+    assert!(matches!(
+        &nonlegendary.affected,
+        Some(TargetFilter::Typed(tf)) if tf.controller == Some(ControllerRef::You)
+    ));
+    assert!(nonlegendary
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 1 }));
+    assert!(nonlegendary
+        .modifications
+        .contains(&ContinuousModification::AddToughness { value: 1 }));
+    assert!(
+        !nonlegendary
+            .modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddKeyword { .. })),
+        "nonlegendary half must NOT grant a keyword, got {:?}",
+        nonlegendary.modifications
+    );
+}
+
+/// Regression guard for the multi-sentence splitter: a single-sentence anthem
+/// must still emit exactly ONE static (the splitter only fires for 2+ sentences
+/// that each parse as statics), and trailing non-static prose must not cause a
+/// partial emit.
+#[test]
+fn single_sentence_anthem_unaffected_by_multi_sentence_split() {
+    let defs = parse_static_line_multi("Creatures you control get +1/+1.");
+    assert_eq!(
+        defs.len(),
+        1,
+        "single-sentence anthem must remain one static, got {defs:?}"
+    );
+    assert!(defs[0]
+        .modifications
+        .contains(&ContinuousModification::AddPower { value: 1 }));
+}


### PR DESCRIPTION
Closes #1489

## Problem
Flowering of the White Tree's anthem â "Legendary creatures you control get +2/+1 and have ward {1}. Nonlegendary creatures you control get +1/+1." â applied neither clause. MTGJSON delivers both sentences as one Oracle line, and the static multi-parser had no general sentence-splitting seam: the line fell through to the single-return fallback, which parsed only the first sentence, swallowed its terminating period, dropped the second sentence entirely, and mangled the ward cost to `{0}` (the keyword extractor saw `ward {1}. Nonlegendary creaturesâ¦`).

## Fix
Add a multi-sentence splitter at the front of `parse_static_line_multi_inner` (`oracle_static/shared.rs`). It segments the line on sentence boundaries (brace/quote-aware, so mana symbols and quoted granted abilities never falsely split) and parses each segment independently, adopting the split only when there are 2+ segments and every one yields a static â covering the whole dual/multi-subject anthem class, not just this card. A back-referential guard (`otherwise`/`instead`/`then`) keeps condition-dependent companions (Hunter's Blowgun, Clutch of Undeath) with their existing handler.

Each sentence already parsed correctly in isolation (supertype filters + ward {1}); the only missing piece was the split. CR-annotated 611.3 / 611.3a / 613.1 / 205.4a.

## Tests
- `multi_sentence_dual_subject_anthem_emits_both_statics` â discriminating: legendaryâ+2/+1+ward{1}, nonlegendaryâ+1/+1, both `You`-controlled (opponent creatures unaffected); ward `mana_value()==1`, not empty `{0}`. Fails pre-fix.
- `single_sentence_anthem_unaffected_by_multi_sentence_split` â regression guard for single-clause anthems.
- Full engine lib (11384) + integration (864) green; clippy `-D warnings` clean; parser-combinator gate passes.
