### PR TITLE
fix(parser): split compound statics with foreign keyword-grant subject; fix trailing-comma keyword drop

### DIFF
--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -2343,3 +2343,146 @@ pub(crate) fn try_parse_scoped_must_attack_block(
             .collect(),
     )
 }
+
+/// CR 611.3a + CR 613.1f: Detect and split
+/// `"PRIMARY and FOREIGN_SUBJECT have/has/gains/gain KEYWORD [as long as COND]"`
+/// (including the inverted form `"As long as COND, PRIMARY and FOREIGN_SUBJECT …"`).
+///
+/// A "foreign subject" is any noun phrase parseable by `parse_continuous_subject_filter`
+/// that does NOT resolve to `SelfRef`. Example: "creatures you control have vigilance"
+/// after "~ gets +2/+2 and" — Angelic Field Marshal's Lieutenant ability.
+///
+/// Returns two `StaticDefinition`s: one for the primary (existing `affected`) plus a
+/// companion `Continuous` def for the foreign-subject keyword grant. Both inherit the
+/// same `StaticCondition` when present so the gate applies to both effects.
+///
+/// CR 109.5 + CR 611.3a: the condition binds each effect independently (CR 611.3a),
+/// but MTG print convention always states one condition for the whole clause, so both
+/// defs receive the same condition object.
+pub(crate) fn try_split_and_foreign_keyword_grant(text: &str) -> Option<Vec<StaticDefinition>> {
+    let lower = text.to_lowercase();
+    let tp = TextPair::new(text, &lower);
+
+    // Normalize the inverted "As long as COND, EFFECT" orientation so the rest
+    // of the logic always operates on EFFECT with an optional separate COND.
+    let (effect_original, condition_text): (String, Option<String>) =
+        if let Some(split) = try_split_inverted_as_long_as(&tp) {
+            (
+                split.effect_text.clone(),
+                Some(split.condition_text.clone()),
+            )
+        } else if let Some((before, after)) = text.split_once(" as long as ") {
+            (
+                before.trim().to_string(),
+                Some(after.trim().trim_end_matches('.').to_string()),
+            )
+        } else {
+            (text.to_string(), None)
+        };
+
+    let effect_lower = effect_original.to_lowercase();
+
+    // Scan for "and FOREIGN_SUBJECT verb KEYWORD" in the effect text.
+    // We try each grant verb and check every " and " position.
+    for verb in [" have ", " has ", " gains ", " gain "] {
+        let mut search_pos = 0;
+        while search_pos < effect_lower.len() {
+            let and_pos = match effect_lower[search_pos..].find(" and ") {
+                Some(offset) => search_pos + offset,
+                None => break,
+            };
+            let after_and = &effect_lower[and_pos + 5..];
+
+            let verb_offset = match after_and.find(verb) {
+                Some(o) => o,
+                None => {
+                    search_pos = and_pos + 5;
+                    continue;
+                }
+            };
+
+            let subject_lower = after_and[..verb_offset].trim();
+            if subject_lower.is_empty() {
+                search_pos = and_pos + 5;
+                continue;
+            }
+
+            // Subject must resolve to a recognised non-SelfRef filter.
+            let companion_filter = match parse_continuous_subject_filter(subject_lower) {
+                Some(f) if !matches!(f, TargetFilter::SelfRef) => f,
+                _ => {
+                    search_pos = and_pos + 5;
+                    continue;
+                }
+            };
+
+            // Keyword text is everything after the verb.
+            let kw_start = and_pos + 5 + verb_offset + verb.len();
+            if kw_start >= effect_original.len() {
+                search_pos = and_pos + 5;
+                continue;
+            }
+            let keyword_text = effect_original[kw_start..].trim().trim_end_matches('.');
+            if keyword_text.is_empty() {
+                search_pos = and_pos + 5;
+                continue;
+            }
+
+            // Parse keyword list into companion modifications.
+            let mut companion_mods = Vec::new();
+            for part in split_keyword_list(keyword_text) {
+                push_grant_clause_modifications(&mut companion_mods, part.as_ref(), None);
+            }
+            if companion_mods.is_empty() {
+                search_pos = and_pos + 5;
+                continue;
+            }
+
+            // Primary text is everything before " and FOREIGN_SUBJECT".
+            let primary_text = effect_original[..and_pos].trim_end_matches(',').trim();
+            if primary_text.is_empty() {
+                search_pos = and_pos + 5;
+                continue;
+            }
+
+            // Re-parse the primary with the condition included so the primary def
+            // already carries the condition object.
+            let primary_full = if let Some(ref cond) = condition_text {
+                format!("{primary_text} as long as {cond}.")
+            } else {
+                format!("{primary_text}.")
+            };
+            let mut primary_defs = parse_static_line_multi(&primary_full);
+            if primary_defs.is_empty() {
+                search_pos = and_pos + 5;
+                continue;
+            }
+
+            for def in &mut primary_defs {
+                def.description = Some(text.to_string());
+            }
+
+            // Resolve the condition object for the companion.
+            let condition = condition_text.as_deref().and_then(|ct| {
+                parse_static_condition(ct).or(Some(StaticCondition::Unrecognized {
+                    text: ct.to_string(),
+                }))
+            });
+            let effective_condition =
+                condition.or_else(|| primary_defs.first().and_then(|d| d.condition.clone()));
+
+            let mut companion = StaticDefinition::continuous()
+                .affected(companion_filter)
+                .modifications(companion_mods)
+                .description(text.to_string());
+            if let Some(cond) = effective_condition {
+                companion.condition = Some(cond);
+            }
+
+            primary_defs.push(companion);
+            return Some(primary_defs);
+        }
+    }
+
+    None
+}

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -2371,10 +2371,10 @@ pub(crate) fn try_split_and_foreign_keyword_grant(text: &str) -> Option<Vec<Stat
                 split.effect_text.clone(),
                 Some(split.condition_text.clone()),
             )
