### PR TITLE
fix(parser): Sarkhan +1 legendary Dragon animation (#2362)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -512,7 +512,7 @@ fn parse_animation_type_token(input: &str) -> OracleResult<'_, AnimationTypeToke
 }
 
 /// Parse a whitespace-separated sequence of type tokens, halting at the first
-/// non-type token. Used by [`parse_animation_types`] as the grammar root.
+/// non-type token. Used by [`parse_animation_type_parts`] as the grammar root.
 fn parse_animation_type_sequence(input: &str) -> OracleResult<'_, Vec<AnimationTypeToken>> {
     separated_list1(multispace1, parse_animation_type_token).parse(input)
 }
@@ -566,7 +566,7 @@ fn parse_animation_type_sequence_loose(input: &str) -> OracleResult<'_, Vec<Anim
 /// "in addition to {its/their/his/her} other [creature ]types" structural signal. The tail
 /// guarantees the preceding phrase is a type expression, so lowercase subtype
 /// words are safe to classify. Shared by [`parse_becomes_type_modifications`]
-/// and [`parse_animation_types`] so both the static-ability and effect-
+/// and [`parse_animation_type_parts`] so both the static-ability and effect-
 /// imperative paths decompose the descriptor identically.
 fn try_parse_type_sequence_with_suffix(input: &str) -> Option<Vec<AnimationTypeToken>> {
     // Strict path first — preserves existing behavior when the CR 205.3
@@ -775,10 +775,6 @@ fn parse_animation_type_parts(text: &str, infer_creature: bool) -> (Vec<Supertyp
     (supertypes, types)
 }
 
-fn parse_animation_types(text: &str, infer_creature: bool) -> Vec<String> {
-    parse_animation_type_parts(text, infer_creature).1
-}
-
 fn split_animation_keyword_clause(text: &str) -> (&str, Vec<Keyword>) {
     const NEEDLE: &str = " with ";
     let lower = text.to_lowercase();
@@ -870,46 +866,47 @@ mod test_den_bugbear {
         assert_eq!(spec.toughness, Some(2));
     }
 
-    /// Regression: parse_animation_types must halt at connectives and
+    /// Regression: parse_animation_type_parts must halt at connectives and
     /// punctuation rather than sweeping subsequent words in as subtypes.
     /// Previously a text like "Dragon, gets +5/+3, and gains flying and trample"
     /// produced subtypes ["Dragon", "Gets", "+5/+3", "And", "Gains", "Flying", "Trample"].
     #[test]
     fn animation_types_halts_at_connectives_and_punctuation() {
         assert_eq!(
-            parse_animation_types("Dragon", true),
+            parse_animation_type_parts("Dragon", true).1,
             vec!["Creature", "Dragon"]
         );
         assert_eq!(
-            parse_animation_types("artifact creature Golem", false),
+            parse_animation_type_parts("artifact creature Golem", false).1,
             vec!["Artifact", "Creature", "Golem"]
         );
 
         // Trailing comma on a valid subtype: accept the subtype, stop after.
         assert_eq!(
-            parse_animation_types("Dragon, gets +5/+3, and gains flying", true),
+            parse_animation_type_parts("Dragon, gets +5/+3, and gains flying", true).1,
             vec!["Creature", "Dragon"]
         );
 
         // Lowercase word immediately after subtype must terminate parsing.
         assert_eq!(
-            parse_animation_types("Golem until end of combat", false),
+            parse_animation_type_parts("Golem until end of combat", false).1,
             vec!["Golem"]
         );
 
         // P/T tokens and quoted triggers must not become subtypes.
         assert_eq!(
-            parse_animation_types("Cat X/X", true),
+            parse_animation_type_parts("Cat X/X", true).1,
             vec!["Creature", "Cat"]
         );
         assert_eq!(
-            parse_animation_types("Shade and gains \"{B}: This creature gets +1/+1\"", true),
+            parse_animation_type_parts("Shade and gains \"{B}: This creature gets +1/+1\"", true,)
+                .1,
             vec!["Creature", "Shade"],
         );
 
         // Leading lowercase connective before any subtype → nothing parseable.
         assert_eq!(
-            parse_animation_types("in addition to its other types and gains flying", false),
+            parse_animation_type_parts("in addition to its other types and gains flying", false).1,
             Vec::<String>::new()
         );
     }
@@ -1106,7 +1103,7 @@ mod test_den_bugbear {
         assert_eq!(types, vec!["Creature", "Angel"]);
 
         assert_eq!(
-            parse_animation_types("legendary Angel creature", false),
+            parse_animation_type_parts("legendary Angel creature", false).1,
             vec!["Creature", "Angel"]
         );
         let (supertypes, types) = parse_animation_type_parts("basic Forest", false);
@@ -1118,7 +1115,7 @@ mod test_den_bugbear {
         assert_eq!(supertypes, vec![Supertype::Snow]);
         assert_eq!(types, vec!["Creature", "Elemental"]);
         assert_eq!(
-            parse_animation_types("snow Creature Elemental", false),
+            parse_animation_type_parts("snow Creature Elemental", false).1,
             vec!["Creature", "Elemental"]
         );
     }
@@ -1311,9 +1308,9 @@ mod test_den_bugbear {
         // but lacking the structural signal we must reject lowercase input.
         assert!(parse_becomes_type_modifications("demon").is_empty());
 
-        // parse_animation_types exercises the same fallback.
+        // parse_animation_type_parts exercises the same fallback.
         assert_eq!(
-            parse_animation_types("demon in addition to its other types", false),
+            parse_animation_type_parts("demon in addition to its other types", false).1,
             vec!["Demon"]
         );
     }

--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -17,8 +17,10 @@ use super::token::{
 };
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
+use crate::parser::oracle_nom::bridge::nom_on_lower;
 use crate::parser::oracle_quantity;
 use crate::types::ability::{PtValue, QuantityExpr, QuantityRef};
+use crate::types::card_type::Supertype;
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaColor;
 
@@ -56,6 +58,10 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
     } else if let Some(stripped) = rest.strip_prefix("an ") {
         rest = stripped;
     }
+
+    let (leading_supertypes, after_supertypes) = strip_animation_supertypes(rest);
+    spec.supertypes = leading_supertypes;
+    rest = after_supertypes;
 
     // CR 107.3c: "X/X where X is ~'s power" — X is bound to a dynamic quantity
     // (source's power), NOT the cost paid. This pattern must be detected BEFORE
@@ -139,11 +145,37 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
         && spec.colors.is_none()
         && spec.keywords.is_empty()
         && spec.types.is_empty()
+        && spec.supertypes.is_empty()
         && !spec.remove_all_abilities
     {
         None
     } else {
         Some(spec)
+    }
+}
+
+/// CR 205.4a: Peel leading supertype words before P/T/color/type parsing so
+/// "becomes a legendary 4/4 …" (Sarkhan, the Dragonspeaker) does not stall at
+/// `legendary` and fall through to keyword-only partial parses.
+fn strip_animation_supertypes(mut text: &str) -> (Vec<Supertype>, &str) {
+    let mut supertypes = Vec::new();
+    loop {
+        let trimmed = text.trim_start();
+        let trimmed_lower = trimmed.to_lowercase();
+        let Some((supertype, stripped)) = nom_on_lower(trimmed, &trimmed_lower, |i| {
+            alt((
+                value(Supertype::Legendary, tag("legendary ")),
+                value(Supertype::Snow, tag("snow ")),
+                value(Supertype::Basic, tag("basic ")),
+            ))
+            .parse(i)
+        }) else {
+            return (supertypes, trimmed);
+        };
+        if !supertypes.contains(&supertype) {
+            supertypes.push(supertype);
+        }
+        text = stripped;
     }
 }
 
@@ -178,6 +210,11 @@ pub(crate) fn animation_modifications(
     }
     if spec.remove_all_abilities {
         modifications.push(ContinuousModification::RemoveAllAbilities);
+    }
+    for supertype in &spec.supertypes {
+        modifications.push(ContinuousModification::AddSupertype {
+            supertype: *supertype,
+        });
     }
     for keyword in &spec.keywords {
         modifications.push(ContinuousModification::AddKeyword {
@@ -1087,6 +1124,48 @@ mod test_den_bugbear {
             parse_animation_types("snow Creature Elemental", false),
             vec!["Creature", "Elemental"]
         );
+    }
+
+    /// Issue #2362 (Sarkhan, the Dragonspeaker): "+1: … becomes a legendary
+    /// 4/4 red Dragon creature with flying, indestructible, and haste" must emit
+    /// full layer-4 mods, not keywords alone.
+    #[test]
+    fn sarkhan_become_legendary_dragon_animation_spec() {
+        use crate::types::ability::ContinuousModification;
+        use crate::types::card_type::{CoreType, Supertype};
+
+        let spec = parse_animation_spec(
+            "a legendary 4/4 red Dragon creature with flying, indestructible, and haste",
+            &mut ParseContext::default(),
+        )
+        .expect("Sarkhan +1 animation phrase must parse");
+        assert_eq!(spec.supertypes, vec![Supertype::Legendary]);
+        assert_eq!(spec.power, Some(4));
+        assert_eq!(spec.toughness, Some(4));
+        assert_eq!(spec.colors, Some(vec![ManaColor::Red]));
+        assert_eq!(
+            spec.types,
+            vec!["Creature".to_string(), "Dragon".to_string()]
+        );
+        assert!(spec.keywords.contains(&Keyword::Flying));
+        assert!(spec.keywords.contains(&Keyword::Indestructible));
+        assert!(spec.keywords.contains(&Keyword::Haste));
+
+        let mods = animation_modifications(&spec);
+        assert!(mods.contains(&ContinuousModification::AddSupertype {
+            supertype: Supertype::Legendary,
+        }));
+        assert!(mods.contains(&ContinuousModification::SetPower { value: 4 }));
+        assert!(mods.contains(&ContinuousModification::SetToughness { value: 4 }));
+        assert!(mods.contains(&ContinuousModification::SetColor {
+            colors: vec![ManaColor::Red],
+        }));
+        assert!(mods.contains(&ContinuousModification::AddType {
+            core_type: CoreType::Creature,
+        }));
+        assert!(mods.contains(&ContinuousModification::AddSubtype {
+            subtype: "Dragon".to_string(),
+        }));
     }
 
     /// Regression: the subtype grammar must reject tokens where a capital

--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -17,6 +17,7 @@ use super::token::{
 };
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
+use crate::parser::oracle_nom::bridge::nom_on_lower;
 use crate::parser::oracle_quantity;
 use crate::types::ability::{PtValue, QuantityExpr, QuantityRef};
 use crate::types::card_type::Supertype;
@@ -57,6 +58,10 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
     } else if let Some(stripped) = rest.strip_prefix("an ") {
         rest = stripped;
     }
+
+    let (leading_supertypes, after_supertypes) = strip_animation_supertypes(rest);
+    spec.supertypes = leading_supertypes;
+    rest = after_supertypes;
 
     // CR 107.3c: "X/X where X is ~'s power" — X is bound to a dynamic quantity
     // (source's power), NOT the cost paid. This pattern must be detected BEFORE
@@ -125,14 +130,18 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
         rest = after_colors;
     }
 
-    let (supertypes, types) = parse_animation_type_parts(
+    let (parsed_supertypes, types) = parse_animation_type_parts(
         rest,
         spec.power.is_some()
             || spec.toughness.is_some()
             || spec.dynamic_power.is_some()
             || spec.dynamic_toughness.is_some(),
     );
-    spec.supertypes = supertypes;
+    for supertype in parsed_supertypes {
+        if !spec.supertypes.contains(&supertype) {
+            spec.supertypes.push(supertype);
+        }
+    }
     spec.types = types;
 
     if spec.power.is_none()
@@ -148,6 +157,31 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
         None
     } else {
         Some(spec)
+    }
+}
+
+/// CR 205.4a: Peel leading supertype words before P/T/color/type parsing so
+/// "becomes a legendary 4/4 …" (Sarkhan, the Dragonspeaker) does not stall at
+/// `legendary` and fall through to keyword-only partial parses.
+fn strip_animation_supertypes(mut text: &str) -> (Vec<Supertype>, &str) {
+    let mut supertypes = Vec::new();
+    loop {
+        let trimmed = text.trim_start();
+        let trimmed_lower = trimmed.to_lowercase();
+        let Some((supertype, stripped)) = nom_on_lower(trimmed, &trimmed_lower, |i| {
+            alt((
+                value(Supertype::Legendary, tag("legendary ")),
+                value(Supertype::Snow, tag("snow ")),
+                value(Supertype::Basic, tag("basic ")),
+            ))
+            .parse(i)
+        }) else {
+            return (supertypes, trimmed);
+        };
+        if !supertypes.contains(&supertype) {
+            supertypes.push(supertype);
+        }
+        text = stripped;
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -17,7 +17,6 @@ use super::token::{
 };
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
-use crate::parser::oracle_nom::bridge::nom_on_lower;
 use crate::parser::oracle_quantity;
 use crate::types::ability::{PtValue, QuantityExpr, QuantityRef};
 use crate::types::card_type::Supertype;
@@ -58,10 +57,6 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
     } else if let Some(stripped) = rest.strip_prefix("an ") {
         rest = stripped;
     }
-
-    let (leading_supertypes, after_supertypes) = strip_animation_supertypes(rest);
-    spec.supertypes = leading_supertypes;
-    rest = after_supertypes;
 
     // CR 107.3c: "X/X where X is ~'s power" — X is bound to a dynamic quantity
     // (source's power), NOT the cost paid. This pattern must be detected BEFORE
@@ -130,13 +125,15 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
         rest = after_colors;
     }
 
