### PR TITLE
fix(engine): flush layers before sub-ability reads current P/T

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4583,6 +4583,23 @@ fn resolve_chain_body(
         ability
     };
 
+    // CR 608.2c + CR 613.1: A chained sub-ability is the next instruction in the
+    // same resolution (instructions are followed "in the order written"), so it
+    // resolves AFTER the parent's effect and must read the object's CURRENT
+    // characteristics, which the layer system (CR 613) determines. When the
+    // parent effect mutated layer-affecting state (a +1/+1 counter via
+    // `PutCounter`, a P/T-setting continuous effect, …) it only marked
+    // `layers_dirty`; the derived `power`/`toughness` fields are not recomputed
+    // until the next flush. Flush here, before the sub resolves its condition and
+    // effect-quantity reads, so a sub like "add {R} equal to this creature's
+    // power" (Molten-Core Maestro, issue #2384) sees the post-counter power
+    // rather than the stale pre-counter snapshot. `flush_layers` is the single
+    // authority and a no-op when nothing is dirty, so leaf chains and non-P/T
+    // parents pay nothing.
+    if ability.sub_ability.is_some() {
+        crate::game::layers::flush_layers(state);
+    }
+
     // Follow typed sub_ability chain, propagating parent targets when sub has none.
     // This allows sub-abilities like "its controller gains life" to access the object
     // targeted by the parent (e.g. the exiled creature in Swords to Plowshares).

--- a/crates/engine/tests/molten_core_maestro_2384.rs
+++ b/crates/engine/tests/molten_core_maestro_2384.rs
@@ -1,0 +1,57 @@
+//! Runtime reproduction for #2384 — Molten-Core Maestro.
+//!
+//! Opus — "Whenever you cast an instant or sorcery spell, put a +1/+1 counter
+//! on this creature. If five or more mana was spent to cast that spell, add an
+//! amount of {R} equal to this creature's power."
+//!
+//! The two clauses form a SequentialSibling chain (PutCounter, then mana for
+//! each [power]). The mana amount must read the creature's CURRENT power AFTER
+//! the +1/+1 counter resolved (CR 608.2 sequential resolution; CR 613 layers).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const MAESTRO: &str = "Whenever you cast an instant or sorcery spell, put a +1/+1 counter on this creature. If five or more mana was spent to cast that spell, add an amount of {R} equal to this creature's power.";
+
+#[test]
+fn mana_equals_post_counter_power() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Molten-Core Maestro: base 4/4. After the +1/+1 counter it is 5/5.
+    scenario.add_creature_from_oracle(P0, "Molten-Core Maestro", 4, 4, MAESTRO);
+
+    // A five-mana sorcery to cast. Fund the pool with five red mana so exactly
+    // five mana is spent (satisfying the "five or more mana" Opus rider).
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Five Drop", false, "Draw a card.")
+        .with_mana_cost(ManaCost::Cost {
+            generic: 4,
+            shards: vec![ManaCostShard::Red],
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]); 5],
+    );
+
+    let mut runner = scenario.build();
+
+    runner.cast(spell).resolve();
+    runner.advance_until_stack_empty();
+
+    let red = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .map(|p| p.mana_pool.count_color(ManaType::Red))
+        .unwrap_or(0);
+    assert_eq!(
+        red, 5,
+        "Maestro should add R equal to its CURRENT power after the +1/+1 \
+         counter (5/5 → 5 R), not its pre-counter power (4)"
+    );
+}


### PR DESCRIPTION
Closes #2384

## Problem
Molten-Core Maestro's Opus â "put a +1/+1 counter on this creature. If five or more mana was spent to cast that spell, add an amount of {R} equal to this creature's power" â produced mana equal to the creature's **pre-counter** power. A 4/4 casting a 5-mana spell got the +1/+1 counter (becoming 5/5) but produced only 4 R instead of 5.

## Root cause
The two clauses are a `SequentialSibling` chain. The mana clause's `QuantityRef::Power { scope: Source }` reads the live `power` field, but `PutCounter` only marks `layers_dirty` â the derived `power`/`toughness` are not recomputed until the next layer flush. The chain walker recursed from the parent effect into the sub-ability with no flush in between, so the sub read the stale pre-counter value.

## Fix
Flush pending layer re-derivation before resolving any chained sub-ability, so the sub reads current characteristics per **CR 608.2c** (instructions resolved in the order written) and **CR 613.1** (current characteristics come from the layer system). `flush_layers` is the single layer-recompute authority and a no-op when nothing is dirty, so leaf chains and non-P/T parents pay nothing. This covers the whole "do X, then do Y for each [current power/toughness]" sequential-sibling class, not just this card.

## Verification
- New runtime test `molten_core_maestro_2384`: fails pre-fix (4 vs 5), passes post-fix.
- Engine lib (11405) and integration (869) suites green; `clippy -D warnings` clean.
- The #2895 LKI look-back regression (life equal to exiled creature's power with counters) still passes â the flush does not affect the CR 608.2h LKI path.
