### PR TITLE
feat(frontend): surface multi-card top-of-library reveals to all players (#2366, #2005)

### DIFF
--- a/client/src/components/animation/RevealOverlay.tsx
+++ b/client/src/components/animation/RevealOverlay.tsx
@@ -1,0 +1,109 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { useMemo } from "react";
+
+import { useCardImage } from "../../hooks/useCardImage.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+
+function RevealCard({ cardName }: { cardName: string }) {
+  const { src } = useCardImage(cardName, { size: "small" });
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: -14, scale: 0.85 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.85 }}
+      transition={{ type: "spring", stiffness: 320, damping: 26 }}
+      className="overflow-hidden rounded-lg shadow-xl ring-2 ring-amber-400/80"
+      style={{ width: 72, height: 100 }}
+    >
+      {src ? (
+        <img
+          src={src}
+          alt={cardName}
+          className="h-full w-full object-cover"
+          draggable={false}
+        />
+      ) : (
+        <div className="h-full w-full border border-gray-600 bg-gray-700" />
+      )}
+    </motion.div>
+  );
+}
+
+/**
+ * Passive overlay surfacing a multi-card top-of-library reveal to every player.
+ *
+ * CR 701.20b: revealed cards are public to all players. When an effect reveals
+ * several top-of-library cards at once ("reveal the top N", or "look at the top
+ * N, reveal any number" — e.g. Lead the Stampede), the engine publishes them to
+ * `revealed_cards` for the duration of the choice and un-redacts them in every
+ * viewer's filtered state. `LibraryPile` only renders the single top card, so
+ * the cards past the first were otherwise invisible (issues #2366, #2005).
+ *
+ * Scope is deliberately the gap `LibraryPile` leaves: 2+ revealed cards that are
+ * still in a library zone. A single persistently-revealed top card (Future
+ * Sight, Oracle of Mul Daya) is already shown by `LibraryPile`; hand reveals
+ * (Thoughtseize) are not top-of-library and are excluded by the library filter.
+ * The overlay mounts below modals (z-30), so the choosing player's DigChoice
+ * modal occludes it while watching players — who have no modal — see the reveal.
+ */
+export function RevealOverlay() {
+  const gameState = useGameStore((s) => s.gameState);
+
+  const revealed = useMemo(() => {
+    const ids = gameState?.revealed_cards;
+    if (!gameState || !ids || ids.length < 2) return [];
+
+    const libraryIds = new Set<number>();
+    for (const player of gameState.players) {
+      for (const id of player.library ?? []) libraryIds.add(id);
+    }
+
+    const cards: { id: number; name: string }[] = [];
+    for (const id of ids) {
+      if (!libraryIds.has(id)) continue;
+      const obj = gameState.objects[id];
+      // `revealed_cards` is the public set, so the engine un-redacts these for
+      // every viewer; guard against a redacted name defensively only.
+      if (obj?.name && obj.name !== "Hidden Card") {
+        cards.push({ id, name: obj.name });
+      }
+    }
+    return cards;
+  }, [gameState]);
+
+  if (revealed.length < 2) return null;
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-20 z-30 flex justify-center px-4">
+      <motion.div
+        layout
+        initial={{ opacity: 0, y: -8 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0 }}
+        className="flex max-w-full items-center gap-2 overflow-x-auto rounded-2xl bg-black/70 px-4 py-3 shadow-2xl ring-1 ring-amber-400/40 backdrop-blur-sm"
+      >
+        {/* Eye icon — signals "revealed" without a locale string. */}
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-5 w-5 shrink-0 text-amber-300"
+          aria-hidden="true"
+        >
+          <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        <AnimatePresence mode="popLayout">
+          {revealed.map((card) => (
+            <RevealCard key={card.id} cardName={card.name} />
+          ))}
+        </AnimatePresence>
+      </motion.div>
+    </div>
+  );
+}

