### PR TITLE
fix(engine): fire ETB observers when an as-enters-choice permanent enters (#830)

### DIFF
--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -35,16 +35,25 @@ pub(super) fn run_post_action_pipeline_from(
     // (e.g., a creature that just took lethal damage) are found by the scan.
     // This follows the same pattern as process_combat_damage_triggers in combat_damage.rs.
     //
-    // CR 614.12a + CR 707.9: Mid-entry `CopyTargetChoice` deferral happens at
-    // the producer site (`apply_pending_post_replacement_effect`), which both
-    // emits the entering object's `ZoneChanged` and decides whether to pause
-    // for a copy choice. By the time the pipeline reaches this trigger scan,
-    // events that should be deferred have already been moved into
-    // `state.deferred_entry_events` for replay by `handle_copy_target_choice`.
+    // CR 614.12a + CR 707.9: Mid-entry choice deferral (`CopyTargetChoice`,
+    // `ChooseOneOfBranch` enters-counter, and `NamedChoice` as-enters-choose)
+    // captures the entering object's `ZoneChanged` event into
+    // `state.deferred_entry_events` for replay once the choice resolves. The
+    // original event remains in `events` for the frontend animation, but it
+    // MUST NOT reach `process_triggers` / `collect_triggers_into_deferred`
+    // here — the replay in `replay_deferred_entry_events` owns the single
+    // authoritative trigger scan for those events. Without this exclusion, the
+    // entry ZoneChanged is collected once here (into `deferred_triggers` via
+    // `collect_triggers_into_deferred` when `waiting_for` is `NamedChoice`)
+    // and fired a second time by the replay, causing double-fire for ETB
+    // observers like Soul Warden (issue #830).
     if !skip_trigger_scan {
         let filtered_events: Vec<_> = events[event_start..]
             .iter()
-            .filter(|event| !matches!(event, GameEvent::PhaseChanged { .. }))
+            .filter(|event| {
+                !matches!(event, GameEvent::PhaseChanged { .. })
+                    && !state.deferred_entry_events.contains(event)
+            })
             .cloned()
             .collect();
         // CR 603.3b: If the resolution step that just ran paused for a player

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -768,6 +768,44 @@ pub(super) fn handle_copy_target_choice(
     // on the battlefield — concede / error / chained-replacement paths can
     // leave a stale event in the vec, and we discard rather than fire a
     // phantom entry trigger.
+    if let Some(waiting_for) = replay_deferred_entry_events(state, source_id, events)? {
+        return Ok(waiting_for);
+    }
+    Ok(WaitingFor::Priority {
+        player: state.active_player,
+    })
+}
+
+/// CR 603.2 + CR 614.12a: Replay the deferred battlefield-entry `ZoneChanged`
+/// event(s) for `source_id` through the trigger pipeline after a mid-entry
+/// player choice (copy target, enters-with-counter branch, or as-enters named
+/// choice) has resolved, then surface any interactive trigger pause that
+/// replay raised. This is the single authority for deferred-entry replay — both
+/// the copy-completion site (`handle_copy_target_choice`) and the as-enters
+/// named-choice resume site (`engine_resolution_choices.rs`) route through it,
+/// so the pause-propagation logic is defined exactly once.
+///
+/// The entry event was captured into `state.deferred_entry_events` by
+/// `capture_deferred_entry_events_if_mid_entry_choice` *before* the choice was
+/// made, so that ETB observers (constellation, Soul Warden) and any granted
+/// ETB triggers (Callidus Assassin) match against the fully realized,
+/// post-choice object — not a half-entered one (CR 614.12a: the choice is made
+/// before the permanent enters). `process_triggers` (CR 603.2 event-based
+/// triggers) + `check_delayed_triggers` (CR 603.7c delayed triggers) collect
+/// against the realized object.
+///
+/// Drained via `std::mem::take` so replay is idempotent — the event is fired
+/// exactly once and can never also reach a later `Priority`-result pipeline
+/// pass. Returns `None` (no pause) when `deferred_entry_events` is empty (the
+/// no-op guard for non-entry persisted choices, e.g. Pithing Needle naming),
+/// or when the entering source has left the battlefield (concede / error /
+/// chained-replacement paths leave a stale event we discard rather than fire
+/// against a phantom object).
+pub(super) fn replay_deferred_entry_events(
+    state: &mut GameState,
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> Result<Option<WaitingFor>, EngineError> {
     let deferred = std::mem::take(&mut state.deferred_entry_events);
     let source_still_on_battlefield = state
         .objects
@@ -781,7 +819,7 @@ pub(super) fn handle_copy_target_choice(
     effects::drain_pending_continuation(state, events);
     // CR 113.2c + CR 603.3b + CR 707.10: `process_triggers` above may have
     // paused on an interactive replayed ETB trigger fired by the realized
-    // copy. When it pauses it sets `state.pending_trigger` for the active
+    // entry. When it pauses it sets `state.pending_trigger` for the active
     // instance and stashes any simultaneously-fired siblings into
     // `state.deferred_triggers`. This mirrors the priority-time
     // `process_triggers` call site in `engine_priority`, so the resumption
@@ -802,21 +840,20 @@ pub(super) fn handle_copy_target_choice(
     // `engine_modes::handle_triggered_mode_choice`, or the `DistributeAmong`
     // handler) once the player resolves the active trigger.
     if matches!(state.waiting_for, WaitingFor::DistributeAmong { .. }) {
-        return Ok(state.waiting_for.clone());
+        return Ok(Some(state.waiting_for.clone()));
     }
     // CR 603.3b (#531): propagate OrderTriggers pause from process_triggers
-    // above. Without this, a doubled replayed ETB trigger (e.g., Wedding
-    // Announcement's token + Ocelot Pride's life-gain rider both firing on the
-    // copy entry) would silently fall through to Priority.
+    // above. Without this, multiple simultaneously-fired ETB observers on one
+    // entry (e.g., two constellation triggers, or Wedding Announcement's token
+    // + Ocelot Pride's life-gain rider on a copy entry) would silently fall
+    // through to Priority.
     if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
-        return Ok(state.waiting_for.clone());
+        return Ok(Some(state.waiting_for.clone()));
     }
     if let Some(waiting_for) = super::engine::begin_pending_trigger_target_selection(state)? {
-        return Ok(waiting_for);
+        return Ok(Some(waiting_for));
     }
-    Ok(WaitingFor::Priority {
-        player: state.active_player,
-    })
+    Ok(None)
 }
 
 fn copy_effect_for_source(state: &GameState, source_id: ObjectId) -> Option<&AbilityDefinition> {
@@ -961,7 +998,7 @@ pub(super) fn apply_pending_post_replacement_effect(
     // single producer site so both the stack-resolution path (non-optional
     // copy replacements) and the `handle_replacement_choice` path (optional
     // "you may have this enter as a copy" replacements) defer uniformly.
-    capture_deferred_entry_events_if_copy_target_choice(state, waiting_for.as_ref(), events);
+    capture_deferred_entry_events_if_mid_entry_choice(state, waiting_for.as_ref(), events);
     waiting_for
 }
 
@@ -984,20 +1021,35 @@ fn is_enters_counter_choice(branches: &[AbilityDefinition]) -> bool {
         })
 }
 
-/// CR 614.12a + CR 707.9: If `waiting_for` is `CopyTargetChoice`, or a
-/// `ChooseOneOfBranch` that `is_enters_counter_choice` (the enters-with-choice-
-/// of-counter shape), clone any battlefield-entry `ZoneChanged` events for the
-/// entering source into `state.deferred_entry_events`. The original `events` vec
-/// is preserved so the frontend animates the entry as soon as the spell
-/// resolves; the deferred copy is replayed through `process_triggers` /
-/// `check_delayed_triggers` once the choice resolves (in
-/// `handle_copy_target_choice` for copies, in the `ChooseBranch` arm of
-/// `engine_resolution_choices.rs` for enters-counter choices).
+/// CR 603.2 + CR 614.12a: When a permanent's battlefield entry pauses on a
+/// mid-entry player choice — `CopyTargetChoice` (enter as a copy), a
+/// `ChooseOneOfBranch` that `is_enters_counter_choice` (enter with your choice
+/// of counter), or a persisted `NamedChoice` whose `source_id` is the entering
+/// permanent (the "As it enters, choose a color/creature type/…" shape, e.g.
+/// Valgavoth's Lair) — clone any battlefield-entry `ZoneChanged` events for the
+/// entering source into `state.deferred_entry_events`. The original `events`
+/// vec is preserved so the frontend animates the entry as soon as the spell /
+/// land-play resolves; the deferred copy is replayed through `process_triggers`
+/// / `check_delayed_triggers` once the choice resolves (in
+/// `handle_copy_target_choice` for copies, in the `ChooseBranch` arm and the
+/// `NamedChoice` + `ChooseOption` arm of `engine_resolution_choices.rs` for the
+/// other two shapes), so every ETB observer (constellation like Doomwake Giant,
+/// Soul Warden, …) sees the entry against the fully realized post-choice object.
+/// Without this, the entry event returns `WaitingFor::NamedChoice` instead of
+/// `Priority`, so the canonical priority-time trigger collection
+/// (`engine_priority::run_post_action_pipeline`) is skipped and every ETB
+/// observer is silently dropped for that entry (issue #830).
+///
+/// The `NamedChoice` arm is keyed on the structural fact that an entry
+/// `ZoneChanged` for the same source is present in `events` (the capture loop
+/// below only pushes matching events). Non-entry persisted `NamedChoice`s —
+/// Pithing Needle naming, a `Choose` resolved off the stack — carry no such
+/// entry event, so nothing is captured and the downstream replay is a no-op.
 ///
 /// Defense in depth: clears any stale events from a prior choice that exited
 /// abnormally (concede mid-choice, eliminate_player, error return before drain)
 /// so the replay never fires triggers against a phantom object.
-fn capture_deferred_entry_events_if_copy_target_choice(
+fn capture_deferred_entry_events_if_mid_entry_choice(
     state: &mut GameState,
     waiting_for: Option<&WaitingFor>,
     events: &[GameEvent],
@@ -1012,6 +1064,18 @@ fn capture_deferred_entry_events_if_copy_target_choice(
             branches,
             ..
         }) if is_enters_counter_choice(branches) => *source_id,
+        // CR 603.2 + CR 614.12a: an "As it enters, choose …" replacement
+        // (Valgavoth's Lair, the Thriving lands, Voice of All) pauses the entry
+        // on a persisted `NamedChoice` whose `source_id` is the entering
+        // permanent. Defer the entry event exactly like the copy/counter shapes
+        // so ETB observers fire against the post-choice object once the player
+        // answers. The entry-event filter in the capture loop scopes this to the
+        // entering source — a persisted `NamedChoice` with no matching entry
+        // event in `events` (Pithing Needle naming) captures nothing.
+        Some(WaitingFor::NamedChoice {
+            source_id: Some(source_id),
+            ..
+        }) => *source_id,
         _ => return,
     };
     // CR 614.12b boundary (inherited from the CopyTargetChoice path, NOT expanded

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2942,6 +2942,42 @@ pub(super) fn handle_resolution_choice(
                         events,
                     )?;
                 }
+            } else if let Some(source) =
+                source_id.filter(|_| !state.deferred_entry_events.is_empty())
+            {
+                // CR 603.2 + CR 614.12a (#830): an "As it enters, choose …"
+                // replacement (Valgavoth's Lair, the Thriving lands) paused this
+                // permanent's battlefield entry on a persisted `NamedChoice`, so
+                // the entry's `ZoneChanged` never reached the priority-time
+                // trigger collection (`run_post_action_pipeline`). The capture in
+                // `engine_replacement::capture_deferred_entry_events_if_mid_entry_choice`
+                // stashed that event into `state.deferred_entry_events`; now that
+                // the chosen attribute is folded onto the entering permanent,
+                // replay it through the shared deferred-entry authority so every
+                // ETB observer (constellation like Doomwake Giant, Soul Warden, …)
+                // fires against the realized post-choice object. The helper drains
+                // the pending continuation (so this arm fully replaces the plain
+                // `drain_pending_continuation` below) and surfaces any interactive
+                // trigger pause (OrderTriggers / DistributeAmong / target
+                // selection) raised by simultaneously-fired observers.
+                //
+                // Gated on `deferred_entry_events` being non-empty so a non-entry
+                // persisted `NamedChoice` (Pithing Needle naming, Morophon type
+                // choice) takes the unchanged `else` path below — the no-op
+                // disambiguator that keeps the working path byte-for-byte intact.
+                // `last_named_choice` is left set across the helper's continuation
+                // drain (cleared after, mirroring the plain path) so any dependent
+                // continuation reads the answer.
+                let replay = crate::game::engine_replacement::replay_deferred_entry_events(
+                    state, source, events,
+                )?;
+                state.last_named_choice = None;
+                if let Some(waiting_for) = replay {
+                    return Ok(ResolutionChoiceOutcome::WaitingFor(waiting_for));
+                }
+                return Ok(ResolutionChoiceOutcome::WaitingFor(
+                    state.waiting_for.clone(),
+                ));
             } else {
                 effects::drain_pending_continuation(state, events);
             }

--- a/crates/engine/tests/constellation_enters_with_choice.rs
+++ b/crates/engine/tests/constellation_enters_with_choice.rs
@@ -1,0 +1,219 @@
+//! Issue #830 — ETB observers must fire when a permanent enters carrying an
+//! "As it enters, choose …" replacement that pauses the entry on a player
+//! choice (e.g. Valgavoth's Lair — "As it enters, choose a color").
+//!
+//! Root cause: such an entry returns `WaitingFor::NamedChoice` instead of
+//! `WaitingFor::Priority`, so the canonical priority-time trigger collection
+//! (`engine_priority::run_post_action_pipeline`) is skipped and the entering
+//! permanent's `ZoneChanged` event never reaches `process_triggers`. Every ETB
+//! observer on the battlefield (constellation like Doomwake Giant, Soul Warden,
+//! …) is silently dropped for that entry.
+//!
+//! These tests drive the REAL apply() pipeline (play land → resolve as-enters
+//! choice → resolve triggers off the stack), not a hand-built state.
+
+use engine::game::scenario::GameScenario;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+// Doomwake Giant's constellation: every enchantment you control entering gives
+// opponents' creatures -1/-1 until end of turn (CR 603.2 event-based trigger).
+const DOOMWAKE: &str = "Constellation — Whenever this creature or another enchantment you control \
+     enters, creatures your opponents control get -1/-1 until end of turn.";
+
+// Valgavoth's Lair: an enchantment land with an as-enters color choice — the
+// reported failing class. Its `Choose{Color, persist:true}` replacement pauses
+// the entry on `WaitingFor::NamedChoice`.
+const VALGAVOTHS_LAIR: &str = "~ enters tapped. As it enters, choose a color.";
+
+// A plain enchantment with NO as-enters choice — resolves off the stack to
+// `WaitingFor::Priority`, exercising the already-working trigger path.
+// Deliberately has no ETB effect so no side-state is produced (drawing from an
+// empty library would set `drew_from_empty_library` and kill P0 at the next
+// SBA check before Doomwake's trigger resolves).
+const PLAIN_ENCHANTMENT: &str = "Hexproof.";
+
+// Soul Warden: a non-constellation ETB observer (proves the fix covers the
+// general ETB-observer class, not just constellation).
+const SOUL_WARDEN: &str = "Whenever another creature enters, you gain 1 life.";
+
+/// Discriminating bug repro (#830): with Doomwake Giant on the battlefield,
+/// playing an as-enters-choose-color land and answering the color MUST fire
+/// Doomwake's constellation trigger. Fails before the fix — the entry's
+/// `ZoneChanged` never reaches `process_triggers`, so the opponent creature
+/// keeps its full toughness.
+///
+/// Reverting the fix flips the final assertion: `opp_creature.toughness`
+/// remains 2 (trigger never collected) instead of dropping to 1.
+#[test]
+fn as_enters_choice_land_fires_constellation() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Doomwake Giant (the constellation observer) under P0.
+    let doomwake = scenario
+        .add_creature_from_oracle(P0, "Doomwake Giant", 4, 6, DOOMWAKE)
+        .as_enchantment()
+        .id();
+
+    // An opponent creature whose toughness the constellation trigger reduces.
+    let opp_creature = scenario.add_creature(P1, "Opponent Bear", 2, 2).id();
+
+    // The as-enters-choice land in P0's hand.
+    // Valgavoth's Lair is an Enchantment Land — the Enchantment type is what
+    // Doomwake's "another enchantment you control" branch matches on.
+    let lair = {
+        let mut b = scenario.add_land_to_hand(P0, "Valgavoth's Lair");
+        b.from_oracle_text(VALGAVOTHS_LAIR).as_enchantment();
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects.get(&lair).unwrap().card_id;
+
+    let _ = doomwake;
+
+    // Play the land — its entry pauses on the as-enters color choice.
+    runner
+        .act(GameAction::PlayLand {
+            object_id: lair,
+            card_id,
+        })
+        .expect("play Valgavoth's Lair");
+
+    let WaitingFor::NamedChoice { options, .. } = runner.state().waiting_for.clone() else {
+        panic!(
+            "as-enters land must pause on the color choice, got {}",
+            runner.waiting_for_kind()
+        );
+    };
+    let color = options.first().expect("color options").clone();
+
+    // Answer the color — this is where the deferred entry event must replay.
+    runner
+        .act(GameAction::ChooseOption { choice: color })
+        .expect("choose the color");
+
+    // Resolve the now-stacked constellation trigger.
+    runner.advance_until_stack_empty();
+
+    let toughness = runner
+        .state()
+        .objects
+        .get(&opp_creature)
+        .and_then(|o| o.toughness)
+        .expect("opponent creature toughness");
+    assert_eq!(
+        toughness, 1,
+        "Doomwake's constellation must fire when an as-enters-choice land enters \
+         (#830): opponent's 2/2 should be 1/1 after -1/-1, got toughness {toughness}"
+    );
+}
+
+/// Regression guard for the already-working path: a PLAIN enchantment (no
+/// as-enters choice) resolving off the stack to `WaitingFor::Priority` must
+/// STILL fire Doomwake's constellation. Proves the fix does not regress the
+/// canonical priority-time trigger collection nor double-fire the entry.
+#[test]
+fn plain_enchantment_still_fires_constellation() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let doomwake = scenario
+        .add_creature_from_oracle(P0, "Doomwake Giant", 4, 6, DOOMWAKE)
+        .as_enchantment()
+        .id();
+    let opp_creature = scenario.add_creature(P1, "Opponent Bear", 2, 2).id();
+
+    // A plain enchantment cast from hand — no as-enters choice.
+    let aura = {
+        let mut b = scenario.add_creature_to_hand(P0, "Plain Sigil", 0, 0);
+        b.from_oracle_text(PLAIN_ENCHANTMENT).as_enchantment();
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects.get(&aura).unwrap().card_id;
+    let _ = doomwake;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: aura,
+            card_id,
+            targets: vec![],
+            payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+        })
+        .expect("cast the plain enchantment");
+    runner.advance_until_stack_empty();
+
+    let toughness = runner
+        .state()
+        .objects
+        .get(&opp_creature)
+        .and_then(|o| o.toughness)
+        .expect("opponent creature toughness");
+    assert_eq!(
+        toughness, 1,
+        "plain enchantment (Priority-result path) must still fire constellation; \
+         got toughness {toughness}"
+    );
+}
+
+/// Class-generality guard: a NON-constellation ETB observer (Soul Warden, "gain
+/// 1 life whenever another creature enters") must also fire off an as-enters-
+/// choice CREATURE entry. Proves the fix covers the whole ETB-observer class,
+/// not just constellation/enchantment cards.
+#[test]
+fn as_enters_choice_creature_fires_soul_warden() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let soul_warden = scenario
+        .add_creature_from_oracle(P0, "Soul Warden", 1, 1, SOUL_WARDEN)
+        .id();
+    let _ = soul_warden;
+
+    // An as-enters-choose-color creature in P0's hand (Voice of All shape).
+    let voice = {
+        let mut b = scenario.add_creature_to_hand(P0, "Voice of All", 2, 2);
+        b.from_oracle_text("As this creature enters, choose a color.");
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects.get(&voice).unwrap().card_id;
+    let life_before = runner.life(P0);
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: voice,
+            card_id,
+            targets: vec![],
+            payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+        })
+        .expect("cast the as-enters-choice creature");
+    runner.advance_until_stack_empty();
+
+    let WaitingFor::NamedChoice { options, .. } = runner.state().waiting_for.clone() else {
+        panic!(
+            "as-enters creature must pause on the color choice, got {}",
+            runner.waiting_for_kind()
+        );
+    };
+    let color = options.first().expect("color options").clone();
+    runner
+        .act(GameAction::ChooseOption { choice: color })
+        .expect("choose the color");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.life(P0),
+        life_before + 1,
+        "Soul Warden must gain 1 life when an as-enters-choice creature enters (#830)"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes #830 — when a permanent enters carrying an "As it enters, choose …" replacement (e.g. Valgavoth's Lair → "choose a color"), the entry pauses on `WaitingFor::NamedChoice` instead of `WaitingFor::Priority`. The canonical priority-time trigger collection was skipped, so **every ETB observer** (constellation like Doomwake Giant, Soul Warden, etc.) was silently dropped for that entry.

