### PR TITLE
fix(engine): bind "for as long as it has a counter" to the recipient

### DIFF
--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -339,6 +339,76 @@ mod tests {
         )
     }
 
+    /// CR 611.2b + CR 122.1c: Shield Broker — "put a shield counter on target
+    /// noncommander creature you don't control. You gain control of that
+    /// creature for as long as it has a shield counter on it." The control TCE's
+    /// `ForAsLongAs { RecipientHasCounters(shield) }` duration must be evaluated
+    /// against the CONTROLLED creature (the recipient), not the source (Shield
+    /// Broker has no shield counter). Issue #2855: pre-fix the source-scoped
+    /// `HasCounters` check failed immediately, so control never transferred.
+    #[test]
+    fn shield_broker_etb_places_counter_and_transfers_control() {
+        use crate::game::ability_utils::build_resolved_from_def_with_targets;
+        use crate::game::effects::resolve_ability_chain;
+        use crate::game::layers::evaluate_layers;
+        use crate::parser::oracle_trigger::parse_trigger_line;
+        use crate::types::card_type::CoreType;
+        use crate::types::counter::CounterType;
+
+        let mut state = GameState::new_two_player(42);
+        let broker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Shield Broker".to_string(),
+            Zone::Battlefield,
+        );
+        let target = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opp Creature".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let o = state.objects.get_mut(&target).unwrap();
+            o.card_types.core_types = vec![CoreType::Creature];
+            o.base_card_types = o.card_types.clone();
+            o.power = Some(2);
+            o.toughness = Some(2);
+            o.base_power = Some(2);
+            o.base_toughness = Some(2);
+        }
+
+        let def = parse_trigger_line(
+            "When this creature enters, put a shield counter on target noncommander creature you don't control. You gain control of that creature for as long as it has a shield counter on it.",
+            "Shield Broker",
+        );
+        let ability = def.execute.as_ref().expect("execute ability");
+        let resolved = build_resolved_from_def_with_targets(
+            ability,
+            broker,
+            PlayerId(0),
+            vec![TargetRef::Object(target)],
+        );
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &resolved, &mut events, 0).expect("ETB resolves");
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let obj = &state.objects[&target];
+        assert_eq!(
+            obj.counters.get(&CounterType::Shield).copied().unwrap_or(0),
+            1,
+            "a shield counter must be placed on the target"
+        );
+        assert_eq!(
+            obj.controller,
+            PlayerId(0),
+            "control of the target must transfer to Shield Broker's controller while it has a shield counter"
+        );
+    }
+
     /// CR 613.1b: Hellkite Tyrant — "gain control of all artifacts that player
     /// controls". The mass `GainControlAll` enumerates the battlefield, binds
     /// `controller: TargetPlayer` to the effect's player target (the player

--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -407,6 +407,21 @@ mod tests {
             PlayerId(0),
             "control of the target must transfer to Shield Broker's controller while it has a shield counter"
         );
