### PR TITLE
fix(parser): Gonti-class look-and-exile-face-down exiles the dug card, not the source (#1146)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -479,6 +479,28 @@ fn parse_exile_looked_at_card(lower: &str) -> Option<bool> {
     Some(face_down)
 }
 
+/// CR 702.75a + CR 406.3: Recognize "exile one of them face down" — a player
+/// CHOICE of one card from among the cards a preceding private `Dig` looked at
+/// (the Gonti, Lord of Luxury class: "look at the top four cards of an
+/// opponent's library, exile one of them face down ..."). Distinct from
+/// `parse_exile_looked_at_card` ("exile it/them ...", the Gonti, Canny
+/// Acquisitor wholesale impulse idiom): "one of them" means the controller
+/// selects exactly one of the N looked-at cards. The "face down" suffix is the
+/// CR 406.3 hidden-information marker required by this class; pure-peek Digs
+/// (Delver of Secrets — no exile clause) never reach this recognizer.
+fn parse_exile_one_of_them_face_down(lower: &str) -> bool {
+    let trimmed = lower.trim().trim_end_matches('.').trim_end();
+    (
+        tag::<_, _, OracleError<'_>>("exile "),
+        alt((tag("one of them"), tag("one of those cards"))),
+        multispace1,
+        tag("face down"),
+        eof,
+    )
+        .parse(trimmed)
+        .is_ok()
+}
+
 pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
     let mut chunks = Vec::new();
     let mut current = String::new();
@@ -2645,6 +2667,42 @@ pub(super) fn apply_clause_continuation(
                 face_down,
             };
         }
+        // CR 702.75a + CR 406.3: "exile one of them face down" patches the
+        // preceding private `Dig` into the Hideaway shape — the controller
+        // selects ONE looked-at card and the `DigChoice` flow routes it to
+        // exile. Mirror `database/hideaway.rs`: keep_count:1, destination:Exile,
+        // reveal stays false (CR 701.20e — the look was private), and chain a
+        // `HideawayConceal` sub-ability to turn the chosen card face down and
+        // link it to the source (so the trailing "you may cast that card ..."
+        // permission, which reads the published tracked set / `ExiledBySource`,
+        // binds to the dug card). Without this fusion the Dig short-circuited as
+        // a keep_count:0 pure-peek and a sibling `ChangeZone { ParentTarget }`
+        // exiled the trigger source itself (#1146).
+        ContinuationAst::ExileOneOfThemFaceDown => {
+            let Some(previous) = defs
+                .iter_mut()
+                .rev()
+                .find(|d| matches!(&*d.effect, Effect::Dig { .. }))
+            else {
+                return;
+            };
+            if let Effect::Dig {
+                keep_count,
+                up_to,
+                destination,
+                ..
+            } = &mut *previous.effect
+            {
+                *keep_count = Some(1);
+                *up_to = false;
+                *destination = Some(Zone::Exile);
+            }
+            // CR 608.2c: chain the conceal continuation onto the Dig. The
+            // `DigChoice` resolution binds the chosen (exiled) card onto this
+            // sub-ability's `ParentTarget`; `HideawayConceal` then flips it face
+            // down (CR 406.3) and links it to the source (CR 607.2a / CR 702.75a).
+            append_conceal_sub_ability(previous);
+        }
         ContinuationAst::ChooseAndSacrificeRestFilter { sacrifice_filter } => {
             let Some(filter) = sacrifice_filter else {
                 return;
@@ -2661,6 +2719,29 @@ pub(super) fn apply_clause_continuation(
             }
         }
     }
