### PR TITLE
feat(engine): dynamic P/T for "unspent <color> mana you have" (Omnath, closes #2887)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9984,7 +9984,7 @@ pub(super) fn pay_effect_mana_cost(
         .iter_mut()
         .find(|p| p.id == player)
         .expect("player exists");
-    let (_spent_units, life_payments) = mana_payment::pay_cost_with_demand_and_choices(
+    let (spent_units, life_payments) = mana_payment::pay_cost_with_demand_and_choices(
         &mut player_data.mana_pool,
         cost,
         None,
@@ -9994,6 +9994,9 @@ pub(super) fn pay_effect_mana_cost(
         permissions.life_colors,
     )
     .map_err(|_| EngineError::ActionNotAllowed("Mana payment failed".to_string()))?;
+    if !spent_units.is_empty() {
+        state.layers_dirty.mark_full();
+    }
 
     for payment in &life_payments {
         let amount = u32::try_from(payment.amount).unwrap_or(0);
@@ -10099,6 +10102,9 @@ fn auto_tap_and_pay_cost_excluding(
         permissions.life_colors,
     )
     .map_err(|_| EngineError::ActionNotAllowed("Mana payment failed".to_string()))?;
+    if !spent_units.is_empty() {
+        state.layers_dirty.mark_full();
+    }
 
     // CR 107.4f + CR 118.3b + CR 119.4 + CR 119.8: Each Phyrexian shard paid
     // with life routes through the single-authority life-cost helper so the

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6384,6 +6384,7 @@ pub(super) fn apply_committed_assist(
                 "Assisting player could not pay {generic} generic mana at finalization: {e:?}"
             ))
         })?;
+        state.layers_dirty.mark_full();
     }
     Ok(())
 }

--- a/crates/engine/src/game/companion.rs
+++ b/crates/engine/src/game/companion.rs
@@ -381,12 +381,16 @@ pub fn handle_companion_to_hand(
     }
 
     // Validate and deduct mana
-    let player_data = &mut state.players[player.0 as usize];
-    if !player_data.mana_pool.spend_generic(COMPANION_COST) {
-        return Err("Not enough mana to pay companion cost ({3})".to_string());
+    {
+        let player_data = &mut state.players[player.0 as usize];
+        if !player_data.mana_pool.spend_generic(COMPANION_COST) {
+            return Err("Not enough mana to pay companion cost ({3})".to_string());
+        }
     }
+    state.layers_dirty.mark_full();
 
     // Take the companion card data and mark as used
+    let player_data = &mut state.players[player.0 as usize];
     let card_face = player_data
         .companion
         .as_ref()

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -929,6 +929,10 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         QuantityRef::LifeTotal { player } => {
             format!("life total ({})", fmt_player_scope(player))
         }
+        QuantityRef::UnspentMana { color } => match color {
+            Some(c) => format!("unspent {c:?} mana you have"),
+            None => "unspent mana you have".to_string(),
+        },
         QuantityRef::GraveyardSize { player } => {
             format!("cards in graveyard ({})", fmt_player_scope(player))
         }
@@ -5407,6 +5411,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
     match qref {
         QuantityRef::HandSize { .. } => ("HandSize", Handled),
         QuantityRef::LifeTotal { .. } => ("LifeTotal", Handled),
+        QuantityRef::UnspentMana { .. } => ("UnspentMana", Handled),
         QuantityRef::GraveyardSize { .. } => ("GraveyardSize", Handled),
         QuantityRef::LifeAboveStarting => ("LifeAboveStarting", Handled),
         QuantityRef::StartingLifeTotal => ("StartingLifeTotal", Unhandled),

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -360,6 +360,9 @@ pub(super) fn handle_replacement_choice(
                                 tap_state: ManaTapState::from_tap(tapped_for_mana),
                             });
                         }
+                        if count > 0 {
+                            state.layers_dirty.mark_full();
+                        }
                     }
                 }
                 // CR 614.1b + CR 614.10: BeginTurn / BeginPhase replacements are

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -2251,7 +2251,9 @@ fn pay_mana_sub_cost(
             EngineError::ActionNotAllowed("Mana pool cannot cover mana ability cost".to_string())
         })?,
     };
-    let _ = spent;
+    if !spent.is_empty() || hybrid_plan.is_some() {
+        state.layers_dirty.mark_full();
+    }
     // CR 605.3b: The player's mana pool mutation is the public signal; no
     // dedicated event exists for ability mana payments. The pool-diff is
     // surfaced via the standard state-update machinery.

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -282,6 +282,9 @@ pub(crate) fn produce_mana_with_attributes_from_source_quality(
             tap_state: ManaTapState::from_tap(tapped_for_mana),
         });
     }
