### PR TITLE
fix(engine): resolve Reality Shift chained manifest via parent-target referent

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -417,7 +417,7 @@ pub fn build_target_slots_labelled(
 /// object target (CR 109.4 — controller of an object), in target-list order.
 /// Returns `None` if the ability has no targets.
 pub fn parent_target_controller(ability: &ResolvedAbility, state: &GameState) -> Option<PlayerId> {
-    ability.targets.iter().find_map(|t| match t {
+    if let Some(player) = ability.targets.iter().find_map(|t| match t {
         // CR 608.2h (issue #1582): If the parent target has left the
         // battlefield — e.g. a token Recoil bounced to hand, which then ceases
         // to exist per CR 704.5d before the chained "that player discards"
@@ -429,7 +429,20 @@ pub fn parent_target_controller(ability: &ResolvedAbility, state: &GameState) ->
             .map(|obj| obj.controller)
             .or_else(|| state.lki_cache.get(id).map(|lki| lki.controller)),
         TargetRef::Player(pid) => Some(*pid),
-    })
+    }) {
+        return Some(player);
+    }
+
+    // CR 608.2c + CR 608.2h + CR 400.7j (issue #2890): A chained instruction
+    // may inherit the parent effect's singular referent only through
+    // `effect_context_object` — e.g. Reality Shift's manifest after the
+    // exiled creature left the battlefield and parent targets were not copied
+    // onto the sub-ability. The propagated snapshot carries the at-departure
+    // controller per CR 608.2h.
+    ability
+        .effect_context_object
+        .as_ref()
+        .map(|snapshot| snapshot.lki.controller)
 }
 
 /// CR 108.3 + CR 608.2c: Resolve the owner of an ability's first parent target.
@@ -443,7 +456,7 @@ pub fn parent_target_controller(ability: &ResolvedAbility, state: &GameState) ->
 /// ability has no targets, or an object target is absent from both the live
 /// object map and the LKI cache.
 pub fn parent_target_owner(ability: &ResolvedAbility, state: &GameState) -> Option<PlayerId> {
-    ability.targets.iter().find_map(|t| match t {
+    if let Some(player) = ability.targets.iter().find_map(|t| match t {
         // CR 608.2h (issue #1582): Mirror the controller lookup — fall back to
         // last-known information so "its owner" still resolves after the
         // referenced object (e.g. a bounced token) has ceased to exist.
@@ -453,7 +466,15 @@ pub fn parent_target_owner(ability: &ResolvedAbility, state: &GameState) -> Opti
             .map(|obj| obj.owner)
             .or_else(|| state.lki_cache.get(id).map(|lki| lki.owner)),
         TargetRef::Player(_) => None,
-    })
+    }) {
+        return Some(player);
+    }
+
+    // CR 608.2c + CR 400.7j: Mirror the controller fallback for owner anaphors.
+    ability
+        .effect_context_object
+        .as_ref()
+        .map(|snapshot| snapshot.lki.owner)
 }
 
 pub fn target_constraints_from_modal(modal: &ModalChoice) -> Vec<TargetSelectionConstraint> {
@@ -8337,6 +8358,49 @@ mod tests {
             parent_target_controller(&ability, &state),
             None,
             "An ability with no targets has no parent target controller"
+        );
+    }
+
+    /// CR 608.2c + CR 400.7j (issue #2890): Parent-target player anaphors must
+    /// resolve from `effect_context_object` when inherited targets are absent.
+    #[test]
+    fn parent_target_controller_falls_back_to_effect_context_object() {
+        use crate::types::ability::CostPaidObjectSnapshot;
+        use crate::types::game_state::LKISnapshot;
+
+        let state = GameState::new_two_player(42);
+        let gone_id = ObjectId(77);
+        let mut ability = make_simple_ability(vec![], ObjectId(0));
+        ability.effect_context_object = Some(CostPaidObjectSnapshot {
+            object_id: gone_id,
+            lki: LKISnapshot {
+                name: "Exiled Creature".to_string(),
+                power: Some(2),
+                toughness: Some(2),
+                base_power: Some(2),
+                base_toughness: Some(2),
+                mana_value: 2,
+                controller: PlayerId(1),
+                owner: PlayerId(1),
+                card_types: vec![CoreType::Creature],
+                subtypes: vec![],
+                supertypes: vec![],
+                keywords: vec![],
+                colors: vec![],
+                chosen_attributes: Vec::new(),
+                counters: std::collections::HashMap::new(),
+            },
+        });
+
+        assert_eq!(
+            parent_target_controller(&ability, &state),
+            Some(PlayerId(1)),
+            "effect_context_object must supply the parent controller when targets are empty"
+        );
+        assert_eq!(
+            parent_target_owner(&ability, &state),
+            Some(PlayerId(1)),
+            "effect_context_object must supply the parent owner when targets are empty"
         );
     }
 

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -424,10 +424,17 @@ pub fn parent_target_controller(ability: &ResolvedAbility, state: &GameState) ->
         // resolves — fall back to last-known information so the player anaphor
         // still resolves.
         TargetRef::Object(id) => state
-            .objects
-            .get(id)
-            .map(|obj| obj.controller)
-            .or_else(|| state.lki_cache.get(id).map(|lki| lki.controller)),
+            .stack
+            .iter()
+            .find(|entry| entry.id == *id || entry.source_id == *id)
+            .map(|entry| entry.controller)
+            .or_else(|| {
+                state
+                    .objects
+                    .get(id)
+                    .map(|obj| obj.controller)
+                    .or_else(|| state.lki_cache.get(id).map(|lki| lki.controller))
+            }),
         TargetRef::Player(pid) => Some(*pid),
     }) {
         return Some(player);
@@ -8321,6 +8328,42 @@ mod tests {
             parent_target_controller(&ability, &state),
             Some(PlayerId(1)),
             "Object target should resolve to that object's controller"
+        );
+    }
+
+    /// CR 608.2c: Stack-object targets resolve to the stack entry controller.
+    /// This covers targeted activated/triggered abilities where the parent
+    /// target object id is a stack entry, not a battlefield object.
+    #[test]
+    fn parent_target_controller_resolves_stack_entry_controller() {
+        let mut state = GameState::new_two_player(42);
+        let stack_id = ObjectId(77);
+        let source_id = ObjectId(12);
+        state.stack.push_back(crate::types::game_state::StackEntry {
+            id: stack_id,
+            source_id,
+            controller: PlayerId(1),
+            kind: StackEntryKind::TriggeredAbility {
+                source_id,
+                ability: Box::new(make_simple_ability(vec![], source_id)),
+                condition: None,
+                trigger_event: None,
+                description: None,
+                source_name: "Stack Source".to_string(),
+                subject_match_count: None,
+                die_result: None,
+            },
+        });
+        let by_entry_id = make_simple_ability(vec![TargetRef::Object(stack_id)], ObjectId(0));
+        let by_source_id = make_simple_ability(vec![TargetRef::Object(source_id)], ObjectId(0));
+
+        assert_eq!(
+            parent_target_controller(&by_entry_id, &state),
+            Some(PlayerId(1))
+        );
+        assert_eq!(
+            parent_target_controller(&by_source_id, &state),
+            Some(PlayerId(1))
         );
     }
 

