### PR TITLE
fix(engine): Wall of Mourning ETB exiles from library top

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4985,6 +4985,25 @@ pub(super) fn parse_exile_ast(
     let (_, rest_text) = nom_on_lower(text, lower, |input| value((), tag("exile ")).parse(input))?;
     let rest_lower = &lower[lower.len() - rest_text.len()..];
 
+    // CR 701.13a: "exile a card from the top of your library" — synonymous with
+    // "exile the top card of your library". Without ExileTop lowering the generic
+    // path emits ChangeZone(Library→Exile) with a library-wide EffectZoneChoice
+    // prompt (Wall of Mourning, issue #2397).
+    if let Ok((after_lib, _)) = (
+        opt(nom_primitives::parse_article),
+        tag("card from the top of your library"),
+    )
+        .parse(rest_lower)
+    {
+        let (after_lib, face_down) = strip_exile_top_face_down(after_lib);
+        let count = parse_exile_card_from_top_for_each_suffix(after_lib);
+        return Some(ZoneCounterImperativeAst::ExileTop {
+            player: TargetFilter::Controller,
+            count,
+            face_down,
+        });
+    }
+
     // CR 400.12: "exile their graveyard" / "exile target player's graveyard"
     // act on all cards in that zone. Bare possessive zone references and
     // "target {player,opponent}'s <zone>" share semantics with "exile all/each".
@@ -5128,6 +5147,40 @@ pub(super) fn that_player_library_filter(ctx: &ParseContext) -> TargetFilter {
 /// Bomat Courier, Asmodeus the Archfiend, Knowledge Vault). Matching at this
 /// boundary keeps the downstream `where x is` and "those cards" lowering
 /// paths untouched.
+/// Parse an optional trailing "for each opponent you have" (or bare "for each
+/// opponent") suffix on an `exile a card from the top of your library` clause.
+fn parse_exile_card_from_top_for_each_suffix(after_lib: &str) -> QuantityExpr {
+    let trimmed = after_lib.trim_start();
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("for each opponent you have").parse(trimmed)
+    {
+        if rest.trim().trim_start_matches('.').is_empty() {
+            return QuantityExpr::Ref {
+                qty: QuantityRef::PlayerCount {
+                    filter: crate::types::ability::PlayerFilter::Opponent,
+                },
+            };
+        }
+    }
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("for each opponent").parse(trimmed) {
+        if rest.trim().trim_start_matches('.').is_empty() {
+            return QuantityExpr::Ref {
+                qty: QuantityRef::PlayerCount {
+                    filter: crate::types::ability::PlayerFilter::Opponent,
+                },
+            };
+        }
+    }
+    if let Ok((rest, qty)) =
+        crate::parser::oracle_nom::quantity::parse_for_each_clause_ref.parse(trimmed)
+    {
+        let tail = rest.trim().trim_start_matches('.').trim();
+        if tail.is_empty() {
+            return QuantityExpr::Ref { qty };
+        }
+    }
+    QuantityExpr::Fixed { value: 1 }
+}
+
 fn strip_exile_top_face_down(after_lib: &str) -> (&str, bool) {
     let trimmed = after_lib.trim_start();
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("face down").parse(trimmed) {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -27046,6 +27046,32 @@ mod tests {
         );
     }
 
+    /// Issue #2397 (Wall of Mourning ETB) — "exile a card from the top of your
+    /// library face down for each opponent you have" must lower to ExileTop, not
+    /// a library-wide ChangeZone choice prompt.
+    #[test]
+    fn exile_card_from_top_of_your_library_face_down_for_each_opponent() {
+        let effect = parse_effect(
+            "Exile a card from the top of your library face down for each opponent you have.",
+        );
+        assert!(
+            matches!(
+                &effect,
+                Effect::ExileTop {
+                    player: TargetFilter::Controller,
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::PlayerCount {
+                            filter: crate::types::ability::PlayerFilter::Opponent,
+                        },
+                    },
+                    face_down: true,
+                }
+            ),
+            "Expected ExileTop(controller, opponents, face_down), got {:?}",
+            effect
+        );
+    }
+
     /// Issue #594 (Maralen, Fae Ascendant ETB; Court of Locthwain ETB) —
     /// "exile the top N cards of target opponent's library" must preserve
     /// the count (N) and lower the targeted-player phrase to a typed

--- a/crates/engine/tests/integration/issue_2397_wall_of_mourning_etb.rs
+++ b/crates/engine/tests/integration/issue_2397_wall_of_mourning_etb.rs
@@ -1,0 +1,54 @@
+//! Regression for issue #2397: Wall of Mourning ETB must exile from library top,
+//! not from the battlefield.
+//!
+//! https://github.com/phase-rs/phase/issues/2397
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const WALL_ORACLE: &str = "Defender\nWhen this creature enters, exile a card from the top of your library face down for each opponent you have.";
+
+#[test]
+fn issue_2397_wall_of_mourning_etb_exiles_from_library_not_battlefield() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::White, ObjectId(0), false, vec![]),
+        ],
+    );
+    for i in 0..5 {
+        scenario.add_card_to_library_top(P0, &format!("Library Card {i}"));
+    }
+    let opponent_creature = scenario.add_creature(P1, "Opponent Bear", 2, 2).id();
+    let wall = scenario
+        .add_creature_to_hand_from_oracle(P0, "Wall of Mourning", 0, 4, WALL_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let library_before = runner.state().players[P0.0 as usize].library.len();
+
+    runner.cast(wall).resolve();
+
+    let library_after = runner.state().players[P0.0 as usize].library.len();
+    assert_eq!(
+        library_after,
+        library_before - 1,
+        "two-player game: Wall must exile one card from controller's library top"
+    );
+    assert_eq!(
+        runner.state().objects[&opponent_creature].zone,
+        Zone::Battlefield,
+        "Wall's ETB must not exile opponent's battlefield creatures"
+    );
+    assert_eq!(
+        runner.state().exile.len(),
+        1,
+        "exactly one card should be face-down exiled for the sole opponent"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -132,6 +132,7 @@ mod issue_2376_pyromancers_ascension;
 mod issue_2377_mdfc_commander_zone_revert;
 mod issue_2378_surrak_haste_grant;
 mod issue_2380_xenagos_power_boost;
+mod issue_2397_wall_of_mourning_etb;
 mod issue_2414_semblance_anvil;
 mod issue_2415_rottenmouth_viper_sacrifice_cost;
 mod issue_2417_satoru_intervening_if;


### PR DESCRIPTION
## Summary
- Parse "exile a card from the top of your library" as `Effect::ExileTop` instead of a library-wide `ChangeZone` choice prompt
- Honor `face down` and `for each opponent you have` suffixes on that phrasing
- Add integration and parser regression tests for Wall of Mourning (#2397)

## Test plan
- [x] `cargo test -p engine --lib exile_card_from_top_of_your_library_face_down_for_each_opponent`
- [x] `cargo test -p engine --test integration issue_2397`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #2397

Made with [Cursor](https://cursor.com)