### PR TITLE
fix(parser): scope 'creatures that died under your control' count to the controller (#1129)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2741,49 +2741,68 @@ fn parse_for_each_commander_cast_count(input: &str) -> OracleResult<'_, Quantity
 /// CR 700.4: Shared tail for "creature(s) that died" / graveyard-from-battlefield
 /// phrasing. Engine tracking is per-turn-only, so the trailing "this turn"
 /// qualifier is semantically redundant when present.
-fn parse_creatures_died_this_turn_tail(input: &str) -> OracleResult<'_, ()> {
+///
+/// Returns `Some(ControllerRef::You)` for forms qualified by "under your
+/// control" or "your graveyard" (CR 109.5: "your" graveyard = the source's
+/// controller), and `None` for unqualified forms that count every player's
+/// deaths. The longer qualified tags MUST precede the bare "that died" /
+/// "a graveyard" tags so the qualified suffix isn't shadowed by `alt`.
+fn parse_creatures_died_this_turn_tail(input: &str) -> OracleResult<'_, Option<ControllerRef>> {
     alt((
-        value((), tag("creatures that died under your control this turn")),
-        value((), tag("creatures that died under your control")),
-        value((), tag("creatures that died this turn")),
-        value((), tag("creatures that died")),
-        value((), tag("creature that died under your control this turn")),
-        value((), tag("creature that died under your control")),
-        value((), tag("creature that died this turn")),
-        value((), tag("creature that died")),
+        value(
+            Some(ControllerRef::You),
+            tag("creatures that died under your control this turn"),
+        ),
+        value(
+            Some(ControllerRef::You),
+            tag("creatures that died under your control"),
+        ),
+        value(None, tag("creatures that died this turn")),
+        value(None, tag("creatures that died")),
+        value(
+            Some(ControllerRef::You),
+            tag("creature that died under your control this turn"),
+        ),
+        value(
+            Some(ControllerRef::You),
+            tag("creature that died under your control"),
+        ),
+        value(None, tag("creature that died this turn")),
+        value(None, tag("creature that died")),
         // CR 700.4: "creature put into [a/your] graveyard from the battlefield"
         // is the long form of "died" — both reference the same battlefield→
-        // graveyard transition tracked in `zone_changes_this_turn`.
+        // graveyard transition tracked in `zone_changes_this_turn`. CR 109.5:
+        // "your" graveyard scopes the count to the source's controller.
         value(
-            (),
+            Some(ControllerRef::You),
             tag("creatures put into your graveyard from the battlefield this turn"),
         ),
         value(
-            (),
+            Some(ControllerRef::You),
             tag("creatures put into your graveyard from the battlefield"),
         ),
         value(
-            (),
+            None,
             tag("creatures put into a graveyard from the battlefield this turn"),
         ),
         value(
-            (),
+            None,
             tag("creatures put into a graveyard from the battlefield"),
         ),
         value(
-            (),
+            Some(ControllerRef::You),
             tag("creature put into your graveyard from the battlefield this turn"),
         ),
         value(
-            (),
+            Some(ControllerRef::You),
             tag("creature put into your graveyard from the battlefield"),
         ),
         value(
-            (),
+            None,
             tag("creature put into a graveyard from the battlefield this turn"),
         ),
         value(
-            (),
+            None,
             tag("creature put into a graveyard from the battlefield"),
         ),
     ))
@@ -2793,15 +2812,15 @@ fn parse_creatures_died_this_turn_tail(input: &str) -> OracleResult<'_, ()> {
 /// CR 700.4: Parse "creature(s) that died" → filtered zone-change count for
 /// "for each creature that died this turn" iteration sources.
 fn parse_for_each_creature_died_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, _) = parse_creatures_died_this_turn_tail(input)?;
-    Ok((rest, creatures_died_this_turn_ref()))
+    let (rest, controller) = parse_creatures_died_this_turn_tail(input)?;
+    Ok((rest, creatures_died_this_turn_ref(controller)))
 }
 
 /// CR 700.4: Parse "the number of creature(s) that died this turn" → the same
 /// `ZoneChangeCountThisTurn` quantity ref used by for-each iteration.
 fn parse_number_of_creatures_died_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, _) = parse_creatures_died_this_turn_tail(input)?;
-    Ok((rest, creatures_died_this_turn_ref()))
+    let (rest, controller) = parse_creatures_died_this_turn_tail(input)?;
+    Ok((rest, creatures_died_this_turn_ref(controller)))
 }
 
 /// CR 400.7 + CR 603.10a: Parse "creature that left the battlefield under your
@@ -2860,11 +2879,21 @@ fn parse_for_each_subtype_died_this_turn(input: &str) -> OracleResult<'_, Quanti
     ))
 }
 
