### PR TITLE
fix(engine): up-to-N target bounce honors 0-target opt-out

### DIFF
--- a/crates/engine/src/game/effects/bounce.rs
+++ b/crates/engine/src/game/effects/bounce.rs
@@ -1,7 +1,7 @@
 use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest, ZoneMoveResult};
 use crate::types::ability::{
     BounceSelection, ControllerRef, Effect, EffectError, EffectKind, FilterProp, ResolvedAbility,
-    TargetFilter, TargetRef, TypedFilter,
+    TargetChoiceTiming, TargetFilter, TargetRef, TypedFilter,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{CastingVariant, GameState, StackEntryKind, WaitingFor};
@@ -138,6 +138,29 @@ pub fn resolve(
             }
         })
         .collect();
+
+    // CR 115.6 + CR 601.2c + CR 608.2b: "Return up to one target ... " (Wrenn
+    // and Six +1, and every "up to N target" bounce). Such a bounce *requires
+    // targets* but allows zero to be chosen at stack time; per CR 115.6 it is
+    // targeted only if one or more targets were chosen. When the controller
+    // declined (chose zero), `targets` is empty by the player's choice — the
+    // effect resolves doing nothing. Without this guard the empty-target set
+    // falls through to the resolution-time zone-scan branches below, which
+    // re-prompt for a graveyard/battlefield card the player already declined.
+    // Mirrors the `ChangeZone` short-circuit in `change_zone.rs` (same CR 115.6
+    // class). `target_choice_timing == Resolution` is the genuinely-untargeted
+    // case (Skullwinder-class "that player returns a card"): targets are empty
+    // because no choice has been made *yet*, so it must reach the zone-scan.
+    if targets.is_empty()
+        && ability.targeting_is_optional()
+        && !matches!(ability.target_choice_timing, TargetChoiceTiming::Resolution)
+    {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
 
     // CR 115.1 + Whitemane Lion ruling (issue #563): Non-targeted
     // controller-scoped *battlefield* bounce. Oracle text like "return a
@@ -1397,6 +1420,79 @@ mod tests {
             }
             other => panic!("expected EffectZoneChoice for non-targeted bounce, got {other:?}"),
         }
+    }
+
+    /// CR 115.6 + CR 601.2c (issue #2389): A *targeted* "up to one target ...
+    /// from your graveyard" bounce (Wrenn and Six +1) whose controller chose
+    /// ZERO targets at stack time resolves doing nothing — it must NOT fall
+    /// through to the resolution-time graveyard zone-scan and re-prompt the
+    /// player who already declined. The discriminator vs the genuinely
+    /// non-targeted Skullwinder-class branch (which still prompts) is
+    /// `targeting_is_optional()`: true here (`multi_target.min == 0`), false for
+    /// Skullwinder's mandatory "target player" form.
+    #[test]
+    fn targeted_up_to_one_graveyard_bounce_declined_resolves_to_nothing() {
+        use crate::types::ability::{FilterProp, MultiTargetSpec, QuantityExpr, TypeFilter};
+        use crate::types::card_type::CoreType;
+
+        let mut state = GameState::new_two_player(42);
+        let land = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mountain".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&land).unwrap();
+            let card_type = crate::types::card_type::CardType {
+                core_types: vec![CoreType::Land],
+                ..Default::default()
+            };
+            obj.card_types = card_type.clone();
+            obj.base_card_types = card_type;
+        }
+
+        // Targeted "up to one target land card from your graveyard" with an
+        // empty target list — the controller declined during target selection.
+        let mut ability = ResolvedAbility::new(
+            Effect::Bounce {
+                target: TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Land)
+                        .controller(ControllerRef::You)
+                        .properties(vec![FilterProp::InZone {
+                            zone: Zone::Graveyard,
+                        }]),
+                ),
+                destination: None,
+                selection: BounceSelection::Targeted,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        ability.multi_target = Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }));
+        assert!(
+            ability.targeting_is_optional(),
+            "up-to-one targeting must be optional"
+        );
+        let mut events = Vec::new();
+
+        let waiting_before = state.waiting_for.clone();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // No re-prompt: waiting_for is unchanged by the resolver.
+        assert_eq!(
+            state.waiting_for, waiting_before,
+            "declining the up-to-one target must NOT surface an EffectZoneChoice"
+        );
+        // The land stays in the graveyard — nothing was returned.
+        assert_eq!(
+            state.objects.get(&land).map(|o| o.zone),
+            Some(Zone::Graveyard),
+            "no card returned when zero targets were chosen"
+        );
+        assert!(!state.players[0].hand.contains(&land));
     }
 
     /// CR 115.1 + Whitemane Lion ruling (issue #563): When no eligible

