### PR TITLE
Fix Master of Cruelties can only attack alone parsing (fixes #2910)

### DIFF
--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -232,6 +232,10 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     // to StaticMode::AttachmentRestriction instead of an effect.
     "can be attached only to",
     "can't attack",
+    // CR 506.5 + CR 508.1c: Master of Cruelties — "~ can only attack alone"
+    // must route to the static parser (CombatAlone MustBeSole), not the effect
+    // pipeline where it previously lowered to Unimplemented.
+    "can only attack alone",
     "can't block",
     "can't be countered",
     "can't be copied",

--- a/crates/engine/tests/integration/issue_2910_master_of_cruelties.rs
+++ b/crates/engine/tests/integration/issue_2910_master_of_cruelties.rs
@@ -1,0 +1,60 @@
+//! Regression for issue #2910: Master of Cruelties attack-alone restriction.
+//!
+//! https://github.com/phase-rs/phase/issues/2910
+//!
+//! The "can only attack alone" line must parse as a static CombatAlone restriction,
+//! not fall through to Unimplemented with empty static_abilities.
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::statics::{CombatAloneAction, CombatAloneRequirement, StaticMode};
+
+const MASTER_OF_CRUELTIES_ORACLE: &str = "\
+First strike, deathtouch\n\
+This creature can only attack alone.\n\
+Whenever this creature attacks a player and isn't blocked, that player's life total becomes 1. This creature assigns no combat damage this combat.";
+
+#[test]
+fn master_of_cruelties_parses_attack_alone_static() {
+    let parsed = parse_oracle_text(
+        MASTER_OF_CRUELTIES_ORACLE,
+        "Master of Cruelties",
+        &["First strike".to_string(), "Deathtouch".to_string()],
+        &["Creature".to_string()],
+        &["Demon".to_string()],
+    );
+    assert!(
+        parsed.statics.iter().any(|sd| {
+            matches!(
+                sd.mode,
+                StaticMode::CombatAlone {
+                    action: CombatAloneAction::Attack,
+                    requirement: CombatAloneRequirement::MustBeSole,
+                }
+            )
+        }),
+        "expected CombatAlone(Attack, MustBeSole) static, got {:?}",
+        parsed.statics
+    );
+}
+
+#[test]
+fn master_of_cruelties_has_no_unimplemented_attack_alone_leak() {
+    let parsed = parse_oracle_text(
+        "This creature can only attack alone.",
+        "Master of Cruelties",
+        &[],
+        &["Creature".to_string()],
+        &["Demon".to_string()],
+    );
+    assert!(
+        !parsed.statics.is_empty(),
+        "attack-alone line must produce static abilities"
+    );
+    assert!(
+        parsed.statics.iter().all(|sd| {
+            !matches!(&sd.mode, StaticMode::Other(name) if name == "Unimplemented")
+        }),
+        "static line must not leak Unimplemented: {:?}",
+        parsed.statics
+    );
+}

--- a/crates/engine/tests/integration/issue_2910_master_of_cruelties.rs
+++ b/crates/engine/tests/integration/issue_2910_master_of_cruelties.rs
@@ -51,9 +51,10 @@ fn master_of_cruelties_has_no_unimplemented_attack_alone_leak() {
         "attack-alone line must produce static abilities"
     );
     assert!(
-        parsed.statics.iter().all(|sd| {
-            !matches!(&sd.mode, StaticMode::Other(name) if name == "Unimplemented")
-        }),
+        parsed
+            .statics
+            .iter()
+            .all(|sd| { !matches!(&sd.mode, StaticMode::Other(name) if name == "Unimplemented") }),
         "static line must not leak Unimplemented: {:?}",
         parsed.statics
     );

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -152,6 +152,7 @@ mod issue_2900_blinkmoth_urn;
 mod issue_2904_life_of_the_party;
 mod issue_2908_weathered_wayfarer;
 mod issue_2909_blast_furnace_hellkite;
+mod issue_2910_master_of_cruelties;
 mod issue_2914_shiko_flurry_target_gate;
 mod issue_2915_alexios;
 mod issue_2916_torment_repeat_unless;


### PR DESCRIPTION
## Summary

- Add `"can only attack alone"` to `STATIC_CONTAINS_PATTERNS` so the line routes to the static parser instead of the effect pipeline.
- Master of Cruelties now lowers to `CombatAlone(Attack, MustBeSole)` instead of `Unimplemented` with empty statics.

## Test plan

- [x] `cargo test -p engine --test integration master_of_cruelties`

Fixes #2910

Made with [Cursor](https://cursor.com)