### PR TITLE
fix(engine): apply no-target sibling grant to triggering object

### DIFF
--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -143,11 +143,22 @@ fn register_transient_effect(
         return;
     }
     // CR 603.2 + CR 608.2c: Judith modal sub-abilities set `target:
-    // TriggeringSource` (the GenericEffect `target` parameter), not
-    // `static_def.affected`. Short-circuit only on that parameter — when
-    // `affected: TriggeringSource` with chosen targets, the inherited-target
-    // branch below must still run (Earthbender Ascension).
-    if matches!(target_filter, Some(TargetFilter::TriggeringSource)) {
+    // TriggeringSource` (the GenericEffect `target` parameter); a SequentialSibling
+    // continuous grant on a non-targeted trigger ("put a +1/+1 counter on it. It
+    // gains haste until end of turn" — Surrak and Goreclaw, issue #2378) instead
+    // carries `affected: TriggeringSource` with `target: None`. Both name the
+    // triggering object directly, so when there is no chosen target to inherit
+    // (`ability.targets.is_empty()`), resolve via `resolve_event_context_target`
+    // here. We must NOT short-circuit when targets exist: `affected:
+    // TriggeringSource` with chosen targets is the inherited-target form that the
+    // branch below resolves against `ability.targets` (Earthbender Ascension).
+    let affected_is_triggering_source = static_def
+        .affected
+        .as_ref()
+        .is_some_and(|filter| matches!(filter, TargetFilter::TriggeringSource));
+    if matches!(target_filter, Some(TargetFilter::TriggeringSource))
+        || (target_filter.is_none() && affected_is_triggering_source && ability.targets.is_empty())
+    {
         if let Some(TargetRef::Object(obj_id)) =
             crate::game::targeting::resolve_event_context_target(
                 state,
@@ -993,6 +1004,81 @@ mod tests {
             .modifications
             .contains(&ContinuousModification::AddKeyword {
                 keyword: Keyword::Lifelink,
+            }));
+    }
+
+    /// Issue #2378 class: a non-targeted trigger whose SequentialSibling continuous
+    /// grant carries `affected: TriggeringSource` with `target: None` and no chosen
+    /// targets ("put a +1/+1 counter on it. It gains haste until end of turn" —
+    /// Surrak and Goreclaw) must bind the grant to the triggering object via the
+    /// event-context resolver (CR 611.2c). Pre-fix this fell through to the
+    /// broadcast arm, which `return`ed early on the inherited-reference filter and
+    /// dropped the grant entirely. Distinct from the Earthbender test above, which
+    /// has the same affected/target shape *with* a chosen target to inherit.
+    #[test]
+    fn triggering_source_affected_without_target_or_chosen_targets_binds_trigger_source() {
+        use crate::types::game_state::ZoneChangeRecord;
+
+        let mut state = GameState::new_two_player(42);
+        let surrak = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Surrak and Goreclaw".to_string(),
+            Zone::Battlefield,
+        );
+        let entering = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Grizzly Bears".to_string(),
+            Zone::Battlefield,
+        );
+        // The trigger fired from the creature's enter-the-battlefield event;
+        // `TriggeringSource` resolves to `entering` through this record.
+        state.current_trigger_event = Some(GameEvent::ZoneChanged {
+            object_id: entering,
+            from: None,
+            to: Zone::Battlefield,
+            record: Box::new(ZoneChangeRecord::test_minimal(
+                entering,
+                None,
+                Zone::Battlefield,
+            )),
+        });
+
+        let static_def = StaticDefinition::continuous()
+            .affected(TargetFilter::TriggeringSource)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Haste,
+            }]);
+        // No chosen targets: a non-targeted "it gains haste" sibling clause.
+        let ability = ResolvedAbility::new(
+            Effect::GenericEffect {
+                static_abilities: vec![static_def],
+                duration: Some(Duration::UntilEndOfTurn),
+                target: None,
+            },
+            vec![],
+            surrak,
+            PlayerId(0),
+        )
+        .duration(Duration::UntilEndOfTurn);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.transient_continuous_effects.len(),
+            1,
+            "the haste grant must bind to exactly the triggering creature"
+        );
+        let tce = &state.transient_continuous_effects[0];
+        assert_eq!(tce.affected, TargetFilter::SpecificObject { id: entering });
+        assert!(tce
+            .modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Haste,
             }));
     }
 

