### PR TITLE
fix(parser): Dig 'reveal ... on top of your library, rest on bottom' kept-to-top destination (#2349)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -888,6 +888,38 @@ fn split_comma_clause_boundary(current: &str, remainder: &str) -> Option<(Clause
     {
         let after_then = &trimmed["then ".len()..];
         let after_then_lower = &trimmed_lower["then ".len()..];
+        // CR 701.20e + CR 608.2c: "reveal up to N <filter> from among them, then
+        // put that card <kept-destination> ..." is a single from-among selection
+        // action — the ", then put that card …" placement tail is the KEPT-card
+        // destination of the same `DigFromAmong` continuation, not a standalone
+        // clause. `parse_dig_from_among` → `parse_dig_destination_tail` consumes
+        // this tail to patch the preceding `Dig`'s destination, so it must stay
+        // one chunk. Without this, the body is bisected and the look-`Dig` is
+        // never promoted to a selecting dig (Fertile Thicket: no DigChoice).
+        //
+        // Scoped to a KEPT-card anaphor ("that card", "those cards", "it",
+        // "them", "the card") — the exact set `parse_dig_destination_tail`
+        // strips. A "then put THE REST <destination>" tail (Zimone's Experiment:
+        // "reveal up to two ... from among them, then put the rest on the
+        // bottom") is the REST placement, which must still split off into its own
+        // `PutRest` continuation to set `rest_destination`; suppressing that
+        // split would drop the "rest on the bottom" routing. Unrelated trailers
+        // ("…, then shuffle") also still split.
+        let put_kept_card_tail = preceded(
+            tag::<_, _, OracleError<'_>>("put "),
+            alt((
+                tag("that card "),
+                tag("those cards "),
+                tag("the card "),
+                tag("it "),
+                tag("them "),
+            )),
+        )
+        .parse(after_then_lower)
+        .is_ok();
+        if nom_primitives::scan_contains(&current_lower, "from among") && put_kept_card_tail {
+            return None;
+        }
         if starts_clause_text_or_conjugated(after_then)
             || starts_you_control_subject_predicate(after_then_lower)
             || starts_with_damage_clause(after_then_lower)
@@ -2145,6 +2177,7 @@ pub(super) fn apply_clause_continuation(
             enters_under,
             face_down_profile,
             enter_tapped,
+            reveal_verb,
         } => {
             // CR 608.2c: the "from among those cards" continuation patches the
             // earlier "look at the top N" instruction. When a transparent
@@ -2215,8 +2248,14 @@ pub(super) fn apply_clause_continuation(
                 // cards are NOT auto-routed by the Dig resolver; downstream sub_abilities
                 // read the tracked set and route by type. Also promote the
                 // Dig to reveal:true — "from among them" is a reveal-form.
+                //
+                // CR 701.20a vs 701.20e: a "reveal ... from among them" clause is
+                // public, so promote to reveal:true even when the kept card routes
+                // to a fixed library position (Fertile Thicket: reveal_verb=true,
+                // kept_dest=Some(Library)). Look-only digs (reveal_verb=false,
+                // kept_dest=Some(...)) keep reveal=false (private look, CR 701.20e).
                 *destination = kept_dest;
-                if kept_dest.is_none() {
+                if kept_dest.is_none() || reveal_verb {
                     *reveal = true;
                 }
                 if let Some(rd) = rest_dest {
@@ -2955,6 +2994,8 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
             enters_under: None,
             face_down_profile: None,
             enter_tapped,
+            // "put N of them" strips only "put" — never a reveal verb (private).
+            reveal_verb: false,
         });
     }
 
@@ -2969,24 +3010,26 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
     .parse(lower)
     {
         let before_milled = before_milled.trim();
-        let (after_put, prefix_optional) = if let Ok((rest, _)) = alt((
-            tag::<_, _, OracleError<'_>>("you may put "),
-            tag("you may reveal "),
-            tag("you may return "),
+        // CR 701.20a vs 701.20e: capture whether the stripped verb is "reveal"
+        // (public) so the patch arm promotes the Dig to `reveal: true`.
+        let (after_put, prefix_optional, reveal_verb) = if let Ok((rest, is_reveal)) = alt((
+            value(false, tag::<_, _, OracleError<'_>>("you may put ")),
+            value(true, tag("you may reveal ")),
+            value(false, tag("you may return ")),
         ))
         .parse(before_milled)
         {
-            (rest, true)
-        } else if let Ok((rest, _)) = alt((
-            tag::<_, _, OracleError<'_>>("put "),
-            tag("reveal "),
-            tag("return "),
+            (rest, true, is_reveal)
+        } else if let Ok((rest, is_reveal)) = alt((
+            value(false, tag::<_, _, OracleError<'_>>("put ")),
+            value(true, tag("reveal ")),
+            value(false, tag("return ")),
         ))
         .parse(before_milled)
         {
-            (rest, false)
+            (rest, false, is_reveal)
         } else {
-            (before_milled, false)
+            (before_milled, false, false)
         };
 
         // CR 701.17c: A mass quantifier ("put all/each creature cards milled this
@@ -3076,6 +3119,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
             enters_under,
             face_down_profile,
             enter_tapped,
+            reveal_verb,
         });
     }
 
@@ -3086,17 +3130,20 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
     let before_from = &before_from.trim();
 
     // Strip leading "put " or "you may reveal " using nom combinators.
-    let after_put = alt((
-        tag::<_, _, OracleError<'_>>("you may put "),
-        tag("you may reveal "),
-        tag("you may return "),
-        tag("put "),
-        tag("reveal "),
-        tag("return "),
+    // CR 701.20a vs 701.20e: capture whether the stripped verb was "reveal"
+    // (a public action) vs "put"/"return" (a private look) so the patch arm can
+    // promote the Dig to `reveal: true` even when the kept card routes to a
+    // fixed destination (Fertile Thicket).
+    let (after_put, reveal_verb) = alt((
+        value(true, tag::<_, _, OracleError<'_>>("you may reveal ")),
+        value(false, tag("you may put ")),
+        value(false, tag("you may return ")),
+        value(false, tag("put ")),
+        value(true, tag("reveal ")),
+        value(false, tag("return ")),
     ))
     .parse(*before_from)
-    .map(|(rest, _)| rest)
-    .unwrap_or(before_from);
+    .unwrap_or((before_from, false));
 
     // CR 701.20e: Mass quantifier ("put all/each <filter> from among them onto
     // the battlefield ...") moves the entire matching set → `PutCount::All`.
@@ -3175,6 +3222,7 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
         enters_under,
         face_down_profile,
         enter_tapped,
+        reveal_verb,
     })
 }
 
@@ -3211,6 +3259,10 @@ fn parse_dig_from_among_destination(lower: &str) -> Option<(Option<Zone>, bool)>
 }
 
 fn parse_dig_destination_tail(input: &str) -> Option<(Option<Zone>, bool)> {
+    // Strip a leading clause separator: "from among them, then put that card on
+    // top ..." (Fertile Thicket) leaves a ", " before the "then put" verb.
+    let input = input.trim_start();
+    let (input, _) = opt(tag::<_, _, OracleError<'_>>(",")).parse(input).ok()?;
     let input = input.trim_start();
     let (input, _) = opt(alt((tag::<_, _, OracleError<'_>>("and "), tag("then "))))
         .parse(input)
@@ -3252,6 +3304,22 @@ fn parse_dig_destination_tail(input: &str) -> Option<(Option<Zone>, bool)> {
     .is_ok()
     {
         return Some((Some(Zone::Hand), false));
+    }
+
+    // CR 401.4: cards put at a specific library position (top) are arranged by
+    // owner; the DigChoice resolver inserts the kept card at index 0 and the
+    // rest at the bottom. Mirrors `parse_put_one_dig_card_on_top` (the
+    // unfiltered "back on top" phrasing) for the "reveal ... then put that card
+    // on top of your library" form (Fertile Thicket).
+    if alt((
+        tag::<_, _, OracleError<'_>>("on top of your library"),
+        tag("on top of their library"),
+        tag("on top"),
+    ))
+    .parse(input)
+    .is_ok()
+    {
+        return Some((Some(Zone::Library), false));
     }
 
     None
@@ -3854,6 +3922,8 @@ pub(super) fn parse_followup_continuation_ast(
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                // "put one of those cards onto the battlefield" — a put, not a reveal.
+                reveal_verb: false,
             })
         }
         // "You may put one of those cards back on top of your library" after
@@ -3868,6 +3938,8 @@ pub(super) fn parse_followup_continuation_ast(
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                // "put one ... back on top" — a put, not a reveal.
+                reveal_verb: false,
             })
         }
         // "put them back in any order" after Dig means all looked-at cards
@@ -5541,6 +5613,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             })
         );
     }
@@ -5564,6 +5637,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             })
         );
     }
