### PR TITLE
fix(engine): charge each repeated modal unless-pay instance (#2925)

### DIFF
--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -2,7 +2,7 @@ use crate::game::filter;
 use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, Effect, EffectKind, EffectScope, ResolvedAbility,
-    SacrificeRequirement, TapStateChange, TargetFilter, TargetRef,
+    SacrificeRequirement, SubAbilityLink, TapStateChange, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
@@ -901,6 +901,57 @@ pub(super) fn handle_unless_payment(
                     events,
                     &trigger_event,
                 )?);
+            } else if let Some(sub) = pending_effect
+                .sub_ability
+                .as_ref()
+                .filter(|sub| sub.sub_link == SubAbilityLink::SequentialSibling)
+            {
+                // CR 700.2d + CR 608.2c: A `SequentialSibling` sub is the NEXT
+                // INDEPENDENT instruction "in the order written" — not a
+                // continuation of the unless-modified instruction, so it must
+                // resolve regardless of whether the unless cost was paid. The
+                // canonical case is choosing the same modal mode more than once
+                // (Mystic Confluence's "Counter target spell unless its
+                // controller pays {3}" picked twice → two independent counter
+                // instructions, each demanding its own {3}; issue #2925). The
+                // primary instruction's effect was suppressed above (its unless
+                // cost was paid), but the sibling chain is a separate instruction
+                // and is resumed here. The decline path resolves the whole
+                // `pending_effect` chain (which already follows the sibling); the
+                // pay path suppresses the head, so it must hand off only the
+                // sibling sub-chain — `resolve_ability_chain` then surfaces the
+                // sibling's OWN `unless_pay` prompt and follows its own chain.
+                let mut sub_resolved = sub.as_ref().clone();
+                if sub_resolved.targets.is_empty() {
+                    sub_resolved.targets = pending_effect.targets.clone();
+                }
+                sub_resolved.context = pending_effect.context.clone();
+                let event_start = resolve_ability_chain_for_unless_payment(
+                    state,
+                    &sub_resolved,
+                    events,
+                    &trigger_event,
+                )?;
+                // CR 608.2c: If the sibling instruction itself paused for input
+                // (e.g. its OWN unless-pay prompt — the second {3} of a
+                // double-counter), that fresh `WaitingFor` is the next state and
+                // MUST be preserved. The shared post-payment tail below would
+                // overwrite an open `UnlessPayment` with active-player priority
+                // (`set_active_priority`), collapsing the second prompt; run the
+                // trigger/SBA pipeline now and return so it survives.
+                if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                    let default_wf = state.waiting_for.clone();
+                    let wf = engine_priority::run_post_action_pipeline_from(
+                        state,
+                        events,
+                        event_start,
+                        &default_wf,
+                        false,
+                    )?;
+                    state.waiting_for = wf;
+                    return Ok(action_result(events, state.waiting_for.clone()));
+                }
+                post_action_event_start = Some(event_start);
             }
         }
     }

--- a/crates/engine/tests/integration/issue_2925_mystic_confluence_repeated_counter.rs
+++ b/crates/engine/tests/integration/issue_2925_mystic_confluence_repeated_counter.rs
@@ -1,10 +1,11 @@
 //! Issue #2925: Mystic Confluence — choosing the "counter target spell unless
 //! its controller pays {3}" mode TWICE against the same spell must enforce TWO
-//! independent {3} payments (CR 608.2). The two chosen modes are independent
-//! instructions, so the controller must pay {3} for EACH (i.e. {6} total) or
-//! the spell is countered. Pre-fix, a single {3} payment let the spell resolve:
-//! the first mode's unless-payment success silently dropped the second mode's
-//! `SequentialSibling` counter instead of resolving it.
+//! independent {3} payments. CR 700.2d makes duplicate modal choices repeat in
+//! sequence, and CR 608.2c resolves those instructions in written order, so the
+//! controller must pay {3} for EACH (i.e. {6} total) or the spell is countered.
+//! Pre-fix, a single {3} payment let the spell resolve: the first mode's
+//! unless-payment success silently dropped the second mode's `SequentialSibling`
+//! counter instead of resolving it.
 //!
 //! https://github.com/phase-rs/phase/issues/2925
 
@@ -128,7 +129,7 @@ fn paying_three_once_does_not_save_spell_from_double_counter() {
             WaitingFor::UnlessPayment { player: P1, .. }
         ),
         "second counter mode must independently prompt P1 for a SECOND {{3}} \
-         unless cost (CR 608.2), got {:?}",
+         unless cost (CR 700.2d + CR 608.2c), got {:?}",
         runner.state().waiting_for
     );
 

