### PR TITLE
fix(engine): Mechtitan token keeps haste + becomes all colors (#2343)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -373,9 +373,17 @@ pub(crate) fn parse_token_description(text: &str) -> Option<TokenDescription> {
             (None, None, rest)
         };
 
-    let (colors, rest) = parse_token_color_prefix(rest);
+    let (mut colors, rest) = parse_token_color_prefix(rest);
     let (descriptor, suffix) = split_token_head(rest)?;
     let (name_override, suffix) = parse_token_name_clause(suffix);
+    // CR 105.1 + CR 105.2: "that's all colors" (Mechtitan Core, etc.) makes the
+    // token each of the five colors. Strip the clause before keyword parsing so
+    // the trailing keyword ("... and haste that's all colors") still survives,
+    // then set the colors.
+    let (suffix, is_all_colors) = strip_token_all_colors_suffix(suffix);
+    if is_all_colors {
+        colors = ManaColor::ALL.to_vec();
+    }
     let keywords = parse_token_keyword_clause(suffix);
     let (mut name, types) = parse_token_identity(descriptor)?;
 
@@ -567,6 +575,41 @@ fn strip_token_supertypes(mut text: &str) -> (Vec<Supertype>, &str) {
             supertypes.push(supertype);
         }
         text = stripped;
+    }
+}
+
+/// Strip a trailing "that's all colors" color clause from a token suffix.
+///
+/// CR 105.1 + CR 105.2: a token that is "all colors" is each of the five
+/// WUBRG colors. The clause appears as a relative-pronoun suffix on the token
+/// description (e.g. Mechtitan Core's "... and haste that's all colors"), so it
+/// is detected by scanning word boundaries for the relative-pronoun variants
+/// followed by "all colors". Returns the suffix with the clause removed and a
+/// flag indicating whether it was present, so the caller can both set the five
+/// colors and keep the preceding keyword list intact.
+///
+/// Building block for the whole class of "create <token> ... that's all colors"
+/// effects, not just Mechtitan Core.
+fn strip_token_all_colors_suffix(text: &str) -> (&str, bool) {
+    let all_colors_clause = |i| -> OracleResult<'_, ()> {
+        let (i, _) = alt((
+            tag(" that's"),
+            tag(" that is"),
+            tag(" thats"),
+            tag(" that are"),
+        ))
+        .parse(i)?;
+        value((), tag(" all colors")).parse(i)
+    };
+    let lower = text.to_lowercase();
+    let hit = (0..lower.len()).find_map(|pos| {
+        (lower.as_bytes().get(pos) == Some(&b' '))
+            .then(|| all_colors_clause(&lower[pos..]).ok().map(|_| pos))
+            .flatten()
+    });
+    match hit {
+        Some(pos) => (text[..pos].trim_end(), true),
+        None => (text, false),
     }
 }
 
@@ -1420,6 +1463,37 @@ mod tests {
     }
 
     #[test]
+    fn keyword_clause_keeps_keyword_before_all_colors_clause() {
+        // CR 105.1/105.2 + CR 702.10: the "that's all colors" clause is stripped
+        // before keyword parsing so the trailing keyword survives.
+        let (suffix, is_all_colors) =
+            strip_token_all_colors_suffix("with flying and haste that's all colors");
+        assert!(is_all_colors, "'that's all colors' must be detected");
+        assert_eq!(suffix, "with flying and haste");
+        let kws = parse_token_keyword_clause(suffix);
+        assert_eq!(kws, vec![Keyword::Flying, Keyword::Haste]);
+    }
+
+    #[test]
+    fn all_colors_suffix_relative_pronoun_variants() {
+        // CR 105.1/105.2: each relative-pronoun variant of the all-colors clause
+        // is recognized; non-color "that's" clauses are left untouched.
+        for clause in [
+            "with flying that's all colors",
+            "with flying that is all colors",
+            "with flying thats all colors",
+            "with flying that are all colors",
+        ] {
+            let (suffix, is_all_colors) = strip_token_all_colors_suffix(clause);
+            assert!(is_all_colors, "must detect all-colors in {clause:?}");
+            assert_eq!(suffix, "with flying");
+        }
+        let (suffix, is_all_colors) = strip_token_all_colors_suffix("with flying");
+        assert!(!is_all_colors);
+        assert_eq!(suffix, "with flying");
+    }
+
+    #[test]
     fn extract_static_cant_block_from_quoted_ability() {
         use crate::types::ability::TargetFilter;
         use crate::types::statics::StaticMode;
@@ -1709,6 +1783,57 @@ mod tests {
                 }
             ),
             "X count must resolve to CountersOn(Source, P1P1), got {count:?}"
