### PR TITLE
fix(parser): preserve "may" optionality for each-player discard (Mog, Moogle Warrior)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7147,6 +7147,18 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             clause.multi_target = Some(MultiTargetSpec::fixed(0, count as usize));
             clause
         }
+        // CR 117.3a: "you may <effect>" and subject-stripped "each player may
+        // <effect>" both arrive here as `YouMay` (the `you`/`may` first-word
+        // arms). The optionality is an ability-level flag, not part of the
+        // Effect, so lower the body and mark the CLAUSE optional. The bare
+        // `lower_imperative_family_effect` path drops the "may" entirely,
+        // making the effect mandatory — e.g. Mog, Moogle Warrior's "each
+        // player may discard a card" became a forced discard (issue #2901).
+        ImperativeFamilyAst::YouMay { text } => {
+            let mut clause = parsed_clause(super::parse_effect(&text));
+            clause.optional = true;
+            clause
+        }
         // All other arms produce a bare Effect with no sub_ability chain.
         other => parsed_clause(lower_imperative_family_effect(other)),
     }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7147,13 +7147,13 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             clause.multi_target = Some(MultiTargetSpec::fixed(0, count as usize));
             clause
         }
-        // CR 117.3a: "you may <effect>" and subject-stripped "each player may
-        // <effect>" both arrive here as `YouMay` (the `you`/`may` first-word
-        // arms). The optionality is an ability-level flag, not part of the
-        // Effect, so lower the body and mark the CLAUSE optional. The bare
-        // `lower_imperative_family_effect` path drops the "may" entirely,
-        // making the effect mandatory — e.g. Mog, Moogle Warrior's "each
-        // player may discard a card" became a forced discard (issue #2901).
+        // CR 603.5 / CR 608.2d: "you may <effect>" and subject-stripped "each
+        // player may <effect>" both arrive here as `YouMay` (the `you`/`may`
+        // first-word arms). The optionality is an ability-level flag, not part
+        // of the Effect, so lower the body and mark the CLAUSE optional. The
+        // bare `lower_imperative_family_effect` path drops the "may" entirely,
+        // making the effect mandatory — e.g. Mog, Moogle Warrior's "each player
+        // may discard a card" became a forced discard (issue #2901).
         ImperativeFamilyAst::YouMay { text } => {
             let mut clause = parsed_clause(super::parse_effect(&text));
             clause.optional = true;

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23961,10 +23961,10 @@ mod tests {
 
     #[test]
     fn each_player_may_discard_is_optional_per_player() {
-        // CR 117.3a + issue #2901: Mog, Moogle Warrior — "each player MAY
-        // discard a card" must be an optional per-player discard, not a forced
-        // one. The subject-stripped "may discard a card" is lowered via the
-        // `YouMay` wrapper, which previously dropped the optionality.
+        // CR 603.5 / CR 608.2d + issue #2901: Mog, Moogle Warrior — "each
+        // player MAY discard a card" must be an optional per-player discard, not
+        // a forced one. The subject-stripped "may discard a card" is lowered via
+        // the `YouMay` wrapper, which previously dropped the optionality.
         let parsed = crate::parser::oracle::parse_oracle_text(
             "At the beginning of your end step, each player may discard a card.",
             "Mog, Moogle Warrior",

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23960,6 +23960,41 @@ mod tests {
     }
 
     #[test]
+    fn each_player_may_discard_is_optional_per_player() {
+        // CR 117.3a + issue #2901: Mog, Moogle Warrior — "each player MAY
+        // discard a card" must be an optional per-player discard, not a forced
+        // one. The subject-stripped "may discard a card" is lowered via the
+        // `YouMay` wrapper, which previously dropped the optionality.
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "At the beginning of your end step, each player may discard a card.",
+            "Mog, Moogle Warrior",
+            &[],
+            &["Creature".to_string()],
+            &[],
+        );
+        assert_eq!(parsed.triggers.len(), 1, "expected one triggered ability");
+        let execute = parsed.triggers[0]
+            .execute
+            .as_deref()
+            .expect("trigger must have an execute body");
+        assert!(
+            execute.optional,
+            "discard must be optional (each player MAY), got optional=false: {:?}",
+            execute.effect
+        );
+        assert_eq!(
+            execute.player_scope,
+            Some(crate::types::ability::PlayerFilter::All),
+            "discard must apply to each player (player_scope All)"
+        );
+        assert!(
+            matches!(&*execute.effect, Effect::Discard { .. }),
+            "expected Discard, got {:?}",
+            execute.effect
+        );
+    }
+
+    #[test]
     fn effect_cloak_top_card() {
         // CR 701.58a: Cryptic Coat / Ransom Note — "cloak the top card of your library".
         let e = parse_effect("Cloak the top card of your library");


### PR DESCRIPTION
Fixes #2901.

## What

Mog, Moogle Warrior's end-step trigger **"each player may discard a card"** forced every player to discard unconditionally; it should be an optional per-player discard.

## Root cause

The "each player" subject is stripped, leaving "may discard a card", which the first-word `may` arm wraps in `ImperativeFamilyAst::YouMay`. But `lower_imperative_family_ast` had **no `YouMay` arm** — it fell through to the catch-all that lowers the body to a bare `Effect` and **dropped the optionality**, so the discard came out `optional: false` (mandatory).

## Fix

Add a `YouMay` arm to `lower_imperative_family_ast` that lowers the body and marks the clause `optional: true`. This is the correct general behavior for any "may"-wrapped effect reaching this path. The each-player `player_scope: All` lives on the surrounding ability and is unaffected, so the discard is now an **optional per-player** choice.

## Verification

- New regression test parses Mog's real end-step trigger via `parse_oracle_text` and asserts the discard's execute ability is `optional` with `player_scope = All` (and is a `Discard`).
- Confirmed in trigger context: `optional=true`, `player_scope=Some(All)` (previously `optional=false`).
- Full `engine` suite: **12417 passed, 0 failed** (no regression from the broader `YouMay` change). rustfmt + clippy `-D warnings` + engine-authorities + parser-combinator gates all clean.