@@ -5592,6 +5666,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             })
         );
     }
@@ -5614,6 +5689,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             })
         );
     }
@@ -5636,8 +5712,48 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             })
         );
+    }
+
+    /// Issue #2349 — Fertile Thicket. "reveal up to one basic land card from
+    /// among them, then put that card on top of your library and the rest on the
+    /// bottom in any order." The kept card routes to a fixed library position
+    /// (top), but the clause's verb is "reveal" (CR 701.20a, public), so
+    /// `reveal_verb` must be true. Previously `parse_dig_destination_tail` did
+    /// not recognize "on top of your library", so the kept destination resolved
+    /// to None and the clause became Unimplemented.
+    #[test]
+    fn fertile_thicket_reveal_basic_land_to_top_rest_on_bottom() {
+        let dig = make_dig_effect();
+        let result = parse_followup_continuation_ast(
+            "Reveal up to one basic land card from among them, then put that card on top of your library and the rest on the bottom in any order.",
+            &dig,
+            &mut ParseContext::default(),
+        );
+        let Some(ContinuationAst::DigFromAmong {
+            quantity,
+            filter,
+            destination,
+            rest_destination,
+            reveal_verb,
+            ..
+        }) = result
+        else {
+            panic!("expected DigFromAmong continuation, got {result:?}");
+        };
+        assert_eq!(quantity, PutCount::Up(1));
+        // CR 401.4: kept card goes on TOP of the library; the rest go to the bottom.
+        assert_eq!(destination, Some(Zone::Library));
+        assert_eq!(rest_destination, Some(Zone::Library));
+        // CR 701.20a vs 701.20e: "reveal ... from among them" is a public reveal,
+        // so the Dig must be promoted to reveal:true even though the kept card
+        // routes to a fixed library position.
+        assert!(reveal_verb, "the 'reveal' verb must set reveal_verb");
+        // The from-among filter restricts the kept card to a basic land card.
+        let (expected_filter, _) = parse_target("basic land card");
+        assert_eq!(filter, expected_filter);
     }
 
     #[test]
