### PR TITLE
fix(engine): StaticCondition::WasCast for cast-gated continuous statics (closes #2919)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5589,6 +5589,7 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::DuringYourTurn => ("DuringYourTurn", Handled),
         StaticCondition::DayNightIs { .. } => ("DayNightIs", Handled),
         StaticCondition::SourceEnteredThisTurn => ("SourceEnteredThisTurn", Handled),
+        StaticCondition::WasCast { .. } => ("WasCast", Handled),
         StaticCondition::IsRingBearer => ("IsRingBearer", Handled),
         StaticCondition::RingLevelAtLeast { .. } => ("RingLevelAtLeast", Handled),
         StaticCondition::SourceIsTapped => ("SourceIsTapped", Handled),

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -601,6 +601,7 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::UnlessPay { .. }
         | StaticCondition::DuringYourTurn
         | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::WasCast { .. }
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
         | StaticCondition::SourceIsTapped
@@ -716,6 +717,7 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::UnlessPay { .. }
         | StaticCondition::DuringYourTurn
         | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::WasCast { .. }
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
         | StaticCondition::SourceIsTapped
@@ -895,6 +897,12 @@ fn evaluate_condition_with_context(
         }
         // CR 400.7: True when the source permanent entered the battlefield this turn.
         StaticCondition::SourceEnteredThisTurn => eval_source_entered_this_turn(state, source_id),
+        // CR 601.2 + CR 611.3a: True when the source permanent was cast.
+        StaticCondition::WasCast { zone } => state
+            .objects
+            .get(&source_id)
+            .and_then(|obj| obj.cast_from_zone)
+            .is_some_and(|cz| zone.is_none_or(|z| cz == z)),
         // CR 701.54a: True when this creature is the ring-bearer for its controller.
         StaticCondition::IsRingBearer => {
             super::effects::ring::is_current_ring_bearer(state, controller, source_id)

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2278,6 +2278,7 @@ pub(crate) fn static_condition_to_ability_condition(
             Some(AbilityCondition::DayNightIs { state: *state })
         }
         StaticCondition::SourceEnteredThisTurn => None,
+        StaticCondition::WasCast { .. } => None,
         StaticCondition::IsPresent { filter } => {
             let filter = match filter {
                 Some(f) => f.clone(),

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -137,11 +137,51 @@ fn parse_event_history_conditions(input: &str) -> OracleResult<'_, StaticConditi
         parse_damage_dealt_this_turn_conditions,
         parse_source_damage_threshold_this_turn,
         parse_source_didnt_this_turn,
+        parse_was_cast_condition,
         parse_entered_this_turn,
         parse_opponent_cast_spell_this_turn,
         parse_youve_this_turn,
         parse_first_spell_this_game_condition,
         parse_event_state_conditions,
+    ))
+    .parse(input)
+}
+
+/// CR 601.2 + CR 611.3a: "as long as it was cast" — cast-origin gate for
+/// continuous statics (The Tarrasque). Zone-specific "was cast from <zone>"
+/// must be tried before the zoneless form.
+fn parse_was_cast_condition(input: &str) -> OracleResult<'_, StaticCondition> {
+    alt((
+        map(
+            alt((
+                tag::<_, _, OracleError<'_>>("it wasn't cast"),
+                tag("it wasn\u{2019}t cast"),
+            )),
+            |_| StaticCondition::Not {
+                condition: Box::new(StaticCondition::WasCast { zone: None }),
+            },
+        ),
+        map(
+            (
+                alt((
+                    tag::<_, _, OracleError<'_>>("it was cast from "),
+                    tag("~ was cast from "),
+                    tag("this creature was cast from "),
+                    tag("this permanent was cast from "),
+                )),
+                parse_zone_word,
+            ),
+            |(_, zone)| StaticCondition::WasCast { zone: Some(zone) },
+        ),
+        value(
+            StaticCondition::WasCast { zone: None },
+            alt((
+                tag::<_, _, OracleError<'_>>("it was cast"),
+                tag("~ was cast"),
+                tag("this creature was cast"),
+                tag("this permanent was cast"),
+            )),
+        ),
     ))
     .parse(input)
 }
