### PR TITLE
fix(parser): count "cards your opponents have drawn this turn" as a scoped quantity (Heliod)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -19124,6 +19124,103 @@ mod tests {
         );
     }
 
+    /// CR 601.2f + CR 102.2/102.3: Heliod, the Warped Eclipse, in a 3-player
+    /// game. "Spells you cast cost {1} less to cast for each card your opponents
+    /// have drawn this turn." With opponents having drawn 2 and 3, the SUM-across-
+    /// opponents reduction is {5}, so a {5}-generic spell drops to {0}. The reverted
+    /// `ObjectCount{Card}` over-reduction would not equal exactly 5 → discriminates.
+    #[test]
+    fn heliod_warped_eclipse_reduces_by_sum_of_opponents_draws() {
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+        state.turn_number = 2;
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        // CR 102.2/102.3: the two opponents drew 2 and 3 cards this turn → SUM 5.
+        state.players[1].cards_drawn_this_turn = 2;
+        state.players[2].cards_drawn_this_turn = 3;
+
+        // Heliod on the battlefield with the parsed cost-reduction static:
+        // affected = spells the controller casts; dynamic_count = opponents' SUM.
+        let heliod = create_object(
+            &mut state,
+            CardId(840),
+            PlayerId(0),
+            "Heliod, the Warped Eclipse".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&heliod)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::ModifyCost {
+                    mode: CostModifyMode::Reduce,
+                    amount: ManaCost::generic(1),
+                    spell_filter: None,
+                    dynamic_count: Some(QuantityRef::CardsDrawnThisTurn {
+                        player: PlayerScope::Opponent {
+                            aggregate: AggregateFunction::Sum,
+                        },
+                    }),
+                })
+                .affected(TargetFilter::Typed(
+                    TypedFilter::card().controller(ControllerRef::You),
+                )),
+            );
+
+        // A {5} generic spell in the controller's hand.
+        let spell = create_object(
+            &mut state,
+            CardId(841),
+            PlayerId(0),
+            "Generic Spell".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            obj.mana_cost = ManaCost::Cost {
+                generic: 5,
+                shards: vec![],
+            };
+        }
+
+        let mut mana_cost = state.objects.get(&spell).unwrap().mana_cost.clone();
+        apply_battlefield_cost_modifiers(&state, PlayerId(0), spell, &mut mana_cost);
+
+        match mana_cost {
+            ManaCost::Cost { generic, .. } => assert_eq!(
+                generic, 0,
+                "opponents' SUM draw (2 + 3 = 5) must reduce {{5}} to {{0}}, got {generic}"
+            ),
+            other => panic!("expected ManaCost::Cost, got {other:?}"),
+        }
+
+        // 0-draw control: with no opponent draws the reduction is {0} → full {5}.
+        // The buggy ObjectCount{Card} would over-reduce here too (counting the
+        // battlefield permanents), so this discriminates against the misparse.
+        let mut zero_state = state.clone();
+        zero_state.players[1].cards_drawn_this_turn = 0;
+        zero_state.players[2].cards_drawn_this_turn = 0;
+        let mut zero_cost = zero_state.objects.get(&spell).unwrap().mana_cost.clone();
+        apply_battlefield_cost_modifiers(&zero_state, PlayerId(0), spell, &mut zero_cost);
+        match zero_cost {
+            ManaCost::Cost { generic, .. } => assert_eq!(
+                generic, 5,
+                "no opponent draws must leave the {{5}} spell unreduced, got {generic}"
+            ),
+            other => panic!("expected ManaCost::Cost, got {other:?}"),
+        }
+    }
+
     #[test]
     fn activated_ability_cost_reduction_applies_to_matching_permanent_type() {
         let mut state = setup_game_at_main_phase();

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -7546,6 +7546,36 @@ mod tests {
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(2), ObjectId(1)), 5);
     }
 