@@ -5825,6 +5941,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             },
             AbilityKind::Spell,
         );
@@ -5861,6 +5978,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             },
             AbilityKind::Spell,
         );
@@ -5901,6 +6019,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             },
             AbilityKind::Spell,
         );
@@ -5959,6 +6078,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             },
             AbilityKind::Spell,
         );
@@ -6541,6 +6661,7 @@ mod tests {
                 enters_under: None,
                 face_down_profile: None,
                 enter_tapped: false,
+                reveal_verb: false,
             })
         );
     }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -306,6 +306,12 @@ pub(crate) enum ContinuationAst {
         /// from-among put-step.
         #[serde(default)]
         enter_tapped: bool,
+        /// CR 701.20a vs 701.20e: True when the from-among clause's stripped verb
+        /// was "reveal" (a public action) rather than "put"/"choose" (a private
+        /// look). Promotes the patched Dig to `reveal: true` even when the kept
+        /// cards route to a fixed library position (Fertile Thicket).
+        #[serde(default)]
+        reveal_verb: bool,
     },
     /// CR 708.2a + CR 205.1a: "They're N/M [types] [subtypes] creatures." after a
     /// put-face-down clause — refines the preceding face-down move's profile.

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1756,6 +1756,55 @@ fn plotted_grant_linkage_is_only_if_marker(stripped: &str) -> bool {
     !(has_if_marker && !has_as_if_marker && !has_even_if_marker)
 }
 
