### PR TITLE
fix(parser): bind a token creator’s "it gains/gets X" grant to the created token

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1176,6 +1176,30 @@ pub(super) fn is_token_creating_effect(effect: &Effect) -> bool {
     )
 }
 
+/// Rebind a `GenericEffect` grant's `SelfRef` recipient(s) to `LastCreated`.
+/// No-op for any other effect, and for grants that already name a concrete
+/// recipient — only the source-defaulted `SelfRef` is the misbound "it".
+fn rebind_self_ref_grant_to_last_created(effect: &mut Effect) {
+    let Effect::GenericEffect {
+        static_abilities,
+        target,
+        ..
+    } = effect
+    else {
+        return;
+    };
+    let mut rebound = false;
+    for static_def in static_abilities.iter_mut() {
+        if matches!(static_def.affected, Some(TargetFilter::SelfRef)) {
+            static_def.affected = Some(TargetFilter::LastCreated);
+            rebound = true;
+        }
+    }
+    if rebound && matches!(target, None | Some(TargetFilter::SelfRef)) {
+        *target = Some(TargetFilter::LastCreated);
+    }
+}
+
 /// Walk an ability definition, rewriting the populated-token anaphor at
 /// whichever level it appears. Recurses into `CreateDelayedTrigger.effect` so
 /// the "sacrifice it" pattern inside a delayed trigger also rewrites.
@@ -1209,6 +1233,13 @@ fn rewrite_populated_anaphor_in_effect(effect: &mut Effect) {
         rewrite_parent_target_to_last_created(&mut inner.effect);
         rewrite_populated_anaphor_in_effect(&mut inner.effect);
     }
+
+    // Case 3: a bare "it gains/gets X" grant that parsed to a `GenericEffect`
+    // targeting `SelfRef` (the imperative parser's default for the bare pronoun
+    // "it") — directly after a token-creating effect, "it" is the created token
+    // (God-Pharaoh's Gift: "create a token … It gains haste"). Rebind to the
+    // just-created token.
+    rebind_self_ref_grant_to_last_created(effect);
 }
 
 /// If `effect` is `Unimplemented { description: "<anaphor> <verb-phrase>" }`,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -20864,6 +20864,38 @@ mod tests {
         }
     }
 
+    /// CR 603.7c + CR 608.2c: God-Pharaoh's Gift — "create a token that's a copy
+    /// of that card … It gains haste." The "It gains haste" grant, nested as the
+    /// token creator's own sub-ability, must apply to the newly created token
+    /// (`LastCreated`), not the source artifact (`SelfRef`). Issue #2356.
+    #[test]
+    fn token_creator_it_gains_keyword_binds_to_created_token() {
+        fn first_grant_affected(
+            def: &crate::types::ability::AbilityDefinition,
+        ) -> Option<TargetFilter> {
+            if let Effect::GenericEffect {
+                static_abilities, ..
+            } = &*def.effect
+            {
+                if let Some(s) = static_abilities.first() {
+                    return s.affected.clone();
+                }
+            }
+            def.sub_ability.as_deref().and_then(first_grant_affected)
+        }
+
+        let def = parse_trigger_line(
+            "At the beginning of combat on your turn, you may exile a creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a 4/4 black Zombie. It gains haste until end of turn.",
+            "God-Pharaoh's Gift",
+        );
+        let affected = first_grant_affected(def.execute.as_deref().expect("execute ability"));
+        assert_eq!(
+            affected,
+            Some(TargetFilter::LastCreated),
+            "the 'It gains haste' grant must apply to the created token, not SelfRef"
+        );
+    }
+
     /// CR 613.1 + CR 503.1a: The Rack — "the chosen player's upkeep" must
     /// scope the phase trigger to `SourceChosenPlayer`, not every active player.
     #[test]


### PR DESCRIPTION
## What

God-Pharaoh's Gift — "create a token that's a copy of that card … **It gains
haste** until end of turn." — now grants haste to the **created token** instead
of the God-Pharaoh's Gift artifact itself. Fixes #2356.

## The bug (CR 603.7c / CR 608.2c)

The bare pronoun "it" in "It gains haste" is resolved by the imperative parser to
`TargetFilter::SelfRef` (the ability source) by default. Directly after a
token-creating effect, "it" is the just-created token — but the grant parses to
`GenericEffect { static_abilities: [{ affected: SelfRef, AddKeyword Haste }] }`,
so the continuous haste grant applied to the GPG artifact, not the token.

The existing `resolve_populated_token_anaphors` post-pass rewrites this class of
anaphor to `TargetFilter::LastCreated`, but only for **explicit** token
references that parse to `Unimplemented` ("the token gains haste", "this token
…") or for a `CreateDelayedTrigger` carrying `ParentTarget`. A bare "it" that the
parser already lowered to a `GenericEffect{SelfRef}` grant fell through.

## The fix

A third case in `rewrite_populated_anaphor_in_effect` (`rebind_self_ref_grant_to_last_created`)
rebinds a `GenericEffect` grant's `SelfRef` recipient(s) — and its `SelfRef`/None
target — to `LastCreated`. This runs only for a def that **follows a
token-creating effect** in the chain (the existing
`resolve_populated_token_anaphors` gate), so it is scoped to "create a token …
it gains/gets X" and leaves grants that name a concrete recipient untouched.

## Tests

- **`token_creator_it_gains_keyword_binds_to_created_token`**: GPG's full trigger
  parses with the "It gains haste" grant's `affected == LastCreated`, not
  `SelfRef`.
- The full engine lib suite passes (the rewrite is scoped to grants following a
  token creator).

Closes #2356
