### PR TITLE
fix(engine): scope 'If you do' tracked-set reset to producer riders so consumer anaphors stay chain-local (#2350)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5389,21 +5389,38 @@ fn resolve_chain_body(
 
             // CR 608.2c + CR 603.7: An `If you do` boundary (`EffectOutcome
             // { OptionalEffectPerformed }`) opens a new instruction clause —
-            // "you may [do X]. If you do, [rider]." Nothing the gating action X
-            // affected can be named by a "those cards" / "one of them" reference
-            // inside the rider, so the rider's tracked set must NOT unify with
-            // the gating action's. Reset the chain-scoped tracked-set identity
-            // here so the rider's own producer (e.g. ExileTop) starts a fresh
-            // set. Without this, Party Thrasher's "you may discard a card. If
-            // you do, exile the top two cards…, then choose one of them" would
-            // co-publish the discarded card (now in the graveyard) with the two
-            // exiled cards, offering three cards to choose from (issue #1977).
+            // "you may [do X]. If you do, [rider]." The rider falls into one of
+            // two classes by what it does with the tracked-set channel:
+            //
+            //   * PRODUCER rider (e.g. Party Thrasher's `ExileTop`): the rider
+            //     creates its OWN fresh set and nothing the gating action X
+            //     affected may be named by a "those cards" / "one of them"
+            //     reference inside it. The chain-scoped tracked-set identity
+            //     MUST be reset here so the rider's producer starts clean.
+            //     Without this, Party Thrasher's "you may discard a card. If
+            //     you do, exile the top two cards…, then choose one of them"
+            //     co-publishes the discarded card (now in the graveyard) with
+            //     the two exiled cards, offering three to choose from (#1977).
+            //
+            //   * CONSUMER rider (e.g. God-Pharaoh's Gift's `CopyTokenOf {
+            //     target: TrackedSet }`): the rider's "that card" anaphor
+            //     CR 707.2a names the very card the gating exile published into
+            //     `chain_tracked_set_id` THIS resolution. Resetting here would
+            //     orphan it to the turn-global `latest_tracked_set_id` fallback,
+            //     so a second same-turn resolution (whose first exile's set also
+            //     persists) binds to the wrong card (#2350). Skip the reset for
+            //     consumer riders so the anaphor stays chain-local.
+            //
+            // `effect_references_tracked_set` discriminates the two: it is true
+            // exactly for consumer riders (any `TrackedSet` quantity/filter
+            // position, incl. `CopyTokenOf { target }`), false for producers.
             if matches!(
                 condition,
                 AbilityCondition::EffectOutcome {
                     signal: EffectOutcomeSignal::OptionalEffectPerformed,
                 }
-            ) {
+            ) && !effect_references_tracked_set(&sub.effect)
+            {
                 state.chain_tracked_set_id = None;
             }
 

--- a/crates/engine/tests/god_pharaohs_gift_second_instance_2350.rs
+++ b/crates/engine/tests/god_pharaohs_gift_second_instance_2350.rs
@@ -1,0 +1,197 @@
+//! God-Pharaoh's Gift (#2350) — a second same-turn resolution must copy the
+//! creature THIS resolution exiled, not the one a prior same-turn resolution
+//! exiled.
+//!
+//! Oracle (the relevant triggered ability): "you may exile a creature card from
+//! your graveyard. If you do, create a token that's a copy of that card, except
+//! it's a 4/4 black Zombie ... with haste."
+//!
+//! The "If you do, create a token that's a copy of that card" rider is a
+//! tracked-set CONSUMER: `CopyTokenOf { target: TrackedSet }` whose "that card"
+//! anaphor (CR 707.2a — a copy acquires the copiable values of the object it's
+//! copying) names the very card the gating exile published into the chain's
+//! tracked set during THIS resolution.
+//!
+//! CR 608.2c / CR 603.7: the rider resolves in the same instruction chain as
+//! the gating exile, so "that card" must bind to the chain-local
+//! `chain_tracked_set_id`, not the turn-global fallback.
+//!
+//! Pre-fix bug: the "If you do" boundary unconditionally reset
+//! `chain_tracked_set_id = None` (added for Party Thrasher's PRODUCER rider,
+//! #1977). That orphaned GPG's consumer rider to the turn-global
+//! `latest_tracked_set_id` fallback. When GPG resolved twice in one turn, both
+//! exiled cards' tracked sets persisted, so the second resolution's copy bound
+//! to the FIRST resolution's exiled card — copying the wrong creature.
+//!
+//! The fix gates the reset behind `!effect_references_tracked_set(&sub.effect)`:
+//! consumer riders (GPG) keep the chain-local set; producer riders (Party
+//! Thrasher's `ExileTop`) still get the reset. This test fails on revert: the
+//! second token would copy "Grizzly Bears" instead of "Walking Corpse".
+
+use engine::game::ability_utils::build_resolved_from_def_with_targets;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::AbilityKind;
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+use std::collections::HashSet;
+
+/// The effect body of God-Pharaoh's Gift's end-step triggered ability. The
+/// "At the beginning of your end step," trigger prefix is the trigger
+/// condition; `parse_effect_chain` parses the EFFECT chain it gates, so we pass
+/// only that body (mirrors how the trigger parser threads the effect through
+/// `resolve_ability_chain`).
+const ORACLE: &str = "You may exile a creature card from your graveyard. If you do, create a token that's a copy of that card, except it's a 4/4 black Zombie with haste.";
+
+/// Returns the set of copy-token object ids currently on the battlefield. A
+/// copy token is a battlefield object that is NOT one of the originally placed
+/// non-token objects we track ourselves.
+fn battlefield_object_ids(state: &engine::types::game_state::GameState) -> HashSet<ObjectId> {
+    state.battlefield.iter().copied().collect()
+}
+
+/// GPG's top instruction is the optional "you may exile a creature card from
+/// your graveyard." `resolve_ability_chain` parks at
+/// `WaitingFor::OptionalEffectChoice` (stashing the chain in
+/// `pending_optional_effect`) instead of performing the exile. Accept the
+/// optional through the real `apply` pipeline so the gating exile and its
+/// `CopyTokenOf` "If you do" rider actually execute — mirroring how the engine
+/// resumes a suspended "you may" decision in production (CR 117.3a: "you may"
+/// prompts the acting player; CR 608.2c: the rider resolves in the same chain).
+/// The accept re-enters the chain at depth 1, so the resolution's chain-local
+/// tracked set (established by the now-performed exile) is exactly what the
+/// rider's "that card" anaphor must bind to.
+fn accept_pending_optional(runner: &mut engine::game::scenario::GameRunner) {
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "expected the optional 'you may exile' to pause at OptionalEffectChoice, \
+         got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting the optional exile must succeed");
+}
+
+#[test]
+fn second_instance_copies_its_own_exiled_card_not_the_first() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Two DISTINCT creature cards in P0's graveyard. Resolution #1 exiles gy_a,
+    // resolution #2 exiles gy_b. Distinct names let us discriminate which card
+    // each created token copied.
+    let gy_a = scenario
+        .add_creature_to_graveyard(P0, "Grizzly Bears", 2, 2)
+        .id();
+    let gy_b = scenario
+        .add_creature_to_graveyard(P0, "Walking Corpse", 2, 2)
+        .id();
+
+    // GPG itself is on the battlefield; use a land as a stand-in source object
+    // so the source is never part of any creature/copy filter.
+    let source = scenario.add_basic_land(P0, ManaColor::Black);
+
+    let mut runner = scenario.build();
+
+    // Parse the real Oracle text into the exile -> CopyTokenOf -> Haste chain.
+    let def = parse_effect_chain(ORACLE, AbilityKind::Spell);
+
+    // --- Resolution #1: exile Grizzly Bears (gy_a). ---
+    let before_res1 = battlefield_object_ids(runner.state());
+    let ability1 =
+        build_resolved_from_def_with_targets(&def, source, P0, vec![TargetRef::Object(gy_a)]);
+    let mut events1 = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability1, &mut events1, 0)
+        .expect("GPG resolution #1 must resolve");
+    // Accept the "you may exile" optional so the gating exile + copy rider run.
+    accept_pending_optional(&mut runner);
+
+    // The gating exile moved gy_a out of the graveyard.
+    assert_eq!(
+        runner.state().objects[&gy_a].zone,
+        Zone::Exile,
+        "resolution #1 must exile Grizzly Bears from the graveyard"
+    );
+
+    // Exactly one new battlefield object: the copy token created by res #1.
+    let after_res1 = battlefield_object_ids(runner.state());
+    let new_after_res1: Vec<ObjectId> = after_res1.difference(&before_res1).copied().collect();
+    assert_eq!(
+        new_after_res1.len(),
+        1,
+        "resolution #1 must create exactly one copy token, got {new_after_res1:?}"
+    );
+    let token1 = new_after_res1[0];
+    assert_eq!(
+        runner.state().objects[&token1].name,
+        "Grizzly Bears",
+        "resolution #1's token must copy the card IT exiled (Grizzly Bears)"
+    );
+
+    // --- Resolution #2: exile Walking Corpse (gy_b). ---
+    let before_res2 = battlefield_object_ids(runner.state());
+    let ability2 =
+        build_resolved_from_def_with_targets(&def, source, P0, vec![TargetRef::Object(gy_b)]);
+    let mut events2 = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability2, &mut events2, 0)
+        .expect("GPG resolution #2 must resolve");
+    // Accept the second resolution's "you may exile" optional.
+    accept_pending_optional(&mut runner);
+
+    assert_eq!(
+        runner.state().objects[&gy_b].zone,
+        Zone::Exile,
+        "resolution #2 must exile Walking Corpse from the graveyard"
+    );
+
+    // The token created by res #2 is the one new battlefield object since res #1.
+    let after_res2 = battlefield_object_ids(runner.state());
+    let new_after_res2: Vec<ObjectId> = after_res2.difference(&before_res2).copied().collect();
+    assert_eq!(
+        new_after_res2.len(),
+        1,
+        "resolution #2 must create exactly one copy token, got {new_after_res2:?}"
+    );
+    let token2 = new_after_res2[0];
+
+    // THE DISCRIMINATING ASSERTION: the second token must copy the card THIS
+    // resolution exiled (Walking Corpse), NOT the card the first resolution
+    // exiled (Grizzly Bears). On revert, the unconditional reset orphans the
+    // anaphor to the turn-global fallback (max-by-id non-empty set = gy_a's set),
+    // so token2.name would be "Grizzly Bears" and this flips.
+    assert_eq!(
+        runner.state().objects[&token2].name,
+        "Walking Corpse",
+        "resolution #2's token must copy the card IT exiled (Walking Corpse), \
+         not the first resolution's exiled card (Grizzly Bears)"
+    );
+
+    // Exactly two copy tokens exist overall, one per distinct exiled card —
+    // no duplicate-named copy of Grizzly Bears.
+    let copy_token_names: Vec<&str> = [token1, token2]
+        .iter()
+        .map(|id| runner.state().objects[id].name.as_str())
+        .collect();
+    assert!(
+        copy_token_names.contains(&"Grizzly Bears"),
+        "one copy token must be Grizzly Bears, got {copy_token_names:?}"
+    );
+    assert!(
+        copy_token_names.contains(&"Walking Corpse"),
+        "one copy token must be Walking Corpse, got {copy_token_names:?}"
+    );
+    assert_ne!(
+        token1, token2,
+        "the two resolutions must create distinct tokens"
+    );
+}


