### PR TITLE
fix(engine): apply token-count doubling to copy-token creation

### DIFF
--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 /// CR 707.2 / CR 707.5: Create a token that's a copy of a permanent.
 /// Copies copiable characteristics from the target to a newly created token.
 ///
-/// CR 707.10: When `count` resolves to N > 1, N independent copy-tokens are
+/// CR 707.1: When `count` resolves to N > 1, N independent copy-tokens are
 /// created (e.g., Rite of Replication kicked = 5, Adrix and Nev doubling).
 pub fn resolve(
     state: &mut GameState,
@@ -57,7 +57,8 @@ pub fn resolve(
         ),
         _ => return Err(EffectError::MissingParam("CopyTokenOf".to_string())),
     };
-    let count = resolve_quantity(state, &count_expr, ability.controller, ability.source_id).max(0);
+    let base_count =
+        resolve_quantity(state, &count_expr, ability.controller, ability.source_id).max(0);
 
     // CR 109.4 + CR 111.2: The token's creator (and therefore controller) is
     // determined by the `owner` filter. Resolved once, before the creation
@@ -66,6 +67,36 @@ pub fn resolve(
     // under the chosen opponent's control rather than the trigger controller's.
     let token_owner =
         crate::game::effects::token::resolve_token_owner(state, ability, owner_filter);
+
+    // CR 614.1a + CR 707.1: A copy-token's count is subject to the SAME
+    // `CreateToken` count-doubling replacements (Doubling Season, Parallel
+    // Lives, Anointed Procession, Adrix and Nev, Primal Vigor, Mondrak) that a
+    // predefined `Effect::Token` is. Route the resolved base count through the
+    // single shared authority keyed on the copy's CONTROLLER (`token_owner`,
+    // CR 111.2) — not the ability controller — so "target opponent creates a
+    // copy" doubles for the opponent's doublers, mirroring predefined tokens.
+    // The doubled count then flows into the per-copy loop below, so each
+    // doubled instance independently runs its own ETB / enter-with-counters
+    // body (CR 707.2). CR 616.1f: every MANDATORY doubler is baked in first, so
+    // the count is at least doubled whenever a mandatory doubler is present —
+    // even if an optional ("you may", Mondrak) doubler co-exists. An optional
+    // doubler is a deferral the copy path does not yet plumb: the helper returns
+    // `NeedsChoice { floor, .. }` carrying the already-mandatory-doubled `floor`,
+    // and we decline the optional and use that floor (no panic, no silent forced
+    // optional double — and never below the guaranteed mandatory ×2). A mandatory
+    // `Prevent` replacement (no printed copy-token card uses one today) suppresses
+    // creation entirely.
+    let count = match crate::game::replacement::apply_create_token_count_replacements(
+        state,
+        token_owner,
+        base_count as u32,
+    ) {
+        crate::game::replacement::CountReplacementOutcome::Count(n) => n as i32,
+        crate::game::replacement::CountReplacementOutcome::Prevented => 0,
+        crate::game::replacement::CountReplacementOutcome::NeedsChoice { floor, .. } => {
+            floor as i32
+        }
+    };
 
     // Step 1: Resolve the copy source list.
     // CR 608.2c + 603.10a: LTB self-trigger patterns such as Vaultborn Tyrant
@@ -181,9 +212,9 @@ pub fn resolve(
         return Ok(());
     }
 
-    // CR 707.10 + CR 115.1d: Create `count` independent copy-tokens per copy
-    // source. Each is snapshotted from the source values so that subsequent
-    // SBAs (e.g., legendary rule) see identical copies.
+    // CR 707.1: Create `count` independent copy-tokens per copy source. Each is
+    // snapshotted from the source values so that subsequent SBAs (e.g., legendary
+    // rule) see identical copies.
     let mut created_ids: Vec<ObjectId> = Vec::with_capacity(count as usize * copy_source_ids.len());
     for copy_source_id in &copy_source_ids {
         let copy_source_id = *copy_source_id;
@@ -667,6 +698,372 @@ mod tests {
     use crate::types::keywords::Keyword;
     use crate::types::mana::ManaColor;
     use crate::types::player::PlayerId;
+
+    /// Create a Grizzly-Bears-shaped source creature (2/2 Bear) on the
+    /// battlefield for the copy-doubling tests, returning its id.
+    fn grizzly_bears_source(state: &mut GameState, controller: PlayerId) -> ObjectId {
+        let source_id = create_object(
+            state,
+            CardId(1),
+            controller,
+            "Grizzly Bears".to_string(),
+            Zone::Battlefield,
+        );
+        let s = state.objects.get_mut(&source_id).unwrap();
+        s.base_power = Some(2);
+        s.base_toughness = Some(2);
+        s.power = Some(2);
+        s.toughness = Some(2);
+        s.base_card_types = CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec!["Bear".to_string()],
+        };
+        s.card_types = s.base_card_types.clone();
+        source_id
+    }
+
+    /// Attach a `CreateToken` count-doubling replacement (Doubling-Season shape)
+    /// to a fresh permanent controlled by `controller`. `optional` chooses the
+    /// Mondrak-shape optional mode; otherwise mandatory.
+    fn attach_token_doubler(
+        state: &mut GameState,
+        controller: PlayerId,
+        optional: bool,
+    ) -> ObjectId {
+        use crate::types::ability::{QuantityModification, ReplacementDefinition, ReplacementMode};
+        use crate::types::replacements::ReplacementEvent;
+        let doubler_id = create_object(
+            state,
+            CardId(99),
+            controller,
+            "Token Doubler".to_string(),
+            Zone::Battlefield,
+        );
+        let mut def = ReplacementDefinition::new(ReplacementEvent::CreateToken);
+        def.mode = if optional {
+            ReplacementMode::Optional { decline: None }
+        } else {
+            ReplacementMode::Mandatory
+        };
+        def.quantity_modification = Some(QuantityModification::Double);
+        def.token_owner_scope = Some(crate::types::ability::ControllerRef::You);
+        let obj = state.objects.get_mut(&doubler_id).unwrap();
+        obj.replacement_definitions = std::sync::Arc::new(vec![def]).into();
+        obj.base_replacement_definitions = std::sync::Arc::new(vec![]);
+        doubler_id
+    }
+
+    fn copy_self_ability(source_id: ObjectId, count: i32, controller: PlayerId) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::SpecificObject { id: source_id },
+                owner: TargetFilter::Controller,
+                source_filter: Some(TargetFilter::SpecificObject { id: source_id }),
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: count },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            },
+            vec![],
+            source_id,
+            controller,
+        )
+    }
+
+    fn count_grizzly_copies(state: &GameState) -> usize {
+        state
+            .objects
+            .values()
+            .filter(|o| o.is_token && o.name == "Grizzly Bears")
+            .count()
+    }
+
+    /// CR 614.1a + CR 707.1 (issue #1511 (a)): a single mandatory
+    /// `CreateToken` count-doubler (Doubling-Season shape) keyed to the copy's
+    /// controller doubles `CopyTokenOf { count: 1 }` to exactly 2 copies. Each
+    /// is a correct copy of the source (name / P-T / types) entering
+    /// independently. MUST fail if the fix is reverted (un-doubled count = 1).
+    #[test]
+    fn copy_token_mandatory_doubler_doubles_one_to_two() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        attach_token_doubler(&mut state, PlayerId(0), false);
+
+        let mut events = Vec::new();
+        let ability = copy_self_ability(source_id, 1, PlayerId(0));
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let copies: Vec<_> = state
+            .objects
+            .values()
+            .filter(|o| o.is_token && o.name == "Grizzly Bears")
+            .collect();
+        assert_eq!(
+            copies.len(),
+            2,
+            "a mandatory CreateToken doubler must double CopyTokenOf to 2 copies"
+        );
+        // CR 707.2: each doubled copy carries the source's copiable values and
+        // entered the battlefield independently.
+        for copy in &copies {
+            assert_eq!(copy.power, Some(2));
+            assert_eq!(copy.toughness, Some(2));
+            assert!(copy.card_types.core_types.contains(&CoreType::Creature));
+            assert!(copy.card_types.subtypes.contains(&"Bear".to_string()));
+            assert_eq!(copy.zone, Zone::Battlefield);
+        }
+        // CR 603.6a: each copy emitted its own ETB/TokenCreated pair, so two
+        // independent ETB triggers can fire.
+        let token_created = events
+            .iter()
+            .filter(
+                |e| matches!(e, GameEvent::TokenCreated { name, .. } if name == "Grizzly Bears"),
+            )
+            .count();
+        assert_eq!(
+            token_created, 2,
+            "each doubled copy emits its own TokenCreated"
+        );
+    }
+
+    /// CR 614.1a + CR 707.1 (issue #1511 (b)): doubling applies to the FULL
+    /// base count — base `count: 3` + one mandatory doubler => 6 copies.
+    #[test]
+    fn copy_token_mandatory_doubler_doubles_full_base_count() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        attach_token_doubler(&mut state, PlayerId(0), false);
+
+        let mut events = Vec::new();
+        let ability = copy_self_ability(source_id, 3, PlayerId(0));
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            count_grizzly_copies(&state),
+            6,
+            "doubling applies to the full base count (3 * 2 = 6)"
+        );
+    }
+
+    /// CR 616.1 + CR 707.1 (issue #1511 (c)): two mandatory doublers STACK —
+    /// `CopyTokenOf { count: 1 }` => 4 copies. Proves the fix reuses the real
+    /// replacement stack (folding each applicable replacement) rather than a
+    /// hardcoded ×2.
+    #[test]
+    fn copy_token_two_doublers_stack_to_four() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        attach_token_doubler(&mut state, PlayerId(0), false);
+        attach_token_doubler(&mut state, PlayerId(0), false);
+
+        let mut events = Vec::new();
+        let ability = copy_self_ability(source_id, 1, PlayerId(0));
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            count_grizzly_copies(&state),
+            4,
+            "two mandatory doublers stack (1 * 2 * 2 = 4)"
+        );
+    }
+
+    /// Issue #1511 (d) NON-REGRESSION: with NO doubler, `CopyTokenOf` count is
+    /// unchanged — `count: 1` => 1 copy, `count: 3` => 3 copies. MUST pass both
+    /// pre- and post-fix.
+    #[test]
+    fn copy_token_no_doubler_count_unchanged() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &copy_self_ability(source_id, 1, PlayerId(0)),
+            &mut events,
+        )
+        .unwrap();
+        assert_eq!(
+            count_grizzly_copies(&state),
+            1,
+            "no doubler: count 1 stays 1"
+        );
+
+        // Reset and verify count: 3 stays 3.
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &copy_self_ability(source_id, 3, PlayerId(0)),
+            &mut events,
+        )
+        .unwrap();
+        assert_eq!(
+            count_grizzly_copies(&state),
+            3,
+            "no doubler: count 3 stays 3"
+        );
+    }
+
+    /// CR 111.2 + CR 707.1 (issue #1511 multiplayer): the doubler that applies
+    /// is the one affecting the COPY'S CONTROLLER, not the ability controller.
+    /// PlayerId(0) controls the ability but the copy is created under PlayerId(1)
+    /// (the chosen opponent); only PlayerId(1)'s doubler must double it.
+    #[test]
+    fn copy_token_doubler_keys_on_copy_controller_not_ability_controller() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        // A doubler controlled by the ABILITY controller (PlayerId(0)) must NOT
+        // double a copy created under PlayerId(1).
+        attach_token_doubler(&mut state, PlayerId(0), false);
+
+        let mut events = Vec::new();
+        // "Target opponent creates a token that's a copy of it" — owner resolves
+        // to the chosen opponent PlayerId(1).
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::SpecificObject { id: source_id },
+                owner: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent),
+                ),
+                source_filter: Some(TargetFilter::SpecificObject { id: source_id }),
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            source_id,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert_eq!(
+            count_grizzly_copies(&state),
+            1,
+            "ability-controller's doubler must NOT double a copy owned by the opponent"
+        );
+
+        // Now give the OPPONENT (the copy's controller) a doubler — it must double.
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        attach_token_doubler(&mut state, PlayerId(1), false);
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::SpecificObject { id: source_id },
+                owner: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent),
+                ),
+                source_filter: Some(TargetFilter::SpecificObject { id: source_id }),
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            source_id,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut events).unwrap();
+        let opp_copies = state
+            .objects
+            .values()
+            .filter(|o| o.is_token && o.name == "Grizzly Bears" && o.controller == PlayerId(1))
+            .count();
+        assert_eq!(
+            opp_copies, 2,
+            "the copy controller's (opponent's) doubler doubles the copy"
+        );
+    }
+
+    /// Issue #1511 zero: `count: 0` => no tokens and no doubling artifacts even
+    /// with a doubler present.
+    #[test]
+    fn copy_token_zero_count_with_doubler_creates_nothing() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        attach_token_doubler(&mut state, PlayerId(0), false);
+
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &copy_self_ability(source_id, 0, PlayerId(0)),
+            &mut events,
+        )
+        .unwrap();
+        assert_eq!(
+            count_grizzly_copies(&state),
+            0,
+            "count 0 creates nothing even with a doubler present"
+        );
+        assert!(state.last_created_token_ids.is_empty());
+    }
+
+    /// CR 616.1 (issue #1511 optional doubler — DOCUMENTED DEFERRAL): an
+    /// optional ("you may", Mondrak shape) `CreateToken` doubler on the copy
+    /// path returns `NeedsChoice` from the shared count helper, which the copy
+    /// resolver does NOT plumb. The documented behavior is a clean fall-back to
+    /// the un-doubled base count: the resolver must NOT panic or mis-resolve.
+    /// (Mandatory doublers — the primary issue #1511 class — are fully handled;
+    /// the optional-doubler choice plumbing for the copy path is deferred.)
+    #[test]
+    fn copy_token_optional_doubler_falls_back_to_base_count_no_panic() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        attach_token_doubler(&mut state, PlayerId(0), true);
+
+        let mut events = Vec::new();
+        // Must not panic; falls back to the un-doubled base count (1 copy).
+        resolve(
+            &mut state,
+            &copy_self_ability(source_id, 1, PlayerId(0)),
+            &mut events,
+        )
+        .unwrap();
+        assert_eq!(
+            count_grizzly_copies(&state),
+            1,
+            "optional doubler is deferred: copy path falls back to the base count without panicking"
+        );
+    }
+
+    /// CR 616.1f (issue #1511 mandatory floor): when a MANDATORY doubler
+    /// (Doubling-Season shape) co-exists with an OPTIONAL ("you may", Mondrak
+    /// shape) doubler on the copy's controller, the mandatory replacement still
+    /// applies (CR 616.1f: each applicable replacement is applied in turn until
+    /// none remain), so `CopyTokenOf { count: 1 }` yields AT LEAST 2 copies. The
+    /// optional doubler is the deferral the copy path declines — but it must NOT
+    /// cause the guaranteed mandatory ×2 to be dropped. This fails on the
+    /// pre-fix code (which short-circuited to `NeedsChoice` on the first optional
+    /// candidate and fell back to the un-doubled base count = 1 copy).
+    #[test]
+    fn copy_token_mandatory_floor_survives_co_present_optional_doubler() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = grizzly_bears_source(&mut state, PlayerId(0));
+        // Both controlled by the copy's controller (PlayerId(0)): one mandatory,
+        // one optional. The mandatory ×2 must be honored regardless of the
+        // optional doubler that the copy path declines.
+        attach_token_doubler(&mut state, PlayerId(0), false); // mandatory
+        attach_token_doubler(&mut state, PlayerId(0), true); // optional
+
+        let mut events = Vec::new();
+        resolve(
+            &mut state,
+            &copy_self_ability(source_id, 1, PlayerId(0)),
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            count_grizzly_copies(&state) >= 2,
+            "a mandatory doubler's ×2 floor must survive a co-present optional doubler \
+             (got {}, expected >= 2)",
+            count_grizzly_copies(&state)
+        );
+    }
 
     /// CR 707.9b + CR 707.9d: a copy token whose exception sets P/T, replaces
     /// color, and replaces creature subtypes (The Scarab God shape) stamps each

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1347,6 +1347,179 @@ fn remove_counter_applier(
 
 // --- 9. CreateToken ---
 
+/// CR 614.1a: The single authority for how a `QuantityModification` scales a
+/// token-creation count. `None` modification leaves the count unchanged; a
+/// `Prevent` modification returns `None` to signal the creation event is fully
+/// suppressed (CR 614.6 + CR 614.7). Both the predefined-token applier
+/// (`create_token_applier`) and the copy-token count path
+/// (`apply_create_token_count_replacements`) fold doublers through here so the
+/// scaling math lives in exactly one place.
+fn apply_token_count_modification(
+    count: u32,
+    modification: Option<&crate::types::ability::QuantityModification>,
+) -> Option<u32> {
+    use crate::types::ability::QuantityModification;
+    match modification {
+        Some(QuantityModification::Double) => Some(count.saturating_mul(2)),
+        Some(QuantityModification::Plus { value }) => Some(count.saturating_add(*value)),
+        Some(QuantityModification::Minus { value }) => Some(count.saturating_sub(*value)),
+        // CR 614.6 + CR 614.7: the proposed creation event never happens.
+        Some(QuantityModification::Prevent) => None,
+        None => Some(count),
+    }
+}
+
+/// CR 614.1a + CR 707.1: The outcome of folding every applicable `CreateToken`
+/// count-modification replacement (Doubling Season, Parallel Lives, Anointed
+/// Procession, Adrix and Nev, Primal Vigor, Mondrak, …) into a base token count
+/// for a given creating player. Mirrors `ReplacementResult` but is specialized
+/// to the count axis: the copy-token path materializes the copies itself
+/// (CR 707.2 — each copy carries the live source's copiable values), so no
+/// `ProposedEvent` is threaded back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CountReplacementOutcome {
+    /// The base count after all mandatory count-modifications were folded in.
+    Count(u32),
+    /// CR 614.6 + CR 614.7: a `Prevent` replacement suppressed the creation —
+    /// no tokens are created.
+    Prevented,
+    /// CR 616.1 + CR 614.7: at least one optional ("you may", Mondrak)
+    /// replacement co-exists with the (already-applied) mandatory doublers, and
+    /// resolving that optional choice is a deferral the copy-token path does not
+    /// yet plumb. The carried `floor` is the base count AFTER folding in every
+    /// mandatory doubler (CR 616.1f: each mandatory replacement still applies) —
+    /// the copy path declines the optional and uses this mandatory floor, so a
+    /// guaranteed mandatory ×2 is never dropped just because an optional doubler
+    /// is also present. `affected` is the player who would make the deferred
+    /// optional choice.
+    NeedsChoice { affected: PlayerId, floor: u32 },
+}
+
+/// CR 614.1a + CR 616.1 + CR 707.1: Apply the `CreateToken` count-modification
+/// replacements that affect a token created under `owner`'s control to a
+/// `base_count`, reusing the live replacement pipeline's candidate finder,
+/// owner-scope matching, optional-mode detection, and ordering-material check.
+///
+/// This is the single shared authority for token-count doubling on the
+/// `Effect::CopyTokenOf` path. It deliberately applies ONLY the
+/// `quantity_modification` axis of each `CreateToken` replacement — the
+/// spec-based axes (`additional_token_spec` → Chatterfang Squirrels,
+/// `ensure_token_specs` → Manufactor, `token_owner_redirect` → Crafty Cutpurse)
+/// are intentionally NOT evaluated here, because a copy-token carries the live
+/// source's copiable values (CR 707.2) and must be materialized through the
+/// copy loop, never through the predefined `TokenSpec` apply path. Routing a
+/// full `ProposedEvent::CreateToken` through `replace_event` would otherwise
+/// spawn those spurious predefined tokens on the copy. The count math itself
+/// flows through `apply_token_count_modification`, the same helper
+/// `create_token_applier` uses, so predefined and copy tokens double by one
+/// authority.
+///
+/// CR 616.1f: the applicable candidates are partitioned by
+/// `replacement_mode_is_optional` (the SAME predicate the predefined-token
+/// pipeline uses in `token_creation_needs_choice`), then EVERY mandatory
+/// doubler is folded into `base_count` first — a mandatory ×2 is therefore
+/// always baked in and never dropped just because an optional doubler also
+/// applies. A mandatory `Prevent` still suppresses creation. Only after the
+/// mandatory fold does an optional choice come into play.
+///
+/// Returns [`CountReplacementOutcome`]: `Count(n)` after all mandatory doublers
+/// (with no optional candidate remaining), `Prevented` for a mandatory `Prevent`
+/// replacement, or `NeedsChoice { affected, floor }` when an optional doubler
+/// co-exists — `floor` is the already-mandatory-doubled count the copy path
+/// falls back to (declining the deferred optional), so the mandatory floor is
+/// honored regardless of any co-present optional doubler.
+pub fn apply_create_token_count_replacements(
+    state: &GameState,
+    owner: PlayerId,
+    base_count: u32,
+) -> CountReplacementOutcome {
+    if base_count == 0 {
+        // CR 609.3 + CR 101.3: nothing to create — no doubling artifacts.
+        return CountReplacementOutcome::Count(0);
+    }
+
+    let registry = build_replacement_registry();
+    // CR 614.1a: A count-only probe. `CreateToken` replacements key purely on
+    // `token_owner_scope` (owner == source controller) — `affected_object_id`
+    // is `None` for token creation, so `valid_card`/characteristic filters
+    // never gate count-doubling. A minimal placeholder spec therefore suffices
+    // to find every applicable count-modification replacement for `owner`.
+    let probe = ProposedEvent::CreateToken {
+        owner,
+        spec: Box::new(crate::types::proposed_event::TokenSpec::placeholder_for_count_probe(owner)),
+        enter_tapped: EtbTapState::Unspecified,
+        count: base_count,
+        applied: HashSet::new(),
+    };
+
+    // NOTE: the placeholder spec carries empty subtypes, so this probe finds
+    // every owner-scoped count doubler (they key only on `token_owner_scope`),
+    // but it cannot evaluate a hypothetical SUBTYPE-conditional
+    // `quantity_modification` count doubler — none exist in the card pool today
+    // (Chatterfang / Manufactor are non-count-axis and handled separately).
+    let candidates = find_applicable_replacements(state, &probe, &registry);
+    if candidates.is_empty() {
+        return CountReplacementOutcome::Count(base_count);
+    }
+
+    // CR 616.1f: Partition the applicable candidates into mandatory vs optional
+    // using `replacement_mode_is_optional` — the SAME predicate the predefined
+    // token pipeline uses in `token_creation_needs_choice`. Mandatory doublers
+    // are folded FIRST (below) so their ×2 floor is always baked in; an optional
+    // ("you may", Mondrak shape) doubler only matters after the mandatory fold.
+    // An object/definition that cannot be resolved is conservatively treated as
+    // optional (mirrors the predefined pipeline's `unwrap_or(true)`).
+    let (mandatory, optional): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|rid| {
+        let is_optional = state
+            .objects
+            .get(&rid.source)
+            .and_then(|o| o.replacement_definitions.get(rid.index))
+            .map(|r| replacement_mode_is_optional(&r.mode))
+            .unwrap_or(true);
+        !is_optional
+    });
+
+    // CR 616.1f: All mandatory candidates apply exactly once regardless of the
+    // order the affected player would pick. The realistic copy-token
+    // count-modification class is one or more `Double`s, which commute, so
+    // applying them in candidate order yields the order-independent result (two
+    // doublers stack to ×4 exactly as predefined tokens do). A hypothetical
+    // non-commuting mandatory mix (Double + Plus — no printed copy-token card
+    // combines these today) is applied in candidate order rather than prompting;
+    // predefined tokens surface the CR 616.1 ordering prompt for that case via
+    // the full pipeline, a refinement the copy path can adopt if such a card
+    // appears. Each modification folds through the shared math authority
+    // (`apply_token_count_modification`). A mandatory `Prevent` still suppresses
+    // creation even if an optional doubler co-exists.
+    let mut count = base_count;
+    for rid in mandatory {
+        let modification = state
+            .objects
+            .get(&rid.source)
+            .and_then(|obj| obj.replacement_definitions.get(rid.index))
+            .and_then(|def| def.quantity_modification.clone());
+        match apply_token_count_modification(count, modification.as_ref()) {
+            Some(n) => count = n,
+            // CR 614.6 + CR 614.7: a mandatory `Prevent` suppresses creation.
+            None => return CountReplacementOutcome::Prevented,
+        }
+    }
+
+    // CR 616.1: with no optional candidate remaining, the mandatory-folded count
+    // is final. Otherwise an optional ("you may") choice is available that the
+    // copy path does not yet plumb — surface it as `NeedsChoice` carrying the
+    // ALREADY-mandatory-doubled `count` as the floor, so the caller declines the
+    // optional but keeps the guaranteed mandatory ×2 (never falls back below it).
+    if optional.is_empty() {
+        CountReplacementOutcome::Count(count)
+    } else {
+        CountReplacementOutcome::NeedsChoice {
+            affected: probe.affected_player(state),
+            floor: count,
+        }
+    }
+}
+
 fn create_token_matcher(event: &ProposedEvent, _source: ObjectId, _state: &GameState) -> bool {
     matches!(event, ProposedEvent::CreateToken { .. })
 }
