### PR TITLE
fix(ci): refresh Tauri lock during nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -238,6 +238,13 @@ jobs:
 
           cargo release "$VERSION" --workspace --execute --no-confirm --no-publish --no-push --allow-branch main
 
+          cargo update --manifest-path client/src-tauri/Cargo.toml --package phase-tauri
+          if ! git diff --quiet -- client/src-tauri/Cargo.lock; then
+            git add client/src-tauri/Cargo.lock
+            git commit --amend --no-edit
+            git tag -f -a "$TAG" -m "$TAG"
+          fi
+
       - name: Verify release commit and tag
         if: ${{ steps.release-run.outputs.skip_creation != 'true' }}
         env:
@@ -294,6 +301,7 @@ jobs:
               Cargo.lock \
               Cargo.toml \
               client/package.json \
+              client/src-tauri/Cargo.lock \
               client/src-tauri/Cargo.toml \
               client/src-tauri/tauri.conf.json \
               | sort)


### PR DESCRIPTION
## Summary
- refresh client/src-tauri/Cargo.lock after cargo-release bumps the Tauri crate version
- amend the generated release commit/tag before pushing when that nested lockfile changes
- allow client/src-tauri/Cargo.lock in nightly-generated release commits

## Evidence
- Last two Nightly Release runs failed while waiting for CI on the release commit.
- The remaining common failure was Tauri compile check with locked Tauri dependency handling added on main.
- Local simulation confirmed cargo update --manifest-path client/src-tauri/Cargo.toml --package phase-tauri updates the phase-tauri entry in the nested lockfile after a manifest version bump.

## Validation
- git diff --check
- actionlint unavailable locally