--- a/crates/engine/tests/integration/issue_2378_surrak_haste_grant.rs
+++ b/crates/engine/tests/integration/issue_2378_surrak_haste_grant.rs
@@ -1,0 +1,74 @@
+//! Regression for issue #2378: Surrak and Goreclaw's ETB trigger applies the
+//! +1/+1 counter but the sibling "It gains haste until end of turn" grant does
+//! not take effect.
+//!
+//! https://github.com/phase-rs/phase/issues/2378
+//!
+//! Oracle: "Trample\nOther creatures you control have trample.\nWhenever another
+//! nontoken creature you control enters, put a +1/+1 counter on it. It gains
+//! haste until end of turn."
+
+use engine::game::keywords::has_haste;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const SURRAK_ORACLE: &str = "Trample\nOther creatures you control have trample.\n\
+Whenever another nontoken creature you control enters, put a +1/+1 counter on it. \
+It gains haste until end of turn.";
+
+fn plus_one_counters(runner: &GameRunner, id: ObjectId) -> u32 {
+    runner.state().objects[&id]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// A nontoken creature entering under Surrak gets BOTH the +1/+1 counter and
+/// haste until end of turn (CR 611.2c continuous effect, CR 702.10a haste).
+/// FAILS on origin/main: the counter is applied but haste is dropped.
+#[test]
+fn surrak_grants_haste_and_counter_to_entering_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Surrak on P0's battlefield — its "whenever another nontoken creature you
+    // control enters" trigger is registered from the parsed oracle text.
+    scenario.add_creature_from_oracle(P0, "Surrak and Goreclaw", 6, 7, SURRAK_ORACLE);
+
+    let bear = scenario
+        .add_creature_to_hand(P0, "Grizzly Bears", 2, 2)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        })
+        .id();
+
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Green, bear, false, vec![]),
+            ManaUnit::new(ManaType::Green, bear, false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+
+    // Cast and resolve the bear; its ETB fires Surrak's trigger, which itself
+    // resolves off the stack.
+    runner.cast(bear).resolve();
+
+    assert_eq!(
+        plus_one_counters(&runner, bear),
+        1,
+        "Surrak must put a +1/+1 counter on the entering creature"
+    );
+
+    assert!(
+        has_haste(&runner.state().objects[&bear]),
+        "Surrak's sibling clause must grant the entering creature haste until end of turn"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -118,6 +118,7 @@ mod issue_2373_phasing_aura_continuous;
 mod issue_2374_fblthp_library_origin;
 mod issue_2376_pyromancers_ascension;
 mod issue_2377_mdfc_commander_zone_revert;
+mod issue_2378_surrak_haste_grant;
 mod issue_2414_semblance_anvil;
 mod issue_2415_rottenmouth_viper_sacrifice_cost;
 mod issue_2417_satoru_intervening_if;


### PR DESCRIPTION
Closes #2378

## Problem
Surrak and Goreclaw's trigger ("put a +1/+1 counter on it. It gains haste until end of turn") applied the +1/+1 counter but the **haste grant did not take effect** â the creature still couldn't attack the turn it was affected.

## Root cause
The continuous "gains haste" grant is a `SequentialSibling` on a **non-targeted** trigger, so it carries `affected: TriggeringSource` with `target: None` and no chosen targets. In the continuous-grant resolver, that shape fell through to the *broadcast* arm, which `return`ed early on the inherited-reference (`TriggeringSource`) filter â dropping the grant entirely.

## Fix
When the grant's `affected` is `TriggeringSource` and there is no chosen target to inherit (`ability.targets.is_empty()`), bind it to the triggering object via the event-context resolver (`resolve_event_context_target`), per CR 611.2c (the grant names the triggering object directly). The fix is carefully gated so the *inherited-target* form â `affected: TriggeringSource` **with** chosen targets (Earthbender Ascension) â still resolves against `ability.targets` in the branch below; it is not short-circuited.

Built for the class: any non-targeted trigger whose sibling continuous grant names the triggering source ("â¦ it gains <keyword>/gets +N/+M until end of turn"), not just Surrak.

CR 611.2c (continuous effects from resolving abilities reference the objects they affect).

## Tests
- Integration `issue_2378_surrak_haste_grant.rs`: the Surrak trigger gives the entering creature BOTH the +1/+1 counter AND a live haste grant (fails pre-fix â haste dropped).
- Unit test in `effects/effect.rs`: a `TriggeringSource`-affected grant with no chosen targets binds to the triggering object; distinct from the inherited-target (Earthbender) case which still uses the chosen target.

Full lib (11408) + integration (873) green; clippy `-D warnings` clean; parser-combinator gate clean.
