### PR TITLE
feat: grant "all activated abilities of cards exiled with it" (Myr Welder, Territory Forge)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2702,6 +2702,9 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
             format!("remove {}", keyword_label(keyword))
         }
         ContinuousModification::GrantAbility { .. } => "grant ability".into(),
+        ContinuousModification::GrantAllActivatedAbilitiesOf { .. } => {
+            "grant all activated abilities of".into()
+        }
         ContinuousModification::GrantTrigger { .. } => "grant trigger".into(),
         ContinuousModification::RemoveAllAbilities => "remove all abilities".into(),
         ContinuousModification::AddType { core_type } => {

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2373,6 +2373,22 @@ fn active_continuous_effects_from_static_definitions(
                 // `static_definitions` for inspectability and downstream
                 // queries (e.g., parser/coverage walks).
             }
+            // CR 613.1f + CR 113.3: "~ has all activated abilities of [source]"
+            // (Myr Welder, Territory Forge, …). Expand into one `GrantAbility` per
+            // activated ability of each object matching `source`, so the dynamic
+            // set is recomputed each pass and reuses the existing GrantAbility
+            // apply + dedup. The meta-effect itself has no standalone layer-6
+            // behaviour, so skip pushing it.
+            if let ContinuousModification::GrantAllActivatedAbilitiesOf { source } = modification {
+                effects.extend(expand_granted_activated_abilities(
+                    state,
+                    source_id,
+                    timestamp,
+                    &affected_filter,
+                    source,
+                ));
+                continue;
+            }
             effects.push(ActiveContinuousEffect {
                 source_id,
                 controller,
@@ -2479,6 +2495,86 @@ fn expand_granted_static_effects(
                 mode: inner.mode.clone(),
                 characteristic_defining: inner.characteristic_defining,
             });
+        }
+    }
+    out
+}
+
+/// CR 613.1f + CR 113.3: Expand a `GrantAllActivatedAbilitiesOf { source }` host
+/// modification into one `GrantAbility` effect per activated ability of each
+/// object matching `source`. `source` is resolved relative to each recipient
+/// matching the host static's `affected_filter` (so `ExiledBySource` reads the
+/// recipient's own linked exiles). Provider objects are scanned across all zones
+/// — the granted-from cards are typically in exile, not on the battlefield — in
+/// deterministic `ObjectId` order. Both mana and non-mana activated abilities are
+/// granted. Synthesized effects target the recipient via `SelfRef`, reusing the
+/// layer-6 `GrantAbility` apply and its structural dedup, and are recomputed each
+/// pass so the granted set tracks the current `source` membership.
+fn expand_granted_activated_abilities(
+    state: &GameState,
+    host_source_id: ObjectId,
+    host_timestamp: u64,
+    host_affected_filter: &TargetFilter,
+    source: &TargetFilter,
+) -> Vec<ActiveContinuousEffect> {
+    let host_ctx = crate::game::filter::FilterContext::from_source(state, host_source_id);
+    let mut out = Vec::new();
+    let mut provider_ids: Vec<ObjectId> = state.objects.keys().copied().collect();
+    provider_ids.sort_unstable_by_key(|id| id.0);
+    for &recipient_id in &state.battlefield {
+        if !crate::game::filter::matches_target_filter(
+            state,
+            recipient_id,
+            host_affected_filter,
+            &host_ctx,
+        ) {
+            continue;
+        }
+        let recipient_controller = match state.objects.get(&recipient_id) {
+            Some(obj) => obj.controller,
+            None => continue,
+        };
+        // CR 109.5: `source` references like `ExiledBySource` resolve against the
+        // recipient that gained the ability.
+        let provider_ctx = crate::game::filter::FilterContext::from_source(state, recipient_id);
+        let mut next_mod_index = 0usize;
+        for &provider_id in &provider_ids {
+            if provider_id == recipient_id {
+                continue;
+            }
+            if !crate::game::filter::matches_target_filter(
+                state,
+                provider_id,
+                source,
+                &provider_ctx,
+            ) {
+                continue;
+            }
+            let Some(provider) = state.objects.get(&provider_id) else {
+                continue;
+            };
+            for ability in provider.abilities.iter() {
+                if ability.kind != crate::types::ability::AbilityKind::Activated {
+                    continue;
+                }
+                out.push(ActiveContinuousEffect {
+                    source_id: recipient_id,
+                    controller: recipient_controller,
+                    def_index: None,
+                    transient_id: None,
+                    mod_index: next_mod_index,
+                    layer: Layer::Ability,
+                    timestamp: host_timestamp,
+                    modification: ContinuousModification::GrantAbility {
+                        definition: Box::new(ability.clone()),
+                    },
+                    affected_filter: TargetFilter::SelfRef,
+                    condition: None,
+                    mode: StaticMode::Continuous,
+                    characteristic_defining: false,
+                });
+                next_mod_index += 1;
+            }
         }
     }
     out
@@ -3202,6 +3298,7 @@ fn modification_dynamic_quantity(m: &ContinuousModification) -> Option<&Quantity
         | ContinuousModification::AddKeyword { .. }
         | ContinuousModification::RemoveKeyword { .. }
         | ContinuousModification::GrantAbility { .. }
+        | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
         | ContinuousModification::GrantTrigger { .. }
         | ContinuousModification::RemoveAllAbilities
         | ContinuousModification::AddType { .. }
@@ -3826,6 +3923,12 @@ fn apply_continuous_effect_filtered(
                     Arc::make_mut(&mut obj.abilities).push(*definition.clone());
                 }
             }