@@ -1357,7 +1530,6 @@ fn create_token_applier(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
 ) -> ApplyResult {
-    use crate::types::ability::QuantityModification;
     let (modification, additional_spec, ensure_specs, owner_redirect, source_controller) = state
         .objects
         .get(&rid.source)
@@ -1410,18 +1582,20 @@ fn create_token_applier(
         if owner != original_owner {
             spec.controller = owner;
         }
-        // CR 614.1a: Modify token count per replacement effect.
-        let new_count = match modification {
-            Some(QuantityModification::Double) => count.saturating_mul(2),
-            Some(QuantityModification::Plus { value }) => count.saturating_add(value),
-            Some(QuantityModification::Minus { value }) => count.saturating_sub(value),
+        // CR 614.1a: Modify token count per replacement effect through the
+        // single authority for count-replacement math (`apply_token_count_modification`).
+        // Both this predefined-token applier and `Effect::CopyTokenOf`'s copy
+        // path (`apply_create_token_count_replacements`) fold doublers through
+        // the same helper so there is exactly one place that knows how a
+        // `QuantityModification` scales a token-creation count.
+        let new_count = match apply_token_count_modification(count, modification.as_ref()) {
             // CR 614.6 + CR 614.7 + CR 111.1: No printed token-creation
             // replacement uses Prevent today, but the variant composes here for
             // symmetry — fully suppress the token-creation event so any future
             // "tokens can't be created" replacement slots in without re-touching
             // this applier.
-            Some(QuantityModification::Prevent) => return ApplyResult::Prevented,
-            None => count,
+            None => return ApplyResult::Prevented,
+            Some(n) => n,
         };
 
         // CR 614.1a + CR 111.1: "those tokens plus ..." — emit an additional

--- a/crates/engine/src/types/proposed_event.rs
+++ b/crates/engine/src/types/proposed_event.rs
@@ -126,6 +126,47 @@ pub struct TokenSpec {
     pub attach_to: Option<AttachTarget>,
 }
 
+impl TokenSpec {
+    /// CR 614.1a: A minimal placeholder spec for count-only `CreateToken`
+    /// replacement probing on the copy-token path. `CreateToken` count
+    /// replacements (Doubling Season, Parallel Lives, …) key on
+    /// `token_owner_scope` (owner == source controller) and do not read the
+    /// token's characteristics — `ProposedEvent::affected_object_id` is `None`
+    /// for token creation, so no `valid_card`/characteristic filter gates
+    /// count-doubling. This placeholder therefore carries only the creating
+    /// player's identity; it is never materialized into an object (the copy
+    /// loop materializes copies from the live source per CR 707.2).
+    ///
+    /// Limitation: the placeholder carries EMPTY subtypes, so it correctly finds
+    /// all owner-scoped count doublers (which key only on `token_owner_scope`),
+    /// but it cannot evaluate a hypothetical SUBTYPE-conditional
+    /// `quantity_modification` count doubler. None exist in the card pool today
+    /// (Chatterfang / Manufactor are non-count-axis and handled separately).
+    pub fn placeholder_for_count_probe(owner: PlayerId) -> Self {
+        TokenSpec {
+            characteristics: TokenCharacteristics {
+                display_name: String::new(),
+                power: None,
+                toughness: None,
+                core_types: Vec::new(),
+                subtypes: Vec::new(),
+                supertypes: Vec::new(),
+                colors: Vec::new(),
+                keywords: Vec::new(),
+            },
+            script_name: String::new(),
+            static_abilities: Vec::new(),
+            enter_with_counters: Vec::new(),
+            tapped: false,
+            enters_attacking: false,
+            sacrifice_at: None,
+            source_id: ObjectId(0),
+            controller: owner,
+            attach_to: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ProposedEvent {
     ZoneChange {


### PR DESCRIPTION
Fixes #1511.

## Problem

`Effect::CopyTokenOf` resolved a raw count and materialized the copies directly, bypassing the `CreateToken` count-doubling replacement that predefined `Effect::Token` creation runs through `replacement::replace_event`. As a result, token-count-doubling replacements had **no effect on copy-tokens**: with Doubling Season / Parallel Lives / Anointed Procession / Adrix and Nev / Primal Vigor on the battlefield, a "create a token that's a copy of â¦" effect produced one copy instead of two.

This affected the whole class â every count doubler Ã every copy-token effect â not just Adrix.

## Fix

Single shared authority for token-count scaling, reused by both paths:

- Extracted `apply_token_count_modification(count, modification)` as the one place that scales a token-creation count (`Double` â Ã2, `Plus`/`Minus`, `Prevent` â suppress), and refactored the predefined-token applier (`create_token_applier`) to call it â so predefined and copy tokens double through identical math.
- Added `apply_create_token_count_replacements(state, owner, base_count)`, which reuses the live pipeline's `find_applicable_replacements` + owner-scope matching, restricted to the count axis via a non-materialized placeholder probe spec. Count doublers key only on `token_owner_scope`, so the probe finds every applicable one without carrying copy characteristics (and without spawning spurious spec-based tokens the way the full `replace_event` path would for Chatterfang/Manufactor).
- `token_copy::resolve` routes its resolved count through that helper, keyed on the **copy's controller** (`token_owner`), and the doubled count flows into the existing per-copy loop â so each copy still independently snapshots its copiable values (CR 707.2) and runs its own ETB / enter-with-counters.

Mandatory doublers are folded **before** any optional short-circuit: a co-present optional doubler (Mondrak) returns `NeedsChoice { floor }` carrying the mandatory-doubled count, and the resolver falls back to that floor â so a guaranteed mandatory multiplier is never dropped when an optional doubler is also present. Multiple mandatory doublers stack.

Optional-doubler choice plumbing for the copy path is a documented deferral: an optional-alone doubler declines to the base count (deterministic, no panic). No printed card requires offering the choice on a copy-token effect today.

CR 707.1 / 707.2 (token copies, copiable values), CR 614.1a / 616.1f (replacement application â each mandatory replacement applies in turn). Also corrects a pre-existing `CR 707.10` misattribution (that rule governs copying a spell/ability onto the stack) in `token_copy.rs`.

## Tests

`crates/engine/src/game/effects/token_copy.rs` (inline module, drives `resolve` directly against imperatively-built state, matching the file's established pattern):

- mandatory doubler + `CopyTokenOf { count: 1 }` â 2 independent copies (asserts 2 `TokenCreated`);
- base count 3 + mandatory doubler â 6 (doubling applies to full base);
- two mandatory doublers stack â 4 (proves it's the real replacement stack, not a hardcoded Ã2);
- mandatory + optional doubler â â¥ 2 (mandatory floor survives a co-present optional â the regression this fix closes);
- doubler keys on the copy's controller, not the ability controller (opponent's doubler doubles an opponent-owned copy; the ability controller's does not);
- non-regression: no doubler â exactly the requested count; zero count + doubler â nothing.

Predefined-token doubling and the Chatterfang/Manufactor batch paths are covered by the existing `replacement` / `token_doubling` suites and remain green.

Verified locally (engine): `token_copy` 31 passed, `game::replacement` 119 passed, `token_doubling` 3 passed, `clippy -p engine --lib` clean.