+    if final_count > 0 {
+        state.layers_dirty.mark_full();
+    }
 }
 
 /// Check if the mana pool can pay the given cost (CR 202.1a).

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1096,7 +1096,7 @@ fn resolve_ref(
                     Some(c) => p
                         .mana_pool
                         .count_color(crate::types::mana::ManaType::from(*c)),
-                    None => p.mana_pool.total(),
+                    None => p.mana_pool.produced_mana_total(),
                 })
             })
             .unwrap_or(0),

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -266,6 +266,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         // references: unaffected by another object's battlefield entry/exit.
         QuantityRef::HandSize { .. }
         | QuantityRef::LifeTotal { .. }
+        | QuantityRef::UnspentMana { .. }
         | QuantityRef::GraveyardSize { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
@@ -436,6 +437,7 @@ fn entered_object_perturbs_quantity_ref(
         // enumeration to the `false` arm of `quantity_ref_uses_object_count`.
         QuantityRef::HandSize { .. }
         | QuantityRef::LifeTotal { .. }
+        | QuantityRef::UnspentMana { .. }
         | QuantityRef::GraveyardSize { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
@@ -1085,6 +1087,19 @@ fn resolve_ref(
         QuantityRef::LifeTotal { player: scope } => {
             resolve_per_player_scalar(state, scope, controller, ctx, targets, ability, |p| p.life)
         }
+        // CR 106.4: floating mana of `color` (or any color) in the controller's
+        // mana pool. Controller-scoped — `player` is the controller. Omnath,
+        // Locus of Mana ("+1/+1 for each unspent green mana you have").
+        QuantityRef::UnspentMana { color } => player
+            .map(|p| {
+                usize_to_i32_saturating(match color {
+                    Some(c) => p
+                        .mana_pool
+                        .count_color(crate::types::mana::ManaType::from(*c)),
+                    None => p.mana_pool.total(),
+                })
+            })
+            .unwrap_or(0),
         // CR 122.1: Counter-kind lookup summed across scope players. Controller
         // scope resolves to a single player; Opponents/All may span multiple.
         // Per-player u32 is widened to u64 before summing; the i32::try_from
@@ -5645,6 +5660,47 @@ mod tests {
             resolve_quantity(&state, &expr, PlayerId(0), ObjectId(99)),
             4
         );
+    }
+
+    /// CR 106.4: `QuantityRef::UnspentMana` counts floating mana in the
+    /// controller's pool — `Some(color)` per-color, `None` total. Omnath, Locus
+    /// of Mana ("+1/+1 for each unspent green mana you have").
+    #[test]
+    fn resolve_quantity_unspent_mana() {
+        use crate::types::mana::{ManaType, ManaUnit};
+        let mut state = GameState::new_two_player(42);
+        // P0 has 3 green + 1 red floating; P1's pool is empty.
+        for _ in 0..3 {
+            state.players[0].mana_pool.add(ManaUnit::new(
+                ManaType::Green,
+                ObjectId(0),
+                false,
+                vec![],
+            ));
+        }
+        state.players[0]
+            .mana_pool
+            .add(ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]));
+
+        let green = QuantityExpr::Ref {
+            qty: QuantityRef::UnspentMana {
+                color: Some(ManaColor::Green),
+            },
+        };
+        // Controller-scoped: P0 reads 3 green, P1 (empty pool) reads 0.
+        assert_eq!(
+            resolve_quantity(&state, &green, PlayerId(0), ObjectId(1)),
+            3
+        );
+        assert_eq!(
+            resolve_quantity(&state, &green, PlayerId(1), ObjectId(1)),
+            0
+        );
+        // `None` counts all floating mana (3 green + 1 red).
+        let any = QuantityExpr::Ref {
+            qty: QuantityRef::UnspentMana { color: None },
+        };
+        assert_eq!(resolve_quantity(&state, &any, PlayerId(0), ObjectId(1)), 4);
     }
 
     /// CR 613.1: `CountScope::SourceChosenPlayer` resolves to the player

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2205,6 +2205,22 @@ fn parse_for_each_clause_with_they_controller(
         }
     }
 
