### PR TITLE
fix(parser): Gideon Blackblade turn-conditional 'is a creature ... still a planeswalker' animation (#1155)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -775,13 +775,15 @@ fn split_animation_keyword_clause(text: &str) -> (&str, Vec<Keyword>) {
         .trim()
         .trim_end_matches('.')
         .trim_end_matches(" in addition to its other types");
-    // CR 305.7 + CR 613.1d (#2917): a trailing "that's still a land" rider
-    // (Nissa, Who Shakes the World and the land-animation family) confirms the
-    // permanent keeps its land type — it is NOT a keyword. Without stripping it
-    // the last keyword fuses with the rider ("haste that's still a land") and is
-    // dropped by `map_token_keyword`, so e.g. "with vigilance and haste that's
-    // still a land" silently lost haste.
-    let keyword_text = strip_still_a_land_rider(keyword_text);
+    // CR 205.1b + CR 305.7 + CR 613.1d (#2917, #1155): a trailing "that's still
+    // a <type>" rider confirms the permanent keeps a prior card type — it is NOT
+    // a keyword. The land family (Nissa, Who Shakes the World — "that's still a
+    // land") and the planeswalker family (Gideon Blackblade — "that's still a
+    // planeswalker") both carry such a rider. Without stripping it the last
+    // keyword fuses with the rider ("haste that's still a land" /
+    // "indestructible that's still a planeswalker") and is dropped by
+    // `map_token_keyword`.
+    let keyword_text = strip_still_a_type_rider(keyword_text);
     let keywords = split_token_keyword_list(keyword_text)
         .into_iter()
         .filter_map(map_token_keyword)
@@ -789,9 +791,13 @@ fn split_animation_keyword_clause(text: &str) -> (&str, Vec<Keyword>) {
     (prefix, keywords)
 }
 
-/// Cut a trailing "that's/that is/it's/they're still a[n] land[s]" rider off a
-/// keyword phrase so it cannot fuse with (and discard) the final keyword.
-fn strip_still_a_land_rider(text: &str) -> &str {
+/// Cut a trailing "that's/that is/it's/they're still a[n] <type>" rider off a
+/// keyword phrase so it cannot fuse with (and discard) the final keyword. The
+/// rider marker (" that's still" et al.) is the same regardless of the trailing
+/// type word, so truncating at the marker covers every "still a <type>" family
+/// ("still a land" — Nissa; "still a planeswalker" — Gideon Blackblade #1155;
+/// "still a creature"; "still an artifact") without enumerating type words.
+fn strip_still_a_type_rider(text: &str) -> &str {
     let lower = text.to_lowercase();
     [
         " that's still",

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -940,23 +940,39 @@ pub(crate) fn parse_pronoun_becomes_type_static(
     tp: &TextPair<'_>,
     text: &str,
 ) -> Option<StaticDefinition> {
+    // STEP A.0 — peel an optional leading "during your turn, " timing clause.
+    // Mirror of `parse_compound_turn_counter_animation` (anthem.rs): the
+    // alternate printing convention writes the turn restriction as a leading
+    // timing prefix ("During your turn, ~ is a 4/4 ...") rather than a trailing
+    // "as long as it's your turn" clause. The peel is Option-returning, so when
+    // absent it falls through to `*tp` unchanged and no condition is attached.
+    let (tp, turn_condition) = match nom_tag_tp(tp, "during your turn, ") {
+        Some(rest) => (rest, Some(StaticCondition::DuringYourTurn)),
+        None => (*tp, None),
+    };
+
     // STEP A — peel a trailing " as long as <condition>" FIRST. The canonical
     // inverted-form rewrite produces "<effect> as long as <condition>"; the
     // condition must come off before the effect is parsed, or it leaks into
     // the " with " tail and never becomes a StaticCondition.
     let (effect_tp, condition_tp) = match tp.split_around(" as long as ") {
         Some((before, after)) => (before, Some(after)),
-        None => (*tp, None),
+        None => (tp, None),
     };
 
     // STEP B — pronoun + article prefix. Accept gender-neutral ("it's", "~'s",
     // "they're") and gendered ("he's", "she's") pronouns; planeswalker
     // animation statics use gendered pronouns (Grand Master of Flowers, Kaito,
-    // Gideon classes).
+    // Gideon classes). Also accept the bare "is"-copula form ("~ is a/an ...")
+    // produced when an inverted "As long as it's your turn, ~ is a ..." line
+    // (Gideon Blackblade, #1155) is split by `parse_conditional_static` and the
+    // pronoun-less effect clause "~ is a 4/4 ..." re-enters this parser.
     let body = nom_tag_tp(&effect_tp, "it's a ")
         .or_else(|| nom_tag_tp(&effect_tp, "it's an "))
         .or_else(|| nom_tag_tp(&effect_tp, "~'s a "))
         .or_else(|| nom_tag_tp(&effect_tp, "~'s an "))
+        .or_else(|| nom_tag_tp(&effect_tp, "~ is a "))
+        .or_else(|| nom_tag_tp(&effect_tp, "~ is an "))
         .or_else(|| nom_tag_tp(&effect_tp, "they're a "))
         .or_else(|| nom_tag_tp(&effect_tp, "they're an "))
         .or_else(|| nom_tag_tp(&effect_tp, "he's a "))
@@ -995,17 +1011,35 @@ pub(crate) fn parse_pronoun_becomes_type_static(
         return None;
     }
 
-    // STEP D — attach the condition peeled in STEP A.
+    // STEP D — attach the condition(s). The leading "during your turn, " timing
+    // peel (STEP A.0) and the trailing " as long as <cond>" peel (STEP A) are
+    // independent; either, both, or neither may be present.
+    // CR 205.1b + CR 613.7: "~ is a [P/T] [types] creature ... that's still a
+    // planeswalker" — additive type-change (AddType is non-replacing, so the
+    // permanent retains its Planeswalker type while it is also a creature).
+    let trailing_condition = condition_tp.map(|cond_tp| {
+        let cond_text = cond_tp.original.trim().trim_end_matches('.');
+        parse_static_condition(cond_text).unwrap_or(StaticCondition::Unrecognized {
+            text: cond_text.to_string(),
+        })
+    });
+    let condition = match (turn_condition, trailing_condition) {
+        // CR 611.3a: when both a leading turn restriction and a trailing
+        // "as long as" condition are present, compose via `And` rather than
+        // dropping one (mirrors `parse_conditional_static` in anthem.rs).
+        (Some(turn), Some(inner)) => Some(StaticCondition::And {
+            conditions: vec![turn, inner],
+        }),
+        (Some(turn), None) => Some(turn),
+        (None, Some(inner)) => Some(inner),
+        (None, None) => None,
+    };
+
     let mut def = StaticDefinition::continuous()
         .affected(TargetFilter::SelfRef)
         .modifications(modifications)
         .description(text.to_string());
-    if let Some(cond_tp) = condition_tp {
-        let cond_text = cond_tp.original.trim().trim_end_matches('.');
-        let condition =
-            parse_static_condition(cond_text).unwrap_or(StaticCondition::Unrecognized {
-                text: cond_text.to_string(),
-            });
+    if let Some(condition) = condition {
         def = def.condition(condition);
     }
     Some(def)

--- a/crates/engine/tests/gideon_blackblade_turn_conditional_creature_1155.rs
+++ b/crates/engine/tests/gideon_blackblade_turn_conditional_creature_1155.rs
@@ -1,0 +1,152 @@
+//! Discriminating regression test for **issue #1155**: Gideon Blackblade's
+//! turn-conditional animation static must parse and drive the layer system.
+//!
+//! Gideon Blackblade's static:
+//!
+//! > As long as it's your turn, Gideon Blackblade is a 4/4 Human Soldier
+//! > creature with indestructible that's still a planeswalker.
+//!
+//! Before the fix the line failed to parse as a static and was dropped to an
+//! `Effect::Unimplemented` ability, so the layer system never animated Gideon.
+//! The root cause was two parser gaps: `parse_pronoun_becomes_type_static` only
+//! accepted possessive-pronoun copulas (`it's a`, `~'s a`, `he's a`) and not the
+//! bare `~ is a` copula produced when `parse_conditional_static` splits the
+//! inverted "As long as it's your turn, ~ is a ..." line.
+//!
+//! After the fix the static parses to a `StaticCondition::DuringYourTurn` gate
+//! carrying `AddType { Creature }` (additive — CR 205.1b retains Planeswalker),
+//! `SetPower/SetToughness 4/4`, and `AddKeyword(Indestructible)`.
+//!
+//! CR 205.1b: "still a [type]" retains the object's prior card types — so
+//!   `AddType` is non-replacing and Gideon stays a planeswalker while a creature.
+//! CR 306: Planeswalkers.
+//! CR 613.7: continuous type-change from a static ability (timestamp/layers).
+//! CR 702.12: indestructible.
+
+use std::sync::Arc;
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{ContinuousModification, StaticCondition};
+use engine::types::card_type::{CoreType, Supertype};
+use engine::types::keywords::KeywordKind;
+use engine::types::phase::Phase;
+
+const GIDEON_ORACLE: &str = "Indestructible\n\
+As long as it's your turn, Gideon Blackblade is a 4/4 Human Soldier creature with indestructible that's still a planeswalker.\n\
+Whenever Gideon Blackblade attacks, choose up to one target creature an opponent controls. Prevent all combat damage that creature would deal this turn.";
+
+/// Returns true if the condition is `DuringYourTurn`, or an `And` that contains
+/// `DuringYourTurn`. Robust to whichever composition the parser emits.
+fn condition_gates_on_your_turn(cond: &StaticCondition) -> bool {
+    match cond {
+        StaticCondition::DuringYourTurn => true,
+        StaticCondition::And { conditions } => conditions.iter().any(condition_gates_on_your_turn),
+        _ => false,
+    }
+}
+
+#[test]
+fn gideon_blackblade_is_turn_conditional_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Build Gideon from his real Oracle text. Parsing of the animation static
+    // happens here, at build time.
+    let gideon = scenario
+        .add_creature_from_oracle(P0, "Gideon Blackblade", 0, 0, GIDEON_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Reshape the printed baseline into a Legendary Planeswalker with no printed
+    // P/T — the actual card. `GameScenario` exposes object mutation only after
+    // `build()` (via `GameRunner::state_mut()`, mirroring the priest test). The
+    // animation static must add the Creature type and 4/4 P/T on top of this
+    // baseline, retaining the Planeswalker type (CR 205.1b). The reshape touches
+    // only the type/P-T baseline, not `base_static_definitions` (already parsed).
+    {
+        let obj = runner.state_mut().objects.get_mut(&gideon).unwrap();
+        obj.card_types.core_types = vec![CoreType::Planeswalker];
+        obj.card_types.supertypes = vec![Supertype::Legendary];
+        obj.card_types.subtypes = vec!["Gideon".to_string()];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = None;
+        obj.toughness = None;
+        obj.base_power = None;
+        obj.base_toughness = None;
+        obj.base_loyalty = Some(4);
+        obj.loyalty = Some(4);
+    }
+
+    // ----- Assertion 3: the static parsed (not dropped to Unimplemented) -----
+    let statics: &Arc<Vec<_>> = &runner.state().objects[&gideon].base_static_definitions;
+    let animation = statics
+        .iter()
+        .find(|s| {
+            s.modifications.contains(&ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            })
+        })
+        .expect(
+            "Gideon's animation line must parse to a static carrying \
+             AddType{Creature}, not drop to Effect::Unimplemented (#1155)",
+        );
+    let cond = animation
+        .condition
+        .as_ref()
+        .expect("animation static must carry a turn condition");
+    assert!(
+        condition_gates_on_your_turn(cond),
+        "animation static must gate on DuringYourTurn, got {cond:?}"
+    );
+
+    // ----- Assertion 1: on P0's turn, Gideon animates -----
+    runner.state_mut().active_player = P0;
+    evaluate_layers(runner.state_mut());
+
+    let obj = &runner.state().objects[&gideon];
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Creature),
+        "On its controller's turn Gideon must be a Creature, got {:?}",
+        obj.card_types.core_types
+    );
+    // CR 205.1b: "still a planeswalker" — Planeswalker type is retained.
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Planeswalker),
+        "Gideon must remain a Planeswalker (CR 205.1b 'still a planeswalker'), got {:?}",
+        obj.card_types.core_types
+    );
+    assert_eq!(obj.power, Some(4), "Gideon's animated power must be 4");
+    assert_eq!(
+        obj.toughness,
+        Some(4),
+        "Gideon's animated toughness must be 4"
+    );
+    assert!(
+        obj.keywords
+            .iter()
+            .any(|k| k.kind() == KeywordKind::Indestructible),
+        "Gideon must have Indestructible while animated (CR 702.12), got {:?}",
+        obj.keywords
+    );
+
+    // ----- Assertion 2 (THE DISCRIMINATOR): on the opponent's turn, Gideon is
+    // NOT a creature. This fails both before the fix (never animates → fails
+    // Assertion 1) AND under a naive always-on fix that drops the turn gate. -----
+    runner.state_mut().active_player = P1;
+    evaluate_layers(runner.state_mut());
+
+    let obj = &runner.state().objects[&gideon];
+    assert!(
+        !obj.card_types.core_types.contains(&CoreType::Creature),
+        "On the OPPONENT's turn Gideon must NOT be a Creature (turn-conditional \
+         static), got {:?}",
+        obj.card_types.core_types
+    );
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Planeswalker),
+        "Gideon is always a Planeswalker, got {:?}",
+        obj.card_types.core_types
+    );
+}