+fn def_tree_has_dig(def: &AbilityDefinition) -> bool {
+    if matches!(&*def.effect, Effect::Dig { .. }) {
+        return true;
+    }
+    if let Some(ref sub) = def.sub_ability {
+        if def_tree_has_dig(sub) {
+            return true;
+        }
+    }
+    if let Some(ref else_ab) = def.else_ability {
+        if def_tree_has_dig(else_ab) {
+            return true;
+        }
+    }
+    def.mode_abilities.iter().any(def_tree_has_dig)
+}
+
+/// CR 608.2c + CR 701.20: "you may look at the top N cards ... If you do,
+/// reveal/put ... from among them ..." (Fertile Thicket, Munda, Planar Atlas).
+/// The optional "look" lowers to an optional `Dig`; the dependent "reveal ...
+/// from among them" is a continuation that patches that same `Dig`. The
+/// "if you do" is not an independent game-state condition — per CR 608.2c
+/// (read the whole text and apply the rules of English) it links the dependent
+/// reveal to the optional look having happened, and the optional `Dig` (the
+/// player may decline the look, and then nothing in the chain resolves) IS that
+/// gate. So when the parse contains a `Dig` inside an optional ability/trigger,
+/// the "if you do" marker is represented, not swallowed.
+fn any_optional_ability_has_dig(parsed: &ParsedAbilities) -> bool {
+    parsed
+        .abilities
+        .iter()
+        .any(|def| def_tree_has_optional(def) && def_tree_has_dig(def))
+        || parsed.triggers.iter().any(|t| {
+            trigger_tree_has_optional(t) && t.execute.as_deref().is_some_and(def_tree_has_dig)
+        })
+}
+
+fn dig_if_you_do_is_only_if_marker(stripped: &str) -> bool {
+    // allow-noncombinator: swallow detector marker scan on classified text
+    if !stripped.contains("if you do") {
+        return false;
+    }
+    let without_link = stripped.replace("if you do", "");
+    let has_if_marker = without_link.contains(" if "); // allow-noncombinator: swallow detector marker scan on classified text
+    let has_as_if_marker = without_link.contains(" as if "); // allow-noncombinator: swallow detector marker scan on classified text
+    let has_even_if_marker = without_link.contains(" even if "); // allow-noncombinator: swallow detector marker scan on classified text
+    !(has_if_marker && !has_as_if_marker && !has_even_if_marker)
+}
+
 // ── Detector G: Condition_If ────────────────────────────────────────────
 
 /// CR 608.2c: "if [condition], [effect]" — conditional gate. Must be
@@ -1820,6 +1869,15 @@ fn detect_condition_if(
     // the "if you do" is the optional-exile linkage, represented by the
     // chained `Plotted` casting-permission grant (see `any_ability_has_plotted_grant`).
     if any_ability_has_plotted_grant(parsed) && plotted_grant_linkage_is_only_if_marker(&stripped) {
+        return;
+    }
+    // CR 608.2c + CR 701.20: "you may look at the top N cards ... If you do,
+    // reveal ... from among them ..." (Fertile Thicket, Munda Ambush Leader,
+    // Planar Atlas). The optional look lowers to an optional `Dig` and the
+    // dependent "reveal ... from among them" is a continuation patching that
+    // same `Dig`; the "if you do" linkage IS represented by the optional `Dig`
+    // (declining the look stops the whole chain), not swallowed.
+    if any_optional_ability_has_dig(parsed) && dig_if_you_do_is_only_if_marker(&stripped) {
         return;
     }
     // CR 615.5: "If damage is prevented this way, [effect]" is not an
@@ -3482,6 +3540,55 @@ mod tests {
         ));
         assert!(!super::plotted_grant_linkage_is_only_if_marker(
             "you may exile a card. if you do, it becomes plotted. if another condition is true, draw a card."
+        ));
+    }
+
+    /// CR 608.2c + CR 701.20: "you may look at the top N cards ... If you do,
+    /// reveal ... from among them ..." — the optional look lowers to an optional
+    /// `Dig` and the dependent reveal patches it, so the "if you do" linkage is
+    /// represented (not a swallowed condition). Fertile Thicket, Munda, and
+    /// Planar Atlas are the motivating cards (#2349).
+    #[test]
+    fn condition_if_accepts_you_may_look_if_you_do_reveal_from_among() {
+        let fertile = parse_named(
+            "When this land enters, you may look at the top five cards of your library. \
+             If you do, reveal up to one basic land card from among them, then put that \
+             card on top of your library and the rest on the bottom in any order.",
+            "Fertile Thicket",
+            &["Land"],
+        );
+        assert!(!has_swallowed_detector(&fertile, "Condition_If"));
+
+        let munda = parse_named(
+            "Whenever this creature or another Ally you control enters, you may look at \
+             the top four cards of your library. If you do, reveal any number of Ally \
+             cards from among them, then put those cards on top of your library in any \
+             order and the rest on the bottom in any order.",
+            "Munda, Ambush Leader",
+            &["Creature"],
+        );
+        assert!(!has_swallowed_detector(&munda, "Condition_If"));
+
+        let atlas = parse_named(
+            "When this artifact enters, you may look at the top four cards of your \
+             library. If you do, reveal up to one land card from among them, then put \
+             that card on top of your library and the rest on the bottom in a random order.",
+            "Planar Atlas",
+            &["Artifact"],
+        );
+        assert!(!has_swallowed_detector(&atlas, "Condition_If"));
+    }
+
+    /// CR 608.2c: the optional-look "if you do" exemption is scoped to the
+    /// linkage phrase; a separate game-state conditional on the same card must
+    /// still reach the detector.
+    #[test]
+    fn dig_if_you_do_exemption_is_text_scoped() {
+        assert!(super::dig_if_you_do_is_only_if_marker(
+            "you may look at the top five cards. if you do, reveal a land card from among them."
+        ));
+        assert!(!super::dig_if_you_do_is_only_if_marker(
+            "you may look at the top five cards. if you do, reveal a land. if you control a forest, draw a card."
         ));
     }
 