-fn creatures_died_this_turn_ref() -> QuantityRef {
+/// CR 700.4: "died" = put into a graveyard from the battlefield, so the count
+/// is taken over `zone_changes_this_turn` records from battlefield to graveyard.
+/// CR 109.5: when the phrasing is qualified by "under your control" / "your
+/// graveyard", `controller` is `Some(ControllerRef::You)` and the count is
+/// scoped to creatures controlled by the source's controller when they died;
+/// otherwise it is `None` and every player's deaths are counted.
+fn creatures_died_this_turn_ref(controller: Option<ControllerRef>) -> QuantityRef {
+    let mut tf = TypedFilter::creature();
+    if let Some(c) = controller {
+        tf = tf.controller(c);
+    }
     QuantityRef::ZoneChangeCountThisTurn {
         from: Some(Zone::Battlefield),
         to: Some(Zone::Graveyard),
-        filter: TargetFilter::Typed(TypedFilter::creature()),
+        filter: TargetFilter::Typed(tf),
     }
 }
 
@@ -5235,6 +5264,73 @@ mod tests {
                     ),
                     "{phrase:?} got {q:?}"
                 );
+                // CR 700.4: unqualified "creatures that died this turn" counts
+                // every player's deaths — controller must stay unscoped.
+                let QuantityRef::ZoneChangeCountThisTurn {
+                    filter: TargetFilter::Typed(tf),
+                    ..
+                } = q
+                else {
+                    unreachable!()
+                };
+                assert_eq!(tf.controller, None, "{phrase:?} must not scope controller");
+            }
+        }
+    }
+
+    /// CR 109.5 + #1129: "creatures that died under your control" / "put into
+    /// your graveyard" forms must scope the zone-change count to the source's
+    /// controller (`ControllerRef::You`) for BOTH the for-each and "the number
+    /// of" surfaces, while unqualified forms leave the controller unset. Mirrors
+    /// `parse_for_each_creature_left_battlefield_under_your_control`.
+    #[test]
+    fn parse_creatures_died_under_your_control_scopes_controller() {
+        let qualified = [
+            "creatures that died under your control this turn",
+            "creature that died under your control",
+            "creatures put into your graveyard from the battlefield this turn",
+        ];
+        for phrase in qualified {
+            let (_, for_each) = parse_for_each_clause_ref(phrase)
+                .unwrap_or_else(|_| panic!("for-each {phrase:?} should parse"));
+            let (_, number_of) = parse_quantity_ref(&format!("the number of {phrase}"))
+                .unwrap_or_else(|_| panic!("number-of {phrase:?} should parse"));
+            for q in [for_each, number_of] {
+                let QuantityRef::ZoneChangeCountThisTurn {
+                    from: Some(Zone::Battlefield),
+                    to: Some(Zone::Graveyard),
+                    filter: TargetFilter::Typed(tf),
+                } = q
+                else {
+                    panic!("expected graveyard ZoneChangeCountThisTurn for {phrase:?}, got {q:?}");
+                };
+                assert!(tf.type_filters.contains(&TypeFilter::Creature));
+                assert_eq!(
+                    tf.controller,
+                    Some(ControllerRef::You),
+                    "{phrase:?} must scope to the controller"
+                );
+            }
+        }
+
+        let unqualified = [
+            "creatures that died this turn",
+            "creatures put into a graveyard from the battlefield",
+        ];
+        for phrase in unqualified {
+            let (_, for_each) = parse_for_each_clause_ref(phrase)
+                .unwrap_or_else(|_| panic!("for-each {phrase:?} should parse"));
+            let (_, number_of) = parse_quantity_ref(&format!("the number of {phrase}"))
+                .unwrap_or_else(|_| panic!("number-of {phrase:?} should parse"));
+            for q in [for_each, number_of] {
+                let QuantityRef::ZoneChangeCountThisTurn {
+                    filter: TargetFilter::Typed(tf),
+                    ..
+                } = q
+                else {
+                    panic!("expected ZoneChangeCountThisTurn for {phrase:?}, got {q:?}");
+                };
+                assert_eq!(tf.controller, None, "{phrase:?} must not scope controller");
             }
         }
     }

