### PR TITLE
Add Eon Hub

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -31,8 +31,10 @@ use crate::types::replacements::ReplacementEvent;
 use crate::types::statics::{CostModifyMode, StaticMode};
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
+use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::{all_consuming, value};
+use nom::character::complete::space1;
+use nom::combinator::{all_consuming, opt, value};
 use nom::Parser;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -1581,14 +1583,61 @@ fn skip_step_phrase(step: Phase) -> Option<&'static str> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum CoverageAllPlayerStepSkipSubject {
+    Players,
+    EachPlayer,
+}
+
+fn coverage_all_player_step_skip_subject(
+    input: &str,
+) -> nom::IResult<&str, CoverageAllPlayerStepSkipSubject> {
+    alt((
+        value(CoverageAllPlayerStepSkipSubject::Players, tag("players")),
+        value(
+            CoverageAllPlayerStepSkipSubject::EachPlayer,
+            tag("each player"),
+        ),
+    ))
+    .parse(input)
+}
+
+fn coverage_all_player_step_skip_verb(
+    subject: CoverageAllPlayerStepSkipSubject,
+    input: &str,
+) -> nom::IResult<&str, ()> {
+    match subject {
+        CoverageAllPlayerStepSkipSubject::Players => value((), tag("skip")).parse(input),
+        CoverageAllPlayerStepSkipSubject::EachPlayer => value((), tag("skips")).parse(input),
+    }
+}
+
+fn coverage_all_player_skip_step_line<'a>(
+    input: &'a str,
+    step_phrase: &str,
+) -> nom::IResult<&'a str, ()> {
+    let (input, subject) = coverage_all_player_step_skip_subject(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = coverage_all_player_step_skip_verb(subject, input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = tag("their").parse(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = tag(step_phrase).parse(input)?;
+    let (input, _) = opt(tag("s")).parse(input)?;
+    let (input, _) = tag(".").parse(input)?;
+    Ok((input, ()))
+}
+
 fn oracle_line_matches_skip_step(effective_lower: &str, step: Phase) -> bool {
     let Some(step_phrase) = skip_step_phrase(step) else {
         return false;
     };
 
-    let result: nom::IResult<&str, ()> =
-        all_consuming(value((), (tag("skip your "), tag(step_phrase), tag("."))))
-            .parse(effective_lower);
+    let result: nom::IResult<&str, ()> = all_consuming(alt((
+        value((), (tag("skip your "), tag(step_phrase), tag("."))),
+        |input| coverage_all_player_skip_step_line(input, step_phrase),
+    )))
+    .parse(effective_lower);
     result.is_ok()
 }
 
@@ -10549,7 +10598,7 @@ mod tests {
         face.oracle_text = Some(oracle.to_string());
         face.static_abilities.push(StaticDefinition {
             mode: StaticMode::SkipStep { step: Phase::Draw },
-            affected: Some(TargetFilter::SelfRef),
+            affected: Some(TargetFilter::Controller),
             modifications: vec![],
             condition: None,
             per_player_condition: None,
@@ -10564,6 +10613,35 @@ mod tests {
         assert!(
             card_face_gaps(&face).is_empty(),
             "'Skip your draw step.' should be covered by SkipStep(Draw) static"
+        );
+    }
+
+    /// CR 614.1b + CR 614.10: Eon Hub's all-player wording is the same
+    /// step-skip replacement mode with player-wide scope.
+    #[test]
+    fn players_skip_upkeep_steps_static_has_no_coverage_gap() {
+        let mut face = make_face();
+        let oracle = "Players skip their upkeep steps.";
+        face.oracle_text = Some(oracle.to_string());
+        face.static_abilities.push(StaticDefinition {
+            mode: StaticMode::SkipStep {
+                step: Phase::Upkeep,
+            },
+            affected: Some(TargetFilter::Player),
+            modifications: vec![],
+            condition: None,
+            per_player_condition: None,
+            affected_zone: None,
+            effect_zone: None,
+            active_zones: vec![],
+            characteristic_defining: false,
+            description: Some("Players skip their upkeep steps.".to_string()),
+            attack_defended: None,
+        });
+
+        assert!(
+            card_face_gaps(&face).is_empty(),
+            "'Players skip their upkeep steps.' should be covered by SkipStep(Upkeep) static"
         );
     }
 

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1292,16 +1292,28 @@ pub fn should_skip_draw(state: &GameState) -> bool {
         || should_skip_step_static(state, Phase::Draw)
 }
 
-/// CR 614.1b + CR 614.10: Check whether the active player should skip the given step
-/// due to a "skip your [step] step" static ability on a permanent they control.
+/// CR 614.1b + CR 614.10: Check whether the active player should skip the given
+/// step due to a static step-skip replacement that affects them.
 fn should_skip_step_static(state: &GameState, step: Phase) -> bool {
     let active = state.active_player;
+    let context = super::static_abilities::StaticCheckContext {
+        player_id: Some(active),
+        ..Default::default()
+    };
     // CR 702.26b + CR 604.1: `active_static_definitions` owns the gating.
     state.battlefield.iter().any(|id| {
         state.objects.get(id).is_some_and(|obj| {
-            obj.controller == active
-                && super::functioning_abilities::active_static_definitions(state, obj)
-                    .any(|sd| sd.mode == StaticMode::SkipStep { step })
+            super::functioning_abilities::active_static_definitions(state, obj).any(|sd| {
+                if sd.mode != (StaticMode::SkipStep { step }) {
+                    return false;
+                }
+
+                if let Some(ref affected) = sd.affected {
+                    super::static_abilities::static_filter_matches(state, &context, affected, *id)
+                } else {
+                    obj.controller == active
+                }
+            })
         })
     })
 }
@@ -4308,6 +4320,66 @@ mod tests {
             "draw step should be skipped when SkipStep(Draw) static is active"
         );
         assert!(!state.players[0].hand.contains(&card_id));
+    }
+
+    #[test]
+    fn all_player_static_step_skip_affects_noncontroller_active_player() {
+        use crate::types::ability::TargetFilter;
+        use crate::types::statics::StaticMode;
+
+        let mut state = setup();
+        state.active_player = PlayerId(1);
+
+        let hub_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Eon Hub".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&hub_id)
+            .unwrap()
+            .static_definitions
+            .push(
+                crate::types::ability::StaticDefinition::new(StaticMode::SkipStep {
+                    step: Phase::Upkeep,
+                })
+                .affected(TargetFilter::Player),
+            );
+
+        assert!(should_skip_step_static(&state, Phase::Upkeep));
+    }
+
+    #[test]
+    fn controller_static_step_skip_does_not_affect_opponent() {
+        use crate::types::ability::TargetFilter;
+        use crate::types::statics::StaticMode;
+
+        let mut state = setup();
+        state.active_player = PlayerId(1);
+
+        let enchant_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Necropotence".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&enchant_id)
+            .unwrap()
+            .static_definitions
+            .push(
+                crate::types::ability::StaticDefinition::new(StaticMode::SkipStep {
+                    step: Phase::Draw,
+                })
+                .affected(TargetFilter::Controller),
+            );
+
+        assert!(!should_skip_step_static(&state, Phase::Draw));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -54,6 +54,72 @@ fn parse_each_other_players_untap_step_suffix(input: &str) -> OracleResult<'_, (
     .parse(input)
 }
 
+#[derive(Clone, Copy)]
+enum AllPlayerStepSkipSubject {
+    Players,
+    EachPlayer,
+}
+
+fn parse_all_player_step_skip_subject(input: &str) -> OracleResult<'_, AllPlayerStepSkipSubject> {
+    alt((
+        value(AllPlayerStepSkipSubject::Players, tag("players")),
+        value(AllPlayerStepSkipSubject::EachPlayer, tag("each player")),
+    ))
+    .parse(input)
+}
+
+fn parse_all_player_step_skip_verb(
+    subject: AllPlayerStepSkipSubject,
+    input: &str,
+) -> OracleResult<'_, ()> {
+    match subject {
+        AllPlayerStepSkipSubject::Players => value((), tag("skip")).parse(input),
+        AllPlayerStepSkipSubject::EachPlayer => value((), tag("skips")).parse(input),
+    }
+}
+
+fn parse_all_player_skip_step(input: &str) -> OracleResult<'_, Phase> {
+    let (input, subject) = parse_all_player_step_skip_subject(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = parse_all_player_step_skip_verb(subject, input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = tag("their").parse(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, step) = parse_step_name_nom(input)?;
+    let (input, _) = opt(tag("s")).parse(input)?;
+    Ok((input, step))
+}
+
+fn parse_skip_step_static(tp: &TextPair<'_>, text: &str) -> Option<StaticDefinition> {
+    // CR 614.1b + CR 614.10: continuous static replacement effects that
+    // replace a named step with nothing. Keep the subject axis explicit so
+    // controller-scoped "your" and all-player "players/their" text share the
+    // same StaticMode without over-broadening either one.
+    let (_, (affected, step)) = all_consuming(terminated(
+        alt((
+            map(
+                preceded(
+                    tag::<_, _, OracleError<'_>>("skip your "),
+                    parse_step_name_nom,
+                ),
+                |step| (TargetFilter::Controller, step),
+            ),
+            map(parse_all_player_skip_step, |step| {
+                (TargetFilter::Player, step)
+            }),
+        )),
+        opt(tag(".")),
+    ))
+    .parse(tp.lower)
+    .ok()?;
+
+    Some(
+        StaticDefinition::new(StaticMode::SkipStep { step })
+            .affected(affected)
+            .description(text.to_string()),
+    )
+}
+
 pub(crate) fn parse_static_line_inner(
     text: &str,
     inverted: InvertedAsLongAs,
@@ -389,16 +455,9 @@ pub(crate) fn parse_static_line_inner(
         }
     }
 
-    // --- "Skip your [step] step" ---
-    // CR 614.1b + CR 614.10: Replacement effect that replaces the named step with nothing.
-    if let Some(rest_tp) = nom_tag_tp(&tp, "skip your ") {
-        if let Some(step) = parse_step_name(rest_tp.lower.trim_end_matches('.')) {
-            return Some(
-                StaticDefinition::new(StaticMode::SkipStep { step })
-                    .affected(TargetFilter::SelfRef)
-                    .description(text.to_string()),
-            );
-        }
+    // --- "Skip your [step] step" / "Players skip their [step] steps" ---
+    if let Some(def) = parse_skip_step_static(&tp, &text) {
+        return Some(def);
     }
 
     // CR 402.2 + CR 514.1: Maximum hand size modification.

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -239,17 +239,13 @@ pub(crate) fn parse_named_color(text: &str) -> Option<ManaColor> {
 }
 
 /// CR 614.1b: Parse a step name from Oracle text using nom combinators.
-pub(crate) fn parse_step_name(input: &str) -> Option<Phase> {
-    use crate::parser::oracle_nom::error::OracleError;
-    let result: Result<(&str, Phase), nom::Err<OracleError<'_>>> = alt((
+pub(crate) fn parse_step_name_nom(input: &str) -> OracleResult<'_, Phase> {
+    alt((
         value(Phase::Draw, tag("draw step")),
         value(Phase::Untap, tag("untap step")),
         value(Phase::Upkeep, tag("upkeep step")),
     ))
-    .parse(input);
-    result
-        .ok()
-        .and_then(|(rest, phase)| rest.is_empty().then_some(phase))
+    .parse(input)
 }
 
 /// CR 205.2a: Check if a lowercase descriptor names a core card type that can modify

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10357,6 +10357,7 @@ fn negative_dynamic_power() {
 fn skip_draw_step() {
     let def = parse_static_line("Skip your draw step.").unwrap();
     assert_eq!(def.mode, StaticMode::SkipStep { step: Phase::Draw });
+    assert_eq!(def.affected, Some(TargetFilter::Controller));
 }
 
 #[test]
@@ -10374,6 +10375,31 @@ fn skip_upkeep_step() {
             step: Phase::Upkeep
         }
     );
+    assert_eq!(def.affected, Some(TargetFilter::Controller));
+}
+
+#[test]
+fn players_skip_their_upkeep_steps() {
+    let def = parse_static_line("Players skip their upkeep steps.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::SkipStep {
+            step: Phase::Upkeep
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::Player));
+}
+
+#[test]
+fn each_player_skips_their_upkeep_step() {
+    let def = parse_static_line("Each player skips their upkeep step.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::SkipStep {
+            step: Phase::Upkeep
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::Player));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Adds engine support for **Eon Hub** by parsing all-player static step-skip text and applying `StaticMode::SkipStep` to the affected active player instead of assuming only the source controller can be skipped.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan -> review-plan -> implement -> review-impl -> commit)
- [x] **Not** `/engine-implementer` — explain why below

This Codex environment does not expose the repository's Claude slash-command pipeline. I kept the change narrow and manually followed the AI-CONTRIBUTOR gates that apply to Standard-tier parser/engine work: duplicate PR scan, current `origin/main` base, Gate A parser-combinator check, pattern anchoring, targeted runtime/parser/coverage tests, and a closed-PR failure-mode review.

## Files changed
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/parser/oracle_static/grammar.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`
- `crates/engine/src/game/turns.rs`
- `crates/engine/src/game/coverage.rs`

## CR references
- `CR 614.1b`
- `CR 614.10`
- Existing touched context also references `CR 103.8`, `CR 604.1`, and `CR 702.26b`.

## Track
Developer

## LLM
Model: gpt-5-codex
Thinking: high
Tier: Standard

## Gate A
`./scripts/check-parser-combinators.sh`

```text
(no output; exited 0)
```

## Anchored on
- `crates/engine/src/parser/oracle_static/dispatch.rs:32` — existing static sentence parser uses `all_consuming(terminated(..., opt(tag("."))))` instead of string-method dispatch.
- `crates/engine/src/parser/oracle_static/dispatch.rs:41` — existing step-related suffix parser uses nom tuple/alt combinators for Oracle step wording.
- `crates/engine/src/game/turns.rs:1160` — maximum-hand-size statics build `StaticCheckContext { player_id }` and delegate affected-player filtering to `static_filter_matches`.
- `crates/engine/src/game/static_abilities.rs:1249` — `static_filter_matches` already defines player-scope behavior for `TargetFilter::Player` and `TargetFilter::Controller`.

## Verification
- `./scripts/setup.sh --agent` — clean
- `cargo fmt --all --check` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine players_skip` — 2 passed / 0 failed
- `cargo test -p engine each_player_skips` — 1 passed / 0 failed
- `cargo test -p engine static_step_skip` — 3 passed / 0 failed
- `cargo test -p engine skip_draw_step_static_has_no_coverage_gap` — 1 passed / 0 failed
- `cargo test -p engine skip_step_static_must_match_parsed_phase` — 1 passed / 0 failed
- Coverage JSON check: Eon Hub reports `supported: true`, `gap_count: 0`, `oracle_text: "Players skip their upkeep steps."`

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
