### PR TITLE
Add Telepathy

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -132,6 +132,10 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             // support via is_data_carrying_static() because the variant is
             // parameterized.
             | StaticMode::RevealTopOfLibrary { .. }
+            // CR 400.2 + CR 701.20a: RevealHand carries the affected player
+            // scope (`opponents`, `all_players`, or `controller`). Runtime
+            // visibility sync is in derived.rs::sync_continuous_hand_reveals().
+            | StaticMode::RevealHand { .. }
             // CR 614.1c + CR 122.1: EntersWithAdditionalCounters carries the
             // CounterType + fixed count. Runtime enforcement is in the
             // battlefield-entry counter hook in effects/change_zone.rs, which
@@ -6896,6 +6900,11 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                 effective_lower.contains("play with the top card")
                     || effective_lower.contains("play with the top")
             }
+            StaticMode::RevealHand { .. } => {
+                effective_lower.contains("play with")
+                    && effective_lower.contains("hand")
+                    && effective_lower.contains("revealed")
+            }
             // CR 601.2f: ReduceCost / RaiseCost / MinimumCost coverage markers,
             // discriminated by the `mode` axis. Trinisphere's "would cost less than"
             // distinguishes Minimum from Reduce ("less to cast") and Raise ("more").
@@ -10715,6 +10724,38 @@ mod tests {
         assert!(
             gaps.is_empty(),
             "'You can't draw cards.' should be fully supported by CantDraw(controller), but got gaps: {:?}",
+            gaps
+        );
+    }
+
+    /// CR 400.2 + CR 701.20a: parameterized `RevealHand` statics must be
+    /// coverage-recognized so Telepathy/Revelation-class cards do not become
+    /// silent drops after parsing.
+    #[test]
+    fn reveal_hand_static_does_not_count_as_silent_drop() {
+        let mut face = make_face();
+        let oracle = "Your opponents play with their hands revealed.";
+        face.oracle_text = Some(oracle.to_string());
+        face.static_abilities.push(StaticDefinition {
+            mode: StaticMode::RevealHand {
+                who: ProhibitionScope::Opponents,
+            },
+            affected: Some(TargetFilter::SelfRef),
+            modifications: vec![],
+            condition: None,
+            per_player_condition: None,
+            affected_zone: None,
+            effect_zone: None,
+            active_zones: vec![],
+            characteristic_defining: false,
+            description: Some(oracle.to_string()),
+            attack_defended: None,
+        });
+
+        let gaps = card_face_gaps(&face);
+        assert!(
+            gaps.is_empty(),
+            "'Your opponents play with their hands revealed.' should be fully supported by RevealHand(opponents), but got gaps: {:?}",
             gaps
         );
     }

--- a/crates/engine/src/game/derived.rs
+++ b/crates/engine/src/game/derived.rs
@@ -12,7 +12,7 @@ use crate::types::card_type::CoreType;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
-use crate::types::statics::StaticMode;
+use crate::types::statics::{ProhibitionScope, StaticMode};
 use crate::types::zones::Zone;
 
 /// Compute display-only derived fields (CR 302.6 summoning sickness, CR 700.5 devotion).
@@ -257,6 +257,7 @@ pub fn derive_display_state(state: &mut GameState) {
     // momentary reveals at the start of each action, so re-sync here on every
     // derive pass before the state is exported to clients.
     sync_continuous_library_top_reveals(state);
+    sync_continuous_hand_reveals(state);
 }
 
 /// CR 400.2: Repopulate `revealed_cards` for every active `RevealTopOfLibrary`
@@ -304,6 +305,48 @@ fn sync_continuous_library_top_reveals(state: &mut GameState) {
     }
 }
 
