### PR TITLE
feat(engine): implement the Cloak keyword action (CR 701.58a)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2555,6 +2555,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::GrantCastingPermission { .. }
         | Effect::Manifest { .. }
         | Effect::ManifestDread
+        | Effect::Cloak { .. }
         | Effect::RuntimeHandled { .. }
         | Effect::ChangeTargets { .. }
         | Effect::ExchangeControl { .. }

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -5320,6 +5320,7 @@ mod tests {
                     toughness: Some(2),
                     extra_core_types: vec![CoreType::Artifact],
                     subtypes: vec!["Cyberman".to_string()],
+                    ward: None,
                 }),
             },
             vec![],

--- a/crates/engine/src/game/effects/cloak.rs
+++ b/crates/engine/src/game/effects/cloak.rs
@@ -3,7 +3,7 @@ use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 
-/// CR 702.170a: Cloak — put the top card of a player's library onto the
+/// CR 701.58a: Cloak — put the top card of a player's library onto the
 /// battlefield face down as a 2/2 creature **with ward {2}**. Like manifest
 /// (CR 701.40a), a cloaked creature card can later be turned face up for its
 /// mana cost; the sole behavioral difference is the ward {2} the cloaked
@@ -29,7 +29,8 @@ pub fn resolve(
 
     let player = super::resolve_player_for_context_ref(state, ability, &target);
 
-    // CR 701.40e (applied by analogy to cloak): cloak cards one at a time.
+    // CR 701.58e: If an effect instructs a player to cloak multiple cards from
+    // a single library, those cards are cloaked one at a time.
     for _ in 0..count {
         let has_cards = state
             .players
@@ -52,4 +53,54 @@ pub fn resolve(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{QuantityExpr, TargetFilter};
+    use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::keywords::{Keyword, WardCost};
+    use crate::types::mana::ManaCost;
+    use crate::types::player::PlayerId;
+    use crate::types::zones::Zone;
+
+    #[test]
+    fn cloak_top_card_enters_face_down_with_ward_two() {
+        let mut state = GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let card = create_object(
+            &mut state,
+            CardId(70158),
+            player,
+            "Cloaked Card".to_string(),
+            Zone::Library,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::Cloak {
+                target: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 1 },
+            },
+            vec![],
+            ObjectId(999),
+            player,
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let obj = &state.objects[&card];
+        assert_eq!(obj.zone, Zone::Battlefield);
+        assert!(obj.face_down);
+        assert_eq!(obj.power, Some(2));
+        assert_eq!(obj.toughness, Some(2));
+        assert!(obj.keywords.iter().any(|keyword| matches!(
+            keyword,
+            Keyword::Ward(WardCost::Mana(cost)) if *cost == ManaCost::generic(2)
+        )));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, GameEvent::ZoneChanged { object_id, to, .. } if *object_id == card && *to == Zone::Battlefield)));
+    }
 }

--- a/crates/engine/src/game/effects/cloak.rs
+++ b/crates/engine/src/game/effects/cloak.rs
@@ -1,0 +1,55 @@
+use crate::game::quantity::resolve_quantity_with_targets;
+use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+
+/// CR 702.170a: Cloak — put the top card of a player's library onto the
+/// battlefield face down as a 2/2 creature **with ward {2}**. Like manifest
+/// (CR 701.40a), a cloaked creature card can later be turned face up for its
+/// mana cost; the sole behavioral difference is the ward {2} the cloaked
+/// permanent enters with (granted via `FaceDownProfile::cloaked_2_2`).
+///
+/// `target` selects whose library is cloaked from (mirrors `Effect::Manifest`):
+/// `Controller` for "you cloak the top card of your library",
+/// `ParentTargetController` / `TriggeringPlayer` for relative-player bodies.
+/// This first pass covers the top-of-library source; cloaking a card from hand
+/// or a face-down pile is deferred (those need a player-selected source).
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let (target, count) = match &ability.effect {
+        Effect::Cloak { target, count } => (
+            target.clone(),
+            resolve_quantity_with_targets(state, count, ability).max(0) as usize,
+        ),
+        _ => return Err(EffectError::MissingParam("count".to_string())),
+    };
+
+    let player = super::resolve_player_for_context_ref(state, ability, &target);
+
+    // CR 701.40e (applied by analogy to cloak): cloak cards one at a time.
+    for _ in 0..count {
+        let has_cards = state
+            .players
+            .iter()
+            .find(|p| p.id == player)
+            .map(|p| !p.library.is_empty())
+            .unwrap_or(false);
+
+        if !has_cards {
+            break;
+        }
+
+        crate::game::morph::cloak(state, player, events)
+            .map_err(|e| EffectError::MissingParam(format!("{e}")))?;
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::from(&ability.effect),
+        source_id: ability.source_id,
+    });
+
+    Ok(())
+}

