### PR TITLE
fix(parser): Taigam exiles the cast spell (not itself) with time counters (#749)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3150,7 +3150,18 @@ pub(super) fn parse_utility_imperative_ast(
                     let rem = &rest[rest.len() - rem_lower.len()..];
                     (target, rem)
                 } else {
-                    parse_target(rest)
+                    // CR 707.10 + CR 608.2k: thread ctx so "copy it" routes the
+                    // "it" pronoun through resolve_it_pronoun → TriggeringSource
+                    // (the triggering spell), matching "copy that spell".
+                    // Precondition (resolve_it_pronoun, oracle_effect/mod.rs:165):
+                    // this yields TriggeringSource ONLY for trigger subjects that
+                    // are non-SelfRef / non-Any (Taigam's subject is Controller —
+                    // the "you" arm — so it qualifies). For SelfRef/Any subjects
+                    // "it" stays SelfRef/ParentTarget and the CopySpell runtime
+                    // fallback (triggering_spell_stack_entry, copy_spell.rs)
+                    // keeps them working — behavior-neutral-or-better, never a
+                    // regression for non-Taigam "copy it" cards.
+                    parse_target_with_ctx(rest, ctx)
                 };
                 let retarget = if super::sequence::recognize_copy_retarget_clause(_rem.trim()) {
                     // CR 707.10c: "copy that spell and may choose new targets for the
@@ -5114,7 +5125,23 @@ pub(super) fn parse_exile_ast(
     // bodies ("Whenever an Elf you control dies, exile it") bind to the
     // triggering subject via `resolve_pronoun_target`, not the ability source.
     // Issue #319: Serpent's Soul-Jar exiled itself instead of the dying Elf.
-    let (parsed_target, _rem) = parse_target_with_ctx(rest_text, ctx);
+    let (parsed_target, rem) = parse_target_with_ctx(rest_text, ctx);
+    // CR 122.1 + CR 702.62: "exile … with N <type> counter(s) on it" lifts the
+    // counter clause onto the exile ChangeZone's `enter_with_counters` so the
+    // object enters Exile carrying them (Taigam, Master Opportunist: "exile the
+    // spell you cast with four time counters on it" — the count is PARSED from
+    // "four" via parse_number inside parse_with_counters_suffix, not hardcoded).
+    // The engine applies these at the exile destination (change_zone.rs
+    // resolved_counters path, covered by the egg-counter regression test).
+    // Excise the consumed clause so the debug-only compound-remainder assert
+    // below does not flag it.
+    let rem_lower = rem.to_ascii_lowercase();
+    let (enter_with_counters, counters_offset) =
+        super::parse_with_counters_suffix_spanned(&rem_lower);
+    let _rem = match counters_offset {
+        Some(off) => &rem[..off],
+        None => rem,
+    };
     #[cfg(debug_assertions)]
     assert_no_compound_remainder(_rem, text);
     // CR 701.5a: "exile target spell" must constrain targeting to the stack,
@@ -5129,7 +5156,7 @@ pub(super) fn parse_exile_ast(
         origin,
         target,
         all: false,
-        enter_with_counters: vec![],
+        enter_with_counters,
     })
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -15,8 +15,8 @@ pub(crate) use search::parse_search_name_reference_suffix;
 
 pub(crate) use lower::{
     capitalize, lower_effect_chain_ir, parse_controls_permanent_object,
-    parse_counter_suffix_body_combinator, parse_with_counters_suffix, strip_trailing_duration,
-    strip_trailing_where_x,
+    parse_counter_suffix_body_combinator, parse_with_counters_suffix,
+    parse_with_counters_suffix_spanned, strip_trailing_duration, strip_trailing_where_x,
 };
 // pub(super) re-exports used by sibling submodules via `super::fn_name()`.
 pub(super) use lower::{

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -796,6 +796,33 @@ pub fn parse_target_with_syntax<'a>(
         }
     }
 