### PR DESCRIPTION
## Summary
Closes #2350.

God-Pharaoh's Gift's second same-turn trigger created a token copying the **wrong** creature: the 2nd resolution's "create a token that's a copy of **that card**" anaphor rebound to the 1st resolution's exiled card.

Root cause: every `If you do` boundary (`AbilityCondition::EffectOutcome { OptionalEffectPerformed }`) unconditionally ran `state.chain_tracked_set_id = None` (`game/effects/mod.rs`). That reset exists for Party Thrasher (#1977), whose rider is a tracked-set **producer**. But GPG's rider is a tracked-set **consumer** (`CopyTokenOf { target: TrackedSet }`) — "that card" *is* the gating exile's set. Resetting orphaned the consumer to the turn-global `latest_tracked_set_id` fallback (max-by-id non-empty set), so with two GPGs in a turn the 2nd bound to the 1st's still-exiled card.

Class fix: gate the reset behind `!effect_references_tracked_set(&sub.effect)` (an existing predicate that already recognizes `Effect::CopyTokenOf { target }`).
- Consumer rider (GPG class: any "move/exile X. If you do, [effect referencing that-card]") → predicate true → **skip** reset → anaphor stays chain-local to its own resolution.
- Producer rider (Party Thrasher's `ExileTop`) → predicate false → **keep** reset → #1977 preserved.

## Tests
New `god_pharaohs_gift_second_instance_2350.rs`: two GPG resolutions exile two different graveyard creatures (Grizzly Bears, Walking Corpse); each token must copy the creature **its own** resolution exiled. The discriminating assert (token2 == "Walking Corpse") flips on revert (turn-global fallback → "Grizzly Bears"). Drives the real exile→CopyTokenOf rider via the optional-accept path.

## Verification
Local Tilt `clippy` + `test-engine` green (full suite, no regressions — Party Thrasher path preserved).

CR 608.2c, 707.2a, 603.7 (grep-verified).