### PR TITLE
fix(engine): equipment DamageDone triggers on combat damage (#2348)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1040,6 +1040,16 @@ pub(super) fn match_changes_zone_all(
 }
 
 // CR 603.6d: DamageDone trigger fires on damage dealt events.
+
+/// CR 510.2 + CR 603.2: Only equipment-style `AttachedTo` observers listen on
+/// the aggregate `CombatDamageDealtToPlayer` event. Self-referential creature
+/// triggers already fire on per-source `DamageDealt` events emitted during the
+/// combat damage step; matching them again on the aggregate event double-fires.
+pub(super) fn listens_on_aggregate_combat_damage_done(trigger: &TriggerDefinition) -> bool {
+    trigger.mode == TriggerMode::DamageDone
+        && matches!(trigger.valid_source, Some(TargetFilter::AttachedTo))
+}
+
 fn matching_combat_damage_to_player_sources(
     trigger: &TriggerDefinition,
     source_id: ObjectId,
@@ -1139,7 +1149,7 @@ pub(super) fn match_damage_done(
         ..
     } = event
     {
-        if trigger.valid_source.is_none() {
+        if !listens_on_aggregate_combat_damage_done(trigger) {
             return false;
         }
         !matching_combat_damage_to_player_sources(
@@ -1166,7 +1176,7 @@ pub(super) fn matching_damage_done_events(
     source_id: ObjectId,
     state: &GameState,
 ) -> Vec<GameEvent> {
-    if trigger.mode != TriggerMode::DamageDone || trigger.valid_source.is_none() {
+    if !listens_on_aggregate_combat_damage_done(trigger) {
         return Vec::new();
     }
 
@@ -6846,6 +6856,7 @@ mod tests {
             .push(CoreType::Creature);
 
         let mut trigger = make_trigger(TriggerMode::DamageDone);
+        trigger.valid_source = Some(TargetFilter::SelfRef);
         trigger.valid_target = Some(TargetFilter::Player);
         trigger.damage_kind = DamageKindFilter::CombatOnly;
 
@@ -6857,8 +6868,9 @@ mod tests {
 
         assert!(
             !match_damage_done(&event, &trigger, attacker, &state),
-            "self/no-source triggers already fire from per-source DamageDealt events"
+            "SelfRef triggers must not match aggregate combat damage"
         );
+        assert!(!listens_on_aggregate_combat_damage_done(&trigger));
         assert!(matching_damage_done_events(&event, &trigger, attacker, &state).is_empty());
     }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1139,6 +1139,9 @@ pub(super) fn match_damage_done(
         ..
     } = event
     {
+        if trigger.valid_source.is_none() {
+            return false;
+        }
         !matching_combat_damage_to_player_sources(
             trigger,
             source_id,
@@ -6852,7 +6855,10 @@ mod tests {
             total_damage: 2,
         };
 
-        assert!(match_damage_done(&event, &trigger, attacker, &state));
+        assert!(
+            !match_damage_done(&event, &trigger, attacker, &state),
+            "self/no-source triggers already fire from per-source DamageDealt events"
+        );
         assert!(matching_damage_done_events(&event, &trigger, attacker, &state).is_empty());
     }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1041,13 +1041,17 @@ pub(super) fn match_changes_zone_all(
 
 // CR 603.6d: DamageDone trigger fires on damage dealt events.
 
-/// CR 510.2 + CR 603.2: Only equipment-style `AttachedTo` observers listen on
-/// the aggregate `CombatDamageDealtToPlayer` event. Self-referential creature
-/// triggers already fire on per-source `DamageDealt` events emitted during the
-/// combat damage step; matching them again on the aggregate event double-fires.
+/// CR 510.2 + CR 603.2: Source-filtered observers whose source is not the
+/// trigger source itself listen on the aggregate `CombatDamageDealtToPlayer`
+/// event. Self/no-source creature triggers already fire on per-source
+/// `DamageDealt` events emitted during the combat damage step; matching them
+/// again on the aggregate event double-fires.
 pub(super) fn listens_on_aggregate_combat_damage_done(trigger: &TriggerDefinition) -> bool {
     trigger.mode == TriggerMode::DamageDone
-        && matches!(trigger.valid_source, Some(TargetFilter::AttachedTo))
+        && matches!(
+            trigger.valid_source,
+            Some(ref filter) if !matches!(filter, TargetFilter::SelfRef)
+        )
 }
 
 fn matching_combat_damage_to_player_sources(
@@ -1093,6 +1097,12 @@ pub(super) fn match_damage_done(
         ..
     } = event
     {
+        if *is_combat
+            && matches!(target, TargetRef::Player(_))
+            && listens_on_aggregate_combat_damage_done(trigger)
+        {
+            return false;
+        }
         // Check if trigger requires damage from a specific source
         if !valid_source_matches(trigger, state, *dmg_source, source_id) {
             return false;
@@ -6784,6 +6794,71 @@ mod tests {
     }
 
     #[test]
+    fn matching_damage_done_events_expands_source_filtered_combat_damage() {
+        let mut state = setup();
+        let watcher = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Damage Watcher".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker_a = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Attacker A".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker_b = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Attacker B".to_string(),
+            Zone::Battlefield,
+        );
+        for attacker in [attacker_a, attacker_b] {
+            state
+                .objects
+                .get_mut(&attacker)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+
+        let mut trigger = make_trigger(TriggerMode::DamageDoneOnce);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        trigger.valid_target = Some(TargetFilter::Player);
+        trigger.damage_kind = DamageKindFilter::CombatOnly;
+
+        let event = GameEvent::CombatDamageDealtToPlayer {
+            player_id: PlayerId(1),
+            source_amounts: vec![(attacker_a, 2), (attacker_b, 3)],
+            total_damage: 5,
+        };
+
+        let per_source_event = GameEvent::DamageDealt {
+            source_id: attacker_a,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 2,
+            is_combat: true,
+            excess: 0,
+        };
+        assert!(
+            !match_damage_done(&per_source_event, &trigger, watcher, &state),
+            "source-filtered observers use the aggregate event for combat damage to players"
+        );
+        assert!(match_damage_done(&event, &trigger, watcher, &state));
+        assert_eq!(
+            matching_damage_done_events(&event, &trigger, watcher, &state).len(),
+            2
+        );
+    }
+
+    #[test]
     fn matching_damage_done_events_does_not_expand_once_modes() {
         let mut state = setup();
         let watcher = create_object(
@@ -6830,10 +6905,7 @@ mod tests {
             total_damage: 5,
         };
 
-        assert!(
-            !match_damage_done(&event, &trigger, watcher, &state),
-            "aggregate combat damage matching is reserved for AttachedTo observers"
-        );
+        assert!(!match_damage_done(&event, &trigger, watcher, &state));
         assert!(matching_damage_done_events(&event, &trigger, watcher, &state).is_empty());
     }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1139,12 +1139,6 @@ pub(super) fn match_damage_done(
         ..
     } = event
     {
-        // Self-referential creature triggers already fire on per-source `DamageDealt`
-        // events. Only equipment-style observers (`AttachedTo`) listen on the
-        // aggregate combat-damage event.
-        if !matches!(trigger.valid_source, Some(TargetFilter::AttachedTo)) {
-            return false;
-        }
         !matching_combat_damage_to_player_sources(
             trigger,
             source_id,
@@ -1169,9 +1163,7 @@ pub(super) fn matching_damage_done_events(
     source_id: ObjectId,
     state: &GameState,
 ) -> Vec<GameEvent> {
-    if trigger.mode != TriggerMode::DamageDone
-        || !matches!(trigger.valid_source, Some(TargetFilter::AttachedTo))
-    {
+    if trigger.mode != TriggerMode::DamageDone || trigger.valid_source.is_none() {
         return Vec::new();
     }
 
@@ -6851,7 +6843,6 @@ mod tests {
             .push(CoreType::Creature);
 
         let mut trigger = make_trigger(TriggerMode::DamageDone);
-        trigger.valid_source = Some(TargetFilter::SelfRef);
         trigger.valid_target = Some(TargetFilter::Player);
         trigger.damage_kind = DamageKindFilter::CombatOnly;
 
@@ -6861,10 +6852,7 @@ mod tests {
             total_damage: 2,
         };
 
-        assert!(
-            !match_damage_done(&event, &trigger, attacker, &state),
-            "SelfRef triggers must not match aggregate combat damage"
-        );
+        assert!(match_damage_done(&event, &trigger, attacker, &state));
         assert!(matching_damage_done_events(&event, &trigger, attacker, &state).is_empty());
     }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1139,6 +1139,12 @@ pub(super) fn match_damage_done(
         ..
     } = event
     {
+        // Self-referential creature triggers already fire on per-source `DamageDealt`
+        // events. Only equipment-style observers (`AttachedTo`) listen on the
+        // aggregate combat-damage event.
+        if !matches!(trigger.valid_source, Some(TargetFilter::AttachedTo)) {
+            return false;
+        }
         !matching_combat_damage_to_player_sources(
             trigger,
             source_id,
@@ -1163,7 +1169,9 @@ pub(super) fn matching_damage_done_events(
     source_id: ObjectId,
     state: &GameState,
 ) -> Vec<GameEvent> {
-    if trigger.mode != TriggerMode::DamageDone || trigger.valid_source.is_none() {
+    if trigger.mode != TriggerMode::DamageDone
+        || !matches!(trigger.valid_source, Some(TargetFilter::AttachedTo))
+    {
         return Vec::new();
     }
 
@@ -6843,6 +6851,7 @@ mod tests {
             .push(CoreType::Creature);
 
         let mut trigger = make_trigger(TriggerMode::DamageDone);
+        trigger.valid_source = Some(TargetFilter::SelfRef);
         trigger.valid_target = Some(TargetFilter::Player);
         trigger.damage_kind = DamageKindFilter::CombatOnly;
 
@@ -6852,7 +6861,10 @@ mod tests {
             total_damage: 2,
         };
 
-        assert!(match_damage_done(&event, &trigger, attacker, &state));
+        assert!(
+            !match_damage_done(&event, &trigger, attacker, &state),
+            "SelfRef triggers must not match aggregate combat damage"
+        );
         assert!(matching_damage_done_events(&event, &trigger, attacker, &state).is_empty());
     }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -6827,7 +6827,7 @@ mod tests {
                 .push(CoreType::Creature);
         }
 
-        let mut trigger = make_trigger(TriggerMode::DamageDoneOnce);
+        let mut trigger = make_trigger(TriggerMode::DamageDone);
         trigger.valid_source = Some(TargetFilter::Typed(
             TypedFilter::creature().controller(ControllerRef::You),
         ));

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1139,6 +1139,13 @@ pub(super) fn match_damage_done(
         ..
     } = event
     {
+        // Self-referential "this creature deals combat damage" triggers already
+        // fire on per-source `DamageDealt` events emitted during the combat
+        // damage step. Only equipment-style observer triggers (`AttachedTo`)
+        // listen on the aggregate `CombatDamageDealtToPlayer` event.
+        if !matches!(trigger.valid_source, Some(TargetFilter::AttachedTo)) {
+            return false;
+        }
         !matching_combat_damage_to_player_sources(
             trigger,
             source_id,
@@ -6817,7 +6824,10 @@ mod tests {
             total_damage: 5,
         };
 
-        assert!(match_damage_done(&event, &trigger, watcher, &state));
+        assert!(
+            !match_damage_done(&event, &trigger, watcher, &state),
+            "aggregate combat damage matching is reserved for AttachedTo observers"
+        );
         assert!(matching_damage_done_events(&event, &trigger, watcher, &state).is_empty());
     }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1040,6 +1040,35 @@ pub(super) fn match_changes_zone_all(
 }
 
 // CR 603.6d: DamageDone trigger fires on damage dealt events.
+fn matching_combat_damage_to_player_sources(
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+    player_id: PlayerId,
+    source_amounts: &[(ObjectId, u32)],
+) -> Vec<(ObjectId, u32)> {
+    if trigger.damage_kind == DamageKindFilter::NoncombatOnly {
+        return Vec::new();
+    }
+    if let Some(ref vt) = trigger.valid_target {
+        if !player_matches_filter(vt, state, player_id, source_id) {
+            return Vec::new();
+        }
+    }
+    source_amounts
+        .iter()
+        .filter(|(src, amt)| {
+            if let Some((cmp, threshold)) = trigger.damage_amount {
+                if !cmp.evaluate(*amt as i32, threshold as i32) {
+                    return false;
+                }
+            }
+            valid_source_matches(trigger, state, *src, source_id)
+        })
+        .copied()
+        .collect()
+}
+
 pub(super) fn match_damage_done(
     event: &GameEvent,
     trigger: &TriggerDefinition,
@@ -1104,9 +1133,55 @@ pub(super) fn match_damage_done(
             }
         }
         true
+    } else if let GameEvent::CombatDamageDealtToPlayer {
+        player_id,
+        source_amounts,
+        ..
+    } = event
+    {
+        !matching_combat_damage_to_player_sources(
+            trigger,
+            source_id,
+            state,
+            *player_id,
+            source_amounts,
+        )
+        .is_empty()
     } else {
         false
     }
+}
+
+/// CR 510.2 + CR 603.2: `DamageDone` triggers on equipment (and other
+/// observers) listen for per-source combat damage via the aggregate
+/// `CombatDamageDealtToPlayer` event. Expand matching sources into synthetic
+/// `DamageDealt` events so downstream `EventContextAmount` and intervening-if
+/// checks see the per-source amount.
+pub(super) fn matching_damage_done_events(
+    event: &GameEvent,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> Vec<GameEvent> {
+    let GameEvent::CombatDamageDealtToPlayer {
+        player_id,
+        source_amounts,
+        ..
+    } = event
+    else {
+        return Vec::new();
+    };
+
+    matching_combat_damage_to_player_sources(trigger, source_id, state, *player_id, source_amounts)
+        .into_iter()
+        .map(|(src, amt)| GameEvent::DamageDealt {
+            source_id: src,
+            target: TargetRef::Player(*player_id),
+            amount: amt,
+            is_combat: true,
+            excess: 0,
+        })
+        .collect()
 }
 
 pub(super) fn match_damage_done_once_by_controller(
@@ -6640,6 +6715,55 @@ mod tests {
         assert_eq!(rebuilt_amounts, vec![(creature_a, 3)]);
         // Only creature_a's 3 damage counts, not the aggregate 5.
         assert_eq!(total_damage, 3);
+    }
+
+    #[test]
+    fn matching_damage_done_events_expands_equipped_creature_combat_damage() {
+        let mut state = setup();
+        let equipment = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "The Key to the Vault".to_string(),
+            Zone::Battlefield,
+        );
+        let bearer = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Equipped Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&bearer).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+        }
+        state.objects.get_mut(&equipment).unwrap().attached_to = Some(AttachTarget::Object(bearer));
+
+        let mut trigger = make_trigger(TriggerMode::DamageDone);
+        trigger.valid_source = Some(TargetFilter::AttachedTo);
+        trigger.valid_target = Some(TargetFilter::Player);
+        trigger.damage_kind = DamageKindFilter::CombatOnly;
+
+        let event = GameEvent::CombatDamageDealtToPlayer {
+            player_id: PlayerId(1),
+            source_amounts: vec![(bearer, 3)],
+            total_damage: 3,
+        };
+
+        assert!(match_damage_done(&event, &trigger, equipment, &state));
+        let expanded = matching_damage_done_events(&event, &trigger, equipment, &state);
+        assert_eq!(expanded.len(), 1);
+        assert!(matches!(
+            expanded[0],
+            GameEvent::DamageDealt {
+                source_id,
+                target: TargetRef::Player(PlayerId(1)),
+                amount: 3,
+                is_combat: true,
+                ..
+            } if source_id == bearer
+        ));
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1163,6 +1163,10 @@ pub(super) fn matching_damage_done_events(
     source_id: ObjectId,
     state: &GameState,
 ) -> Vec<GameEvent> {
+    if trigger.mode != TriggerMode::DamageDone {
+        return Vec::new();
+    }
+
     let GameEvent::CombatDamageDealtToPlayer {
         player_id,
         source_amounts,
@@ -6764,6 +6768,57 @@ mod tests {
                 ..
             } if source_id == bearer
         ));
+    }
+
+    #[test]
+    fn matching_damage_done_events_does_not_expand_once_modes() {
+        let mut state = setup();
+        let watcher = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Damage Watcher".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker_a = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Attacker A".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker_b = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Attacker B".to_string(),
+            Zone::Battlefield,
+        );
+        for attacker in [attacker_a, attacker_b] {
+            state
+                .objects
+                .get_mut(&attacker)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+
+        let mut trigger = make_trigger(TriggerMode::DamageDoneOnce);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        trigger.valid_target = Some(TargetFilter::Player);
+        trigger.damage_kind = DamageKindFilter::CombatOnly;
+
+        let event = GameEvent::CombatDamageDealtToPlayer {
+            player_id: PlayerId(1),
+            source_amounts: vec![(attacker_a, 2), (attacker_b, 3)],
+            total_damage: 5,
+        };
+
+        assert!(match_damage_done(&event, &trigger, watcher, &state));
+        assert!(matching_damage_done_events(&event, &trigger, watcher, &state).is_empty());
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1139,13 +1139,6 @@ pub(super) fn match_damage_done(
         ..
     } = event
     {
-        // Self-referential "this creature deals combat damage" triggers already
-        // fire on per-source `DamageDealt` events emitted during the combat
-        // damage step. Only equipment-style observer triggers (`AttachedTo`)
-        // listen on the aggregate `CombatDamageDealtToPlayer` event.
-        if !matches!(trigger.valid_source, Some(TargetFilter::AttachedTo)) {
-            return false;
-        }
         !matching_combat_damage_to_player_sources(
             trigger,
             source_id,
@@ -1170,7 +1163,7 @@ pub(super) fn matching_damage_done_events(
     source_id: ObjectId,
     state: &GameState,
 ) -> Vec<GameEvent> {
-    if trigger.mode != TriggerMode::DamageDone {
+    if trigger.mode != TriggerMode::DamageDone || trigger.valid_source.is_none() {
         return Vec::new();
     }
 
@@ -6829,6 +6822,38 @@ mod tests {
             "aggregate combat damage matching is reserved for AttachedTo observers"
         );
         assert!(matching_damage_done_events(&event, &trigger, watcher, &state).is_empty());
+    }
+
+    #[test]
+    fn matching_damage_done_events_does_not_expand_self_source_triggers() {
+        let mut state = setup();
+        let attacker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Tempest Hawk".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let mut trigger = make_trigger(TriggerMode::DamageDone);
+        trigger.valid_target = Some(TargetFilter::Player);
+        trigger.damage_kind = DamageKindFilter::CombatOnly;
+
+        let event = GameEvent::CombatDamageDealtToPlayer {
+            player_id: PlayerId(1),
+            source_amounts: vec![(attacker, 2)],
+            total_damage: 2,
+        };
+
+        assert!(match_damage_done(&event, &trigger, attacker, &state));
+        assert!(matching_damage_done_events(&event, &trigger, attacker, &state).is_empty());
     }
 
     #[test]

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -630,7 +630,7 @@ fn collect_matching_triggers(
                 .map(|trigger_event| vec![trigger_event])
                 .collect()
             } else if matches!(trig_def.mode, TriggerMode::DamageDone)
-                && matches!(trig_def.valid_source, Some(TargetFilter::AttachedTo))
+                && trig_def.valid_source.is_some()
                 && matches!(event, GameEvent::CombatDamageDealtToPlayer { .. })
             {
                 super::trigger_matchers::matching_damage_done_events(event, trig_def, obj_id, state)

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -629,8 +629,7 @@ fn collect_matching_triggers(
                 .into_iter()
                 .map(|trigger_event| vec![trigger_event])
                 .collect()
-            } else if matches!(trig_def.mode, TriggerMode::DamageDone)
-                && trig_def.valid_source.is_some()
+            } else if super::trigger_matchers::listens_on_aggregate_combat_damage_done(trig_def)
                 && matches!(event, GameEvent::CombatDamageDealtToPlayer { .. })
             {
                 super::trigger_matchers::matching_damage_done_events(event, trig_def, obj_id, state)

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -630,7 +630,7 @@ fn collect_matching_triggers(
                 .map(|trigger_event| vec![trigger_event])
                 .collect()
             } else if matches!(trig_def.mode, TriggerMode::DamageDone)
-                && trig_def.valid_source.is_some()
+                && matches!(trig_def.valid_source, Some(TargetFilter::AttachedTo))
                 && matches!(event, GameEvent::CombatDamageDealtToPlayer { .. })
             {
                 super::trigger_matchers::matching_damage_done_events(event, trig_def, obj_id, state)

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -630,6 +630,7 @@ fn collect_matching_triggers(
                 .map(|trigger_event| vec![trigger_event])
                 .collect()
             } else if matches!(trig_def.mode, TriggerMode::DamageDone)
+                && matches!(trig_def.valid_source, Some(TargetFilter::AttachedTo))
                 && matches!(event, GameEvent::CombatDamageDealtToPlayer { .. })
             {
                 super::trigger_matchers::matching_damage_done_events(event, trig_def, obj_id, state)

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -629,13 +629,8 @@ fn collect_matching_triggers(
                 .into_iter()
                 .map(|trigger_event| vec![trigger_event])
                 .collect()
-            } else if matches!(
-                trig_def.mode,
-                TriggerMode::DamageDone
-                    | TriggerMode::DamageDoneOnce
-                    | TriggerMode::DamageAll
-                    | TriggerMode::DamageDealtOnce
-            ) && matches!(event, GameEvent::CombatDamageDealtToPlayer { .. })
+            } else if matches!(trig_def.mode, TriggerMode::DamageDone)
+                && matches!(event, GameEvent::CombatDamageDealtToPlayer { .. })
             {
                 super::trigger_matchers::matching_damage_done_events(event, trig_def, obj_id, state)
                     .into_iter()

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -629,6 +629,18 @@ fn collect_matching_triggers(
                 .into_iter()
                 .map(|trigger_event| vec![trigger_event])
                 .collect()
+            } else if matches!(
+                trig_def.mode,
+                TriggerMode::DamageDone
+                    | TriggerMode::DamageDoneOnce
+                    | TriggerMode::DamageAll
+                    | TriggerMode::DamageDealtOnce
+            ) && matches!(event, GameEvent::CombatDamageDealtToPlayer { .. })
+            {
+                super::trigger_matchers::matching_damage_done_events(event, trig_def, obj_id, state)
+                    .into_iter()
+                    .map(|trigger_event| vec![trigger_event])
+                    .collect()
             } else {
                 vec![vec![event.clone()]]
             };

--- a/crates/engine/tests/integration/issue_2348_key_to_the_vault.rs
+++ b/crates/engine/tests/integration/issue_2348_key_to_the_vault.rs
@@ -1,0 +1,73 @@
+//! Regression for issue #2348: The Key to the Vault must trigger when its
+//! equipped creature deals combat damage to a player.
+//!
+//! https://github.com/phase-rs/phase/issues/2348
+
+use engine::game::effects::attach::attach_to;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::TargetFilter;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+
+use super::rules::run_combat;
+
+const KEY_ORACLE: &str = "Whenever equipped creature deals combat damage to a player, look at the \
+top X cards of your library, where X is the amount of damage dealt. Exile a nonland card from \
+among them. You may cast that card without paying its mana cost. Put the rest on the bottom of \
+your library in a random order.\nEquip {3}{U}";
+
+#[test]
+fn key_to_the_vault_parses_equipped_creature_combat_damage_trigger() {
+    let parsed = parse_oracle_text(
+        KEY_ORACLE,
+        "The Key to the Vault",
+        &["Legendary".to_string()],
+        &["Artifact".to_string()],
+        &["Equipment".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::DamageDone)
+        .expect("Key to the Vault must parse equipped combat-damage trigger");
+    assert_eq!(trigger.valid_source, Some(TargetFilter::AttachedTo));
+    assert_eq!(trigger.valid_target, Some(TargetFilter::Player));
+}
+
+#[test]
+fn key_to_the_vault_triggers_on_equipped_creature_combat_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let attacker = scenario.add_creature(P0, "Vault Bearer", 3, 3).id();
+    let key = scenario
+        .add_creature(P0, "The Key to the Vault", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Equipment"])
+        .from_oracle_text(KEY_ORACLE)
+        .id();
+
+    for idx in 0..5 {
+        scenario.add_spell_to_library_top(P0, &format!("Library Spell {idx}"), true);
+    }
+
+    let mut runner = scenario.build();
+    attach_to(runner.state_mut(), key, attacker);
+    evaluate_layers(runner.state_mut());
+
+    let life_before = runner.life(P1);
+    run_combat(&mut runner, vec![attacker], vec![]);
+
+    assert_eq!(
+        runner.life(P1),
+        life_before - 3,
+        "equipped attacker should deal 3 combat damage"
+    );
+    assert!(
+        !runner.state().stack.is_empty(),
+        "Key to the Vault trigger must go on the stack after combat damage, stack={:?}",
+        runner.state().stack
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -122,6 +122,7 @@ mod issue_1985_dfc_command_zone_cast;
 mod issue_1987_bucknards_everfull_purse;
 mod issue_2011_eldrazi_temple_kozilek_cast;
 mod issue_2345_lavinia_no_mana_spent;
+mod issue_2348_key_to_the_vault;
 mod issue_2351_aven_interrupter;
 mod issue_2359_rod_of_absorption;
 mod issue_2360_the_rack;


### PR DESCRIPTION
## Summary
- Match `DamageDone` triggers against aggregate `CombatDamageDealtToPlayer` events, not only per-source `DamageDealt` events.
- Fan out matching equipped-creature sources into synthetic `DamageDealt` events so `EventContextAmount` and intervening-if checks see the correct damage amount.
- Add regression tests for The Key to the Vault (parser + combat trigger fires on stack).

Fixes #2348

## Test plan
- [x] `cargo test -p engine issue_2348`
- [x] `cargo test -p engine --lib matching_damage_done_events_expands`
- [x] `cargo clippy -p engine -- -D warnings`

Made with [Cursor](https://cursor.com)