### PR TITLE
Fix Torment of Hailfire repeat resolution order (#2916)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1042,6 +1042,8 @@ fn waits_for_resolution_choice(waiting_for: &WaitingFor) -> bool {
             | WaitingFor::MultiTargetSelection { .. }
             | WaitingFor::ReplacementChoice { .. }
             | WaitingFor::OptionalEffectChoice { .. }
+            | WaitingFor::UnlessPayment { .. }
+            | WaitingFor::UnlessPaymentChooseCost { .. }
             | WaitingFor::PairChoice { .. }
             | WaitingFor::OpponentMayChoice { .. }
             | WaitingFor::TributeChoice { .. }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2808,6 +2808,61 @@ fn has_member_driven_repeat_after_hydration(state: &GameState, ability: &Resolve
     has_member_driven_repeat(&ability_with_event_context_targets(state, ability))
 }
 
+/// CR 608.2c + CR 609.3: True when a counted repeat loop must wrap scoped
+/// and/or unless-pay instructions (Torment of Hailfire — "Repeat X times.
+/// Each opponent loses 3 life unless …"). The repeat count is the outermost
+/// process; `player_scope` and `unless_pay` resolve inside each iteration.
+fn repeat_for_outermost_with_scope_or_unless(ability: &ResolvedAbility) -> bool {
+    ability.repeat_for.is_some()
+        && !has_kind_driven_repeat(ability)
+        && !has_member_driven_repeat(ability)
+        && (ability.player_scope.is_some() || ability.unless_pay.is_some())
+}
+
+/// CR 609.3: Drive a `repeat_for` loop whose iterations each run the full
+/// `resolve_chain_body` (scoped fan-out + unless-pay + effect) with
+/// `repeat_for` cleared so the inner pass does not re-enter this driver.
+fn drive_repeat_for_outermost(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+    depth: u32,
+) -> Result<(), EffectError> {
+    let hydrated = hydrate_event_context_targets(state, ability);
+    let effective = hydrated.as_ref();
+    let base_iterations = if let Some(ref qty) = effective.repeat_for {
+        crate::game::quantity::resolve_quantity_with_targets(state, qty, effective).max(0) as usize
+    } else {
+        1
+    };
+
+    let initial_waiting_for = state.waiting_for.clone();
+    let mut iteration = 0usize;
+    while iteration < base_iterations {
+        let mut iter_ability = effective.clone();
+        iter_ability.repeat_for = None;
+        resolve_chain_body(state, &iter_ability, events, depth)?;
+        if state.waiting_for != initial_waiting_for {
+            let next_iteration = iteration + 1;
+            if next_iteration < base_iterations {
+                let mut resume = effective.clone();
+                resume.repeat_for = None;
+                state.pending_repeat_iteration =
+                    Some(crate::types::game_state::PendingRepeatIteration {
+                        ability: Box::new(resume),
+                        tracked_members: Vec::new(),
+                        iterated_counter_kinds: Vec::new(),
+                        next_iteration,
+                        total_iterations: base_iterations,
+                    });
+            }
+            break;
+        }
+        iteration += 1;
+    }
+    Ok(())
+}
+
 fn rebind_iterated_counter_kind(
     ability: &mut ResolvedAbility,
     kind: crate::types::counter::CounterType,
@@ -3535,6 +3590,12 @@ fn resolve_chain_body(
         Cow::Borrowed(ability)
     };
     let ability = ability.as_ref();
+
+    if repeat_for_outermost_with_scope_or_unless(ability)
+        && !has_member_driven_repeat_after_hydration(state, ability)
+    {
+        return drive_repeat_for_outermost(state, ability, events, depth);
+    }
 
     // CR 608.2: player_scope iteration — when an ability has player_scope set,
     // execute the scoped instruction once per matching player. Runtime keeps

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -938,7 +938,10 @@ pub(super) fn handle_unless_payment(
         )?);
     }
 