+    /// CR 121.1 + CR 102.2/102.3: Heliod, the Warped Eclipse. The
+    /// opponents'-SUM form of `CardsDrawnThisTurn` adds each opponent's draws.
+    /// From P0's seat (opponents P1=2, P2=3) the sum is 5; the buggy
+    /// `ObjectCount` misparse would never produce this player-scoped sum.
+    #[test]
+    fn resolve_quantity_cards_drawn_this_turn_sum_opponents() {
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        state.players[0].cards_drawn_this_turn = 7;
+        state.players[1].cards_drawn_this_turn = 2;
+        state.players[2].cards_drawn_this_turn = 3;
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::CardsDrawnThisTurn {
+                player: PlayerScope::Opponent {
+                    aggregate: AggregateFunction::Sum,
+                },
+            },
+        };
+
+        // From P0's seat: opponents are P1 + P2 = 2 + 3 = 5.
+        assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 5);
+        // From P1's seat: opponents are P0 + P2 = 7 + 3 = 10.
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(1), ObjectId(1)),
+            10
+        );
+    }
+
     /// CR 701.9: `CardsDiscardedThisTurn` reads the per-player discard-count
     /// map populated by discard resolution and composes through PlayerScope.
     #[test]

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -400,18 +400,36 @@ fn parse_pre_controller_chosen_filter_suffix(input: &str) -> OracleResult<'_, Fi
     .parse(input)
 }
 
-/// CR 121.1 + CR 604.3: "cards you've drawn this turn" after "the number of".
-/// Reuses the runtime `CardsDrawnThisTurn` quantity ref already wired for
-/// condition checks (Duelist of the Mind CDA).
+/// CR 121.1 + CR 604.3: "card(s) [you('ve) / your opponents have] drawn this
+/// turn". Reuses the runtime `CardsDrawnThisTurn` quantity ref already wired for
+/// condition checks (Duelist of the Mind CDA) and now for the opponents'-draw
+/// cost reduction (Heliod, the Warped Eclipse).
+///
+/// The leading "card" word is optionally plural so this combinator serves both
+/// surface forms uniformly: the "the number of *cards* …" count phrase (plural)
+/// and the "for each *card* …" cost-mod clause (singular). The scope tails come
+/// from a shared sub-combinator; opponents arms come FIRST so their longer,
+/// more-specific phrase wins over the controller arms (longest-match-first,
+/// avoiding a controller arm shadowing the opponents phrase on the shared
+/// "card[s] " prefix).
 fn parse_number_of_cards_drawn_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("card").parse(input)?;
+    let (rest, _) = opt(tag("s")).parse(rest)?;
+    let (rest, _) = tag(" ").parse(rest)?;
     let (rest, player) = alt((
-        value(PlayerScope::Controller, tag("cards you've drawn this turn")),
+        // CR 121.1 + CR 102.2/102.3: opponents' draws this turn, summed across
+        // all opponents.
         value(
-            PlayerScope::Controller,
-            tag("cards you have drawn this turn"),
+            PlayerScope::Opponent {
+                aggregate: AggregateFunction::Sum,
+            },
+            tag("your opponents have drawn this turn"),
         ),
+        // CR 121.1: the caster's own draws this turn.
+        value(PlayerScope::Controller, tag("you've drawn this turn")),
+        value(PlayerScope::Controller, tag("you have drawn this turn")),
     ))
-    .parse(input)?;
+    .parse(rest)?;
     Ok((rest, QuantityRef::CardsDrawnThisTurn { player }))
 }
 
@@ -482,7 +500,18 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         // dedicated party combinator instead of a generic zone fallback.
         parse_party_size_ref,
         parse_speed_ref,
