### PR TITLE
fix(parser): distribute trailing search-filter predicate across disjunctive type list (#2892)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -5128,24 +5128,87 @@ mod tests {
         );
     }
 
-    /// #2892 anti-regression — Journey for the Elixir: "a basic land card and a
-    /// card named Jiang Yanggu". CR 201.2: the name predicate must stay on its
-    /// own disjunct; distributing `Named` onto the basic-land leg ("basic land
-    /// named jiang yanggu") would empty that leg's match set.
+    /// #2892 building-block guard — CR 201.2 / CR 201.2a (card name) +
+    /// CR 202.3 (mana value): asserts the leg-locality registry directly on the
+    /// distributor, independent of any card's parse path. `FilterProp::Named` is
+    /// inherently leg-local (a name predicate binds only to its own disjunct,
+    /// same class as `HasKeywordKind`/`WithKeyword`), so it must NOT distribute
+    /// across an `Or`; `FilterProp::Cmc` is a trailing-suffix predicate and MUST.
+    ///
+    /// Constructing the `Or` AST directly is deliberate: no current card routes a
+    /// `Named` leg through a real `" or "`/`" and/or "` disjunction with a
+    /// non-`Named` earlier leg (name-disjunction cards either use bare "and",
+    /// which takes the dual-filter `MatchEachFilter` path and never reaches this
+    /// distributor, or carry `Named` on every leg and are deduped by
+    /// `same_kind`). The exclusion is defense-in-depth; this test guards it.
+    ///
+    /// The `Cmc` positive control is the discriminator: if the `Named` exclusion
+    /// were removed, `Named` would wrongly land on the first leg and the first
+    /// assertion would fail — while the `Cmc` assertions prove the test does not
+    /// merely block all distribution.
     #[test]
-    fn search_disjunction_keeps_named_leg_local() {
-        let details = parse_search_library_details(
-            "search your library and graveyard for a basic land card and a card named jiang yanggu",
-            &mut ParseContext::default(),
+    fn distribute_or_keeps_named_leg_local_but_distributes_cmc() {
+        // Or { Creature [], Card [Named "jiang yanggu", Cmc<=3] }
+        let filter = TargetFilter::Or {
+            filters: vec![
+                TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Card],
+                    controller: None,
+                    properties: vec![
+                        FilterProp::Named {
+                            name: "jiang yanggu".to_string(),
+                        },
+                        FilterProp::Cmc {
+                            comparator: Comparator::LE,
+                            value: QuantityExpr::Fixed { value: 3 },
+                        },
+                    ],
+                }),
+            ],
+        };
+
+        let out = distribute_properties_to_or(filter);
+        let TargetFilter::Or { filters } = &out else {
+            panic!("expected Or filter, got {out:?}");
+        };
+        let TargetFilter::Typed(first) = &filters[0] else {
+            panic!("expected first leg Typed, got {:?}", filters[0]);
+        };
+        let TargetFilter::Typed(second) = &filters[1] else {
+            panic!("expected second leg Typed, got {:?}", filters[1]);
+        };
+
+        // Named stayed leg-local: the Creature leg did NOT receive it. This is
+        // the assertion that flips if the `Named` exclusion is removed from
+        // `is_adjective_prefix_prop`.
+        assert!(
+            !first
+                .properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::Named { .. })),
+            "Named must NOT distribute to the earlier (Creature) leg, got {first:?}"
         );
-        let (with_named, _typed) = legs_with_prop(
-            &details.filter,
-            |p| matches!(p, FilterProp::Named { name } if name == "jiang yanggu"),
+        // ...but the originating (Card) leg still carries its own Named.
+        assert!(
+            second
+                .properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::Named { name } if name == "jiang yanggu")),
+            "Named must remain on its originating (Card) leg, got {second:?}"
         );