--- a/crates/engine/tests/integration/issue_2925_mystic_confluence_repeated_counter.rs
+++ b/crates/engine/tests/integration/issue_2925_mystic_confluence_repeated_counter.rs
@@ -1,0 +1,193 @@
+//! Issue #2925: Mystic Confluence — choosing the "counter target spell unless
+//! its controller pays {3}" mode TWICE against the same spell must enforce TWO
+//! independent {3} payments (CR 608.2). The two chosen modes are independent
+//! instructions, so the controller must pay {3} for EACH (i.e. {6} total) or
+//! the spell is countered. Pre-fix, a single {3} payment let the spell resolve:
+//! the first mode's unless-payment success silently dropped the second mode's
+//! `SequentialSibling` counter instead of resolving it.
+//!
+//! https://github.com/phase-rs/phase/issues/2925
+
+use engine::game::ability_utils::build_chained_resolved;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityCost, AbilityKind, Effect, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastingVariant, StackEntry, StackEntryKind, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::zones::Zone;
+
+const COUNTER_MODE_ORACLE: &str = "Counter target spell unless its controller pays {3}.";
+
+/// The counter mode parses to a `Counter` effect carrying an `unless_pay` of
+/// {3} payable by the spell's controller. (Sanity guard for the test premise.)
+#[test]
+fn counter_mode_parses_with_unless_pay_three() {
+    let def = parse_effect_chain(COUNTER_MODE_ORACLE, AbilityKind::Spell);
+    assert!(
+        matches!(*def.effect, Effect::Counter { .. }),
+        "counter mode must parse to Effect::Counter, got {:?}",
+        def.effect
+    );
+    let unless = def
+        .unless_pay
+        .as_ref()
+        .expect("counter mode must carry an unless_pay modifier");
+    assert!(
+        matches!(&unless.cost, AbilityCost::Mana { cost } if cost.mana_value() == 3),
+        "the unless cost must be {{3}}, got {:?}",
+        unless.cost
+    );
+}
+
+fn give_generic_mana(
+    runner: &mut engine::game::scenario::GameRunner,
+    player: engine::types::player::PlayerId,
+    amount: usize,
+) {
+    let dummy = ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == player)
+        .unwrap()
+        .mana_pool;
+    for _ in 0..amount {
+        pool.add(ManaUnit::new(ManaType::Colorless, dummy, false, vec![]));
+    }
+}
+
+fn put_spell_on_stack(runner: &mut engine::game::scenario::GameRunner) -> ObjectId {
+    let spell = engine::game::zones::create_object(
+        runner.state_mut(),
+        CardId(77),
+        P1,
+        "Opponent Spell".to_string(),
+        Zone::Stack,
+    );
+    runner.state_mut().stack.push_back(StackEntry {
+        id: spell,
+        source_id: spell,
+        controller: P1,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(77),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    spell
+}
+
+/// THE discriminating test. The counter mode chosen twice produces a chained
+/// `Counter -> Counter(SequentialSibling)`, each with its own {3} unless cost.
+/// Paying {3} for the FIRST mode must NOT save the spell — the SECOND mode's
+/// {3} unless prompt must still surface, and declining it must counter the
+/// spell. Pre-fix, the first payment dropped the second instruction and the
+/// spell survived.
+#[test]
+fn paying_three_once_does_not_save_spell_from_double_counter() {
+    let mut runner = GameScenario::new().build();
+    let spell = put_spell_on_stack(&mut runner);
+    // The controller of the targeted spell (P1) can afford a single {3}.
+    give_generic_mana(&mut runner, P1, 3);
+
+    let def = parse_effect_chain(COUNTER_MODE_ORACLE, AbilityKind::Spell);
+    // "Choose counter twice" — both indices select the same (counter) mode.
+    let mut chained =
+        build_chained_resolved(&[def], &[0, 0], ObjectId(9000), P0).expect("chain builds");
+    chained.targets = vec![TargetRef::Object(spell)];
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &chained, &mut events, 0)
+        .expect("resolve double-counter chain");
+
+    // First unless prompt: P1 may pay {3}.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player: P1, .. }
+        ),
+        "first counter mode must prompt P1 for its {{3}} unless cost, got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("P1 pays the first {3}");
+
+    // SECOND unless prompt MUST surface (the second mode is an independent
+    // instruction). This is the core regression assertion — pre-fix the second
+    // mode was dropped and the state went straight to Priority with the spell
+    // surviving on the stack.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player: P1, .. }
+        ),
+        "second counter mode must independently prompt P1 for a SECOND {{3}} \
+         unless cost (CR 608.2), got {:?}",
+        runner.state().waiting_for
+    );
+
+    // P1 spent its only {3} on the first mode and cannot pay again — decline.
+    runner
+        .act(GameAction::PayUnlessCost { pay: false })
+        .expect("P1 declines the second {3}");
+
+    // The spell is countered: off the stack and in its owner's graveyard.
+    assert!(
+        runner.state().stack.is_empty(),
+        "the spell must be countered when only one of the two {{3}} costs is paid"
+    );
+    assert!(
+        runner.state().players[1].graveyard.contains(&spell),
+        "the countered spell must be in its owner's graveyard"
+    );
+}
+
+/// Paying BOTH {3} costs ({6} total) saves the spell — neither counter fires.
+#[test]
+fn paying_three_twice_saves_spell_from_double_counter() {
+    let mut runner = GameScenario::new().build();
+    let spell = put_spell_on_stack(&mut runner);
+    // P1 can afford {6} — both unless costs.
+    give_generic_mana(&mut runner, P1, 6);
+
+    let def = parse_effect_chain(COUNTER_MODE_ORACLE, AbilityKind::Spell);
+    let mut chained =
+        build_chained_resolved(&[def], &[0, 0], ObjectId(9000), P0).expect("chain builds");
+    chained.targets = vec![TargetRef::Object(spell)];
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &chained, &mut events, 0)
+        .expect("resolve double-counter chain");
+
+    // Pay both {3} prompts.
+    for which in ["first", "second"] {
+        assert!(
+            matches!(
+                runner.state().waiting_for,
+                WaitingFor::UnlessPayment { player: P1, .. }
+            ),
+            "{which} counter mode must prompt P1 for {{3}}, got {:?}",
+            runner.state().waiting_for
+        );
+        runner
+            .act(GameAction::PayUnlessCost { pay: true })
+            .unwrap_or_else(|e| panic!("P1 pays the {which} {{3}}: {e:?}"));
+    }
+
+    // Both {3} paid → the spell survives.
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "paying both {{3}} costs must leave the spell on the stack"
+    );
+    assert!(
+        !runner.state().players[1].graveyard.contains(&spell),
+        "a spell that paid both unless costs must not be countered"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -143,6 +143,7 @@ mod issue_2916_torment_repeat_unless;
 mod issue_2918_future_sight_reveal;
 mod issue_2919_tarrasque_was_cast;
 mod issue_2921_amareth_shares_card_type;
+mod issue_2925_mystic_confluence_repeated_counter;
 mod issue_2929_arc_trail_any_other_target;
 mod issue_2938_deflecting_swat;
 mod issue_2940_krark_thumbless;


### PR DESCRIPTION
Closes #2925

## Problem

Mystic Confluence reads "Choose three. You may choose the same mode more than once." with one mode being "Counter target spell unless its controller pays {3}." Choosing that mode twice against the same spell only demanded a single {3} payment â paying {3} once let the spell resolve, instead of requiring {3} for each chosen instance ({6} total) or countering the spell.

## Root cause

Per CR 700.2d, when a mode is chosen multiple times the spell is treated as if that mode appeared that many times in sequence. `build_chained_resolved` correctly models this: the second counter is appended as a `SequentialSibling` sub-ability of the first, each carrying its own `{3}` unless cost.

The unless-payment handler (`handle_unless_payment`) was asymmetric:

- On the **decline** path it resolved the whole `pending_effect` chain, which followed the `SequentialSibling` sibling and surfaced its own unless prompt.
- On the **pay** path it suppressed the head instruction's effect but only resumed a conditional `IfAPlayerDoes` (`OptionalEffectPerformed`) sub-ability. A plain unconditional `SequentialSibling` sibling â the next independent modal instruction â was silently dropped.

So paying the first {3} dropped the second counter entirely and the spell survived.

## Fix

On the unless-payment success path, after suppressing the head instruction, resume an unconditional `SequentialSibling` sub-chain via `resolve_ability_chain` (CR 608.2c â instructions follow "in the order written"; a sibling is independent of the unless outcome). When the sibling pauses for its own unless prompt (the second {3}), the trigger/SBA pipeline is run and the function returns immediately so the fresh `WaitingFor::UnlessPayment` is not overwritten by the shared post-payment priority reset.

The fix is class-general: any unless-modified instruction followed by an independent sibling now resolves that sibling on the pay path, not just the counter case. It generalizes to N repeats (each paid prompt resumes the next sibling).

## Tests

New `crates/engine/tests/integration/issue_2925_mystic_confluence_repeated_counter.rs`:

- `counter_mode_parses_with_unless_pay_three` â sanity guard that the mode parses to `Counter` with a `{3}` unless cost.
- `paying_three_once_does_not_save_spell_from_double_counter` â the discriminating regression test: paying {3} once surfaces a SECOND independent {3} prompt; declining it counters the spell (fails pre-fix: state went straight to Priority and the spell survived).
- `paying_three_twice_saves_spell_from_double_counter` â paying both {3} ({6} total) leaves the spell on the stack.

Full engine lib suite (11491) and integration suite (912) pass; `cargo clippy -p engine --all-targets -- -D warnings` is clean.

## CR references

- CR 700.2d â a mode chosen multiple times is treated as appearing that many times in sequence.
- CR 608.2c â the controller follows instructions in the order written.
- CR 118.12a â "[Effect] unless [a player does something]" semantics.
