### PR TITLE
fix(engine): draw only when no copy made for if-you-dont-copy rider

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2498,6 +2498,19 @@ fn mandatory_parent_effect_performed(effect: &Effect, events: &[GameEvent]) -> b
         Effect::Token { .. } => events
             .iter()
             .any(|event| matches!(event, GameEvent::TokenCreated { .. })),
+        // CR 707.10 + CR 608.2c: to copy a spell is to put a copy of it onto the
+        // stack, so a `CopySpell` "did anything" iff a copy was actually pushed.
+        // This drives the reflexive "if you don't copy a spell this way,
+        // <effect>" negation (Shiko and Narset, Unified): the rider fires only
+        // when NO copy was made. `copy_spell::resolve` emits `StackPushed` for
+        // the new copy on success, and returns early WITHOUT it when the source
+        // can't be copied — so the event's presence is the authoritative "a copy
+        // was made" signal. Without this arm CopySpell fell into the `_ => true`
+        // default, which claimed a copy always happened and wrongly suppressed
+        // the draw on the no-copy branch.
+        Effect::CopySpell { .. } => events
+            .iter()
+            .any(|event| matches!(event, GameEvent::StackPushed { .. })),
         // CR 701.26a: a tap "did anything" iff some permanent became tapped.
         Effect::SetTapState {
             state: TapStateChange::Tap,
@@ -16197,6 +16210,44 @@ mod tests {
         assert!(
             !cards.contains(&caster_library_relic),
             "search must not offer same-named card from the caster's library"
+        );
+    }
+
+    /// CR 707.10 + CR 608.2c (issue #1370): the reflexive "if you don't copy a
+    /// spell this way" gate keys on whether a copy was actually made. A
+    /// `CopySpell` parent counts as "performed" iff it pushed a copy onto the
+    /// stack (`StackPushed`); when the source can't be copied no such event
+    /// fires, so the negated rider (Shiko's draw) must run. This is
+    /// the building-block contract the full-pipeline `shiko_*` integration tests
+    /// exercise end to end — asserted here directly so the class is covered
+    /// independent of the parser/scenario wiring.
+    #[test]
+    fn copy_spell_performed_tracks_stack_pushed_event() {
+        let copy = Effect::CopySpell {
+            target: TargetFilter::Any,
+            retarget: crate::types::ability::CopyRetargetPermission::MayChooseNewTargets,
+            copier: None,
+        };
+
+        // A copy was put on the stack → the effect was performed → the negated
+        // "if you don't copy" rider must NOT fire.
+        let made = [GameEvent::StackPushed {
+            object_id: ObjectId(7),
+        }];
+        assert!(
+            mandatory_parent_effect_performed(&copy, &made),
+            "a CopySpell that pushed a copy onto the stack is 'performed'"
+        );
+
+        // No copy was made (e.g. the source can't be copied) → not performed →
+        // the negated rider fires.
+        let not_made = [GameEvent::EffectResolved {
+            kind: EffectKind::CopySpell,
+            source_id: ObjectId(7),
+        }];
+        assert!(
+            !mandatory_parent_effect_performed(&copy, &not_made),
+            "a CopySpell that made no copy is NOT 'performed' — the draw rider must run"
         );
     }
 }

