### PR TITLE
feat: trigger on "a spell or ability an opponent controls causes you to discard this card"

### DIFF
--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -114,6 +114,7 @@ pub(crate) fn complete_discard_to_graveyard(
     events.push(GameEvent::Discarded {
         player_id,
         object_id,
+        source_id,
     });
     DiscardOutcome::Complete
 }
@@ -236,6 +237,7 @@ pub fn resolve(
                             events.push(GameEvent::Discarded {
                                 player_id,
                                 object_id: oid,
+                                source_id: Some(ability.source_id),
                             });
                         }
                         _ => {}
@@ -431,6 +433,7 @@ fn route_discard(
                 events.push(GameEvent::Discarded {
                     player_id: player,
                     object_id: oid,
+                    source_id,
                 });
             }
             _ => {}

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -6076,6 +6076,7 @@ mod tests {
         state.current_trigger_event = Some(GameEvent::Discarded {
             player_id: PlayerId(0),
             object_id: discarded,
+            source_id: None,
         });
 
         let filter =
@@ -6154,15 +6155,18 @@ mod tests {
         state.current_trigger_event = Some(GameEvent::Discarded {
             player_id: PlayerId(0),
             object_id: discarded_creature,
+            source_id: None,
         });
         state.current_trigger_events = vec![
             GameEvent::Discarded {
                 player_id: PlayerId(0),
                 object_id: discarded_creature,
+                source_id: None,
             },
             GameEvent::Discarded {
                 player_id: PlayerId(0),
                 object_id: discarded_instant,
+                source_id: None,
             },
         ];
 

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -426,6 +426,7 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
         GameEvent::Discarded {
             player_id,
             object_id,
+            ..
         } => vec![
             player_seg(state, *player_id),
             text(" discards "),

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -268,6 +268,7 @@ pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]
             | GameEvent::Discarded {
                 player_id,
                 object_id,
+                ..
             }
             | GameEvent::Cycled {
                 player_id,

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2060,6 +2060,7 @@ pub(super) fn match_discarded(
     if let GameEvent::Discarded {
         player_id,
         object_id,
+        ..
     } = event
     {
         // CR 603.2: The trigger event includes which player discarded; scope
@@ -2599,6 +2600,7 @@ pub(super) fn match_cycled_or_discarded(
     if let GameEvent::Discarded {
         player_id,
         object_id,
+        ..
     } = event
     {
         if !valid_player_matches(trigger, state, *player_id, source_id) {
@@ -4371,6 +4373,7 @@ mod tests {
             &GameEvent::Discarded {
                 player_id: PlayerId(1),
                 object_id: discarded,
+                source_id: None,
             },
             &trigger,
             source,
@@ -4380,6 +4383,7 @@ mod tests {
             &GameEvent::Discarded {
                 player_id: PlayerId(0),
                 object_id: discarded,
+                source_id: None,
             },
             &trigger,
             source,
@@ -4443,6 +4447,7 @@ mod tests {
             &GameEvent::Discarded {
                 player_id: PlayerId(1),
                 object_id: card,
+                source_id: None,
             },
             &trigger,
             source,
@@ -4452,6 +4457,7 @@ mod tests {
             &GameEvent::Discarded {
                 player_id: PlayerId(0),
                 object_id: card,
+                source_id: None,
             },
             &trigger,
             source,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4311,6 +4311,35 @@ fn check_trigger_constraint(
             state.active_player == controller
                 && matches!(state.phase, Phase::PreCombatMain | Phase::PostCombatMain)
         }
+        // CR 109.5 + CR 603.2: Fires only when the triggering discard was caused
+        // by a spell/ability controlled by `ctrl_ref` relative to the trigger's
+        // controller (mirrors the replacement-side `EventSourceControlledBy`).
+        TriggerConstraint::EventSourceControlledBy {
+            controller: ctrl_ref,
+        } => {
+            let event_source = match event {
+                GameEvent::Discarded {
+                    source_id: Some(source_id),
+                    ..
+                } => *source_id,
+                _ => return false,
+            };
+            let Some(event_source_controller) = state
+                .objects
+                .get(&event_source)
+                .map(|o| o.controller)
+                .or_else(|| state.lki_cache.get(&event_source).map(|lki| lki.controller))
+            else {
+                return false;
+            };
+            match ctrl_ref {
+                crate::types::ability::ControllerRef::You => event_source_controller == controller,
+                crate::types::ability::ControllerRef::Opponent => {
+                    event_source_controller != controller
+                }
+                _ => false,
+            }
+        }
         // CR 603.2: Per-caster spell count. The caster is extracted from the SpellCast
         // event; the count comes from the per-player map (not the global counter).
         // When `filter` contains `TypeFilter::Non(Creature)`, use the noncreature counter.
@@ -5359,8 +5388,9 @@ fn record_trigger_fired(
         | TriggerConstraint::OnlyDuringYourMainPhase
         | TriggerConstraint::NthSpellThisTurn { .. }
         | TriggerConstraint::NthDrawThisTurn { .. }
+        | TriggerConstraint::EventSourceControlledBy { .. }
         | TriggerConstraint::AtClassLevel { .. } => {
-            // No tracking needed — checked at fire time via game/object state
+            // No tracking needed — checked at fire time via game/object/event state
         }
         // CR 603.4: Increment fire count for MaxTimesPerTurn tracking.
         TriggerConstraint::MaxTimesPerTurn { .. } => {
@@ -5699,6 +5729,54 @@ pub mod tests {
         obj.power = Some(power);
         obj.toughness = Some(toughness);
         id
+    }
+
+    /// CR 109.5 + CR 603.2: the `EventSourceControlledBy { Opponent }` trigger
+    /// constraint (Guerrilla Tactics) fires only when the discard's cause is a
+    /// spell/ability controlled by an opponent — not a self-caused discard or one
+    /// with no recorded cause. (issue67)
+    #[test]
+    fn event_source_controlled_by_opponent_gates_discard_trigger() {
+        use crate::types::ability::{ControllerRef, TriggerConstraint};
+        let mut state = setup();
+        let source = make_creature(&mut state, PlayerId(0), "Guerrilla Tactics", 0, 0);
+        let opp_cause = make_creature(&mut state, PlayerId(1), "Opponent's Spell", 0, 0);
+        let own_cause = make_creature(&mut state, PlayerId(0), "Your Own Spell", 0, 0);
+
+        let mut def = make_trigger(TriggerMode::Discarded);
+        def.constraint = Some(TriggerConstraint::EventSourceControlledBy {
+            controller: ControllerRef::Opponent,
+        });
+
+        let opp = GameEvent::Discarded {
+            player_id: PlayerId(0),
+            object_id: source,
+            source_id: Some(opp_cause),
+        };
+        assert!(
+            check_trigger_constraint(&state, &def, source, 0, PlayerId(0), &opp),
+            "an opponent-controlled cause must satisfy the constraint"
+        );
+
+        let own = GameEvent::Discarded {
+            player_id: PlayerId(0),
+            object_id: source,
+            source_id: Some(own_cause),
+        };
+        assert!(
+            !check_trigger_constraint(&state, &def, source, 0, PlayerId(0), &own),
+            "a self-controlled cause must NOT satisfy the constraint"
+        );
+
+        let no_cause = GameEvent::Discarded {
+            player_id: PlayerId(0),
+            object_id: source,
+            source_id: None,
+        };
+        assert!(
+            !check_trigger_constraint(&state, &def, source, 0, PlayerId(0), &no_cause),
+            "a discard with no recorded cause must NOT satisfy the constraint"
+        );
     }
 
     /// CR 702.149a + CR 508.1a: the synthesized Training condition is a filtered
@@ -13649,10 +13727,12 @@ pub mod tests {
                 GameEvent::Discarded {
                     player_id: PlayerId(0),
                     object_id: discarded_creature,
+                    source_id: None,
                 },
                 GameEvent::Discarded {
                     player_id: PlayerId(0),
                     object_id: discarded_instant,
+                    source_id: None,
                 },
             ],
         );

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5779,6 +5779,121 @@ pub mod tests {
         );
     }
 
+    /// CR 113.6k + CR 701.9a + CR 109.5: end-to-end proof that an
+    /// "a spell or ability an opponent controls causes you to discard this card"
+    /// trigger (Sand Golem) actually fires through the real discard pipeline.
+    /// `complete_discard_to_graveyard` moves the card hand->graveyard BEFORE
+    /// pushing `GameEvent::Discarded`, so the trigger can only be observed by the
+    /// off-zone (graveyard) scan in `process_triggers`. This discriminates the
+    /// `trigger_zones = [Graveyard, Exile]` fix: with the empty `trigger_zones`
+    /// bug the definition is battlefield-only and never reaches the
+    /// `EventSourceControlledBy` constraint, so the positive case would fail.
+    ///
+    /// Installs the *parsed* trigger (not a hand-built one) on a card in HAND and
+    /// varies only the discard's cause across the three cases.
+    #[test]
+    fn opponent_caused_self_discard_trigger_fires_through_real_pipeline() {
+        use crate::game::effects::discard;
+
+        // Build the printed trigger from Oracle text — this is the production
+        // parser output, including the `trigger_zones = [Graveyard, Exile]` fix.
+        let parsed = crate::parser::oracle_trigger::parse_trigger_line(
+            "When a spell or ability an opponent controls causes you to discard this card, \
+             this card deals 4 damage to any target.",
+            "Sand Golem",
+        );
+        assert_eq!(parsed.mode, TriggerMode::Discarded);
+        assert_eq!(parsed.trigger_zones, vec![Zone::Graveyard, Zone::Exile]);
+
+        // Fresh state with the Sand Golem card in PlayerId(0)'s HAND carrying the
+        // parsed trigger, plus a live source object whose controller we vary.
+        // Returns whether the trigger fired (reached the stack or pending target
+        // selection with `card` as its source).
+        let run_case = |source_controller: PlayerId, with_cause: bool| -> bool {
+            let mut state = setup();
+            state.active_player = PlayerId(0);
+
+            let card = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Sand Golem".to_string(),
+                Zone::Hand,
+            );
+            state
+                .objects
+                .get_mut(&card)
+                .unwrap()
+                .trigger_definitions
+                .push(parsed.clone());
+
+            // A live source object on the battlefield, controlled by whichever
+            // player this case wants to be the discard's cause.
+            let source = make_creature(&mut state, source_controller, "Discard Source", 2, 2);
+
+            let mut events = Vec::new();
+            if with_cause {
+                // Real "caused by a spell/ability" discard seam — records the
+                // cause as `source_id`.
+                discard::discard_caused_by_effect_with_source(
+                    &mut state,
+                    card,
+                    PlayerId(0),
+                    Some(source),
+                    &mut events,
+                );
+            } else {
+                // Cost-style discard with no recorded cause (source_id = None).
+                discard::discard_as_cost(&mut state, card, PlayerId(0), &mut events);
+            }
+
+            // The card must have actually moved hand->graveyard so the off-zone
+            // scan can observe it.
+            assert_eq!(
+                state.objects.get(&card).map(|o| o.zone),
+                Some(Zone::Graveyard),
+                "complete_discard_to_graveyard must move the card to the graveyard \
+                 before the Discarded event is scanned"
+            );
+            assert!(
+                events.iter().any(
+                    |e| matches!(e, GameEvent::Discarded { object_id, .. } if *object_id == card)
+                ),
+                "the real discard seam must emit a Discarded event for the card"
+            );
+
+            process_triggers(&mut state, &events);
+
+            let on_stack = state.stack.iter().any(|entry| {
+                entry.source_id == card
+                    && matches!(entry.kind, StackEntryKind::TriggeredAbility { .. })
+            });
+            let pending = state
+                .pending_trigger
+                .as_ref()
+                .is_some_and(|p| p.source_id == card);
+            on_stack || pending
+        };
+
+        // Positive: opponent-controlled cause => trigger fires.
+        assert!(
+            run_case(PlayerId(1), true),
+            "an opponent-caused self-discard must fire the trigger from the graveyard"
+        );
+
+        // Negative (a): self-caused (PlayerId(0)) => constraint rejects, no trigger.
+        assert!(
+            !run_case(PlayerId(0), true),
+            "a self-caused discard must NOT fire the opponent-gated trigger"
+        );
+
+        // Negative (b): no recorded cause (discard_as_cost) => no trigger.
+        assert!(
+            !run_case(PlayerId(1), false),
+            "a discard with no recorded cause must NOT fire the trigger"
+        );
+    }
+
     /// CR 702.149a + CR 508.1a: the synthesized Training condition is a filtered
     /// `MinCoAttackers { minimum: 1, filter: Some(power > source) }`. This drives
     /// the *real* synthesized condition through `check_trigger_condition` to prove

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11465,6 +11465,29 @@ fn try_parse_discard_trigger(
         return Some((TriggerMode::DiscardedAll, def));
     }
 
+    // CR 109.5 + CR 603.2: "a spell or ability an opponent controls causes you to
+    // discard this card" — the self-discard caused by an opponent's spell/ability
+    // (Guerrilla Tactics, Sand Golem, Quagnoth, Mangara's Blessing). The
+    // `EventSourceControlledBy { Opponent }` constraint gates on the discard
+    // event's cause; mirrors the replacement form in `oracle_replacement.rs`.
+    if tag::<_, _, OracleError<'_>>(
+        "a spell or ability an opponent controls causes you to discard this card",
+    )
+    .parse(event)
+    .is_ok()
+    {
+        let mut def = make_base();
+        def.mode = TriggerMode::Discarded;
+        def.valid_card = Some(TargetFilter::SelfRef);
+        def.valid_target = Some(TargetFilter::Controller);
+        def.constraint = Some(
+            crate::types::ability::TriggerConstraint::EventSourceControlledBy {
+                controller: ControllerRef::Opponent,
+            },
+        );
+        return Some((TriggerMode::Discarded, def));
+    }
+
     // Determine subject and find "discards"/"discard" verb using nom alt()
     fn parse_discard_subject(input: &str) -> OracleResult<'_, Option<ControllerRef>> {
         alt((
@@ -21190,6 +21213,29 @@ mod tests {
             Some(TargetFilter::Typed(
                 TypedFilter::new(TypeFilter::Card).controller(ControllerRef::Opponent)
             ))
+        );
+    }
+
+    /// CR 109.5 + CR 603.2: "When a spell or ability an opponent controls causes
+    /// you to discard this card, [effect]" (Guerrilla Tactics, Sand Golem) — a
+    /// self-discard trigger gated by the `EventSourceControlledBy { Opponent }`
+    /// constraint. Issue #3109-style. (issue67)
+    #[test]
+    fn trigger_opponent_causes_you_to_discard_this_card() {
+        let def = parse_trigger_line(
+            "When a spell or ability an opponent controls causes you to discard this card, this card deals 4 damage to any target.",
+            "Guerrilla Tactics",
+        );
+        assert_eq!(def.mode, TriggerMode::Discarded);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+        assert_eq!(
+            def.constraint,
+            Some(
+                crate::types::ability::TriggerConstraint::EventSourceControlledBy {
+                    controller: ControllerRef::Opponent
+                }
+            )
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11485,6 +11485,13 @@ fn try_parse_discard_trigger(
                 controller: ControllerRef::Opponent,
             },
         );
+        // CR 113.6 + CR 113.6k: the source is the discarded card itself. By the time
+        // process_triggers scans the Discarded event, complete_discard_to_graveyard has
+        // already moved the card hand->graveyard (CR 701.9a), so the trigger must
+        // function from the graveyard it lands in (the same off-zone seam Necropotence-
+        // style self-discard triggers use). Exile keeps it live under a madness/RIP-class
+        // redirect (a redirected discard is still a discard).
+        def.trigger_zones = vec![Zone::Graveyard, Zone::Exile];
         return Some((TriggerMode::Discarded, def));
     }
 
@@ -21237,6 +21244,10 @@ mod tests {
                 }
             )
         );
+        // The discarded card has already moved hand->graveyard (or exile under a
+        // madness/RIP redirect) by the time the Discarded event is scanned, so the
+        // trigger must function off the battlefield to fire at all.
+        assert_eq!(def.trigger_zones, vec![Zone::Graveyard, Zone::Exile]);
     }
 
     /// CR 701.9 + CR 603.7c + CR 406.1: Necropotence's on-discard trigger

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -12996,6 +12996,13 @@ pub enum TriggerConstraint {
     /// per opponent per turn. Used by Valgavoth, Harrower of Souls: "Whenever
     /// an opponent loses life for the first time during each of their turns, ..."
     OncePerOpponentPerTurn,
+    /// CR 109.5 + CR 603.2: Fires only when the triggering event was caused by a
+    /// spell or ability controlled by `controller` relative to the trigger's
+    /// controller. Mirrors [`ReplacementCondition::EventSourceControlledBy`] for
+    /// the trigger side — used by "when a spell or ability an opponent controls
+    /// causes you to discard this card, …" (Guerrilla Tactics, Sand Golem). The
+    /// event must carry the cause's source id (e.g. `GameEvent::Discarded.source_id`).
+    EventSourceControlledBy { controller: ControllerRef },
 }
 
 /// CR 603.6c: source-zone constraint for one clause of a zone-change trigger.

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -333,6 +333,13 @@ pub enum GameEvent {
     Discarded {
         player_id: PlayerId,
         object_id: ObjectId,
+        /// CR 603.2 + CR 109.5: The spell/ability that caused this discard, if any
+        /// (effect- or cost-driven discards). `None` for a player's own
+        /// turn-based / hand-size discards. Carried from `ProposedEvent::Discard`
+        /// so triggers like "when a spell or ability an opponent controls causes
+        /// you to discard this card" can resolve the cause's controller.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_id: Option<ObjectId>,
     },
     DamageCleared {
         object_id: ObjectId,


### PR DESCRIPTION
## What

Implements the triggered ability **"When a spell or ability an opponent controls causes you to discard this card, [effect]"** — previously unparsed. First pass of #3115.

**Cards:** Guerrilla Tactics, Sand Golem, Quagnoth, Mangara's Blessing, Ajani's Last Stand, Pure Intentions.

Refs #3115 — first pass is the "**this card**" self-discard form; the "a card" form (Spiritual Focus) stays tracked under #3115.

## How

The *replacement* form of this event already exists (`oracle_replacement.rs`), but the *trigger* form didn't because `GameEvent::Discarded` dropped the discard's cause when lowering from `ProposedEvent`. So:

- Added `source_id: Option<ObjectId>` to `GameEvent::Discarded` and threaded the cause through the three discard emission sites (effect/cost/madness paths). `None` for turn-based/hand-size discards.
- Added `TriggerConstraint::EventSourceControlledBy { controller }` (CR 109.5 + CR 603.2) — the trigger-side mirror of `ReplacementCondition::EventSourceControlledBy`. Evaluated in `check_trigger_constraint` by resolving the cause's controller (objects / LKI cache), reusing the replacement's exact logic.
- Parser: "a spell or ability an opponent controls causes you to discard this card" → `Discarded` mode, `valid_card: SelfRef`, `valid_target: Controller`, `constraint: EventSourceControlledBy { Opponent }`.

All `GameEvent::Discarded` match/construct sites updated (engine-only; no wildcards in the constraint matches).

## Tests

- Parser: the phrase → the expected trigger shape + constraint.
- Runtime: `check_trigger_constraint` returns true for an opponent-controlled cause, false for a self-controlled cause and for a discard with no recorded cause.

All gates green: rustfmt, clippy `-D warnings`, parser-combinators, engine-authorities, integration (956), and a regenerated card-data → coverage diff confirming **swallowed-clause delta 0** (no flip-trap regression) with the target cards gaining support.