--- a/crates/engine/tests/priest_of_the_crossing_died_under_control.rs
+++ b/crates/engine/tests/priest_of_the_crossing_died_under_control.rs
@@ -1,0 +1,105 @@
+//! Discriminating regression test for **issue #1129**: a count phrased
+//! "creatures that died **under your control** this turn" must count only the
+//! source controller's deaths, not every player's.
+//!
+//! Priest of the Crossing's end-step trigger:
+//!
+//! > At the beginning of each end step, put X +1/+1 counters on each creature
+//! > you control, where X is the number of creatures that died under your
+//! > control this turn.
+//!
+//! Confirmed parse (`client/public/card-data.json` → "priest of the crossing"):
+//! the trigger's `execute` is `Effect::PutCounterAll { counter_type: P1P1,
+//! count: ZoneChangeCountThisTurn { from: Battlefield, to: Graveyard, filter:
+//! Typed(Creature) }, target: Typed(Creature, controller: You) }`. Before the
+//! fix the `count` filter's `controller` was `null`, so X counted EVERY
+//! player's deaths. After the fix the parser stamps `controller: You` on the
+//! count filter, and the runtime (`game::filter::zone_change_filter_inner`)
+//! scopes the count to the source controller's deaths.
+//!
+//! Setup: P0 controls Priest plus a surviving creature; P0 and P1 each control
+//! a creature that dies this turn. Resolving the trigger under P0 must place
+//! exactly ONE +1/+1 counter on P0's surviving creature (only P0's death),
+//! NOT two. With the fix reverted the count would be 2 and the assertion fails.
+//!
+//! CR 700.4: "dies" = put into a graveyard from the battlefield.
+//! CR 109.5: "your"/"under your control" = the source's controller.
+//! CR 122.1: +1/+1 counters placed by the resolving ability.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::move_to_zone;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::AbilityKind;
+use engine::types::counter::CounterType;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const PRIEST_ORACLE: &str = "Flying\n\
+At the beginning of each end step, put X +1/+1 counters on each creature you control, where X is the number of creatures that died under your control this turn.";
+
+#[test]
+fn priest_counts_only_creatures_that_died_under_your_control() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Priest of the Crossing under P0's control, parsed from real Oracle text.
+    let priest = scenario
+        .add_creature_from_oracle(P0, "Priest of the Crossing", 3, 3, PRIEST_ORACLE)
+        .id();
+
+    // A surviving P0 creature that will RECEIVE the +1/+1 counters.
+    let survivor = scenario.add_creature(P0, "P0 Survivor", 2, 2).id();
+
+    // One creature dies under P0's control (counts) and one under P1's control
+    // (the negative control — must NOT count toward "under your control").
+    let my_dead = scenario.add_creature(P0, "P0 Casualty", 1, 1).id();
+    let their_dead = scenario.add_creature(P1, "P1 Casualty", 1, 1).id();
+
+    let mut runner = scenario.build();
+
+    // Drive both deaths through the production zone-change recorder so
+    // `zone_changes_this_turn` is populated exactly as in a real game.
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), my_dead, Zone::Graveyard, &mut events);
+    move_to_zone(runner.state_mut(), their_dead, Zone::Graveyard, &mut events);
+    assert_eq!(
+        runner.state().zone_changes_this_turn.len(),
+        2,
+        "sanity: both deaths must be recorded"
+    );
+
+    // Build the end-step trigger's execute ability (the count-and-place effect,
+    // parsed standalone) and resolve it under P0 — same parser path the real
+    // card uses, so the count's `controller` scope is exercised end-to-end.
+    let execute_def = parse_effect_chain(
+        "Put X +1/+1 counters on each creature you control, where X is the number \
+         of creatures that died under your control this turn.",
+        AbilityKind::Spell,
+    );
+
+    let ability = build_resolved_from_def(&execute_def, priest, P0);
+
+    events.clear();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Priest end-step trigger must resolve");
+
+    let counters = runner
+        .state()
+        .objects
+        .get(&survivor)
+        .expect("survivor still on battlefield")
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0);
+
+    // DISCRIMINATOR (#1129): only P0's death is "under your control", so X = 1.
+    // With the controller scope dropped (the bug), X would be 2.
+    assert_eq!(
+        counters, 1,
+        "X must count only creatures that died under P0's control (1), not all \
+         players' deaths (2); got {counters}"
+    );
+}


### PR DESCRIPTION
## Summary
Closes #1129.

Priest of the Crossing's "for each creature that died under your control this turn" counted **every** player's creature deaths. `creatures_died_this_turn_ref()` (`oracle_nom/quantity.rs`) always emitted `ZoneChangeCountThisTurn{ filter: TypedFilter::creature() }` with **no controller restriction**, because `parse_creatures_died_this_turn_tail` collapsed both the controller-qualified ("under your control", "your graveyard") and unqualified ("creatures that died this turn", "a graveyard") phrasings into the same unit value.

Class fix (mirrors the already-correct `parse_for_each_creature_left_battlefield_this_turn`): thread `Option<ControllerRef>` through the tail so qualified forms emit `.controller(ControllerRef::You)` and unqualified forms keep no restriction (counts all). The runtime resolver already honors the controller filter (`zone_change_filter_inner`, CR 109.5) — only the parser was dropping it. ~16 "died under your control" + ~8 "your graveyard" cards corrected; unqualified all-players cards unchanged.

## Tests
- Runtime `priest_of_the_crossing_died_under_control.rs`: P0's + P1's creatures both die; Priest counts **only P0's** (1, not 2). Fails on revert.
- Parser test: qualified forms → `controller == Some(You)`, unqualified → `None` (both `for each` and `the number of` surfaces).

CR 700.4, 109.5 (grep-verified). Verified locally via the parser combinator gate; full verification deferred to CI (local main checkout was transiently stale).