--- a/crates/engine/tests/shiko_reflexive_copy_draw_1370.rs
+++ b/crates/engine/tests/shiko_reflexive_copy_draw_1370.rs
@@ -1,0 +1,173 @@
+//! CR 608.2c + CR 707.10: reflexive "if you don't copy a spell this way, draw a
+//! card" gate (Shiko and Narset, Unified — issue #1370).
+//!
+//! Flurry copies the controller's second spell each turn and, *only when no copy
+//! is made*, draws a card. The draw is gated on
+//! `Not(EffectOutcome(OptionalEffectPerformed))` — "the preceding copy did NOT
+//! occur this resolution". Before the fix, `mandatory_parent_effect_performed`
+//! lacked a `CopySpell` arm and fell into its `_ => true` default, so the engine
+//! always claimed a copy had happened and suppressed the draw even when no copy
+//! was actually made. These tests discriminate the two branches:
+//!   - a copyable second spell => a copy IS made => NO draw;
+//!   - an uncopyable second spell => NO copy => the draw fires.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::zones::Zone;
+use engine::types::Phase;
+
+const SHIKO: &str = "Flying, vigilance\nFlurry — Whenever you cast your second spell each turn, copy that spell if it targets a permanent or player, and you may choose new targets for the copy. If you don't copy a spell this way, draw a card.";
+
+fn red_mana(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit {
+            color: ManaType::Red,
+            source_id: ObjectId(0),
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: Vec::new(),
+            grants: vec![],
+            expiry: None,
+        })
+        .collect()
+}
+
+fn card_id_of(runner: &GameRunner, id: ObjectId) -> CardId {
+    runner.state().objects.get(&id).unwrap().card_id
+}
+
+fn cast(runner: &mut GameRunner, spell: ObjectId) {
+    let card_id = card_id_of(runner, spell);
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: Default::default(),
+        })
+        .expect("cast spell");
+    drive(runner);
+}
+
+/// Drive the pipeline to stack-empty, answering each prompt with a fixed policy:
+/// player targets choose P1, trigger/copy targets keep their default, priority
+/// passes. The Flurry copy's `MayChooseNewTargets` retarget keeps targets.
+fn drive(runner: &mut GameRunner) {
+    for _ in 0..80 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::TargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let slot = &target_slots[selection.current_slot];
+                let t = slot
+                    .legal_targets
+                    .iter()
+                    .find(|t| matches!(t, TargetRef::Player(P1)))
+                    .or_else(|| slot.legal_targets.first())
+                    .cloned();
+                runner
+                    .act(GameAction::ChooseTarget { target: t })
+                    .expect("choose cast target");
+            }
+            WaitingFor::TriggerTargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let t = target_slots[selection.current_slot]
+                    .legal_targets
+                    .first()
+                    .cloned();
+                runner
+                    .act(GameAction::ChooseTarget { target: t })
+                    .expect("choose trigger target");
+            }
+            WaitingFor::CopyRetarget {
+                target_slots,
+                current_slot,
+                ..
+            } => {
+                let keep = target_slots[current_slot].current.clone();
+                runner
+                    .act(GameAction::ChooseTarget { target: keep })
+                    .expect("keep copy target");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() || runner.act(GameAction::PassPriority).is_err()
+                {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+/// "Opt" sits on top of P0's library; it reaches P0's hand iff Flurry draws.
+fn opt_drawn(runner: &GameRunner) -> bool {
+    runner
+        .state()
+        .objects
+        .values()
+        .any(|o| o.name == "Opt" && o.zone == Zone::Hand && o.owner == P0)
+}
+
+/// CR 608.2c + CR 707.10: a COPYABLE second spell is copied this way, so the
+/// "if you don't copy a spell this way" rider must NOT draw.
+#[test]
+fn copyable_second_spell_does_not_draw() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Shiko and Narset, Unified", 3, 3, SHIKO);
+    let bolt1 = scenario.add_bolt_to_hand(P0);
+    let bolt2 = scenario.add_bolt_to_hand(P0);
+    scenario.add_spell_to_library_top(P0, "Opt", true);
+    scenario.with_mana_pool(P0, red_mana(6));
+    let mut runner = scenario.build();
+
+    cast(&mut runner, bolt1);
+    cast(&mut runner, bolt2);
+
+    assert!(
+        !opt_drawn(&runner),
+        "CR 608.2c: Flurry copied the second spell, so it must NOT also draw."
+    );
+}
+
+/// CR 608.2c + CR 707.10: an UNCOPYABLE second spell isn't put onto the stack as
+/// a copy, so the rider's negated gate holds and Flurry MUST draw a card.
+#[test]
+fn uncopyable_second_spell_draws() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Shiko and Narset, Unified", 3, 3, SHIKO);
+    let bolt = scenario.add_bolt_to_hand(P0);
+    let uncopyable = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Uncopyable Bolt",
+            true,
+            "Uncopyable Bolt deals 3 damage to any target.\nThis spell can't be copied.",
+        )
+        .id();
+    scenario.add_spell_to_library_top(P0, "Opt", true);
+    scenario.with_mana_pool(P0, red_mana(6));
+    let mut runner = scenario.build();
+
+    cast(&mut runner, bolt);
+    cast(&mut runner, uncopyable);
+
+    assert!(
+        opt_drawn(&runner),
+        "CR 608.2c: Flurry made no copy (the spell can't be copied), so it must draw."
+    );
+}


### PR DESCRIPTION
Closes #1370

## Problem
Shiko and Narset, Unified's Flurry trigger reads: "copy that spell â¦ If you don't copy a spell this way, draw a card." The draw should fire only when no copy is made, but the engine resolved it wrong: it always treated the `CopySpell` parent as "performed," so the reflexive draw â gated on `Not(EffectOutcome(OptionalEffectPerformed))` (CR 608.2c) â never reflected whether a copy was actually made.

## Root cause
`mandatory_parent_effect_performed` (the single helper that seeds the "did the preceding effect happen" signal for a mandatory parent whose rider depends on it) had no `Effect::CopySpell` arm and fell into its `_ => true` default. That hard-coded "a copy always happened," suppressing the draw even on the no-copy branch.

## Fix
Add a `CopySpell` arm keyed on whether a copy was actually put onto the stack (`GameEvent::StackPushed`, CR 707.10). `copy_spell::resolve` emits `StackPushed` on a successful copy and returns early without it when the source can't be copied, so the event's presence is the authoritative "a copy was made" signal. This fixes the whole "if you don't &lt;verb&gt; this way, &lt;effect&gt;" reflexive-negation class over copy effects, not just this card.

## Tests
- Building-block unit test on `mandatory_parent_effect_performed` (copy pushed â performed; no copy â not performed).
- Two discriminating full-pipeline integration tests: a copyable second spell is copied and does NOT draw; an uncopyable second spell makes no copy and DOES draw. The uncopyable case fails pre-fix.

`cargo test -p engine --lib` (11406) and `--test integration` (869) green; `clippy -D warnings` clean.

## Out of scope
The conditional copy itself ("copy that spell **if it targets a permanent or player**") is still parsed as an unconditional copy â a separate parser/engine gap, independent of this reflexive-gate fix. Happy to follow up on it separately.