-        assert_eq!(
-            with_named, 1,
-            "Named must remain on the non-land leg only, got {:?}",
-            details.filter
+
+        // Positive control: the trailing Cmc<=N predicate DID distribute back to
+        // the earlier leg, proving the guard doesn't wrongly suppress everything.
+        assert!(
+            first.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::Cmc {
+                    comparator: Comparator::LE,
+                    ..
+                }
+            )),
+            "Cmc<=N must distribute to the earlier (Creature) leg, got {first:?}"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -13,8 +13,8 @@ use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_quantity;
 use super::super::oracle_target::{
-    parse_mana_value_suffix, parse_shared_quality_clause, parse_target, parse_type_phrase,
-    parse_zone_word,
+    distribute_properties_to_or, parse_mana_value_suffix, parse_shared_quality_clause,
+    parse_target, parse_type_phrase, parse_zone_word,
 };
 use super::super::oracle_util::{
     contains_possessive, infer_core_type_for_subtype, split_around, strip_after,
@@ -1030,7 +1030,14 @@ fn parse_search_filter_disjunction(text: &str, ctx: &mut ParseContext) -> Option
         .collect();
     (filters.len() >= 2).then(|| {
         let filter = normalize_search_filter(TargetFilter::Or { filters });
-        apply_shared_leading_search_properties(filter_region, filter)
+        let filter = apply_shared_leading_search_properties(filter_region, filter);
+        // CR 701.23a: each comma/or disjunct is parsed independently, so a
+        // trailing "with mana value N" suffix lands only on the final leg
+        // ("creature, instant, or sorcery card with mana value N", #2892).
+        // Distribute that trailing predicate back onto the earlier `Typed`
+        // legs via the shared leg-locality authority, which keeps inherently
+        // leg-local props (keyword/name/adjective) on their originating leg.
+        distribute_properties_to_or(filter)
     })
 }
 
@@ -5019,5 +5026,126 @@ mod tests {
             }
             other => panic!("expected MostPrevalentCreatureTypeIn, got {other:?}"),
         }
