### PR TITLE
fix(engine): bind 'deal damage to that player' to triggering drawer (#2893)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -3056,13 +3056,30 @@ fn try_parse_have_causative(
                 let after_damage = after_count_lower
                     .strip_prefix("damage to ") // allow-noncombinator: structural tail check on classified count remainder
                     .unwrap_or("");
-                let recipient_implicit = after_damage
+                let recipient = after_damage
                     .trim_end_matches('.')
                     .trim_end_matches(',')
-                    .trim()
-                    .eq("them")
-                    || after_damage.trim_end_matches('.').trim().eq("that player");
-                if recipient_implicit {
+                    .trim();
+                // CR 608.2k + CR 120.1: "that player" is an untargeted anaphoric
+                // reference to the player named by the trigger condition (the
+                // drawing opponent in "Whenever an opponent draws a card, ... you
+                // may have ~ deal N damage to that player" — Kederekt Parasite).
+                // It binds to the triggering player, not a fresh chooseable
+                // `Player` target. `parse_event_context_ref_with_ctx` resolves
+                // it to `TriggeringPlayer` (rebound to `ScopedPlayer` /
+                // `SourceChosenPlayer` / `ParentTargetController` when the trigger
+                // carries one of those player scopes), matching the non-causative
+                // "deals N damage to that player" path (issue #2893).
+                if let Some((target, ecr_rem)) = parse_event_context_ref_with_ctx(recipient, ctx) {
+                    if ecr_rem.trim().is_empty() {
+                        return Some(parsed_clause(Effect::DealDamage {
+                            amount,
+                            target,
+                            damage_source: None,
+                        }));
+                    }
+                }
+                if recipient.eq("them") {
                     return Some(parsed_clause(Effect::DealDamage {
                         amount,
                         target: TargetFilter::Player,
@@ -3072,7 +3089,7 @@ fn try_parse_have_causative(
                 // CR 608.2d: "have this artifact deal 1 damage to it" (Requiem
                 // Monolith) — optional self-damage the targeted creature's
                 // controller may cause the source artifact to deal.
-                if after_damage.trim_end_matches('.').trim() == "it" {
+                if recipient == "it" {
                     return Some(parsed_clause(Effect::DealDamage {
                         amount,
                         target: TargetFilter::ParentTarget,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -3060,7 +3060,7 @@ fn try_parse_have_causative(
                     .trim_end_matches('.')
                     .trim_end_matches(',')
                     .trim();
-                // CR 608.2k + CR 120.1: "that player" is an untargeted anaphoric
+                // CR 608.2c + CR 115.10a + CR 120.1: "that player" is an untargeted anaphoric
                 // reference to the player named by the trigger condition (the
                 // drawing opponent in "Whenever an opponent draws a card, ... you
                 // may have ~ deal N damage to that player" — Kederekt Parasite).

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -21309,7 +21309,7 @@ mod tests {
         );
     }
 
-    /// CR 603.2 + CR 119.3: Kederekt Parasite — "Whenever an opponent draws a
+    /// CR 603.2 + CR 608.2c + CR 115.10a: Kederekt Parasite — "Whenever an opponent draws a
     /// card, ... you may have this creature deal 1 damage to that player." The
     /// optional "you may have ~ deal N damage to that player" causative frame
     /// must bind "that player" to the triggering (drawing) player, not to a

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -21309,6 +21309,39 @@ mod tests {
         );
     }
 
+    /// CR 603.2 + CR 119.3: Kederekt Parasite — "Whenever an opponent draws a
+    /// card, ... you may have this creature deal 1 damage to that player." The
+    /// optional "you may have ~ deal N damage to that player" causative frame
+    /// must bind "that player" to the triggering (drawing) player, not to a
+    /// chooseable `Player` target. The damaged player is fixed by the trigger
+    /// event (CR 603.2), so no target selection is offered (issue #2893).
+    #[test]
+    fn opponent_draws_may_have_deal_damage_to_that_player_binds_triggering_player() {
+        let def = parse_trigger_line(
+            "Whenever an opponent draws a card, if you control a red permanent, you may have this creature deal 1 damage to that player.",
+            "Kederekt Parasite",
+        );
+        let execute = def.execute.as_ref().expect("execute must be Some");
+        // The "you may" wording makes the resolution optional (yes/no), not a
+        // forced effect.
+        assert!(
+            execute.optional,
+            "execute.optional must be true ('you may')"
+        );
+        match execute.effect.as_ref() {
+            Effect::DealDamage { target, amount, .. } => {
+                assert_eq!(
+                    target,
+                    &TargetFilter::TriggeringPlayer,
+                    "'that player' must bind to the drawing opponent (TriggeringPlayer), \
+                     not a chooseable Player target",
+                );
+                assert_eq!(amount, &QuantityExpr::Fixed { value: 1 });
+            }
+            other => panic!("expected DealDamage to TriggeringPlayer, got {other:?}"),
+        }
+    }
+
     /// CR 613.1 + CR 503.1a: The Rack — "the chosen player's upkeep" must
     /// scope the phase trigger to `SourceChosenPlayer`, not every active player.
     #[test]


### PR DESCRIPTION
Fixes #2893.

## Problem

Kederekt Parasite reads: "Whenever an opponent draws a card, if you control a red permanent, **you may have this creature deal 1 damage to that player.**"

"That player" is an untargeted anaphoric reference to the player named by the trigger condition — the opponent who drew (CR 608.2k). It is *not* a fresh chooseable target. But the optional "may have ~ deal N damage to that player" causative frame was lowering the recipient to a chooseable `TargetFilter::Player`, so the engine prompted the controller to pick an opponent instead of automatically damaging the drawing player.

## Root cause

`try_parse_have_causative` (`crates/engine/src/parser/oracle_effect/mod.rs`) handles "have it / have ~ / have this artifact deal N damage to <recipient>". Its implicit-recipient branch hardcoded `target: TargetFilter::Player` for both "them" *and* "that player", bypassing the event-context resolution that the non-causative "deals N damage to that player" path already performs via `parse_event_context_ref_with_ctx`. That resolver maps "that player" → `TargetFilter::TriggeringPlayer` (`oracle_nom/target.rs`), which the runtime binds to the `CardDrawn` event's player (`game/targeting.rs`).

## Fix

Route the recipient phrase in the causative frame through the existing `parse_event_context_ref_with_ctx` building block before falling back. This binds "that player" to `TriggeringPlayer` (and to `ScopedPlayer` / `SourceChosenPlayer` / `ParentTargetController` when the trigger carries one of those player scopes), exactly matching the non-causative path. The "them" anaphor and the "it" self-damage branch (Requiem Monolith) are unchanged. This fixes the whole class — any "you may have ~ deal N damage to that player" on a player-actor-event trigger — not just Kederekt Parasite.

## Tests

New discriminating parser test `opponent_draws_may_have_deal_damage_to_that_player_binds_triggering_player` parses the full Kederekt Parasite trigger line and asserts the `DealDamage` target is `TriggeringPlayer` (fails pre-fix with `Player`, passes post-fix) and that the resolution is optional (`execute.optional == true`). Sibling tests confirmed green: Razorkin Needlehead ("...to them"), the "have it deal 4 damage to them" spell frame, and the Requiem Monolith "...to it" self-damage frame.

- New + sibling tests: pass
- `oracle_effect` + `oracle_trigger` modules: 2454 passed, 0 failed
- `cargo clippy -p engine --lib`: 0 warnings
- `cargo fmt --all`: clean

## CR

- CR 608.2k — an effect's untargeted reference to an object/player previously named by the trigger condition still affects that same object/player ("that player" = the drawing opponent).
- CR 120.1 — objects deal damage to players.
- CR 603.2 — the trigger event that establishes "that player".