+}
+
+/// CR 702.75a + CR 608.2c: Append the Hideaway conceal continuation to the
+/// deepest point of `dig`'s sub-ability chain. Mirrors `database/hideaway.rs`:
+/// the chained `HideawayConceal { target: ParentTarget }` flips the just-exiled
+/// dug card face down (CR 406.3) and links it to the source. Appended at the
+/// deepest sub so it never clobbers an existing continuation (e.g. a trailing
+/// "put the rest on the bottom" patch lives on the Dig itself, not as a sub).
+fn append_conceal_sub_ability(dig: &mut AbilityDefinition) {
+    let conceal = Box::new(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::HideawayConceal {
+            target: TargetFilter::ParentTarget,
+        },
+    ));
+    let mut cursor = dig;
+    while cursor.sub_ability.is_some() {
+        cursor = cursor
+            .sub_ability
+            .as_mut()
+            .expect("sub_ability checked above");
+    }
+    cursor.sub_ability = Some(conceal);
 }
 
 fn apply_search_destination_to_ability_chain(
@@ -2759,6 +2840,10 @@ pub(super) fn continuation_absorbs_current(
         // parse_followup_continuation_ast; the "exile it [face down]" clause is
         // folded into that Dig (rewritten to ExileTop) and emits no sibling def.
         ContinuationAst::ExileLookedAtCard { .. } => true,
+        // Recognition was already gated on a preceding `Dig`; the "exile one of
+        // them face down" clause patches that Dig (keep_count:1 / Exile) and
+        // pushes the conceal sub-ability — it emits no sibling def.
+        ContinuationAst::ExileOneOfThemFaceDown => true,
         ContinuationAst::ChooseAndSacrificeRestFilter { .. } => true,
     }
 }
