### PR TITLE
fix(parser): fix tracked-set scan shadowed by intermediate clause; add end-of-combat delayed prefix

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -551,20 +551,27 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         // and bind direct follow-up ParentTarget references to the affected set.
         if !current_defs.is_empty() {
             let source_text_lower = clause_ir.source_text.to_lowercase();
+            // CR 603.7: Scan ALL prior clauses for a tracked-set publisher — an
+            // intermediate non-publishing clause (e.g. Investigate) must not
+            // shadow an earlier exile clause. Example: Disorder in the Court
+            // (exile → investigate → return the exiled cards).
+            let any_prior_publishes = defs
+                .iter()
+                .any(|d| publishes_tracked_set_from_resolution(&d.effect));
+            if any_prior_publishes {
+                let has_tracked_ref = contains_explicit_tracked_set_pronoun(&source_text_lower)
+                    || contains_implicit_tracked_set_pronoun(&source_text_lower);
+                if has_tracked_ref {
+                    for current in &mut current_defs {
+                        mark_uses_tracked_set(current);
+                        rewrite_parent_targets_to_tracked_set(&mut current.effect);
+                    }
+                }
+            }
+
             // Find the previous non-special, non-absorbed clause
             let prev_effect = defs.last().map(|d| &*d.effect);
             if let Some(prev_eff) = prev_effect {
-                if publishes_tracked_set_from_resolution(prev_eff) {
-                    let has_tracked_ref = contains_explicit_tracked_set_pronoun(&source_text_lower)
-                        || contains_implicit_tracked_set_pronoun(&source_text_lower);
-                    if has_tracked_ref {
-                        for current in &mut current_defs {
-                            mark_uses_tracked_set(current);
-                            rewrite_parent_targets_to_tracked_set(&mut current.effect);
-                        }
-                    }
-                }
-
                 // CR 603.7c: Stamp the prior clause's zone destination as the
                 // expected origin of any delayed `ParentTarget` return, so the
                 // resolver's CR 400.7 `origin` guard suppresses the return when the
@@ -2686,6 +2693,17 @@ pub(super) fn strip_temporal_prefix(text: &str) -> (&str, Option<DelayedTriggerC
                     phase: Phase::BeginCombat,
                 },
                 tag("at the beginning of that combat, "),
+            ),
+            // CR 511.2 + CR 603.7a: "At this turn's next end of combat, …"
+            // fires at the end-of-combat step of the current turn.
+            // Covers Triton Tactics, Glyph of Doom, Gaze of the Gorgon,
+            // Venomous Breath, and the full class of spells that schedule
+            // an end-of-combat effect during resolution.
+            value(
+                DelayedTriggerCondition::AtNextPhase {
+                    phase: Phase::EndCombat,
+                },
+                tag("at this turn's next end of combat, "),
             ),
         ))
         .parse(i)
@@ -5817,6 +5835,22 @@ mod tests {
             strip_temporal_suffix("you lose the game at the beginning of that turn's end step");
         assert_eq!(rest, "you lose the game");
         assert_eq!(cond, Some(expected));
+    }
+
+    /// CR 511.2 + CR 603.7a: "At this turn's next end of combat, …" prefix-form
+    /// delayed trigger fires at the end-of-combat step of the current turn.
+    /// Covers Triton Tactics, Glyph of Doom.
+    #[test]
+    fn strip_temporal_prefix_at_this_turns_next_end_of_combat() {
+        let (text, cond) =
+            strip_temporal_prefix("at this turn's next end of combat, untap that creature");
+        assert_eq!(text, "untap that creature");
+        assert_eq!(
+            cond,
+            Some(DelayedTriggerCondition::AtNextPhase {
+                phase: Phase::EndCombat,
+            })
+        );
     }
 
     /// Build-the-class: the extra-turn-with-a-cost family parses to BOTH an

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16932,15 +16932,15 @@ pub(crate) fn parse_effect_chain_ir(
         // CR 603.7: Cross-clause pronoun → mark uses_tracked_set flag.
         // This needs to check whether the previous clause publishes an affected
         // object set (zone changes, token creation, counter placement, etc.).
-        let needs_tracked_set = clauses
-            .iter()
-            .rev()
-            .find(|c| !c.absorbed_by_followup)
-            .is_some_and(|previous| {
-                publishes_tracked_set_from_resolution(&previous.parsed.effect)
-                    && (contains_explicit_tracked_set_pronoun(&lower_check)
-                        || contains_implicit_tracked_set_pronoun(&lower_check))
-            });
+        // CR 603.7: Scan ALL prior non-absorbed clauses for a tracked-set
+        // publisher, not just the nearest. An intermediate non-publishing
+        // clause (e.g. Investigate) must not shadow an earlier exile.
+        let any_prior_publishes = clauses.iter().any(|c| {
+            !c.absorbed_by_followup && publishes_tracked_set_from_resolution(&c.parsed.effect)
+        });
+        let needs_tracked_set = any_prior_publishes
+            && (contains_explicit_tracked_set_pronoun(&lower_check)
+                || contains_implicit_tracked_set_pronoun(&lower_check));
 
         // Continuation recognition — store on ClauseIr, application moves to lowering.
         //
@@ -31003,6 +31003,32 @@ mod tests {
             }
         );
         assert!(*tapped);