--- a/crates/engine/src/game/effects/manifest.rs
+++ b/crates/engine/src/game/effects/manifest.rs
@@ -238,6 +238,54 @@ mod tests {
     }
 
     #[test]
+    fn manifest_parent_target_controller_falls_back_to_effect_context_object() {
+        // CR 608.2c + CR 400.7j (issue #2890): Reality Shift's chained manifest
+        // must resolve the exiled creature's controller from the propagated
+        // referent snapshot when inherited targets are absent.
+        let mut state = GameState::new_two_player(42);
+        let target_controller = PlayerId(1);
+
+        let lib_card = create_object(
+            &mut state,
+            CardId(1),
+            target_controller,
+            "Opponent Card".to_string(),
+            Zone::Library,
+        );
+
+        let mut ability =
+            make_manifest_ability_for_target(1, TargetFilter::ParentTargetController, vec![]);
+        ability.effect_context_object = Some(crate::types::ability::CostPaidObjectSnapshot {
+            object_id: ObjectId(404),
+            lki: crate::types::game_state::LKISnapshot {
+                name: "Exiled Creature".to_string(),
+                power: Some(2),
+                toughness: Some(2),
+                base_power: Some(2),
+                base_toughness: Some(2),
+                mana_value: 2,
+                controller: target_controller,
+                owner: target_controller,
+                card_types: vec![crate::types::card_type::CoreType::Creature],
+                subtypes: vec![],
+                supertypes: vec![],
+                keywords: vec![],
+                colors: vec![],
+                chosen_attributes: Vec::new(),
+                counters: std::collections::HashMap::new(),
+            },
+        });
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let obj = &state.objects[&lib_card];
+        assert!(obj.face_down);
+        assert_eq!(obj.zone, Zone::Battlefield);
+        assert_eq!(obj.controller, target_controller);
+    }
+
+    #[test]
     fn manifest_triggering_player_uses_damaged_players_library() {
         let mut state = GameState::new_two_player(42);
         let caster = PlayerId(0);

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2822,7 +2822,9 @@ pub(crate) fn publish_fresh_tracked_set(
 /// surfaces `SearchLibrary::target_player`, so iterated-search variants are
 /// covered through the same single path.
 fn effect_refs_parent_target(effect: &Effect) -> bool {
-    effect_target_filter(effect).is_some_and(filter_refs_parent_target)
+    effect_parent_ref_slots(effect)
+        .iter()
+        .any(|filter| filter_refs_parent_target(filter))
 }
 
 /// Every object-target filter slot of an effect that may carry a parent-ref,
@@ -2908,6 +2910,10 @@ fn filter_refs_parent_target(filter: &TargetFilter) -> bool {
         TargetFilter::ParentTargetController
         | TargetFilter::ParentTargetOwner
         | TargetFilter::ParentTarget => true,
+        TargetFilter::Typed(typed) => matches!(
+            typed.controller,
+            Some(ControllerRef::ParentTargetController)
+        ),
         TargetFilter::Or { filters } | TargetFilter::And { filters } => {
             filters.iter().any(filter_refs_parent_target)
         }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5277,6 +5277,28 @@ fn resolve_chain_body(
                 effect_context_object.as_ref(),
             );
             resolve_ability_chain(state, &sub_with_targets, events, depth + 1)?;
+        } else if sub.targets.is_empty()
+            && ability.targets.is_empty()
+            && effect_refs_parent_target(&sub.effect)
+            && effect_context_object.is_some()
+        {
+            // CR 608.2c + CR 400.7j (issue #2890): When neither the parent nor
+            // the sub carries propagated `targets`, but the parent instruction
+            // stamped a singular referent snapshot (exile/move/sacrifice), seed
+            // the sub's target list so every ParentTarget* consumer — not only
+            // `parent_target_controller` — can bind to the departed object.
+            let mut sub_with_referent = sub.as_ref().clone();
+            if let Some(snapshot) = &effect_context_object {
+                sub_with_referent
+                    .targets
+                    .push(TargetRef::Object(snapshot.object_id));
+            }
+            apply_parent_chain_context(
+                &mut sub_with_referent,
+                ability,
+                effect_context_object.as_ref(),
+            );
+            resolve_ability_chain(state, &sub_with_referent, events, depth + 1)?;
         } else {
             // Propagate SpellContext so additional_cost_paid and other flags
             // survive through the chain (e.g., Gift delivery → spell effects
@@ -7821,6 +7843,69 @@ mod tests {
             resolve_player_for_context_ref(&state, &ability, &TargetFilter::ParentTargetController,),
             PlayerId(1),
         );
+    }
+
+    /// CR 701.34 + CR 608.2c (issue #2890): Reality Shift — exile then manifest
+    /// for the exiled creature's controller, including when the chained manifest
+    /// sub inherits only `effect_context_object` and not parent targets.
+    #[test]
+    fn change_zone_exile_then_manifest_parent_target_controller_chain() {
+        let mut state = GameState::new_two_player(42);
+        let victim = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Victim".to_string(),
+            Zone::Battlefield,
+        );
+        let opponent_top = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Top".to_string(),
+            Zone::Library,
+        );
+
+        let manifest = ResolvedAbility::new(
+            Effect::Manifest {
+                target: TargetFilter::ParentTargetController,
+                count: QuantityExpr::Fixed { value: 1 },
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let exile = ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Battlefield),
+                destination: Zone::Exile,
+                target: TargetFilter::Typed(TypedFilter::default().with_type(TypeFilter::Creature)),
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+            vec![TargetRef::Object(victim)],
+            ObjectId(100),
+            PlayerId(0),
+        )
+        .sub_ability(manifest);
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &exile, &mut events, 0).unwrap();
+
+        assert_eq!(
+            state.objects.get(&victim).map(|o| o.zone),
+            Some(Zone::Exile)
+        );
+        let manifested = state.objects.get(&opponent_top).expect("manifested card");
+        assert!(manifested.face_down);
+        assert_eq!(manifested.zone, Zone::Battlefield);
+        assert_eq!(manifested.controller, PlayerId(1));
     }
 
     #[test]

