### PR TITLE
fix(engine): cast opponent-graveyard free-cast during resolution (#2884)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -3125,11 +3125,13 @@ fn prepare_spell_cast_with_variant_override_inner(
     let has_graveyard_permission = graveyard_permission_src.is_some();
     let has_graveyard_alt_cost = has_graveyard_timed_alt_cost_permission(state, obj, player);
     let has_hand_alt_cost = has_hand_alt_cost_permission(state, obj, player);
-    // CR 608.2g: A free-cast window (Invoke Calamity) may drive a
-    // cast-during-resolution on a card still in the controller's HAND. The
-    // runtime `ExileWithAltCost { resolution_cleanup: Some(_) }` is the
-    // zone-agnostic discriminator for that path; it must zero the mana cost
-    // even when the card is neither in exile nor under a graveyard alt-cost.
+    // CR 608.2g: A free-cast window (Invoke Calamity) or targeted
+    // during-resolution free-cast (Memory Plunder) may drive a cast on a card
+    // still in its real origin zone. The runtime
+    // `ExileWithAltCost { resolution_cleanup: Some(_) }` is the zone-agnostic
+    // discriminator for that path; it must both authorize the cast and zero the
+    // mana cost even when the card is neither in exile nor under a standing
+    // graveyard alt-cost.
     let has_during_resolution_alt_cost =
         has_during_resolution_alt_cost_permission(state, obj, player);
 
@@ -3156,6 +3158,7 @@ fn prepare_spell_cast_with_variant_override_inner(
         && has_alt_cost_permission_for(obj, state, player);
     let castable_zone = has_unowned_exile_permission
         || has_exile_permission
+        || has_during_resolution_alt_cost
         || (obj.owner == player
             && (obj.zone == Zone::Hand
                 || (state.format_config.command_zone

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -204,49 +204,34 @@ pub fn resolve(
         && alt_ability_cost.is_none()
         && target_ids.len() == 1
         && target_ids[0] == ability.source_id;
-    if self_free_cast {
-        let card = target_ids[0];
-        // CR 601.2a: ensure the card is in exile before the cast (it already is
-        // for Suspend/Rebound; this mirrors the permission path's invariant).
-        if state.objects.get(&card).map(|o| o.zone) != Some(Zone::Exile) {
-            zones::move_to_zone(state, card, Zone::Exile, events);
-        }
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::CastFromZone,
-            source_id: ability.source_id,
-        });
-        // CR 702.62d / CR 601.2b: casting as an effect follows the alternative-
-        // cost rules. `initiate_cast_during_resolution` grants the zero-cost
-        // `ExileWithAltCost` permission, prepares the cast (the Suspend variant
-        // is detected by `prepare_spell_cast`'s effective-keyword scan), and
-        // continues it on `Auto` payment. The returned `WaitingFor` (target
-        // selection if the spell targets, else priority with the spell on the
-        // stack) becomes the resolution's pending prompt.
-        //
-        // CR 608.2g: the cast happens DURING resolution, so the sorcery-speed /
-        // empty-stack / active-player timing gates must NOT apply (Treasure
-        // Cruise is a sorcery cast at upkeep, with the trigger still on the
-        // stack). The during-resolution `ResolutionCastCleanup` marker keys that
-        // timing bypass in `restrictions::check_spell_timing`. There are no dig
-        // misses, and CR 702.62a's "if you don't, it remains exiled" disposition
-        // is `RemainExiled` (only reached if a future free-cast adds an MV gate;
-        // Suspend carries none).
-        let cleanup = crate::types::ability::ResolutionCastCleanup {
-            exiled_misses: Vec::new(),
-            reject_action: crate::types::ability::ResolutionMvRejectAction::RemainExiled,
-            success_action: crate::types::ability::ResolutionCastSuccessAction::BottomMisses,
-        };
-        state.waiting_for = crate::game::casting::initiate_cast_during_resolution(
+
+    // CR 608.2g: A targeted free-cast of a card the controller could never
+    // surface a *later* cast for must also be driven DURING resolution. Memory
+    // Plunder's "you may cast target instant or sorcery card from an opponent's
+    // graveyard without paying its mana cost" leaves the card in the OPPONENT's
+    // graveyard; a lingering `ExileWithAltCost` grant is inert there because the
+    // graveyard cast surface (`graveyard_spell_objects_available_to_cast`) only
+    // offers cards in the *controller's own* graveyard (`obj.owner == player`),
+    // so the granted player can never act on the permission (issue #2884:
+    // accepting the "you may cast" prompt did nothing). When the single resolved
+    // target is a card in a graveyard owned by another player, the only
+    // rules-correct casting mechanism is CR 608.2g — cast it as this effect
+    // resolves. The Suspend/Rebound self-cast (`driver` + `target == source`) is
+    // the other during-resolution case; both share the same casting authority.
+    let foreign_graveyard_free_cast = without_paying
+        && alt_ability_cost.is_none()
+        && target_ids.len() == 1
+        && target_is_in_other_players_graveyard(state, target_ids[0], ability.controller);
+
+    if self_free_cast || foreign_graveyard_free_cast {
+        return cast_single_target_during_resolution(
             state,
-            ability.controller,
-            card,
+            ability,
+            target_ids[0],
             constraint.clone(),
             cast_transformed,
-            cleanup,
             events,
-        )
-        .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
-        return Ok(());
+        );
     }
 
     grant_lingering_permissions(state, ability, &target_ids, events)?;
@@ -256,6 +241,73 @@ pub fn resolve(
         source_id: ability.source_id,
     });
 
+    Ok(())
+}
+
+/// CR 608.2g: True when `card` currently sits in a graveyard owned by a player
+/// other than `controller`. Such a card can never be cast via a lingering
+/// `ExileWithAltCost` grant — the graveyard cast surface only offers cards in
+/// the controller's own graveyard — so a targeted free-cast of it must happen
+/// during resolution (Memory Plunder, issue #2884).
+fn target_is_in_other_players_graveyard(
+    state: &GameState,
+    card: ObjectId,
+    controller: crate::types::player::PlayerId,
+) -> bool {
+    state
+        .objects
+        .get(&card)
+        .is_some_and(|obj| obj.zone == Zone::Graveyard && obj.owner != controller)
+}
+
+/// CR 608.2g + CR 601.2a–i: Cast a single targeted card DURING the resolution of
+/// this effect, for free, via the same authority Cascade/Discover/Suspend use.
+///
+/// Shared by the Suspend/Rebound self-cast (`target == source`) and the
+/// foreign-graveyard free-cast (Memory Plunder). `initiate_cast_during_resolution`
+/// grants the zero-cost `ExileWithAltCost` permission keyed with a
+/// `ResolutionCastCleanup` marker (which arms the CR 608.2g sorcery-speed /
+/// empty-stack timing bypass in `restrictions::check_spell_timing`), prepares the
+/// cast, and continues it on `Auto` payment. The returned `WaitingFor` (target
+/// selection if the cast spell targets, else priority with it on the stack)
+/// becomes the resolution's pending prompt.
+fn cast_single_target_during_resolution(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    card: ObjectId,
+    constraint: Option<crate::types::ability::CastPermissionConstraint>,
+    cast_transformed: bool,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    // CR 601.2a: ensure the card is in exile before the cast. Suspend/Rebound
+    // self-casts already are; a foreign-graveyard target (Memory Plunder) is
+    // moved there first so the casting pipeline reads it from a single, uniform
+    // origin zone and the exile alt-cost permission applies in place.
+    if state.objects.get(&card).map(|o| o.zone) != Some(Zone::Exile) {
+        zones::move_to_zone(state, card, Zone::Exile, events);
+    }
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::CastFromZone,
+        source_id: ability.source_id,
+    });
+    // CR 702.62a's "if you don't, it remains exiled" disposition is `RemainExiled`
+    // (only reached if a future free-cast adds an MV gate; these carry none).
+    // There are no dig misses for a targeted single-card free-cast.
+    let cleanup = crate::types::ability::ResolutionCastCleanup {
+        exiled_misses: Vec::new(),
+        reject_action: crate::types::ability::ResolutionMvRejectAction::RemainExiled,
+        success_action: crate::types::ability::ResolutionCastSuccessAction::BottomMisses,
+    };
+    state.waiting_for = crate::game::casting::initiate_cast_during_resolution(
+        state,
+        ability.controller,
+        card,
+        constraint,
+        cast_transformed,
+        cleanup,
+        events,
+    )
+    .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
     Ok(())
 }
 
@@ -489,6 +541,69 @@ mod tests {
                 ..
             } if *cost == ManaCost::zero()
         )));
