### PR TITLE
Fix Agitator Ant end-step counters and scoped goad (fixes #2903)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2394,6 +2394,11 @@ fn effect_references_tracked_set(effect: &Effect) -> bool {
             return true;
         }
     }
+    if let Effect::GoadAll { target } = effect {
+        if filter_references_tracked_set(target) {
+            return true;
+        }
+    }
     if let Effect::SetTapState {
         scope: EffectScope::All,
         target,
@@ -9275,6 +9280,70 @@ mod tests {
         assert!(
             state.objects.get(&noncreature).unwrap().tapped,
             "non-gained object must not be included in the tracked set"
+        );
+    }
+
+    /// CR 608.2c + CR 701.15a + CR 122.1: when a counter instruction is
+    /// followed by "goad each creature that had counters put on it this way",
+    /// the countered objects publish as the tracked set consumed by GoadAll.
+    #[test]
+    fn put_counter_publishes_tracked_set_for_goad_all_tail() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Agitator Ant".to_string(),
+            Zone::Battlefield,
+        );
+        let countered = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Countered Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let other = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Other Creature".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [countered, other] {
+            state.objects.get_mut(&id).unwrap().card_types.core_types = vec![CoreType::Creature];
+        }
+
+        let goad_countered_this_way = ResolvedAbility::new(
+            Effect::GoadAll {
+                target: TargetFilter::TrackedSetFiltered {
+                    id: TrackedSetId(0),
+                    filter: Box::new(TargetFilter::Typed(TypedFilter::creature())),
+                },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let put_counter = ResolvedAbility::new(
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Typed(TypedFilter::creature()),
+            },
+            vec![TargetRef::Object(countered)],
+            source,
+            PlayerId(0),
+        )
+        .sub_ability(goad_countered_this_way);
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &put_counter, &mut events, 0).unwrap();
+
+        assert!(state.objects[&countered].goaded_by.contains(&PlayerId(0)));
+        assert!(
+            !state.objects[&other].goaded_by.contains(&PlayerId(0)),
+            "only the creature that received counters this way should be goaded"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13786,6 +13786,7 @@ pub(crate) fn each_target_filter_mut(effect: &mut Effect, f: &mut impl FnMut(&mu
         | Effect::Manifest { target, .. }
         | Effect::TargetOnly { target, .. } => f(target),
         Effect::PutCounter { target, .. } | Effect::RemoveCounter { target, .. } => f(target),
+        Effect::GoadAll { target } => f(target),
         Effect::ChangeZone { target, .. } | Effect::ChangeZoneAll { target, .. } => f(target),
         Effect::LoseLife {
             target: Some(target),
@@ -13963,6 +13964,11 @@ fn rewrite_player_scope_refs(def: &mut AbilityDefinition) {
     }
 
     each_quantity_expr_mut(&mut def.effect, &mut rewrite_quantity_expr);
+    // CR 608.2 + CR 109.5: Rebind `You`-scoped target filters (e.g. "a creature
+    // they control" when `relative_player_scope` was unset at parse time) to
+    // `ScopedPlayer` so each-player iterations act on the iterated player's
+    // permanents — Agitator Ant's optional counter placement (issue #2903).
+    each_target_filter_mut(&mut def.effect, &mut rewrite_filter_controller_to_scoped);
     if let Some(condition) = def.condition.as_mut() {
         rewrite_condition(condition);
     }
@@ -24336,6 +24342,46 @@ mod tests {
             matches!(&*execute.effect, Effect::Discard { .. }),
             "expected Discard, got {:?}",
             execute.effect
+        );
+    }
+
+    #[test]
+    fn agitator_ant_end_step_counters_and_goad_parsed() {
+        // Issue #2903: optional per-player counter placement on each player's
+        // creature, then goad only creatures that received counters this way.
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "At the beginning of your end step, each player may put two +1/+1 counters on a creature they control. Goad each creature that had counters put on it this way.",
+            "Agitator Ant",
+            &[],
+            &["Creature".to_string()],
+            &["Insect".to_string()],
+        );
+        let execute = parsed.triggers[0]
+            .execute
+            .as_deref()
+            .expect("Agitator Ant trigger execute");
+        assert!(
+            execute.optional,
+            "counter placement must be optional (each player MAY)"
+        );
+        assert_eq!(execute.player_scope, Some(PlayerFilter::All));
+        let Effect::PutCounter { target, .. } = execute.effect.as_ref() else {
+            panic!("expected PutCounter, got {:?}", execute.effect);
+        };
+        assert_eq!(
+            *target,
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::ScopedPlayer))
+        );
+        let sub = execute.sub_ability.as_ref().expect("goad sub_ability");
+        let Effect::GoadAll { target } = sub.effect.as_ref() else {
+            panic!("expected GoadAll, got {:?}", sub.effect);
+        };
+        assert_eq!(
+            *target,
+            TargetFilter::TrackedSetFiltered {
+                id: crate::types::identifiers::TrackedSetId(0),
+                filter: Box::new(TargetFilter::Typed(TypedFilter::creature())),
+            }
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13964,11 +13964,13 @@ fn rewrite_player_scope_refs(def: &mut AbilityDefinition) {
     }
 
     each_quantity_expr_mut(&mut def.effect, &mut rewrite_quantity_expr);
-    // CR 608.2 + CR 109.5: Rebind `You`-scoped target filters (e.g. "a creature
-    // they control" when `relative_player_scope` was unset at parse time) to
-    // `ScopedPlayer` so each-player iterations act on the iterated player's
-    // permanents — Agitator Ant's optional counter placement (issue #2903).
-    each_target_filter_mut(&mut def.effect, &mut rewrite_filter_controller_to_scoped);
+    // CR 608.2 + CR 109.5: Rebind actor-default `You` controllers to
+    // `ScopedPlayer` for each-*player* iterations only. Each-opponent scopes
+    // keep `You` so optional opponent-choice sacrifices ("permanent of their
+    // choice") retain the chooser-as-controller binding (issue #2903).
+    if matches!(def.player_scope, Some(PlayerFilter::All)) {
+        each_target_filter_mut(&mut def.effect, &mut rewrite_filter_controller_to_scoped);
+    }
     if let Some(condition) = def.condition.as_mut() {
         rewrite_condition(condition);
     }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2238,6 +2238,25 @@ pub fn parse_type_phrase_with_ctx<'a>(
         pos += exiled_offset + (remaining_exiled.len() - rest.len());
     }
 
+    // CR 608.2c + CR 122.1: "that had counters put on it this way" — relative-
+    // clause linkage to objects that received counters from the preceding
+    // instruction in the same ability (Agitator Ant: "Goad each creature that
+    // had counters put on it this way"). The resolver publishes the affected
+    // set when counters are placed; `TrackedSetFiltered` intersects it with the
+    // type filter.
+    let mut counters_put_this_way = false;
+    let remaining_counters = lower[pos..].trim_start();
+    let counters_offset = lower[pos..].len() - remaining_counters.len();
+    if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>("that had counters put on it this way"),
+        tag::<_, _, OracleError<'_>>("that had a counter put on it this way"),
+    ))
+    .parse(remaining_counters)
+    {
+        counters_put_this_way = true;
+        pos += counters_offset + (remaining_counters.len() - rest.len());
+    }
+
     // CR 608.2d: "of their choice" / "of his or her choice" — informational qualifier
     // on opponent-choice effects. The actual choice is handled by the WaitingFor state machine.
     let remaining_choice = lower[pos..].trim_start();