--- a/crates/engine/src/game/effects/search_library.rs
+++ b/crates/engine/src/game/effects/search_library.rs
@@ -38,13 +38,8 @@ fn resolve_library_owner(
     // object in the parent ability chain's targets (the Destroyed permanent
     // for Assassin's Trophy, the exiled spell for Praetor's Grasp variants, …).
     if matches!(target_player, TargetFilter::ParentTargetController) {
-        if let Some(parent_obj_id) = ability.targets.iter().find_map(|t| match t {
-            TargetRef::Object(id) => Some(*id),
-            _ => None,
-        }) {
-            if let Some(obj) = state.objects.get(&parent_obj_id) {
-                return obj.controller;
-            }
+        if let Some(player) = crate::game::ability_utils::parent_target_controller(ability, state) {
+            return player;
         }
     }
     ability.controller
@@ -1902,6 +1897,62 @@ mod tests {
                 .contains(&PlayerId(0)),
             "caster did NOT search — turn-tracking flag must not record them"
         );
+    }
+
+    /// CR 608.2h + CR 701.23a: if the parent target has already left the object
+    /// map, "its controller may search" must use the target's LKI controller,
+    /// not fall back to the caster.
+    #[test]
+    fn parent_target_controller_search_uses_lki_for_missing_target() {
+        let mut state = GameState::new_two_player(42);
+        let destroyed = create_object(
+            &mut state,
+            CardId(100),
+            PlayerId(1),
+            "Destroyed Token".to_string(),
+            Zone::Graveyard,
+        );
+        let lki = state.objects[&destroyed].snapshot_for_mana_spent();
+        state.lki_cache.insert(destroyed, lki);
+        state.objects.remove(&destroyed);
+        let _opp_basic = add_library_land(&mut state, 1, PlayerId(1), "Forest", true);
+
+        let ability = ResolvedAbility::new(
+            Effect::SearchLibrary {
+                filter: TargetFilter::Typed(TypedFilter::land().properties(vec![
+                    crate::types::ability::FilterProp::HasSupertype {
+                        value: crate::types::card_type::Supertype::Basic,
+                    },
+                ])),
+                count: QuantityExpr::Fixed { value: 1 },
+                reveal: false,
+                target_player: Some(TargetFilter::ParentTargetController),
+                selection_constraint: SearchSelectionConstraint::None,
+                split: None,
+                source_zones: vec![crate::types::zones::Zone::Library],
+            },
+            vec![TargetRef::Object(destroyed)],
+            ObjectId(9997),
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::SearchChoice { player, .. } => assert_eq!(
+                *player,
+                PlayerId(1),
+                "LKI must identify the missing parent target's controller"
+            ),
+            other => panic!("expected SearchChoice, got {other:?}"),
+        }
+        assert!(state
+            .players_who_searched_library_this_turn
+            .contains(&PlayerId(1)));
+        assert!(!state
+            .players_who_searched_library_this_turn
+            .contains(&PlayerId(0)));
     }
 
     /// CR 701.23a: Praetor's Grasp-shape regression — "search target opponent's

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -856,26 +856,20 @@ pub fn resolve_effect_player_ref(
             TargetRef::Player(player) => Some(*player),
             _ => None,
         }),
