### PR TITLE
Fix Flurry target gate for Shiko and Narset, Unified (#2914)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5364,6 +5364,9 @@ fn condition_feature(cond: &AbilityCondition) -> (&'static str, FeatureSupport) 
         // `evaluate_condition` (effects/mod.rs) with current-state and optional
         // LKI paths.
         AbilityCondition::TargetMatchesFilter { .. } => ("TargetMatchesFilter", Handled),
+        AbilityCondition::TriggeringSpellTargetsFilter { .. } => {
+            ("TriggeringSpellTargetsFilter", Handled)
+        }
         // CR 608.2c: Source filter conditions — resolved by `evaluate_condition`
         // against the ability source object.
         AbilityCondition::SourceMatchesFilter { .. } => ("SourceMatchesFilter", Handled),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1272,6 +1272,7 @@ fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> b
             | AbilityCondition::HasCityBlessing
             | AbilityCondition::TargetHasKeywordInstead { .. }
             | AbilityCondition::TargetMatchesFilter { .. }
+            | AbilityCondition::TriggeringSpellTargetsFilter { .. }
             | AbilityCondition::SourceMatchesFilter { .. }
             | AbilityCondition::ZoneChangeObjectMatchesFilter { .. }
             | AbilityCondition::ControllerControlsMatching { .. }
@@ -5437,6 +5438,18 @@ pub(crate) fn evaluate_condition(
             };
             matched
         }
+        // CR 608.2c + CR 603.2: "if it targets a [filter]" — check the triggering
+        // spell's committed targets (Flurry on Shiko and Narset, Unified).
+        AbilityCondition::TriggeringSpellTargetsFilter { filter } => state
+            .current_trigger_event
+            .as_ref()
+            .and_then(|event| match event {
+                crate::types::events::GameEvent::SpellCast { object_id, .. } => Some(*object_id),
+                _ => None,
+            })
+            .is_some_and(|spell_id| {
+                super::restrictions::triggering_spell_targets_filter(state, spell_id, filter)
+            }),
         // CR 608.2c: "If this creature/permanent is a [type]" — check source object.
         AbilityCondition::SourceMatchesFilter { filter } => {
             // CR 107.3a + CR 601.2b: ability-context filter evaluation.

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1292,6 +1292,94 @@ fn spell_targets_filter(
     })
 }
 