@@ -3828,6 +3913,18 @@ pub(super) fn parse_followup_continuation_ast(
                 && recognize_copy_retarget_clause(&lower) =>
         {
             Some(ContinuationAst::CopyMayRetarget)
+        }
+        // CR 702.75a + CR 406.3: "exile one of them face down" after a private
+        // `Dig` (the "look at the top N cards of <player>'s library" look step)
+        // — the Gonti, Lord of Luxury class. The controller selects ONE of the N
+        // looked-at cards and exiles it face down. Patches the `Dig` into the
+        // Hideaway shape (keep_count: 1, destination: Exile) + chains a
+        // `HideawayConceal` so the player-selected dug card is the one exiled
+        // face down and linked to the source — NOT a sibling
+        // `ChangeZone { ParentTarget }`, which exiled the trigger source itself.
+        // `reveal: false` scopes this to the private look form.
+        Effect::Dig { reveal: false, .. } if parse_exile_one_of_them_face_down(&lower) => {
+            Some(ContinuationAst::ExileOneOfThemFaceDown)
         }
         // CR 201.2 + CR 608.2c: "[You may] put one of those cards onto the
         // battlefield if it has the same name as a permanent" after Dig —
@@ -7059,6 +7156,82 @@ mod tests {
         assert!(
             chunks.len() > 1,
             "expected a split (sticky must not engage), got single chunk: {chunks:?}"
+        );
+    }
+
+    /// Build a private-look (`reveal: false`) peek `Dig` matching the shape a
+    /// "look at the top N cards" clause lowers to before any exile follow-on.
+    fn make_peek_dig() -> Effect {
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 4 },
+            destination: None,
+            keep_count: None,
+            up_to: false,
+            filter: TargetFilter::Any,
+            rest_destination: None,
+            reveal: false,
+            enter_tapped: false,
+        }
+    }
+
+    /// #1146: "exile one of them face down" after a private `Dig` is recognized
+    /// as the Gonti-class continuation (not the wholesale impulse `ExileTop`).
+    #[test]
+    fn exile_one_of_them_face_down_recognized_after_peek_dig() {
+        let dig = make_peek_dig();
+        let result = parse_followup_continuation_ast(
+            "Exile one of them face down.",
+            &dig,
+            &mut ParseContext::default(),
+        );
+        assert_eq!(
+            result,
+            Some(ContinuationAst::ExileOneOfThemFaceDown),
+            "the Gonti-class exile-the-dug-card clause must be recognized"
+        );
+    }
+
+    /// #1146: the variant phrasing "exile one of those cards face down" maps to
+    /// the same continuation.
+    #[test]
+    fn exile_one_of_those_cards_face_down_recognized_after_peek_dig() {
+        let dig = make_peek_dig();
+        let result = parse_followup_continuation_ast(
+            "Exile one of those cards face down.",
+            &dig,
+            &mut ParseContext::default(),
+        );
+        assert_eq!(result, Some(ContinuationAst::ExileOneOfThemFaceDown));
+    }
+
+    /// #1146 scope guard: the recognizer requires the "face down" CR 406.3
+    /// marker — a "one of them" clause WITHOUT it is NOT this continuation, so a
+    /// card with different selection semantics is not mis-fused.
+    #[test]
+    fn exile_one_of_them_without_face_down_is_not_gonti_continuation() {
+        assert!(
+            !parse_exile_one_of_them_face_down("exile one of them"),
+            "without the 'face down' marker this is not the Gonti look-and-exile class"
+        );
+    }
+
+    /// #1146 regression guard: a genuine pure-peek `Dig` with NO exile clause
+    /// (the Delver of Secrets idiom — "look at the top card … you may reveal it")
+    /// must NOT lower to the Gonti exile-the-dug-card continuation, so it stays a
+    /// `keep_count: 0` peek and never surfaces a `DigChoice`.
+    #[test]
+    fn delver_pure_peek_is_not_gonti_continuation() {
+        let dig = make_peek_dig();
+        let result = parse_followup_continuation_ast(
+            "You may reveal it.",
+            &dig,
+            &mut ParseContext::default(),
+        );
+        assert_ne!(
+            result,
+            Some(ContinuationAst::ExileOneOfThemFaceDown),
+            "a pure-peek 'you may reveal it' must not be fused into the Gonti exile continuation"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -362,6 +362,17 @@ pub(crate) enum ContinuationAst {
         count: QuantityExpr,
         face_down: bool,
     },
+    /// CR 702.75a + CR 406.3: "exile one of them face down" after a private
+    /// `Dig` (the "look at the top N cards of <player>'s library" look step) —
+    /// the Gonti, Lord of Luxury class. Unlike `ExileLookedAtCard` (which exiles
+    /// the looked-at card(s) wholesale via `ExileTop`), this is a player choice
+    /// of ONE card from among the N looked at. It patches the preceding `Dig`
+    /// into the Hideaway shape (`keep_count: Some(1)`, `destination: Exile`) so
+    /// the dug card is player-selected and routed to exile by the `DigChoice`
+    /// flow, then chains a `HideawayConceal` sub-ability to turn the chosen card
+    /// face down and link it to the source. Gated on the exile-the-dug-card
+    /// continuation, so genuine pure-peek Digs (Delver of Secrets) are untouched.
+    ExileOneOfThemFaceDown,
     /// CR 608.2c + CR 701.21a: absorbs the explicit/bare sacrifice-rest clause
     /// following a choose-and-sacrifice-rest effect, optionally narrowing the
     /// final sacrifice sweep ("all other nonland permanents they control").

--- a/crates/engine/tests/gonti_lord_of_luxury_exiles_dug_card.rs
+++ b/crates/engine/tests/gonti_lord_of_luxury_exiles_dug_card.rs
@@ -1,0 +1,186 @@
+//! Discriminating regression test for **issue #1146**: Gonti, Lord of Luxury's
+//! ETB ("look at the top four cards … exile one of them face down, then you may
+//! look at and play that card …") must exile the player-CHOSEN dug card — never
+//! Gonti himself.
+//!
+//! Root cause (pre-fix): the parser lowered "exile one of them face down" as a
+//! `Dig { keep_count: 0 }` pure-peek (CR 701.20e) plus a SEPARATE sibling
+//! `ChangeZone { target: ParentTarget → Exile }`. At runtime the keep_count:0
+//! Dig short-circuited WITHOUT surfacing a `WaitingFor::DigChoice` (no card was
+//! ever selected), and the chained `ChangeZone { ParentTarget }` resolved with an
+//! empty object-target set → the `ParentTarget && targets.is_empty()` fallback in
+//! `effect_object_targets` used `ability.source_id` = Gonti, so GONTI was exiled.
+//!
+//! Fix (parser): when "exile one of them face down" follows a private "look at
+//! top N" `Dig`, fuse it into `Dig { keep_count: Some(1), destination: Exile }`
+//! (the Hideaway model, CR 702.75a) plus a chained `HideawayConceal` that flips
+//! the dug card face down (CR 406.3) and links it to the source. The dug card is
+//! now player-selected through the real `DigChoice` flow and routed to exile by
+//! the Dig itself — no sibling `ChangeZone` exists.
+//!
+//! This test drives the full cast pipeline: it casts Gonti from hand, lets the
+//! ETB trigger fire, and answers the `DigChoice` that the fix introduces.
+//! Pre-fix, no `DigChoice` ever surfaces (the assertion `saw_dig_choice` fails)
+//! AND Gonti ends in exile — both flip with the fix.
+//!
+//! Note on scope: the body parser lowers "an opponent's library" to the
+//! controller's-library `Dig` (`parse_dig_library_owner` returns
+//! `TargetFilter::Controller`), so this test exercises the dig against the
+//! controller's own library. The "an opponent's library" → opponent-targeting
+//! is a separate latent gap, out of scope for #1146 (which concerns WHICH card
+//! is exiled, not WHOSE library is read).
+//!
+//! CR 701.20e: looking at cards is private. CR 406.3 / CR 708.2: a card exiled
+//! face down has no characteristics and can't be examined. CR 702.75a: Hideaway
+//! is the structural analog this lowering mirrors.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+use engine::types::ObjectId;
+
+const GONTI_ORACLE: &str = "Deathtouch\n\
+When Gonti, Lord of Luxury enters the battlefield, look at the top four cards of an opponent's library, exile one of them face down, then you may look at and play that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.";
+
+#[test]
+fn gonti_exiles_the_dug_card_not_himself() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Stack the dug library so the top four are the looked-at cards and a fifth
+    // deeper card must NOT be seen (proves the dig is bounded to 4).
+    // `add_card_to_library_top` inserts at the top (index 0), so add the deepest
+    // card first and the top-of-four last.
+    let lib_deep = scenario.add_card_to_library_top(P0, "Lib Deep Card");
+    let lib4 = scenario.add_card_to_library_top(P0, "Lib Card 4");
+    let lib3 = scenario.add_card_to_library_top(P0, "Lib Card 3");
+    let lib2 = scenario.add_card_to_library_top(P0, "Lib Card 2");
+    let lib1 = scenario.add_card_to_library_top(P0, "Lib Card 1");
+
+    // Gonti in P0's hand, free to cast.
+    let gonti = {
+        let mut b = scenario.add_creature_to_hand_from_oracle(
+            P0,
+            "Gonti, Lord of Luxury",
+            2,
+            3,
+            GONTI_ORACLE,
+        );
+        b.as_legendary();
+        b.with_mana_cost(ManaCost::default());
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&gonti].card_id;
+
+    // Cast Gonti (free — auto-pays from an empty pool). Resolving it puts Gonti
+    // onto the battlefield and fires its ETB trigger.
+    runner
+        .act(GameAction::CastSpell {
+            object_id: gonti,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("CastSpell accepted");
+
+    // Drive the pipeline by hand: pass priority to resolve the spell + the ETB
+    // trigger, accept the optional "you may play" rider, and answer the
+    // DigChoice the fix introduces.
+    let mut saw_dig_choice = false;
+    let mut dug_card: Option<ObjectId> = None;
+    let mut looked_at: Vec<ObjectId> = Vec::new();
+
+    for _ in 0..96 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                // Accept the "you may look at and play that card" rider so the
+                // resolution proceeds to the dig selection.
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("DecideOptionalEffect accepted");
+            }
+            WaitingFor::DigChoice { cards, .. } => {
+                saw_dig_choice = true;
+                looked_at = cards.clone();
+                let chosen = cards[0];
+                dug_card = Some(chosen);
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![chosen],
+                    })
+                    .expect("SelectCards (dig keep) accepted");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() && saw_dig_choice {
+                    break;
+                }
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("PassPriority accepted");
+            }
+            other => panic!("unexpected prompt while driving Gonti ETB: {other:?}"),
+        }
+    }
+
+    // DISCRIMINATOR (#1146), part 1: the keep_count:1 fix surfaces a DigChoice.
+    // Pre-fix the keep_count:0 pure-peek short-circuited and this never fired.
+    assert!(
+        saw_dig_choice,
+        "Gonti's ETB must surface a DigChoice so the controller selects the card to exile; \
+         pre-fix the keep_count:0 peek short-circuited and no choice was offered"
+    );
+
+    // The dig looked at exactly the top four cards (CR 701.20e) — not the deeper
+    // card — proving the keep_count:1 dig is bounded to the four looked-at cards.
+    assert_eq!(looked_at.len(), 4, "Gonti looks at the top FOUR cards");
+    assert!(
+        !looked_at.contains(&lib_deep),
+        "the deeper (5th) card must not be looked at"
+    );
+
+    let dug_card = dug_card.expect("a card was dug");
+    let state = runner.state();
+
+    // DISCRIMINATOR (#1146), part 2 — the regression direction: Gonti is NOT
+    // exiled. Pre-fix the sibling ChangeZone{ParentTarget} exiled the trigger
+    // source (Gonti) because no object target had been selected.
+    assert_eq!(
+        state.objects[&gonti].zone,
+        Zone::Battlefield,
+        "Gonti must remain on the battlefield — the dug card is exiled, not Gonti"
+    );
+    assert!(
+        !state.objects[&gonti].face_down,
+        "Gonti must not be turned face down"
+    );
+
+    // The player-chosen dug card is the exiled, face-down object (CR 406.3).
+    assert_eq!(
+        state.objects[&dug_card].zone,
+        Zone::Exile,
+        "the chosen dug card must be in exile"
+    );
+    assert!(
+        state.objects[&dug_card].face_down,
+        "the exiled dug card must be face down (CR 406.3)"
+    );
+
+    // The other three looked-at cards were not exiled (they go to the bottom of
+    // the library in a random order).
+    for &id in &looked_at {
+        if id == dug_card {
+            continue;
+        }
+        assert_ne!(
+            state.objects[&id].zone,
+            Zone::Exile,
+            "only the chosen card is exiled; the other looked-at cards are not"
+        );
+    }
+    let _ = (lib1, lib2, lib3, lib4);
+}