-    if matches!(state.waiting_for, WaitingFor::UnlessPayment { .. }) {
+    if matches!(
+        state.waiting_for,
+        WaitingFor::UnlessPayment { .. } | WaitingFor::UnlessPaymentChooseCost { .. }
+    ) {
         set_active_priority(state);
     }
     resume_pending_continuation_if_priority(state, events)?;

--- a/crates/engine/tests/integration/issue_2916_torment_repeat_unless.rs
+++ b/crates/engine/tests/integration/issue_2916_torment_repeat_unless.rs
@@ -6,6 +6,8 @@ use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::parser::oracle_effect::parse_effect_chain;
 use engine::types::ability::{AbilityKind, Effect, UnlessPayModifier};
+use engine::types::actions::{GameAction, UnlessCostBranch};
+use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
 
 const TORMENT_ORACLE: &str = "Repeat the following process X times. Each opponent loses 3 life unless that player sacrifices a nonland permanent of their choice or discards a card.";
@@ -43,6 +45,47 @@ fn torment_repeat_x_applies_lose_life_each_iteration() {
         runner.state().players[P1.0 as usize].life,
         life_before - 6,
         "X=2 repeat iterations must each apply 3 life loss to the opponent"
+    );
+}
+
+#[test]
+fn torment_repeat_x_declined_unless_choices_resume_each_iteration() {
+    let def = parse_effect_chain(TORMENT_ORACLE, AbilityKind::Spell);
+    let scenario = GameScenario::new();
+    let mut runner = scenario.build();
+
+    let mut ability = build_resolved_from_def(&def, ObjectId(900), P0);
+    ability.chosen_x = Some(2);
+
+    let life_before = runner.state().players[P1.0 as usize].life;
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).unwrap();
+
+    for prompt_number in 1..=2 {
+        assert!(
+            matches!(
+                runner.state().waiting_for,
+                WaitingFor::UnlessPaymentChooseCost { player: P1, .. }
+            ),
+            "Torment iteration {prompt_number} must ask P1 to pay or decline its disjunctive unless cost, got {:?}",
+            runner.state().waiting_for
+        );
+        runner
+            .act(GameAction::ChooseUnlessCostBranch {
+                choice: UnlessCostBranch::Decline,
+            })
+            .expect("decline Torment unless cost");
+    }
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        life_before - 6,
+        "declining both X=2 unless prompts must apply 3 life loss per iteration"
+    );
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "Torment should return to priority after both repeat iterations, got {:?}",
+        runner.state().waiting_for
     );
 }
 

--- a/crates/engine/tests/integration/issue_2916_torment_repeat_unless.rs
+++ b/crates/engine/tests/integration/issue_2916_torment_repeat_unless.rs
@@ -1,0 +1,58 @@
+//! Issue #2916: Torment of Hailfire — the repeat-X process must run before the
+//! per-opponent torment; each iteration applies the scoped LoseLife effect.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, UnlessPayModifier};
+use engine::types::identifiers::ObjectId;
+
+const TORMENT_ORACLE: &str = "Repeat the following process X times. Each opponent loses 3 life unless that player sacrifices a nonland permanent of their choice or discards a card.";
+
+#[test]
+fn torment_repeat_x_applies_lose_life_each_iteration() {
+    let mut def = parse_effect_chain(TORMENT_ORACLE, AbilityKind::Spell);
+    assert!(
+        def.repeat_for.is_some(),
+        "Torment must carry repeat_for X, got {:?}",
+        def.repeat_for
+    );
+    assert!(
+        def.player_scope.is_some(),
+        "Torment must carry player_scope, got {:?}",
+        def.player_scope
+    );
+    assert!(matches!(*def.effect, Effect::LoseLife { .. }));
+    // Exercise the repeat × player_scope ordering without interactive unless-pay
+    // prompts; the unless modifier is validated at parse time above.
+    def.unless_pay = None;
+
+    let scenario = GameScenario::new();
+    let mut runner = scenario.build();
+
+    let mut ability = build_resolved_from_def(&def, ObjectId(900), P0);
+    ability.chosen_x = Some(2);
+    ability.unless_pay = None;
+
+    let life_before = runner.state().players[P1.0 as usize].life;
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        life_before - 6,
+        "X=2 repeat iterations must each apply 3 life loss to the opponent"
+    );
+}
+
+#[test]
+fn torment_parses_repeat_player_scope_and_unless_pay() {
+    let def = parse_effect_chain(TORMENT_ORACLE, AbilityKind::Spell);
+    assert!(def.unless_pay.is_some());
+    assert!(matches!(
+        def.unless_pay.as_ref().map(|u| &u.cost),
+        Some(engine::types::ability::AbilityCost::OneOf { .. })
+    ));
+    let _ = UnlessPayModifier::clone(def.unless_pay.as_ref().unwrap());
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -135,6 +135,7 @@ mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_2894_spymasters_vault_connive;
 mod issue_2908_weathered_wayfarer;
+mod issue_2916_torment_repeat_unless;
 mod issue_2929_arc_trail_any_other_target;
 mod issue_2938_deflecting_swat;
 mod issue_2940_krark_thumbless;


### PR DESCRIPTION
## Summary
- Run `repeat_for` as the outermost resolution loop when it shares an ability with `player_scope` or `unless_pay`.
- Each X iteration now executes the full per-opponent torment process instead of fanning out opponents only once.
- Add integration tests for Torment parsing and X=2 life-loss ordering.

## Test plan
- [x] `cargo test -p engine --test integration issue_2916`

Closes #2916


Made with [Cursor](https://cursor.com)