--- a/crates/engine/tests/fertile_thicket_reveal_to_top_2349.rs
+++ b/crates/engine/tests/fertile_thicket_reveal_to_top_2349.rs
@@ -1,0 +1,155 @@
+//! Runtime regression for #2349 — Fertile Thicket reveal-to-top.
+//!
+//! Fertile Thicket: "When this land enters, you may look at the top five cards
+//! of your library. If you do, reveal up to one basic land card from among them,
+//! then put that card on top of your library and the rest on the bottom in any
+//! order."
+//!
+//! On `main` the parser's `parse_dig_destination_tail` recognized only "onto the
+//! battlefield" / "into your hand" — NOT "on top of your library". So the kept
+//! destination resolved to `None`, the reveal-from-among clause became
+//! Unimplemented, and the chosen basic land was NOT kept on top of the library.
+//!
+//! After the fix the parser recognizes the library-top kept destination
+//! (CR 401.4) and promotes the Dig to `reveal: true` because the clause's verb
+//! is "reveal" (CR 701.20a, public). The DigChoice resolver — unchanged — then
+//! inserts the kept card at index 0 (top) and the rest at the bottom.
+//!
+//! Driven through a sorcery host (the plan's permitted fallback): the same
+//! parsed Dig config runs through the real cast pipeline, so reverting either
+//! parser step breaks the assertions below.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::card_type::{CoreType, Supertype};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Fertile Thicket's ETB clause, driven through a sorcery host so the cast
+/// pipeline exercises the same parsed Dig configuration.
+const FERTILE_THICKET_CLAUSE: &str =
+    "You may look at the top five cards of your library. If you do, reveal up to \
+     one basic land card from among them, then put that card on top of your \
+     library and the rest on the bottom in any order.";
+
+#[test]
+fn fertile_thicket_keeps_revealed_basic_land_on_top_and_rest_on_bottom() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Stage P0's top five cards. Exactly one basic land (a Forest) plus four
+    // non-basic-land cards. `add_card_to_library_top` inserts at index 0, so add
+    // bottom-of-the-five first and top-of-the-five last. We want the basic land
+    // somewhere in the middle so a destination-blind move can't accidentally
+    // leave it on top.
+    let other4 = scenario.add_card_to_library_top(P0, "Other 4");
+    let other3 = scenario.add_card_to_library_top(P0, "Other 3");
+    let basic_land = scenario.add_card_to_library_top(P0, "Forest");
+    let other2 = scenario.add_card_to_library_top(P0, "Other 2");
+    let other1 = scenario.add_card_to_library_top(P0, "Other 1");
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Fertile Thicket Probe", false, FERTILE_THICKET_CLAUSE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Type the staged cards: the basic land is a basic Forest; the others are
+    // non-land cards so they cannot match the "basic land card" filter.
+    {
+        let forest = runner.state_mut().objects.get_mut(&basic_land).unwrap();
+        forest.card_types.core_types.push(CoreType::Land);
+        forest.card_types.supertypes.push(Supertype::Basic);
+        forest.base_card_types = forest.card_types.clone();
+    }
+    for &id in &[other1, other2, other3, other4] {
+        let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Sorcery);
+        obj.base_card_types = obj.card_types.clone();
+    }
+
+    // Cast and accept the optional "you may look". The resolution driver halts at
+    // the DigChoice prompt (it does not auto-answer dig selections).
+    let outcome = runner.cast(spell).accept_optional().resolve();
+
+    let WaitingFor::DigChoice {
+        cards,
+        selectable_cards,
+        ..
+    } = outcome.final_waiting_for()
+    else {
+        panic!(
+            "expected DigChoice for the reveal-from-among clause, got {:?}",
+            outcome.final_waiting_for()
+        );
+    };
+
+    // The looked-at set is the top five; only the basic land is selectable.
+    assert!(
+        cards.contains(&basic_land),
+        "the basic land must be among the looked-at cards; got {cards:?}"
+    );
+    assert!(
+        selectable_cards.contains(&basic_land),
+        "only the basic land may be kept; selectable = {selectable_cards:?}"
+    );
+
+    // Submit the keep-selection: the revealed Forest.
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![basic_land],
+        })
+        .expect("selecting the revealed basic land should succeed");
+    runner.advance_until_stack_empty();
+
+    let state = runner.state();
+    let library: Vec<ObjectId> = state.players[0].library.iter().copied().collect();
+
+    // CR 401.4 (primary assertion — fails if Step 1 reverted): the chosen basic
+    // land is kept on TOP of the library, not on the bottom.
+    assert_eq!(
+        library.first().copied(),
+        Some(basic_land),
+        "the chosen basic land must be on TOP of the library; library = {library:?}"
+    );
+    assert_eq!(
+        state.objects[&basic_land].zone,
+        Zone::Library,
+        "the chosen basic land stays in the library"
+    );
+    assert_ne!(
+        library.last().copied(),
+        Some(basic_land),
+        "the chosen basic land must NOT be on the bottom of the library"
+    );
+
+    // The other four cards are pushed to the bottom (in any order).
+    let bottom_four: Vec<ObjectId> = library.iter().skip(1).copied().collect();
+    for &id in &[other1, other2, other3, other4] {
+        assert!(
+            bottom_four.contains(&id),
+            "non-basic-land card {id:?} must be on the bottom; bottom = {bottom_four:?}"
+        );
+    }
+
+    // The kept land was not stolen into hand or onto the battlefield.
+    assert!(
+        !state.players[0].hand.contains(&basic_land),
+        "the kept basic land must not be moved to hand"
+    );
+
+    // CR 701.20a (second assertion — fails if Step 2 reverted): the looked-at
+    // cards were publicly revealed because the clause's verb is "reveal". If the
+    // Dig were left at reveal:false (a private look), `revealed_cards` would be
+    // empty for these cards.
+    assert!(
+        state.revealed_cards.contains(&basic_land),
+        "the revealed basic land must be publicly revealed (reveal:true); \
+         revealed_cards = {:?}",
+        state.revealed_cards
+    );
+}