--- a/crates/engine/tests/station_threshold_teardown_1134.rs
+++ b/crates/engine/tests/station_threshold_teardown_1134.rs
@@ -1,0 +1,201 @@
+//! Discriminating regression test for **issue #1134**: the Station mechanic
+//! (Edge of Eternities Spacecraft, CR 721 / CR 702.184) gates its threshold
+//! striations on charge counters, and those grants MUST tear down the instant
+//! the counter total drops below the printed `{N+}` threshold.
+//!
+//! Inspirit, Flagship Vessel — a Legendary Artifact Spacecraft, printed P/T 5/5
+//! (CR 721.2b box), with the printed striations:
+//!
+//! > 1+ | At the beginning of combat on your turn, put your choice of a +1/+1
+//! >      counter or two charge counters on up to one other target artifact.
+//! > 8+ | Flying
+//! > Other artifacts you control have hexproof and indestructible.
+//!
+//! The `8+` striation contributes three continuous effects, all gated on
+//! `StaticCondition::HasCounters { OfType(charge), minimum: 8 }`:
+//!   1. Spacecraft becomes an artifact *creature* with base P/T 5/5 (CR 721.2b,
+//!      synthesized by `database::synthesis::synthesize_station`).
+//!   2. The Spacecraft itself gains Flying (SelfRef `AddKeyword`).
+//!   3. *Other* artifacts the controller controls gain Hexproof and
+//!      Indestructible (a non-SelfRef static, a continuation line under the
+//!      `8+` striation per CR 721.2).
+//!
+//! THE DISCRIMINATOR (the behavior that would regress pre-67bf02ec7): when the
+//! charge total falls from 8 to 7, the layer system must re-evaluate the
+//! `HasCounters` gate and *remove* all three grants. CR 611.3a: a continuous
+//! effect from a static ability "isn't locked in; it applies at any given
+//! moment to whatever its text indicates." CR 721.2a/b phrases the striation as
+//! "As long as this permanent has N or more charge counters on it…". A fix that
+//! only added the grant at threshold but failed to tear it down on counter loss
+//! would leave Flying/Hexproof/Indestructible/Creature-type present at 7
+//! counters — every "torn down" assertion below would then fail.
+//!
+//! This test drives the real pipeline: it builds the Spacecraft from its
+//! verbatim Oracle text through the scenario harness (the same `synthesize_all`
+//! production runs), manipulates `obj.counters` directly (mirroring the runtime
+//! effect of `Effect::PutCounter` / removal), and reads the *effective*
+//! post-layer characteristics via `evaluate_layers`. It is a runtime regression
+//! test, not an AST shape test.
+//!
+//! CR 122.1: a counter is a marker placed on an object that interacts with
+//! rules, abilities, or effects (here, the charge-counter gate).
+//! CR 611.3a: continuous effects from static abilities are not locked in.
+//! CR 721.2a/b: a station symbol `{N+}` static applies only while the permanent
+//! has N or more charge counters.
+
+use engine::game::keywords::has_keyword;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+
+/// Inspirit, Flagship Vessel — verbatim Oracle text (from card-data.json).
+const INSPIRIT_ORACLE: &str = "Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery. It's an artifact creature at 8+.)\n\
+1+ | At the beginning of combat on your turn, put your choice of a +1/+1 counter or two charge counters on up to one other target artifact.\n\
+8+ | Flying\n\
+Other artifacts you control have hexproof and indestructible.";
+
+/// Recompute every layer, then return the object after a fresh evaluation.
+/// CR 611.3a: the `HasCounters` gate is re-tested here every pass, so the
+/// effective characteristics always reflect the current counter total.
+fn recompute(runner: &mut GameRunner) {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+}
+
+/// Set the charge-counter total on `id` to exactly `n` (CR 122.1). `n == 0`
+/// leaves a zeroed entry, which `counter_condition_matches` treats as below any
+/// positive minimum — the same result the runtime sees when counters are
+/// removed.
+fn set_charge(runner: &mut GameRunner, id: ObjectId, n: u32) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.counters
+        .insert(CounterType::Generic("charge".to_string()), n);
+}
+
+fn is_creature(runner: &GameRunner, id: ObjectId) -> bool {
+    runner.state().objects[&id]
+        .card_types
+        .core_types
+        .contains(&CoreType::Creature)
+}
+
+fn has_kw(runner: &GameRunner, id: ObjectId, kw: &Keyword) -> bool {
+    has_keyword(&runner.state().objects[&id], kw)
+}
+
+#[test]
+fn station_grant_tears_down_when_charge_drops_below_threshold() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Build Inspirit, Flagship Vessel inline as a Legendary Artifact Spacecraft
+    // with printed P/T 5/5. The type line must be set BEFORE `from_oracle_text`
+    // so the synthesis pipeline (`synthesize_station`) sees the Spacecraft
+    // subtype + printed P/T and emits the 8+ creature-shift static (CR 721.2b).
+    let inspirit = scenario
+        .add_creature(P0, "Inspirit, Flagship Vessel", 5, 5)
+        .as_artifact()
+        .as_legendary()
+        .with_subtypes(vec!["Spacecraft"])
+        .from_oracle_text(INSPIRIT_ORACLE)
+        .id();
+
+    // A second artifact P0 controls — the recipient of the gated "Other
+    // artifacts you control have hexproof and indestructible" grant.
+    let recipient = scenario
+        .add_creature(P0, "Recipient Artifact", 0, 0)
+        .as_artifact()
+        .id();
+
+    let mut runner = scenario.build();
+
+    // --- Below threshold (0 charge counters): no grants ---
+    recompute(&mut runner);
+    assert!(
+        !is_creature(&runner, inspirit),
+        "CR 721.2b: at 0 charge counters the Spacecraft is a noncreature artifact"
+    );
+    assert!(
+        !has_kw(&runner, inspirit, &Keyword::Flying),
+        "CR 721.2a: Flying (8+ striation) absent below threshold"
+    );
+    assert!(
+        !has_kw(&runner, recipient, &Keyword::Hexproof),
+        "CR 611.3a: other-artifact Hexproof grant absent below threshold"
+    );
+    assert!(
+        !has_kw(&runner, recipient, &Keyword::Indestructible),
+        "CR 611.3a: other-artifact Indestructible grant absent below threshold"
+    );
+
+    // --- At threshold (8 charge counters): all grants active ---
+    set_charge(&mut runner, inspirit, 8);
+    recompute(&mut runner);
+    assert!(
+        is_creature(&runner, inspirit),
+        "CR 721.2b: at 8 charge counters the Spacecraft becomes an artifact creature"
+    );
+    {
+        let obj = &runner.state().objects[&inspirit];
+        assert_eq!(
+            (obj.power, obj.toughness),
+            (Some(5), Some(5)),
+            "CR 721.2b: artifact creature uses its printed 5/5 box at threshold"
+        );
+    }
+    assert!(
+        has_kw(&runner, inspirit, &Keyword::Flying),
+        "CR 721.2a: Flying granted at 8 charge counters"
+    );
+    assert!(
+        has_kw(&runner, recipient, &Keyword::Hexproof),
+        "CR 611.3a: other artifacts gain Hexproof at threshold"
+    );
+    assert!(
+        has_kw(&runner, recipient, &Keyword::Indestructible),
+        "CR 611.3a: other artifacts gain Indestructible at threshold"
+    );
+
+    // --- TEARDOWN (the discriminator): drop to 7, just below threshold ---
+    // Pre-67bf02ec7 (grant added but never torn down) these four assertions
+    // fail: the keywords / creature type survive at 7 counters.
+    set_charge(&mut runner, inspirit, 7);
+    recompute(&mut runner);
+    assert!(
+        !is_creature(&runner, inspirit),
+        "CR 611.3a / CR 721.2b: creature-shift torn down at 7 (< 8) charge counters"
+    );
+    assert!(
+        !has_kw(&runner, inspirit, &Keyword::Flying),
+        "CR 611.3a: Flying torn down at 7 (< 8) charge counters"
+    );
+    assert!(
+        !has_kw(&runner, recipient, &Keyword::Hexproof),
+        "CR 611.3a: other-artifact Hexproof torn down at 7 (< 8) charge counters"
+    );
+    assert!(
+        !has_kw(&runner, recipient, &Keyword::Indestructible),
+        "CR 611.3a: other-artifact Indestructible torn down at 7 (< 8) charge counters"
+    );
+
+    // --- Drop all the way to 0: re-assert the all-clear ---
+    set_charge(&mut runner, inspirit, 0);
+    recompute(&mut runner);
+    assert!(!is_creature(&runner, inspirit), "all-clear at 0 counters");
+    assert!(
+        !has_kw(&runner, inspirit, &Keyword::Flying),
+        "all-clear at 0 counters: Flying"
+    );
+    assert!(
+        !has_kw(&runner, recipient, &Keyword::Hexproof),
+        "all-clear at 0 counters: Hexproof"
+    );
+    assert!(
+        !has_kw(&runner, recipient, &Keyword::Indestructible),
+        "all-clear at 0 counters: Indestructible"
+    );
+}