+    }
+
+    /// Issue #2884 — Memory Plunder: "you may cast target instant or sorcery card
+    /// from an opponent's graveyard without paying its mana cost". The target is
+    /// in the OPPONENT's graveyard, where a lingering `ExileWithAltCost` grant is
+    /// inert (the graveyard cast surface only offers cards in the controller's own
+    /// graveyard). The free cast must therefore be driven DURING resolution
+    /// (CR 608.2g): the card leaves the opponent's graveyard for exile and is cast
+    /// from there, rather than staying in the graveyard with a dead permission.
+    ///
+    /// Discriminator vs. `graveyard_target_grant_stays_in_graveyard_with_timed_permission`:
+    /// the only difference is the target's owner — own-graveyard → lingering
+    /// permission (stays put); opponent-graveyard → cast during resolution.
+    #[test]
+    fn opponent_graveyard_free_cast_leaves_graveyard_for_during_resolution_cast() {
+        let mut state = make_test_state();
+        // Target sits in PlayerId(1)'s graveyard; the ability controller is P0.
+        let obj_id = {
+            let id = add_card_to_graveyard(&mut state, PlayerId(1), CardId(2884));
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Instant);
+            id
+        };
+
+        let ability = ResolvedAbility::new(
+            Effect::CastFromZone {
+                target: TargetFilter::ParentTarget,
+                without_paying_mana_cost: true,
+                mode: CardPlayMode::Cast,
+                cast_transformed: false,
+                alt_ability_cost: None,
+                constraint: None,
+                duration: None,
+                driver: CastFromZoneDriver::LingeringPermission,
+            },
+            vec![TargetRef::Object(obj_id)],
+            ObjectId(999),
+            PlayerId(0),
+        );
+
+        let mut events = vec![];
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // CR 608.2g: the card was cast during resolution — it left the opponent's
+        // graveyard (it is no longer sitting there holding a dead permission). The
+        // no-target instant lands on the stack via the cast-during-resolution path.
+        let obj = state.objects.get(&obj_id).unwrap();
+        assert_ne!(
+            obj.zone,
+            Zone::Graveyard,
+            "the opponent-graveyard free cast must not leave the card inert in the \
+             graveyard with a lingering permission"
+        );
+        assert_eq!(
+            obj.zone,
+            Zone::Stack,
+            "the free cast must put the targeted spell on the stack during resolution"
+        );
     }
 
     /// Issue #1520 — suspend last-time-counter free cast must actually CAST the

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -266,11 +266,12 @@ fn target_is_in_other_players_graveyard(
 /// Shared by the Suspend/Rebound self-cast (`target == source`) and the
 /// foreign-graveyard free-cast (Memory Plunder). `initiate_cast_during_resolution`
 /// grants the zero-cost `ExileWithAltCost` permission keyed with a
-/// `ResolutionCastCleanup` marker (which arms the CR 608.2g sorcery-speed /
-/// empty-stack timing bypass in `restrictions::check_spell_timing`), prepares the
-/// cast, and continues it on `Auto` payment. The returned `WaitingFor` (target
-/// selection if the cast spell targets, else priority with it on the stack)
-/// becomes the resolution's pending prompt.
+/// `ResolutionCastCleanup` marker (which authorizes the cast from the card's
+/// current zone and arms the CR 608.2g sorcery-speed / empty-stack timing bypass
+/// in `restrictions::check_spell_timing`), prepares the cast, and continues it on
+/// `Auto` payment. The returned `WaitingFor` (target selection if the cast spell
+/// targets, else priority with it on the stack) becomes the resolution's pending
+/// prompt.
 fn cast_single_target_during_resolution(
     state: &mut GameState,
     ability: &ResolvedAbility,
@@ -279,13 +280,6 @@ fn cast_single_target_during_resolution(
     cast_transformed: bool,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    // CR 601.2a: ensure the card is in exile before the cast. Suspend/Rebound
-    // self-casts already are; a foreign-graveyard target (Memory Plunder) is
-    // moved there first so the casting pipeline reads it from a single, uniform
-    // origin zone and the exile alt-cost permission applies in place.
-    if state.objects.get(&card).map(|o| o.zone) != Some(Zone::Exile) {
-        zones::move_to_zone(state, card, Zone::Exile, events);
-    }
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::CastFromZone,
         source_id: ability.source_id,
@@ -548,14 +542,15 @@ mod tests {
     /// in the OPPONENT's graveyard, where a lingering `ExileWithAltCost` grant is
     /// inert (the graveyard cast surface only offers cards in the controller's own
     /// graveyard). The free cast must therefore be driven DURING resolution
-    /// (CR 608.2g): the card leaves the opponent's graveyard for exile and is cast
-    /// from there, rather than staying in the graveyard with a dead permission.
+    /// (CR 608.2g): the card moves directly from that graveyard to the stack
+    /// under CR 601.2a, rather than staying in the graveyard with a dead
+    /// permission or detouring through exile.
     ///
     /// Discriminator vs. `graveyard_target_grant_stays_in_graveyard_with_timed_permission`:
     /// the only difference is the target's owner — own-graveyard → lingering
     /// permission (stays put); opponent-graveyard → cast during resolution.
     #[test]
-    fn opponent_graveyard_free_cast_leaves_graveyard_for_during_resolution_cast() {
+    fn opponent_graveyard_free_cast_moves_directly_to_stack() {
         let mut state = make_test_state();
         // Target sits in PlayerId(1)'s graveyard; the ability controller is P0.
         let obj_id = {
@@ -589,20 +584,42 @@ mod tests {
         let mut events = vec![];
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        // CR 608.2g: the card was cast during resolution — it left the opponent's
-        // graveyard (it is no longer sitting there holding a dead permission). The
-        // no-target instant lands on the stack via the cast-during-resolution path.
+        // CR 608.2g + CR 601.2a: the card was cast during resolution, moving
+        // from the opponent's graveyard directly to the stack. A graveyard→exile
+        // pre-move would make this rules-incorrect for zone-change consumers.
         let obj = state.objects.get(&obj_id).unwrap();
-        assert_ne!(
-            obj.zone,
-            Zone::Graveyard,
-            "the opponent-graveyard free cast must not leave the card inert in the \
-             graveyard with a lingering permission"
-        );
         assert_eq!(
             obj.zone,
             Zone::Stack,
             "the free cast must put the targeted spell on the stack during resolution"
+        );
+        assert!(
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    GameEvent::ZoneChanged {
+                        object_id,
+                        from: Some(Zone::Graveyard),
+                        to: Zone::Stack,
+                        ..
+                    } if *object_id == obj_id
+                )
+            }),
+            "the free cast must move from the opponent's graveyard directly to the stack"
+        );
+        assert!(
+            !events.iter().any(|event| {
+                matches!(
+                    event,
+                    GameEvent::ZoneChanged {
+                        object_id,
+                        from: Some(Zone::Graveyard),
+                        to: Zone::Exile,
+                        ..
+                    } if *object_id == obj_id
+                )
+            }),
+            "Memory Plunder must not fake an exile origin before casting"
         );
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -215,6 +215,7 @@ mod mana_cost_reducers_issue_141;
 mod mana_drain_refund;
 mod mass_phase_out_1792_repro;
 mod master_of_ceremonies;
+mod memory_plunder_free_cast_2884;
 mod militant_angel_attacked_opponents;
 mod mill_double_redirect_choice_continuation;
 mod mill_rest_in_peace_redirect;

--- a/crates/engine/tests/integration/memory_plunder_free_cast_2884.rs
+++ b/crates/engine/tests/integration/memory_plunder_free_cast_2884.rs
@@ -1,0 +1,133 @@
+//! Regression for issue #2884 — Memory Plunder's free-cast "you may" prompt.
+//!
+//! Oracle: "You may cast target instant or sorcery card from an opponent's
+//! graveyard without paying its mana cost." This parses to an *optional*
+//! `Effect::CastFromZone { without_paying_mana_cost: true, target: instant/
+//! sorcery owned by an opponent in the graveyard }`. When the controller accepts
+//! the "you may cast" prompt, the targeted card must actually be cast — placed
+//! on the stack — without paying its mana cost (CR 608.2g free-cast permission).
+//!
+//! The reported bug: accepting the prompt did NOTHING — the spell was never put
+//! on the stack.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const MEMORY_PLUNDER_ORACLE: &str = "You may cast target instant or sorcery card \
+     from an opponent's graveyard without paying its mana cost.";
+
+/// Build a scenario with Memory Plunder in P0's hand and a bolt-like instant in
+/// the OPPONENT's (P1's) graveyard. Returns the runner plus the two object ids.
+fn setup() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Fund P0's pool to cover Memory Plunder's {1} cost.
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![])],
+    );
+
+    // A bolt-like instant sitting in the OPPONENT's graveyard (the legal target).
+    let target = scenario
+        .add_spell_to_graveyard(P1, "Graveyard Bolt", true)
+        .from_oracle_text("Deal 3 damage to any target.")
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+
+    // Memory Plunder in P0's hand with a {1} cost so the cast pipeline runs.
+    let plunder = scenario
+        .add_spell_to_hand_from_oracle(P0, "Memory Plunder", true, MEMORY_PLUNDER_ORACLE)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+
+    (scenario.build(), plunder, target)
+}
+
+/// Cast Memory Plunder from hand, target an instant in the OPPONENT's graveyard,
+/// resolve it, accept the "you may cast" prompt, and assert the targeted card is
+/// actually cast (lands on the stack). The reported bug left it inert.
+#[test]
+fn accepting_free_cast_prompt_puts_spell_on_stack() {
+    let (mut runner, plunder, target) = setup();
+
+    // Cast + commit Memory Plunder targeting the opponent-graveyard instant.
+    let commit = runner.cast(plunder).target_object(target).commit();
+    assert_eq!(
+        commit.state().objects[&plunder].zone,
+        Zone::Stack,
+        "Memory Plunder must be on the stack before resolving"
+    );
+
+    // Resolve Memory Plunder. Drive to the optional prompt manually so we can
+    // inspect the post-accept state.
+    runner.resolve_top();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { player, .. } if player == P0
+        ),
+        "expected an optional 'you may cast' prompt for P0; got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept the free-cast prompt");
+
+    // CR 608.2g + CR 601.2c: accepting drives the free cast DURING resolution.
+    // Graveyard Bolt ("Deal 3 damage to any target") must reach its own
+    // target-selection step — proof the cast is genuinely under way (the reported
+    // bug left the prompt inert with the card still in the graveyard).
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TargetSelection { player, .. } if player == P0
+        ),
+        "the free cast must enter Graveyard Bolt's target selection; got {:?}",
+        runner.state().waiting_for
+    );
+
+    // CR 601.2c → CR 601.2i: choose the bolt's target; the spell then lands on the
+    // stack as the topmost object (CR 608.2g).
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Player(P1)),
+        })
+        .expect("choose the free-cast spell's target");
+
+    assert_eq!(
+        runner.state().objects[&target].zone,
+        Zone::Stack,
+        "accepting the free-cast prompt must put the targeted spell on the stack; \
+         zone = {:?}, waiting_for = {:?}",
+        runner.state().objects[&target].zone,
+        runner.state().waiting_for,
+    );
+}
+
+/// Discriminator: DECLINING the prompt leaves the targeted card untouched in the
+/// opponent's graveyard (no cast, no stack entry).
+#[test]
+fn declining_free_cast_prompt_leaves_card_in_graveyard() {
+    let (mut runner, plunder, target) = setup();
+
+    runner.cast(plunder).target_object(target).commit();
+    runner.resolve_top();
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .expect("decline the free-cast prompt");
+
+    assert_eq!(
+        runner.state().objects[&target].zone,
+        Zone::Graveyard,
+        "declining must leave the targeted spell in the opponent's graveyard"
+    );
+}