## Root cause
`run_post_action_pipeline` collects ETB triggers only on a `WaitingFor::Priority` result; an as-enters-choice entry returns `NamedChoice`, so the entering permanent's `ZoneChanged` never reached `process_triggers`.

## Fix
Generalize the existing `state.deferred_entry_events` mechanism (previously gated to copy-target / counter choices) to capture as-enters `NamedChoice { source_id: Some(_) }` entries, and replay them on choice resolution through a shared `replay_deferred_entry_events` helper that surfaces interactive `OrderTriggers`/`DistributeAmong` pauses. **CR 614.12a** (the choice is made before the permanent enters).

### Double-fire fix (engine_priority.rs)
The `CastSpell` path (creature/enchantment via stack resolution) does **not** skip `run_post_action_pipeline` the way `PlayLand` does, so an as-enters-choice creature's ETB observer was collected twice — once from the still-present entry `ZoneChanged` in `events`, once from the deferred replay. The trigger scan now **excludes events already in `deferred_entry_events`** while leaving them in `events` for frontend animation (a "two readers, one writer" contract). This also eliminates a pre-existing latent double-fire on the copy-target-choice path.

## Class coverage
Engine-pipeline-level fix covering ~280 as-enters-choice permanents × the entire ETB-observer class — both `PlayLand` (lands) and `CastSpell` (creatures/enchantments) entry paths.

## Tests (`constellation_enters_with_choice.rs`, 3/3)
- `as_enters_choice_land_fires_constellation` — land path repro (toughness 2→1; discriminates zero-fire AND double-fire).
- `plain_enchantment_still_fires_constellation` — regression guard for the untouched Priority path.
- `as_enters_choice_creature_fires_soul_warden` — creature-via-stack double-fire discriminator (life +1, not +2).

Plan reviewed clean. Implementation reviewed clean **twice** (the second review, after the double-fire fix, adversarially verified copy-path safety, hot-path perf N≈0, `GameEvent` `PartialEq` soundness, and double-fire completeness). Full `test-engine` suite green (12791 passed). CR numbers grep-verified.