+fn target_filter_accepts_player(filter: &crate::types::ability::TargetFilter) -> bool {
+    use crate::types::ability::TargetFilter;
+    match filter {
+        TargetFilter::Player => true,
+        TargetFilter::Or { filters } => filters.iter().any(target_filter_accepts_player),
+        TargetFilter::And { filters } => filters.iter().all(target_filter_accepts_player),
+        TargetFilter::Not { filter } => !target_filter_accepts_player(filter),
+        _ => false,
+    }
+}
+
+fn target_ref_matches_spell_targets_filter(
+    state: &crate::types::game_state::GameState,
+    spell_id: crate::types::identifiers::ObjectId,
+    target: &crate::types::ability::TargetRef,
+    filter: &crate::types::ability::TargetFilter,
+) -> bool {
+    use crate::types::ability::{TargetFilter, TargetRef};
+    match target {
+        TargetRef::Player(_) => target_filter_accepts_player(filter),
+        TargetRef::Object(object_id) => {
+            let ctx = super::filter::FilterContext::from_source(state, spell_id);
+            match filter {
+                TargetFilter::Player => false,
+                TargetFilter::Or { filters } => filters.iter().any(|branch| match branch {
+                    TargetFilter::Player => false,
+                    branch => super::filter::matches_target_filter(state, *object_id, branch, &ctx),
+                }),
+                _ => super::filter::matches_target_filter(state, *object_id, filter, &ctx),
+            }
+        }
+    }
+}
+
+/// CR 608.2c + CR 603.2: Evaluate `TriggeringSpellTargetsFilter` against the
+/// triggering spell's committed targets at resolution time.
+pub(crate) fn triggering_spell_targets_filter(
+    state: &crate::types::game_state::GameState,
+    spell_id: crate::types::identifiers::ObjectId,
+    filter: &crate::types::ability::TargetFilter,
+) -> bool {
+    use crate::types::ability::TargetRef;
+    use crate::types::events::GameEvent;
+    use crate::types::game_state::StackEntryKind;
+
+    let targets: Option<Vec<TargetRef>> = state
+        .stack
+        .iter()
+        .rev()
+        .find(|entry| entry.id == spell_id)
+        .and_then(|entry| match &entry.kind {
+            StackEntryKind::Spell {
+                ability: Some(resolved),
+                ..
+            } => Some(super::ability_utils::flatten_targets_in_chain(resolved)),
+            _ => None,
+        })
+        .or_else(|| {
+            state
+                .current_trigger_event
+                .as_ref()
+                .and_then(|event| match event {
+                    GameEvent::SpellCast { object_id, .. } if *object_id == spell_id => state
+                        .stack
+                        .iter()
+                        .rev()
+                        .find(|entry| entry.id == spell_id)
+                        .and_then(|entry| match &entry.kind {
+                            StackEntryKind::Spell {
+                                ability: Some(resolved),
+                                ..
+                            } => Some(super::ability_utils::flatten_targets_in_chain(resolved)),
+                            _ => None,
+                        }),
+                    _ => None,
+                })
+        });
+    let Some(targets) = targets else {
+        return false;
+    };
+    if targets.is_empty() {
+        return false;
+    }
+    targets
+        .iter()
+        .any(|target| target_ref_matches_spell_targets_filter(state, spell_id, target, filter))
+}
+
 /// CR 601.3d + CR 702.8a: Validate, post-target, that every target-dependent
 /// flash permission on the cast object is satisfied by the chosen targets in
 /// `ability`. Returns `Ok(())` when each `AsThoughHadFlash` option whose

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -1144,7 +1144,7 @@ fn parse_you_control_subtype_count(text: &str) -> Option<(usize, String)> {
 /// remainder returned by `parse_type_phrase` must be empty for the parse to
 /// succeed; otherwise we'd silently truncate qualifying clauses that the filter
 /// layer hasn't absorbed.
-fn parse_spell_targets_filter(text: &str) -> Option<ParsedCondition> {
+pub(crate) fn parse_spell_targets_filter(text: &str) -> Option<ParsedCondition> {
     let rest = alt((
         tag::<_, _, OracleError<'_>>("it targets a "),
         tag("it targets an "),
@@ -1171,6 +1171,19 @@ fn parse_spell_targets_filter(text: &str) -> Option<ParsedCondition> {
                 }),
             });
         }
+    }
+    // CR 115.1: "it targets a permanent or player" — proliferate-style pool
+    // (Shiko and Narset, Unified Flurry gate). Matched before `parse_type_phrase`
+    // so the "or player" half is not dropped.
+    if rest.trim() == "permanent or player" {
+        return Some(ParsedCondition::SpellTargetsFilter {
+            filter: TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Typed(TypedFilter::permanent()),
+                    TargetFilter::Player,
+                ],
+            },
+        });
     }
     let (filter, remainder) = parse_type_phrase(rest);
     if !remainder.trim().is_empty() {
@@ -1205,7 +1218,7 @@ fn capitalize_condition_word(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{CountScope, FilterProp, QuantityExpr};
+    use crate::types::ability::{CountScope, FilterProp, QuantityExpr, TargetFilter, TypeFilter};
 
     #[test]
     fn parses_source_conditions() {
@@ -1661,6 +1674,24 @@ mod tests {
                 );
             }
             other => panic!("expected SpellTargetsFilter(IsCommander), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn it_targets_a_permanent_or_player_parses_to_spell_targets_filter() {
+        let parsed = parse_restriction_condition("it targets a permanent or player")
+            .expect("should parse the permanent-or-player predicate");
+        match parsed {
+            ParsedCondition::SpellTargetsFilter {
+                filter: TargetFilter::Or { filters },
+            } => {
+                assert!(filters.iter().any(|f| matches!(
+                    f,
+                    TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Permanent)
+                )));
+                assert!(filters.contains(&TargetFilter::Player));
+            }
+            other => panic!("expected SpellTargetsFilter(Or), got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1580,7 +1580,10 @@ pub(crate) fn condition_text_is_rehomeable(condition_text: &str) -> bool {
 /// rider (", and you may choose new targets for the copy"), peel the rider off so
 /// the condition parser sees only the predicate (Shiko and Narset, Unified).
 fn peel_copy_retarget_tail_from_condition_text(condition_text: &str) -> (&str, Option<&str>) {
-    let Some((prefix, tail)) = condition_text.split_once(", and ") else {
+    let Ok((tail, prefix)) =
+        terminated(take_until(", and "), tag::<_, _, OracleError<'_>>(", and "))
+            .parse(condition_text)
+    else {
         return (condition_text, None);
     };
     if super::sequence::recognize_copy_retarget_clause(tail) {

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -19,8 +19,8 @@ use super::{parse_effect_chain, scan_contains_phrase, ParseContext};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, AbilityKind, CastVariantPaid, Comparator, ControllerRef,
-    CountScope, Duration, Effect, FilterProp, ObjectScope, PlayerScope, QuantityExpr, QuantityRef,
-    StaticCondition, TargetFilter, TypeFilter, TypedFilter,
+    CountScope, Duration, Effect, FilterProp, ObjectScope, ParsedCondition, PlayerScope,
+    QuantityExpr, QuantityRef, StaticCondition, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
@@ -1576,6 +1576,29 @@ pub(crate) fn condition_text_is_rehomeable(condition_text: &str) -> bool {
         .any(|prefix| condition_text.starts_with(prefix))
 }
 
+/// CR 707.10c: When a suffix condition is immediately followed by a copy-retarget
+/// rider (", and you may choose new targets for the copy"), peel the rider off so
+/// the condition parser sees only the predicate (Shiko and Narset, Unified).
+fn peel_copy_retarget_tail_from_condition_text(condition_text: &str) -> (&str, Option<&str>) {
+    let Some((prefix, tail)) = condition_text.split_once(", and ") else {
+        return (condition_text, None);
+    };
+    if super::sequence::recognize_copy_retarget_clause(tail) {
+        (prefix.trim(), Some(tail.trim()))
+    } else {
+        (condition_text, None)
+    }
+}
+
+fn parse_triggering_spell_targets_filter_ability_condition(text: &str) -> Option<AbilityCondition> {
+    match crate::parser::oracle_condition::parse_spell_targets_filter(text)? {
+        ParsedCondition::SpellTargetsFilter { filter } => {
+            Some(AbilityCondition::TriggeringSpellTargetsFilter { filter })
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn strip_suffix_conditional(
     text: &str,
     ctx: &mut ParseContext,
@@ -1590,16 +1613,24 @@ pub(super) fn strip_suffix_conditional(
         return (None, text.to_string());
     }
 
-    if let Some(cond) = parse_its_a_type_condition(condition_text) {
-        let effect_text = text[..if_pos].trim().to_string();
+    let (condition_core, copy_retarget_tail) =
+        peel_copy_retarget_tail_from_condition_text(condition_text);
+    let effect_prefix = text[..if_pos].trim();
+    let effect_text = if let Some(tail) = copy_retarget_tail {
+        format!("{effect_prefix}, and {tail}")
+    } else {
+        effect_prefix.to_string()
+    };
+
+    if let Some(cond) = parse_its_a_type_condition(condition_core) {
         return (Some(cond), effect_text);
     }
 
-    if let Some(condition) = try_nom_condition_as_ability_condition(condition_text, ctx)
-        .or_else(|| parse_condition_text(condition_text))
-        .or_else(|| parse_control_count_as_ability_condition(condition_text))
+    if let Some(condition) = parse_triggering_spell_targets_filter_ability_condition(condition_core)
+        .or_else(|| try_nom_condition_as_ability_condition(condition_core, ctx))
+        .or_else(|| parse_condition_text(condition_core))
+        .or_else(|| parse_control_count_as_ability_condition(condition_core))
     {
-        let effect_text = text[..if_pos].trim().to_string();
         return (Some(condition), effect_text);
     }
 
@@ -2536,6 +2567,7 @@ pub(crate) fn ability_condition_to_static_condition(
         | AbilityCondition::PreviousEffectAmount { .. }
         | AbilityCondition::TargetHasKeywordInstead { .. }
         | AbilityCondition::TargetMatchesFilter { .. }
+        | AbilityCondition::TriggeringSpellTargetsFilter { .. }
         | AbilityCondition::ZoneChangeObjectMatchesFilter { .. }
         | AbilityCondition::ZoneChangedThisWay { .. }
         | AbilityCondition::CostPaidObjectMatchesFilter { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -35658,6 +35658,23 @@ mod tests {
     }
 
     #[test]
+    fn strip_suffix_conditional_extracts_flurry_target_gate_with_copy_retarget_tail() {
+        let (cond, text) = strip_suffix_conditional(
+            "copy that spell if it targets a permanent or player, and you may choose new targets for the copy",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(
+            text,
+            "copy that spell, and you may choose new targets for the copy"
+        );
+        let cond = cond.expect("should extract triggering-spell target gate");
+        assert!(matches!(
+            cond,
+            AbilityCondition::TriggeringSpellTargetsFilter { .. }
+        ));
+    }
+
+    #[test]
     fn strip_suffix_conditional_extracts_quantity_check() {
         let (cond, text) = strip_suffix_conditional(
             "draw a card if your life total is greater than your starting life total",

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11348,6 +11348,14 @@ pub enum AbilityCondition {
         #[serde(default)]
         use_lki: bool,
     },
+    /// CR 608.2c + CR 603.2: "if it targets a [filter]" on a triggered ability —
+    /// gates the sub_ability on whether the triggering spell's chosen targets
+    /// include at least one permanent or player matching `filter`. The pronoun
+    /// `it` refers to the spell that caused the trigger (e.g. Flurry's "copy
+    /// that spell if it targets a permanent or player"). Contrast with
+    /// `ParsedCondition::SpellTargetsFilter`, which gates casting permissions on
+    /// the spell being cast.
+    TriggeringSpellTargetsFilter { filter: TargetFilter },
     /// CR 608.2c: "If this creature/permanent is a [type]" — gates sub_ability on whether
     /// the ability's source object matches the filter. Used by leveler-style cards
     /// (e.g. Figure of Fable) where each activated ability gates on the source's current type.

--- a/crates/engine/tests/integration/issue_2914_shiko_flurry_target_gate.rs
+++ b/crates/engine/tests/integration/issue_2914_shiko_flurry_target_gate.rs
@@ -126,6 +126,11 @@ fn targeted_second_spell_is_copied_not_drawn() {
         !opt_drawn(&runner),
         "Flurry copied the targeted second spell, so it must not draw."
     );
+    assert_eq!(
+        runner.life(P1),
+        11,
+        "two Lightning Bolts plus the copied second Bolt should deal 9 total damage"
+    );
 }
 
 /// CR 608.2c + CR 707.10: an untargeted second spell is not copied, so Flurry draws.

--- a/crates/engine/tests/integration/issue_2914_shiko_flurry_target_gate.rs
+++ b/crates/engine/tests/integration/issue_2914_shiko_flurry_target_gate.rs
@@ -1,0 +1,152 @@
+//! Issue #2914: Shiko and Narset, Unified — Flurry must copy the second spell
+//! only when it targets a permanent or player; otherwise the reflexive draw fires.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::zones::Zone;
+use engine::types::Phase;
+
+const SHIKO: &str = "Flying, vigilance\nFlurry — Whenever you cast your second spell each turn, copy that spell if it targets a permanent or player, and you may choose new targets for the copy. If you don't copy a spell this way, draw a card.";
+
+fn red_mana(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit {
+            color: ManaType::Red,
+            source_id: ObjectId(0),
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: Vec::new(),
+            grants: vec![],
+            expiry: None,
+        })
+        .collect()
+}
+
+fn card_id_of(runner: &GameRunner, id: ObjectId) -> CardId {
+    runner.state().objects.get(&id).unwrap().card_id
+}
+
+fn cast(runner: &mut GameRunner, spell: ObjectId) {
+    let card_id = card_id_of(runner, spell);
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: Default::default(),
+        })
+        .expect("cast spell");
+    drive(runner);
+}
+
+fn drive(runner: &mut GameRunner) {
+    for _ in 0..80 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::TargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let slot = &target_slots[selection.current_slot];
+                let t = slot
+                    .legal_targets
+                    .iter()
+                    .find(|t| matches!(t, TargetRef::Player(P1)))
+                    .or_else(|| slot.legal_targets.first())
+                    .cloned();
+                runner
+                    .act(GameAction::ChooseTarget { target: t })
+                    .expect("choose cast target");
+            }
+            WaitingFor::TriggerTargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let t = target_slots[selection.current_slot]
+                    .legal_targets
+                    .first()
+                    .cloned();
+                runner
+                    .act(GameAction::ChooseTarget { target: t })
+                    .expect("choose trigger target");
+            }
+            WaitingFor::CopyRetarget {
+                target_slots,
+                current_slot,
+                ..
+            } => {
+                let keep = target_slots[current_slot].current.clone();
+                runner
+                    .act(GameAction::ChooseTarget { target: keep })
+                    .expect("keep copy target");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() || runner.act(GameAction::PassPriority).is_err()
+                {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+fn opt_drawn(runner: &GameRunner) -> bool {
+    runner
+        .state()
+        .objects
+        .values()
+        .any(|o| o.name == "Opt" && o.zone == Zone::Hand && o.owner == P0)
+}
+
+/// CR 608.2c + CR 707.10: a targeted second spell is copied, so Flurry must not draw.
+#[test]
+fn targeted_second_spell_is_copied_not_drawn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Shiko and Narset, Unified", 3, 3, SHIKO);
+    let bolt1 = scenario.add_bolt_to_hand(P0);
+    let bolt2 = scenario.add_bolt_to_hand(P0);
+    scenario.add_spell_to_library_top(P0, "Opt", true);
+    scenario.with_mana_pool(P0, red_mana(6));
+    let mut runner = scenario.build();
+
+    cast(&mut runner, bolt1);
+    cast(&mut runner, bolt2);
+
+    assert!(
+        !opt_drawn(&runner),
+        "Flurry copied the targeted second spell, so it must not draw."
+    );
+}
+
+/// CR 608.2c + CR 707.10: an untargeted second spell is not copied, so Flurry draws.
+#[test]
+fn untargeted_second_spell_draws_instead_of_copying() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Shiko and Narset, Unified", 3, 3, SHIKO);
+    let bolt = scenario.add_bolt_to_hand(P0);
+    let draw_spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Simple Draw", true, "Draw a card.")
+        .id();
+    scenario.add_spell_to_library_top(P0, "Opt", true);
+    scenario.with_mana_pool(P0, red_mana(3));
+    let mut runner = scenario.build();
+
+    cast(&mut runner, bolt);
+    cast(&mut runner, draw_spell);
+
+    assert!(
+        opt_drawn(&runner),
+        "Flurry did not copy the untargeted second spell, so it must draw."
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -135,6 +135,7 @@ mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_2894_spymasters_vault_connive;
 mod issue_2908_weathered_wayfarer;
+mod issue_2914_shiko_flurry_target_gate;
 mod issue_2929_arc_trail_any_other_target;
 mod issue_2938_deflecting_swat;
 mod issue_2940_krark_thumbless;


### PR DESCRIPTION
## Summary
- Parse Flurry's "if it targets a permanent or player" suffix as `AbilityCondition::TriggeringSpellTargetsFilter`, preserving the copy-retarget rider in the same clause.
- Evaluate the condition against the triggering spell's committed stack targets at resolution time.
- Add integration tests proving targeted second spells are copied while untargeted second spells trigger the reflexive draw.

## Test plan
- [x] `cargo test -p engine --test integration issue_2914`
- [x] `cargo test -p engine strip_suffix_conditional_extracts_flurry`

Closes #2914


Made with [Cursor](https://cursor.com)