-    spec.types = parse_animation_types(
+    let (supertypes, types) = parse_animation_type_parts(
         rest,
         spec.power.is_some()
             || spec.toughness.is_some()
             || spec.dynamic_power.is_some()
             || spec.dynamic_toughness.is_some(),
     );
+    spec.supertypes = supertypes;
+    spec.types = types;
 
     if spec.power.is_none()
         && spec.toughness.is_none()
@@ -151,31 +148,6 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
         None
     } else {
         Some(spec)
-    }
-}
-
-/// CR 205.4a: Peel leading supertype words before P/T/color/type parsing so
-/// "becomes a legendary 4/4 …" (Sarkhan, the Dragonspeaker) does not stall at
-/// `legendary` and fall through to keyword-only partial parses.
-fn strip_animation_supertypes(mut text: &str) -> (Vec<Supertype>, &str) {
-    let mut supertypes = Vec::new();
-    loop {
-        let trimmed = text.trim_start();
-        let trimmed_lower = trimmed.to_lowercase();
-        let Some((supertype, stripped)) = nom_on_lower(trimmed, &trimmed_lower, |i| {
-            alt((
-                value(Supertype::Legendary, tag("legendary ")),
-                value(Supertype::Snow, tag("snow ")),
-                value(Supertype::Basic, tag("basic ")),
-            ))
-            .parse(i)
-        }) else {
-            return (supertypes, trimmed);
-        };
-        if !supertypes.contains(&supertype) {
-            supertypes.push(supertype);
-        }
-        text = stripped;
     }
 }
 