-        } else if let Some((before, after)) = text.split_once(" as long as ") {
+        } else if let Some((before, after)) = tp.split_around(" as long as ") {
             (
-                before.trim().to_string(),
-                Some(after.trim().trim_end_matches('.').to_string()),
+                before.original.trim().to_string(),
+                Some(after.original.trim().trim_end_matches('.').to_string()),
             )
         } else {
             (text.to_string(), None)
@@ -2385,25 +2385,22 @@ pub(crate) fn try_split_and_foreign_keyword_grant(text: &str) -> Option<Vec<Stat
     // Scan for "and FOREIGN_SUBJECT verb KEYWORD" in the effect text.
     // We try each grant verb and check every " and " position.
     for verb in [" have ", " has ", " gains ", " gain "] {
-        let mut search_pos = 0;
-        while search_pos < effect_lower.len() {
-            let and_pos = match effect_lower[search_pos..].find(" and ") {
-                Some(offset) => search_pos + offset,
-                None => break,
-            };
-            let after_and = &effect_lower[and_pos + 5..];
+        let mut search_lower = effect_lower.as_str();
+        let mut search_offset = 0;
+        while let Some((before_and, subject_lower, keyword_lower)) =
+            nom_primitives::scan_preceded(search_lower, |input| {
+                let (after_and, _) = tag::<_, _, OracleError<'_>>("and ").parse(input)?;
+                let (after_subject, subject) = take_until(verb).parse(after_and)?;
+                let (after_verb, _) = tag::<_, _, OracleError<'_>>(verb).parse(after_subject)?;
+                Ok((after_verb, subject))
+            })
+        {
+            let and_pos = search_offset + before_and.len();
 
-            let verb_offset = match after_and.find(verb) {
-                Some(o) => o,
-                None => {
-                    search_pos = and_pos + 5;
-                    continue;
-                }
-            };
-
-            let subject_lower = after_and[..verb_offset].trim();
+            let subject_lower = subject_lower.trim();
             if subject_lower.is_empty() {
-                search_pos = and_pos + 5;
+                search_offset = and_pos + "and ".len();
+                search_lower = &effect_lower[search_offset..];
                 continue;
             }
 
@@ -2411,20 +2408,23 @@ pub(crate) fn try_split_and_foreign_keyword_grant(text: &str) -> Option<Vec<Stat
             let companion_filter = match parse_continuous_subject_filter(subject_lower) {
                 Some(f) if !matches!(f, TargetFilter::SelfRef) => f,
                 _ => {
-                    search_pos = and_pos + 5;
+                    search_offset = and_pos + "and ".len();
+                    search_lower = &effect_lower[search_offset..];
                     continue;
                 }
             };
 
             // Keyword text is everything after the verb.
-            let kw_start = and_pos + 5 + verb_offset + verb.len();
+            let kw_start = effect_lower.len() - keyword_lower.len();
             if kw_start >= effect_original.len() {
-                search_pos = and_pos + 5;
+                search_offset = and_pos + "and ".len();
+                search_lower = &effect_lower[search_offset..];
                 continue;
             }
             let keyword_text = effect_original[kw_start..].trim().trim_end_matches('.');
             if keyword_text.is_empty() {
-                search_pos = and_pos + 5;
+                search_offset = and_pos + "and ".len();
+                search_lower = &effect_lower[search_offset..];
                 continue;
             }
 
@@ -2434,14 +2434,16 @@ pub(crate) fn try_split_and_foreign_keyword_grant(text: &str) -> Option<Vec<Stat
                 push_grant_clause_modifications(&mut companion_mods, part.as_ref(), None);
             }
             if companion_mods.is_empty() {
-                search_pos = and_pos + 5;
+                search_offset = and_pos + "and ".len();
+                search_lower = &effect_lower[search_offset..];
                 continue;
             }
 
             // Primary text is everything before " and FOREIGN_SUBJECT".
             let primary_text = effect_original[..and_pos].trim_end_matches(',').trim();
             if primary_text.is_empty() {
-                search_pos = and_pos + 5;
+                search_offset = and_pos + "and ".len();
+                search_lower = &effect_lower[search_offset..];
                 continue;
             }
 
@@ -2454,7 +2456,8 @@ pub(crate) fn try_split_and_foreign_keyword_grant(text: &str) -> Option<Vec<Stat
             };
             let mut primary_defs = parse_static_line_multi(&primary_full);
             if primary_defs.is_empty() {
-                search_pos = and_pos + 5;
+                search_offset = and_pos + "and ".len();
+                search_lower = &effect_lower[search_offset..];
                 continue;
             }
 

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -892,10 +892,7 @@ pub(crate) fn split_keyword_list(text: &str) -> Vec<Cow<'_, str>> {
     // `strip_quoted_segments` removes `and "Whenever..."` from the end of a list
     // like "has first strike, trample, haste, and \"Whenever...\""— the connector
     // `, and` is dropped but the comma after the last bare keyword remains.
-    let text = text
-        .trim()
-        .trim_end_matches(|c: char| c == '.' || c == ',')
-        .trim();
+    let text = text.trim().trim_end_matches(['.', ',']).trim();
     // Split on ", and/or ", ", and ", " and ", or ", " — longest-match-first
     // ordering prevents ", and " from consuming the prefix of ", and/or ".
     let mut parts: Vec<&str> = Vec::new();

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -888,7 +888,14 @@ pub(crate) fn classify_quoted_inner(ability_text: &str) -> Vec<ContinuousModific
 
 /// CR 702: Split a keyword list like "flying and first strike" into individual keywords.
 pub(crate) fn split_keyword_list(text: &str) -> Vec<Cow<'_, str>> {
-    let text = text.trim().trim_end_matches('.');
+    // Strip both trailing periods and trailing commas. A comma tail arises when
+    // `strip_quoted_segments` removes `and "Whenever..."` from the end of a list
+    // like "has first strike, trample, haste, and \"Whenever...\""— the connector
+    // `, and` is dropped but the comma after the last bare keyword remains.
+    let text = text
+        .trim()
+        .trim_end_matches(|c: char| c == '.' || c == ',')
+        .trim();
     // Split on ", and/or ", ", and ", " and ", or ", " — longest-match-first
     // ordering prevents ", and " from consuming the prefix of ", and/or ".
     let mut parts: Vec<&str> = Vec::new();

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -107,7 +107,7 @@ mod support {
         try_split_and_cant_attack_scoped, try_split_and_cant_be_attached,
         try_split_and_cant_be_blocked, try_split_and_cant_be_sacrificed,
         try_split_and_cant_be_targeted, try_split_and_cant_block, try_split_and_doesnt_untap,
-        try_split_and_must_attack_block,
+        try_split_and_foreign_keyword_grant, try_split_and_must_attack_block,
     };
     pub(super) use super::grammar::*;
     pub(super) use super::keyword_grant::{

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -814,6 +814,15 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         return defs;
     }
 
+    // CR 611.3a + CR 613.1f: "PRIMARY and FOREIGN_SUBJECT have/has/gains/gain
+    // KEYWORD [as long as COND]" — compound static where the second conjunct has
+    // a different subject (e.g., Angelic Field Marshal: "~ gets +2/+2 and
+    // creatures you control have vigilance as long as you control your commander").
+    // Must run before the single-return fallback that can only produce one def.
+    if let Some(defs) = try_split_and_foreign_keyword_grant(&stripped) {
+        return defs;
+    }
+
     // CR 509.1b + CR 604.1 + CR 611.3a + CR 613.1f: Attached-subject grant lines
     // ("enchanted creature ...", "equipped creature ...") may decompose into more
     // than one StaticDefinition (e.g. CantBeBlocked + Continuous{AddKeyword}).

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15241,3 +15241,105 @@ fn single_sentence_anthem_unaffected_by_multi_sentence_split() {
         .modifications
         .contains(&ContinuousModification::AddPower { value: 1 }));
 }
+
+/// CR 611.3a + CR 613.1f: Compound static where the keyword-grant conjunct has
+/// a different subject ("creatures you control") than the P/T conjunct ("~").
+/// Angelic Field Marshal: "As long as you control your commander, ~ gets +2/+2
+/// and creatures you control have vigilance."
+/// Must decompose into TWO StaticDefinitions sharing the same condition:
+///   - def[0]: SelfRef subject, [AddPower(2), AddToughness(2)], condition present
+///   - def[1]: Typed(creatures you control) subject, [AddKeyword(Vigilance)], condition present
+#[test]
+fn compound_static_foreign_keyword_grant_splits_angelic_field_marshal() {
+    let defs = parse_static_line_multi(
+        "As long as you control your commander, ~ gets +2/+2 and creatures you control have vigilance.",
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "expected 2 StaticDefinitions (self P/T + foreign keyword), got {defs:?}"
+    );
+
+    // Primary def: self-ref P/T boost with condition.
+    let primary = &defs[0];
+    assert_eq!(primary.mode, StaticMode::Continuous);
+    assert!(
+        matches!(&primary.affected, Some(TargetFilter::SelfRef)),
+        "primary must target SelfRef, got {:?}",
+        primary.affected
+    );
+    assert!(
+        primary
+            .modifications
+            .contains(&ContinuousModification::AddPower { value: 2 }),
+        "primary must add +2 power, got {:?}",
+        primary.modifications
+    );
+    assert!(
+        primary
+            .modifications
+            .contains(&ContinuousModification::AddToughness { value: 2 }),
+        "primary must add +2 toughness, got {:?}",
+        primary.modifications
+    );
+    assert!(
+        primary.condition.is_some(),
+        "primary must carry the as-long-as condition"
+    );
+
+    // Companion def: creatures you control get vigilance with same condition.
+    let companion = &defs[1];
+    assert_eq!(companion.mode, StaticMode::Continuous);
+    match &companion.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "companion must affect creatures you control, got {:?}",
+                tf.type_filters
+            );
+        }
+        other => panic!("companion affected must be Typed(creatures you control), got {other:?}"),
+    }
+    assert!(
+        companion.modifications.iter().any(|m| matches!(m, ContinuousModification::AddKeyword { keyword } if *keyword == Keyword::Vigilance)),
+        "companion must add Vigilance, got {:?}",
+        companion.modifications
+    );
+    assert!(
+        companion.condition.is_some(),
+        "companion must carry the as-long-as condition"
+    );
+}
+
+/// CR 702 + CR 613.1f: Kaldra Compleat — keyword list preceding a quoted
+/// trigger ability must not drop the last bare keyword. `strip_quoted_segments`
+/// removes the `, and "Whenever..."` tail but leaves a trailing comma; all five
+/// keywords (first strike, trample, indestructible, haste, and the trigger)
+/// must survive.
+#[test]
+fn static_keyword_list_before_quoted_trigger_keeps_last_keyword() {
+    let defs = parse_static_line_multi(
+        "Equipped creature gets +5/+5 and has first strike, trample, indestructible, haste, and \"Whenever this creature deals combat damage to a creature, exile that creature.\"",
+    );
+    assert_eq!(defs.len(), 1);
+    let mods = &defs[0].modifications;
+    for kw in [
+        Keyword::FirstStrike,
+        Keyword::Trample,
+        Keyword::Indestructible,
+        Keyword::Haste,
+    ] {
+        assert!(
+            mods.iter().any(
+                |m| matches!(m, ContinuousModification::AddKeyword { keyword } if *keyword == kw)
+            ),
+            "keyword {kw:?} missing from mods: {mods:?}"
+        );
+    }
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::GrantTrigger { .. })),
+        "GrantTrigger missing: {mods:?}"
+    );
+}