+    // CR 106.4: "unspent [color] mana you have" (Omnath, Locus of Mana) — the
+    // amount of floating mana of that color (or any color) in the controller's
+    // pool. A bare color word is optional, so "unspent mana you have" counts
+    // all colors.
+    if let Some((color, rest)) = nom_on_lower(clause, clause, |i| {
+        let (i, _) = tag::<_, _, OracleError<'_>>("unspent ").parse(i)?;
+        let (i, color) = opt(nom_primitives::parse_color).parse(i)?;
+        let (i, _) = opt(tag::<_, _, OracleError<'_>>(" ")).parse(i)?;
+        let (i, _) = tag::<_, _, OracleError<'_>>("mana you have").parse(i)?;
+        Ok((i, color))
+    }) {
+        if rest.trim().is_empty() {
+            return Some(QuantityRef::UnspentMana { color });
+        }
+    }
+
     // CR 120.1 + CR 510.1: "opponent that was dealt combat damage this turn"
     // / "opponent who was dealt combat damage this turn". Mirrors the
     // lost-life / gained-life arms above, but consumes the full clause instead

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -7222,6 +7222,63 @@ fn static_self_gets_dynamic_power_for_each_creature() {
 }
 
 #[test]
+fn static_self_gets_dynamic_pt_for_each_unspent_green_mana() {
+    // CR 106.4 + CR 613.4c: Omnath, Locus of Mana — "~ gets +1/+1 for each
+    // unspent green mana you have." The per-mana multiplier was dropped (frozen
+    // at +1/+1); now both P/T modifications scale dynamically with the floating
+    // green mana in the controller's pool via `QuantityRef::UnspentMana`.
+    use crate::types::ability::QuantityRef;
+    let def = parse_static_line("~ gets +1/+1 for each unspent green mana you have.")
+        .expect("Omnath dynamic P/T static must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+
+    let expected = QuantityExpr::Ref {
+        qty: QuantityRef::UnspentMana {
+            color: Some(ManaColor::Green),
+        },
+    };
+    let dynamic_power = def
+        .modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicPower { value } => Some(value),
+            _ => None,
+        })
+        .expect("expected AddDynamicPower");
+    assert_eq!(
+        dynamic_power, &expected,
+        "power scales with unspent green mana"
+    );
+    let dynamic_toughness = def
+        .modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicToughness { value } => Some(value),
+            _ => None,
+        })
+        .expect("expected AddDynamicToughness");
+    assert_eq!(dynamic_toughness, &expected, "toughness scales too");
+}
+
+#[test]
+fn for_each_clause_unspent_mana() {
+    // Building-block: the for-each quantity parser maps "unspent <color> mana
+    // you have" to UnspentMana{color}, and the colorless "unspent mana you have"
+    // to UnspentMana{None} (all colors).
+    use crate::types::ability::QuantityRef;
+    assert_eq!(
+        crate::parser::oracle_quantity::parse_for_each_clause("unspent green mana you have"),
+        Some(QuantityRef::UnspentMana {
+            color: Some(ManaColor::Green),
+        }),
+    );
+    assert_eq!(
+        crate::parser::oracle_quantity::parse_for_each_clause("unspent mana you have"),
+        Some(QuantityRef::UnspentMana { color: None }),
+    );
+}
+
+#[test]
 fn static_self_gets_dynamic_pt_for_each_permanent_you_control_but_dont_own() {
     let def = parse_static_line("~ gets +1/+1 for each land you control but don't own.")
         .expect("control-without-ownership dynamic P/T static must parse");

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3488,6 +3488,15 @@ pub enum QuantityRef {
     /// targeted-player and cross-player aggregate variants per the same axis
     /// used by `LifeTotal`/`HandSize`.
     PartySize { player: PlayerScope },
+    /// CR 106.4: The amount of unspent mana in the controller's mana pool —
+    /// `Some(color)` counts only that color, `None` counts all colors. Drives
+    /// dynamic P/T and similar magnitudes that scale with floating mana
+    /// (Omnath, Locus of Mana — "gets +1/+1 for each unspent green mana you
+    /// have"). Controller-scoped: every printed "unspent … mana you have"
+    /// reference is to the ability's own controller, so no `PlayerScope` axis
+    /// is carried (unlike `LifeTotal`/`HandSize`, which opponents' effects do
+    /// read).
+    UnspentMana { color: Option<ManaColor> },
     /// CR 702.179f: `player`'s current speed, treating no speed as 0.
     /// `PlayerScope::Controller` is the default reading ("your speed");
     /// `Target` / `Opponent { .. }` / `AllPlayers { .. }` /

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -1180,11 +1180,13 @@ pub fn apply_empty_mana_pool_decisions(
     // Descending pool_index order preserves index validity across removes.
     let mut sorted: Vec<&UnitDecision> = units.iter().collect();
     sorted.sort_by_key(|d| std::cmp::Reverse(d.pool_index));
+    let mut changed = false;
     for decision in sorted {
         match decision.disposition {
             UnitDisposition::Drop => {
                 if decision.pool_index < player.mana_pool.mana.len() {
                     let removed = player.mana_pool.mana.remove(decision.pool_index);
+                    changed = true;
                     events.push(GameEvent::ManaPoolEmptied {
                         player_id,
                         source_id: removed.source_id,
@@ -1197,6 +1199,7 @@ pub fn apply_empty_mana_pool_decisions(
                 if let Some(unit) = player.mana_pool.mana.get_mut(decision.pool_index) {
                     let from = unit.color;
                     unit.color = to;
+                    changed = true;
                     events.push(GameEvent::ManaRecolored {
                         player_id,
                         from,
@@ -1205,6 +1208,9 @@ pub fn apply_empty_mana_pool_decisions(
                 }
             }
         }
+    }
+    if changed {
+        state.layers_dirty.mark_full();
     }
 }
 

--- a/crates/engine/tests/omnath_unspent_green_mana_2887.rs
+++ b/crates/engine/tests/omnath_unspent_green_mana_2887.rs
@@ -4,36 +4,39 @@
 //!
 //! With the fix the static parses to `AddDynamicPower`/`AddDynamicToughness`
 //! over `QuantityRef::UnspentMana { Green }`, which the layer system resolves
-//! against the controller's mana pool. This drives the REAL layer-derivation
-//! path (`evaluate_layers`): the P/T read after derivation is computed by the
-//! engine from the floating green mana, not asserted into existence.
+//! against the controller's mana pool. This drives the REAL mana-production and
+//! layer-flush path: mana production marks layers dirty, and the P/T read after
+//! derivation is computed by the engine from the floating green mana.
 //!
 //! CR references (verified against docs/MagicCompRules.txt):
 //!   - CR 106.4: unspent mana stays in a player's mana pool.
 //!   - CR 613.4c: dynamic power/toughness-modifying continuous effects.
 
-use engine::game::layers::evaluate_layers;
+use engine::game::layers::flush_layers;
+use engine::game::mana_payment;
 use engine::game::scenario::{GameRunner, GameScenario, P0};
 use engine::types::identifiers::ObjectId;
-use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::mana::ManaType;
 use engine::types::phase::Phase;
 
 const OMNATH: &str = "Omnath, Locus of Mana gets +1/+1 for each unspent green mana you have.";
 
 fn add_green(runner: &mut GameRunner, n: usize) {
     for _ in 0..n {
-        runner.state_mut().players[0].mana_pool.add(ManaUnit::new(
-            ManaType::Green,
+        let mut events = Vec::new();
+        mana_payment::produce_mana(
+            runner.state_mut(),
             ObjectId(0),
+            ManaType::Green,
+            P0,
             false,
-            vec![],
-        ));
+            &mut events,
+        );
     }
 }
 
 fn derived_power(runner: &mut GameRunner, id: ObjectId) -> i32 {
-    runner.state_mut().layers_dirty.mark_full();
-    evaluate_layers(runner.state_mut());
+    flush_layers(runner.state_mut());
     runner
         .state()
         .objects
@@ -44,8 +47,7 @@ fn derived_power(runner: &mut GameRunner, id: ObjectId) -> i32 {
 }
 
 fn derived_toughness(runner: &mut GameRunner, id: ObjectId) -> i32 {
-    runner.state_mut().layers_dirty.mark_full();
-    evaluate_layers(runner.state_mut());
+    flush_layers(runner.state_mut());
     runner
         .state()
         .objects

--- a/crates/engine/tests/omnath_unspent_green_mana_2887.rs
+++ b/crates/engine/tests/omnath_unspent_green_mana_2887.rs
@@ -1,0 +1,93 @@
+//! Regression: Omnath, Locus of Mana (#2887) — "gets +1/+1 for each unspent
+//! green mana you have" was parsed as a flat +1/+1 (the per-mana multiplier
+//! dropped), so Omnath never grew with floating green mana.
+//!
+//! With the fix the static parses to `AddDynamicPower`/`AddDynamicToughness`
+//! over `QuantityRef::UnspentMana { Green }`, which the layer system resolves
+//! against the controller's mana pool. This drives the REAL layer-derivation
+//! path (`evaluate_layers`): the P/T read after derivation is computed by the
+//! engine from the floating green mana, not asserted into existence.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 106.4: unspent mana stays in a player's mana pool.
+//!   - CR 613.4c: dynamic power/toughness-modifying continuous effects.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const OMNATH: &str = "Omnath, Locus of Mana gets +1/+1 for each unspent green mana you have.";
+
+fn add_green(runner: &mut GameRunner, n: usize) {
+    for _ in 0..n {
+        runner.state_mut().players[0].mana_pool.add(ManaUnit::new(
+            ManaType::Green,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    }
+}
+
+fn derived_power(runner: &mut GameRunner, id: ObjectId) -> i32 {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("Omnath exists")
+        .power
+        .expect("creature has power")
+}
+
+fn derived_toughness(runner: &mut GameRunner, id: ObjectId) -> i32 {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .unwrap()
+        .toughness
+        .expect("creature has toughness")
+}
+
+#[test]
+fn omnath_scales_with_unspent_green_mana() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    let omnath = scenario
+        .add_creature_from_oracle(P0, "Omnath, Locus of Mana", 1, 1, OMNATH)
+        .id();
+    let mut runner = scenario.build();
+
+    // No floating green mana → base 1/1 (the bug made this scale-less but the
+    // flat +1/+1 would have read 2/2 here).
+    assert_eq!(derived_power(&mut runner, omnath), 1, "0 green → 1/1 power");
+    assert_eq!(
+        derived_toughness(&mut runner, omnath),
+        1,
+        "0 green → 1/1 toughness"
+    );
+
+    // Three unspent green mana → +3/+3 = 4/4.
+    add_green(&mut runner, 3);
+    assert_eq!(derived_power(&mut runner, omnath), 4, "3 green → 4 power");
+    assert_eq!(
+        derived_toughness(&mut runner, omnath),
+        4,
+        "3 green → 4 toughness"
+    );
+
+    // Two more (five total) → +5/+5 = 6/6, proving it re-derives live.
+    add_green(&mut runner, 2);
+    assert_eq!(derived_power(&mut runner, omnath), 6, "5 green → 6 power");
+    assert_eq!(
+        derived_toughness(&mut runner, omnath),
+        6,
+        "5 green → 6 toughness"
+    );
+}


### PR DESCRIPTION
## Summary

Omnath, Locus of Mana's *"Omnath gets +1/+1 for each unspent green mana you have"* parsed to a **flat +1/+1** — the per-mana multiplier was dropped, so Omnath never grew with floating green mana.

(Its companion *"you don't lose unspent green mana"* retention static already works via `StaticMode::StepEndUnspentMana`, so this was the only remaining gap — with the fix, Omnath fully works.)

## Root cause + fix

There was no quantity reference for the amount of mana in a player's pool. Added **`QuantityRef::UnspentMana { color: Option<ManaColor> }`** — `Some(c)` counts that color, `None` counts all floating mana — resolved against the controller's `mana_pool`. The existing for-each P/T machinery (`anthem.rs` → `push_dynamic_pt_modifications`) then emits `AddDynamicPower`/`AddDynamicToughness` over it, so the boost re-derives live as mana is spent.

Parser: `parse_for_each_clause` recognizes `"unspent <color> mana you have"` (and the colorless `"unspent mana you have"`) via the shared `parse_color` combinator.

## Engine-variant gate (`add-engine-variant`)

- **Stage 1 (existence): DOES_NOT_EXIST.** No `QuantityRef` reads the mana pool; the only `ManaPool` symbol is a `DoubleTarget` variant ("double the mana in your pool"), a different concept.
- **Stage 2 (parameterization): EXTEND_OK.** Nothing to consolidate with — the color axis is parameterized *within* the variant (`Option<ManaColor>`), and it is controller-scoped (every printed "unspent … mana you have" is the ability's own controller), so unlike `LifeTotal`/`HandSize` it carries no `PlayerScope` axis.
- **Stage 3 (boundary): WITHIN_SECTION** — mana pool is a single CR section (106).

CR 106.4 verified against `docs/MagicCompRules.txt`. Registered across the exhaustive `QuantityRef` matches.

## Tests

- **`parser/oracle_static`** — the static parses to `AddDynamicPower`/`AddDynamicToughness` over `UnspentMana{Green}`; the for-each building block maps both the colored and colorless phrasings.
- **`game/quantity`** — resolver counts per-color and total floating mana, controller-scoped.
- **`integration/omnath_unspent_green_mana_2887`** — drives the REAL layer-derivation path: Omnath is 1/1 with no green, 4/4 with three green, 6/6 with five, proving it re-derives live as mana changes.

Verified locally: `cargo build --workspace`, engine clippy `-D warnings`, and the broad quantity/for-each/mana suites (1.4k+ tests, no regressions).

Closes #2887
