### PR TITLE
fix: Inti reflexive counter after interactive discard (#1328)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1043,6 +1043,9 @@ fn try_begin_reflexive_target_selection(
         reflexive.target_selection_mode,
         crate::types::ability::TargetSelectionMode::Random
     ) {
+        // CR 115.1d + CR 603.12: Random-mode reflexive triggers still choose
+        // the targets for the reflexive triggered ability; the seeded RNG
+        // supplies that choice without entering an interactive prompt.
         let chosen = crate::game::ability_utils::random_select_targets_for_ability(
             state,
             &target_slots,
@@ -1051,18 +1054,10 @@ fn try_begin_reflexive_target_selection(
         .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
         let mut reflexive_clone = reflexive.clone();
         if let Some(parent) = parent {
-            apply_parent_chain_context(
-                &mut reflexive_clone,
-                parent,
-                effect_context_object,
-            );
+            apply_parent_chain_context(&mut reflexive_clone, parent, effect_context_object);
         }
-        crate::game::ability_utils::assign_targets_in_chain(
-            state,
-            &mut reflexive_clone,
-            &chosen,
-        )
-        .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
+        crate::game::ability_utils::assign_targets_in_chain(state, &mut reflexive_clone, &chosen)
+            .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
         resolve_ability_chain(state, &reflexive_clone, events, depth + 1)?;
         return Ok(true);
     }
@@ -1077,11 +1072,7 @@ fn try_begin_reflexive_target_selection(
 
     let mut reflexive_clone = reflexive.clone();
     if let Some(parent) = parent {
-        apply_parent_chain_context(
-            &mut reflexive_clone,
-            parent,
-            effect_context_object,
-        );
+        apply_parent_chain_context(&mut reflexive_clone, parent, effect_context_object);
     }
     let trigger_description = reflexive_clone
         .description
@@ -1104,10 +1095,12 @@ fn try_begin_reflexive_target_selection(
         description: trigger_description.clone(),
         may_trigger_origin: None,
         subject_match_count: None,
+        // CR 706.2 + CR 603.12: capture the live die-roll result from the
+        // creating ability so the reflexive entry can re-stamp it when it
+        // resolves as its own stack object.
         die_result: state.die_result_this_resolution,
     };
-    let trigger_events =
-        crate::game::triggers::take_pending_trigger_event_batch(state, &pending);
+    let trigger_events = crate::game::triggers::take_pending_trigger_event_batch(state, &pending);
     let pending_for_state = pending.clone();
     let entry_id = crate::game::triggers::push_pending_trigger_to_stack_with_event_batch(
         state,
@@ -1117,6 +1110,9 @@ fn try_begin_reflexive_target_selection(
     );
     state.pending_trigger = Some(pending_for_state);
     state.pending_trigger_entry = Some(entry_id);
+    // CR 115.1d + CR 603.3d: the reflexive triggered ability is on the stack
+    // before targets are chosen; finalization mutates this pending entry once
+    // the controller completes TriggerTargetSelection.
     state.waiting_for = WaitingFor::TriggerTargetSelection {
         player: controller,
         target_slots,
@@ -4172,14 +4168,8 @@ fn resolve_chain_body(
         if matches!(
             condition,
             AbilityCondition::WhenYouDo | AbilityCondition::QuantityCheck { .. }
-        ) && try_begin_reflexive_target_selection(
-            state,
-            ability,
-            None,
-            None,
-            events,
-            depth,
-        )? {
+        ) && try_begin_reflexive_target_selection(state, ability, None, None, events, depth)?
+        {
             return Ok(());
         }
     }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1018,6 +1018,117 @@ fn is_public_zone(zone: crate::types::zones::Zone) -> bool {
     )
 }
 
+/// CR 603.12: Begin reflexive target selection for a `WhenYouDo` /
+/// `QuantityCheck` ability whose targets were deferred to resolution time.
+/// Returns `true` when `WaitingFor::TriggerTargetSelection` (or inline random
+/// resolution) was entered.
+fn try_begin_reflexive_target_selection(
+    state: &mut GameState,
+    reflexive: &ResolvedAbility,
+    parent: Option<&ResolvedAbility>,
+    effect_context_object: Option<&CostPaidObjectSnapshot>,
+    events: &mut Vec<GameEvent>,
+    depth: u32,
+) -> Result<bool, EffectError> {
+    if !reflexive.targets.is_empty() {
+        return Ok(false);
+    }
+    let target_slots = crate::game::ability_utils::build_target_slots(state, reflexive)
+        .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
+    if target_slots.is_empty() {
+        return Ok(false);
+    }
+
+    if matches!(
+        reflexive.target_selection_mode,
+        crate::types::ability::TargetSelectionMode::Random
+    ) {
+        let chosen = crate::game::ability_utils::random_select_targets_for_ability(
+            state,
+            &target_slots,
+            &reflexive.target_constraints,
+        )
+        .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
+        let mut reflexive_clone = reflexive.clone();
+        if let Some(parent) = parent {
+            apply_parent_chain_context(
+                &mut reflexive_clone,
+                parent,
+                effect_context_object,
+            );
+        }
+        crate::game::ability_utils::assign_targets_in_chain(
+            state,
+            &mut reflexive_clone,
+            &chosen,
+        )
+        .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
+        resolve_ability_chain(state, &reflexive_clone, events, depth + 1)?;
+        return Ok(true);
+    }
+
+    let selection = crate::game::ability_utils::begin_target_selection_for_ability(
+        state,
+        reflexive,
+        &target_slots,
+        &reflexive.target_constraints,
+    )
+    .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
+
+    let mut reflexive_clone = reflexive.clone();
+    if let Some(parent) = parent {
+        apply_parent_chain_context(
+            &mut reflexive_clone,
+            parent,
+            effect_context_object,
+        );
+    }
+    let trigger_description = reflexive_clone
+        .description
+        .clone()
+        .or_else(|| parent.and_then(|p| p.description.clone()));
+    let source_id = parent.map(|p| p.source_id).unwrap_or(reflexive.source_id);
+    let controller = parent.map(|p| p.controller).unwrap_or(reflexive.controller);
+
+    let pending = crate::game::triggers::PendingTrigger {
+        source_id,
+        controller,
+        condition: None,
+        ability: reflexive_clone,
+        timestamp: state.turn_number,
+        target_constraints: reflexive.target_constraints.clone(),
+        distribute: None,
+        trigger_event: state.current_trigger_event.clone(),
+        modal: None,
+        mode_abilities: vec![],
+        description: trigger_description.clone(),
+        may_trigger_origin: None,
+        subject_match_count: None,
+        die_result: state.die_result_this_resolution,
+    };
+    let trigger_events =
+        crate::game::triggers::take_pending_trigger_event_batch(state, &pending);
+    let pending_for_state = pending.clone();
+    let entry_id = crate::game::triggers::push_pending_trigger_to_stack_with_event_batch(
+        state,
+        pending,
+        trigger_events,
+        events,
+    );
+    state.pending_trigger = Some(pending_for_state);
+    state.pending_trigger_entry = Some(entry_id);
+    state.waiting_for = WaitingFor::TriggerTargetSelection {
+        player: controller,
+        target_slots,
+        mode_labels: Vec::new(),
+        target_constraints: reflexive.target_constraints.clone(),
+        selection,
+        source_id: Some(source_id),
+        description: trigger_description,
+    };
+    Ok(true)
+}
+
 fn apply_parent_chain_context(
     child: &mut ResolvedAbility,
     parent: &ResolvedAbility,
@@ -4053,6 +4164,24 @@ fn resolve_chain_body(
             }
             return Ok(());
         }
+        // CR 603.12: A `WhenYouDo` / `QuantityCheck` ability resumed from
+        // `pending_continuation` (e.g. Inti's attack trigger after an
+        // interactive `DiscardChoice`) carries its gate on `ability.condition`
+        // itself, not as a parent's `sub_ability`. Mirror the reflexive target
+        // selection path used for inline sub-chains.
+        if matches!(
+            condition,
+            AbilityCondition::WhenYouDo | AbilityCondition::QuantityCheck { .. }
+        ) && try_begin_reflexive_target_selection(
+            state,
+            ability,
+            None,
+            None,
+            events,
+            depth,
+        )? {
+            return Ok(());
+        }
     }
 
     // CR 608.2d + CR 101.4: "Any opponent may" — prompt opponents in APNAP order.
@@ -4944,125 +5073,19 @@ fn resolve_chain_body(
                 state.chain_tracked_set_id = None;
             }
 
-            // CR 603.12: When a deferred conditional sub-ability (WhenYouDo,
-            // QuantityCheck) has its condition met and needs player-selected targets,
-            // create a reflexive trigger that goes on the stack for target selection.
-            // Targets were not pre-collected (see defers_conditional_target_selection
-            // in ability_utils), so we must collect them now.
+            // CR 603.12: Deferred reflexive target selection for inline sub-chains.
             if matches!(
                 condition,
                 AbilityCondition::WhenYouDo | AbilityCondition::QuantityCheck { .. }
-            ) && sub.targets.is_empty()
-            {
-                let target_slots = crate::game::ability_utils::build_target_slots(state, sub)
-                    .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
-                if !target_slots.is_empty() {
-                    // CR 115.1 + CR 701.9b: Random-mode reflexive triggers (WhenYouDo /
-                    // QuantityCheck) auto-resolve via the seeded RNG. Same shape as
-                    // casting/activation: no `WaitingFor::TriggerTargetSelection` is
-                    // emitted; the chosen targets are assigned and the resolution
-                    // continues inline.
-                    if matches!(
-                        sub.target_selection_mode,
-                        crate::types::ability::TargetSelectionMode::Random
-                    ) {
-                        let chosen = crate::game::ability_utils::random_select_targets_for_ability(
-                            state,
-                            &target_slots,
-                            &sub.target_constraints,
-                        )
-                        .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
-                        let mut reflexive = sub.as_ref().clone();
-                        apply_parent_chain_context(
-                            &mut reflexive,
-                            ability,
-                            effect_context_object.as_ref(),
-                        );
-                        crate::game::ability_utils::assign_targets_in_chain(
-                            state,
-                            &mut reflexive,
-                            &chosen,
-                        )
-                        .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
-                        resolve_ability_chain(state, &reflexive, events, depth + 1)?;
-                        return Ok(());
-                    }
-
-                    // Compute selection first — if this fails (no legal targets for a
-                    // required slot), we skip the reflexive trigger cleanly without
-                    // leaving an orphaned pending_trigger.
-                    let selection = crate::game::ability_utils::begin_target_selection_for_ability(
-                        state,
-                        sub,
-                        &target_slots,
-                        &sub.target_constraints,
-                    )
-                    .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
-
-                    let mut reflexive = sub.as_ref().clone();
-                    apply_parent_chain_context(
-                        &mut reflexive,
-                        ability,
-                        effect_context_object.as_ref(),
-                    );
-                    let trigger_description = sub
-                        .description
-                        .clone()
-                        .or_else(|| ability.description.clone());
-                    // CR 601.2c + CR 603.3d: Reflexive triggered ability whose
-                    // target choice is still outstanding. Push the entry to the
-                    // stack FIRST (in mid-construction state — `ability.targets`
-                    // empty), then enter `TriggerTargetSelection`. The on-stack
-                    // entry is identified by `state.pending_trigger_entry` and
-                    // mutated by `engine_stack::finalize_trigger_target_selection`
-                    // when the selection completes. The resolver refuses to
-                    // fire entries identified by `pending_trigger_entry` (see
-                    // `stack::resolve_top`).
-                    let pending = crate::game::triggers::PendingTrigger {
-                        source_id: ability.source_id,
-                        controller: ability.controller,
-                        condition: None,
-                        ability: reflexive,
-                        timestamp: state.turn_number,
-                        target_constraints: sub.target_constraints.clone(),
-                        distribute: None,
-                        trigger_event: state.current_trigger_event.clone(),
-                        modal: None,
-                        mode_abilities: vec![],
-                        description: trigger_description.clone(),
-                        may_trigger_origin: None,
-                        subject_match_count: None,
-                        // CR 706.2 + CR 603.12: capture the live die-roll result
-                        // (still stamped by the inline `roll_die::resolve` of the
-                        // creating ability) onto the reflexive entry so the
-                        // "When you do … the result" sub-ability — which resolves
-                        // on its own stack entry in a later apply() — can re-stamp
-                        // it into resolution scope.
-                        die_result: state.die_result_this_resolution,
-                    };
-                    let trigger_events =
-                        crate::game::triggers::take_pending_trigger_event_batch(state, &pending);
-                    let pending_for_state = pending.clone();
-                    let entry_id =
-                        crate::game::triggers::push_pending_trigger_to_stack_with_event_batch(
-                            state,
-                            pending,
-                            trigger_events,
-                            events,
-                        );
-                    state.pending_trigger = Some(pending_for_state);
-                    state.pending_trigger_entry = Some(entry_id);
-                    state.waiting_for = WaitingFor::TriggerTargetSelection {
-                        player: ability.controller,
-                        target_slots,
-                        mode_labels: Vec::new(),
-                        target_constraints: sub.target_constraints.clone(),
-                        selection,
-                        source_id: Some(ability.source_id),
-                        description: trigger_description,
-                    };
-                    return Ok(());
-                }
+            ) && try_begin_reflexive_target_selection(
+                state,
+                sub,
+                Some(ability),
+                effect_context_object.as_ref(),
+                events,
+                depth,
+            )? {
+                return Ok(());
             }
         }
         // If the effect resolver already set up a pending_continuation without

--- a/crates/engine/tests/integration/issue_1328_inti.rs
+++ b/crates/engine/tests/integration/issue_1328_inti.rs
@@ -15,6 +15,7 @@ use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
 
 use super::rules::AttackTarget;
@@ -160,10 +161,7 @@ fn inti_reflexive_counter_after_interactive_discard_choice() {
         .act(GameAction::DecideOptionalEffect { accept: true })
         .expect("accept optional discard");
     assert!(
-        matches!(
-            runner.state().waiting_for,
-            WaitingFor::DiscardChoice { .. }
-        ),
+        matches!(runner.state().waiting_for, WaitingFor::DiscardChoice { .. }),
         "multiple cards in hand must prompt DiscardChoice before reflexive targeting, got {:?}",
         runner.state().waiting_for
     );
@@ -193,5 +191,14 @@ fn inti_reflexive_counter_after_interactive_discard_choice() {
         p1p1(&runner, attacker),
         1,
         "Inti must put a +1/+1 counter on the attacker after interactive discard"
+    );
+    assert!(
+        runner
+            .state()
+            .objects
+            .get(&attacker)
+            .expect("attacker should remain on battlefield")
+            .has_keyword(&Keyword::Trample),
+        "Inti must also grant trample to the chosen attacker"
     );
 }

--- a/crates/engine/tests/integration/issue_1328_inti.rs
+++ b/crates/engine/tests/integration/issue_1328_inti.rs
@@ -1,0 +1,197 @@
+//! Regression for issue #1328 — Inti, Seneschal of the Sun.
+//!
+//! Oracle (first ability):
+//!   Whenever you attack, you may discard a card. When you do, put a +1/+1
+//!   counter on target attacking creature. It gains trample until end of turn.
+//!
+//! CR 603.12: the +1/+1 counter is a reflexive triggered ability that targets
+//! an attacking creature when the optional discard is performed.
+//!
+//! https://github.com/phase-rs/phase/issues/1328
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+const INTI_ATTACK_ABILITY: &str = "Whenever you attack, you may discard a card. When you do, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.";
+
+#[test]
+fn inti_attack_trigger_ast_has_reflexive_counter_after_optional_discard() {
+    use engine::parser::oracle::parse_oracle_text;
+    use engine::types::ability::{AbilityCondition, Effect};
+
+    let parsed = parse_oracle_text(
+        INTI_ATTACK_ABILITY,
+        "Inti, Seneschal of the Sun",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Knight".to_string()],
+    );
+    let execute = parsed
+        .triggers
+        .first()
+        .and_then(|t| t.execute.as_ref())
+        .expect("Inti must parse an attack trigger");
+
+    assert!(
+        matches!(*execute.effect, Effect::Discard { .. }),
+        "root effect must be optional discard, got {:?}",
+        execute.effect
+    );
+    assert!(execute.optional, "discard must be optional");
+    let sub = execute
+        .sub_ability
+        .as_ref()
+        .expect("discard must chain to reflexive sub-ability");
+    assert_eq!(
+        sub.condition,
+        Some(AbilityCondition::WhenYouDo),
+        "reflexive sub must be gated by WhenYouDo"
+    );
+    assert!(
+        matches!(*sub.effect, Effect::PutCounter { .. }),
+        "reflexive sub root must put a counter, got {:?}",
+        sub.effect
+    );
+}
+
+fn p1p1(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .and_then(|obj| obj.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+#[test]
+fn inti_reflexive_counter_prompts_for_attacking_creature_after_discard() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Inti, Seneschal of the Sun", 2, 2, INTI_ATTACK_ABILITY);
+    let attacker = scenario.add_creature(P0, "Attacker", 2, 2).id();
+    let _hand_card = scenario.add_card_to_hand(P0, "Hand Card");
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("declare attackers");
+    runner.pass_both_players();
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept optional discard");
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "reflexive ability must prompt for an attacking creature target after discard, got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+#[test]
+fn inti_reflexive_counter_puts_plus_one_on_chosen_attacker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Inti, Seneschal of the Sun", 2, 2, INTI_ATTACK_ABILITY);
+    let attacker = scenario.add_creature(P0, "Attacker", 2, 2).id();
+    let _hand_card = scenario.add_card_to_hand(P0, "Hand Card");
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("declare attackers");
+    runner.pass_both_players();
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept optional discard");
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(attacker)),
+        })
+        .expect("choose attacking creature for reflexive counter");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        p1p1(&runner, attacker),
+        1,
+        "Inti's reflexive ability must put a +1/+1 counter on the chosen attacker"
+    );
+}
+
+#[test]
+fn inti_reflexive_counter_after_interactive_discard_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Inti, Seneschal of the Sun", 2, 2, INTI_ATTACK_ABILITY);
+    let attacker = scenario.add_creature(P0, "Attacker", 2, 2).id();
+    let discard_a = scenario.add_card_to_hand(P0, "Discard A");
+    let _discard_b = scenario.add_card_to_hand(P0, "Discard B");
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("declare attackers");
+    runner.pass_both_players();
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept optional discard");
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DiscardChoice { .. }
+        ),
+        "multiple cards in hand must prompt DiscardChoice before reflexive targeting, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![discard_a],
+        })
+        .expect("choose card to discard");
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "reflexive ability must prompt for attacking creature after discard resolves, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(attacker)),
+        })
+        .expect("choose attacking creature");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        p1p1(&runner, attacker),
+        1,
+        "Inti must put a +1/+1 counter on the attacker after interactive discard"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -96,6 +96,7 @@ mod issue_1305_thalisse_tokens_created_this_turn;
 mod issue_1308_unstoppable_plan;
 mod issue_1312_prepared_spell_cast_triggers;
 mod issue_1326_tabernacle_upkeep_destroy;
+mod issue_1328_inti;
 mod issue_1354_coveted_jewel;
 mod issue_1374_atraxa_grand_unifier;
 mod issue_1499_arabella;


### PR DESCRIPTION
## Summary

- When Inti's attack trigger pauses on `DiscardChoice` (hand size > 1), the stashed `WhenYouDo` continuation now surfaces `TriggerTargetSelection` for the attacking creature instead of silently completing.
- Extract `try_begin_reflexive_target_selection` so inline sub-chains and resumed continuations share one reflexive targeting path (CR 603.12).
- Add integration coverage for auto-discard and interactive-discard paths.

Fixes #1328

## Test plan

- [x] `cargo test -p engine inti --test integration`
- [x] `cargo test -p engine optional_discard_if_you_do --lib`


Made with [Cursor](https://cursor.com)