-        TargetFilter::ParentTargetController => ability
-            .targets
-            .iter()
-            .find_map(|target| match target {
-                TargetRef::Object(id) => state
-                    .stack
-                    .iter()
-                    .find(|entry| entry.id == *id || entry.source_id == *id)
-                    .map(|entry| entry.controller)
-                    .or_else(|| state.objects.get(id).map(|obj| obj.controller)),
-                TargetRef::Player(player) => Some(*player),
-            })
-            .or_else(|| {
+        TargetFilter::ParentTargetController => {
+            crate::game::ability_utils::parent_target_controller(ability, state).or_else(|| {
                 resolve_event_context_target(state, filter, ability.source_id).and_then(|target| {
                     match target {
                         TargetRef::Player(player) => Some(player),
-                        TargetRef::Object(id) => state.objects.get(&id).map(|obj| obj.controller),
+                        TargetRef::Object(id) => state
+                            .objects
+                            .get(&id)
+                            .map(|obj| obj.controller)
+                            .or_else(|| state.lki_cache.get(&id).map(|lki| lki.controller)),
                     }
                 })
-            }),
+            })
+        }
         // CR 108.3 + CR 608.2c: Parent target's *owner* — mirrors the controller
         // path above, but resolves through `parent_target_owner` and falls back
         // to the event-context resolver (which itself may fall back to the