### PR DESCRIPTION
Closes #1155.

## Problem
Gideon Blackblade's static — *"As long as it's your turn, Gideon Blackblade is a 4/4 Human Soldier creature with indestructible that's still a planeswalker"* — was dropped to `Effect::Unimplemented`, so the layer system never animated him. He stayed a non-creature planeswalker on his own turn.

Two parser gaps:
- **Copula `is`:** `parse_pronoun_becomes_type_static` only accepted possessive/`becomes` prefixes (`it's a`, `~'s a`, `they're a`…) — never the `~ is a`/`~ is an` copula Gideon uses.
- **"still a planeswalker" rider:** the still-a-\<type\> rider stripper was named/scoped for `land` only.

## Fix
- Add `~ is a`/`~ is an` copula arms to `parse_pronoun_becomes_type_static` (additive `.or_else` arms; existing pronoun cards unaffected). Optional `during your turn,` timing-peel + `And`-composition for the conditional.
- Generalize `strip_still_a_land_rider` → `strip_still_a_type_rider` (covers `still a land`/`planeswalker`/`creature`/`artifact`), preserving `still a land` byte-for-byte.

`AddType{Creature}` is additive (CR 205.1b) — it appends Creature without removing Planeswalker, so "still a planeswalker" is satisfied with no new variant. Covers the `~ is/becomes a [P/T] [types] creature … that's still a [type]` family (~9 cards), not just Gideon.

## Test
`gideon_blackblade_turn_conditional_creature_1155.rs` drives the real layer-eval pipeline:
- **P0's turn:** Gideon IS a Creature AND still a Planeswalker (CR 205.1b), 4/4, indestructible.
- **P1's turn (discriminator):** Gideon is NOT a Creature — fails both today's bug AND a naive always-on fix.

Tilt `test-engine` green: `gideon_blackblade_is_turn_conditional_creature ... PASS` (12765 passed); clippy green.

## CR
- CR 205.1b: "still a [type]" retains prior card types (AddType is additive).
- CR 613.7 / 613.1d: continuous type-change from a static ability (Layer 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)