### PR TITLE
fix(engine): play-from-exile permission is consultable from the graveyard for milled cards (#751)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -603,6 +603,7 @@ fn graveyard_spell_objects_available_to_cast(
     let mut keyword_objects = Vec::new();
     let mut permission_objects = Vec::new();
     let mut timed_permission_objects = Vec::new();
+    let mut play_from_exile_objects = Vec::new();
 
     for &obj_id in graveyard {
         let Some(obj) = state.objects.get(&obj_id) else {
@@ -610,6 +611,18 @@ fn graveyard_spell_objects_available_to_cast(
         };
         if obj.owner != player {
             continue;
+        }
+
+        // CR 701.17d: A mill effect that grants permission to play "that card"
+        // attaches an object-tagged `PlayFromExile` to the milled card in the
+        // graveyard (Ark of Hunger, Tablet of Discovery). The permission is
+        // consultable from the graveyard exactly as from exile; only non-land
+        // cards reach the cast path (CR 305.1 — milled lands are played via
+        // `graveyard_lands_playable_by_permission`).
+        if play_from_exile_object_in_cast_path(obj)
+            && play_from_exile_permission_source(state, obj, player, state.turn_number).is_some()
+        {
+            play_from_exile_objects.push(obj_id);
         }
 
         // CR 702.34 / CR 702.81 / CR 702.127 / CR 702.138 / CR 702.180:
@@ -654,6 +667,7 @@ fn graveyard_spell_objects_available_to_cast(
     let mut objects = keyword_objects;
     objects.extend(permission_objects);
     objects.extend(timed_permission_objects);
+    objects.extend(play_from_exile_objects);
     objects
 }
 
@@ -1396,8 +1410,37 @@ fn has_exile_cast_permission(
 
 /// CR 305.1 + CR 601.2a: Lands in exile may be played by permissions that say
 /// "play", but they never enter the spell-cast path.
+///
+/// EXILE-ONLY BY RULE: this predicate gates the battlefield-static
+/// `StaticMode::ExileCastPermission` path (Maralen, The Matrix of Time). Those
+/// statics function on cards exiled *with* their source (CR 113.6b), so a card
+/// that has since left exile (e.g. milled into a graveyard by another effect)
+/// must NOT be admitted — see the zone re-check at the static callers. Do not
+/// widen this to other zones; the object-tagged `PlayFromExile` path uses
+/// [`play_from_exile_object_in_cast_path`] instead.
 fn exile_object_can_enter_cast_path(obj: &GameObject) -> bool {
     obj.zone == Zone::Exile
+        && !obj
+            .card_types
+            .core_types
+            .contains(&crate::types::card_type::CoreType::Land)
+}
+
+/// CR 701.17d + CR 305.1 + CR 601.2a: A card carrying an object-tagged
+/// [`CastingPermission::PlayFromExile`] may enter the spell-cast path from
+/// exile (impulse draw) OR from the graveyard (a mill effect that grants
+/// permission to play "that card" — CR 701.17d — attaches the permission to the
+/// milled card in the graveyard). Lands are excluded from the cast path in both
+/// zones (CR 305.1: lands are *played*, not cast); a milled land flows through
+/// [`graveyard_lands_playable_by_permission`] / [`exile_lands_playable_by_permission`]
+/// instead.
+///
+/// This is the single DRY admission predicate for the three object-tagged
+/// `PlayFromExile` consult sites (legal-actions surface, `prepare_spell_cast`).
+/// It does NOT touch the battlefield-static path, which stays exile-only via
+/// [`exile_object_can_enter_cast_path`].
+fn play_from_exile_object_in_cast_path(obj: &GameObject) -> bool {
+    matches!(obj.zone, Zone::Exile | Zone::Graveyard)
         && !obj
             .card_types
             .core_types
@@ -1409,7 +1452,7 @@ fn exile_object_castable_by_permission(
     obj: &GameObject,
     player: PlayerId,
 ) -> bool {
-    exile_object_can_enter_cast_path(obj)
+    play_from_exile_object_in_cast_path(obj)
         && has_exile_cast_permission(state, obj, player, state.turn_number)
 }
 
@@ -2376,8 +2419,13 @@ pub(crate) fn top_of_library_alt_ability_cost_for_object(
     )
 }
 
-/// CR 604.2 + CR 305.1: Find lands in the player's graveyard that can be played
-/// via a GraveyardCastPermission static with `play_mode: Play`.
+/// CR 604.2 + CR 305.1 + CR 701.17d: Find lands in the player's graveyard that
+/// can be played, via either a `GraveyardCastPermission` static with
+/// `play_mode: Play` (Muldrotha class) OR an object-tagged
+/// [`CastingPermission::PlayFromExile`] (a milled land whose "you may play that
+/// card" mill grant attached the permission to it in the graveyard — CR 701.17d,
+/// Ark of Hunger / Tablet of Discovery milling a land). Returns
+/// `(land_id, source_id)` for once-per-turn tracking by the play-land path.
 pub fn graveyard_lands_playable_by_permission(
     state: &GameState,
     player: PlayerId,
@@ -2387,6 +2435,27 @@ pub fn graveyard_lands_playable_by_permission(
         Some(p) => p,
         None => return results,
     };
+
+    // CR 701.17d: Object-tagged `PlayFromExile` on a milled land in the
+    // graveyard. Mirrors the object-tagged branch of
+    // `exile_lands_playable_by_permission`.
+    for &gy_obj_id in &player_data.graveyard {
+        let Some(obj) = state.objects.get(&gy_obj_id) else {
+            continue;
+        };
+        if !obj
+            .card_types
+            .core_types
+            .contains(&crate::types::card_type::CoreType::Land)
+        {
+            continue;
+        }
+        if let Some((source, _)) =
+            play_from_exile_permission_source(state, obj, player, state.turn_number)
+        {
+            results.push((gy_obj_id, source));
+        }
+    }
 
     let sources = graveyard_permission_sources(state, player, Some(CardPlayMode::Play));
     for source in &sources {
@@ -3096,9 +3165,15 @@ fn prepare_spell_cast_with_variant_override_inner(
         .objects
         .get(&object_id)
         .ok_or_else(|| EngineError::InvalidAction("Object not found".to_string()))?;
-    // CR 715.3d: Cards in exile with AdventureCreature or ExileWithAltCost permission.
-    let has_exile_permission =
-        obj.zone == Zone::Exile && has_exile_cast_permission(state, obj, player, state.turn_number);
+    // CR 715.3d + CR 701.17d: Cards carrying an object-tagged play/cast
+    // permission. Exile sources cover AdventureCreature / ExileWithAltCost /
+    // impulse `PlayFromExile`; the graveyard branch covers a milled card whose
+    // `PlayFromExile` was granted by a "you may play that card" mill effect
+    // (CR 701.17d — the permission lands on the card in the graveyard). Lands
+    // are excluded in both zones (CR 305.1) via
+    // `play_from_exile_object_in_cast_path`.
+    let has_object_tagged_play_permission = play_from_exile_object_in_cast_path(obj)
+        && has_exile_cast_permission(state, obj, player, state.turn_number);
     let has_madness = obj.zone == Zone::Exile
         && matches!(variant_override, Some(CastingVariant::Madness))
         && obj.owner == player
@@ -3157,7 +3232,7 @@ fn prepare_spell_cast_with_variant_override_inner(
         && obj.owner != player
         && has_alt_cost_permission_for(obj, state, player);
     let castable_zone = has_unowned_exile_permission
-        || has_exile_permission
+        || has_object_tagged_play_permission
         || has_during_resolution_alt_cost
         || (obj.owner == player
             && (obj.zone == Zone::Hand

--- a/crates/engine/tests/integration/ark_of_hunger_play_from_graveyard_751.rs
+++ b/crates/engine/tests/integration/ark_of_hunger_play_from_graveyard_751.rs
@@ -1,0 +1,314 @@
+//! Regression test for GitHub issue #751 — Ark of Hunger / Tablet of Discovery
+//! ("{T}: Mill a card. You may play that card this turn.").
+//!
+//! CR 701.17d: When a mill effect grants permission to play "that card", the
+//! permission applies to the milled card — which lives in the GRAVEYARD
+//! (CR 701.17a/c, a public zone), not in exile. The parser emits
+//! `Mill (→ Graveyard)` chained to `GrantCastingPermission { PlayFromExile,
+//! TrackedSet 0 }`, so the grant lands on a graveyard object. Before the fix
+//! every `PlayFromExile` consult site hard-gated on `Zone::Exile`, so the
+//! milled card carried a live-but-never-consulted permission and was reported
+//! "not in a castable zone".
+//!
+//! The fix makes the three object-tagged `PlayFromExile` consult sites
+//! zone-aware (exile OR graveyard, lands excluded from the cast path per
+//! CR 305.1). The battlefield-static exile-cast path (Maralen / The Matrix of
+//! Time) stays exile-only by rule (CR 113.6b), which the Advanced
+//! Reconstruction case below asserts.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::casting::{
+    graveyard_lands_playable_by_permission, spell_objects_available_to_cast,
+};
+use engine::game::effects::resolve_ability_chain;
+use engine::game::layers::prune_end_of_turn_casting_permissions;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, CastingPermission, Duration};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::CardId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::zones::Zone;
+
+/// Ark of Hunger's `{T}` ability chain: `Mill a card. You may play that card
+/// this turn.` The parser emits `Mill (→ Graveyard)` then
+/// `GrantCastingPermission { PlayFromExile UntilEndOfTurn, TrackedSet 0 }`.
+fn ark_of_hunger_mill_grant_chain() -> engine::types::ability::AbilityDefinition {
+    parse_effect_chain(
+        "Mill a card. You may play that card this turn.",
+        AbilityKind::Activated,
+    )
+}
+
+/// Build a battlefield Ark-of-Hunger-like source plus a single library card,
+/// drive the real `Mill → GrantCastingPermission` chain, and return the runner
+/// with the milled card now in the graveyard carrying `PlayFromExile`.
+fn mill_one_and_grant(
+    runner: &mut GameRunner,
+    library_card_name: &str,
+    is_land: bool,
+    mana_cost: ManaCost,
+) -> engine::types::identifiers::ObjectId {
+    let source = {
+        let state = runner.state_mut();
+        let id = create_object(
+            state,
+            CardId(1),
+            P0,
+            "Ark of Hunger".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Artifact);
+        id
+    };
+
+    let milled = {
+        let state = runner.state_mut();
+        let id = create_object(
+            state,
+            CardId(2),
+            P0,
+            library_card_name.to_string(),
+            Zone::Library,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        if is_land {
+            obj.card_types.core_types = vec![CoreType::Land];
+        } else {
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = mana_cost;
+        }
+        id
+    };
+
+    let chain = ark_of_hunger_mill_grant_chain();
+    let resolved = build_resolved_from_def(&chain, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("Ark of Hunger mill + grant resolution");
+
+    milled
+}
+
+/// Primary fix: a milled NON-LAND card lands in the graveyard, carries a live
+/// `PlayFromExile`, surfaces on the cast path, and actually casts from the
+/// graveyard through the pipeline.
+///
+/// Discriminating assertion (flips when the fix is reverted): the milled card
+/// MUST appear in `spell_objects_available_to_cast(state, P0)`. Pre-fix this
+/// returns an empty set for the graveyard card (the consult site gated on
+/// `Zone::Exile`), and the subsequent `runner.cast(...)` would fail with
+/// "Card is not in a castable zone".
+#[test]
+fn milled_card_is_castable_from_graveyard() {
+    let mut scenario = GameScenario::new();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(
+            ManaType::Red,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        )],
+    );
+    let mut runner = scenario.build();
+
+    let milled = mill_one_and_grant(
+        &mut runner,
+        "Milled Bear",
+        false,
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        },
+    );
+
+    // CR 701.17a/c: the milled card is in the graveyard (public zone), NOT exile.
+    assert_eq!(
+        runner.state().objects[&milled].zone,
+        Zone::Graveyard,
+        "milled card must be in the graveyard"
+    );
+    // CR 701.17d: the grant attached `PlayFromExile` to the graveyard card.
+    assert!(
+        runner.state().objects[&milled]
+            .casting_permissions
+            .iter()
+            .any(|p| matches!(
+                p,
+                CastingPermission::PlayFromExile {
+                    duration: Duration::UntilEndOfTurn,
+                    granted_to,
+                    ..
+                } if *granted_to == P0
+            )),
+        "milled card must carry PlayFromExile (UntilEndOfTurn) for P0; got {:?}",
+        runner.state().objects[&milled].casting_permissions
+    );
+
+    // DISCRIMINATING ASSERTION — flips when the fix is reverted.
+    assert!(
+        spell_objects_available_to_cast(runner.state(), P0).contains(&milled),
+        "milled non-land card must surface on the cast path from the graveyard (#751)"
+    );
+
+    // Drive the real cast pipeline: graveyard -> stack.
+    runner.state_mut().phase = engine::types::phase::Phase::PreCombatMain;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = engine::types::game_state::WaitingFor::Priority { player: P0 };
+    runner.cast(milled).resolve();
+    assert_ne!(
+        runner.state().objects[&milled].zone,
+        Zone::Graveyard,
+        "casting from the graveyard must move the card out of the graveyard \
+         (graveyard -> stack -> battlefield)"
+    );
+}
+
+/// Land variant: a milled LAND with `PlayFromExile` is playable via the
+/// land-play path (`graveyard_lands_playable_by_permission`) and MUST NOT reach
+/// the spell-cast path (CR 305.1 — lands are played, not cast).
+#[test]
+fn milled_land_is_playable_via_land_path_not_cast_path() {
+    let scenario = GameScenario::new();
+    let mut runner = scenario.build();
+
+    let milled = mill_one_and_grant(&mut runner, "Milled Island", true, ManaCost::NoCost);
+
+    assert_eq!(runner.state().objects[&milled].zone, Zone::Graveyard);
+
+    // CR 305.1: lands never enter the cast path.
+    assert!(
+        !spell_objects_available_to_cast(runner.state(), P0).contains(&milled),
+        "milled land must NOT surface on the spell-cast path (CR 305.1)"
+    );
+
+    // DISCRIMINATING ASSERTION — flips when the fix is reverted: the milled land
+    // is playable via the graveyard land-play sweep.
+    assert!(
+        graveyard_lands_playable_by_permission(runner.state(), P0)
+            .iter()
+            .any(|(id, _)| *id == milled),
+        "milled land must be playable from the graveyard via the land-play path (#751)"
+    );
+
+    // Drive the play-land action through the real pipeline.
+    let card_id = runner.state().objects[&milled].card_id;
+    runner.state_mut().phase = engine::types::phase::Phase::PreCombatMain;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: milled,
+            card_id,
+        })
+        .expect("milled land must be playable via the land-play special action");
+    assert_eq!(
+        runner.state().objects[&milled].zone,
+        Zone::Battlefield,
+        "playing the milled land must move it to the battlefield"
+    );
+}
+
+/// Regression: Advanced Reconstruction mills, then EXILES a graveyard card and
+/// grants `PlayFromExile` on the EXILED card. That card lives in exile, so it
+/// must continue to surface only on the exile path. The new graveyard gate
+/// (`Zone::Graveyard` AND live `PlayFromExile`) must NOT over-broaden to admit
+/// it twice or relocate it off the exile path.
+///
+/// This proves the zone gate is `exile OR graveyard`, not "any zone": a
+/// `PlayFromExile`-tagged card sitting in EXILE is still recognized exactly as
+/// before, and a `PlayFromExile`-tagged card sitting in the GRAVEYARD is the
+/// only new admission.
+#[test]
+fn exiled_card_with_play_permission_stays_on_exile_path() {
+    let scenario = GameScenario::new();
+    let mut runner = scenario.build();
+
+    // Mirror Advanced Reconstruction's end state: a non-land card in EXILE
+    // carrying PlayFromExile for P0 (its ChangeZone(-> Exile) resolved the
+    // TrackedSet sentinel to a card in exile).
+    let exiled = {
+        let state = runner.state_mut();
+        let id = create_object(state, CardId(3), P0, "Exiled Bear".to_string(), Zone::Exile);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        };
+        obj.casting_permissions
+            .push(CastingPermission::PlayFromExile {
+                duration: Duration::UntilEndOfTurn,
+                granted_to: P0,
+                frequency: engine::types::statics::CastFrequency::Unlimited,
+                source_id: None,
+                exiled_by_ability_controller: None,
+                mana_spend_permission: None,
+                card_filter: None,
+                single_use_group: None,
+                single_use: false,
+            });
+        id
+    };
+
+    // The exiled card still surfaces on the cast path (unchanged behavior).
+    assert!(
+        spell_objects_available_to_cast(runner.state(), P0).contains(&exiled),
+        "an exiled card with PlayFromExile must remain castable from exile"
+    );
+    // It is NOT in the graveyard, so the new graveyard land sweep must ignore it.
+    assert!(
+        !graveyard_lands_playable_by_permission(runner.state(), P0)
+            .iter()
+            .any(|(id, _)| *id == exiled),
+        "the exiled card must not appear in the graveyard land-play sweep"
+    );
+}
+
+/// Duration prune: a graveyard object's `UntilEndOfTurn` `PlayFromExile` must be
+/// removed at cleanup (CR 514.2), so the milled card is no longer castable from
+/// the graveyard after the turn ends.
+#[test]
+fn graveyard_play_permission_is_pruned_at_end_of_turn() {
+    let scenario = GameScenario::new();
+    let mut runner = scenario.build();
+
+    let milled = mill_one_and_grant(
+        &mut runner,
+        "Milled Bear",
+        false,
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        },
+    );
+
+    assert!(
+        spell_objects_available_to_cast(runner.state(), P0).contains(&milled),
+        "milled card must be castable before cleanup"
+    );
+
+    // CR 514.2: cleanup prunes UntilEndOfTurn casting permissions, zone-agnostic.
+    prune_end_of_turn_casting_permissions(runner.state_mut());
+
+    assert!(
+        runner.state().objects[&milled]
+            .casting_permissions
+            .is_empty(),
+        "UntilEndOfTurn PlayFromExile on a graveyard object must be pruned at cleanup"
+    );
+    assert!(
+        !spell_objects_available_to_cast(runner.state(), P0).contains(&milled),
+        "after cleanup the milled card must no longer be castable from the graveyard"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -8,6 +8,7 @@ mod anaphoric_scope_allowlist_guard;
 mod ancient_brass_dragon_roll_d20;
 mod ancient_bronze_dragon_roll_d20;
 mod ancient_copper_dragon_roll_d20;
+mod ark_of_hunger_play_from_graveyard_751;
 mod armored_kincaller_or_condition;
 mod ashaya_nontoken_lands;
 mod auntie_ool_minus_one_counter_trigger;


### PR DESCRIPTION
## Issue
Fixes #751. Ark of Hunger (and the class of "mill a card, then you may play it" cards — CR 701.17d) grants a `PlayFromExile` permission on a card that lands in the **graveyard**, but the engine's "can this object enter the cast path?" consult sites were gated to `Zone::Exile` only. The milled card carried a live permission yet was never castable/playable.

## Fix
Introduces a **separate** predicate `play_from_exile_object_in_cast_path(obj)` = `matches!(obj.zone, Zone::Exile | Zone::Graveyard) && !is_land`, used at the **three object-tagged** `PlayFromExile` consult sites plus a new graveyard cast-surface branch and a new graveyard land sweep.

The original `exile_object_can_enter_cast_path` stays `Zone::Exile`-only, and the **two static-`ExileCastPermission` callers are byte-for-byte unchanged** — a card milled into a graveyard must not reach the static path (exile-only by CR 113.6b). Lands are excluded from the cast path (CR 305.1) and routed through the land-play sweep.

## Tests
`crates/engine/tests/integration/ark_of_hunger_play_from_graveyard_751.rs` drives the real Mill→grant→cast pipeline:
- `milled_card_is_castable_from_graveyard` (discriminating — flips false→true on the fix)
- `milled_land_is_playable_via_land_path_not_cast_path` (CR 305.1 carve-out)
- `exiled_card_with_play_permission_stays_on_exile_path` (Advanced Reconstruction regression — gate is exile-OR-graveyard, never any-zone)
- `graveyard_play_permission_is_pruned_at_end_of_turn` (CR 514.2)

All four PASS in local Tilt `test-engine`. Independent `/review-impl`: APPROVED, zero findings. CR annotations (113.6b, 305.1, 514.2, 601.2a, 604.2, 701.17a, 701.17d, 715.3d) grep-verified against the Comprehensive Rules.