### PR TITLE
fix(engine): Bring to Light free-cast is resolution-only, not a lingering permission (#2880)

### DIFF
--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -161,29 +161,45 @@ pub fn resolve(
         return Ok(());
     }
 
-    // CR 702.62a + CR 608.2g: Suspend's last-time-counter ability casts the
-    // card it is attached to, for free, AS THE TRIGGER RESOLVES. The card casts
-    // itself (the single resolved target IS the ability's source), there is no
-    // mana cost (`without_paying`), and no replacement alt-cost
-    // (`alt_ability_cost == None`). Per CR 702.62a/702.62d the cast happens
-    // during resolution — it must NOT be deferred to a lingering permission the
-    // player acts on at a later priority window (issue #1520: accepting the
-    // optional "cast it?" prompt appeared to do nothing because only a
-    // permission was stamped — the spell was never put on the stack, and a
-    // sorcery like Treasure Cruise was additionally blocked by the
-    // sorcery-speed timing gate at upkeep). Drive the cast immediately through
-    // the same cast-during-resolution authority Cascade/Discover use
-    // (`initiate_cast_during_resolution`).
+    // CR 608.2g: A `DuringResolution` cast-from-zone casts the single resolved
+    // target, for free, AS THE GRANTING ABILITY RESOLVES — the card goes onto
+    // the stack immediately rather than being deferred to a lingering
+    // permission the player acts on at a later priority window. Two producers
+    // share this path:
+    //
+    //   - CR 702.62a + CR 702.62d: Suspend's last-time-counter ability casts
+    //     the card it is attached to (the single resolved target IS the
+    //     ability's source). Issue #1520: accepting the optional "cast it?"
+    //     prompt appeared to do nothing because only a permission was stamped —
+    //     the spell was never put on the stack, and a sorcery like Treasure
+    //     Cruise was additionally blocked by the sorcery-speed timing gate at
+    //     upkeep.
+    //   - CR 701.23 + CR 608.2g (tutor-and-cast): Bring to Light tutors a card into the
+    //     controller's OWN exile, then "you may cast it without paying its mana
+    //     cost." The tutored card is NOT the source (target != source) and sits
+    //     in the controller's own exile, so the Suspend-specific
+    //     `target == source` defense and the foreign-graveyard defense below
+    //     both miss it. Issue #2880: it fell to `grant_lingering_permissions`,
+    //     which stamped an indefinite `ExileWithAltCost { duration: None }` —
+    //     a free-cast permission that persists forever instead of being a
+    //     one-shot resolution offer.
+    //
+    // Drive the cast immediately through the same cast-during-resolution
+    // authority Cascade/Discover use (`initiate_cast_during_resolution`).
     //
     // The router reads the EXPLICIT `driver` discriminator
-    // (`CastFromZoneDriver::DuringResolution`, set by
-    // `build_suspend_last_counter_cast_trigger`), NOT `duration`. `duration` is
+    // (`CastFromZoneDriver::DuringResolution`), NOT `duration`. `duration` is
     // CR 611.2a permission-expiry and says nothing about the casting mechanism;
     // routing on it conflated two axes. The structural-shape guard
-    // (`without_paying` + no alt-cost + single self target) is retained as a
+    // (`without_paying` + no alt-cost + single target) is retained as a
     // defense-in-depth invariant — a `DuringResolution` body must always be a
-    // self-free-cast, since `initiate_cast_during_resolution` casts the single
-    // card object itself at zero cost.
+    // free cast of a single card, since `initiate_cast_during_resolution` casts
+    // that single card object at zero cost. The Suspend-era
+    // `target == source` clause is intentionally dropped: every existing
+    // `DuringResolution` producer (Suspend) uses `target: SelfRef`, so
+    // `target == source` still holds for them, and the tutor-and-cast producer
+    // (Bring to Light, `target != source` but in the controller's own exile)
+    // must reach this path.
     //
     // FOLLOW-UP (#1520 twin): Rebound (CR 702.88a) is still a
     // `LingeringPermission` driver because its recast permission legitimately
@@ -199,11 +215,10 @@ pub fn resolve(
     // `ExiledBySource` filter, or an `alt_ability_cost`) are also
     // `LingeringPermission`: the controller casts them during the granting
     // effect's own priority window.
-    let self_free_cast = driver.is_during_resolution()
+    let driver_free_cast = driver.is_during_resolution()
         && without_paying
         && alt_ability_cost.is_none()
-        && target_ids.len() == 1
-        && target_ids[0] == ability.source_id;
+        && target_ids.len() == 1;
 
     // CR 608.2g: A targeted free-cast of a card the controller could never
     // surface a *later* cast for must also be driven DURING resolution. Memory
@@ -223,7 +238,7 @@ pub fn resolve(
         && target_ids.len() == 1
         && target_is_in_other_players_graveyard(state, target_ids[0], ability.controller);
 
-    if self_free_cast || foreign_graveyard_free_cast {
+    if driver_free_cast || foreign_graveyard_free_cast {
         return cast_single_target_during_resolution(
             state,
             ability,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12150,17 +12150,47 @@ fn try_parse_cast_effect(lower: &str) -> Option<Effect> {
         let duration = dur.or_else(|| {
             scan_contains_phrase(lower, "this turn").then_some(Duration::UntilEndOfTurn)
         });
+        // CR 118.9 + CR 701.9a: "cast that card by discarding a card rather
+        // than paying its mana cost" (The Infamous Cruelclaw).
+        let alt_ability_cost = parse_alt_ability_cost_rider(lower);
+        // CR 608.2g + CR 118.9 + CR 118.9b: a bare "cast that card / it without
+        // paying its mana cost" with no lingering-permission duration is a
+        // resolution-only free cast (Bring to Light tutors a card into the
+        // controller's own exile, then casts it AS this effect resolves — issue
+        // #2880). The card goes on the stack now; no standing `ExileWithAltCost`
+        // permission lingers afterward. Restricted to `mode == Cast`: CR 305.1
+        // land plays are a special action, not a cast, and have no
+        // during-resolution casting mechanism — the Play-mode hideaway/wish
+        // cards (Mosswort Bridge, Djinn of Wishes, etc.) must stay on the
+        // lingering-permission path. An `alt_ability_cost` or an explicit
+        // `duration` likewise keeps the lingering grant (Cruelclaw's discard
+        // alt cost; Rebound-style durational recasts). A `constraint` (a
+        // conditional free-cast such as Beseech the Mirror's "you may cast the
+        // exiled card without paying its mana cost if that spell's mana value
+        // is 4 or less", with a "put into your hand if it wasn't cast this way"
+        // fallback) also keeps the lingering grant: the constraint is evaluated
+        // when the permission is exercised, and the not-cast fallback relies on
+        // the standing permission, neither of which the one-shot
+        // during-resolution path models.
+        let driver = if mode == CardPlayMode::Cast
+            && without_paying
+            && alt_ability_cost.is_none()
+            && duration.is_none()
+            && constraint.is_none()
+        {
+            crate::types::ability::CastFromZoneDriver::DuringResolution
+        } else {
+            crate::types::ability::CastFromZoneDriver::LingeringPermission
+        };
         return Some(Effect::CastFromZone {
             target: TargetFilter::ParentTarget,
             without_paying_mana_cost: without_paying,
             mode,
             cast_transformed: false,
-            // CR 118.9 + CR 701.9a: "cast that card by discarding a card rather
-            // than paying its mana cost" (The Infamous Cruelclaw).
-            alt_ability_cost: parse_alt_ability_cost_rider(lower),
+            alt_ability_cost,
             constraint,
             duration,
-            driver: crate::types::ability::CastFromZoneDriver::LingeringPermission,
+            driver,
         });
     }
 

--- a/crates/engine/tests/integration/bring_to_light_free_cast_2880.rs
+++ b/crates/engine/tests/integration/bring_to_light_free_cast_2880.rs
@@ -1,0 +1,211 @@
+//! Issue #2880 — Bring to Light's free cast must happen DURING resolution and
+//! leave NO lingering casting permission, rather than stamping an indefinite
+//! `CastingPermission::ExileWithAltCost { duration: None }` the player could
+//! exploit on any future turn.
+//!
+//! Bring to Light tutors a card into the controller's OWN exile, then "you may
+//! cast that card without paying its mana cost." This is the same
+//! `Effect::CastFromZone { without_paying_mana_cost: true, target: ParentTarget,
+//! driver: DuringResolution }` shape as Suspend's last-counter cast (CR 608.2g):
+//! the card must go on the stack AS the granting effect resolves, with no
+//! standing permission afterward.
+//!
+//! The reported bug: accepting the prompt stamped an indefinite free-cast
+//! `ExileWithAltCost` permission on the tutored card and never put it on the
+//! stack — `cast_from_zone.rs`'s during-resolution guard required
+//! `target == source` (a Suspend-specific clause), so Bring to Light's
+//! `target != source` tutored card fell through to `grant_lingering_permissions`.
+//!
+//! This drives the REAL parser (`from_oracle_text`) and the REAL resolver
+//! through the cast-during-resolution pipeline. The tutor mechanism here is an
+//! `ExileFromTopUntil` (deterministic, no library-search prompt) instead of
+//! Converge search, but the fix-relevant clause — "You may cast that card
+//! without paying its mana cost" → `CastFromZone { ParentTarget,
+//! DuringResolution }` over a card in the controller's own exile (target !=
+//! source) — is byte-for-byte the Bring to Light shape.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{CastingPermission, Effect};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+use super::rules::run_combat;
+
+/// Tutor-and-cast oracle: exile from the top of the controller's OWN library
+/// until a nonland card is exiled (it lands in the controller's exile, owner ==
+/// controller), then offer to cast it for free DURING resolution. Identical to
+/// The Infamous Cruelclaw minus its discard alt cost — dropping the alt cost is
+/// what flips the cast onto the during-resolution driver (a non-`None`
+/// `alt_ability_cost` keeps the lingering-permission path).
+const TUTOR_CAST_ORACLE: &str = "Whenever this creature deals combat damage to a player, \
+exile cards from the top of your library until you exile a nonland card. \
+You may cast that card without paying its mana cost.";
+
+fn put_on_library_top(state: &mut GameState, obj_id: ObjectId, owner: PlayerId) {
+    let mut events = Vec::new();
+    engine::game::zones::move_to_zone(state, obj_id, Zone::Library, &mut events);
+    let player = state.players.iter_mut().find(|p| p.id == owner).unwrap();
+    player.library.retain(|id| *id != obj_id);
+    player.library.insert(0, obj_id);
+}
+
+/// True when `id` retains any `ExileWithAltCost` permission — the indefinite
+/// lingering grant this fix eliminates (issue #2880).
+fn has_exile_alt_cost(state: &GameState, id: ObjectId) -> bool {
+    state.objects[&id]
+        .casting_permissions
+        .iter()
+        .any(|p| matches!(p, CastingPermission::ExileWithAltCost { .. }))
+}
+
+/// Build a scenario: a 3/3 attacker with the tutor-and-cast trigger, and a
+/// target-less castable sorcery ("Draw a card.") sitting on top of P0's library
+/// so the `ExileFromTopUntil` deterministically exiles it into P0's own exile.
+/// Returns the runner, the attacker id, and the tutored card id.
+fn setup() -> (engine::game::scenario::GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let attacker = scenario
+        .add_creature_from_oracle(P0, "Tutoring Beast", 3, 3, TUTOR_CAST_ORACLE)
+        .id();
+
+    // A land first so `ExileFromTopUntil` exiles at least one nonmatching card,
+    // then the target-less sorcery as the nonland stop. A target-less spell
+    // lands straight on the stack on accept (no intervening target prompt).
+    let land = scenario.add_basic_land(P0, ManaColor::Blue);
+    let tutored = scenario
+        .add_spell_to_library_top(P0, "Free Cantrip", false)
+        .from_oracle_text("Draw a card.")
+        .with_mana_cost(ManaCost::generic(3))
+        .id();
+
+    let mut runner = scenario.build();
+    // Library top → bottom: land, then the sorcery (the nonland stop).
+    put_on_library_top(runner.state_mut(), tutored, P0);
+    put_on_library_top(runner.state_mut(), land, P0);
+
+    (runner, attacker, tutored)
+}
+
+/// (a) Accepting the free-cast prompt casts the card DURING resolution — it
+/// reaches `Zone::Stack` (the cast is genuinely under way) — and afterward the
+/// card carries NO standing `ExileWithAltCost` permission. Pre-fix: the card
+/// stayed in exile with an indefinite `ExileWithAltCost { duration: None }`.
+#[test]
+fn free_cast_offered_during_resolution_then_no_lingering_permission() {
+    let (mut runner, attacker, tutored) = setup();
+
+    // Sanity: the trigger's cast sub-ability must parse to a during-resolution
+    // `CastFromZone` (no alt cost, no duration). If this regresses to a
+    // lingering-permission driver, the runtime asserts below would no longer
+    // discriminate, so anchor the input shape here.
+    let trigger = &runner.state().objects[&attacker].trigger_definitions[0];
+    let execute = trigger.execute.as_ref().expect("trigger execute");
+    let cast = execute.sub_ability.as_ref().expect("cast sub-ability");
+    let Effect::CastFromZone {
+        without_paying_mana_cost,
+        alt_ability_cost,
+        driver,
+        ..
+    } = cast.effect.as_ref()
+    else {
+        panic!("expected CastFromZone sub-ability, got {:?}", cast.effect);
+    };
+    assert!(without_paying_mana_cost, "free cast must be without paying");
+    assert!(alt_ability_cost.is_none(), "no alt cost on this clause");
+    assert!(
+        driver.is_during_resolution(),
+        "bare free cast with no alt cost / duration must use the DuringResolution driver"
+    );
+
+    run_combat(&mut runner, vec![attacker], vec![]);
+    runner.advance_until_stack_empty();
+
+    // The exiled nonland is in P0's OWN exile (owner == controller, target !=
+    // source) — the exact Bring to Light input that the Suspend-specific
+    // `target == source` guard used to reject.
+    assert_eq!(
+        runner.state().objects[&tutored].zone,
+        Zone::Exile,
+        "tutored card must be exiled into the controller's own exile"
+    );
+    assert_eq!(
+        runner.state().objects[&tutored].owner,
+        P0,
+        "tutored card is owned by the controller (own exile)"
+    );
+
+    // CR 608.2g: the free cast is offered as the trigger resolves.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { player, .. } if player == P0
+        ),
+        "expected an optional 'you may cast' prompt for P0; got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept the free-cast prompt");
+
+    // CR 608.2g: accepting casts the card DURING resolution — it is the topmost
+    // object on the stack. (Target-less sorcery → straight to the stack, no
+    // intervening target prompt.) This assertion flips when the fix is reverted:
+    // pre-fix the card stayed in Exile and only a lingering permission was stamped.
+    assert_eq!(
+        runner.state().objects[&tutored].zone,
+        Zone::Stack,
+        "accepting the free cast must put the card on the stack; zone = {:?}, waiting_for = {:?}",
+        runner.state().objects[&tutored].zone,
+        runner.state().waiting_for,
+    );
+
+    // The card must carry NO standing ExileWithAltCost permission — the indefinite
+    // lingering grant (issue #2880) is gone. This is the second discriminating
+    // assertion: pre-fix an `ExileWithAltCost { duration: None }` persisted.
+    assert!(
+        !has_exile_alt_cost(runner.state(), tutored),
+        "the cast card must not retain a lingering ExileWithAltCost permission"
+    );
+}
+
+/// (b) Declining the free-cast prompt leaves the card in exile with NO standing
+/// `ExileWithAltCost` permission — there is no indefinite free-cast grant to
+/// exploit later.
+#[test]
+fn declining_free_cast_leaves_no_lingering_permission() {
+    let (mut runner, attacker, tutored) = setup();
+
+    run_combat(&mut runner, vec![attacker], vec![]);
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { player, .. } if player == P0
+        ),
+        "expected an optional 'you may cast' prompt for P0; got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .expect("decline the free-cast prompt");
+
+    assert_eq!(
+        runner.state().objects[&tutored].zone,
+        Zone::Exile,
+        "declining must leave the tutored card in exile"
+    );
+    assert!(
+        !has_exile_alt_cost(runner.state(), tutored),
+        "declining must not leave a lingering ExileWithAltCost permission"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -26,6 +26,7 @@ mod boon_reflection_gain_life_drain;
 mod bounce_destination_redirect;
 mod braids_arisen_nightmare_decline;
 mod brigid_mana_ability;
+mod bring_to_light_free_cast_2880;
 mod cascade_intervening_if_pipeline;
 mod case_solve_condition;
 mod cast_during_resolution_pipeline;


### PR DESCRIPTION
## Summary
Closes #2880.

Bring to Light's "You may cast that card without paying its mana cost" granted an **indefinite** `ExileWithAltCost` permission, so the free cast could be taken at any later priority for the rest of the game. Per CR 608.2g the cast happens *during the spell's resolution*; the permission must not linger.

This is a class fix for the **resolution-only free-cast** family (~28 Cast-mode cards), root-caused in two layers:
- **Parser** (`oracle_effect/mod.rs`, Branch-1 `ParentTarget` anaphor arm only): emit `CastFromZoneDriver::DuringResolution` for a bare free cast (`mode == Cast && without_paying && alt_ability_cost.is_none() && duration.is_none() && constraint.is_none()`), else `LingeringPermission`.
- **Engine** (`cast_from_zone.rs`): generalized the `self_free_cast` guard (renamed `driver_free_cast`) by dropping the Suspend-specific `target == source` clause, so a tutored card (target ≠ source, in the controller's own exile) routes through `cast_single_target_during_resolution` like Suspend/Memory Plunder.

### Deliberately excluded (stay on the lingering-permission path)
- **Play-mode** hideaway/wish lands (Mosswort Bridge, Windbrisk Heights, Shelldock Isle, Djinn of Wishes…) — `mode == Play`; land play is a special action (CR 305.1), not a during-resolution cast.
- **Alternative-cost** recasts (The Infamous Cruelclaw's discard) — `alt_ability_cost`.
- **Durational** recasts — explicit `duration`.
- **Constrained** free-casts with a not-cast fallback (**Beseech the Mirror**: "cast the exiled card … if that spell's mana value is 4 or less … put it into your hand if it wasn't cast this way") — `constraint`; the constraint is evaluated when the permission is exercised and the fallback depends on the standing permission.
- **Cascade/Etali/Jeleva** `from among them` / `ExiledBySource` arms — untouched.
- **`the copy`** (Isochron Scepter, Elite Arcanist) — folds to `CastCopyOfCard` before reaching the resolver; driver irrelevant.

## Tests
New `bring_to_light_free_cast_2880.rs` drives the real parser+resolver pipeline: accept → tutored card reaches the **stack** and leaves **no** standing permission; decline → stays in exile with **no** lingering permission. Both fail on revert.

## Verification
Local Tilt `clippy` + `test-engine` green (including the Beseech `constraint`-path regression guard `beseech_bargained_accept_grants_cast_without_hand_fallback`). Independent `/review-impl`: APPROVED.

CR: 608.2g, 608.2c, 118.9/118.9b, 305.1, 701.23 (all grep-verified).