-        parse_cards_in_zone_ref,
+        // CR 121.1: bare "card(s) [you('ve) / your opponents have] drawn this
+        // turn" (no "the number of" prefix) — reached from the for-each cost-mod
+        // path (Heliod, the Warped Eclipse) and other bare-quantity contexts.
+        // Nested with `parse_cards_in_zone_ref` to keep the outer `alt` within
+        // nom's tuple arity. The draws arm must precede the zone arm: the zone
+        // arm requires a " in " tag after the card word and so cannot consume
+        // "cards your opponents have …", while the draws arm only fires on the
+        // exact complete phrase (no greedy prefix consumption).
+        alt((
+            parse_number_of_cards_drawn_this_turn,
+            parse_cards_in_zone_ref,
+        )),
         parse_self_power_ref,
         parse_self_toughness_ref,
         parse_damage_dealt_this_turn_ref,
@@ -3264,6 +3293,69 @@ mod tests {
                 "{text:?}"
             );
         }
+    }
+
+    /// CR 121.1 + CR 102.2/102.3: the opponents'-draw form must parse to a
+    /// SUM-across-opponents scope, both bare (for-each cost-mod path, Heliod,
+    /// the Warped Eclipse) and behind "the number of". The controller forms must
+    /// still resolve to `Controller` (regression lock against the opponents arm
+    /// shadowing them).
+    #[test]
+    fn parse_cards_drawn_this_turn_opponents_sum_and_controller_regression() {
+        // Bare opponents form — reachable only via the new top-level arm.
+        for text in [
+            "cards your opponents have drawn this turn",
+            "the number of cards your opponents have drawn this turn",
+        ] {
+            let (rest, q) = parse_quantity_ref(text).unwrap();
+            assert_eq!(rest, "", "{text:?} should fully consume");
+            assert_eq!(
+                q,
+                QuantityRef::CardsDrawnThisTurn {
+                    player: PlayerScope::Opponent {
+                        aggregate: AggregateFunction::Sum,
+                    },
+                },
+                "{text:?} must be opponents' SUM, not ObjectCount or Controller"
+            );
+        }
+
+        // Controller forms (bare + the-number-of) still resolve to Controller.
+        for text in [
+            "cards you've drawn this turn",
+            "cards you have drawn this turn",
+            "the number of cards you've drawn this turn",
+            "the number of cards you have drawn this turn",
+        ] {
+            let (rest, q) = parse_quantity_ref(text).unwrap();
+            assert_eq!(rest, "", "{text:?} should fully consume");
+            assert_eq!(
+                q,
+                QuantityRef::CardsDrawnThisTurn {
+                    player: PlayerScope::Controller,
+                },
+                "{text:?} must remain Controller-scoped"
+            );
+        }
+    }
+
+    /// CR 601.2f: the for-each cost-mod path (Heliod) routes "card your opponents
+    /// have drawn this turn" through `parse_for_each_clause`. Previously this fell
+    /// to `None`/`ObjectCount{Card}`; it must now yield the opponents' SUM ref.
+    #[test]
+    fn parse_for_each_clause_opponents_cards_drawn() {
+        use crate::parser::oracle_quantity::parse_for_each_clause;
+
+        let qty = parse_for_each_clause("card your opponents have drawn this turn");
+        assert_eq!(
+            qty,
+            Some(QuantityRef::CardsDrawnThisTurn {
+                player: PlayerScope::Opponent {
+                    aggregate: AggregateFunction::Sum,
+                },
+            }),
+            "for-each over opponents' draws must yield the SUM-scoped ref, not None/ObjectCount"
+        );
     }
 
     /// End-to-end: CDA static lines must lower once the quantity arms parse.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2012,6 +2012,47 @@ fn chandras_incinerator_self_cost_reduction_uses_noncombat_damage_to_opponents()
     );
 }
 