@@ -443,17 +415,16 @@ fn split_animation_dynamic_pt_clause(text: &str) -> Option<(&str, QuantityExpr)>
 
 /// Classification of a single token within a "becomes [type expression]" noun
 /// phrase. Encodes the full design space so callers can't conflate core types
-/// (emitted as `AddType`) with subtypes (emitted as `AddSubtype`) or leak
-/// supertypes (recognized-but-discarded: animations never change supertypes).
+/// (emitted as `AddType`) with subtypes (emitted as `AddSubtype`) or supertypes
+/// (emitted as `AddSupertype`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum AnimationTypeToken {
     /// CR 205.2a core type — maps to `ContinuousModification::AddType`.
     CoreType(&'static str),
     /// CR 205.3 subtype — maps to `ContinuousModification::AddSubtype`.
     Subtype(String),
-    /// CR 205.4 supertype — recognized to avoid halting the sequence, but
-    /// not emitted as a modification (animations don't grant supertypes).
-    Supertype,
+    /// CR 205.4 supertype — maps to `ContinuousModification::AddSupertype`.
+    Supertype(Supertype),
 }
 
 /// Zero-width word-boundary check: next char must be non-alphabetic (whitespace,
@@ -491,14 +462,16 @@ fn parse_animation_core_type(input: &str) -> OracleResult<'_, AnimationTypeToken
 
 /// Parse a CR 205.4 supertype keyword (case-insensitive, word-boundary terminated).
 fn parse_animation_supertype(input: &str) -> OracleResult<'_, AnimationTypeToken> {