+            // CR 613.1f: Handled entirely at continuous-effect collection time —
+            // `active_continuous_effects_from_static_definitions` expands this into
+            // one `GrantAbility` effect per matching activated ability (it needs
+            // read access to the provider objects, which the per-object apply
+            // borrow cannot give). No direct per-object mutation here.
+            ContinuousModification::GrantAllActivatedAbilitiesOf { .. } => {}
             // CR 604.1: Push granted trigger to trigger_definitions so
             // the trigger's event matching and condition metadata is preserved.
             ContinuousModification::GrantTrigger { trigger } => {
@@ -7892,6 +7995,75 @@ mod tests {
         assert!(
             !obj.keywords.contains(&Keyword::Hexproof),
             "should not have hexproof on opponent's turn"
+        );
+    }
+
+    /// CR 613.1f + CR 113.3: A permanent with "has all activated abilities of all
+    /// cards exiled with it" (Myr Welder) gains each exiled card's activated
+    /// ability after layer evaluation, via the dynamic GrantAllActivatedAbilitiesOf
+    /// expansion. Issue #3101.
+    #[test]
+    fn grants_all_activated_abilities_of_cards_exiled_with_it() {
+        use crate::types::ability::{
+            AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr,
+        };
+        use crate::types::game_state::{ExileLink, ExileLinkKind};
+
+        let mut state = setup();
+
+        // Host: Myr Welder-like artifact carrying the self-static.
+        let host = create_object(
+            &mut state,
+            CardId(700),
+            PlayerId(0),
+            "Myr Welder".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions = vec![StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+                    source: TargetFilter::ExiledBySource,
+                }])]
+            .into();
+        }
+
+        // A card exiled with the host, carrying a "{T}: deal 1 damage" activated
+        // ability.
+        let exiled = create_object(
+            &mut state,
+            CardId(701),
+            PlayerId(0),
+            "Exiled Source".to_string(),
+            Zone::Exile,
+        );
+        let granted = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Any,
+                damage_source: None,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        Arc::make_mut(&mut state.objects.get_mut(&exiled).unwrap().abilities).push(granted.clone());
+        state.exile_links.push(ExileLink {
+            exiled_id: exiled,
+            source_id: host,
+            kind: ExileLinkKind::TrackedBySource,
+        });
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let host_obj = state.objects.get(&host).unwrap();
+        assert!(
+            host_obj.abilities.iter().any(|a| a == &granted),
+            "Myr Welder must gain the exiled card's activated ability; got {:?}",
+            host_obj.abilities
         );
     }
 

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -583,7 +583,11 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         ContinuousModification::GrantStaticAbility { definition } => walk_static(definition, out),
         ContinuousModification::CopyValues { values, .. } => walk_copiable_values(values, out),
         // Remaining modifications carry no nested ability/effect carriers.