@@ -2392,6 +2411,15 @@ pub fn parse_type_phrase_with_ctx<'a>(
     let filter = if exiled_by_source {
         TargetFilter::And {
             filters: vec![filter, TargetFilter::ExiledBySource],
+        }
+    } else {
+        filter
+    };
+
+    let filter = if counters_put_this_way {
+        TargetFilter::TrackedSetFiltered {
+            id: TrackedSetId(0),
+            filter: Box::new(filter),
         }
     } else {
         filter
@@ -2560,6 +2588,7 @@ fn starts_with_type_phrase_lead(text: &str) -> bool {
 fn target_filter_has_meaningful_content(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::Typed(tf) => !tf.type_filters.is_empty() || !tf.properties.is_empty(),
+        TargetFilter::TrackedSet { .. } | TargetFilter::TrackedSetFiltered { .. } => true,
         TargetFilter::Or { filters } | TargetFilter::And { filters } => {
             filters.iter().any(target_filter_has_meaningful_content)
         }
@@ -8012,6 +8041,34 @@ mod tests {
         let (f, rest) = parse_target("cards they own exiled with it");
         assert_eq!(f, TargetFilter::ExiledBySource);
         assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn parse_type_phrase_creature_that_had_counters_put_on_it_this_way() {
+        let (f, rest) = parse_type_phrase("creature that had counters put on it this way");
+        assert_eq!(rest, "", "remainder was {rest:?}");
+        assert_eq!(
+            f,
+            TargetFilter::TrackedSetFiltered {
+                id: TrackedSetId(0),
+                filter: Box::new(TargetFilter::Typed(TypedFilter::creature())),
+            }
+        );
+    }
+
+    /// Issue #2903 — Agitator Ant: goad only creatures that received counters
+    /// from the preceding instruction in the same ability.
+    #[test]
+    fn creature_that_had_counters_put_on_it_this_way_is_tracked_set_filtered() {
+        let (f, rest) = parse_target("creature that had counters put on it this way");
+        assert_eq!(rest, "");
+        assert_eq!(
+            f,
+            TargetFilter::TrackedSetFiltered {
+                id: TrackedSetId(0),
+                filter: Box::new(TargetFilter::Typed(TypedFilter::creature())),
+            }
+        );
     }
 
     /// Issue #547 — Espers to Magicite: "choose up to one target creature card

--- a/crates/engine/tests/integration/issue_2903_agitator_ant.rs
+++ b/crates/engine/tests/integration/issue_2903_agitator_ant.rs
@@ -36,12 +36,7 @@ fn agitator_ant_parsed_trigger_scopes_counters_and_goad() {
     let execute = trigger.execute.as_ref().expect("execute");
     assert!(execute.optional, "counter step must be optional");
     assert_eq!(execute.player_scope, Some(PlayerFilter::All));
-    let Effect::PutCounter {
-        target,
-        count,
-        ..
-    } = execute.effect.as_ref()
-    else {
+    let Effect::PutCounter { target, count, .. } = execute.effect.as_ref() else {
         panic!("expected PutCounter, got {:?}", execute.effect);
     };
     assert_eq!(
@@ -56,10 +51,7 @@ fn agitator_ant_parsed_trigger_scopes_counters_and_goad() {
     let Effect::GoadAll { target } = sub.effect.as_ref() else {
         panic!("expected GoadAll, got {:?}", sub.effect);
     };
-    assert!(matches!(
-        target,
-        TargetFilter::TrackedSetFiltered { .. }
-    ));
+    assert!(matches!(target, TargetFilter::TrackedSetFiltered { .. }));
 }
 
 #[test]

--- a/crates/engine/tests/integration/issue_2903_agitator_ant.rs
+++ b/crates/engine/tests/integration/issue_2903_agitator_ant.rs
@@ -1,0 +1,85 @@
+//! Regression for issue #2903: Agitator Ant end-step counters and goad.
+//!
+//! https://github.com/phase-rs/phase/issues/2903
+//!
+//! Each player may put counters on their own creature; only creatures that
+//! received counters this way are goaded.
+
+use engine::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use engine::types::ability::{
+    ControllerRef, Effect, PlayerFilter, QuantityExpr, TargetFilter, TypedFilter,
+};
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+
+const AGITATOR_ANT_ORACLE: &str = "\
+At the beginning of your end step, each player may put two +1/+1 counters on a creature they control. Goad each creature that had counters put on it this way.";
+
+fn parse_agitator_ant() -> ParsedAbilities {
+    parse_oracle_text(
+        AGITATOR_ANT_ORACLE,
+        "Agitator Ant",
+        &[],
+        &["Creature".to_string()],
+        &["Insect".to_string()],
+    )
+}
+
+#[test]
+fn agitator_ant_parsed_trigger_scopes_counters_and_goad() {
+    let parsed = parse_agitator_ant();
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::Phase && t.phase == Some(Phase::End))
+        .expect("Agitator Ant end step trigger");
+    let execute = trigger.execute.as_ref().expect("execute");
+    assert!(execute.optional, "counter step must be optional");
+    assert_eq!(execute.player_scope, Some(PlayerFilter::All));
+    let Effect::PutCounter {
+        target,
+        count,
+        ..
+    } = execute.effect.as_ref()
+    else {
+        panic!("expected PutCounter, got {:?}", execute.effect);
+    };
+    assert_eq!(
+        *target,
+        TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::ScopedPlayer))
+    );
+    assert!(
+        matches!(count, QuantityExpr::Fixed { value: 2 }),
+        "expected two counters, got {count:?}"
+    );
+    let sub = execute.sub_ability.as_ref().expect("goad sub");
+    let Effect::GoadAll { target } = sub.effect.as_ref() else {
+        panic!("expected GoadAll, got {:?}", sub.effect);
+    };
+    assert!(matches!(
+        target,
+        TargetFilter::TrackedSetFiltered { .. }
+    ));
+}
+
+#[test]
+fn agitator_ant_parsed_has_no_unimplemented_leaks() {
+    fn has_unimplemented(effect: &Effect) -> bool {
+        matches!(effect, Effect::Unimplemented { .. })
+    }
+
+    let parsed = parse_agitator_ant();
+    let execute = parsed.triggers[0].execute.as_ref().expect("execute");
+    assert!(
+        !has_unimplemented(execute.effect.as_ref()),
+        "primary effect leaked Unimplemented: {:?}",
+        execute.effect
+    );
+    if let Some(sub) = &execute.sub_ability {
+        assert!(
+            !has_unimplemented(sub.effect.as_ref()),
+            "goad sub leaked Unimplemented: {:?}",
+            sub.effect
+        );
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -145,6 +145,7 @@ mod issue_2888_unbreathing_horde_self_prevention;
 mod issue_2894_spymasters_vault_connive;
 mod issue_2897_nexus_of_fate;
 mod issue_2900_blinkmoth_urn;
+mod issue_2903_agitator_ant;
 mod issue_2904_life_of_the_party;
 mod issue_2908_weathered_wayfarer;
 mod issue_2914_shiko_flurry_target_gate;


### PR DESCRIPTION
## Summary

- Rewrite `You`-scoped counter targets to `ScopedPlayer` under each-player iteration so every player puts counters on their own creature.
- Parse "that had counters put on it this way" as `TrackedSetFiltered` so the goad follow-up only hits creatures that received counters from the optional step.
- Treat `TrackedSetFiltered` as meaningful content in `parse_target` so the filter is not dropped to `Any`.

## Test plan

- [x] `cargo test -p engine --lib agitator_ant`
- [x] `cargo test -p engine --test integration agitator_ant`

Fixes #2903

Made with [Cursor](https://cursor.com)