### PR TITLE
fix(parser): route subject-led mana to ScopedPlayer for Blinkmoth Urn

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -2487,6 +2487,37 @@ mod tests {
         }
     }
 
+    /// Issue #2900: Blinkmoth Urn effect body after the intervening-if clause.
+    #[test]
+    fn parse_add_mana_that_player_for_each_artifact_they_control() {
+        let effect =
+            try_parse_add_mana_effect("that player adds {C} for each artifact they control.")
+                .expect("Blinkmoth Urn mana body must parse");
+        match effect {
+            Effect::Mana {
+                produced: ManaProduction::Colorless { count },
+                target,
+                ..
+            } => {
+                assert_eq!(
+                    target,
+                    Some(TargetFilter::ScopedPlayer),
+                    "recipient must be the scoped phase player"
+                );
+                assert!(
+                    matches!(
+                        count,
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::ObjectCount { .. }
+                        }
+                    ),
+                    "count must be ObjectCount, got {count:?}"
+                );
+            }
+            other => panic!("expected Effect::Mana, got {other:?}"),
+        }
+    }
+
     /// CR 106.1: `{C}{C} for each X` preserves the literal symbol count as a
     /// `Multiply` factor; `{C} for each X` emits a bare `Ref` (no `Multiply`).
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11174,6 +11174,15 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
         Effect::LoseLife { ref mut target, .. } if target.is_none() => {
             *target = Some(subject_filter);
         }
+        // CR 106.4 + CR 505.1 + CR 608.2c: "<player> adds {mana}" — subject-predicate
+        // classification deconjugates "adds" → "add" and routes through the imperative
+        // mana parser with `target: None`. Stamp the stripped subject ("that player",
+        // "the active player") as the mana recipient (Blinkmoth Urn, issue #2900).
+        Effect::Mana { ref mut target, .. }
+            if target.is_none() && target_filter_can_target_player(&subject_filter) =>
+        {
+            *target = Some(subject_filter);
+        }
         // CR 608.2c + CR 113.7a + CR 120.3: When the stripped subject is the
         // source object ("~ deals damage equal to its toughness/power/mana
         // value..."), an anaphoric "its <characteristic>" reads the ability
@@ -39314,6 +39323,35 @@ mod tests {
                 }
                 other => panic!("expected Sacrifice for {text:?}, got: {other:?}"),
             }