--- a/crates/engine/src/game/effects/bounce.rs
+++ b/crates/engine/src/game/effects/bounce.rs
@@ -152,6 +152,7 @@ pub fn resolve(
     // case (Skullwinder-class "that player returns a card"): targets are empty
     // because no choice has been made *yet*, so it must reach the zone-scan.
     if targets.is_empty()
+        && !non_targeting
         && ability.targeting_is_optional()
         && !matches!(ability.target_choice_timing, TargetChoiceTiming::Resolution)
     {
@@ -1493,6 +1494,78 @@ mod tests {
             "no card returned when zero targets were chosen"
         );
         assert!(!state.players[0].hand.contains(&land));
+    }
+
+    /// CR 115.1 + CR 608.2c: the zero-target short-circuit is only for
+    /// targeted "up to N target ..." bounce. Non-targeted at-resolution bounce
+    /// must still enumerate legal permanents even if it happens to carry
+    /// optional multi-target metadata.
+    #[test]
+    fn non_targeted_optional_bounce_still_prompts_at_resolution() {
+        use crate::types::ability::{MultiTargetSpec, QuantityExpr, TypeFilter};
+        use crate::types::card_type::CoreType;
+
+        let mut state = GameState::new_two_player(42);
+        let own_bear = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        let own_dragon = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Dragon".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [own_bear, own_dragon] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            let card_type = crate::types::card_type::CardType {
+                core_types: vec![CoreType::Creature],
+                ..Default::default()
+            };
+            obj.card_types = card_type.clone();
+            obj.base_card_types = card_type;
+        }
+
+        let mut ability = ResolvedAbility::new(
+            Effect::Bounce {
+                target: TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Creature).controller(ControllerRef::You),
+                ),
+                destination: None,
+                selection: BounceSelection::AtResolution,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        ability.multi_target = Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }));
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::EffectZoneChoice {
+                player,
+                cards,
+                count,
+                min_count,
+                effect_kind: EffectKind::ChangeZone,
+                zone: Zone::Battlefield,
+                destination: Some(Zone::Hand),
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(*count, 1);
+                assert_eq!(*min_count, 1);
+                assert!(cards.contains(&own_bear));
+                assert!(cards.contains(&own_dragon));
+            }
+            other => panic!("expected EffectZoneChoice for non-targeted bounce, got {other:?}"),
+        }
     }
 
     /// CR 115.1 + Whitemane Lion ruling (issue #563): When no eligible

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -247,4 +247,5 @@ mod wernog_riders_chaplain_investigate_count;
 mod white_suns_twilight;
 mod wise_mothman_milled_trigger;
 mod wise_mothman_target_distinctness;
+mod wrenn_and_six_up_to_one_optout;
 mod yuriko_combat_damage;