+    }
+
+    /// Counts how many `Typed` legs of an `Or` carry a `FilterProp` of the given
+    /// discriminant. Building-block assertion over the leg-locality distribution.
+    fn legs_with_prop(
+        filter: &TargetFilter,
+        predicate: impl Fn(&FilterProp) -> bool,
+    ) -> (usize, usize) {
+        let TargetFilter::Or { filters } = filter else {
+            panic!("expected Or filter, got {filter:?}");
+        };
+        let mut typed = 0;
+        let mut matching = 0;
+        for f in filters {
+            if let TargetFilter::Typed(t) = f {
+                typed += 1;
+                if t.properties.iter().any(&predicate) {
+                    matching += 1;
+                }
+            }
+        }
+        (matching, typed)
+    }
+
+    /// #2892 — CR 701.23a + CR 202.3: Bring to Light's "creature, instant, or
+    /// sorcery card with mana value less than or equal to N" parses each comma/or
+    /// disjunct independently, so the trailing mana-value predicate must be
+    /// distributed back across ALL three type legs. Pre-fix only the final
+    /// (Sorcery) leg carried `Cmc`, leaving the Creature/Instant legs
+    /// unconstrained (a MV-6 creature was wrongly findable).
+    #[test]
+    fn search_disjunction_distributes_trailing_mana_value_to_all_legs() {
+        let details = parse_search_library_details(
+            "search your library for a creature, instant, or sorcery card with mana value less than or equal to the number of colors of mana spent to cast this spell",
+            &mut ParseContext::default(),
+        );
+        let (with_cmc, typed) = legs_with_prop(&details.filter, |p| {
+            matches!(
+                p,
+                FilterProp::Cmc {
+                    comparator: Comparator::LE,
+                    ..
+                }
+            )
+        });
+        assert_eq!(typed, 3, "expected 3 type legs, got {:?}", details.filter);
+        assert_eq!(
+            with_cmc, 3,
+            "every leg must carry the trailing Cmc<=N predicate, got {:?}",
+            details.filter
+        );
+    }
+
+    /// CR 115.1: anti-regression — adjective/keyword-suffix props that bind to a
+    /// single disjunct ("creature, artifact, or enchantment with flying") must
+    /// stay leg-local. Only the creature leg may carry `WithKeyword(Flying)`.
+    #[test]
+    fn search_disjunction_keeps_with_keyword_leg_local() {
+        let details = parse_search_library_details(
+            "search your library for a creature, artifact, or enchantment with flying",
+            &mut ParseContext::default(),
+        );
+        let (with_flying, _typed) = legs_with_prop(&details.filter, |p| {
+            matches!(
+                p,
+                FilterProp::WithKeyword {
+                    value: Keyword::Flying
+                }
+            )
+        });
+        assert_eq!(
+            with_flying, 1,
+            "WithKeyword(Flying) must remain on its originating leg only, got {:?}",
+            details.filter
+        );
+    }
+
+    /// #2892 anti-regression — Clever Combo: "a host card or a card with augment".
+    /// CR 702.1: the augment keyword-kind predicate must stay on its own
+    /// disjunct; distributing it onto the host leg ("host card with augment")
+    /// would empty that leg's match set.
+    #[test]
+    fn search_disjunction_keeps_keyword_kind_leg_local() {
+        let details = parse_search_library_details(
+            "search your library for a host card or a card with augment",
+            &mut ParseContext::default(),
+        );
+        let (with_augment, _typed) = legs_with_prop(&details.filter, |p| {
+            matches!(
+                p,
+                FilterProp::HasKeywordKind {
+                    value: KeywordKind::Augment
+                }
+            )
+        });
+        assert_eq!(
+            with_augment, 1,
+            "HasKeywordKind(Augment) must remain on the non-host leg only, got {:?}",
+            details.filter
+        );
+    }
+
+    /// #2892 anti-regression — Journey for the Elixir: "a basic land card and a
+    /// card named Jiang Yanggu". CR 201.2: the name predicate must stay on its
+    /// own disjunct; distributing `Named` onto the basic-land leg ("basic land
+    /// named jiang yanggu") would empty that leg's match set.
+    #[test]
+    fn search_disjunction_keeps_named_leg_local() {
+        let details = parse_search_library_details(
+            "search your library and graveyard for a basic land card and a card named jiang yanggu",
+            &mut ParseContext::default(),
+        );
+        let (with_named, _typed) = legs_with_prop(
+            &details.filter,
+            |p| matches!(p, FilterProp::Named { name } if name == "jiang yanggu"),
+        );
+        assert_eq!(
+            with_named, 1,
+            "Named must remain on the non-land leg only, got {:?}",
+            details.filter
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2727,7 +2727,17 @@ fn distribute_shared_properties(filter: TargetFilter, shared_props: &[FilterProp
 /// only to the creature disjunct. Spreading `WithKeyword(Flying)` onto the
 /// artifact/enchantment legs would require those permanents to have flying and
 /// would block activation when only a legal enchantment is present (#2941).
-fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
+///
+/// SHARED LEG-LOCALITY AUTHORITY: this predicate is the single registry of
+/// inherently-leg-local `FilterProp`s for BOTH disjunctive grammars — the
+/// target-phrase grammar (`parse_type_phrase`) and the search-filter
+/// disjunction grammar (`oracle_effect::search::parse_search_filter_disjunction`,
+/// CR 701.23a). Every `FilterProp` that an adjective prefix or a type-scoped
+/// suffix binds to exactly one disjunct MUST be registered here, or it will be
+/// wrongly distributed across earlier `Or` legs and silently break the affected
+/// cards (e.g. #2892). When adding a new leg-local search/target prop, add it to
+/// this match.
+pub(crate) fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
     matches!(
         prop,
         // CR 700.4 + CR 700.9: "modified [type]" adjective prefix.
@@ -2766,6 +2776,16 @@ fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
             | FilterProp::WithKeyword { .. }
             | FilterProp::WithoutKeyword { .. }
             | FilterProp::WithoutKeywordKind { .. }
+            // CR 702.1: "<type> with [keyword kind]" (e.g. "a card with
+            // augment", Clever Combo) is a keyword-membership predicate that
+            // binds only to its own disjunct — distributing it onto a sibling
+            // leg ("host card with augment") would empty that leg's match set.
+            | FilterProp::HasKeywordKind { .. }
+            // CR 201.2: "card named X" binds the name predicate only to its own
+            // disjunct (Journey for the Elixir, "a basic land card and a card
+            // named Jiang Yanggu") — distributing `Named` onto a sibling leg
+            // ("basic land named jiang yanggu") would empty that leg's match set.
+            | FilterProp::Named { .. }
     )
 }
 
@@ -2779,8 +2799,18 @@ fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
 /// produced by adjective prefixes (e.g. FilterProp::Modified from "modified
 /// creatures", FilterProp::EnchantedBy from "enchanted creature") are
 /// leg-local and retained only on their originating leg. See
-/// `is_trailing_suffix_prop`.
-fn distribute_properties_to_or(filter: TargetFilter) -> TargetFilter {
+/// `is_adjective_prefix_prop`.
+///
+/// Exposed `pub(crate)` so disjunctive grammars that compose their own `Or` from
+/// independently-parsed disjuncts can reuse this shared trailing-suffix
+/// distribution instead of duplicating it. In particular the search-filter
+/// disjunction grammar (CR 701.23a, "creature, instant, or sorcery card with
+/// mana value N", #2892) parses each comma/or segment independently, so only the
+/// final segment carries the "with mana value N" suffix — this distributes the
+/// `Cmc` prop back onto the earlier `Typed` legs. `is_adjective_prefix_prop` is
+/// the shared registry that keeps leg-local props (keyword/name/adjective) from
+/// being distributed; every leg-local search prop MUST be registered there.
+pub(crate) fn distribute_properties_to_or(filter: TargetFilter) -> TargetFilter {
     let TargetFilter::Or { mut filters } = filter else {
         return filter;
     };

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2781,10 +2781,15 @@ pub(crate) fn is_adjective_prefix_prop(prop: &FilterProp) -> bool {
             // binds only to its own disjunct — distributing it onto a sibling
             // leg ("host card with augment") would empty that leg's match set.
             | FilterProp::HasKeywordKind { .. }
-            // CR 201.2: "card named X" binds the name predicate only to its own
-            // disjunct (Journey for the Elixir, "a basic land card and a card
-            // named Jiang Yanggu") — distributing `Named` onto a sibling leg
-            // ("basic land named jiang yanggu") would empty that leg's match set.
+            // CR 201.2 / CR 201.2a: a card-name predicate binds only to its own
+            // disjunct — distributing `Named` onto a sibling leg ("basic land
+            // named jiang yanggu") would empty that leg's match set. Named is
+            // inherently leg-local, the same class as HasKeywordKind/WithKeyword.
+            // This is defense-in-depth: no current card routes a `Named` leg
+            // through the Or distributor (name-disjunction cards either use bare
+            // "and", which takes the dual-filter MatchEachFilter path and never
+            // reaches this distributor, or carry `Named` on every leg and are
+            // deduped by `same_kind`), but excluding it future-proofs the guard.
             | FilterProp::Named { .. }
     )
 }

--- a/crates/engine/tests/bring_to_light_converge_mana_value.rs
+++ b/crates/engine/tests/bring_to_light_converge_mana_value.rs
@@ -1,0 +1,151 @@
+//! Bring to Light — "Converge — Search your library for a creature, instant, or
+//! sorcery card with mana value less than or equal to the number of colors of
+//! mana spent to cast this spell, exile that card, ..."
+//!
+//! Regression for issue #2892. The search filter is an `Or` of three type legs
+//! ("creature, instant, or sorcery card") with a single trailing "with mana
+//! value ≤ N" suffix. The parser builds each comma/or disjunct independently
+//! (CR 701.23a), so only the FINAL (Sorcery) leg carried the `Cmc ≤ N`
+//! predicate — the Creature and Instant legs were left unconstrained. As a
+//! result a high-mana-value creature was wrongly findable at any converge.
+//!
+//! The fix distributes the trailing predicate back onto every `Typed` leg of the
+//! disjunction. This test drives the REAL parsed Bring to Light search through
+//! the resolver, arranging a converge of 5 (the maximum — converge counts
+//! DISTINCT colors of mana spent and only five colors exist), and asserts that:
+//!   * an MV-5 creature IS a legal find (constraint does not over-reject), and
+//!   * an MV-6 creature (mana cost {2/B}{2/R}{2/G}, CR 202.3f) is NOT findable.
+//!
+//! The MV-6-creature exclusion is the load-bearing assertion: pre-fix the
+//! Creature leg is unconstrained, so the MV-6 creature is WRONGLY offered and
+//! the test fails. This is a pipeline test (parse → build → resolve_ability_chain
+//! → SearchChoice candidate set), not an AST-shape test.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::zones::create_object;
+use engine::parser::parse_oracle_text;
+use engine::types::ability::Effect;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ColoredManaCount, ManaColor, ManaCost, ManaCostShard};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const BRING_TO_LIGHT: &str = "Converge — Search your library for a creature, instant, or sorcery \
+card with mana value less than or equal to the number of colors of mana spent to cast this spell, \
+exile that card, then shuffle. You may cast that card without paying its mana cost.";
+
+/// The fixed `ObjectId` `build_resolved_from_def` uses as the resolving spell's
+/// source; the converge metric (`ManaSpentToCast { scope: SelfObject }`)
+/// resolves against this object's `colors_spent_to_cast`.
+const SPELL_ID: ObjectId = ObjectId(100);
+
+fn add_library_creature(
+    state: &mut GameState,
+    card_id: u64,
+    owner: PlayerId,
+    name: &str,
+    mana_cost: ManaCost,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(card_id),
+        owner,
+        name.to_string(),
+        Zone::Library,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.mana_cost = mana_cost;
+    id
+}
+
+#[test]
+fn bring_to_light_converge_five_excludes_mana_value_six_creature() {
+    let parsed = parse_oracle_text(
+        BRING_TO_LIGHT,
+        "Bring to Light",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    let definition = parsed
+        .abilities
+        .first()
+        .expect("Bring to Light should parse as a spell ability");
+    // Sanity: the root effect is the SearchLibrary disjunction under test.
+    assert!(
+        matches!(definition.effect.as_ref(), Effect::SearchLibrary { .. }),
+        "expected SearchLibrary root effect, got {:?}",
+        definition.effect
+    );
+
+    let mut state = GameState::new_two_player(42);
+
+    // The resolving Bring to Light spell object. Converge = 5 distinct colors of
+    // mana spent (the physical maximum). `build_resolved_from_def` anchors the
+    // ability on SPELL_ID, and `ManaSpentToCast { scope: SelfObject }` reads this
+    // object's `colors_spent_to_cast`.
+    let spell = create_object(
+        &mut state,
+        CardId(100),
+        PlayerId(0),
+        "Bring to Light".to_string(),
+        Zone::Stack,
+    );
+    assert_eq!(spell, SPELL_ID, "source-id assumption for converge scope");
+    let mut converge = ColoredManaCount::default();
+    for color in ManaColor::ALL {
+        converge.add(color, 1);
+    }
+    state.objects.get_mut(&spell).unwrap().colors_spent_to_cast = converge;
+
+    // MV-5 creature: a legal find at converge 5 (control proving no over-reject).
+    let mv5 = add_library_creature(
+        &mut state,
+        1,
+        PlayerId(0),
+        "MV5 Creature",
+        ManaCost::generic(5),
+    );
+    // CR 202.3f: {2/B}{2/R}{2/G} is mana value 6 (largest component of each
+    // monocolored-hybrid symbol). The Reaper analog — MUST be excluded at
+    // converge 5, since 6 > 5.
+    let mv6 = add_library_creature(
+        &mut state,
+        2,
+        PlayerId(0),
+        "MV6 Creature",
+        ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::TwoBlack,
+                ManaCostShard::TwoRed,
+                ManaCostShard::TwoGreen,
+            ],
+            generic: 0,
+        },
+    );
+
+    let ability = build_resolved_from_def(definition, SPELL_ID, PlayerId(0));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    match &state.waiting_for {
+        WaitingFor::SearchChoice { cards, .. } => {
+            assert!(
+                cards.contains(&mv5),
+                "MV-5 creature must be a legal Bring to Light find at converge 5 (5 ≤ 5); \
+                 the distributed Cmc constraint must not over-reject. Got {cards:?}"
+            );
+            assert!(
+                !cards.contains(&mv6),
+                "MV-6 creature ({{2/B}}{{2/R}}{{2/G}}, CR 202.3f) must NOT be findable at \
+                 converge 5 (6 > 5). Pre-fix the unconstrained Creature leg wrongly offers it. \
+                 Got {cards:?}"
+            );
+        }
+        other => panic!("expected SearchChoice, got {other:?}"),
+    }
+}

--- a/crates/engine/tests/bring_to_light_converge_mana_value.rs
+++ b/crates/engine/tests/bring_to_light_converge_mana_value.rs
@@ -37,11 +37,6 @@ const BRING_TO_LIGHT: &str = "Converge — Search your library for a creature, i
 card with mana value less than or equal to the number of colors of mana spent to cast this spell, \
 exile that card, then shuffle. You may cast that card without paying its mana cost.";
 
-/// The fixed `ObjectId` `build_resolved_from_def` uses as the resolving spell's
-/// source; the converge metric (`ManaSpentToCast { scope: SelfObject }`)
-/// resolves against this object's `colors_spent_to_cast`.
-const SPELL_ID: ObjectId = ObjectId(100);
-
 fn add_library_creature(
     state: &mut GameState,
     card_id: u64,
@@ -85,9 +80,10 @@ fn bring_to_light_converge_five_excludes_mana_value_six_creature() {
     let mut state = GameState::new_two_player(42);
 
     // The resolving Bring to Light spell object. Converge = 5 distinct colors of
-    // mana spent (the physical maximum). `build_resolved_from_def` anchors the
-    // ability on SPELL_ID, and `ManaSpentToCast { scope: SelfObject }` reads this
-    // object's `colors_spent_to_cast`.
+    // mana spent (the physical maximum). The ability is anchored on this object's
+    // own id (below), and `ManaSpentToCast { scope: SelfObject }` reads its
+    // `colors_spent_to_cast`. `create_object` assigns ids sequentially, so the
+    // spell's concrete id must be threaded through — not assumed.
     let spell = create_object(
         &mut state,
         CardId(100),
@@ -95,7 +91,6 @@ fn bring_to_light_converge_five_excludes_mana_value_six_creature() {
         "Bring to Light".to_string(),
         Zone::Stack,
     );
-    assert_eq!(spell, SPELL_ID, "source-id assumption for converge scope");
     let mut converge = ColoredManaCount::default();
     for color in ManaColor::ALL {
         converge.add(color, 1);
@@ -128,7 +123,7 @@ fn bring_to_light_converge_five_excludes_mana_value_six_creature() {
         },
     );
 
-    let ability = build_resolved_from_def(definition, SPELL_ID, PlayerId(0));
+    let ability = build_resolved_from_def(definition, spell, PlayerId(0));
     let mut events = Vec::new();
     resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
 


### PR DESCRIPTION
## Issue
Fixes #2892. The Reaper, King no More ({2/B}{2/R}{2/G}, a Creature, MV 6) was wrongly findable by **Bring to Light** at converge 5 ("search for a creature, instant, or sorcery card with mana value ≤ the number of colors of mana spent").

## Root cause (NOT the {2/C} mana value)
The issue blamed `{2/C}` mana-value undercounting, but that is a red herring — `ManaCost::mana_value()` correctly returns 6 (CR 202.3f). The real bug is in the **search-filter parser**: `parse_search_filter_disjunction` parses each comma/or disjunct independently, so the trailing "with mana value ≤ N" predicate was attached **only to the last leg (Sorcery)**. The Creature and Instant legs were left unconstrained — so a creature like The Reaper matched the unconstrained Creature leg and was findable at any converge.

## Fix
Reuse the target parser's existing, tested `distribute_properties_to_or` (promoted to `pub(crate)`, mirroring the established `distribute_controller_to_or` idiom) to distribute the last leg's trailing predicate across every `Typed` leg of the disjunction. The `is_adjective_prefix_prop` leg-locality guard keeps inherently-local predicates on their own leg.

**This is a class fix**, not a one-card fix: it corrects every "X, Y, or Z card with <trailing predicate>" tutor.

### Leg-locality guard completeness (reviewed)
Audited the full search-disjunction card pool and closed two holes that would otherwise silently break cards: added `FilterProp::HasKeywordKind` (else **Clever Combo** "host card or a card with augment" → empty Host leg) and `FilterProp::Named` (defensive; name predicates are inherently leg-local) to the guard. `Cmc` correctly distributes; `WithKeyword(Flying)` correctly stays leg-local.

## Tests
- Runtime (discriminating): `bring_to_light_converge_mana_value.rs` drives the real parsed Bring to Light search through `resolve_ability_chain` — at converge 5, the MV-6 Reaper analog is excluded and an MV-5 control is included (flips when reverted). **PASS.**
- Building-block: trailing `Cmc` distributes to all 3 legs; `Named` stays leg-local while `Cmc` distributes; Clever Combo keeps `HasKeywordKind` leg-local; "creature, artifact, or enchantment with flying" keeps `WithKeyword(Flying)` leg-local. **All PASS.**

Independent `/review-engine-plan` (2 blockers caught + folded: guard holes, impossible converge-6 boundary) and `/review-impl` (2 rounds: mis-targeted test path, then a hardcoded object-id assumption) both clean. CR annotations (202.3f, 701.23a, 201.2/201.2a, 702.1) grep-verified. Parser-combinator gate exit 0; no new string dispatch. The only local Tilt failures are the pre-existing `anaphoric_scope_allowlist_guard` Marvel-card data-sync artifact (independent; self-skips in CI).