### PR TITLE
fix(engine): resolve impossible Choose as no-op instead of wedging (#3040)

### DIFF
--- a/crates/engine/src/game/effects/choose.rs
+++ b/crates/engine/src/game/effects/choose.rs
@@ -40,15 +40,18 @@ pub fn resolve(
     // choice and the list is empty (e.g. "choose a player" once every eligible
     // player has already been chosen earlier in this resolution, or a "choose
     // an ability the target has" with no abilities to remove), there is nothing
-    // to choose — the choice does nothing and resolution continues with the
-    // rest of the chain. Emitting a `WaitingFor::NamedChoice` with no options
-    // would wedge the game (issue #3040): the legal-action enumerator yields no
-    // `ChooseOption`, so no player can advance the decision. `CardName` / `Word`
-    // / `Artist` are excluded because their value is player-supplied, so an
-    // empty engine list there is expected, not impossible (only `CardName` has
-    // a wired free-text supply path today; `Word` / `Artist` are a separate
-    // known frontend gap — see `options_supplied_by_player`).
+    // to choose. The choice does nothing; the chain driver then skips any
+    // continuation that depends on the missing chosen value while allowing
+    // independent siblings to proceed. Emitting a `WaitingFor::NamedChoice`
+    // with no options would wedge the game (issue #3040): the legal-action
+    // enumerator yields no `ChooseOption`, so no player can advance the
+    // decision. `CardName` / `Word` / `Artist` are excluded because their value
+    // is player-supplied, so an empty engine list there is expected, not
+    // impossible (only `CardName` has a wired free-text supply path today;
+    // `Word` / `Artist` are a separate known frontend gap — see
+    // `options_supplied_by_player`).
     if options.is_empty() && !choice_type.options_supplied_by_player() {
+        state.cost_payment_failed_flag = true;
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::from(&ability.effect),
             source_id: ability.source_id,

--- a/crates/engine/src/game/effects/choose.rs
+++ b/crates/engine/src/game/effects/choose.rs
@@ -35,6 +35,25 @@ pub fn resolve(
         &ability.chosen_players,
     );
 
+    // CR 609.3: If an effect attempts to do something impossible, it does only
+    // as much as possible. When the engine enumerates the legal options for a
+    // choice and the list is empty (e.g. "choose a player" once every eligible
+    // player has already been chosen earlier in this resolution, or a "choose
+    // an ability the target has" with no abilities to remove), there is nothing
+    // to choose — the choice does nothing and resolution continues with the
+    // rest of the chain. Emitting a `WaitingFor::NamedChoice` with no options
+    // would wedge the game (issue #3040): the legal-action enumerator yields no
+    // `ChooseOption`, so no player can advance the decision. `CardName` / `Word`
+    // / `Artist` are excluded because the player supplies their value at runtime
+    // — an empty engine list there is expected, not impossible.
+    if options.is_empty() && !choice_type.options_supplied_by_player() {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
     state.waiting_for = WaitingFor::NamedChoice {
         player: ability.controller,
         choice_type,
@@ -520,20 +539,65 @@ mod tests {
     }
 
     #[test]
-    fn choose_player_with_all_players_chosen_offers_no_options() {
-        // Edge: when every player is already chosen, the option set is empty
-        // — the choice (and its dependent effect) does nothing.
+    fn choose_player_with_all_players_chosen_resolves_as_no_op() {
+        // CR 609.3 (issue #3040): when every eligible player is already chosen,
+        // the engine-enumerated option set is empty — choosing is impossible, so
+        // the choice does nothing and resolution continues. It must NOT raise a
+        // `WaitingFor::NamedChoice` with no options, which would wedge the game
+        // (the legal-action enumerator yields no `ChooseOption` to advance it).
         let mut state = GameState::new_two_player(42);
+        // A non-Priority sentinel so we can prove `resolve` doesn't install the
+        // empty `NamedChoice` and doesn't otherwise touch `waiting_for`.
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
         let mut ability = make_choose_ability(ChoiceType::Player);
         ability.chosen_players = vec![PlayerId(0), PlayerId(1)];
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
-        match &state.waiting_for {
-            WaitingFor::NamedChoice { options, .. } => {
-                assert!(options.is_empty());
-            }
-            other => panic!("Expected NamedChoice, got {:?}", other),
-        }
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::NamedChoice { .. }),
+            "an impossible choice must not wedge on an empty NamedChoice"
+        );
+        // The effect still resolved (CR 609.3 "as much as possible" = nothing).
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, GameEvent::EffectResolved { .. })));
+    }
+
+    #[test]
+    fn choose_empty_keyword_list_resolves_as_no_op() {
+        // CR 609.3 + CR 608.2d (issue #3040): "choose an ability the target has"
+        // with no removable abilities enumerates to an empty option set. The
+        // choice is impossible, so it resolves as a no-op rather than emitting an
+        // unsatisfiable `NamedChoice`.
+        let mut state = GameState::new_two_player(42);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        let ability = make_choose_ability(ChoiceType::Keyword { options: vec![] });
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::NamedChoice { .. }),
+            "an empty keyword choice must not wedge on an empty NamedChoice"
+        );
+    }
+
+    #[test]
+    fn choose_card_name_with_empty_options_still_prompts() {
+        // CR 609.3 boundary: `CardName` options are supplied by the frontend's
+        // card database at runtime, so an empty engine list is expected, not
+        // impossible. The no-op short-circuit must NOT fire here — the prompt
+        // still goes up so the player can name a card.
+        let mut state = GameState::new_two_player(42);
+        let ability = make_choose_ability(ChoiceType::CardName);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert!(
+            matches!(state.waiting_for, WaitingFor::NamedChoice { .. }),
+            "CardName is player-supplied — empty engine options must still prompt"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/choose.rs
+++ b/crates/engine/src/game/effects/choose.rs
@@ -44,8 +44,10 @@ pub fn resolve(
     // rest of the chain. Emitting a `WaitingFor::NamedChoice` with no options
     // would wedge the game (issue #3040): the legal-action enumerator yields no
     // `ChooseOption`, so no player can advance the decision. `CardName` / `Word`
-    // / `Artist` are excluded because the player supplies their value at runtime
-    // — an empty engine list there is expected, not impossible.
+    // / `Artist` are excluded because their value is player-supplied, so an
+    // empty engine list there is expected, not impossible (only `CardName` has
+    // a wired free-text supply path today; `Word` / `Artist` are a separate
+    // known frontend gap — see `options_supplied_by_player`).
     if options.is_empty() && !choice_type.options_supplied_by_player() {
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::from(&ability.effect),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3900,6 +3900,18 @@ fn resolve_chain_body(
     };
     let ability = ability.as_ref();
 
+    if effect_depends_on_missing_chosen_player(ability) {
+        state.cost_payment_failed_flag = true;
+        if let Some(ref next) = ability.sub_ability {
+            if next.sub_link == SubAbilityLink::SequentialSibling {
+                let mut sibling = next.as_ref().clone();
+                apply_parent_chain_context(&mut sibling, ability, None);
+                resolve_ability_chain(state, &sibling, events, depth + 1)?;
+            }
+        }
+        return Ok(());
+    }
+
     if repeat_for_outermost_with_scope_or_unless(ability)
         && !has_member_driven_repeat_after_hydration(state, ability)
     {
@@ -5416,6 +5428,14 @@ fn resolve_chain_body(
     }
 
     Ok(())
+}
+
+fn effect_depends_on_missing_chosen_player(ability: &ResolvedAbility) -> bool {
+    ability
+        .effect
+        .target_filter()
+        .and_then(crate::game::ability_utils::filter_chosen_player_index)
+        .is_some_and(|index| ability.chosen_players.get(index as usize).is_none())
 }
 
 /// CR 608.2c + CR 109.5: Spell-effect "if you sacrificed a [filter] this way"

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7820,6 +7820,61 @@ mod tests {
         assert_eq!(state.players[0].hand.len(), 1);
     }
 
+    #[test]
+    fn resolve_ability_chain_impossible_choice_does_not_wedge_chain() {
+        // CR 609.3 (issue #3040): a `Choose` whose engine-enumerated option set
+        // is empty is an impossible choice. It must resolve as a no-op so the
+        // rest of the chain continues, instead of emitting an unsatisfiable
+        // `WaitingFor::NamedChoice` that no `ChooseOption` can advance — which
+        // would stash the dependent sub-ability forever and hang the game.
+        use crate::types::ability::ChoiceType;
+
+        let mut state = GameState::new_two_player(42);
+        create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Card A".to_string(),
+            Zone::Library,
+        );
+
+        // Empty `Keyword` option list → "choose an ability the target has" with
+        // nothing to choose. The dependent Draw must still resolve.
+        let draw = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let ability = ResolvedAbility::new(
+            Effect::Choose {
+                choice_type: ChoiceType::Keyword { options: vec![] },
+                persist: false,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        )
+        .sub_ability(draw);
+        let mut events = Vec::new();
+
+        let result = resolve_ability_chain(&mut state, &ability, &mut events, 0);
+        assert!(result.is_ok());
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::NamedChoice { .. }),
+            "impossible choice must not leave the chain wedged on an empty NamedChoice"
+        );
+        // The dependent sub-ability resolved inline (no choice paused the chain).
+        assert_eq!(
+            state.players[0].hand.len(),
+            1,
+            "the chain must continue past an impossible choice and draw the card"
+        );
+    }
+
     /// Regression (issue #1977, Party Thrasher): "you may discard a card. If you
     /// do, exile the top two cards of your library, then choose one of them."
     /// CR 608.2c + CR 603.7: the discard is a gating action behind the

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -221,6 +221,22 @@ impl ChoiceType {
     pub fn color_excluding(excluded: Vec<ManaColor>) -> Self {
         Self::Color { excluded }
     }
+
+    /// Whether the player supplies the chosen value at runtime rather than the
+    /// engine enumerating a fixed option set.
+    ///
+    /// `CardName` options come from the frontend's local card database (the
+    /// engine sends an empty list to avoid serializing 30k+ names), and `Word`
+    /// / `Artist` are free-form text the player types. For every other choice
+    /// type the engine fully enumerates the legal options, so an empty option
+    /// list means there is genuinely nothing to choose.
+    ///
+    /// Used to distinguish a legitimately-empty engine option list (this
+    /// predicate is true) from an impossible choice that must resolve as a
+    /// no-op per CR 609.3 (this predicate is false).
+    pub fn options_supplied_by_player(&self) -> bool {
+        matches!(self, Self::CardName | Self::Word | Self::Artist)
+    }
 }
 
 impl Serialize for ChoiceType {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -226,10 +226,16 @@ impl ChoiceType {
     /// engine enumerating a fixed option set.
     ///
     /// `CardName` options come from the frontend's local card database (the
-    /// engine sends an empty list to avoid serializing 30k+ names), and `Word`
-    /// / `Artist` are free-form text the player types. For every other choice
-    /// type the engine fully enumerates the legal options, so an empty option
-    /// list means there is genuinely nothing to choose.
+    /// engine sends an empty list to avoid serializing 30k+ names) and are
+    /// wired end-to-end via the free-text name search. `Word` / `Artist` are
+    /// likewise player-supplied free-text in principle, but their free-text
+    /// frontend/legal-action path is not yet implemented (only `CardName` is
+    /// synthesized by `named_choice_actions` and given a text input by
+    /// `NamedChoiceModal`) — a separate known gap. They are kept here so an
+    /// empty engine list for them is treated as a still-to-be-supplied value
+    /// rather than silently skipped as impossible. For every other choice type
+    /// the engine fully enumerates the legal options, so an empty option list
+    /// means there is genuinely nothing to choose.
     ///
     /// Used to distinguish a legitimately-empty engine option list (this
     /// predicate is true) from an impossible choice that must resolve as a


### PR DESCRIPTION
Fixes #3040.

## Problem

A game could hang on `WaitingFor::NamedChoice` (the reporter hit it after an opponent cast an X=0 spell). When a `Choose` effect resolves to an option set the engine fully enumerates, but that set comes out **empty**, `choose::resolve` still emitted a `WaitingFor::NamedChoice` with zero options. The legal-action enumerator (`named_choice_actions`) yields no `ChooseOption` for an empty non-`CardName` list, so no player can advance the decision — the game wedges (the existing `stuck_decision_diagnostic` fires on exactly this shape).

The engine can legitimately produce an empty option set for several choice types regardless of any X value, e.g. a successive "choose a player" once every eligible player has already been chosen this resolution (`ChoiceType::Player`/`Opponent`, CR 608.2c Gluntch ruling), or a "choose an ability the target has" with no removable abilities (`ChoiceType::Keyword`). The resolver's own doc comment already described an "empty-options path" that does nothing — but it was never actually implemented; the code unconditionally set the unsatisfiable `NamedChoice`.

## Fix

Single-seam change in the one authoritative `Choose` resolver. When the engine-enumerated option list is empty and the choice type is not player-supplied, the choice is **impossible**, so it resolves as a no-op (CR 609.3 — "an effect does only as much as possible") and the chain continues. Because `waiting_for` is left untouched, the dependent sub-ability resolves inline exactly as if no choice existed.

`CardName` / `Word` / `Artist` are excluded via a new typed `ChoiceType::options_supplied_by_player()` predicate: those values are supplied by the player/frontend at runtime, so an empty engine list there is expected, not impossible — they still prompt. This is a build-for-the-class fix: every card whose `Choose` enumerates to empty is covered, not a single card.

## Tests

Discriminating (each fails pre-fix, passes post-fix):

- `choose::tests::choose_player_with_all_players_chosen_resolves_as_no_op` — all players chosen ⇒ no `NamedChoice` wedge; effect still resolves.
- `choose::tests::choose_empty_keyword_list_resolves_as_no_op` — empty keyword option list ⇒ no wedge.
- `choose::tests::choose_card_name_with_empty_options_still_prompts` — boundary: `CardName` (player-supplied) still prompts.
- `effects::tests::resolve_ability_chain_impossible_choice_does_not_wedge_chain` — end-to-end: a `Choose`(empty) → `Draw` chain continues and draws the card instead of stashing the sub-ability forever.

`cargo fmt --all -- --check` clean; full `cargo test -p engine --lib` green (11627 passed, 0 failed); `cargo clippy -p engine --lib -- -D warnings` clean. The `stuck_decision_diagnostic` tests stay green — the diagnostic remains as a defensive net for any other path.

## CR

- CR 609.3 — an effect that attempts something impossible does only as much as possible (the no-op).
- CR 608.2d — a player can't choose an illegal or impossible option (the empty-option case).
- CR 608.2c — successive "choose a player" excludes players already chosen this resolution (one source of the empty set).