+/// CR 601.2f + CR 102.2/102.3: Heliod, the Warped Eclipse. "Spells you cast cost
+/// {1} less to cast for each card your opponents have drawn this turn." must lower
+/// to a `ModifyCost { mode: Reduce, dynamic_count: CardsDrawnThisTurn{Opponent{Sum}} }`.
+/// On the buggy parser the for-each clause fell to `ObjectCount{Typed{[Card]}}`
+/// (every card on the battlefield), over-reducing. This pins the typed
+/// opponents'-draw shape and asserts the dynamic_count is NOT an `ObjectCount`.
+#[test]
+fn heliod_warped_eclipse_cost_reduction_counts_opponents_draws() {
+    let def = parse_static_line(
+        "Spells you cast cost {1} less to cast for each card your opponents have drawn this turn.",
+    )
+    .unwrap();
+
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        amount,
+        dynamic_count,
+        ..
+    } = def.mode
+    else {
+        panic!("expected ReduceCost, got {:?}", def.mode);
+    };
+
+    assert_eq!(amount, ManaCost::generic(1));
+    assert_eq!(
+        dynamic_count,
+        Some(QuantityRef::CardsDrawnThisTurn {
+            player: PlayerScope::Opponent {
+                aggregate: AggregateFunction::Sum,
+            },
+        }),
+        "dynamic_count must be opponents' SUM of cards drawn, not an ObjectCount; got {dynamic_count:?}"
+    );
+    // Discriminating against the over-reduction bug: the generic-card-count
+    // misparse would surface as an `ObjectCount` here.
+    assert!(
+        !matches!(dynamic_count, Some(QuantityRef::ObjectCount { .. })),
+        "dynamic_count must NOT be the generic ObjectCount{{Card}} misparse"
+    );
+}
+
 #[test]
 fn ghalta_self_cost_reduction_is_active_from_command_zone() {
     let def = parse_static_line(


### PR DESCRIPTION
## What

Fixes **#2849** — Heliod, the Warped Eclipse: "Spells you cast cost {1} less to
cast **for each card your opponents have drawn this turn**." over-reduced —
the cost-reduction's dynamic count parsed to a generic `ObjectCount` over a
`Card` filter (no controller/zone/turn scope), so it counted far more than the
opponents' this-turn draws and stripped the whole generic cost.

## Root cause

`parse_number_of_cards_drawn_this_turn` only recognized the **controller** forms
("cards you('ve) drawn this turn") and was reachable only behind a `"the number
of "` prefix — never as a bare quantity. So the "for each `<clause>`"
cost-reduction path fell through to the `ObjectCount{Card}` fallback (the
controller form was mis-parsed there too).

## Fix (parser-only)

`QuantityRef::CardsDrawnThisTurn`, `PlayerScope::Opponent{Sum}`, and
`AggregateFunction::Sum` all already exist, and the runtime resolver already
sums per-player `cards_drawn_this_turn` over opponents — so this is purely a
parse-semantic fix:

- Add the opponents arm: "cards your opponents have drawn this turn" →
  `CardsDrawnThisTurn { player: Opponent { aggregate: Sum } }` (CR 121.1 +
  CR 102.2/102.3 — the total across all opponents).
- Factor the `card(s)` head so one combinator covers both the plural
  "the number of cards…" and the singular "for each card…" surface forms.
- Promote the combinator to a bare top-level `parse_quantity_ref` arm (mirroring
  `parse_life_lost_ref`), so the for-each cost-reduction path reaches it; the
  existing "the number of" entry is preserved.

No type or runtime change.

## Tests

- Parser: opponents bare + "the number of" forms → `Opponent{Sum}`; the 4
  controller forms still → `Controller` (regression lock); `parse_for_each_clause`
  opponents → `Some`.
- Static: Heliod's line → `ModifyCost{ Reduce, dynamic_count:
  CardsDrawnThisTurn{Opponent{Sum}} }`, asserted **not** `ObjectCount` (the
  discriminator).
- Runtime: 3-player, opponents drew 2+3 → a {5} spell reduces to {0} via the real
  `apply_battlefield_cost_modifiers`; 0-draw control stays {5} (the buggy
  `ObjectCount{Card}` over-reduces both).

Full engine lib suite (11,647) + 58 cost integration tests pass; workspace clippy
(incl. mtgish-import) + parser-combinator gate + fmt clean; coverage regenerated
locally — no in-blast-radius regressions.

Closes #2849