+        );
+    }
+
+    /// CR 111.3 + CR 702.10 (Haste) + CR 105.1/105.2 (all five colors):
+    /// Mechtitan Core's token has a "with <keywords> that's all colors" suffix
+    /// where the "that's all colors" color clause trails the keyword list. The
+    /// final keyword ("haste") and the all-five-colors characteristic must both
+    /// survive parsing. Building-block regression for the whole class of
+    /// "create <token> with <keywords> that's all colors" effects.
+    #[test]
+    fn token_with_keywords_then_thats_all_colors_keeps_haste_and_colors() {
+        use crate::types::mana::ManaColor;
+
+        let text = "create mechtitan, a legendary 10/10 construct artifact creature token with flying, vigilance, trample, lifelink, and haste that's all colors";
+        let effect = try_parse_token(
+            text,
+            "Create Mechtitan, a legendary 10/10 Construct artifact creature token with flying, vigilance, trample, lifelink, and haste that's all colors",
+            &mut ParseContext::default(),
+        )
+        .expect("expected Token effect");
+        let Effect::Token {
+            keywords, colors, ..
+        } = effect
+        else {
+            panic!("expected Token effect, got {effect:?}");
+        };
+        assert!(
+            keywords.contains(&Keyword::Haste),
+            "the trailing keyword before \"that's all colors\" must survive: {keywords:?}",
+        );
+        for keyword in [
+            Keyword::Flying,
+            Keyword::Vigilance,
+            Keyword::Trample,
+            Keyword::Lifelink,
+        ] {
+            assert!(
+                keywords.contains(&keyword),
+                "{keyword:?} must be present: {keywords:?}",
+            );
+        }
+        for color in ManaColor::ALL {
+            assert!(
+                colors.contains(&color),
+                "\"that's all colors\" must set {color:?}: {colors:?}",
+            );
+        }
+        assert_eq!(
+            colors.len(),
+            5,
+            "all-colors must be exactly the five WUBRG colors: {colors:?}",
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -380,6 +380,7 @@ pub(crate) fn parse_token_description(text: &str) -> Option<TokenDescription> {
     // token each of the five colors. Strip the clause before keyword parsing so
     // the trailing keyword ("... and haste that's all colors") still survives,
     // then set the colors.
+    let saved_all_colors_where_x_expr = extract_token_where_x_expression(suffix);
     let (suffix, is_all_colors) = strip_token_all_colors_suffix(suffix);
     if is_all_colors {
         colors = ManaColor::ALL.to_vec();
@@ -394,7 +395,9 @@ pub(crate) fn parse_token_description(text: &str) -> Option<TokenDescription> {
     // CR 107.3: when the attacking clause was stripped and took the ", where X
     // is …" tail with it, `saved_where_x_expr` carries the expression; fall
     // back to it so the variable count is still resolved.
-    if let Some(where_expression) = extract_token_where_x_expression(suffix).or(saved_where_x_expr)
+    if let Some(where_expression) = extract_token_where_x_expression(suffix)
+        .or(saved_where_x_expr)
+        .or(saved_all_colors_where_x_expr)
     {
         // CR 107.3i + CR 117.1: The Token-effect `where X is …` rebind shares
         // the Join-Forces normalization path with non-Token effects via
@@ -582,35 +585,41 @@ fn strip_token_supertypes(mut text: &str) -> (Vec<Supertype>, &str) {
 ///
 /// CR 105.1 + CR 105.2: a token that is "all colors" is each of the five
 /// WUBRG colors. The clause appears as a relative-pronoun suffix on the token
-/// description (e.g. Mechtitan Core's "... and haste that's all colors"), so it
-/// is detected by scanning word boundaries for the relative-pronoun variants
-/// followed by "all colors". Returns the suffix with the clause removed and a
-/// flag indicating whether it was present, so the caller can both set the five
-/// colors and keep the preceding keyword list intact.
+/// description (e.g. Mechtitan Core's "... and haste that's all colors" or a
+/// bare "... token that's all colors"), so it is detected by scanning word
+/// boundaries for the relative-pronoun variants followed by "all colors".
+/// Returns the suffix with the clause removed and a flag indicating whether it
+/// was present, so the caller can both set the five colors and keep the
+/// preceding keyword list intact.
 ///
 /// Building block for the whole class of "create <token> ... that's all colors"
 /// effects, not just Mechtitan Core.
 fn strip_token_all_colors_suffix(text: &str) -> (&str, bool) {
-    let all_colors_clause = |i| -> OracleResult<'_, ()> {
-        let (i, _) = alt((
-            tag(" that's"),
-            tag(" that is"),
-            tag(" thats"),
-            tag(" that are"),
-        ))
-        .parse(i)?;
-        value((), tag(" all colors")).parse(i)
-    };
-    let lower = text.to_lowercase();
-    let hit = (0..lower.len()).find_map(|pos| {
-        (lower.as_bytes().get(pos) == Some(&b' '))
-            .then(|| all_colors_clause(&lower[pos..]).ok().map(|_| pos))
-            .flatten()
-    });
-    match hit {
-        Some(pos) => (text[..pos].trim_end(), true),
-        None => (text, false),
+    fn all_colors_clause(i: &str) -> OracleResult<'_, ()> {
+        let (i, _) =
+            alt((tag("that's"), tag("that is"), tag("thats"), tag("that are"))).parse(i)?;
+        let (i, _) = value((), tag(" all colors")).parse(i)?;
+        let (i, _) = alt((value((), nom::combinator::eof), value((), tag(", where ")))).parse(i)?;
+        Ok((i, ()))
     }
+
+    let lower = text.to_lowercase();
+    if all_colors_clause(&lower).is_ok() {
+        return ("", true);
+    }
+
+    for (pos, ch) in text.char_indices() {
+        if ch != ' ' {
+            continue;
+        }
+        let candidate = &text[pos + ch.len_utf8()..];
+        let candidate_lower = candidate.to_lowercase();
+        if all_colors_clause(&candidate_lower).is_ok() {
+            return (text[..pos].trim_end(), true);
+        }
+    }
+
+    (text, false)
 }
 
 fn parse_token_color_prefix(mut text: &str) -> (Vec<ManaColor>, &str) {
@@ -1479,6 +1488,7 @@ mod tests {
         // CR 105.1/105.2: each relative-pronoun variant of the all-colors clause
         // is recognized; non-color "that's" clauses are left untouched.
         for clause in [
+            "that's all colors",
             "with flying that's all colors",
             "with flying that is all colors",
             "with flying thats all colors",
@@ -1486,8 +1496,20 @@ mod tests {
         ] {
             let (suffix, is_all_colors) = strip_token_all_colors_suffix(clause);
             assert!(is_all_colors, "must detect all-colors in {clause:?}");
-            assert_eq!(suffix, "with flying");
+            if clause == "that's all colors" {
+                assert_eq!(suffix, "");
+            } else {
+                assert_eq!(suffix, "with flying");
+            }
         }
+        let (suffix, is_all_colors) =
+            strip_token_all_colors_suffix("with flying that's all colors, where X is that value");
+        assert!(is_all_colors);
+        assert_eq!(suffix, "with flying");
+        let (suffix, is_all_colors) =
+            strip_token_all_colors_suffix("with flying that's all colors and haste");
+        assert!(!is_all_colors);
+        assert_eq!(suffix, "with flying that's all colors and haste");
         let (suffix, is_all_colors) = strip_token_all_colors_suffix("with flying");
         assert!(!is_all_colors);
         assert_eq!(suffix, "with flying");
@@ -1834,6 +1856,59 @@ mod tests {
             colors.len(),
             5,
             "all-colors must be exactly the five WUBRG colors: {colors:?}",
+        );
+    }
+
+    /// CR 111.3 + CR 105.1/105.2: the all-colors clause may be the whole token
+    /// suffix, without a preceding `with <keyword>` list.
+    #[test]
+    fn token_thats_all_colors_without_keywords_sets_colors() {
+        use crate::types::mana::ManaColor;
+
+        let text = "create a 2/2 elemental creature token that's all colors";
+        let effect = try_parse_token(
+            text,
+            "Create a 2/2 Elemental creature token that's all colors",
+            &mut ParseContext::default(),
+        )
+        .expect("expected Token effect");
+        let Effect::Token {
+            colors, keywords, ..
+        } = effect
+        else {
+            panic!("expected Token effect, got {effect:?}");
+        };
+        assert!(keywords.is_empty());
+        assert_eq!(colors, ManaColor::ALL.to_vec());
+    }
+
+    /// CR 105.1/105.2 + CR 107.3: stripping the all-colors suffix must not drop
+    /// the trailing `where X is ...` binding for variable token counts.
+    #[test]
+    fn token_all_colors_where_clause_keeps_x_binding() {
+        use crate::types::mana::ManaColor;
+
+        let text = "Create X 1/1 Stained Glass artifact creature tokens that are all colors, where X is the number of creatures you control";
+        let effect = try_parse_token(&text.to_lowercase(), text, &mut ParseContext::default())
+            .expect("expected Token effect");
+        let Effect::Token { colors, count, .. } = effect else {
+            panic!("expected Token effect, got {effect:?}");
+        };
+        assert_eq!(colors, ManaColor::ALL.to_vec());
+        let QuantityExpr::Ref {
+            qty:
+                QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(tf),
+                },
+        } = count
+        else {
+            panic!("expected where-clause to bind X to an ObjectCount, got {count:?}");
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(
+            tf.type_filters.contains(&TypeFilter::Creature),
+            "X must count controlled creatures, got {:?}",
+            tf.type_filters
         );
     }
 }


### PR DESCRIPTION
Partially addresses #2343 (token keyword/color only; #2343 remains open for the activation-cost and return-trigger bugs).

## Problem

Mechtitan Core's activated ability creates "Mechtitan, a legendary 10/10 Construct artifact creature token with flying, vigilance, trample, lifelink, **and haste** that's **all colors**." The token was parsed missing **Haste** and was not made **all colors**:

- `parse_token_keyword_clause` only stripped `" where "` / `" attached "` from the keyword list. The trailing `"that's all colors"` color clause stayed glued to the last keyword, so the final chunk became `"haste that's all colors"`, which never mapped to `Keyword::Haste`. Result: `[Flying, Vigilance, Trample, Lifelink]`.
- Colors were only parsed as a *prefix* before the type word (`parse_token_color_prefix`). The `"that's all colors"` suffix was never interpreted, so the token's color list was empty.

## Fix

Built for the class of `create <token> ... that's all colors` effects, not just Mechtitan:

- New nom-combinator building block `strip_token_all_colors_suffix` detects and strips the trailing all-colors clause (relative-pronoun variants `that's` / `that is` / `thats` / `that are` + `all colors`) by word-boundary scanning, mirroring the existing `attacking_clause` scan in the same module.
- `parse_token_description` strips the clause from the suffix **before** keyword parsing (so the trailing keyword survives) and, when present, sets `colors = ManaColor::ALL` (the five WUBRG colors).

The parsed `Effect::Token.colors` / `.keywords` already flow to the created permanent via `build_token_attrs_from_effect`, so no runtime change is needed.

## Tests

- `token_with_keywords_then_thats_all_colors_keeps_haste_and_colors` — Mechtitan's exact text now yields all five keywords (incl. Haste) and all five colors. Verified to **fail pre-fix** (`[Flying, Vigilance, Trample, Lifelink]`, no colors) and pass post-fix.
- `keyword_clause_keeps_keyword_before_all_colors_clause` and `all_colors_suffix_relative_pronoun_variants` — building-block-level coverage of the suffix stripper across all relative-pronoun variants.
- Full `cargo test -p engine` green; `cargo clippy -p engine --lib -D warnings` clean; `cargo fmt --all --check` clean; `./scripts/check-parser-combinators.sh` clean.

## CR

- CR 111.3 — characteristics a token-creating ability defines.
- CR 105.1 / 105.2 — the five colors; an object can be one or more of them ("all colors" = each of WUBRG).
- CR 702.10 — Haste.

## Out of scope

The issue also reports (2) the activation exile cost only removing the Core itself rather than the four other artifact creatures/Vehicles, and (3) the missing leaves-the-battlefield return trigger. Those are separate, heavier cost/trigger-parsing bugs; this PR is scoped to the issue's primary complaint — the token's Haste and all-colors characteristics.

