### PR TITLE
Fix Shelob spider-damage death trigger (fixes #1206)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4647,6 +4647,27 @@ pub(crate) fn check_trigger_condition(
                 _ => false,
             }
         }
+        // CR 700.4 + CR 120.1 + CR 608.2i: "another creature dealt damage this turn
+        // by [source filter] dies" — match the dying creature against damage records
+        // whose source satisfies the filter (Spider you controlled, etc.).
+        TriggerCondition::DealtDamageThisTurnBySource { source } => {
+            let dying_creature = trigger_event.and_then(|e| match e {
+                GameEvent::CreatureDestroyed { object_id } => Some(*object_id),
+                GameEvent::ZoneChanged { object_id, .. } => Some(*object_id),
+                _ => None,
+            });
+            let Some(subj) = dying_creature else {
+                return false;
+            };
+            let ctx = FilterContext::from_source_with_controller(
+                source_id.unwrap_or(ObjectId(0)),
+                controller,
+            );
+            state.damage_dealt_this_turn.iter().any(|record| {
+                record.target == TargetRef::Object(subj)
+                    && matches_target_filter_on_damage_record_source(state, record, source, &ctx)
+            })
+        }
         // CR 400.7 + CR 603.10: "if it was a [type]" — check LKI for the source's
         // core types at the time it left the battlefield.
         TriggerCondition::WasType { card_type } => source_id
@@ -5588,8 +5609,8 @@ pub mod tests {
     use crate::types::card_type::CoreType;
     use crate::types::events::{GameEvent, ManaTapState};
     use crate::types::game_state::{
-        DelayedTrigger, DistributionUnit, GameState, SpellCastRecord, StackEntry, StackEntryKind,
-        WaitingFor, ZoneChangeRecord,
+        DamageRecord, DelayedTrigger, DistributionUnit, GameState, SpellCastRecord, StackEntry,
+        StackEntryKind, WaitingFor, ZoneChangeRecord,
     };
     use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
     use crate::types::keywords::{Keyword, KeywordKind};
@@ -10397,6 +10418,143 @@ pub mod tests {
             Some(source),
             None,
         ));
