### PR TITLE
fix(engine): resolve city's blessing race and Siege self-cast from exile (#2873, #2876)

### DIFF
--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -141,6 +141,19 @@ pub fn resolve(
             .collect();
     }
 
+    // CR 310.11b + CR 608.2c: "exile it, then you may cast it transformed" —
+    // the SelfRef filter resolves to the source object itself. When
+    // `ability.targets` is empty (no pre-selected target, as is typical for
+    // Siege defeat and Suspend self-cast triggers), fall back to the source
+    // directly so the card can be cast during resolution rather than silently
+    // staying in exile.
+    if target_ids.is_empty()
+        && matches!(target_filter, TargetFilter::SelfRef)
+        && ability.source_is_current(state)
+    {
+        target_ids = vec![ability.source_id];
+    }
+
     if target_ids.is_empty() {
         if let Some(source_zone) = target_filter.extract_in_zone() {
             if source_zone == Zone::Hand {
@@ -724,6 +737,68 @@ mod tests {
         assert!(
             state.players.iter().all(|p| p.mana_pool.total() == 0),
             "the free cast must not require or consume mana"
+        );
+    }
+
+    /// CR 310.11b (#2876): Siege defeat — "exile it, then you may cast it
+    /// transformed". The `CastFromZone { target: SelfRef }` sub-ability fires
+    /// with an EMPTY `ability.targets` (the exile step doesn't pre-select a
+    /// target; the source IS the card to cast). Without the SelfRef fallback in
+    /// `resolve`, `target_ids` stays empty and the function returns early,
+    /// leaving the Siege card in exile forever. With the fix, the source id is
+    /// used directly and the card is cast onto the stack.
+    ///
+    /// Discriminating assertion: stack grows by 1 and the exiled card moves to
+    /// Zone::Stack. Reverting the SelfRef fallback makes target_ids stay empty,
+    /// hitting the early-return path — stack stays 0, card stays in exile.
+    #[test]
+    fn siege_self_ref_cast_with_empty_targets_casts_from_exile() {
+        let mut state = make_test_state();
+        let siege_id = create_object(
+            &mut state,
+            CardId(9001),
+            PlayerId(0),
+            "Invasion of Ikoria".to_string(),
+            Zone::Exile,
+        );
+        {
+            let obj = state.objects.get_mut(&siege_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Battle);
+            obj.mana_cost = ManaCost::generic(4);
+        }
+
+        // The Siege defeat sub-ability has SelfRef target and DuringResolution
+        // driver. Crucially, ability.targets is EMPTY — the Siege card is the
+        // source, not a pre-selected target.
+        let ability = ResolvedAbility::new(
+            Effect::CastFromZone {
+                target: TargetFilter::SelfRef,
+                without_paying_mana_cost: true,
+                mode: CardPlayMode::Cast,
+                cast_transformed: true,
+                alt_ability_cost: None,
+                constraint: None,
+                duration: None,
+                driver: CastFromZoneDriver::DuringResolution,
+            },
+            vec![], // empty — the bug: source is the card to cast, not a named target
+            siege_id,
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "CR 310.11b: Siege defeat must put the card on the stack (cast it), \
+             not silently return with it still in exile"
+        );
+        assert_eq!(
+            state.objects.get(&siege_id).map(|o| o.zone),
+            Some(Zone::Stack),
+            "the Siege card must move from exile to the stack on defeat"
         );
     }
 

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -759,18 +759,19 @@ mod tests {
             CardId(9001),
             PlayerId(0),
             "Invasion of Ikoria".to_string(),
-            Zone::Exile,
+            Zone::Battlefield,
         );
         {
             let obj = state.objects.get_mut(&siege_id).unwrap();
             obj.card_types.core_types.push(CoreType::Battle);
             obj.mana_cost = ManaCost::generic(4);
         }
+        let captured_incarnation = state.objects[&siege_id].incarnation;
 
         // The Siege defeat sub-ability has SelfRef target and DuringResolution
         // driver. Crucially, ability.targets is EMPTY — the Siege card is the
         // source, not a pre-selected target.
-        let ability = ResolvedAbility::new(
+        let mut ability = ResolvedAbility::new(
             Effect::CastFromZone {
                 target: TargetFilter::SelfRef,
                 without_paying_mana_cost: true,
@@ -785,8 +786,17 @@ mod tests {
             siege_id,
             PlayerId(0),
         );
+        ability.set_source_incarnation_recursive(Some(captured_incarnation));
 
         let mut events = Vec::new();
+        zones::move_to_zone(&mut state, siege_id, Zone::Exile, &mut events);
+        assert_eq!(
+            state.objects[&siege_id].incarnation, captured_incarnation,
+            "the engine's self-reference epoch guard is bumped on battlefield entry, so the \
+             Siege defeat zone exit must not make its same-resolution self-cast stale"
+        );
+        events.clear();
+
         resolve(&mut state, &ability, &mut events).unwrap();
 
         assert_eq!(

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1437,6 +1437,7 @@ fn condition_contains_city_blessing(condition: &AbilityCondition) -> bool {
     match condition {
         AbilityCondition::HasCityBlessing => true,
         AbilityCondition::Not { condition } => condition_contains_city_blessing(condition),
+        AbilityCondition::ConditionInstead { inner } => condition_contains_city_blessing(inner),
         AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
             conditions.iter().any(condition_contains_city_blessing)
         }
@@ -17258,6 +17259,7 @@ mod tests {
     fn city_blessing_race_grants_sub_ability_token_same_resolution() {
         let mut state = GameState::new_two_player(42);
 
+        let mut ascend_permanent = None;
         for i in 0..9u64 {
             let id = create_object(
                 &mut state,
@@ -17267,17 +17269,38 @@ mod tests {
                 Zone::Battlefield,
             );
             if i == 0 {
-                state
-                    .objects
-                    .get_mut(&id)
-                    .unwrap()
-                    .keywords
-                    .push(Keyword::Ascend);
+                let obj = state.objects.get_mut(&id).unwrap();
+                obj.card_types.core_types.push(CoreType::Creature);
+                obj.base_card_types = obj.card_types.clone();
+                obj.base_power = Some(1);
+                obj.base_toughness = Some(1);
+                obj.power = Some(1);
+                obj.toughness = Some(1);
+                obj.keywords.push(Keyword::Ascend);
+                obj.static_definitions.push(
+                    StaticDefinition::continuous()
+                        .condition(crate::types::ability::StaticCondition::HasCityBlessing)
+                        .affected(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)))
+                        .modifications(vec![
+                            ContinuousModification::AddPower { value: 1 },
+                            ContinuousModification::AddToughness { value: 1 },
+                        ]),
+                );
+                ascend_permanent = Some(id);
             }
         }
+        crate::game::layers::flush_layers(&mut state);
         assert!(
             !state.city_blessing.contains(&PlayerId(0)),
             "precondition: no city's blessing at 9 permanents"
+        );
+        assert_eq!(
+            state
+                .objects
+                .get(&ascend_permanent.unwrap())
+                .and_then(|obj| obj.power),
+            Some(1),
+            "the city's-blessing-gated continuous effect must be inactive before the grant"
         );
 
         let make_cat = || Effect::Token {
@@ -17316,6 +17339,28 @@ mod tests {
             11,
             "9 starting permanents + parent Cat + sub-ability Cat = 11; a missing \
              city's-blessing re-evaluation would drop the sub-ability token (10)"
+        );
+        assert_eq!(
+            state
+                .objects
+                .get(&ascend_permanent.unwrap())
+                .and_then(|obj| obj.power),
+            Some(2),
+            "CR 702.131d: continuous effects gated on the city's blessing must be \
+             reapplied before the sub-ability condition/effect continues"
+        );
+    }
+
+    #[test]
+    fn condition_contains_city_blessing_recurses_through_condition_instead() {
+        let condition = AbilityCondition::ConditionInstead {
+            inner: Box::new(AbilityCondition::HasCityBlessing),
+        };
+
+        assert!(
+            condition_contains_city_blessing(&condition),
+            "city's-blessing gated continuations wrapped in ConditionInstead must run the \
+             mid-chain blessing check before the condition is evaluated"
         );
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1433,6 +1433,17 @@ fn condition_depends_on_effect_performed(condition: &AbilityCondition) -> bool {
     }
 }
 
+fn condition_contains_city_blessing(condition: &AbilityCondition) -> bool {
+    match condition {
+        AbilityCondition::HasCityBlessing => true,
+        AbilityCondition::Not { condition } => condition_contains_city_blessing(condition),
+        AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
+            conditions.iter().any(condition_contains_city_blessing)
+        }
+        _ => false,
+    }
+}
+
 /// CR 608.2c: Whether a parent effect computes its own "if you do" outcome
 /// signal (`optional_effect_performed`) rather than that signal meaning "the
 /// mandatory action occurred."
@@ -5197,6 +5208,20 @@ fn resolve_chain_body(
     // parents pay nothing.
     if ability.sub_ability.is_some() {
         crate::game::layers::flush_layers(state);
+    }
+
+    // CR 702.131b + CR 702.131d: If the sub-ability's condition is gated on
+    // the city's blessing, re-evaluate the blessing now — before checking the
+    // condition — so a permanent created by the parent effect (e.g. Ocelot
+    // Pride's Cat token becoming the 10th permanent) is reflected in
+    // `state.city_blessing`. This mirrors the SBA loop's "any time" semantics
+    // without waiting for the next priority pass.
+    if ability.sub_ability.as_ref().is_some_and(|sub| {
+        sub.condition
+            .as_ref()
+            .is_some_and(condition_contains_city_blessing)
+    }) {
+        crate::game::sba::apply_city_blessing_if_triggered(state, events);
     }
 
     // Follow typed sub_ability chain, propagating parent targets when sub has none.
@@ -17213,6 +17238,84 @@ mod tests {
         assert!(
             !mandatory_parent_effect_performed(&copy, &not_made),
             "a CopySpell that made no copy is NOT 'performed' — the draw rider must run"
+        );
+    }
+
+    /// CR 702.131b + CR 702.131d (#2873): Ocelot Pride's race. The parent
+    /// `Effect::Token` pushes the controller from 9 to 10 permanents *during*
+    /// resolution. The sub-ability is gated on `HasCityBlessing`. Without the
+    /// eager re-evaluation in `resolve_chain_body`, `state.city_blessing` is
+    /// still empty when the sub-ability condition is checked (it would only be
+    /// updated by the SBA loop at the next priority pass), so the sub-ability's
+    /// token would NOT be created. With the fix, the blessing is granted before
+    /// the gate fires, so BOTH tokens exist.
+    ///
+    /// Discriminating assertion: `state.battlefield.len() == 11` (9 + 2 tokens)
+    /// and `state.city_blessing.contains(PlayerId(0))`. Reverting the fix makes
+    /// the sub-ability gate read a false `HasCityBlessing`, dropping the second
+    /// token (battlefield 10, not 11).
+    #[test]
+    fn city_blessing_race_grants_sub_ability_token_same_resolution() {
+        let mut state = GameState::new_two_player(42);
+
+        for i in 0..9u64 {
+            let id = create_object(
+                &mut state,
+                CardId(i + 1),
+                PlayerId(0),
+                format!("Permanent {i}"),
+                Zone::Battlefield,
+            );
+            if i == 0 {
+                state
+                    .objects
+                    .get_mut(&id)
+                    .unwrap()
+                    .keywords
+                    .push(Keyword::Ascend);
+            }
+        }
+        assert!(
+            !state.city_blessing.contains(&PlayerId(0)),
+            "precondition: no city's blessing at 9 permanents"
+        );
+
+        let make_cat = || Effect::Token {
+            name: "Cat".to_string(),
+            power: PtValue::Fixed(1),
+            toughness: PtValue::Fixed(1),
+            types: vec!["Creature".to_string(), "Cat".to_string()],
+            colors: vec![ManaColor::White],
+            keywords: vec![],
+            tapped: false,
+            count: QuantityExpr::Fixed { value: 1 },
+            owner: TargetFilter::Controller,
+            attach_to: None,
+            enters_attacking: false,
+            supertypes: vec![],
+            static_abilities: vec![],
+            enter_with_counters: vec![],
+        };
+
+        let mut sub = ResolvedAbility::new(make_cat(), vec![], ObjectId(1000), PlayerId(0));
+        sub.condition = Some(AbilityCondition::HasCityBlessing);
+
+        let mut parent = ResolvedAbility::new(make_cat(), vec![], ObjectId(1000), PlayerId(0));
+        parent.sub_ability = Some(Box::new(sub));
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &parent, &mut events, 0).unwrap();
+
+        assert!(
+            state.city_blessing.contains(&PlayerId(0)),
+            "the parent token made the 10th permanent, so the blessing must be granted \
+             before the sub-ability gate fires"
+        );
+        assert_eq!(
+            state.battlefield.len(),
+            11,
+            "9 starting permanents + parent Cat + sub-ability Cat = 11; a missing \
+             city's-blessing re-evaluation would drop the sub-ability token (10)"
         );
     }
 }

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -229,6 +229,17 @@ fn check_city_blessing(
     }
 }
 
+/// CR 702.131b + CR 702.131d: Eagerly re-evaluate the city's blessing for all
+/// players outside the normal SBA loop. Called from `resolve_chain_body` after
+/// a parent effect resolves and before a `HasCityBlessing`-gated sub-ability
+/// condition is evaluated, so that a token or permanent created by the parent
+/// effect (which may have pushed a player to 10+ permanents) is reflected in
+/// `state.city_blessing` before the sub-ability gate fires.
+pub(crate) fn apply_city_blessing_if_triggered(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    let mut any_performed = false;
+    check_city_blessing(state, events, &mut any_performed);
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 struct AscendStatus {
     permanents_controlled: usize,

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -238,6 +238,9 @@ fn check_city_blessing(
 pub(crate) fn apply_city_blessing_if_triggered(state: &mut GameState, events: &mut Vec<GameEvent>) {
     let mut any_performed = false;
     check_city_blessing(state, events, &mut any_performed);
+    if any_performed {
+        crate::game::layers::flush_layers(state);
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]


### PR DESCRIPTION
## Summary

- **#2873 (Ocelot Pride):** `resolve_chain_body` evaluates `HasCityBlessing`-gated sub-ability conditions after `flush_layers` but before the SBA loop updates `state.city_blessing`. A parent token created during resolution (pushing the controller from 9 → 10 permanents) is invisible to the gate, so the bonus token is silently dropped. Fixed by eagerly calling a new `apply_city_blessing_if_triggered` wrapper (over the existing private `check_city_blessing`) when the sub-ability condition tree contains `HasCityBlessing`. CR 702.131b + CR 702.131d.

- **#2876 (Invasion of Ikoria):** `cast_from_zone::resolve` populates `target_ids` only from `ability.targets`, which is empty for self-referential triggered abilities (`CastFromZone { target: SelfRef }`). The `ExiledBySource` fallback doesn't cover `SelfRef`, so `target_ids` stays empty and the function returns early — the Siege card stays in exile forever. Fixed by adding a SelfRef fallback before the empty-targets early return: when `target_filter == SelfRef` and the source is still current, set `target_ids = [source_id]`, routing into the existing `DuringResolution` cast path. CR 310.11b + CR 608.2c.

## Test plan

- [ ] `city_blessing_race_grants_sub_ability_token_same_resolution` — asserts `battlefield.len() == 11` (9 starters + parent token + sub-ability token); reverting the fix drops the sub-ability token (10)
- [ ] `siege_self_ref_cast_with_empty_targets_casts_from_exile` — asserts `stack.len() == 1` and card moves to `Zone::Stack`; reverting the fix leaves the card in exile and the stack empty