### PR DESCRIPTION
Closes #1146.

## Problem
Gonti, Lord of Luxury's ETB — *"look at the top four cards of an opponent's library, exile one of them face down, then you may … play that card"* — incorrectly exiled **Gonti himself** instead of the chosen card.

Root cause: the parser lowered "exile one of them face down" as a `Dig { keep_count: 0 }` peek + a **sibling** `ChangeZone { target: ParentTarget → Exile }`. At runtime the `keep_count:0` peek short-circuits (`dig.rs:96`) without ever surfacing a `DigChoice`, so no card is selected; the sibling `ChangeZone{ParentTarget}` then resolves with an empty object-target set and falls back to `source_id` (`targeting.rs:509`) — exiling Gonti.

## Fix
Fuse the clause into the **Hideaway model**: `Dig { keep_count: Some(1), destination: Exile }` + a `HideawayConceal { ParentTarget }` face-down step (mirrors `database/hideaway.rs`). The dug card is now player-selected and routed to exile by the Dig itself; the trailing "you may play that card" permission binds to it via the existing tracked-set publish.

Gated on an `eof`-anchored "exile one of them face down" recognizer so genuine pure-peek (Delver) and "exile target X card" siblings are untouched. Class fix (~17 cards: Thief of Sanity, Siphon Insight, …).

## Test
`gonti_lord_of_luxury_exiles_dug_card.rs` drives the real cast pipeline:
- **Discriminators:** a `DigChoice` now surfaces (pre-fix it didn't); Gonti stays on the **battlefield**; the chosen library card is the **exiled, face-down** object.
- **Regression guard:** Delver-class pure-peek still lowers to `keep_count:0` / no DigChoice.

Tilt `test-engine` green: `gonti_exiles_the_dug_card_not_himself ... PASS`, full suite 12772 passed.

## CR
- CR 701.20e: looking is private. CR 406.3 / 708.2: face-down exile. CR 702.75a: Hideaway structural analog. CR 608.2c: continuation ordering.

## Known follow-up (out of scope)
"an opponent's library" currently lowers to `Controller` (Gonti digs its own controller's library) — a *separate* parser gap, not this bug. Flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)