+/// CR 400.2 + CR 701.20a: Continuous "play with [a] hand revealed" statics
+/// keep affected players' hands public after action-boundary reveal clears.
+fn sync_continuous_hand_reveals(state: &mut GameState) {
+    let mut reveal_all_players = false;
+    let mut reveal_controllers = HashSet::<PlayerId>::new();
+    let mut reveal_opponents_of = HashSet::<PlayerId>::new();
+
+    for (source, def) in game_active_statics(state) {
+        let StaticMode::RevealHand { who } = &def.mode else {
+            continue;
+        };
+        match who {
+            ProhibitionScope::AllPlayers => reveal_all_players = true,
+            ProhibitionScope::Controller => {
+                reveal_controllers.insert(source.controller);
+            }
+            ProhibitionScope::Opponents => {
+                reveal_opponents_of.insert(source.controller);
+            }
+            ProhibitionScope::EnchantedCreatureController => {}
+        }
+    }
+
+    if !reveal_all_players && reveal_controllers.is_empty() && reveal_opponents_of.is_empty() {
+        return;
+    }
+
+    let hand_cards = state
+        .players
+        .iter()
+        .filter(|player| {
+            reveal_all_players
+                || reveal_controllers.contains(&player.id)
+                || reveal_opponents_of
+                    .iter()
+                    .any(|controller| player.id != *controller)
+        })
+        .flat_map(|player| player.hand.iter().copied());
+
+    state.revealed_cards.extend(hand_cards);
+}
+
 /// Commander damage received by `victim`, grouped by the commander's
 /// controller (the attacking opponent). Each inner entry is
 /// `(commander_object_id, damage)`. The frontend renders one badge per
@@ -346,8 +389,10 @@ pub fn commander_damage_received(
 mod tests {
     use super::*;
     use crate::game::zones::create_object;
+    use crate::types::ability::StaticDefinition;
     use crate::types::identifiers::CardId;
     use crate::types::player::PlayerId;
+    use crate::types::statics::ProhibitionScope;
     use crate::types::zones::Zone;
 
     #[test]
@@ -418,6 +463,90 @@ mod tests {
         // Should have set the flag (false for a card with no mechanics)
         let obj = &state.objects[&id];
         assert!(obj.unimplemented_mechanics.is_empty());
+    }
+
+    #[test]
+    fn derive_reveals_opponents_hands_for_static_reveal_hand() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Telepathy".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::RevealHand {
+                who: ProhibitionScope::Opponents,
+            }));
+        let controller_card = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Controller Card".to_string(),
+            Zone::Hand,
+        );
+        let opponent_card = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Opponent Card".to_string(),
+            Zone::Hand,
+        );
+
+        derive_display_state(&mut state);
+
+        assert!(
+            !state.revealed_cards.contains(&controller_card),
+            "Telepathy-style static must not reveal its controller's hand"
+        );
+        assert!(
+            state.revealed_cards.contains(&opponent_card),
+            "Telepathy-style static must reveal opponents' hands"
+        );
+    }
+
+    #[test]
+    fn derive_reveals_all_hands_for_static_reveal_hand() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Revelation".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::RevealHand {
+                who: ProhibitionScope::AllPlayers,
+            }));
+        let controller_card = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Controller Card".to_string(),
+            Zone::Hand,
+        );
+        let opponent_card = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Opponent Card".to_string(),
+            Zone::Hand,
+        );
+
+        derive_display_state(&mut state);
+
+        assert!(state.revealed_cards.contains(&controller_card));
+        assert!(state.revealed_cards.contains(&opponent_card));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6457,6 +6457,25 @@ mod tests {
     }
 
     #[test]