--- a/crates/engine/tests/integration/issue_2890_reality_shift.rs
+++ b/crates/engine/tests/integration/issue_2890_reality_shift.rs
@@ -1,0 +1,171 @@
+//! GitHub issue #2890 — Reality Shift exiles the creature but the chained
+//! manifest on its controller's top library card never happens.
+//!
+//! CR 701.34: Manifest — put the top card of a player's library onto the
+//! battlefield face down as a 2/2 creature.
+//! CR 608.2c: Chained instructions resolve in order; "its controller" anaphors
+//! the exiled creature's controller.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const REALITY_SHIFT: &str =
+    "Exile target creature. Its controller manifests the top card of their library.";
+
+fn face_down_battlefield_count(state: &engine::types::game_state::GameState) -> usize {
+    state
+        .objects
+        .values()
+        .filter(|o| o.zone == Zone::Battlefield && o.face_down)
+        .count()
+}
+
+#[test]
+fn reality_shift_exiles_creature_and_manifests_for_its_controller() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Opponent's creature on the battlefield.
+    let victim = scenario
+        .add_creature_from_oracle(P1, "Victim Creature", 2, 2, "")
+        .id();
+
+    // Top card of each library — manifest should use P1's, not P0's.
+    let opponent_top = scenario.add_card_to_library_top(P1, "Opponent Top Card");
+    let _caster_top = scenario.add_card_to_library_top(P0, "Caster Top Card");
+
+    let reality_shift = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reality Shift", true, REALITY_SHIFT)
+        .id();
+
+    let mut runner = scenario.build();
+    let face_down_before = face_down_battlefield_count(runner.state());
+
+    let outcome = runner
+        .cast(reality_shift)
+        .target_objects(&[victim])
+        .resolve();
+
+    outcome.assert_zone(&[victim], Zone::Exile);
+
+    let state = outcome.state();
+    let face_down_after = face_down_battlefield_count(state);
+    assert_eq!(
+        face_down_after,
+        face_down_before + 1,
+        "issue #2890: Reality Shift must manifest the exiled creature's controller's top card; \
+         face_down_before={face_down_before} face_down_after={face_down_after}, \
+         waiting_for={:?}",
+        state.waiting_for
+    );
+
+    let manifested = state
+        .objects
+        .get(&opponent_top)
+        .expect("opponent's top library card should be manifested");
+    assert!(manifested.face_down);
+    assert_eq!(manifested.zone, Zone::Battlefield);
+    assert_eq!(manifested.controller, P1);
+    assert_eq!(manifested.power, Some(2));
+    assert_eq!(manifested.toughness, Some(2));
+}
+
+#[test]
+fn reality_shift_manifests_when_exiled_target_is_a_token() {
+    // CR 704.5d: Tokens in exile cease to exist at the next SBA, but CR 608.2h
+    // last-known information must still bind "its controller" for the chained
+    // manifest (issue #1582 class).
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let token = scenario
+        .add_creature_from_oracle(P1, "Goblin Token", 1, 1, "")
+        .id();
+    let opponent_top = scenario.add_card_to_library_top(P1, "Opponent Top Card");
+
+    let reality_shift = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reality Shift", true, REALITY_SHIFT)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().objects.get_mut(&token).unwrap().is_token = true;
+
+    let outcome = runner
+        .cast(reality_shift)
+        .target_objects(&[token])
+        .resolve();
+
+    let state = outcome.state();
+    assert!(
+        !state.objects.contains_key(&token),
+        "CR 704.5d: exiled token must cease to exist before manifest resolves"
+    );
+
+    let manifested = state
+        .objects
+        .get(&opponent_top)
+        .expect("token exile must not drop the chained manifest");
+    assert!(manifested.face_down);
+    assert_eq!(manifested.zone, Zone::Battlefield);
+    assert_eq!(manifested.controller, P1);
+}
+
+#[test]
+fn reality_shift_manifest_resolves_via_effect_context_object_snapshot() {
+    // Regression for the reported failure mode: chained manifest with
+    // ParentTargetController but no propagated object targets — only the
+    // parent instruction's referent snapshot.
+    use engine::game::effects::manifest;
+    use engine::types::ability::{CostPaidObjectSnapshot, Effect, QuantityExpr, ResolvedAbility};
+    use engine::types::game_state::LKISnapshot;
+    use engine::types::identifiers::ObjectId;
+    use std::collections::HashMap;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let opponent_top = scenario.add_card_to_library_top(P1, "Opponent Top Card");
+    let mut runner = scenario.build();
+
+    let mut ability = ResolvedAbility::new(
+        Effect::Manifest {
+            target: engine::types::ability::TargetFilter::ParentTargetController,
+            count: QuantityExpr::Fixed { value: 1 },
+        },
+        vec![],
+        ObjectId(100),
+        P0,
+    );
+    ability.effect_context_object = Some(CostPaidObjectSnapshot {
+        object_id: ObjectId(404),
+        lki: LKISnapshot {
+            name: "Exiled Creature".to_string(),
+            power: Some(2),
+            toughness: Some(2),
+            base_power: Some(2),
+            base_toughness: Some(2),
+            mana_value: 2,
+            controller: P1,
+            owner: P1,
+            card_types: vec![engine::types::card_type::CoreType::Creature],
+            subtypes: vec![],
+            supertypes: vec![],
+            keywords: vec![],
+            colors: vec![],
+            chosen_attributes: Vec::new(),
+            counters: HashMap::new(),
+        },
+    });
+
+    let mut events = Vec::new();
+    manifest::resolve(runner.state_mut(), &ability, &mut events).unwrap();
+
+    let state = runner.state();
+    let manifested = state
+        .objects
+        .get(&opponent_top)
+        .expect("manifest must use effect_context_object controller's library");
+    assert!(manifested.face_down);
+    assert_eq!(manifested.zone, Zone::Battlefield);
+    assert_eq!(manifested.controller, P1);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -144,6 +144,7 @@ mod issue_2435_traumatic_critique;
 mod issue_2439_wayta_trigger_doubling;
 mod issue_2856_shatterskull_divide_softlock;
 mod issue_2888_unbreathing_horde_self_prevention;
+mod issue_2890_reality_shift;
 mod issue_2894_spymasters_vault_connive;
 mod issue_2897_nexus_of_fate;
 mod issue_2900_blinkmoth_urn;


### PR DESCRIPTION
## Summary

- Fix chained `Manifest { ParentTargetController }` after `ChangeZone` exile when the exiled creature's controller must be resolved from last-known information or the parent referent snapshot (`effect_context_object`), not only from propagated `ability.targets`.
- Route `resolve_effect_player_ref(ParentTargetController)` through the canonical `parent_target_controller` helper (includes LKI fallback).
- Seed chained sub-abilities from `effect_context_object` when both parent and sub carry empty targets but the sub references a parent-target player anaphor.
Fixes #2890

## Problem

Reality Shift exiled the creature correctly, but the follow-up manifest silently failed when `ParentTargetController` could not bind after the target left the battlefield — the reported Discord bug in [#2890](https://github.com/phase-rs/phase/issues/2890).

## Test plan

- [x] `cargo test -p engine --test integration issue_2890`
- [x] `cargo test -p engine --lib change_zone_exile_then_manifest`
- [x] `cargo test -p engine --lib parent_target_controller_falls_back`
- [x] `cargo test -p engine --lib effect_its_controller_manifests_top_card` (parser shape unchanged)
- [ ] Cast Reality Shift in-client: exile opponent creature → opponent gets face-down 2/2 from top of their library
- [ ] Repeat with a token target (ceases to exist in exile per CR 704.5d)