@@ -11480,5 +11520,13 @@ mod tests {
     #[test]
     fn parse_creature_has_keyword_rejects_non_keyword() {
         assert!(parse_creature_has_keyword("a creature you control has counters").is_err());
+    }
+
+    /// Issue #2919: "as long as it was cast" must lower to WasCast, not Unrecognized.
+    #[test]
+    fn parse_inner_condition_it_was_cast() {
+        let (rest, c) = parse_inner_condition("it was cast").unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(c, StaticCondition::WasCast { zone: None });
     }
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2493,6 +2493,10 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
             })
         }
 
+        // CR 601.2 + CR 611.3a: "as long as it was cast" — 1:1 bridge to the
+        // trigger-side cast-origin check (same `cast_from_zone` field).
+        StaticCondition::WasCast { zone } => Some(TriggerCondition::WasCast { zone: *zone }),
+
         // CR 702.176a + CR 603.4: Impending's battlefield trigger checks the
         // persistent alternative-cost marker, not whether it was paid this turn.
         StaticCondition::CastVariantPaid { variant } => {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4579,6 +4579,14 @@ pub enum StaticCondition {
     /// CR 400.7: True when the source permanent entered the battlefield this turn.
     /// Used for "as long as this [permanent] entered this turn" conditional statics.
     SourceEnteredThisTurn,
+    /// CR 601.2 + CR 611.3a: True when the source permanent was cast (its
+    /// `cast_from_zone` is `Some`). `zone: None` = cast from any zone; `Some(z)`
+    /// = cast specifically from zone `z`. Used for "as long as it was cast"
+    /// continuous grants (The Tarrasque).
+    WasCast {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        zone: Option<crate::types::zones::Zone>,
+    },
     /// CR 701.54a: True when this creature is the ring-bearer for its controller.
     IsRingBearer,
     /// CR 701.54c: True when the controller's ring level is at least this value (0-indexed).

--- a/crates/engine/tests/integration/issue_2919_tarrasque_was_cast.rs
+++ b/crates/engine/tests/integration/issue_2919_tarrasque_was_cast.rs
@@ -27,7 +27,7 @@ fn tarrasque_was_cast_static_condition_parses() {
     let continuous = parsed
         .statics
         .iter()
-        .find(|d| matches!(d.mode, StaticMode::Continuous { .. }))
+        .find(|d| matches!(d.mode, StaticMode::Continuous))
         .expect("Tarrasque must produce a Continuous static");
     assert!(
         matches!(

--- a/crates/engine/tests/integration/issue_2919_tarrasque_was_cast.rs
+++ b/crates/engine/tests/integration/issue_2919_tarrasque_was_cast.rs
@@ -1,0 +1,79 @@
+//! Regression for GitHub issue #2919 — The Tarrasque's "has haste and ward {10}
+//! as long as it was cast" static must gate on cast provenance, not apply
+//! unconditionally via `StaticCondition::Unrecognized`.
+
+use engine::game::keywords::has_keyword;
+use engine::game::layers::{evaluate_layers, flush_layers, mark_layers_full};
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::keywords::Keyword;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::StaticCondition;
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+use engine::types::zones::Zone;
+
+const TARRASQUE_ORACLE: &str = "The Tarrasque has haste and ward {10} as long as it was cast.\n\
+Whenever The Tarrasque attacks, it fights target creature defending player controls.";
+
+#[test]
+fn tarrasque_was_cast_static_condition_parses() {
+    let parsed = parse_oracle_text(
+        TARRASQUE_ORACLE,
+        "The Tarrasque",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let continuous = parsed
+        .statics
+        .iter()
+        .find(|d| matches!(d.mode, StaticMode::Continuous { .. }))
+        .expect("Tarrasque must produce a Continuous static");
+    assert!(
+        matches!(
+            continuous.condition,
+            Some(StaticCondition::WasCast { zone: None })
+        ),
+        "expected WasCast condition, got {:?}",
+        continuous.condition
+    );
+}
+
+#[test]
+fn tarrasque_haste_only_when_cast_from_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let cast_id = scenario
+        .add_creature_from_oracle(P0, "The Tarrasque", 10, 10, TARRASQUE_ORACLE)
+        .id();
+
+    let mut cast_runner = scenario.build();
+    cast_runner
+        .state_mut()
+        .objects
+        .get_mut(&cast_id)
+        .unwrap()
+        .cast_from_zone = Some(Zone::Hand);
+    mark_layers_full(cast_runner.state_mut());
+    flush_layers(cast_runner.state_mut());
+
+    assert!(
+        has_keyword(&cast_runner.state().objects[&cast_id], &Keyword::Haste),
+        "cast Tarrasque must have haste while WasCast condition is true"
+    );
+
+    let mut put_scenario = GameScenario::new();
+    put_scenario.at_phase(Phase::PreCombatMain);
+    let put_id = put_scenario
+        .add_creature_from_oracle(P0, "The Tarrasque", 10, 10, TARRASQUE_ORACLE)
+        .id();
+
+    let mut put_runner = put_scenario.build();
+    put_runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(put_runner.state_mut());
+
+    assert!(
+        !has_keyword(&put_runner.state().objects[&put_id], &Keyword::Haste),
+        "put Tarrasque must not have haste without cast_from_zone"
+    );
+}

--- a/crates/engine/tests/integration/issue_2919_tarrasque_was_cast.rs
+++ b/crates/engine/tests/integration/issue_2919_tarrasque_was_cast.rs
@@ -5,9 +5,9 @@
 use engine::game::keywords::has_keyword;
 use engine::game::layers::{evaluate_layers, flush_layers, mark_layers_full};
 use engine::game::scenario::{GameScenario, P0};
-use engine::types::keywords::Keyword;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::StaticCondition;
+use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
 use engine::types::statics::StaticMode;
 use engine::types::zones::Zone;

--- a/crates/engine/tests/integration/issue_2919_tarrasque_was_cast.rs
+++ b/crates/engine/tests/integration/issue_2919_tarrasque_was_cast.rs
@@ -3,7 +3,7 @@
 //! unconditionally via `StaticCondition::Unrecognized`.
 
 use engine::game::keywords::has_keyword;
-use engine::game::layers::{evaluate_layers, flush_layers, mark_layers_full};
+use engine::game::layers::evaluate_layers;
 use engine::game::scenario::{GameScenario, P0};
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::StaticCondition;
@@ -44,18 +44,17 @@ fn tarrasque_haste_only_when_cast_from_hand() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let cast_id = scenario
-        .add_creature_from_oracle(P0, "The Tarrasque", 10, 10, TARRASQUE_ORACLE)
+        .add_creature_to_hand_from_oracle(P0, "The Tarrasque", 10, 10, TARRASQUE_ORACLE)
         .id();
 
     let mut cast_runner = scenario.build();
-    cast_runner
-        .state_mut()
-        .objects
-        .get_mut(&cast_id)
-        .unwrap()
-        .cast_from_zone = Some(Zone::Hand);
-    mark_layers_full(cast_runner.state_mut());
-    flush_layers(cast_runner.state_mut());
+    let outcome = cast_runner.cast(cast_id).resolve();
+    outcome.assert_zone(&[cast_id], Zone::Battlefield);
+    assert_eq!(
+        cast_runner.state().objects[&cast_id].cast_from_zone,
+        Some(Zone::Hand),
+        "precondition: the real cast pipeline must stamp cast provenance"
+    );
 
     assert!(
         has_keyword(&cast_runner.state().objects[&cast_id], &Keyword::Haste),

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -134,6 +134,7 @@ mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_2908_weathered_wayfarer;
+mod issue_2919_tarrasque_was_cast;
 mod issue_2929_arc_trail_any_other_target;
 mod issue_2938_deflecting_swat;
 mod issue_2940_krark_thumbless;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -135,12 +135,9 @@ mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_2894_spymasters_vault_connive;
 mod issue_2908_weathered_wayfarer;
-<<<<<<< fix/issue-2919-tarrasque-was-cast
-mod issue_2919_tarrasque_was_cast;
-=======
 mod issue_2914_shiko_flurry_target_gate;
 mod issue_2915_alexios;
->>>>>>> main
+mod issue_2919_tarrasque_was_cast;
 mod issue_2929_arc_trail_any_other_target;
 mod issue_2938_deflecting_swat;
 mod issue_2940_krark_thumbless;


### PR DESCRIPTION
## Summary

- Adds `StaticCondition::WasCast { zone: Option<Zone> }` so "as long as it was cast" parses and evaluates against the source permanent's `cast_from_zone` instead of falling through to `Unrecognized` (always true).
- Wires the parser combinator for `it was cast` / zone-specific variants in `oracle_nom/condition.rs`.
- Evaluates the condition in `layers.rs` and registers coverage/bridge arms.

Closes #2919

## Test plan

- [x] `cargo test -p engine --test integration issue_2919`
- [x] `cargo test -p engine parse_inner_condition_it_was_cast`

Made with [Cursor](https://cursor.com)