+    // CR 608.2k / CR 603.7c: "the spell you cast" / bare "the spell" is an
+    // untargeted anaphor to the triggering spell object on a cast trigger
+    // (Taigam, Master Opportunist: "exile the spell you cast"). It maps to
+    // TriggeringSource, mirroring the bare-"that spell" arm above. Disambiguate
+    // purely by textual continuation (no ctx.subject gate): an explicit
+    // "you cast" continuation, or an empty / comma / semicolon continuation,
+    // names the triggering spell. A predicate continuation ("the spell is
+    // countered this way") keeps ParentTarget — preserving the
+    // "Counter target spell … the spell is countered this way" compound
+    // carve-out — by falling through to the bare "the spell" → ParentTarget arm
+    // below. Placed before the longest-match anaphor block so this earlier
+    // match wins, exactly as the "that spell" arm precedes its fallbacks.
+    if let Ok((rest_subject, _)) = tag::<_, _, OracleError<'_>>("the ").parse(lower.as_str()) {
+        let original_rest = &text[lower.len() - rest_subject.len()..];
+        if let Ok((after, _)) = parse_word_bounded(rest_subject, "spell") {
+            let orig_after = original_rest.get("spell".len()..).unwrap_or(original_rest);
+            if let Ok((you_cast_after, _)) = tag::<_, _, OracleError<'_>>(" you cast").parse(after)
+            {
+                let consumed = after.len() - you_cast_after.len();
+                let orig_after = orig_after.get(consumed..).unwrap_or(orig_after);
+                return (TargetFilter::TriggeringSource, orig_after, syntax);
+            }
+            if after.is_empty() || after.starts_with([',', ';']) {
+                return (TargetFilter::TriggeringSource, orig_after, syntax);
+            }
+        }
+    }
     // CR 608.2c: Definite anaphoric references to previously-mentioned objects/players.
     // Longest-match-first: "the creature's controller" before "the creature".
     if let Some((filter, rest)) = nom_on_lower(text, &lower, |input| {

--- a/crates/engine/tests/taigam_master_opportunist_exiles_cast_spell_749.rs
+++ b/crates/engine/tests/taigam_master_opportunist_exiles_cast_spell_749.rs
@@ -1,0 +1,174 @@
+//! Issue #749: Taigam, Master Opportunist must exile the *cast spell* (with four
+//! time counters), not itself.
+//!
+//! Flurry — "Whenever you cast your second spell each turn, copy it, then exile
+//! the spell you cast with four time counters on it. If it doesn't have suspend,
+//! it gains suspend."
+//!
+//! Pre-fix, "exile the spell you cast" parsed to `ChangeZone { target:
+//! ParentTarget }`. On a SpellCast trigger ParentTarget finds no event-context
+//! match and falls through to `use_self`, exiling Taigam (the trigger source).
+//! The "four time counters" clause was also dropped. This test drives the real
+//! cast pipeline and discriminates all three gaps:
+//!   (a) Taigam stays on the battlefield (regression direction — pre-fix it is
+//!       exiled);
+//!   (b) the cast spell is the object exiled;
+//!   (c) the exiled spell carries 4 time counters (CR 702.62).
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::zones::Zone;
+use engine::types::Phase;
+
+const TAIGAM: &str = "Flurry — Whenever you cast your second spell each turn, copy it, then exile the spell you cast with four time counters on it. If it doesn't have suspend, it gains suspend.";
+
+fn red_mana(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit {
+            color: ManaType::Red,
+            source_id: ObjectId(0),
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: Vec::new(),
+            grants: vec![],
+            expiry: None,
+        })
+        .collect()
+}
+
+fn card_id_of(runner: &GameRunner, id: ObjectId) -> CardId {
+    runner.state().objects.get(&id).unwrap().card_id
+}
+
+fn cast(runner: &mut GameRunner, spell: ObjectId) {
+    let card_id = card_id_of(runner, spell);
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: Default::default(),
+        })
+        .expect("cast spell");
+    drive(runner);
+}
+
+/// Drive the pipeline to stack-empty: player targets choose P1, trigger/copy
+/// targets keep their default, priority passes.
+fn drive(runner: &mut GameRunner) {
+    for _ in 0..80 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::TargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let slot = &target_slots[selection.current_slot];
+                let t = slot
+                    .legal_targets
+                    .iter()
+                    .find(|t| matches!(t, TargetRef::Player(P1)))
+                    .or_else(|| slot.legal_targets.first())
+                    .cloned();
+                runner
+                    .act(GameAction::ChooseTarget { target: t })
+                    .expect("choose cast target");
+            }
+            WaitingFor::TriggerTargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let t = target_slots[selection.current_slot]
+                    .legal_targets
+                    .first()
+                    .cloned();
+                runner
+                    .act(GameAction::ChooseTarget { target: t })
+                    .expect("choose trigger target");
+            }
+            WaitingFor::CopyRetarget {
+                target_slots,
+                current_slot,
+                ..
+            } => {
+                let keep = target_slots[current_slot].current.clone();
+                runner
+                    .act(GameAction::ChooseTarget { target: keep })
+                    .expect("keep copy target");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() || runner.act(GameAction::PassPriority).is_err()
+                {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+/// Issue #749 regression: casting the controller's second spell fires Flurry,
+/// which must exile the *cast spell* (not Taigam) with four time counters.
+#[test]
+fn taigam_exiles_cast_spell_not_itself_with_time_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let taigam = scenario
+        .add_creature_from_oracle(P0, "Taigam, Master Opportunist", 3, 4, TAIGAM)
+        .id();
+    let bolt1 = scenario.add_bolt_to_hand(P0);
+    let bolt2 = scenario.add_bolt_to_hand(P0);
+    scenario.with_mana_pool(P0, red_mana(6));
+    let mut runner = scenario.build();
+
+    cast(&mut runner, bolt1);
+    cast(&mut runner, bolt2);
+
+    // (a) Regression direction: pre-fix Taigam itself is exiled by the
+    // misparsed `ParentTarget → use_self` fallthrough. It must remain on the
+    // battlefield.
+    assert!(
+        runner.state().battlefield.contains(&taigam),
+        "CR 608.2k: Taigam must stay on the battlefield, not exile itself. \
+         Taigam zone = {:?}",
+        runner.state().objects.get(&taigam).map(|o| o.zone),
+    );
+
+    // (b) The cast second spell (bolt2) is the object that was exiled.
+    let bolt2_obj = runner
+        .state()
+        .objects
+        .get(&bolt2)
+        .expect("the cast spell object must still exist");
+    assert_eq!(
+        bolt2_obj.zone,
+        Zone::Exile,
+        "CR 608.2k: the spell you cast (bolt2) must be exiled, got {:?}",
+        bolt2_obj.zone,
+    );
+    assert!(
+        runner.state().exile.contains(&bolt2),
+        "the cast spell must be in the exile zone",
+    );
+
+    // (c) The exiled cast spell carries four time counters (CR 702.62), parsed
+    // from "four" — not Taigam, and not zero.
+    let time_counters = bolt2_obj
+        .counters
+        .get(&CounterType::Time)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        time_counters, 4,
+        "CR 702.62: the exiled spell must carry four time counters, got {time_counters}",
+    );
+}


