### PR TITLE
build: bump time to 0.3.48 to fix Tauri E0119 conflicting impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1824,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -3133,12 +3132,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3148,15 +3146,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "9d3bfe86347f0cc659f586f01e26303ccd32418f26f30c7b0309b3ca3a07d695"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Problem
CI on `main` is red (the Tauri compile check, which cascades into the aggregate `Rust (fmt, clippy, test, coverage-gate)` job, so every open PR shows two red checks and cannot merge). The failure is:

```
error[E0119]: conflicting implementations of trait `From<...HourBase>`
  for type `<...HourBase as ...ModifierValue>::Type`
```

This is a known regression in `time` **0.3.47** (a duplicate `From` impl), not in our code â our Rust lint, Rust tests, WASM, and Frontend checks all pass; only the Tauri build (which compiles `time` with the affected features) hits it.

## Fix
`cargo update -p time` â bumps the lockfile from `time` 0.3.47 to **0.3.48** (the patch that removes the conflicting impl), along with its companions `time-core` 0.1.8â0.1.9, `time-macros` 0.2.27â0.2.28, and `num-conv` 0.2.1â0.2.2. **Lockfile-only change** â no source or manifest edits.

## Verification
`cargo build -p phase-server` (which pulls `time` via `tracing-appender`) compiles `time v0.3.48` cleanly and finishes â the E0119 is gone. The Tauri compile check on CI will confirm end-to-end.

This unblocks the merge queue for `main` and all open PRs.