### PR DESCRIPTION
## Summary
Closes #2349.

Fertile Thicket ("reveal up to one basic land card from among them, then put that card on top of your library and the rest on the bottom") did not keep the revealed land on top — the parser's `parse_dig_destination_tail` (`oracle_effect/sequence.rs`) recognized only "onto the battlefield"/"into your hand" as kept destinations, **not "on top of your library"**, so the kept destination resolved to `None` and the reveal became unimplemented. The DigChoice resolver already routes kept→top / rest→bottom correctly when `destination == Some(Library)` — only the parser couldn't reach it.

Class fix (parser-only):
- Add an "on top of your library" arm to `parse_dig_destination_tail` → `Some((Some(Zone::Library), false))` (+ leading-comma strip so ", then put that card on top..." is reached).
- Promote `reveal: true` for reveal-from-among clauses via a new parser-internal `reveal_verb` field on `ContinuationAst::DigFromAmong` (look-only digs keep `reveal_verb: false` — no regression).

Covers the reveal-to-top peek class; resolver/types unchanged.

## Tests
- Runtime `fertile_thicket_reveal_to_top_2349.rs`: revealed basic land ends on **library top** (index 0) and is publicly **revealed**; the other 4 go to the bottom. Both asserts fail on revert.
- Parser unit test: the clause → `DigFromAmong{ Up(1), destination: Some(Library), rest_destination: Some(Library), reveal_verb: true }`.

CR 401.4, 701.20a, 701.20e (grep-verified). Verified locally via the parser combinator gate; full verification deferred to CI.