### PR TITLE
Fix Teferi's Protection mass phase-out targeting (fixes #2907)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5234,12 +5234,9 @@ fn phase_out_or_in_filter_is_mass(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::Controller | TargetFilter::Player | TargetFilter::ScopedPlayer => true,
         TargetFilter::Typed(tf) => {
-            tf.type_filters.contains(&TypeFilter::Permanent)
-                && !tf
-                    .type_filters
-                    .iter()
-                    .any(|t| matches!(t, TypeFilter::Creature))
+            tf.type_filters == [TypeFilter::Permanent]
                 && tf.controller.is_some()
+                && tf.properties.is_empty()
         }
         _ => false,
     }
@@ -11153,6 +11150,23 @@ pub mod tests {
         assert!(
             extract_target_filter_from_effect(&effect).is_some(),
             "targeted PhaseOut{{Creature}} must generate a target slot"
+        );
+    }
+
+    /// CR 115.1: "Any number of target nonland permanents you control phase
+    /// out" uses declared targets even though the filter is controller-scoped.
+    #[test]
+    fn extract_target_keeps_targeted_phase_out_nonland_permanents_you_control() {
+        let effect = Effect::PhaseOut {
+            target: TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .with_type(TypeFilter::Non(Box::new(TypeFilter::Land)))
+                    .controller(ControllerRef::You),
+            ),
+        };
+        assert!(
+            extract_target_filter_from_effect(&effect).is_some(),
+            "targeted PhaseOut{{Nonland Permanent, You}} must generate a target slot"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -11136,9 +11136,7 @@ pub mod tests {
     #[test]
     fn extract_target_skips_mass_phase_out_permanents_you_control() {
         let effect = Effect::PhaseOut {
-            target: TargetFilter::Typed(
-                TypedFilter::permanent().controller(ControllerRef::You),
-            ),
+            target: TargetFilter::Typed(TypedFilter::permanent().controller(ControllerRef::You)),
         };
         assert!(
             extract_target_filter_from_effect(&effect).is_none(),

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5228,6 +5228,23 @@ fn build_triggered_ability(
 /// Note: TriggeringSpellController, TriggeringSpellOwner, TriggeringPlayer,
 /// and TriggeringSource auto-resolve from event context at resolution time
 /// (via `state.current_trigger_event`), so they do not require player selection.
+/// CR 115.1 + CR 702.26a: True when a `PhaseOut`/`PhaseIn` filter denotes a
+/// population to expand at resolution rather than a single declared target.
+fn phase_out_or_in_filter_is_mass(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Controller | TargetFilter::Player | TargetFilter::ScopedPlayer => true,
+        TargetFilter::Typed(tf) => {
+            tf.type_filters.contains(&TypeFilter::Permanent)
+                && !tf
+                    .type_filters
+                    .iter()
+                    .any(|t| matches!(t, TypeFilter::Creature))
+                && tf.controller.is_some()
+        }
+        _ => false,
+    }
+}
+
 pub(crate) fn extract_target_filter_from_effect(effect: &Effect) -> Option<&TargetFilter> {
     // CR 701.21a: Sacrifice does not target — the controller chooses permanents
     // at resolution time via EffectZoneChoice. Returning a filter here would
@@ -5332,6 +5349,17 @@ pub(crate) fn extract_target_filter_from_effect(effect: &Effect) -> Option<&Targ
     // class).
     if effect.target_filter() == Some(&TargetFilter::Any)
         && !matches!(effect, Effect::DealDamage { .. })
+    {
+        return None;
+    }
+    // CR 115.1 + CR 702.26a: Mass phase-out / phase-in ("all permanents you
+    // control phase out" — Teferi's Protection; "you phase out") expands its
+    // population filter at resolution. Only "target [type] phase(s) out/in"
+    // requires a stack-time target slot.
+    if matches!(effect, Effect::PhaseOut { .. } | Effect::PhaseIn { .. })
+        && effect
+            .target_filter()
+            .is_some_and(phase_out_or_in_filter_is_mass)
     {
         return None;
     }
@@ -11100,6 +11128,33 @@ pub mod tests {
         assert!(
             extract_target_filter_from_effect(&effect).is_none(),
             "GenericEffect{{target: Some(Any)}} is a mass effect — must not generate a target slot (issue #824)"
+        );
+    }
+
+    /// CR 115.1 + CR 702.26a: Teferi's Protection mass phase-out must not
+    /// surface a target slot — permanents are expanded at resolution.
+    #[test]
+    fn extract_target_skips_mass_phase_out_permanents_you_control() {
+        let effect = Effect::PhaseOut {
+            target: TargetFilter::Typed(
+                TypedFilter::permanent().controller(ControllerRef::You),
+            ),
+        };
+        assert!(
+            extract_target_filter_from_effect(&effect).is_none(),
+            "mass PhaseOut{{Permanent, You}} must not generate a target slot (issue #2907)"
+        );
+    }
+
+    /// CR 115.1: "Target creature phases out" still requires a target slot.
+    #[test]
+    fn extract_target_keeps_targeted_phase_out_creature() {
+        let effect = Effect::PhaseOut {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+        };
+        assert!(
+            extract_target_filter_from_effect(&effect).is_some(),
+            "targeted PhaseOut{{Creature}} must generate a target slot"
         );
     }
 

--- a/crates/engine/tests/integration/issue_2907_teferis_protection.rs
+++ b/crates/engine/tests/integration/issue_2907_teferis_protection.rs
@@ -1,0 +1,80 @@
+//! Regression for issue #2907: Teferi's Protection mass phase-out targeting.
+//!
+//! https://github.com/phase-rs/phase/issues/2907
+//!
+//! "All permanents you control phase out" must not prompt for a single target at
+//! cast time; the effect expands its mass filter at resolution.
+
+use engine::game::ability_utils::{build_resolved_from_def, build_target_slots};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{ControllerRef, Effect, TargetFilter, TypeFilter, TypedFilter};
+use engine::types::game_state::GameState;
+use engine::types::identifiers::CardId;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+use engine::game::zones::create_object;
+
+const TEFERIS_PROTECTION_ORACLE: &str = "\
+Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out.\n\
+Exile Teferi's Protection.";
+
+fn phase_out_def_from_parsed() -> engine::types::ability::AbilityDefinition {
+    let parsed = parse_oracle_text(
+        TEFERIS_PROTECTION_ORACLE,
+        "Teferi's Protection",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let mut node = &parsed.abilities[0];
+    loop {
+        if matches!(node.effect.as_ref(), Effect::PhaseOut { .. }) {
+            return node.clone();
+        }
+        node = node
+            .sub_ability
+            .as_ref()
+            .expect("Teferi's Protection must chain to PhaseOut");
+    }
+}
+
+#[test]
+fn teferis_protection_mass_phase_out_builds_no_target_slots() {
+    let mut state = GameState::new_two_player(42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Teferi's Protection".to_string(),
+        Zone::Stack,
+    );
+    let phase_out = phase_out_def_from_parsed();
+    let resolved = build_resolved_from_def(&phase_out, source, PlayerId(0));
+    let slots = build_target_slots(&state, &resolved).expect("slot build");
+    assert!(
+        slots.is_empty(),
+        "mass phase-out must not require target selection, got {slots:?}"
+    );
+}
+
+#[test]
+fn teferis_protection_parsed_phase_out_uses_mass_permanent_filter() {
+    let phase_out = phase_out_def_from_parsed();
+    let Effect::PhaseOut { target } = phase_out.effect.as_ref() else {
+        panic!("expected PhaseOut, got {:?}", phase_out.effect);
+    };
+    assert_eq!(
+        *target,
+        TargetFilter::Typed(TypedFilter::permanent().controller(ControllerRef::You))
+    );
+    assert!(
+        matches!(
+            target,
+            TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: Some(ControllerRef::You),
+                ..
+            }) if type_filters.contains(&TypeFilter::Permanent)
+        )
+    );
+}

--- a/crates/engine/tests/integration/issue_2907_teferis_protection.rs
+++ b/crates/engine/tests/integration/issue_2907_teferis_protection.rs
@@ -6,13 +6,13 @@
 //! cast time; the effect expands its mass filter at resolution.
 
 use engine::game::ability_utils::{build_resolved_from_def, build_target_slots};
+use engine::game::zones::create_object;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{ControllerRef, Effect, TargetFilter, TypeFilter, TypedFilter};
 use engine::types::game_state::GameState;
 use engine::types::identifiers::CardId;
 use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
-use engine::game::zones::create_object;
 
 const TEFERIS_PROTECTION_ORACLE: &str = "\
 Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out.\n\
@@ -67,14 +67,12 @@ fn teferis_protection_parsed_phase_out_uses_mass_permanent_filter() {
         *target,
         TargetFilter::Typed(TypedFilter::permanent().controller(ControllerRef::You))
     );
-    assert!(
-        matches!(
-            target,
-            TargetFilter::Typed(TypedFilter {
-                type_filters,
-                controller: Some(ControllerRef::You),
-                ..
-            }) if type_filters.contains(&TypeFilter::Permanent)
-        )
-    );
+    assert!(matches!(
+        target,
+        TargetFilter::Typed(TypedFilter {
+            type_filters,
+            controller: Some(ControllerRef::You),
+            ..
+        }) if type_filters.contains(&TypeFilter::Permanent)
+    ));
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -146,6 +146,7 @@ mod issue_2894_spymasters_vault_connive;
 mod issue_2897_nexus_of_fate;
 mod issue_2900_blinkmoth_urn;
 mod issue_2904_life_of_the_party;
+mod issue_2907_teferis_protection;
 mod issue_2908_weathered_wayfarer;
 mod issue_2914_shiko_flurry_target_gate;
 mod issue_2915_alexios;


### PR DESCRIPTION
## Summary

- Treat mass `PhaseOut`/`PhaseIn` filters (controller-scoped permanent populations and player phase-out) as non-targeted in `extract_target_filter_from_effect`.
- Teferi's Protection now phases out all controlled permanents without a single-target prompt at cast time.

## Test plan

- [x] `cargo test -p engine --lib mass_phase_out_permanents`
- [x] `cargo test -p engine --test integration teferis_protection`

Fixes #2907

Made with [Cursor](https://cursor.com)