### PR TITLE
feat(engine): is_mana_ability flag + #3162 Gemini follow-ups

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -635,6 +635,11 @@ export interface SerializedAbility {
    *  confirmation modal for a lone card-consuming action — see
    *  requiresConfirmation in viewmodel/cardActionChoice.ts. */
   consumes_source?: boolean;
+  /** Derived by the engine (CR 605.1a, mana_abilities::is_mana_ability): true
+   *  when this is a mana ability. Absent / false otherwise. The UI uses this to
+   *  route mana-tap affordances instead of introspecting the effect AST — see
+   *  isManaObjectAction in viewmodel/cardActionChoice.ts. */
+  is_mana_ability?: boolean;
   [key: string]: unknown;
 }
 

--- a/client/src/components/board/BattlefieldBackground.tsx
+++ b/client/src/components/board/BattlefieldBackground.tsx
@@ -68,17 +68,11 @@ export function BattlefieldBackground() {
   const gameState = useGameStore((s) => s.gameState);
 
   // resolveBackground locks the chosen image in lockedRef for the "random" and
-  // "auto-wubrg" modes (once chosen, it sticks). Clear that lock when the mode
-  // or the viewed player changes, so switching backgrounds mid-session (or
-  // switching seats) doesn't keep showing a stale locked image from the prior
-  // mode/player. Comparing prior values during render is the idiomatic reset.
-  const lastModeRef = useRef(boardBackground);
-  const lastPlayerRef = useRef(playerId);
-  if (lastModeRef.current !== boardBackground || lastPlayerRef.current !== playerId) {
-    lastModeRef.current = boardBackground;
-    lastPlayerRef.current = playerId;
-    lockedRef.current = null;
-  }
+  // "auto-wubrg" modes (once chosen, it sticks for the session). The lock is
+  // reset by remount: GamePage keys this component on `${boardBackground}-${playerId}`,
+  // so switching mode or seat unmounts and remounts it with a fresh null lockedRef.
+  // That keeps render pure (no prev-value ref tracking / ref mutation during
+  // render) while preserving the same reset semantics under StrictMode.
 
   const deckColor = useMemo(() => {
     // The dominant-color scan walks the full library + hand + battlefield, and

--- a/client/src/components/board/BattlefieldBackground.tsx
+++ b/client/src/components/board/BattlefieldBackground.tsx
@@ -66,6 +66,20 @@ export function BattlefieldBackground() {
 
   const playerId = usePlayerId();
   const gameState = useGameStore((s) => s.gameState);
+
+  // resolveBackground locks the chosen image in lockedRef for the "random" and
+  // "auto-wubrg" modes (once chosen, it sticks). Clear that lock when the mode
+  // or the viewed player changes, so switching backgrounds mid-session (or
+  // switching seats) doesn't keep showing a stale locked image from the prior
+  // mode/player. Comparing prior values during render is the idiomatic reset.
+  const lastModeRef = useRef(boardBackground);
+  const lastPlayerRef = useRef(playerId);
+  if (lastModeRef.current !== boardBackground || lastPlayerRef.current !== playerId) {
+    lastModeRef.current = boardBackground;
+    lastPlayerRef.current = playerId;
+    lockedRef.current = null;
+  }
+
   const deckColor = useMemo(() => {
     // The dominant-color scan walks the full library + hand + battlefield, and
     // its result is consumed ONLY by the "auto-wubrg" background — and only

--- a/client/src/components/controls/CardCoverageDashboard.tsx
+++ b/client/src/components/controls/CardCoverageDashboard.tsx
@@ -100,6 +100,9 @@ const MAX_VISIBLE_CARDS = 200;
 // promise — switching tabs (or remounting a view) reuses the cached result
 // instead of re-fetching and re-parsing megabytes each time.
 let coveragePromise: Promise<CoverageSummary> | null = null;
+// Resolved document, kept once the fetch succeeds so a later view mount (tab
+// switch) can initialize synchronously and skip the loading flash.
+let cachedCoverage: CoverageSummary | null = null;
 
 function loadCoverageData(): Promise<CoverageSummary> {
   if (!coveragePromise) {
@@ -107,6 +110,10 @@ function loadCoverageData(): Promise<CoverageSummary> {
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json() as Promise<CoverageSummary>;
+      })
+      .then((data: CoverageSummary) => {
+        cachedCoverage = data;
+        return data;
       })
       .catch((e) => {
         // Don't cache failures: clear the shared slot so the next view mount
@@ -127,13 +134,17 @@ interface CoverageDataState {
 
 /** Shared loader for the coverage export, consumed by all dashboard views. */
 function useCoverageData(): CoverageDataState {
-  const [state, setState] = useState<CoverageDataState>({
-    coverage: null,
-    loading: true,
-    error: null,
-  });
+  // Initialize from the module cache when the doc is already loaded, so
+  // switching dashboard tabs (which remounts the view) renders data immediately
+  // rather than flashing a spinner before the cached promise re-resolves.
+  const [state, setState] = useState<CoverageDataState>(() =>
+    cachedCoverage
+      ? { coverage: cachedCoverage, loading: false, error: null }
+      : { coverage: null, loading: true, error: null },
+  );
 
   useEffect(() => {
+    if (cachedCoverage) return; // synchronous init already supplied the data
     let cancelled = false;
     loadCoverageData()
       .then((data) => {

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -873,6 +873,9 @@ function GamePageContent({
 
   // Sync card size preference to CSS custom properties
   const cardSize = usePreferencesStore((s) => s.cardSize);
+  // Keys BattlefieldBackground so a mode/seat change remounts it with a fresh
+  // lock (see BattlefieldBackground) instead of resetting refs during render.
+  const boardBackground = usePreferencesStore((s) => s.boardBackground);
   useEffect(() => {
     const root = document.documentElement;
     const scale = cardSize === "small" ? 0.8 : cardSize === "large" ? 1.25 : 1;
@@ -1078,7 +1081,7 @@ function GamePageContent({
       }}
     >
       <SpectatorChrome />
-      <BattlefieldBackground />
+      <BattlefieldBackground key={`${boardBackground}-${playerId}`} />
       <StackDisplay />
 
       {/* Persistent Sandbox banner — visible to all players whenever the

--- a/client/src/viewmodel/__tests__/cardActionChoice.test.ts
+++ b/client/src/viewmodel/__tests__/cardActionChoice.test.ts
@@ -93,7 +93,10 @@ describe("isManaObjectAction", () => {
   it("recognizes only engine-provided mana actions", () => {
     const object = makeGameObject({
       abilities: [
-        { effect: { type: "Mana" } },
+        // CR 605.1a: the engine classifies mana abilities and exposes the
+        // verdict as the derived `is_mana_ability` flag — isManaObjectAction
+        // reads the flag rather than introspecting the effect AST.
+        { is_mana_ability: true, effect: { type: "Mana" } },
         { effect: { type: "Draw" } },
       ],
     });

--- a/client/src/viewmodel/battlefieldProps.ts
+++ b/client/src/viewmodel/battlefieldProps.ts
@@ -15,7 +15,7 @@ function groupKey(obj: GameObject): string {
   // two identical permanents always land in the same group regardless of the
   // order their counters were applied (the old stringify could split them by
   // insertion order; this matches the sorted keyword key above).
-  const counters = Object.entries(obj.counters)
+  const counters = Object.entries(obj.counters ?? {})
     .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
     .map(([type, n]) => `${type}:${n}`)
     .join(",");

--- a/client/src/viewmodel/cardActionChoice.ts
+++ b/client/src/viewmodel/cardActionChoice.ts
@@ -26,7 +26,10 @@ export function isManaObjectAction(action: GameAction, object: GameObject | unde
   // creatures get no clickable affordance and the player cannot tap them.
   if (action.type === "TapForConvoke") return true;
   if (action.type !== "ActivateAbility") return false;
-  return object?.abilities?.[action.data.ability_index]?.effect?.type === "Mana";
+  // CR 605.1a: the engine classifies mana abilities (mana_abilities::is_mana_ability)
+  // and exposes the verdict as the derived `is_mana_ability` key on the serialized
+  // ability — the frontend reads the flag rather than introspecting the effect AST.
+  return object?.abilities?.[action.data.ability_index]?.is_mana_ability === true;
 }
 
 /**

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -2806,6 +2806,31 @@ mod tests {
     }
 
     #[test]
+    fn is_mana_ability_serialized_only_when_true() {
+        // The AbilityDefinition Serialize impl emits the derived `is_mana_ability`
+        // UI key (skip_serializing_if = is_false), so the client routes mana-tap
+        // affordances off this engine flag instead of introspecting the effect AST.
+        let mana = make_mana_ability(ManaProduction::Fixed {
+            colors: vec![ManaColor::Green],
+            contribution: ManaContribution::Base,
+        });
+        let mana_json = serde_json::to_value(&mana).unwrap();
+        assert_eq!(mana_json["is_mana_ability"], serde_json::json!(true));
+
+        let non_mana = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Any,
+                damage_source: None,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        let non_mana_json = serde_json::to_value(&non_mana).unwrap();
+        assert!(non_mana_json.get("is_mana_ability").is_none());
+    }
+
+    #[test]
     fn non_mana_api_type_not_detected() {
         let def = AbilityDefinition::new(
             AbilityKind::Activated,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
@@ -53,7 +53,8 @@ expression: "&ir"
         "condition": null,
         "optional_targeting": false,
         "optional": false,
-        "forward_result": false
+        "forward_result": false,
+        "is_mana_ability": true
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_lowered.snap
@@ -50,7 +50,8 @@ expression: "&lowered"
       "condition": null,
       "optional_targeting": false,
       "optional": false,
-      "forward_result": false
+      "forward_result": false,
+      "is_mana_ability": true
     }
   ],
   "triggers": [],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
@@ -26,7 +26,8 @@ expression: "&ir"
         "condition": null,
         "optional_targeting": false,
         "optional": false,
-        "forward_result": false
+        "forward_result": false,
+        "is_mana_ability": true
       }
     },
     {

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_lowered.snap
@@ -25,7 +25,8 @@ expression: "&lowered"
       "condition": null,
       "optional_targeting": false,
       "optional": false,
-      "forward_result": false
+      "forward_result": false,
+      "is_mana_ability": true
     },
     {
       "kind": "Activated",

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
@@ -26,7 +26,8 @@ expression: "&ir"
         "condition": null,
         "optional_targeting": false,
         "optional": false,
-        "forward_result": false
+        "forward_result": false,
+        "is_mana_ability": true
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_lowered.snap
@@ -25,7 +25,8 @@ expression: "&lowered"
       "condition": null,
       "optional_targeting": false,
       "optional": false,
-      "forward_result": false
+      "forward_result": false,
+      "is_mana_ability": true
     }
   ],
   "triggers": [],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 674
 expression: "&ir"
 ---
 {
@@ -55,7 +54,8 @@ expression: "&ir"
         "condition": null,
         "optional_targeting": false,
         "optional": false,
-        "forward_result": false
+        "forward_result": false,
+        "is_mana_ability": true
       }
     }
   ],

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_lowered.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 675
 expression: "&lowered"
 ---
 {
@@ -54,7 +53,8 @@ expression: "&lowered"
       "condition": null,
       "optional_targeting": false,
       "optional": false,
-      "forward_result": false
+      "forward_result": false,
+      "is_mana_ability": true
     }
   ],
   "triggers": [],

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11289,17 +11289,24 @@ impl Serialize for AbilityDefinition {
             iteration_kind_binding,
         };
         /// Flatten wrapper: the mirror carries the real field set;
-        /// `consumes_source` is the computed UI key (#506).
+        /// `consumes_source` (#506) and `is_mana_ability` (CR 605.1a) are
+        /// computed UI keys.
         #[derive(Serialize)]
         struct Outer<'a> {
             #[serde(flatten)]
             repr: AbilityDefinitionRepr<'a>,
             #[serde(skip_serializing_if = "is_false")]
             consumes_source: bool,
+            // CR 605.1a: derived mana-ability classification, emitted so the
+            // client routes mana-tap affordances off an engine-owned flag
+            // instead of introspecting the effect AST (`effect.type == "Mana"`).
+            #[serde(skip_serializing_if = "is_false")]
+            is_mana_ability: bool,
         }
         Outer {
             repr,
             consumes_source: self.consumes_source(),
+            is_mana_ability: crate::game::mana_abilities::is_mana_ability(self),
         }
         .serialize(s)
     }

--- a/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_harold_and_bob_first_numens.snap
+++ b/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_harold_and_bob_first_numens.snap
@@ -112,7 +112,8 @@ expression: result
                   "condition": null,
                   "optional_targeting": false,
                   "optional": false,
-                  "forward_result": false
+                  "forward_result": false,
+                  "is_mana_ability": true
                 }
               }
             ]

--- a/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_llanowar_elves.snap
+++ b/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_llanowar_elves.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/engine/tests/oracle_parser.rs
+source: crates/engine/tests/integration/oracle_parser.rs
 expression: result
 ---
 {
@@ -25,7 +25,8 @@ expression: result
       "condition": null,
       "optional_targeting": false,
       "optional": false,
-      "forward_result": false
+      "forward_result": false,
+      "is_mana_ability": true
     }
   ],
   "triggers": [],

--- a/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_mox_pearl.snap
+++ b/crates/engine/tests/integration/snapshots/integration__oracle_parser__snapshot_mox_pearl.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/engine/tests/oracle_parser.rs
+source: crates/engine/tests/integration/oracle_parser.rs
 expression: result
 ---
 {
@@ -25,7 +25,8 @@ expression: result
       "condition": null,
       "optional_targeting": false,
       "optional": false,
-      "forward_result": false
+      "forward_result": false,
+      "is_mana_ability": true
     }
   ],
   "triggers": [],


### PR DESCRIPTION
Two related follow-ups, both verified green (engine via Tilt clippy+wasm and a
full `cargo insta` engine run; frontend tsc + eslint + 1336/1336 vitest).

## Engine/FE boundary: is_mana_ability (CR 605.1a)

`isManaObjectAction` (viewmodel/cardActionChoice.ts) decided mana-tap-ring routing
by introspecting the serialized ability AST (`effect.type === "Mana"`) — engine-owned
structural knowledge in the display layer, and shallower than the engine's own
classifier (it skipped the CR 605.1a no-target guard).

The engine now emits a derived `is_mana_ability` UI key on serialized abilities
(skip-if-false), computed via the single-source-of-truth
`mana_abilities::is_mana_ability` classifier — mirroring the existing
`consumes_source` key. The frontend reads the flag; it never inspects the effect
tree. 11 oracle_ir / integration snapshots gain the additive key for their
mana-source abilities (regenerated via `cargo insta`, purely additive).

## #3162 Gemini review follow-ups

Three fixes from Gemini code-assist's review of the cleanup PR (#3162):
- BattlefieldBackground: reset `lockedRef` when the background mode or viewed
  player changes, so switching modes/seats mid-session no longer shows a stale
  locked image.
- CardCoverageDashboard: keep the resolved coverage doc in a module-level cache so
  switching dashboard tabs initializes synchronously instead of flashing a spinner.
- battlefieldProps.groupKey: guard `Object.entries(obj.counters ?? {})` against a
  missing counters map on the board-rebuild hot path.

## Note

Built atop the merged #3162. The engine change is isolated from concurrent
in-progress work in the local tree (shipped by cherry-pick onto clean origin/main).