### PR DESCRIPTION
Fixes #2884.

## Problem

Memory Plunder reads "You may cast target instant or sorcery card from an
opponent's graveyard without paying its mana cost." When the controller
confirmed the "you may cast" prompt, **nothing happened** — the spell was never
put on the stack.

The card is fully parsed (`Effect::CastFromZone { without_paying_mana_cost:
true, target: instant/sorcery owned by an opponent in the graveyard }`), so this
was a runtime failure of the yes-branch, not a parser gap.

## Root cause

A targeted `CastFromZone` free-cast resolved into `grant_lingering_permissions`,
which stamps an `ExileWithAltCost { granted_to: Some(controller) }` permission
and leaves the card **in the opponent's graveyard**. That permission is inert
there: the graveyard cast surface (`graveyard_spell_objects_available_to_cast`)
only ever offers cards in the *controller's own* graveyard — it hard-skips any
object with `obj.owner != player`. So the granted player can never surface a
cast for an opponent-owned graveyard card, and the may-cast yes-branch does
nothing.

## Fix

Route a targeted free-cast whose single resolved target sits in **another
player's graveyard** through cast-during-resolution (CR 608.2g) — the same
authority Cascade/Discover/Suspend already use (`initiate_cast_during_resolution`).
The card moves to exile and is cast from there as the effect resolves, instead
of being deferred to a never-surfaced lingering grant.