-    let (rest, _) = alt((
-        tag_no_case("legendary"),
-        tag_no_case("basic"),
-        tag_no_case("snow"),
+    let (rest, supertype) = alt((
+        value(Supertype::Legendary, tag_no_case("legendary")),
+        value(Supertype::Basic, tag_no_case("basic")),
+        value(Supertype::Snow, tag_no_case("snow")),
+        value(Supertype::World, tag_no_case("world")),
+        value(Supertype::Ongoing, tag_no_case("ongoing")),
     ))
     .parse(input)?;
     let (rest, _) = alpha_word_boundary(rest)?;
-    Ok((rest, AnimationTypeToken::Supertype))
+    Ok((rest, AnimationTypeToken::Supertype(supertype)))
 }
 
 /// Parse a CR 205.3 subtype: a capitalized proper-noun word of length ≥ 2,
@@ -683,8 +656,8 @@ pub(crate) fn has_in_addition_to_other_types(text: &str) -> bool {
 /// outside the effect-animation path (e.g., static-ability parsing of
 /// "target creature ... becomes a Horror enchantment creature in addition to
 /// its other types") get the same type-line decomposition: one `AddType` per
-/// CR 205.2 core type, one `AddSubtype` per CR 205.3 subtype, supertypes
-/// discarded (CR 205.4 — animations never grant supertypes).
+/// CR 205.2 core type, one `AddSubtype` per CR 205.3 subtype, and one
+/// `AddSupertype` per CR 205.4 supertype.
 ///
 /// The descriptor is the noun phrase *after* the "becomes a"/"becomes an"
 /// article and *before* any trailing "in addition to its other types" clause.
@@ -741,7 +714,12 @@ pub(crate) fn parse_becomes_type_modifications(
                     modifications.push(modification);
                 }
             }
-            AnimationTypeToken::Supertype => {}
+            AnimationTypeToken::Supertype(supertype) => {
+                let modification = ContinuousModification::AddSupertype { supertype };
+                if !modifications.contains(&modification) {
+                    modifications.push(modification);
+                }
+            }
         }
     }
     modifications