+        }
+    }
+
+    /// CR 106.4 + CR 608.2c (issue #2900): Blinkmoth Urn — subject-predicate
+    /// "that player adds {C} for each artifact they control" must stamp
+    /// `Effect::Mana.target = ScopedPlayer` after imperative lowering.
+    #[test]
+    fn that_player_adds_mana_injects_scoped_player_recipient() {
+        let mut ctx = ParseContext {
+            relative_player_scope: Some(ControllerRef::ScopedPlayer),
+            ..Default::default()
+        };
+        let clause = parse_effect_clause(
+            "that player adds {C} for each artifact they control.",
+            &mut ctx,
+        );
+        match clause.effect {
+            Effect::Mana {
+                target,
+                produced: ManaProduction::Colorless { .. },
+                ..
+            } => {
+                assert_eq!(
+                    target,
+                    Some(TargetFilter::ScopedPlayer),
+                    "subject-predicate path must stamp ScopedPlayer recipient"
+                );
+            }
+            other => panic!("expected Effect::Mana, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11564,9 +11564,9 @@ mod tests {
         BounceSelection, CardSelectionMode, CastingPermission, ChosenAttribute, Comparator,
         ContinuousModification, ControllerRef, CountScope, DamageModification, DamageSource,
         DelayedTriggerCondition, DiscardSelfScope, Duration, Effect, EffectScope, FilterProp,
-        ManaSpendPermission, ObjectScope, PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope,
-        QuantityExpr, QuantityRef, SharedQuality, TapStateChange, TargetFilter, TypeFilter,
-        TypedFilter,
+        ManaProduction, ManaSpendPermission, ObjectScope, PlayerFilter, PlayerScope, PtStat,
+        PtValue, PtValueScope, QuantityExpr, QuantityRef, SharedQuality, TapStateChange,
+        TargetFilter, TypeFilter, TypedFilter,
     };
     use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::game_state::WaitingFor;
@@ -22741,6 +22741,56 @@ mod tests {
         assert_eq!(def.mode, TriggerMode::Phase);
         assert_eq!(def.phase, Some(Phase::PreCombatMain));
         assert_eq!(def.constraint, Some(TriggerConstraint::OnlyDuringYourTurn));
+    }
+
+    /// Issue #2900: Blinkmoth Urn — "that player adds {C} for each artifact they
+    /// control" must route mana to `ScopedPlayer` and count the scoped player's
+    /// artifacts, not the source controller's.
+    #[test]
+    fn phase_trigger_blinkmoth_urn_that_player_adds_mana_for_their_artifacts() {
+        let def = parse_trigger_line(
+            "At the beginning of each player's first main phase, if this artifact is untapped, that player adds {C} for each artifact they control.",
+            "Blinkmoth Urn",
+        );
+        assert_eq!(def.mode, TriggerMode::Phase);
+        assert_eq!(def.phase, Some(Phase::PreCombatMain));
+        assert_eq!(def.constraint, None);
+        let exec = def
+            .execute
+            .as_ref()
+            .expect("Blinkmoth Urn must have execute");
+        match exec.effect.as_ref() {
+            Effect::Mana {
+                produced: ManaProduction::Colorless { count },
+                target,
+                ..
+            } => {
+                assert_eq!(
+                    *target,
+                    Some(TargetFilter::ScopedPlayer),
+                    "mana recipient must be the active player (ScopedPlayer)"
+                );
+                let QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(tf),
+                        },
+                } = count
+                else {
+                    panic!("expected ObjectCount artifact filter, got {count:?}");
+                };
+                assert!(
+                    tf.type_filters.contains(&TypeFilter::Artifact),
+                    "count must be artifacts"
+                );
+                assert_eq!(
+                    tf.controller,
+                    Some(ControllerRef::ScopedPlayer),
+                    "\"they control\" must bind to the scoped player"
+                );
+            }
+            other => panic!("expected Effect::Mana, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_2900_blinkmoth_urn.rs
+++ b/crates/engine/tests/integration/issue_2900_blinkmoth_urn.rs
@@ -1,0 +1,134 @@
+//! Regression tests for GitHub issue #2900 — Blinkmoth Urn mana routing.
+//!
+//! At the beginning of each player's first main phase, if Blinkmoth Urn is
+//! untapped, **that player** (the active player whose main phase is beginning)
+//! adds {C} for each **artifact they control**. Before the fix, mana went to the
+//! Urn's controller and the artifact count used the turn player's board while
+//! crediting the wrong pool.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const BLINKMOTH_URN_ORACLE: &str = "At the beginning of each player's first main phase, \
+    if this artifact is untapped, that player adds {C} for each artifact they control.";
+
+fn seed_library(scenario: &mut GameScenario, player: PlayerId) {
+    scenario.with_library_top(player, &["Lib A", "Lib B", "Lib C", "Lib D"]);
+}
+
+fn artifact_vanilla(scenario: &mut GameScenario, player: PlayerId, name: &str) {
+    scenario.add_creature(player, name, 0, 0).as_artifact();
+}
+
+fn runner_at_untap(runner: &mut engine::game::scenario::GameRunner, active: PlayerId) {
+    let state = runner.state_mut();
+    state.turn_number = 2;
+    state.phase = Phase::Untap;
+    state.active_player = active;
+    state.priority_player = active;
+    state.waiting_for = WaitingFor::Priority { player: active };
+}
+
+/// CR 106.4 + CR 603.2b: On the opponent's first main phase, the active player
+/// (P1) receives colorless mana equal to their own artifact count, not the
+/// Urn controller's pool sized by P1's board.
+#[test]
+fn blinkmoth_urn_opponent_main_phase_mana_goes_to_active_player() {
+    let mut scenario = GameScenario::new();
+
+    scenario
+        .add_creature_from_oracle(P0, "Blinkmoth Urn", 0, 0, BLINKMOTH_URN_ORACLE)
+        .as_artifact();
+
+    artifact_vanilla(&mut scenario, P1, "Opponent Artifact A");
+    artifact_vanilla(&mut scenario, P1, "Opponent Artifact B");
+    artifact_vanilla(&mut scenario, P1, "Opponent Artifact C");
+
+    seed_library(&mut scenario, P0);
+    seed_library(&mut scenario, P1);
+
+    let mut runner = scenario.build();
+    runner_at_untap(&mut runner, P1);
+
+    runner.auto_advance_to_main_phase();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().phase,
+        Phase::PreCombatMain,
+        "must reach the opponent's precombat main phase"
+    );
+    assert_eq!(
+        runner.state().players[1]
+            .mana_pool
+            .count_color(ManaType::Colorless),
+        3,
+        "P1 must receive {{C}} equal to their three artifacts"
+    );
+    assert_eq!(
+        runner.state().players[0].mana_pool.total(),
+        0,
+        "P0 must not receive mana on the opponent's main phase"
+    );
+}
+
+/// CR 106.4 + CR 109.4: On the controller's own first main phase, mana counts
+/// the controller's artifacts (including the untapped Urn itself).
+#[test]
+fn blinkmoth_urn_controller_main_phase_counts_own_artifacts() {
+    let mut scenario = GameScenario::new();
+
+    scenario
+        .add_creature_from_oracle(P0, "Blinkmoth Urn", 0, 0, BLINKMOTH_URN_ORACLE)
+        .as_artifact();
+
+    artifact_vanilla(&mut scenario, P0, "Controller Artifact");
+
+    seed_library(&mut scenario, P0);
+    seed_library(&mut scenario, P1);
+
+    let mut runner = scenario.build();
+    runner_at_untap(&mut runner, P0);
+
+    runner.auto_advance_to_main_phase();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[0]
+            .mana_pool
+            .count_color(ManaType::Colorless),
+        2,
+        "P0 must receive {{C}} for the Urn plus one other artifact"
+    );
+}
+
+/// Sanity: passing priority alone must not advance the scenario into a main
+/// phase where triggers would fire spuriously.
+#[test]
+fn blinkmoth_urn_no_mana_before_main_phase() {
+    let mut scenario = GameScenario::new();
+
+    scenario
+        .add_creature_from_oracle(P0, "Blinkmoth Urn", 0, 0, BLINKMOTH_URN_ORACLE)
+        .as_artifact();
+
+    artifact_vanilla(&mut scenario, P0, "Controller Artifact");
+
+    let mut runner = scenario.build();
+    runner_at_untap(&mut runner, P0);
+    runner.state_mut().phase = Phase::Upkeep;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let _ = runner.act(GameAction::PassPriority);
+
+    assert_ne!(
+        runner.state().phase,
+        Phase::PreCombatMain,
+        "precondition: still before the first main phase"
+    );
+    assert_eq!(runner.state().players[0].mana_pool.total(), 0);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -134,6 +134,7 @@ mod issue_2431_ultima_tap_land_for_c;
 mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_2894_spymasters_vault_connive;
+mod issue_2900_blinkmoth_urn;
 mod issue_2904_life_of_the_party;
 mod issue_2908_weathered_wayfarer;
 mod issue_2914_shiko_flurry_target_gate;


### PR DESCRIPTION
## Summary

- Fixes [#2900](https://github.com/phase-rs/phase/issues/2900): Blinkmoth Urn was crediting mana to the Urn's controller instead of the player whose first main phase is beginning.
- Root cause: subject-predicate clauses like `"that player adds {C} for each artifact they control"` parsed `Effect::Mana` with `target: None`. Runtime already binds `ScopedPlayer` to the active player for phase triggers; it just never received the recipient filter from the parser.
- Adds `Effect::Mana` handling to `inject_subject_target` so the stripped subject (`ScopedPlayer`) is stamped onto `Effect::Mana.target`, consistent with `Draw` / `LoseLife`.

## Behavior (CR 106.4 + CR 603.2b)

| Scenario | Before | After |
|----------|--------|-------|
| Opponent's first main phase (P1 has 3 artifacts, P0 owns Urn) | P0 gets 3 `{C}` | P1 gets 3 `{C}`, P0 gets 0 |
| Controller's first main phase (P0 has Urn + 1 other artifact) | Wrong pool / count | P0 gets 2 `{C}` |

## Test plan

- [x] `phase_trigger_blinkmoth_urn_that_player_adds_mana_for_their_artifacts` — full trigger parse asserts `Mana.target = ScopedPlayer` and artifact count uses `ControllerRef::ScopedPlayer`
- [x] `that_player_adds_mana_injects_scoped_player_recipient` — subject-predicate lowering path
- [x] `parse_add_mana_that_player_for_each_artifact_they_control` — direct mana parser
- [x] Integration: opponent main phase, controller main phase, no spurious mana before main phase
- [ ] `cargo test -p engine --test integration blinkmoth_urn`
- [ ] `cargo test -p engine --lib blinkmoth that_player_adds_mana_injects`