+
+        state
+            .objects
+            .get_mut(&target)
+            .expect("target remains on battlefield")
+            .counters
+            .remove(&CounterType::Shield);
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        assert_eq!(
+            state.objects[&target].controller,
+            PlayerId(1),
+            "control must revert when the recipient no longer has a shield counter"
+        );
     }
 
     /// CR 613.1b: Hellkite Tyrant — "gain control of all artifacts that player

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2492,7 +2492,23 @@ pub(crate) fn gather_transient_continuous_effects(
 
         // CR 611.2b: ForAsLongAs durations embed a condition that must hold each layer cycle.
         if let Duration::ForAsLongAs { ref condition } = tce.duration {
-            if !evaluate_condition(state, condition, tce.controller, tce.source_id) {
+            // CR 611.2b: A recipient-referential condition ("for as long as IT
+            // has a shield counter" — Shield Broker's gain-control) refers to
+            // the object the effect applies to, not the source. For a
+            // single-object effect that object is the affected `SpecificObject`;
+            // evaluate against it so the duration tracks the controlled/granted
+            // creature's counters rather than the (counter-less) source.
+            let holds = match (&tce.affected, condition_uses_recipient_context(condition)) {
+                (TargetFilter::SpecificObject { id }, true) => evaluate_condition_with_recipient(
+                    state,
+                    condition,
+                    tce.controller,
+                    tce.source_id,
+                    *id,
+                ),
+                _ => evaluate_condition(state, condition, tce.controller, tce.source_id),
+            };
+            if !holds {
                 continue;
             }
         }
@@ -2750,8 +2766,21 @@ fn collect_transient_combat_assignment_rule_effects(
             continue;
         }
 
+        // CR 611.2b: see the sibling collection pass above — a recipient
+        // ("for as long as it has a counter") condition evaluates against the
+        // affected `SpecificObject`, not the source.
         if let Duration::ForAsLongAs { ref condition } = tce.duration {
-            if !evaluate_condition(state, condition, tce.controller, tce.source_id) {
+            let holds = match (&tce.affected, condition_uses_recipient_context(condition)) {
+                (TargetFilter::SpecificObject { id }, true) => evaluate_condition_with_recipient(
+                    state,
+                    condition,
+                    tce.controller,
+                    tce.source_id,
+                    *id,
+                ),
+                _ => evaluate_condition(state, condition, tce.controller, tce.source_id),
+            };
+            if !holds {
                 continue;
             }
         }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -27,7 +27,9 @@ use crate::types::card_type::{
 use crate::types::counter::{has_positive_counters, CounterType};
 #[cfg(test)]
 use crate::types::game_state::MayTriggerOrigin;
-use crate::types::game_state::{DayNight, GameState, LayersDirty, StaticGateKey};
+use crate::types::game_state::{
+    DayNight, GameState, LayersDirty, StaticGateKey, TransientContinuousEffect,
+};
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 #[cfg(test)]
@@ -2490,27 +2492,8 @@ pub(crate) fn gather_transient_continuous_effects(
             continue;
         }
 
-        // CR 611.2b: ForAsLongAs durations embed a condition that must hold each layer cycle.
-        if let Duration::ForAsLongAs { ref condition } = tce.duration {
-            // CR 611.2b: A recipient-referential condition ("for as long as IT
-            // has a shield counter" — Shield Broker's gain-control) refers to
-            // the object the effect applies to, not the source. For a
-            // single-object effect that object is the affected `SpecificObject`;
-            // evaluate against it so the duration tracks the controlled/granted
-            // creature's counters rather than the (counter-less) source.
-            let holds = match (&tce.affected, condition_uses_recipient_context(condition)) {
-                (TargetFilter::SpecificObject { id }, true) => evaluate_condition_with_recipient(
-                    state,
-                    condition,
-                    tce.controller,
-                    tce.source_id,
-                    *id,
-                ),
-                _ => evaluate_condition(state, condition, tce.controller, tce.source_id),
-            };
-            if !holds {
-                continue;
-            }
+        if !transient_duration_holds(state, tce) {
+            continue;
         }
 
         let retained_condition = if let Some(condition) = &tce.condition {
@@ -2541,6 +2524,24 @@ pub(crate) fn gather_transient_continuous_effects(
                 characteristic_defining: false,
             });
         }
+    }
+}
+
+fn transient_duration_holds(state: &GameState, tce: &TransientContinuousEffect) -> bool {
+    let Duration::ForAsLongAs { ref condition } = tce.duration else {
+        return true;
+    };
+
+    // CR 611.2b: A recipient-referential condition ("for as long as IT has a
+    // shield counter" — Shield Broker's gain-control) refers to the object the
+    // effect applies to, not the source. For a single-object effect that object
+    // is the affected `SpecificObject`; evaluate against it so the duration
+    // tracks the controlled/granted creature's counters rather than the source.
+    match (&tce.affected, condition_uses_recipient_context(condition)) {
+        (TargetFilter::SpecificObject { id }, true) => {
+            evaluate_condition_with_recipient(state, condition, tce.controller, tce.source_id, *id)
+        }
+        _ => evaluate_condition(state, condition, tce.controller, tce.source_id),
     }
 }
 
@@ -2766,23 +2767,8 @@ fn collect_transient_combat_assignment_rule_effects(
             continue;
         }
 
-        // CR 611.2b: see the sibling collection pass above — a recipient
-        // ("for as long as it has a counter") condition evaluates against the
-        // affected `SpecificObject`, not the source.
-        if let Duration::ForAsLongAs { ref condition } = tce.duration {
-            let holds = match (&tce.affected, condition_uses_recipient_context(condition)) {
-                (TargetFilter::SpecificObject { id }, true) => evaluate_condition_with_recipient(
-                    state,
-                    condition,
-                    tce.controller,
-                    tce.source_id,
-                    *id,
-                ),
-                _ => evaluate_condition(state, condition, tce.controller, tce.source_id),
-            };
-            if !holds {
-                continue;
-            }
+        if !transient_duration_holds(state, tce) {
+            continue;
         }
 
         let retained_condition = if let Some(condition) = &tce.condition {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -33265,7 +33265,7 @@ mod tests {
             matches!(
                 dur,
                 Some(Duration::ForAsLongAs {
-                    condition: StaticCondition::HasCounters {
+                    condition: StaticCondition::RecipientHasCounters {
                         counters: crate::types::counter::CounterMatch::OfType(
                             crate::types::counter::CounterType::Generic(ref name)
                         ),

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1124,7 +1124,7 @@ fn parse_source_enchanted_by_aura_count(input: &str) -> OracleResult<'_, StaticC
 /// single `alt()` so new variants add one arm rather than enumerating
 /// permutations.
 pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticCondition> {
-    let (rest, _) = parse_counter_condition_subject(input)?;
+    let (rest, is_recipient) = parse_counter_condition_subject(input)?;
     let (rest, _) = tag("has ").parse(rest)?;
 
     // Quantity axis: produces (minimum, maximum).
@@ -1144,14 +1144,28 @@ pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticC
 
     let (rest, _) = tag(" on it").parse(rest)?;
 
-    Ok((
-        rest,
+    // CR 122.1 + CR 611.2b: "it has a counter" refers to the object the effect
+    // applies to (the *recipient*) — e.g. "gain control of that creature for as
+    // long as it has a shield counter" (Shield Broker), where "it" is the
+    // controlled creature, not the source. A source-referential subject ("~" /
+    // "this creature", Demon Wall) keeps `HasCounters`. The recipient variant is
+    // evaluated against the affected object by the layer system
+    // (`evaluate_condition_with_recipient`).
+    let condition = if is_recipient {
+        StaticCondition::RecipientHasCounters {
+            counters,
+            minimum,
+            maximum,
+        }
+    } else {
         StaticCondition::HasCounters {
             counters,
             minimum,
             maximum,
-        },
-    ))
+        }
+    };
+
+    Ok((rest, condition))
 }
 
 /// Subject axis for counter-has conditions. Accepts the canonical
@@ -1161,8 +1175,17 @@ pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticC
 /// tapped/combat predicate family (which already uses `"it"` as part of
 /// longer phrases) — scoping the pronoun branch to this combinator avoids
 /// that coupling.
-fn parse_counter_condition_subject(input: &str) -> OracleResult<'_, &str> {
-    alt((parse_source_subject, tag("it "))).parse(input)
+fn parse_counter_condition_subject(input: &str) -> OracleResult<'_, bool> {
+    alt((
+        // "~" / "this creature" — the source permanent carrying the static
+        // (Demon Wall). `false` = source-referential.
+        value(false, parse_source_subject),
+        // The bound pronoun "it" — the recipient/affected object, e.g. the
+        // creature controlled "for as long as it has a counter". `true` =
+        // recipient-referential.
+        value(true, tag("it ")),
+    ))
+    .parse(input)
 }
 
 /// Quantity axis for `parse_source_has_counters`.
@@ -10476,7 +10499,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::HasCounters {
+            StaticCondition::RecipientHasCounters {
                 counters: CounterMatch::Any,
                 minimum: 1,
                 maximum: None,
@@ -10493,7 +10516,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::HasCounters {
+            StaticCondition::RecipientHasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 1,
                 maximum: None,
@@ -10538,7 +10561,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::HasCounters {
+            StaticCondition::RecipientHasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 10,
                 maximum: None,
@@ -10599,7 +10622,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::HasCounters {
+            StaticCondition::RecipientHasCounters {
                 counters: CounterMatch::OfType(CounterType::Generic("charge".to_string())),
                 minimum: 3,
                 maximum: None,
@@ -10616,7 +10639,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::HasCounters {
+            StaticCondition::RecipientHasCounters {
                 counters: CounterMatch::OfType(CounterType::Generic("flood".to_string())),
                 minimum: 1,
                 maximum: None,
@@ -10632,7 +10655,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::HasCounters {
+            StaticCondition::RecipientHasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 2,
                 maximum: Some(2),
@@ -10648,7 +10671,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::HasCounters {
+            StaticCondition::RecipientHasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 0,
                 maximum: Some(2),
@@ -10663,7 +10686,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::HasCounters {
+            StaticCondition::RecipientHasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 0,
                 maximum: Some(0),

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1124,6 +1124,53 @@ fn parse_source_enchanted_by_aura_count(input: &str) -> OracleResult<'_, StaticC
 /// single `alt()` so new variants add one arm rather than enumerating
 /// permutations.
 pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticCondition> {
+    // The shared condition path (intervening-"if" triggers and static gates that
+    // delegate to `parse_inner_condition`) reads the subject as
+    // source-referential: "whenever ~ attacks, if it has three +1/+1 counters on
+    // it" (Ayara's Oathsworn) means the triggering source itself. The
+    // recipient-bound "for as long as it has a counter" reading is the duration
+    // grammar's job — see `parse_recipient_has_counters`.
+    let (rest, (_subject, counters, minimum, maximum)) = parse_has_counters_axes(input)?;
+    Ok((
+        rest,
+        StaticCondition::HasCounters {
+            counters,
+            minimum,
+            maximum,
+        },
+    ))
+}
+
+/// Recipient-bound counterpart to [`parse_source_has_counters`] for
+/// `Duration::ForAsLongAs` clauses. CR 122.1 + CR 611.2b: in "for as long as it
+/// has a shield counter" (Shield Broker) the bound pronoun "it" is the object
+/// the effect applies to (the *recipient* — the controlled creature), not the
+/// source. The recipient variant is evaluated against the affected object by the
+/// layer system (`evaluate_condition_with_recipient`); a source subject ("~" /
+/// "this creature", Demon Wall) still yields `HasCounters`.
+pub(crate) fn parse_recipient_has_counters(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, (subject, counters, minimum, maximum)) = parse_has_counters_axes(input)?;
+    let condition = match subject {
+        CounterConditionSubject::Recipient => StaticCondition::RecipientHasCounters {
+            counters,
+            minimum,
+            maximum,
+        },
+        CounterConditionSubject::Source => StaticCondition::HasCounters {
+            counters,
+            minimum,
+            maximum,
+        },
+    };
+    Ok((rest, condition))
+}
+
+/// Shared grammar axes for the counter-has condition family: subject × quantity
+/// × counter-type noun × `"counter[s]"` × `"on it"`. Each axis is a single
+/// `alt()` so new variants add one arm rather than enumerating permutations.
+fn parse_has_counters_axes(
+    input: &str,
+) -> OracleResult<'_, (CounterConditionSubject, CounterMatch, u32, Option<u32>)> {
     let (rest, subject) = parse_counter_condition_subject(input)?;
     let (rest, _) = tag("has ").parse(rest)?;
 
@@ -1144,27 +1191,7 @@ pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticC
 
     let (rest, _) = tag(" on it").parse(rest)?;
 
-    // CR 122.1 + CR 611.2b: "it has a counter" refers to the object the effect
-    // applies to (the *recipient*) — e.g. "gain control of that creature for as
-    // long as it has a shield counter" (Shield Broker), where "it" is the
-    // controlled creature, not the source. A source-referential subject ("~" /
-    // "this creature", Demon Wall) keeps `HasCounters`. The recipient variant is
-    // evaluated against the affected object by the layer system
-    // (`evaluate_condition_with_recipient`).
-    let condition = match subject {
-        CounterConditionSubject::Recipient => StaticCondition::RecipientHasCounters {
-            counters,
-            minimum,
-            maximum,
-        },
-        CounterConditionSubject::Source => StaticCondition::HasCounters {
-            counters,
-            minimum,
-            maximum,
-        },
-    };
-
-    Ok((rest, condition))
+    Ok((rest, (subject, counters, minimum, maximum)))
 }
 
 /// Subject axis for counter-has conditions. Accepts the canonical
@@ -10494,12 +10521,13 @@ mod tests {
         );
     }
 
-    /// Bound-pronoun subject `"it "` — used by `parse_for_as_long_as_condition`
-    /// in oracle_effect (duration clauses like "has flying for as long as it
-    /// has a flood counter on it").
+    /// Bound-pronoun subject `"it "` — the duration grammar
+    /// (`parse_recipient_has_counters`, used by `Duration::ForAsLongAs` in
+    /// duration.rs for clauses like "has flying for as long as it has a flood
+    /// counter on it") binds "it" to the recipient/affected object.
     #[test]
     fn has_counters_pronoun_subject_it_any() {
-        let (rest, c) = parse_source_has_counters("it has a counter on it").unwrap();
+        let (rest, c) = parse_recipient_has_counters("it has a counter on it").unwrap();
         assert_eq!(rest, "");
         assert_eq!(
             c,
@@ -10511,16 +10539,38 @@ mod tests {
         );
     }
 
+    /// Regression for the coverage-honesty flip (#3084): the bare pronoun "it"
+    /// in an intervening-"if" trigger condition (Ayara's Oathsworn — "whenever ~
+    /// attacks, if it has three or more +1/+1 counters on it, …") is
+    /// source-referential. It must stay `HasCounters` (evaluated against the
+    /// triggering source), not `RecipientHasCounters`, which has no recipient at
+    /// trigger-evaluation time and is silently swallowed by the coverage gate.
+    #[test]
+    fn parse_inner_condition_it_has_counters_is_source_referential() {
+        let (rest, c) = parse_inner_condition("it has three or more +1/+1 counters on it").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            c,
+            StaticCondition::HasCounters {
+                counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+                minimum: 3,
+                maximum: None,
+            }
+        );
+    }
+
     // --- Typed-counter (CounterMatch::OfType) variants -----------------------
 
     /// Unleash / Outlast body: "it has a +1/+1 counter on it" (article → min 1).
+    /// A static-gate "as long as" condition (via `parse_inner_condition`) is
+    /// source-referential: "it" = this creature, evaluated against the source.
     #[test]
     fn test_parse_condition_it_has_a_p1p1_counter() {
         let (rest, c) = parse_condition("as long as it has a +1/+1 counter on it").unwrap();
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::RecipientHasCounters {
+            StaticCondition::HasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 1,
                 maximum: None,
@@ -10565,7 +10615,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::RecipientHasCounters {
+            StaticCondition::HasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 10,
                 maximum: None,
@@ -10626,7 +10676,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::RecipientHasCounters {
+            StaticCondition::HasCounters {
                 counters: CounterMatch::OfType(CounterType::Generic("charge".to_string())),
                 minimum: 3,
                 maximum: None,
@@ -10639,7 +10689,7 @@ mod tests {
         // "flood" is a Generic counter type — verifies the terminator-anchored
         // parser in `parse_typed_counter_noun` falls through to Generic via
         // the canonical mapping rather than failing on unknown named types.
-        let (rest, c) = parse_source_has_counters("it has a flood counter on it").unwrap();
+        let (rest, c) = parse_recipient_has_counters("it has a flood counter on it").unwrap();
         assert_eq!(rest, "");
         assert_eq!(
             c,
@@ -10659,7 +10709,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::RecipientHasCounters {
+            StaticCondition::HasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 2,
                 maximum: Some(2),
@@ -10675,7 +10725,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::RecipientHasCounters {
+            StaticCondition::HasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 0,
                 maximum: Some(2),
@@ -10690,7 +10740,7 @@ mod tests {
         assert_eq!(rest, "");
         assert_eq!(
             c,
-            StaticCondition::RecipientHasCounters {
+            StaticCondition::HasCounters {
                 counters: CounterMatch::OfType(CounterType::Plus1Plus1),
                 minimum: 0,
                 maximum: Some(0),

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1124,7 +1124,7 @@ fn parse_source_enchanted_by_aura_count(input: &str) -> OracleResult<'_, StaticC
 /// single `alt()` so new variants add one arm rather than enumerating
 /// permutations.
 pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticCondition> {
-    let (rest, is_recipient) = parse_counter_condition_subject(input)?;
+    let (rest, subject) = parse_counter_condition_subject(input)?;
     let (rest, _) = tag("has ").parse(rest)?;
 
     // Quantity axis: produces (minimum, maximum).
@@ -1151,18 +1151,17 @@ pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticC
     // "this creature", Demon Wall) keeps `HasCounters`. The recipient variant is
     // evaluated against the affected object by the layer system
     // (`evaluate_condition_with_recipient`).
-    let condition = if is_recipient {
-        StaticCondition::RecipientHasCounters {
+    let condition = match subject {
+        CounterConditionSubject::Recipient => StaticCondition::RecipientHasCounters {
             counters,
             minimum,
             maximum,
-        }
-    } else {
-        StaticCondition::HasCounters {
+        },
+        CounterConditionSubject::Source => StaticCondition::HasCounters {
             counters,
             minimum,
             maximum,
-        }
+        },
     };
 
     Ok((rest, condition))
@@ -1175,15 +1174,20 @@ pub(crate) fn parse_source_has_counters(input: &str) -> OracleResult<'_, StaticC
 /// tapped/combat predicate family (which already uses `"it"` as part of
 /// longer phrases) — scoping the pronoun branch to this combinator avoids
 /// that coupling.
-fn parse_counter_condition_subject(input: &str) -> OracleResult<'_, bool> {
+#[derive(Clone, Copy)]
+enum CounterConditionSubject {
+    Source,
+    Recipient,
+}
+
+fn parse_counter_condition_subject(input: &str) -> OracleResult<'_, CounterConditionSubject> {
     alt((
         // "~" / "this creature" — the source permanent carrying the static
-        // (Demon Wall). `false` = source-referential.
-        value(false, parse_source_subject),
+        // (Demon Wall).
+        value(CounterConditionSubject::Source, parse_source_subject),
         // The bound pronoun "it" — the recipient/affected object, e.g. the
-        // creature controlled "for as long as it has a counter". `true` =
-        // recipient-referential.
-        value(true, tag("it ")),
+        // creature controlled "for as long as it has a counter".
+        value(CounterConditionSubject::Recipient, tag("it ")),
     ))
     .parse(input)
 }

--- a/crates/engine/src/parser/oracle_nom/duration.rs
+++ b/crates/engine/src/parser/oracle_nom/duration.rs
@@ -20,7 +20,7 @@ use nom::combinator::{eof, map, opt, rest, value, verify};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
-use super::condition::{parse_inner_condition, parse_source_has_counters};
+use super::condition::{parse_inner_condition, parse_recipient_has_counters};
 use super::error::OracleResult;
 use super::primitives::scan_contains;
 use crate::types::ability::{Duration, PlayerScope, StaticCondition};
@@ -181,11 +181,14 @@ pub fn parse_for_as_long_as_condition(input: &str) -> OracleResult<'_, Duration>
                 scan_contains(tail, "remains on the battlefield")
             }),
         ),
-        // CR 122.1: "[subject] has [N] [type] counter[s] on it" — delegate to
-        // the shared counter-condition combinator so the typed/bare/quantity
-        // grammar lives in a single authority.
+        // CR 122.1 + CR 611.2b: "[subject] has [N] [type] counter[s] on it" —
+        // delegate to the recipient-aware counter-condition combinator so the
+        // bound pronoun "it" in "for as long as it has a counter" binds to the
+        // affected object (the controlled/granted creature), evaluated by the
+        // layer system. A source subject ("~"/"this creature") stays
+        // `HasCounters`. The typed/bare/quantity grammar lives in one authority.
         map(
-            terminated(parse_source_has_counters, (multispace0, eof)),
+            terminated(parse_recipient_has_counters, (multispace0, eof)),
             |condition| Duration::ForAsLongAs { condition },
         ),
         // Any whole-clause condition the shared condition grammar recognizes.


### PR DESCRIPTION
## What

Shield Broker's ETB — "put a shield counter on target noncommander creature you
don't control. You gain control of that creature for as long as it has a shield
counter on it." — now actually transfers control. Fixes #2855.

## The bug (CR 611.2b)

The ETB parsed correctly (`PutCounter{shield}` + a `GainControl` sub-ability with
a `Duration::ForAsLongAs { HasCounters(shield) }`), the shield counter WAS placed,
but **control never transferred**. The `ForAsLongAs` condition was parsed as the
source-referential `StaticCondition::HasCounters`, and the layer system evaluated
it against the control effect's **source** (Shield Broker — which has no shield
counter). The condition failed on the first layer cycle, so the control TCE was
pruned immediately. "It has a shield counter" refers to the **controlled
creature** (the recipient), not the source.

## The fix

Two coordinated changes:

1. **Parser** (`parse_source_has_counters`): the bound pronoun "it" in
   "for as long as **it** has a [counter]" now lowers to the recipient-scoped
   `StaticCondition::RecipientHasCounters`, while a source-referential subject
   ("~" / "this creature", Demon Wall) keeps `HasCounters`.
2. **Runtime** (`layers.rs`): a `ForAsLongAs` duration whose condition uses
   recipient context (`condition_uses_recipient_context`) and whose effect
   targets a single `SpecificObject` is now evaluated against that object via the
   existing `evaluate_condition_with_recipient` — so the duration tracks the
   controlled/granted creature's counters, not the source's.

For self-referential statics where "it" is the permanent itself (Primordial
Hydra's trample gate, Unleash, Outlast, …), the recipient IS the source, so the
behavior is unchanged — confirmed by the full engine test suite (11,532 pass).

## Tests

- **`shield_broker_etb_places_counter_and_transfers_control`** (runtime): drives
  the parsed ETB through `resolve_ability_chain` + `evaluate_layers` and asserts
  the target gets a shield counter AND its controller becomes Shield Broker's
  controller — pre-fix the counter was placed but control reverted instantly.
- Updated the "it has a counter" condition tests (and the flood-counter
  `ForAsLongAs` duration test) to assert `RecipientHasCounters`.

Closes #2855