--- a/crates/engine/tests/integration/wrenn_and_six_up_to_one_optout.rs
+++ b/crates/engine/tests/integration/wrenn_and_six_up_to_one_optout.rs
@@ -1,0 +1,154 @@
+//! Issue #2389: Wrenn and Six's +1 — "Return up to one target land card from
+//! your graveyard to your hand."
+//!
+//! "Up to one target" allows declining (CR 115.6: a spell or ability that
+//! requires targets may allow zero to be chosen; CR 601.2c: the variable target
+//! count is announced at activation). When the controller chooses ZERO targets,
+//! the ability must resolve doing nothing — with no lingering selection prompt.
+//!
+//! Before the fix, the +1 parses to `Effect::Bounce { selection: Targeted }`
+//! with `multi_target { min: 0, max: 1 }`. Declining left `ability.targets`
+//! empty, and the bounce resolver's resolution-time graveyard branch fired
+//! anyway, surfacing an `EffectZoneChoice` that re-prompted the player who had
+//! already opted out. The fix short-circuits an empty *targeted* up-to-one
+//! bounce to "do nothing", mirroring the established `ChangeZone` guard.
+//!
+//! These tests drive the real activation pipeline via `GameRunner::activate`.
+
+use std::sync::Arc;
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityCost, AbilityDefinition, AbilityKind, Effect};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+use engine::types::CounterType;
+
+const WRENN_PLUS_ONE: &str = "Return up to one target land card from your graveyard to your hand.";
+
+fn wrenn_plus_one_definition() -> AbilityDefinition {
+    let mut def = parse_effect_chain(WRENN_PLUS_ONE, AbilityKind::Activated);
+    def.cost = Some(AbilityCost::Loyalty { amount: 1 });
+    def
+}
+
+/// Build a battlefield Wrenn-and-Six planeswalker with the parsed +1 loyalty
+/// ability, and seed P0's graveyard with a single land card. Returns the
+/// runner, the planeswalker id, and the land id.
+fn setup() -> (engine::game::scenario::GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let wrenn_id = scenario.add_creature(P0, "Wrenn and Six", 0, 0).id();
+    let mut runner = scenario.build();
+
+    // `create_object(..., Zone::Graveyard)` adds the card to P0's graveyard.
+    let land_id = create_object(
+        runner.state_mut(),
+        CardId(900),
+        P0,
+        "Mountain".to_string(),
+        Zone::Graveyard,
+    );
+    {
+        let land = runner.state_mut().objects.get_mut(&land_id).unwrap();
+        land.card_types.core_types = vec![CoreType::Land];
+        land.base_card_types = land.card_types.clone();
+    }
+
+    {
+        let obj = runner.state_mut().objects.get_mut(&wrenn_id).unwrap();
+        obj.card_types.core_types = vec![CoreType::Planeswalker];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = None;
+        obj.toughness = None;
+        obj.base_power = None;
+        obj.base_toughness = None;
+        obj.loyalty = Some(3);
+        obj.counters.insert(CounterType::Loyalty, 3);
+
+        let plus_one = wrenn_plus_one_definition();
+        Arc::make_mut(&mut obj.abilities).push(plus_one.clone());
+        Arc::make_mut(&mut obj.base_abilities).push(plus_one);
+    }
+
+    (runner, wrenn_id, land_id)
+}
+
+fn graveyard_len(state: &GameState, player: PlayerId) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .unwrap()
+        .graveyard
+        .len()
+}
+
+/// The +1 parses to a targeted "up to one" bounce: `multi_target { min: 0 }`
+/// makes `targeting_is_optional()` true. This is the structural fact the runtime
+/// fix relies on, and the parser must keep emitting it.
+#[test]
+fn plus_one_parses_as_optional_targeted_graveyard_bounce() {
+    let def = parse_effect_chain(WRENN_PLUS_ONE, AbilityKind::Activated);
+    assert!(
+        matches!(&*def.effect, Effect::Bounce { .. }),
+        "expected Effect::Bounce, got {:?}",
+        def.effect
+    );
+    let spec = def
+        .multi_target
+        .as_ref()
+        .expect("up-to-one must carry a multi_target spec");
+    assert!(
+        spec.min_is_fixed_zero(),
+        "up-to-one must allow zero targets (min == 0)"
+    );
+}
+
+/// Declining the up-to-one target resolves the ability cleanly: no card is
+/// returned and no selection prompt is left pending. Fails pre-fix (the resolver
+/// surfaced an `EffectZoneChoice` for the graveyard land instead).
+#[test]
+fn declining_the_target_resolves_with_no_prompt_and_no_effect() {
+    let (mut runner, wrenn, _land) = setup();
+
+    // `AbilityActivation` declares no target — the driver submits `None` for the
+    // optional slot, exercising the zero-target opt-out.
+    runner.activate(wrenn, 0).resolve();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "declining the up-to-one target must resolve to a Priority window with no \
+         lingering selection prompt, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        graveyard_len(runner.state(), P0),
+        1,
+        "no land is returned when zero targets are chosen"
+    );
+}
+
+/// The select-one path still works: choosing the land returns it to hand.
+#[test]
+fn selecting_the_land_returns_it_to_hand() {
+    let (mut runner, wrenn, land) = setup();
+
+    runner.activate(wrenn, 0).target_object(land).resolve();
+
+    assert_eq!(
+        runner.state().objects.get(&land).map(|o| o.zone),
+        Some(Zone::Hand),
+        "the chosen land card returns to its owner's hand"
+    );
+    assert_eq!(
+        graveyard_len(runner.state(), P0),
+        0,
+        "the returned land leaves the graveyard"
+    );
+}


### PR DESCRIPTION
Closes #2389

## Problem
Wrenn and Six's "+1: Return up to one target land card from your graveyard to your hand" is an *up-to-one* targeted ability â declining (choosing zero targets) is legal (CR 115.6). But when the controller opted out, the engine re-prompted for a graveyard land selection instead of resolving cleanly: the empty-target set fell through to the resolution-time zone-scan branch, which prompts for a card the player already declined.

## Root cause
In `effects/bounce.rs`, an empty `targets` set on a *targeted* "up to N" bounce was indistinguishable from a genuinely non-targeted bounce (Skullwinder's "that player returns a card"), so it reached the zone-scan branch that prompts at resolution time.

## Fix
Short-circuit a *declined optional targeted* bounce before the zone-scan: when `targets` is empty AND `ability.targeting_is_optional()` (the `up to N` / `min == 0` form) AND `target_choice_timing != Resolution`, emit `EffectResolved` and resolve doing nothing (CR 115.6 â the ability was targeted only if one or more targets were chosen; choosing zero is a valid resolution with no effect). The `target_choice_timing == Resolution` carve-out preserves the genuinely-untargeted Skullwinder-class path, where empty targets mean "no choice made yet" and must still reach the zone-scan. Mirrors the existing `ChangeZone` short-circuit for the same CR 115.6 class.

Built for the class â every "up to N target â¦ bounce/return" ability's zero-target opt-out, not just Wrenn +1.

CR 115.6 (targeted only if a target was chosen), CR 601.2c (choosing fewer than the maximum targets), CR 608.2b.

## Tests
`tests/integration/wrenn_and_six_up_to_one_optout.rs`:
- `plus_one_parses_as_optional_targeted_graveyard_bounce` â the ability is an optional (`min 0`) targeted graveyard bounce.
- `declining_the_target_resolves_with_no_prompt_and_no_effect` â zero-target opt-out resolves cleanly, no lingering prompt, nothing returned (fails pre-fix: re-prompts).
- `selecting_the_land_returns_it_to_hand` â the select-one path still returns the land.

Plus a `bounce.rs` unit test for the declined-targeted vs Skullwinder discriminator. Full lib (11403) + integration (870) green; clippy `-D warnings` clean; parser-combinator gate clean.