### PR DESCRIPTION
## Issue
Fixes #749. Taigam, Master Opportunist — "Flurry — Whenever you cast your second spell each turn, copy it, then exile the spell you cast with four time counters on it. If it doesn't have suspend, it gains suspend." Pre-fix, "exile the spell you cast" lowered to `ChangeZone { target: ParentTarget }`; on a SpellCast trigger `ParentTarget` found no event-context match and fell through to `use_self`, so **Taigam exiled itself** — and the "four time counters" clause was dropped entirely.

## Fix (three parser gaps)
1. **`oracle_target.rs`** — new arm mapping "the spell you cast" / bare "the spell" → `TargetFilter::TriggeringSource`, decided by **textual continuation** (` you cast`, or empty/comma/semicolon) — a predicate continuation (e.g. " is countered this way") still falls through to `ParentTarget`, preserving the "Counter target spell … the spell is countered this way" carve-out. Mirrors the existing "that spell" arm; does not consult `ctx.subject`.
2. **`imperative.rs`** — the "copy" arm now threads `ctx` (`parse_target_with_ctx`) so `resolve_it_pronoun` yields `TriggeringSource` for non-SelfRef/non-Any subjects (behavior-neutral; the runtime copy fallback already converged correctly).
3. **`imperative.rs`** — lifts "with N <type> counters on it" onto the exile destination's `enter_with_counters` via the existing `parse_with_counters_suffix_spanned` building block (count and type **parsed**, not hardcoded). Engine side already wired (`change_zone.rs` stamps counters on a `Zone::Exile` destination).

## Tests
`crates/engine/tests/taigam_master_opportunist_exiles_cast_spell_749.rs` drives the real cast pipeline (`CastSpell` ×2 + trigger/copy/target resolution) and discriminates all three gaps:
- (a) Taigam stays on the battlefield (flips — pre-fix it is exiled)
- (b) the cast spell (bolt2) is the exiled object
- (c) the exiled spell carries 4 time counters (0 pre-fix)

`PASS (1/1)` in isolated nextest; passes in local Tilt `test-engine`. Independent `/review-impl`: APPROVED, zero findings (surveyed all 34 non-possessive "the spell" cards — Split Decision's period-continuation correctly falls through to `ParentTarget`, no breadth regression). Parser combinator gate exit 0. CR annotations (608.2k, 603.7c, 707.10, 702.62, 122.1) grep-verified.