-        ContinuousModification::SetName { .. }
+        // GrantAllActivatedAbilitiesOf only holds a source `TargetFilter`; the
+        // granted abilities are pulled live from the provider objects at layer
+        // collection time, not nested here.
+        ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+        | ContinuousModification::SetName { .. }
         | ContinuousModification::AddPower { .. }
         | ContinuousModification::AddToughness { .. }
         | ContinuousModification::SetPower { .. }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5021,6 +5021,7 @@ fn apply_where_x_continuous_modification(
         | ContinuousModification::AddKeyword { .. }
         | ContinuousModification::RemoveKeyword { .. }
         | ContinuousModification::GrantAbility { .. }
+        | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
         | ContinuousModification::GrantTrigger { .. }
         | ContinuousModification::RemoveAllAbilities
         | ContinuousModification::AddType { .. }
@@ -5112,6 +5113,7 @@ fn rebind_target_anaphor_continuous_modification(modification: &mut ContinuousMo
         | ContinuousModification::AddKeyword { .. }
         | ContinuousModification::RemoveKeyword { .. }
         | ContinuousModification::GrantAbility { .. }
+        | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
         | ContinuousModification::GrantTrigger { .. }
         | ContinuousModification::RemoveAllAbilities
         | ContinuousModification::AddType { .. }

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -536,13 +536,19 @@ fn parse_grant_all_activated_abilities_source(
     lower: &str,
 ) -> Option<crate::types::ability::TargetFilter> {
     let p = lower.trim().trim_end_matches('.').trim();
-    matches!(
-        p,
-        "all activated abilities of all cards exiled with it"
-            | "all activated abilities of all cards exiled with ~"
-            | "all activated abilities of the exiled card"
-    )
-    .then_some(crate::types::ability::TargetFilter::ExiledBySource)
+    all_consuming(preceded(
+        tag::<_, _, OracleError<'_>>("all activated abilities of "),
+        alt((
+            value(TargetFilter::ExiledBySource, tag("the exiled card")),
+            value(
+                TargetFilter::ExiledBySource,
+                (tag("all cards exiled with "), alt((tag("it"), tag("~")))),
+            ),
+        )),
+    ))
+    .parse(p)
+    .ok()
+    .map(|(_, source)| source)
 }
 
 pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModification> {

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -527,6 +527,24 @@ pub(crate) fn parse_chosen_qualifier_subject(tp: &TextPair<'_>) -> Option<Target
     Some(TargetFilter::Typed(typed))
 }
 
+/// CR 613.1f + CR 113.3: Recognize the exact `ExiledBySource` forms of "all
+/// activated abilities of [source]" and return the provider `source` filter.
+/// Returns `None` for forms not yet supported (typed "creature cards exiled with
+/// it", counter-gated exile, battlefield filters) so they stay a loud gap rather
+/// than over-granting. `lower` is the already-lowercased predicate.
+fn parse_grant_all_activated_abilities_source(
+    lower: &str,
+) -> Option<crate::types::ability::TargetFilter> {
+    let p = lower.trim().trim_end_matches('.').trim();
+    matches!(
+        p,
+        "all activated abilities of all cards exiled with it"
+            | "all activated abilities of all cards exiled with ~"
+            | "all activated abilities of the exiled card"
+    )
+    .then_some(crate::types::ability::TargetFilter::ExiledBySource)
+}
+
 pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModification> {
     // Strip "where X is [quantity]" before parsing modifications,
     // but only if the text doesn't contain quoted abilities (which have their
@@ -543,6 +561,16 @@ pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModifi
     let unquoted_text = strip_quoted_segments(text_stripped);
     let unquoted_lower = unquoted_text.to_lowercase();
     let unquoted_tp = TextPair::new(&unquoted_text, &unquoted_lower);
+
+    // CR 613.1f + CR 113.3: "all activated abilities of [the exiled card | all
+    // cards exiled with it]" — grant the host all activated abilities of the
+    // cards exiled with it (Myr Welder, Territory Forge). First pass recognizes
+    // only the exact `ExiledBySource` forms; typed ("creature cards exiled with
+    // it"), counter-gated, and battlefield sources stay a gap (follow-ups).
+    if let Some(source) = parse_grant_all_activated_abilities_source(unquoted_tp.lower) {
+        return vec![ContinuousModification::GrantAllActivatedAbilitiesOf { source }];
+    }
+
     let mut modifications = Vec::new();
 
     // CR 205.1a + CR 613.1d/f: "loses all [other] abilities, card types, and

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -4565,6 +4565,36 @@ fn parse_continuous_modifications_are_goaded_emits_goaded_static_mode() {
     )));
 }
 
+/// CR 613.1f + CR 113.3: "all activated abilities of all cards exiled with it" /
+/// "the exiled card" → `GrantAllActivatedAbilitiesOf { ExiledBySource }` (Myr
+/// Welder, Territory Forge). Issue #3101.
+#[test]
+fn parse_continuous_modifications_grants_all_activated_abilities_of_exiled() {
+    use crate::types::ability::TargetFilter;
+    for predicate in [
+        "all activated abilities of all cards exiled with it",
+        "all activated abilities of all cards exiled with ~",
+        "all activated abilities of the exiled card",
+    ] {
+        let mods = parse_continuous_modifications(predicate);
+        assert_eq!(
+            mods,
+            vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+                source: TargetFilter::ExiledBySource
+            }],
+            "predicate: {predicate}"
+        );
+    }
+    // Typed/counter/battlefield forms stay a gap (no modification) for now.
+    assert!(
+        parse_continuous_modifications(
+            "all activated abilities of all creature cards exiled with it"
+        )
+        .is_empty(),
+        "typed 'creature cards exiled with it' must stay a gap (follow-up)"
+    );
+}
+
 #[test]
 fn static_pump_must_be_blocked_and_goaded_emits_all_defs() {
     let defs = parse_static_line_multi(

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -13632,6 +13632,18 @@ pub enum ContinuousModification {
     GrantAbility {
         definition: Box<AbilityDefinition>,
     },
+    /// CR 613.1f + CR 113.3: Grant the affected object **all activated abilities
+    /// of** the objects matching `source` (Myr Welder / Dark Impostor / Patchwork
+    /// Crawler "all [creature] cards exiled with it", Territory Forge "the exiled
+    /// card", Mairsil, Experiment Kraj, …). The set is dynamic — recomputed each
+    /// layer pass — so it is expanded into one `GrantAbility` per matching
+    /// activated ability at continuous-effect collection time
+    /// (`active_continuous_effects_from_static_definitions`); the layer-6 apply of
+    /// this variant itself is therefore a no-op. `source` is resolved relative to
+    /// each recipient of the host static (`FilterContext::from_source(recipient)`).
+    GrantAllActivatedAbilitiesOf {
+        source: TargetFilter,
+    },
     /// CR 604.1: Grant a triggered ability to the affected object.
     /// Unlike GrantAbility (which pushes to obj.abilities), this pushes to
     /// obj.trigger_definitions so the trigger's event/condition metadata is

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -96,6 +96,7 @@ impl ContinuousModification {
             | ContinuousModification::RemoveChosenKeyword
             | ContinuousModification::AddDynamicKeyword { .. }
             | ContinuousModification::GrantAbility { .. }
+            | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
             | ContinuousModification::GrantTrigger { .. }
             | ContinuousModification::RemoveAllAbilities
             | ContinuousModification::AddStaticMode { .. }


### PR DESCRIPTION
## What

Implements the static **"~ has all activated abilities of [the exiled card | all cards exiled with it]"** — first pass of #3101. These previously dropped to an `Effect:static_structure` gap, leaving the card unsupported.

**Cards (first pass):** Myr Welder, Territory Forge.

Refs #3101 — first pass only; the remaining forms in that issue (typed "creature cards exiled with it", counter-gated exile like Mairsil/Rex, and battlefield-filter sources like Robaran/Experiment Kraj/Drana) are **not** handled here and stay tracked under #3101.

## How

Adds `ContinuousModification::GrantAllActivatedAbilitiesOf { source: TargetFilter }` (CR 613.1f). Because the granted set is dynamic, it is expanded at continuous-effect **collection** time (`active_continuous_effects_from_static_definitions`) into one `GrantAbility` per matching activated ability — so it:

- recomputes each layer pass (tracks current `source` membership),
- reuses the existing layer-6 `GrantAbility` apply + structural dedup,
- and needs no activation plumbing (activation reads `obj.abilities` directly).

The per-object layer apply can't read other objects (borrow), so the apply arm for this variant is a documented no-op; all the work happens at collection time.

Parser recognizes only the exact `ExiledBySource` forms ("all cards exiled with it", "the exiled card"); typed/counter/battlefield sources **reject-and-gap** (no over-granting). All exhaustive `ContinuousModification` match sites updated (no wildcards).

## Tests

- Runtime: a permanent with the static gains an exiled-with-it card's `{T}` activated ability after layer evaluation.
- Parser: the recognized predicates → `GrantAllActivatedAbilitiesOf { ExiledBySource }`; the typed "creature cards exiled with it" form stays a gap.

All gates green: rustfmt, clippy `-D warnings`, parser-combinators, engine-authorities, and the full integration suite (942 tests).