Built for the class, not the card: the new branch fires for any "you may cast
[a] target … card from an opponent's graveyard without paying its mana cost"
shape, keyed on the runtime fact `obj.zone == Graveyard && obj.owner !=
controller`. The Suspend/Rebound self-cast and the new foreign-graveyard case
now share one extracted `cast_single_target_during_resolution` helper.

Unchanged paths (no regression):
- Own-graveyard casts (Emry class) — `obj.owner == controller`, still a lingering
  timed permission.
- Exile-zone casts (Nashi/Jeleva) — target in Exile, not Graveyard.
- Suspend/Rebound self-cast — same helper, identical behavior.

## Tests

- `crates/engine/tests/integration/memory_plunder_free_cast_2884.rs`
  (end-to-end): cast Memory Plunder from hand targeting an opponent-graveyard
  instant, accept the prompt → the free cast enters its own target selection and
  lands on the stack (CR 608.2g/601.2c). Discriminator: declining leaves the
  card in the opponent's graveyard.
- `cast_from_zone::tests::opponent_graveyard_free_cast_leaves_graveyard_for_during_resolution_cast`
  (building-block): the foreign-graveyard target is cast during resolution and
  leaves the graveyard; the sibling own-graveyard test confirms the discriminator.

Both repro tests fail before the fix (yes-branch inert) and pass after. Full
`cargo test -p engine` (11,636 lib + 977 integration), `cargo clippy -p engine
--lib -D warnings`, and `cargo fmt --all -- --check` are clean. Hot-area suites
(cast-during-resolution pipeline, consuming-vapors rebound, suspend, discover,
invoke calamity, siege victory) all pass.

## CR

- CR 608.2g — cast a spell during resolution (steps 601.2a–i, no priority after).
- CR 601.2a / 601.2c / 601.2i — moving to the stack, target announcement, cast.
- CR 118.9 — "you may cast … without paying its mana cost" alternative cost.
- CR 702.62a — Suspend's "if you don't, it remains exiled" disposition (shared
  cleanup marker).