+    }
+
+    #[test]
+    fn dealt_damage_this_turn_by_source_trigger_condition() {
+        // Issue #1206 — Shelob's Spider damage gate on another creature's death.
+        let mut state = setup();
+        let shelob = ObjectId(10);
+        let spider = ObjectId(11);
+        let victim = ObjectId(20);
+
+        let mut spider_obj = GameObject::new(
+            spider,
+            CardId(1),
+            PlayerId(0),
+            "Spider".to_string(),
+            Zone::Battlefield,
+        );
+        spider_obj.controller = PlayerId(0);
+        spider_obj.card_types.subtypes.push("Spider".to_string());
+        state.objects.insert(spider, spider_obj);
+
+        state.damage_dealt_this_turn.push_back(DamageRecord {
+            source_id: spider,
+            source_controller: PlayerId(0),
+            target: TargetRef::Object(victim),
+            target_controller: PlayerId(0),
+            amount: 2,
+            is_combat: false,
+            source_controller_snapshot: PlayerId(0),
+            source_owner: PlayerId(0),
+            source_subtypes: vec!["Spider".to_string()],
+            ..Default::default()
+        });
+
+        let condition = TriggerCondition::DealtDamageThisTurnBySource {
+            source: TargetFilter::Typed(
+                TypedFilter::default()
+                    .subtype("Spider".to_string())
+                    .controller(ControllerRef::You),
+            ),
+        };
+        let event = GameEvent::CreatureDestroyed { object_id: victim };
+
+        assert!(check_trigger_condition(
+            &state,
+            &condition,
+            PlayerId(0),
+            Some(shelob),
+            Some(&event),
+        ));
+
+        let wrong_victim = GameEvent::CreatureDestroyed {
+            object_id: ObjectId(99),
+        };
+        assert!(!check_trigger_condition(
+            &state,
+            &condition,
+            PlayerId(0),
+            Some(shelob),
+            Some(&wrong_victim),
+        ));
+    }
+
+    #[test]
+    fn shelob_spider_damage_death_trigger_end_to_end() {
+        use crate::game::sba;
+        use crate::game::scenario::{GameScenario, P0};
+        use crate::parser::oracle_trigger::parse_trigger_line;
+        use crate::types::game_state::TriggerIndex;
+        use crate::types::triggers::TriggerMode;
+
+        const SHELOB_DEATH_TRIGGER: &str = "Whenever another creature dealt damage this turn by a Spider you controlled dies, create a token that's a copy of that creature, except it's a Food artifact with \"{2}, {T}, Sacrifice ~: You gain 3 life,\" and it loses all other card types.";
+
+        let mut scenario = GameScenario::new();
+        let shelob_id = scenario
+            .add_creature(P0, "Shelob, Child of Ungoliant", 4, 4)
+            .id();
+        let spider_id = scenario.add_creature(P0, "Acid Web Spider", 3, 3).id();
+        let victim_id = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+        let mut runner = scenario.build();
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&spider_id)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Spider".to_string());
+
+        let death_trigger = parse_trigger_line(SHELOB_DEATH_TRIGGER, "Shelob, Child of Ungoliant");
+        assert_eq!(death_trigger.mode, TriggerMode::ChangesZone);
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&shelob_id)
+            .unwrap()
+            .trigger_definitions
+            .push(death_trigger);
+
+        TriggerIndex::rebuild_from_battlefield(runner.state_mut());
+
+        runner
+            .state_mut()
+            .damage_dealt_this_turn
+            .push_back(DamageRecord {
+                source_id: spider_id,
+                source_controller: P0,
+                target: TargetRef::Object(victim_id),
+                target_controller: P0,
+                amount: 2,
+                is_combat: false,
+                source_controller_snapshot: P0,
+                source_owner: P0,
+                source_subtypes: vec!["Spider".to_string()],
+                ..Default::default()
+            });
+
+        let mut death_events = Vec::new();
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&victim_id)
+            .unwrap()
+            .damage_marked = 99;
+        sba::check_state_based_actions(runner.state_mut(), &mut death_events);
+
+        let pending = collect_pending_triggers(runner.state_mut(), &death_events);
+        assert!(
+            !pending.is_empty(),
+            "Shelob's spider-damage death trigger must collect pending entries"
+        );
+        process_triggers(runner.state_mut(), &death_events);
+        assert!(
+            !runner.state().stack.is_empty(),
+            "Shelob trigger must reach the stack"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3091,7 +3091,10 @@ fn parse_dealt_damage_this_turn_source_condition(input: &str) -> Option<Replacem
         .then_some(ReplacementCondition::DealtDamageThisTurnBySource { source })
 }
 