--- a/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_bronzehide_lion.snap
+++ b/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_bronzehide_lion.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/tests/integration/oracle_parser.rs
+assertion_line: 662
 expression: result
 ---
 {
@@ -91,9 +92,38 @@ expression: result
                 "definition": {
                   "kind": "Activated",
                   "effect": {
-                    "type": "Unimplemented",
-                    "name": "gain",
-                    "description": "gain indestructible until end of turn,"
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": null,
+                          "properties": [
+                            {
+                              "type": "EnchantedBy"
+                            }
+                          ]
+                        },
+                        "modifications": [
+                          {
+                            "type": "AddKeyword",
+                            "keyword": "Indestructible"
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "gain indestructible until end of turn,"
+                      }
+                    ],
+                    "duration": null,
+                    "target": null
                   },
                   "cost": {
                     "type": "Mana",


### PR DESCRIPTION
## Summary

- **#2864 Kaldra Compleat — haste dropped from keyword list**: `split_keyword_list` now strips trailing commas in addition to trailing periods. The trailing comma arises when `strip_quoted_segments` removes the `, and "Whenever…"` suffix of a keyword list, leaving a bare comma after the last keyword (`haste,`). That comma prevented `strip_trailing_duration` from recognising the duration suffix, so `map_keyword` received `"haste,"` and returned `None`. All five grants (first strike, trample, indestructible, haste, trigger) now resolve correctly.

- **#2885 Angelic Field Marshal — vigilance applies only to itself**: New `try_split_and_foreign_keyword_grant` function in `evasion.rs`, called from `parse_static_line_multi_inner` before the single-def fallback. Detects `"PRIMARY and FOREIGN_SUBJECT have/has/gains/gain KEYWORD [as long as COND]"` — including the inverted `"As long as COND, PRIMARY and FOREIGN_SUBJECT …"` orientation — and produces two `StaticDefinition`s: one for the self-ref primary (P/T) and a companion `Continuous` def for the foreign-subject keyword grant, both carrying the same condition. Covers the Lieutenant ability class generically.

- **Bronzehide Lion snapshot updated**: The `split_keyword_list` comma fix now allows `{G}{W}: Enchanted creature gains indestructible until end of turn,` to parse as `GenericEffect { AddKeyword(Indestructible), affected=EnchantedBy }` instead of `Unimplemented("gain")`. The new output is correct; the old snapshot was stale.

## Test plan

- `static_keyword_list_before_quoted_trigger_keeps_last_keyword` — Kaldra regression: all five keywords (first strike, trample, indestructible, haste, trigger) survive after `strip_quoted_segments` removes the quoted tail.
- `compound_static_foreign_keyword_grant_splits_angelic_field_marshal` — Angelic Field Marshal Lieutenant: `parse_static_line_multi` produces two `StaticDefinition`s with the correct subjects and condition.
- All 11 454 unit tests and 895 integration snapshot tests pass.