@@ -755,31 +733,36 @@ pub(crate) fn parse_becomes_type_modifications(
 /// This prevents misparses like *"this creature becomes a Dragon, gets +5/+3,
 /// and gains flying"* from sweeping `Gets`, `And`, `Gains`, `Flying` in as
 /// AddSubtype modifications — a common coverage false-positive pattern.
-fn parse_animation_types(text: &str, infer_creature: bool) -> Vec<String> {
+fn parse_animation_type_parts(text: &str, infer_creature: bool) -> (Vec<Supertype>, Vec<String>) {
     let descriptor = text.trim().trim_end_matches(',').trim();
     if descriptor.is_empty() {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     }
 
     // See parse_becomes_type_modifications for the same forward-parse pattern.
     // oracle_nom/PATTERNS.md ("Optional trailing clause after a token sequence").
     let tokens = match try_parse_type_sequence_with_suffix(descriptor) {
         Some(tokens) => tokens,
-        None => return Vec::new(),
+        None => return (Vec::new(), Vec::new()),
     };
 
+    let mut supertypes = Vec::new();
     let mut core_types = Vec::new();
     let mut subtypes = Vec::new();
     for token in tokens {
         match token {
             AnimationTypeToken::CoreType(name) => push_unique_string(&mut core_types, name),
             AnimationTypeToken::Subtype(name) => subtypes.push(title_case_word(&name)),
-            AnimationTypeToken::Supertype => {}
+            AnimationTypeToken::Supertype(supertype) => {
+                if !supertypes.contains(&supertype) {
+                    supertypes.push(supertype);
+                }
+            }
         }
     }
 
     if core_types.is_empty() && subtypes.is_empty() {
-        return Vec::new();
+        return (supertypes, Vec::new());
     }
     if core_types.is_empty() && infer_creature {
         push_unique_string(&mut core_types, "Creature");
@@ -789,7 +772,11 @@ fn parse_animation_types(text: &str, infer_creature: bool) -> Vec<String> {
     for subtype in subtypes {
         push_unique_string(&mut types, subtype);
     }
-    types
+    (supertypes, types)
+}
+
+fn parse_animation_types(text: &str, infer_creature: bool) -> Vec<String> {
+    parse_animation_type_parts(text, infer_creature).1
 }
 
 fn split_animation_keyword_clause(text: &str) -> (&str, Vec<Keyword>) {
@@ -1108,18 +1095,28 @@ mod test_den_bugbear {
         ));
     }
 
-    /// Regression: supertypes (CR 205.4) must be recognized-and-discarded
-    /// so they don't halt the sequence. Animations never grant supertypes,
-    /// but a leading `legendary` / `basic` / `snow` word in the noun phrase
-    /// must not prevent the subtype that follows from being captured.
+    /// Regression: supertypes (CR 205.4) must be captured without halting the
+    /// sequence. A leading or mid-phrase `legendary` / `basic` / `snow` word in
+    /// the noun phrase must not prevent the subtype that follows from being
+    /// captured.
     #[test]
-    fn animation_types_discards_supertypes_without_halting_sequence() {
+    fn animation_types_captures_supertypes_without_halting_sequence() {
+        let (supertypes, types) = parse_animation_type_parts("legendary Angel creature", false);
+        assert_eq!(supertypes, vec![Supertype::Legendary]);
+        assert_eq!(types, vec!["Creature", "Angel"]);
+
         assert_eq!(
             parse_animation_types("legendary Angel creature", false),
             vec!["Creature", "Angel"]
         );
-        assert_eq!(parse_animation_types("basic Forest", false), vec!["Forest"]);
+        let (supertypes, types) = parse_animation_type_parts("basic Forest", false);
+        assert_eq!(supertypes, vec![Supertype::Basic]);
+        assert_eq!(types, vec!["Forest"]);
+
         // Supertype between core type and subtype must not halt.
+        let (supertypes, types) = parse_animation_type_parts("snow Creature Elemental", false);
+        assert_eq!(supertypes, vec![Supertype::Snow]);
+        assert_eq!(types, vec!["Creature", "Elemental"]);
         assert_eq!(
             parse_animation_types("snow Creature Elemental", false),
             vec!["Creature", "Elemental"]
@@ -1147,9 +1144,10 @@ mod test_den_bugbear {
             spec.types,
             vec!["Creature".to_string(), "Dragon".to_string()]
         );
-        assert!(spec.keywords.contains(&Keyword::Flying));
-        assert!(spec.keywords.contains(&Keyword::Indestructible));
-        assert!(spec.keywords.contains(&Keyword::Haste));
+        assert_eq!(
+            spec.keywords,
+            vec![Keyword::Flying, Keyword::Indestructible, Keyword::Haste]
+        );
 
         let mods = animation_modifications(&spec);
         assert!(mods.contains(&ContinuousModification::AddSupertype {
@@ -1188,7 +1186,7 @@ mod test_den_bugbear {
     #[test]
     fn becomes_type_modifications_decomposes_subtype_and_core_types() {
         use crate::types::ability::ContinuousModification;
-        use crate::types::card_type::CoreType;
+        use crate::types::card_type::{CoreType, Supertype};
 
         // Pure core type.
         assert_eq!(
@@ -1261,10 +1259,13 @@ mod test_den_bugbear {
             ]
         );
 
-        // Supertype (CR 205.4) is recognized and discarded.
+        // Supertype (CR 205.4) is recognized and emitted with the type phrase.
         assert_eq!(
             parse_becomes_type_modifications("legendary Angel creature"),
             vec![
+                ContinuousModification::AddSupertype {
+                    supertype: Supertype::Legendary
+                },
                 ContinuousModification::AddSubtype {
                     subtype: "Angel".into()
                 },

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -90,6 +90,7 @@ pub(crate) struct AnimationSpec {
     pub(crate) colors: Option<Vec<ManaColor>>,
     pub(crate) keywords: Vec<Keyword>,
     pub(crate) types: Vec<String>,
+    pub(crate) supertypes: Vec<crate::types::card_type::Supertype>,
     pub(crate) remove_all_abilities: bool,
 }
 


### PR DESCRIPTION
## Summary
- Strip leading supertypes before P/T parsing in `parse_animation_spec` so "becomes a legendary 4/4 …" phrases parse fully
- Emit `AddSupertype(Legendary)` from animation specs alongside P/T, color, type, and keyword mods
- Fixes Sarkhan, the Dragonspeaker's +1 ability (and the same pattern on other legendary animate lines)

## Test plan
- [x] `cargo test -p engine --lib sarkhan_become_legendary_dragon`
- [x] `cargo clippy -p engine -- -D warnings`
- [x] `./scripts/check-parser-combinators.sh origin/main`

Fixes #2362

Made with [Cursor](https://cursor.com)