+    fn parser_reaches_static_line_for_hands_revealed() {
+        let r = parse(
+            "Your opponents play with their hands revealed.",
+            "Telepathy",
+            &[],
+            &["Enchantment"],
+            &[],
+        );
+        assert_eq!(r.abilities.len(), 0, "{r:#?}");
+        assert_eq!(r.statics.len(), 1, "{r:#?}");
+        assert_eq!(
+            r.statics[0].mode,
+            crate::types::statics::StaticMode::RevealHand {
+                who: crate::types::statics::ProhibitionScope::Opponents,
+            }
+        );
+    }
+
+    #[test]
     fn bonesplitter_static_plus_equip() {
         let r = parse(
             "Equipped creature gets +2/+0.\nEquip {1}",

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -250,6 +250,11 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     "no maximum hand size",
     "may choose not to untap",
     "play with the top card",
+    // CR 400.2 + CR 701.20a: Telepathy/Revelation class. Keep this narrower
+    // than generic hand-reveal effects ("reveal a card from your hand") by
+    // matching the continuous "hand(s) revealed" wording.
+    "hands revealed",
+    "hand revealed",
     "cost {",
     "costs {",
     "cost less",

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -7,6 +7,7 @@ use super::{
     anthem::*, cda::*, cost_mod::*, evasion::*, keyword_grant::*, loyalty::*, mana_transform::*,
     restriction::*, type_change::*,
 };
+use crate::types::statics::ProhibitionScope;
 
 /// Whether the inverted `"As long as <cond>, <effect>"` detector may fire.
 ///
@@ -120,6 +121,81 @@ fn parse_skip_step_static(tp: &TextPair<'_>, text: &str) -> Option<StaticDefinit
     )
 }
 
+#[derive(Clone, Copy)]
+enum RevealHandSubject {
+    Opponents,
+    Players,
+    AllPlayers,
+    EachPlayer,
+    Controller,
+}
+
+fn parse_reveal_hand_subject(input: &str) -> OracleResult<'_, RevealHandSubject> {
+    alt((
+        value(RevealHandSubject::Opponents, tag("your opponents")),
+        value(RevealHandSubject::AllPlayers, tag("all players")),
+        value(RevealHandSubject::Players, tag("players")),
+        value(RevealHandSubject::EachPlayer, tag("each player")),
+        map(opt(tag("you")), |_| RevealHandSubject::Controller),
+    ))
+    .parse(input)
+}
+
+fn parse_reveal_hand_verb(subject: RevealHandSubject, input: &str) -> OracleResult<'_, ()> {
+    match subject {
+        RevealHandSubject::Opponents
+        | RevealHandSubject::Players
+        | RevealHandSubject::AllPlayers
+        | RevealHandSubject::Controller => value((), tag("play with")).parse(input),
+        RevealHandSubject::EachPlayer => value((), tag("plays with")).parse(input),
+    }
+}
+
+fn parse_reveal_hand_possessive(subject: RevealHandSubject, input: &str) -> OracleResult<'_, ()> {
+    match subject {
+        RevealHandSubject::Controller => value((), tag("your")).parse(input),
+        RevealHandSubject::Opponents
+        | RevealHandSubject::Players
+        | RevealHandSubject::AllPlayers
+        | RevealHandSubject::EachPlayer => value((), tag("their")).parse(input),
+    }
+}
+
+fn reveal_hand_scope(subject: RevealHandSubject) -> ProhibitionScope {
+    match subject {
+        RevealHandSubject::Opponents => ProhibitionScope::Opponents,
+        RevealHandSubject::Players
+        | RevealHandSubject::AllPlayers
+        | RevealHandSubject::EachPlayer => ProhibitionScope::AllPlayers,
+        RevealHandSubject::Controller => ProhibitionScope::Controller,
+    }
+}
+
+fn parse_reveal_hand_scope(input: &str) -> OracleResult<'_, ProhibitionScope> {
+    let (input, subject) = parse_reveal_hand_subject(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = parse_reveal_hand_verb(subject, input)?;
+    let (input, _) = space1(input)?;
+    let (input, _) = parse_reveal_hand_possessive(subject, input)?;
+    let (input, _) = space1(input)?;
+    let (input, _) = alt((tag("hands"), tag("hand"))).parse(input)?;
+    let (input, _) = space1(input)?;
+    let (input, _) = tag("revealed").parse(input)?;
+    Ok((input, reveal_hand_scope(subject)))
+}
+
+fn parse_reveal_hand_static(tp: &TextPair<'_>, text: &str) -> Option<StaticDefinition> {
+    let (_, who) = all_consuming(terminated(parse_reveal_hand_scope, (opt(tag(".")), space0)))
+        .parse(tp.lower)
+        .ok()?;
+
+    Some(
+        StaticDefinition::new(StaticMode::RevealHand { who })
+            .affected(TargetFilter::SelfRef)
+            .description(text.to_string()),
+    )
+}
+
 pub(crate) fn parse_static_line_inner(
     text: &str,
     inverted: InvertedAsLongAs,
@@ -201,6 +277,24 @@ pub(crate) fn parse_static_line_inner(
         if let Some(split) = try_split_inverted_as_long_as(&tp) {
             if let Some(def) = try_parse_inverted_attached_subject_grant(&split, &text) {
                 return Some(def);
+            }
+            // CR 400.2 + CR 701.20a: "As long as <condition>, all players
+            // play with their hands revealed." The generic continuous fallback
+            // can otherwise accept the canonical rewrite before this data-
+            // carrying static sees the isolated effect clause.
+            {
+                let effect_lower = split.effect_text.to_lowercase();
+                let tp_effect = TextPair::new(&split.effect_text, &effect_lower);
+                if let Some(mut def) = parse_reveal_hand_static(&tp_effect, &split.effect_text) {
+                    let condition = parse_static_condition(&split.condition_text).unwrap_or(
+                        StaticCondition::Unrecognized {
+                            text: split.condition_text.clone(),
+                        },
+                    );
+                    def.condition = Some(condition);
+                    def.description = Some(text.to_string());
+                    return Some(def);
+                }
             }
             if let Some(def) = parse_static_line_inner(&split.canonical, InvertedAsLongAs::Skip) {
                 return Some(def.description(text.to_string()));
@@ -453,6 +547,12 @@ pub(crate) fn parse_static_line_inner(
                     .description(text.to_string()),
             );
         }
+    }
+
+    // --- "Your opponents/Players play with their hands revealed" ---
+    // CR 400.2 + CR 701.20a: continuous effect making hand cards public.
+    if let Some(def) = parse_reveal_hand_static(&tp, &text) {
+        return Some(def);
     }
 
     // --- "Skip your [step] step" / "Players skip their [step] steps" ---

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10856,6 +10856,93 @@ fn cant_draw_opponents() {
 }
 
 #[test]
+fn reveal_hand_opponents() {
+    let def = parse_static_line("Your opponents play with their hands revealed.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::RevealHand {
+            who: ProhibitionScope::Opponents,
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+}
+
+#[test]
+fn reveal_hand_all_players() {
+    let def = parse_static_line("Players play with their hands revealed.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::RevealHand {
+            who: ProhibitionScope::AllPlayers,
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+}
+
+#[test]
+fn reveal_hand_all_players_explicit_subject() {
+    let def = parse_static_line("All players play with their hands revealed.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::RevealHand {
+            who: ProhibitionScope::AllPlayers,
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+}
+
+#[test]
+fn reveal_hand_each_player_singular_hand() {
+    let def = parse_static_line("Each player plays with their hand revealed.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::RevealHand {
+            who: ProhibitionScope::AllPlayers,
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+}
+
+#[test]
+fn reveal_hand_all_players_with_untapped_condition() {
+    let def =
+        parse_static_line("As long as ~ is untapped, all players play with their hands revealed.")
+            .unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::RevealHand {
+            who: ProhibitionScope::AllPlayers,
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert!(
+        matches!(
+            def.condition,
+            Some(StaticCondition::Not { ref condition })
+                if matches!(**condition, StaticCondition::SourceIsTapped)
+        ),
+        "expected Not(SourceIsTapped), got {:?}",
+        def.condition
+    );
+}
+
+#[test]
+fn reveal_hand_controller_with_optional_you_subject() {
+    let def = parse_static_line("You play with your hand revealed.").unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::RevealHand {
+            who: ProhibitionScope::Controller,
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+
+    let imperative = parse_static_line("Play with your hand revealed.").unwrap();
+    assert_eq!(imperative.mode, def.mode);
+    assert_eq!(imperative.affected, Some(TargetFilter::SelfRef));
+}
+
+#[test]
 fn spell_cost_reduction_uses_card_types_in_graveyard_quantity() {
     let def = parse_static_line(
         "This spell costs {1} less to cast for each card type among cards in your graveyard.",

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -849,6 +849,11 @@ pub enum StaticMode {
     RevealTopOfLibrary {
         all_players: bool,
     },
+    /// CR 400.2 + CR 701.20a: Play with hands revealed.
+    /// `who` identifies whose hand is public: controller, opponents, or all players.
+    RevealHand {
+        who: ProhibitionScope,
+    },
     /// CR 604.2 + CR 305.1: Static ability granting permission to play/cast
     /// matching cards from owner's graveyard.
     GraveyardCastPermission {
@@ -1386,6 +1391,7 @@ impl Hash for StaticMode {
             StaticMode::MaxAttackersEachCombat { max }
             | StaticMode::MaxBlockersEachCombat { max } => max.hash(state),
             StaticMode::RevealTopOfLibrary { all_players } => all_players.hash(state),
+            StaticMode::RevealHand { who } => who.hash(state),
             StaticMode::CantBeBlockedExceptBy { kind } => match kind {
                 // TargetFilter does not implement Hash; discriminant only.
                 BlockExceptionKind::Quality(_) => {}
@@ -1517,6 +1523,7 @@ impl StaticMode {
             | StaticMode::IgnoreHexproof
             | StaticMode::ExtraBlockers { .. }
             | StaticMode::RevealTopOfLibrary { .. }
+            | StaticMode::RevealHand { .. }
             | StaticMode::GraveyardCastPermission { .. }
             | StaticMode::TopOfLibraryCastPermission { .. }
             | StaticMode::CastFromHandFree { .. }
@@ -1739,6 +1746,7 @@ impl fmt::Display for StaticMode {
                     write!(f, "RevealTopOfLibrary(you)")
                 }
             }
+            StaticMode::RevealHand { who } => write!(f, "RevealHand({who})"),
             // Tier 1
             StaticMode::CantBeBlocked => write!(f, "CantBeBlocked"),
             StaticMode::CantBeBlockedExceptBy { kind } => match kind {
@@ -2337,6 +2345,14 @@ impl FromStr for StaticMode {
                     StaticMode::RevealTopOfLibrary {
                         all_players: rest == "all",
                     }
+                } else if let Some(inner) = other
+                    .strip_prefix("RevealHand(")
+                    .and_then(|s| s.strip_suffix(')'))
+                {
+                    if let Ok(who) = ProhibitionScope::from_str(inner) {
+                        return Ok(StaticMode::RevealHand { who });
+                    }
+                    return Ok(StaticMode::Other(other.to_string()));
                 } else if let Some(rest) = other.strip_prefix("AdditionalLandDrop(") {
                     let rest = rest.strip_suffix(')').unwrap_or(rest);
                     StaticMode::AdditionalLandDrop {
@@ -2611,6 +2627,12 @@ mod tests {
             StaticMode::CantBeBlockedByMoreThan { max: 2 },
             StaticMode::RevealTopOfLibrary { all_players: false },
             StaticMode::RevealTopOfLibrary { all_players: true },
+            StaticMode::RevealHand {
+                who: ProhibitionScope::Opponents,
+            },
+            StaticMode::RevealHand {
+                who: ProhibitionScope::AllPlayers,
+            },
             // Tier 1: keyword/evasion statics
             StaticMode::CantBeBlocked,
             StaticMode::CantBeBlockedExceptBy {


### PR DESCRIPTION
## Summary

Adds support for Telepathy/Revelation-style continuous hand reveal static abilities:

- parses `Your opponents play with their hands revealed.` as `StaticMode::RevealHand { who: Opponents }`
- parses `Players play with their hands revealed.`, `All players play with their hands revealed.`, and `Each player plays with their hand revealed.` as `StaticMode::RevealHand { who: AllPlayers }`
- handles inverted condition text such as `As long as ~ is untapped, all players play with their hands revealed.` without falling back to a generic continuous static
- keeps affected hand cards in `revealed_cards` during derived-state sync, reusing the existing public-card visibility path
- marks the parameterized static as coverage-supported so it does not become a silent drop

This covers the single-gap cards Telepathy, Revelation, Wandering Eye, and Squee without committing generated card-data.

## Rules / implementation notes

- CR 400.2: hands are hidden zones unless an effect reveals them.
- CR 701.20a: revealed cards are shown to all players for the relevant duration.
- CR 701.20b: revealed cards do not leave the zone they are revealed from.
- This mirrors the existing `RevealTopOfLibrary` continuous reveal path instead of adding a separate visibility mechanism.

## Validation

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `cargo test -p engine reveal_hand --lib`
- `cargo test -p engine reveal_hand_all_players --lib`
- `cargo test -p engine parser_reaches_static_line_for_hands_revealed --lib`
- `cargo test -p engine display_roundtrips --lib`
- temp `oracle-gen --filter 'Telepathy|Revelation|Wandering Eye|Squee'` export showed the target cards lowering to `RevealHand`
- temp `coverage-report` over that filtered export showed Telepathy, Revelation, Wandering Eye, and Squee as `supported=true`, `gap_count=0`
- pre-push suite on the prior revision passed: fmt check, clippy, parser tests, phase-ai tests, full oracle-gen/card-data-validate/coverage-report, client lint/type-check