+    }
+
+    /// CR 603.7: Exile → non-publishing clause → delayed return: uses_tracked_set
+    /// must be true even when the non-publishing clause (Investigate) is nearest.
+    /// Covers Disorder in the Court.
+    #[test]
+    fn exile_then_investigate_then_return_exiled_cards_uses_tracked_set() {
+        let e = parse_effect_chain(
+            "Exile X target creatures, then investigate X times. Return the exiled cards to the battlefield tapped under their owners' control at the beginning of the next end step.",
+            AbilityKind::Spell,
+        );
+        fn find_delayed(def: &AbilityDefinition) -> bool {
+            if let Effect::CreateDelayedTrigger {
+                uses_tracked_set, ..
+            } = &*def.effect
+            {
+                if *uses_tracked_set {
+                    return true;
+                }
+            }
+            def.sub_ability.as_deref().is_some_and(find_delayed)
+        }
+        assert!(
+            find_delayed(&e),
+            "expected CreateDelayedTrigger {{ uses_tracked_set: true }} for 'the exiled cards', got {e:?}"
+        );
     }
 
     /// Issue #1696 — Myrkul, Lord of Bones full chain: an exile that publishes a


### PR DESCRIPTION
## Summary

Fixes two independent Oracle parser gaps that caused delayed trigger effects to be silently dropped.

### Issue #2850 — Disorder in the Court: exiled creatures never return

The tracked-set publisher scan at both lowering sites (`lower_effect_chain_ir` and `parse_effect_chain_ir`) checked only the **nearest** prior clause. For spells where an intermediate non-publishing clause (e.g. Investigate) separates the exile clause from the delayed return clause, `needs_tracked_set` was always `false` — so `CreateDelayedTrigger { uses_tracked_set: false }` was written and `bind_tracked_set_to_ability_chain` never fired at resolution.

Fixed by replacing `.rev().find(nearest)` with `.iter().any(all prior)` at both scan sites. The zone-origin stamping block that also uses `defs.last()` is preserved unchanged (it serves a different purpose — CR 603.7c origin guard). CR 603.7.

### Issue #3010 — "At this turn's next end of combat, …" prefix dropped

`strip_temporal_prefix` had no arm for `"at this turn's next end of combat, "`. Cards using this prefix form (Triton Tactics, Glyph of Doom, Gaze of the Gorgon, Venomous Breath) produced `Effect::Unimplemented` instead of `CreateDelayedTrigger { condition: AtNextPhase { EndCombat } }`. The suffix form `" at end of combat"` was already handled; this adds symmetric prefix coverage. CR 511.2 + CR 603.7a.

## Changes

- `crates/engine/src/parser/oracle_effect/lower.rs` — Fix #3010 nom arm in `strip_temporal_prefix`; Fix #2850 all-prior scan in `lower_effect_chain_ir`; two inline tests
- `crates/engine/src/parser/oracle_effect/mod.rs` — Fix #2850 all-prior scan in `parse_effect_chain_ir`; Disorder in the Court discriminating test

Closes #2850
Closes #3010