### PR TITLE
Add Baldin toughness damage static

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -196,6 +196,24 @@ fn parse_reveal_hand_static(tp: &TextPair<'_>, text: &str) -> Option<StaticDefin
     )
 }
 
+fn parse_during_your_turn_prefix(input: &str) -> OracleResult<'_, StaticCondition> {
+    // CR 611.3a: The following continuous static applies only while the
+    // "during your turn" condition is true.
+    let (input, _) = tag::<_, _, OracleError<'_>>("during your turn").parse(input)?;
+    let (input, _) = tag(",").parse(input)?;
+    let (input, _) = space1(input)?;
+    Ok((input, StaticCondition::DuringYourTurn))
+}
+
+fn strip_during_your_turn_prefix<'a>(tp: &TextPair<'a>) -> Option<(TextPair<'a>, StaticCondition)> {
+    let (rest_lower, condition) = parse_during_your_turn_prefix(tp.lower).ok()?;
+    let consumed = tp.lower.len() - rest_lower.len();
+    Some((
+        TextPair::new(&tp.original[consumed..], rest_lower),
+        condition,
+    ))
+}
+
 pub(crate) fn parse_static_line_inner(
     text: &str,
     inverted: InvertedAsLongAs,
@@ -790,8 +808,13 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
-    // --- "Each creature you control [with condition] assigns combat damage equal to its toughness" ---
     // CR 510.1c: Doran-class effects that cause creatures to use toughness for combat damage.
+    // CR 611.3a: Optional leading "during your turn" gates that continuous effect.
+    if let Some((rest_tp, condition)) = strip_during_your_turn_prefix(&tp) {
+        if let Some(def) = parse_assigns_damage_from_toughness(rest_tp.lower, rest_tp.original) {
+            return Some(def.condition(condition).description(text.to_string()));
+        }
+    }
     if let Some(def) = parse_assigns_damage_from_toughness(&lower, &text) {
         return Some(def);
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -11279,6 +11279,25 @@ fn static_assigns_damage_from_toughness_all_creatures() {
 }
 
 #[test]
+fn static_assigns_damage_from_toughness_all_creatures_during_your_turn() {
+    // CR 510.1c + CR 611.3a: Baldin's global toughness-damage static is
+    // active only during its controller's turn.
+    let def = parse_static_line(
+        "During your turn, each creature assigns combat damage equal to its toughness rather than its power.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::Typed(TypedFilter::creature()))
+    );
+    assert!(def
+        .modifications
+        .contains(&ContinuousModification::AssignDamageFromToughness));
+    assert_eq!(def.condition, Some(StaticCondition::DuringYourTurn));
+}
+
+#[test]
 fn static_assigns_damage_from_toughness_self() {
     // CR 510.1c: Self-referential variant — "This creature assigns..."
     let def = parse_static_line(


### PR DESCRIPTION
## Summary

Adds the missing turn-gated form for Doran-style toughness combat damage statics:

- parses `During your turn, each creature assigns combat damage equal to its toughness rather than its power.`
- reuses the existing `parse_assigns_damage_from_toughness` path and attaches `StaticCondition::DuringYourTurn`
- covers Baldin, Century Herdmaster without adding a new runtime primitive or generated card data

## Rules / implementation notes

- CR 510.1c: combat damage assignment is the rule axis affected by the existing `AssignDamageFromToughness` modification.
- CR 611.3a: the static ability's continuous effect applies while its condition is true.
- This keeps the change scoped to the existing parser/condition composition instead of adding a separate Baldin-specific mode.

## Validation

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `cargo test -p engine static_assigns_damage_from_toughness_all_creatures_during_your_turn --lib`
- `cargo test -p engine static_assigns_damage_from_toughness --lib`
- temp `oracle-gen --filter 'Baldin, Century Herdmaster'` export
- temp `coverage-report` over that filtered export showed `Baldin, Century Herdmaster` as `supported=true`, `gap_count=0`