--- a/client/src/components/animation/__tests__/RevealOverlay.test.tsx
+++ b/client/src/components/animation/__tests__/RevealOverlay.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { type GameState } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { RevealOverlay } from "../RevealOverlay.tsx";
+
+// Return a non-null src so each RevealCard renders an <img alt={name}> we can query.
+vi.mock("../../../hooks/useCardImage", () => ({
+  useCardImage: (cardName: string) => ({ src: `img:${cardName}`, isLoading: false }),
+}));
+
+function setStore(opts: {
+  library?: number[];
+  hand?: number[];
+  objects: Record<number, string>;
+  revealed: number[];
+}) {
+  const objects: Record<string, unknown> = {};
+  for (const [id, name] of Object.entries(opts.objects)) {
+    objects[id] = { id: Number(id), name, zone: "Library" };
+  }
+  const gameState = {
+    players: [
+      { id: 0, library: opts.library ?? [], hand: opts.hand ?? [] },
+      { id: 1, library: [], hand: [] },
+    ],
+    objects,
+    revealed_cards: opts.revealed,
+  } as unknown as GameState;
+
+  useGameStore.setState({ gameState });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("RevealOverlay", () => {
+  it("renders every revealed top-of-library card when two or more are revealed", () => {
+    setStore({
+      library: [10, 11, 12],
+      objects: { 10: "Beast Alpha", 11: "Beast Beta", 12: "Beast Gamma" },
+      revealed: [10, 11],
+    });
+
+    render(<RevealOverlay />);
+
+    expect(screen.getByAltText("Beast Alpha")).toBeInTheDocument();
+    expect(screen.getByAltText("Beast Beta")).toBeInTheDocument();
+    // In the library but not revealed — not surfaced.
+    expect(screen.queryByAltText("Beast Gamma")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a single revealed card (LibraryPile already shows the top)", () => {
+    setStore({
+      library: [10, 11],
+      objects: { 10: "Solo Beast", 11: "Filler" },
+      revealed: [10],
+    });
+
+    const { container } = render(<RevealOverlay />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("excludes hand reveals, surfacing only library reveals", () => {
+    setStore({
+      library: [10, 11],
+      hand: [20],
+      objects: { 10: "Lib A", 11: "Lib B", 20: "Hand X" },
+      revealed: [10, 11, 20],
+    });
+
+    render(<RevealOverlay />);
+
+    expect(screen.getByAltText("Lib A")).toBeInTheDocument();
+    expect(screen.getByAltText("Lib B")).toBeInTheDocument();
+    expect(screen.queryByAltText("Hand X")).not.toBeInTheDocument();
+  });
+
+  it("defensively skips a redacted name but still surfaces the rest", () => {
+    setStore({
+      library: [10, 11, 12],
+      objects: { 10: "Real Beast A", 11: "Hidden Card", 12: "Real Beast B" },
+      revealed: [10, 11, 12],
+    });
+
+    render(<RevealOverlay />);
+
+    expect(screen.getByAltText("Real Beast A")).toBeInTheDocument();
+    expect(screen.getByAltText("Real Beast B")).toBeInTheDocument();
+    expect(screen.queryByAltText("Hidden Card")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -21,6 +21,7 @@ import { BetweenGamesSideboardModal } from "../components/multiplayer/BetweenGam
 import { audioManager } from "../audio/AudioManager.ts";
 import { useAudioContext } from "../audio/useAudioContext.ts";
 import { AnimationOverlay } from "../components/animation/AnimationOverlay.tsx";
+import { RevealOverlay } from "../components/animation/RevealOverlay.tsx";
 import { TurnBanner } from "../components/animation/TurnBanner.tsx";
 import { DiceRollOverlay } from "../components/animation/DiceRollOverlay.tsx";
 import { flashStartingPlayerContest } from "../game/diceContest.ts";
@@ -1399,6 +1400,8 @@ function GamePageContent({
 
       {/* Animation overlay (above board, below modals) */}
       <AnimationOverlay containerRef={containerRef} />
+      {/* Multi-card top-of-library reveal (CR 701.20b), e.g. Lead the Stampede */}
+      <RevealOverlay />
       <TurnBanner />
       <DiceRollOverlay />
 


### PR DESCRIPTION
Closes #2366. Closes #2005.

`LibraryPile` renders only the single top card, so a multi-card top-of-library reveal ("reveal the top N"; "look at the top N, reveal any number" — e.g. Lead the Stampede) showed nothing past the first, including to opponents watching the reveal. The engine already publishes the cards to `revealed_cards` and un-redacts them in every viewer's filtered state (CR 701.20b — verified by `tests/lead_the_stampede_reveal_visibility_2005.rs`, #3181). The gap was purely client-side.

**Fix:** a passive `RevealOverlay` that, while 2+ revealed cards are still in a library zone, fans them out for every player. Mounted below modals (z-30) so the choosing player's `DigChoice` modal occludes it while watching players (no modal) see the reveal.

**Scope** is exactly the gap `LibraryPile` leaves: a single persistently-revealed top card (Future Sight, Oracle of Mul Daya) is already shown by the pile and stays out of the overlay; hand reveals (Thoughtseize) are excluded by the library-zone filter.

Verified: `vitest` (4 new tests) pass, `tsc -b --noEmit` clean, `eslint` clean. No new i18n keys (eye icon, not text) so the 7-locale parity gate is untouched.