-fn parse_damage_history_source(input: &str) -> Option<(&str, TargetFilter)> {
+pub(crate) fn parse_damage_history_source(input: &str) -> Option<(&str, TargetFilter)> {
+    if let Ok(result) = parse_typed_permanent_you_controlled_damage_source(input) {
+        return Some(result);
+    }
     alt((
         value(
             TargetFilter::SelfRef,
@@ -3111,6 +3114,47 @@ fn parse_damage_history_source(input: &str) -> Option<(&str, TargetFilter)> {
     ))
     .parse(input)
     .ok()
+}
+
+/// CR 608.2i: "a [type] you controlled" damage-source look-back (Shelob's Spider gate).
+fn parse_typed_permanent_you_controlled_damage_source(
+    input: &str,
+) -> OracleResult<'_, TargetFilter> {
+    let (rest, _) = tag("a ").parse(input)?;
+    let lower_rest = rest.to_lowercase();
+    let suffix = " you controlled";
+    let idx = lower_rest
+        .find(suffix)
+        .ok_or_else(|| nom::Err::Error(OracleError::new(rest, nom::error::ErrorKind::Tag)))?;
+    let type_text = rest[..idx].trim();
+    let after = &rest[idx + suffix.len()..];
+    let (filter, leftover) = parse_type_phrase(type_text);
+    if !leftover.trim().is_empty() {
+        return Err(nom::Err::Error(OracleError::new(
+            leftover,
+            nom::error::ErrorKind::Eof,
+        )));
+    }
+    let filter = match filter {
+        TargetFilter::Typed(mut tf) => {
+            if tf.controller.is_none() {
+                tf.controller = Some(ControllerRef::You);
+            }
+            TargetFilter::Typed(tf)
+        }
+        TargetFilter::Or { mut filters } => {
+            for branch in &mut filters {
+                if let TargetFilter::Typed(tf) = branch {
+                    if tf.controller.is_none() {
+                        tf.controller = Some(ControllerRef::You);
+                    }
+                }
+            }
+            TargetFilter::Or { filters }
+        }
+        other => other,
+    };
+    Ok((after, filter))
 }
 
 /// CR 614.1a: Match the exile-anaphor clause in either word order, returning
@@ -9038,6 +9082,21 @@ mod tests {
             Some(ReplacementCondition::DealtDamageThisTurnBySource {
                 source: TargetFilter::AttachedTo,
             })
+        );
+    }
+
+    #[test]
+    fn creature_damaged_by_spider_you_controlled_replacement_source_filter() {
+        let (rest, source) =
+            parse_damage_history_source("a spider you controlled would die").unwrap();
+        assert_eq!(rest, " would die");
+        assert_eq!(
+            source,
+            TargetFilter::Typed(
+                TypedFilter::default()
+                    .subtype("Spider".to_string())
+                    .controller(ControllerRef::You)
+            )
         );
     }
 

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3121,13 +3121,9 @@ fn parse_typed_permanent_you_controlled_damage_source(
     input: &str,
 ) -> OracleResult<'_, TargetFilter> {
     let (rest, _) = tag("a ").parse(input)?;
-    let lower_rest = rest.to_lowercase();
-    let suffix = " you controlled";
-    let idx = lower_rest
-        .find(suffix)
-        .ok_or_else(|| nom::Err::Error(OracleError::new(rest, nom::error::ErrorKind::Tag)))?;
-    let type_text = rest[..idx].trim();
-    let after = &rest[idx + suffix.len()..];
+    let (after_type, type_text) =
+        take_until::<_, _, OracleError<'_>>(" you controlled").parse(rest)?;
+    let (after, _) = tag::<_, _, OracleError<'_>>(" you controlled").parse(after_type)?;
     let (filter, leftover) = parse_type_phrase(type_text);
     if !leftover.trim().is_empty() {
         return Err(nom::Err::Error(OracleError::new(

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8132,6 +8132,35 @@ fn try_parse_special_trigger_pattern(lower: &str) -> Option<(TriggerMode, Trigge
         }
     }
 
+    // CR 700.4 + CR 120.1 + CR 608.2i: "another creature dealt damage this turn
+    // by [source filter] dies" (Shelob, Child of Ungoliant).
+    for prefix in [
+        "whenever another creature dealt damage this turn by ",
+        "when another creature dealt damage this turn by ",
+    ] {
+        if let Some(rest) = lower.strip_prefix(prefix) {
+            let Some((after_source, source)) =
+                super::oracle_replacement::parse_damage_history_source(rest)
+            else {
+                continue;
+            };
+            if tag::<_, _, OracleError<'_>>(" dies")
+                .parse(after_source)
+                .is_ok()
+            {
+                let mut def = make_base();
+                def.mode = TriggerMode::ChangesZone;
+                def.origin = Some(Zone::Battlefield);
+                def.destination = Some(Zone::Graveyard);
+                def.valid_card = Some(TargetFilter::Typed(
+                    TypedFilter::creature().properties(vec![FilterProp::Another]),
+                ));
+                def.condition = Some(TriggerCondition::DealtDamageThisTurnBySource { source });
+                return Some((TriggerMode::ChangesZone, def));
+            }
+        }
+    }
+
     // CR 603.8: "when ~ has no [type] counters on it" — state trigger that fires
     // when the source permanent has zero counters of the specified type.
     // Handles: Dark Depths ("has no ice counters"), Afiya Grove ("has no +1/+1
@@ -24194,6 +24223,34 @@ mod tests {
         assert_eq!(
             def.condition,
             Some(TriggerCondition::DealtDamageBySourceThisTurn)
+        );
+    }
+
+    #[test]
+    fn trigger_another_creature_damaged_by_spider_you_controlled_dies() {
+        // Issue #1206 — Shelob, Child of Ungoliant
+        let def = parse_trigger_line(
+            "Whenever another creature dealt damage this turn by a Spider you controlled dies, create a token that's a copy of that creature, except it's a Food artifact with \"{2}, {T}, Sacrifice ~: You gain 3 life,\" and it loses all other card types.",
+            "Shelob, Child of Ungoliant",
+        );
+        assert_eq!(def.mode, TriggerMode::ChangesZone);
+        assert_eq!(def.origin, Some(Zone::Battlefield));
+        assert_eq!(def.destination, Some(Zone::Graveyard));
+        assert_eq!(
+            def.valid_card,
+            Some(TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::Another])
+            ))
+        );
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::DealtDamageThisTurnBySource {
+                source: TargetFilter::Typed(
+                    TypedFilter::default()
+                        .subtype("Spider".to_string())
+                        .controller(ControllerRef::You)
+                )
+            })
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8134,7 +8134,7 @@ fn try_parse_special_trigger_pattern(lower: &str) -> Option<(TriggerMode, Trigge
 
     // CR 700.4 + CR 120.1 + CR 608.2i: "another creature dealt damage this turn
     // by [source filter] dies" (Shelob, Child of Ungoliant).
-    let damaged_this_turn_prefix = alt((
+    let mut damaged_this_turn_prefix = alt((
         tag::<_, _, OracleError<'_>>("whenever another creature dealt damage this turn by "),
         tag("when another creature dealt damage this turn by "),
     ));

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8134,16 +8134,14 @@ fn try_parse_special_trigger_pattern(lower: &str) -> Option<(TriggerMode, Trigge
 
     // CR 700.4 + CR 120.1 + CR 608.2i: "another creature dealt damage this turn
     // by [source filter] dies" (Shelob, Child of Ungoliant).
-    for prefix in [
-        "whenever another creature dealt damage this turn by ",
-        "when another creature dealt damage this turn by ",
-    ] {
-        if let Some(rest) = lower.strip_prefix(prefix) {
-            let Some((after_source, source)) =
-                super::oracle_replacement::parse_damage_history_source(rest)
-            else {
-                continue;
-            };
+    let damaged_this_turn_prefix = alt((
+        tag::<_, _, OracleError<'_>>("whenever another creature dealt damage this turn by "),
+        tag("when another creature dealt damage this turn by "),
+    ));
+    if let Ok((rest, _)) = damaged_this_turn_prefix.parse(lower) {
+        if let Some((after_source, source)) =
+            super::oracle_replacement::parse_damage_history_source(rest)
+        {
             if tag::<_, _, OracleError<'_>>(" dies")
                 .parse(after_source)
                 .is_ok()

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -12475,6 +12475,11 @@ pub enum TriggerCondition {
     /// gated on the dying creature having been dealt damage by the trigger source this turn.
     DealtDamageBySourceThisTurn,
 
+    /// CR 700.4 + CR 120.1 + CR 608.2i: "another creature dealt damage this turn by
+    /// [source filter] dies" — death trigger gated on the dying creature having been
+    /// dealt damage this turn by a source matching the filter (e.g. Shelob's Spider gate).
+    DealtDamageThisTurnBySource { source: TargetFilter },
+
     /// CR 400.7 + CR 603.10: "if it was a [type]" — true when the trigger source's
     /// last known information includes the specified core type. Used by the Glimmer cycle
     /// ("when this dies, if it was a creature, return it").

--- a/crates/engine/tests/integration/issue_1206_shelob_spider_death_tokens.rs
+++ b/crates/engine/tests/integration/issue_1206_shelob_spider_death_tokens.rs
@@ -1,0 +1,70 @@
+//! Issue #1206 — Shelob, Child of Ungoliant must not trigger without spider damage.
+//!
+//! End-to-end regression (spider damage → creature dies → Food copy token) lives in
+//! `engine::game::triggers::tests::shelob_spider_damage_death_trigger_end_to_end`.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::triggers::process_triggers;
+use engine::types::game_state::WaitingFor;
+
+const SHELOB_DEATH_TRIGGER: &str = "Whenever another creature dealt damage this turn by a Spider you controlled dies, create a token that's a copy of that creature, except it's a Food artifact with \"{2}, {T}, Sacrifice ~: You gain 3 life,\" and it loses all other card types.";
+
+fn drain_to_priority(runner: &mut engine::game::scenario::GameRunner) {
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(
+            guard < 256,
+            "drain exceeded bound; waiting_for = {:?}",
+            runner.state().waiting_for
+        );
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            _ => {
+                if runner
+                    .act(engine::types::actions::GameAction::PassPriority)
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn destroy_with_lethal_damage(
+    runner: &mut engine::game::scenario::GameRunner,
+    object_id: engine::types::identifiers::ObjectId,
+) {
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&object_id)
+        .unwrap()
+        .damage_marked = 99;
+
+    let mut events = Vec::new();
+    engine::game::sba::check_state_based_actions(runner.state_mut(), &mut events);
+    process_triggers(runner.state_mut(), &events);
+    drain_to_priority(runner);
+}
+
+#[test]
+fn shelob_does_not_trigger_without_spider_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+
+    scenario.add_creature_from_oracle(P0, "Shelob, Child of Ungoliant", 4, 4, SHELOB_DEATH_TRIGGER);
+    let victim_id = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+    let stack_before = runner.state().stack.len();
+
+    destroy_with_lethal_damage(&mut runner, victim_id);
+
+    assert_eq!(
+        runner.state().stack.len(),
+        stack_before,
+        "Shelob must not trigger when the dying creature was not damaged by a Spider"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -92,6 +92,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod invoke_calamity_free_cast;
+mod issue_1206_shelob_spider_death_tokens;
 mod issue_1297_venture_initiative_triggers;
 mod issue_1302_final_parting;
 mod issue_1305_thalisse_tokens_created_this_turn;


### PR DESCRIPTION
## Summary
- Parse Shelob's "another creature dealt damage this turn by a Spider you controlled dies" line as a `ChangesZone` death trigger with a `DealtDamageThisTurnBySource` condition instead of `Unknown`.
- Extend damage-history source parsing to recognize typed permanents like "a Spider you controlled".
- Evaluate the new trigger condition against the per-turn damage ledger using damage-time source snapshots.

## Test plan
- [x] `cargo clippy -p engine -- -D warnings`
- [x] Parser regression: `trigger_another_creature_damaged_by_spider_you_controlled_dies`
- [x] Trigger condition unit test: `dealt_damage_this_turn_by_source_trigger_condition`
- [x] End-to-end stack test: `shelob_spider_damage_death_trigger_end_to_end`
- [x] Integration regression: `shelob_does_not_trigger_without_spider_damage`

Fixes #1206


Made with [Cursor](https://cursor.com)