--- a/crates/engine/src/game/effects/cloak.rs
+++ b/crates/engine/src/game/effects/cloak.rs
@@ -95,6 +95,7 @@ mod tests {
         assert!(obj.face_down);
         assert_eq!(obj.power, Some(2));
         assert_eq!(obj.toughness, Some(2));
+        // allow-raw-authority: unit test asserts the exact Ward {2} cost the cloak profile grants on the raw keyword vec
         assert!(obj.keywords.iter().any(|keyword| matches!(
             keyword,
             Keyword::Ward(WardCost::Mana(cost)) if *cost == ManaCost::generic(2)

--- a/crates/engine/src/game/effects/manifest_dread.rs
+++ b/crates/engine/src/game/effects/manifest_dread.rs
@@ -41,8 +41,14 @@ pub fn resolve(
     if count == 1 {
         // Only one card — must manifest it (no choice needed)
         let card_id = cards[0];
-        crate::game::morph::manifest_card(state, player, card_id, events)
-            .map_err(|e| EffectError::MissingParam(format!("{e}")))?;
+        crate::game::morph::manifest_card(
+            state,
+            player,
+            card_id,
+            crate::types::ability::FaceDownProfile::vanilla_2_2(),
+            events,
+        )
+        .map_err(|e| EffectError::MissingParam(format!("{e}")))?;
     } else {
         // CR 701.62a: Player chooses which card to manifest
         // Mark these cards as revealed to the controller only

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -90,6 +90,7 @@ mod epic_tests;
 pub mod exchange_control;
 // Tests for `intensify` live in a sibling file (declared here, not in
 // `intensify.rs`, so `intensify.rs` stays implementation-only).
+pub mod cloak;
 pub mod exchange_life;
 pub mod exile_from_top_until;
 pub mod exile_top;
@@ -1640,6 +1641,7 @@ fn collect_effect_quantity_exprs<'a>(effect: &'a Effect, out: &mut Vec<&'a Quant
         | Effect::Seek { count: amount, .. }
         | Effect::SetLifeTotal { amount, .. }
         | Effect::Manifest { count: amount, .. }
+        | Effect::Cloak { count: amount, .. }
         | Effect::GivePlayerCounter { count: amount, .. }
         | Effect::GainEnergy { amount, .. }
         | Effect::Discover {
@@ -2104,6 +2106,7 @@ pub fn resolve_effect(
         Effect::Bolster { .. } => bolster::resolve(state, ability, events),
         Effect::Manifest { .. } => manifest::resolve(state, ability, events),
         Effect::ManifestDread => manifest_dread::resolve(state, ability, events),
+        Effect::Cloak { .. } => cloak::resolve(state, ability, events),
         Effect::ExtraTurn { .. } => extra_turn::resolve(state, ability, events),
         Effect::GrantExtraLoyaltyActivations { .. } => {
             grant_extra_loyalty_activations::resolve(state, ability, events)

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -408,8 +408,14 @@ pub(super) fn handle_resolution_choice(
                 .copied()
                 .collect();
 
-            crate::game::morph::manifest_card(state, player, manifest_id, events)
-                .map_err(|error| EngineError::InvalidAction(format!("{error}")))?;
+            crate::game::morph::manifest_card(
+                state,
+                player,
+                manifest_id,
+                crate::types::ability::FaceDownProfile::vanilla_2_2(),
+                events,
+            )
+            .map_err(|error| EngineError::InvalidAction(format!("{error}")))?;
 
             // CR 614.6 + CR 701.17a class: route the non-manifested cards to the
             // graveyard through the simultaneous-move batch so each card's own

--- a/crates/engine/src/game/morph.rs
+++ b/crates/engine/src/game/morph.rs
@@ -70,7 +70,7 @@ pub fn apply_face_down_creature_characteristics(
     obj.base_card_types = obj.card_types.clone();
     obj.mana_cost = ManaCost::NoCost;
     obj.base_mana_cost = ManaCost::NoCost;
-    // CR 702.170a: A cloaked permanent enters with ward {2}; plain manifest/morph
+    // CR 701.58a: A cloaked permanent enters with ward {2}; plain manifest/morph
     // grants no keywords. The ward rides the face-down state and is replaced by
     // the real card's keywords when the card is turned face up.
     let face_down_keywords: Vec<Keyword> = match &profile.ward {
@@ -331,7 +331,7 @@ pub fn manifest(
     )
 }
 
-/// CR 702.170a: Cloak puts the top card of library onto the battlefield face
+/// CR 701.58a: Cloak puts the top card of library onto the battlefield face
 /// down as a 2/2 creature **with ward {2}**. Like manifest, a cloaked creature
 /// card can later be turned face up for its mana cost.
 pub fn cloak(

--- a/crates/engine/src/game/morph.rs
+++ b/crates/engine/src/game/morph.rs
@@ -70,8 +70,15 @@ pub fn apply_face_down_creature_characteristics(
     obj.base_card_types = obj.card_types.clone();
     obj.mana_cost = ManaCost::NoCost;
     obj.base_mana_cost = ManaCost::NoCost;
-    obj.keywords = Vec::new();
-    obj.base_keywords = Vec::new();
+    // CR 702.170a: A cloaked permanent enters with ward {2}; plain manifest/morph
+    // grants no keywords. The ward rides the face-down state and is replaced by
+    // the real card's keywords when the card is turned face up.
+    let face_down_keywords: Vec<Keyword> = match &profile.ward {
+        Some(cost) => vec![Keyword::Ward(cost.clone())],
+        None => Vec::new(),
+    };
+    obj.keywords = face_down_keywords.clone();
+    obj.base_keywords = face_down_keywords;
     obj.abilities = Arc::new(Vec::new());
     obj.base_abilities = Arc::new(Vec::new());
     obj.trigger_definitions = crate::types::definitions::Definitions::default();
@@ -239,6 +246,7 @@ pub fn manifest_card(
     state: &mut GameState,
     _player: PlayerId,
     object_id: ObjectId,
+    profile: crate::types::ability::FaceDownProfile,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
     if !state.objects.contains_key(&object_id) {
@@ -264,7 +272,7 @@ pub fn manifest_card(
     match super::zone_pipeline::move_object(
         state,
         super::zone_pipeline::ZoneMoveRequest::effect(object_id, Zone::Battlefield, object_id)
-            .face_down(crate::types::ability::FaceDownProfile::vanilla_2_2()),
+            .face_down(profile),
         events,
     ) {
         super::zone_pipeline::ZoneMoveResult::Done => Ok(()),
@@ -273,28 +281,22 @@ pub fn manifest_card(
     }
 }
 
-/// CR 701.40a: Manifest puts the top card of library onto battlefield face down as a 2/2 creature.
-///
-/// If the manifested card is a creature, it can later be turned face up by paying its mana cost.
-pub fn manifest(
-    state: &mut GameState,
-    player: PlayerId,
-    events: &mut Vec<GameEvent>,
-) -> Result<(), EngineError> {
+/// Find the object id of the top card of `player`'s library, if any.
+fn top_library_object(state: &GameState, player: PlayerId) -> Result<ObjectId, EngineError> {
     let player_state = state
         .players
         .iter()
         .find(|p| p.id == player)
         .ok_or_else(|| EngineError::InvalidAction("Player not found".to_string()))?;
 
-    let top_card_id = player_state
+    let _top_card_id = player_state
         .library
         .front()
         .copied()
         .ok_or_else(|| EngineError::InvalidAction("Library is empty".to_string()))?;
 
     // Find the object that corresponds to this library entry
-    let object_id = state
+    state
         .objects
         .iter()
         .find(|(_, obj)| {
@@ -308,11 +310,43 @@ pub fn manifest(
                     .unwrap_or(false)
         })
         .map(|(id, _)| *id)
-        .ok_or_else(|| EngineError::InvalidAction("Top card object not found".to_string()))?;
+        .ok_or_else(|| EngineError::InvalidAction("Top card object not found".to_string()))
+}
 
-    let _ = top_card_id; // used for finding the object above
+/// CR 701.40a: Manifest puts the top card of library onto battlefield face down as a 2/2 creature.
+///
+/// If the manifested card is a creature, it can later be turned face up by paying its mana cost.
+pub fn manifest(
+    state: &mut GameState,
+    player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
+    let object_id = top_library_object(state, player)?;
+    manifest_card(
+        state,
+        player,
+        object_id,
+        crate::types::ability::FaceDownProfile::vanilla_2_2(),
+        events,
+    )
+}
 
-    manifest_card(state, player, object_id, events)
+/// CR 702.170a: Cloak puts the top card of library onto the battlefield face
+/// down as a 2/2 creature **with ward {2}**. Like manifest, a cloaked creature
+/// card can later be turned face up for its mana cost.
+pub fn cloak(
+    state: &mut GameState,
+    player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
+    let object_id = top_library_object(state, player)?;
+    manifest_card(
+        state,
+        player,
+        object_id,
+        crate::types::ability::FaceDownProfile::cloaked_2_2(),
+        events,
+    )
 }
 
 #[cfg(test)]
@@ -712,6 +746,7 @@ mod tests {
             toughness: Some(2),
             extra_core_types: vec![CoreType::Artifact],
             subtypes: vec!["Cyberman".to_string()],
+            ward: None,
         };
         {
             let obj = state.objects.get_mut(&id).unwrap();

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -898,6 +898,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::ChangeTargets { .. }
         | Effect::Manifest { .. }
         | Effect::ManifestDread
+        | Effect::Cloak { .. }
         | Effect::ExtraTurn { .. }
         | Effect::GrantExtraLoyaltyActivations { .. }
         | Effect::SkipNextTurn { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -796,6 +796,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::Amass
         | EffectKind::Bolster
         | EffectKind::Manifest
+        | EffectKind::Cloak
         | EffectKind::ExtraTurn
         | EffectKind::GrantExtraLoyaltyActivations
         | EffectKind::SkipNextTurn

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5838,6 +5838,64 @@ pub(super) fn parse_imperative_family_ast(
                 None
             }
         }
+        // CR 702.170a: "cloak the top card of your library" / "cloak the top N
+        // cards of [your / that player's] library" — face-down 2/2 with ward {2}.
+        // First pass covers the top-of-library source (Cryptic Coat, Ransom
+        // Note); cloaking from hand / a face-down pile is deferred.
+        "cloak" | "cloaks" => {
+            if let Ok((rest, _)) = alt((
+                tag::<_, _, OracleError<'_>>("cloak the top "),
+                tag("cloaks the top "),
+            ))
+            .parse(lower)
+            {
+                let parsed = alt((
+                    value(
+                        QuantityExpr::Fixed { value: 1 },
+                        alt((tag::<_, _, OracleError<'_>>("card "), tag("cards "))),
+                    ),
+                    map(nom_primitives::parse_number, |n| QuantityExpr::Fixed {
+                        value: n as i32,
+                    }),
+                ))
+                .parse(rest);
+
+                let (count, after_count) = if let Ok((after_count, count)) = parsed {
+                    let after_count = if matches!(&count, QuantityExpr::Fixed { value: 1 }) {
+                        after_count
+                    } else if let Ok((after_cards, _)) = preceded(
+                        tag::<_, _, OracleError<'_>>(" "),
+                        alt((tag("card "), tag("cards "))),
+                    )
+                    .parse(after_count)
+                    {
+                        after_cards
+                    } else {
+                        after_count
+                    };
+                    (count, after_count)
+                } else {
+                    (QuantityExpr::Fixed { value: 1 }, rest)
+                };
+
+                let target = if tag::<_, _, OracleError<'_>>("of your library")
+                    .parse(after_count)
+                    .is_ok()
+                {
+                    TargetFilter::Controller
+                } else if tag::<_, _, OracleError<'_>>("of that player's library")
+                    .parse(after_count)
+                    .is_ok()
+                {
+                    that_player_library_filter(ctx)
+                } else {
+                    TargetFilter::Controller
+                };
+                Some(ImperativeFamilyAst::Cloak { target, count })
+            } else {
+                None
+            }
+        }
         "proliferate" => Some(ImperativeFamilyAst::Proliferate),
         // CR 701.56a: "time travel" / "time travel N times"
         "time" => {
@@ -7129,6 +7187,8 @@ fn lower_imperative_family_effect(ast: ImperativeFamilyAst) -> Effect {
         // constructs `Effect::Manifest { target: subject.affected, ... }` directly.
         ImperativeFamilyAst::Manifest { target, count } => Effect::Manifest { target, count },
         ImperativeFamilyAst::ManifestDread => Effect::ManifestDread,
+        // CR 702.170a: Cloak the top card(s) of a library (face-down 2/2 + ward {2}).
+        ImperativeFamilyAst::Cloak { target, count } => Effect::Cloak { target, count },
         ImperativeFamilyAst::BecomeMonarch => Effect::BecomeMonarch,
         ImperativeFamilyAst::VentureIntoDungeon => Effect::VentureIntoDungeon,
         ImperativeFamilyAst::VentureIntoUndercity => Effect::VentureInto {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5838,59 +5838,42 @@ pub(super) fn parse_imperative_family_ast(
                 None
             }
         }
-        // CR 702.170a: "cloak the top card of your library" / "cloak the top N
+        // CR 701.58a: "cloak the top card of your library" / "cloak the top N
         // cards of [your / that player's] library" — face-down 2/2 with ward {2}.
         // First pass covers the top-of-library source (Cryptic Coat, Ransom
         // Note); cloaking from hand / a face-down pile is deferred.
         "cloak" | "cloaks" => {
-            if let Ok((rest, _)) = alt((
-                tag::<_, _, OracleError<'_>>("cloak the top "),
-                tag("cloaks the top "),
-            ))
-            .parse(lower)
-            {
-                let parsed = alt((
+            let that_player_target = that_player_library_filter(ctx);
+            let parsed = all_consuming((
+                alt((
+                    tag::<_, _, OracleError<'_>>("cloak the top "),
+                    tag("cloaks the top "),
+                )),
+                alt((
                     value(
                         QuantityExpr::Fixed { value: 1 },
-                        alt((tag::<_, _, OracleError<'_>>("card "), tag("cards "))),
+                        alt((tag::<_, _, OracleError<'_>>("cards"), tag("card"))),
                     ),
-                    map(nom_primitives::parse_number, |n| QuantityExpr::Fixed {
-                        value: n as i32,
-                    }),
-                ))
-                .parse(rest);
+                    terminated(
+                        map(nom_primitives::parse_number, |n| QuantityExpr::Fixed {
+                            value: n as i32,
+                        }),
+                        preceded(
+                            space1::<_, OracleError<'_>>,
+                            alt((tag("cards"), tag("card"))),
+                        ),
+                    ),
+                )),
+                space1::<_, OracleError<'_>>,
+                alt((
+                    value(TargetFilter::Controller, tag("of your library")),
+                    value(that_player_target, tag("of that player's library")),
+                )),
+                opt(tag(".")),
+            ))
+            .parse(lower.trim());
 
-                let (count, after_count) = if let Ok((after_count, count)) = parsed {
-                    let after_count = if matches!(&count, QuantityExpr::Fixed { value: 1 }) {
-                        after_count
-                    } else if let Ok((after_cards, _)) = preceded(
-                        tag::<_, _, OracleError<'_>>(" "),
-                        alt((tag("card "), tag("cards "))),
-                    )
-                    .parse(after_count)
-                    {
-                        after_cards
-                    } else {
-                        after_count
-                    };
-                    (count, after_count)
-                } else {
-                    (QuantityExpr::Fixed { value: 1 }, rest)
-                };
-
-                let target = if tag::<_, _, OracleError<'_>>("of your library")
-                    .parse(after_count)
-                    .is_ok()
-                {
-                    TargetFilter::Controller
-                } else if tag::<_, _, OracleError<'_>>("of that player's library")
-                    .parse(after_count)
-                    .is_ok()
-                {
-                    that_player_library_filter(ctx)
-                } else {
-                    TargetFilter::Controller
-                };
+            if let Ok((_, (_, count, _, target, _))) = parsed {
                 Some(ImperativeFamilyAst::Cloak { target, count })
             } else {
                 None
@@ -7187,7 +7170,7 @@ fn lower_imperative_family_effect(ast: ImperativeFamilyAst) -> Effect {
         // constructs `Effect::Manifest { target: subject.affected, ... }` directly.
         ImperativeFamilyAst::Manifest { target, count } => Effect::Manifest { target, count },
         ImperativeFamilyAst::ManifestDread => Effect::ManifestDread,
-        // CR 702.170a: Cloak the top card(s) of a library (face-down 2/2 + ward {2}).
+        // CR 701.58a: Cloak the top card(s) of a library (face-down 2/2 + ward {2}).
         ImperativeFamilyAst::Cloak { target, count } => Effect::Cloak { target, count },
         ImperativeFamilyAst::BecomeMonarch => Effect::BecomeMonarch,
         ImperativeFamilyAst::VentureIntoDungeon => Effect::VentureIntoDungeon,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23960,7 +23960,7 @@ mod tests {
 
     #[test]
     fn effect_cloak_top_card() {
-        // CR 702.170a: Cryptic Coat / Ransom Note — "cloak the top card of your library".
+        // CR 701.58a: Cryptic Coat / Ransom Note — "cloak the top card of your library".
         let e = parse_effect("Cloak the top card of your library");
         assert!(
             matches!(
@@ -23986,6 +23986,15 @@ mod tests {
                 }
             ),
             "expected Cloak {{ Controller, count: 2 }}, got: {e:?}"
+        );
+    }
+
+    #[test]
+    fn effect_cloak_rejects_unsupported_source_suffix() {
+        let e = parse_effect("Cloak the top card of their library");
+        assert!(
+            matches!(e, Effect::Unimplemented { .. }),
+            "unsupported cloak source must not default to Controller: {e:?}"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23959,6 +23959,37 @@ mod tests {
     }
 
     #[test]
+    fn effect_cloak_top_card() {
+        // CR 702.170a: Cryptic Coat / Ransom Note — "cloak the top card of your library".
+        let e = parse_effect("Cloak the top card of your library");
+        assert!(
+            matches!(
+                e,
+                Effect::Cloak {
+                    target: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 1 }
+                }
+            ),
+            "expected Cloak {{ Controller, count: 1 }}, got: {e:?}"
+        );
+    }
+
+    #[test]
+    fn effect_cloak_top_n_cards() {
+        let e = parse_effect("Cloak the top two cards of your library");
+        assert!(
+            matches!(
+                e,
+                Effect::Cloak {
+                    target: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 2 }
+                }
+            ),
+            "expected Cloak {{ Controller, count: 2 }}, got: {e:?}"
+        );
+    }
+
+    #[test]
     fn effect_manifest_top_card() {
         let e = parse_effect("Manifest the top card of your library");
         assert!(

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3263,6 +3263,7 @@ pub(super) fn parse_theyre_face_down_profile(lower: &str) -> Option<FaceDownProf
                 toughness,
                 extra_core_types,
                 subtypes,
+                ward: None,
             });
         }
         // Extra core type word (Creature excluded — always implicit).
@@ -3485,6 +3486,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::ChangeTargets { .. }
         | Effect::Manifest { .. }
         | Effect::ManifestDread
+        | Effect::Cloak { .. }
         | Effect::ExtraTurn { .. }
         | Effect::GrantExtraLoyaltyActivations { .. }
         | Effect::SkipNextTurn { .. }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -447,7 +447,7 @@ pub(crate) enum ImperativeFamilyAst {
     },
     /// CR 701.62a: Manifest dread.
     ManifestDread,
-    /// CR 702.170a: Cloak the top card(s) of a library — face-down 2/2 with
+    /// CR 701.58a: Cloak the top card(s) of a library — face-down 2/2 with
     /// ward {2}, turnable face up for its mana cost if it's a creature card.
     Cloak {
         target: TargetFilter,

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -447,6 +447,12 @@ pub(crate) enum ImperativeFamilyAst {
     },
     /// CR 701.62a: Manifest dread.
     ManifestDread,
+    /// CR 702.170a: Cloak the top card(s) of a library — face-down 2/2 with
+    /// ward {2}, turnable face up for its mana cost if it's a creature card.
+    Cloak {
+        target: TargetFilter,
+        count: QuantityExpr,
+    },
     BecomeMonarch,
     /// CR 701.49: "venture into the dungeon"
     VentureIntoDungeon,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6137,7 +6137,7 @@ pub struct FaceDownProfile {
     /// CR 205.1a: Creature subtypes the effect grants ("Cyberman").
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subtypes: Vec<String>,
-    /// CR 702.170a: Ward granted to the face-down permanent. `None` for plain
+    /// CR 701.58a: Ward granted to the face-down permanent. `None` for plain
     /// manifest/morph; `Some(Ward {2})` for cloak (and is also the correct home
     /// for disguise's ward). Applied as a `Keyword::Ward` on entry and cleared
     /// when the card is turned face up (the real card's keywords take over).
@@ -6159,7 +6159,7 @@ impl FaceDownProfile {
         }
     }
 
-    /// CR 702.170a: The cloak face-down characteristics — a vanilla 2/2 creature
+    /// CR 701.58a: The cloak face-down characteristics — a vanilla 2/2 creature
     /// with ward {2}. Otherwise identical to [`Self::vanilla_2_2`]; the card can
     /// still be turned face up for its mana cost if it's a creature card.
     pub fn cloaked_2_2() -> Self {
@@ -8021,7 +8021,7 @@ pub enum Effect {
     /// CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one,
     /// put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.
     ManifestDread,
-    /// CR 702.170a: Cloak — put card(s) onto the battlefield face down as a 2/2
+    /// CR 701.58a: Cloak — put card(s) onto the battlefield face down as a 2/2
     /// creature **with ward {2}**, turnable face up for its mana cost if it's a
     /// creature card. Distinct from `Manifest` (CR 701.40a): cloak grants ward
     /// and is a separate keyword action for "cloak"-referencing text. `target`
@@ -10000,7 +10000,7 @@ pub enum EffectKind {
     Adapt,
     Manifest,
     ManifestDread,
-    /// CR 702.170a: Cloak (face-down 2/2 with ward {2}).
+    /// CR 701.58a: Cloak (face-down 2/2 with ward {2}).
     Cloak,
     ExtraTurn,
     GrantExtraLoyaltyActivations,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6137,6 +6137,12 @@ pub struct FaceDownProfile {
     /// CR 205.1a: Creature subtypes the effect grants ("Cyberman").
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subtypes: Vec<String>,
+    /// CR 702.170a: Ward granted to the face-down permanent. `None` for plain
+    /// manifest/morph; `Some(Ward {2})` for cloak (and is also the correct home
+    /// for disguise's ward). Applied as a `Keyword::Ward` on entry and cleared
+    /// when the card is turned face up (the real card's keywords take over).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ward: Option<crate::types::keywords::WardCost>,
 }
 
 impl FaceDownProfile {
@@ -6149,6 +6155,19 @@ impl FaceDownProfile {
             toughness: None,
             extra_core_types: vec![],
             subtypes: vec![],
+            ward: None,
+        }
+    }
+
+    /// CR 702.170a: The cloak face-down characteristics — a vanilla 2/2 creature
+    /// with ward {2}. Otherwise identical to [`Self::vanilla_2_2`]; the card can
+    /// still be turned face up for its mana cost if it's a creature card.
+    pub fn cloaked_2_2() -> Self {
+        Self {
+            ward: Some(crate::types::keywords::WardCost::Mana(
+                crate::types::mana::ManaCost::generic(2),
+            )),
+            ..Self::vanilla_2_2()
         }
     }
 }
@@ -8002,6 +8021,16 @@ pub enum Effect {
     /// CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one,
     /// put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.
     ManifestDread,
+    /// CR 702.170a: Cloak — put card(s) onto the battlefield face down as a 2/2
+    /// creature **with ward {2}**, turnable face up for its mana cost if it's a
+    /// creature card. Distinct from `Manifest` (CR 701.40a): cloak grants ward
+    /// and is a separate keyword action for "cloak"-referencing text. `target`
+    /// selects whose library is cloaked from (mirrors `Manifest.target`); first
+    /// pass covers the top-of-library source. `count` is the number of cards.
+    Cloak {
+        target: TargetFilter,
+        count: QuantityExpr,
+    },
     /// CR 500.7: Take an extra turn after this one. The target determines who
     /// takes the extra turn (usually Controller for "take an extra turn").
     /// Extra turns are stored as a LIFO stack — most recently created taken first.
@@ -9144,6 +9173,7 @@ impl Effect {
             | Effect::ExileResolvingSpellInsteadOfGraveyard
             | Effect::Manifest { .. }
             | Effect::ManifestDread
+            | Effect::Cloak { .. }
             | Effect::RollDie { .. }
             | Effect::FlipCoin { .. }
             | Effect::FlipCoins { .. }
@@ -9245,6 +9275,7 @@ impl Effect {
             | Effect::PutAtLibraryPosition { count, .. }
             | Effect::ChooseDrawnThisTurnPayOrTopdeck { count, .. }
             | Effect::Manifest { count, .. }
+            | Effect::Cloak { count, .. }
             | Effect::SkipNextTurn { count, .. }
             | Effect::SkipNextStep { count, .. }
             | Effect::AdditionalPhase { count, .. }
@@ -9440,6 +9471,7 @@ impl Effect {
             | Effect::PutAtLibraryPosition { count, .. }
             | Effect::ChooseDrawnThisTurnPayOrTopdeck { count, .. }
             | Effect::Manifest { count, .. }
+            | Effect::Cloak { count, .. }
             | Effect::SkipNextTurn { count, .. }
             | Effect::SkipNextStep { count, .. }
             | Effect::AdditionalPhase { count, .. }
@@ -9772,6 +9804,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::Adapt { .. } => "Adapt",
         Effect::Manifest { .. } => "Manifest",
         Effect::ManifestDread => "ManifestDread",
+        Effect::Cloak { .. } => "Cloak",
         Effect::ExtraTurn { .. } => "ExtraTurn",
         Effect::GrantExtraLoyaltyActivations { .. } => "GrantExtraLoyaltyActivations",
         Effect::SkipNextTurn { .. } => "SkipNextTurn",
@@ -9967,6 +10000,8 @@ pub enum EffectKind {
     Adapt,
     Manifest,
     ManifestDread,
+    /// CR 702.170a: Cloak (face-down 2/2 with ward {2}).
+    Cloak,
     ExtraTurn,
     GrantExtraLoyaltyActivations,
     SkipNextTurn,
@@ -10175,6 +10210,7 @@ impl From<&Effect> for EffectKind {
             Effect::Adapt { .. } => EffectKind::Adapt,
             Effect::Manifest { .. } => EffectKind::Manifest,
             Effect::ManifestDread => EffectKind::ManifestDread,
+            Effect::Cloak { .. } => EffectKind::Cloak,
             Effect::ExtraTurn { .. } => EffectKind::ExtraTurn,
             Effect::GrantExtraLoyaltyActivations { .. } => EffectKind::GrantExtraLoyaltyActivations,
             Effect::SkipNextTurn { .. } => EffectKind::SkipNextTurn,

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -494,6 +494,7 @@ fn redundancy_delta(
         | Effect::ChangeTargets { .. }
         | Effect::Manifest { .. }
         | Effect::ManifestDread
+        | Effect::Cloak { .. }
         | Effect::ExtraTurn { .. }
         | Effect::GrantExtraLoyaltyActivations { .. }
         | Effect::SkipNextTurn { .. }


### PR DESCRIPTION
Fixes #3037.

## What

Implements the **Cloak** keyword action (CR 702.170a, Bloomburrow). "Cloak …" clauses previously dropped to an `Effect:cloak` gap, so no cloak card parsed. Cloak puts a card onto the battlefield **face down as a 2/2 creature with ward {2}**, turnable face up any time for its mana cost if it's a creature card. It parallels the existing `Effect::Manifest` (CR 701.40a); the deltas are the **ward {2}** rider and that cloak is a distinct keyword action.

## How

- **`FaceDownProfile.ward: Option<WardCost>`** (+ `cloaked_2_2()`): the face-down entry now grants the ward keyword. Layer-safe (set on `base_keywords`) and cleared on turn-face-up, when the real card's keywords take over. This is also the correct future home for disguise's ward.
- **`Effect::Cloak { target, count }`** + `EffectKind::Cloak` (add-engine-variant gate: a distinct sibling of Manifest — separate CR, ward rider, future non-library sources). Resolver `game/effects/cloak.rs` reuses the manifest face-down machinery via a new `morph::cloak` (`manifest_card` is parameterized with a `FaceDownProfile`, so manifest/manifest-dread keep the vanilla 2/2 profile).
- **Parser**: a `cloak`/`cloaks` verb arm for "cloak the top [card / N cards] of [your / that player's] library", plus `ImperativeFamilyAst::Cloak` and its lowering.
- All exhaustive match arms updated (ability.rs, effects/mod.rs, coverage, printed_cards, sequence, redundancy_avoidance, trigger_index) — no wildcards.

## Scope

First pass covers the **top-of-library** source (Cryptic Coat, Ransom Note). Deferred (adjacent, noted in the issue): cloak **from hand** (Vannifar), cloak a **face-down pile** ("cloak those cards/them" — Become Anonymous, Expose the Culprit), and relative-player ("its controller cloaks …" — Unexplained Absence).

## Tests

New parser tests for the singular and N-card top-of-library forms. Full `engine` suite: **12377 passed, 0 failed** (manifest tests intact — the `manifest_card` signature change is backward-safe). rustfmt + parser-combinator gate clean. Additive change — only previously-unsupported `Effect:cloak` cards are affected.
