### PR TITLE
feat(ai): only cast creature removal that can actually kill the target

### DIFF
--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -31,12 +31,13 @@ use super::context::PolicyContext;
 use super::copy_value::{copy_target_penalties, score_legend_rule_keep};
 use super::effect_classify::{
     aggregate_player_impact, aura_polarity, effect_polarity, effect_targets_object,
-    extract_target_filter, is_spell_beneficial, targeted_object_impact, targeted_player_impact,
-    targets_creatures, targets_creatures_only, EffectPolarity,
+    extract_target_filter, is_spell_beneficial, lethal_to_creature, targeted_object_impact,
+    targeted_player_impact, targets_creatures, targets_creatures_only, EffectPolarity,
 };
 use super::registry::{
     DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy, CRITICAL_MAX,
 };
+use super::strategy_helpers::can_pay_ward_cost;
 use crate::features::DeckFeatures;
 #[cfg(test)]
 use engine::types::game_state::CastPaymentMode;
@@ -529,7 +530,29 @@ fn harmful_effect_has_opponent_creature_target(ctx: &PolicyContext<'_>, effect: 
     let Some(source) = ctx.source_object() else {
         return true;
     };
-    ctx.has_legal_opponent_creature_target(filter, source.id, |_| true)
+    let effects = ctx.effects();
+    ctx.has_legal_opponent_creature_target(filter, source.id, |id| {
+        is_useful_removal_target(ctx, id, &effects)
+    })
+}
+
+/// Whether a removal target is worth casting at: the AI can pay any ward cost
+/// (CR 702.21a — otherwise the spell is merely countered) and the spell can
+/// actually kill it. Provably non-lethal damage / shrink (CR 704.5f/g) is a
+/// wasted cast. Variable-X effects and non-damage removal (Destroy, Exile,
+/// Bounce) stay useful, since `lethal_to_creature` returns `None` for them.
+fn is_useful_removal_target(ctx: &PolicyContext<'_>, id: ObjectId, effects: &[&Effect]) -> bool {
+    if let Some(object) = ctx.state.objects.get(&id) {
+        for keyword in &object.keywords {
+            if let Keyword::Ward(ward) = keyword {
+                if !can_pay_ward_cost(ctx, ward) {
+                    return false;
+                }
+                break;
+            }
+        }
+    }
+    lethal_to_creature(ctx.state, id, effects) != Some(false)
 }
 
 fn is_hostile_or_neutral_bounce(effect: &&Effect) -> bool {
@@ -696,6 +719,13 @@ fn score_target_object(ctx: &PolicyContext<'_>, object_id: ObjectId, beneficial:
         score += controller_delta * evaluate_creature(ctx.state, object_id);
 
         if !beneficial {
+            // CR 704.5f/g: penalize removal that provably won't kill its target.
+            // `lethal_to_creature` unifies the three shrink/burn modalities (damage,
+            // -X/-X, -1/-1 counters); variable-X and non-damage removal return
+            // `None` (no penalty). The penalty is a discouragement, not a veto, so
+            // a genuine multi-spell kill can still emerge from search lookahead.
+            let lethal = lethal_to_creature(ctx.state, object_id, &effects);
+
             if let Some(damage) = extract_damage_amount(&effects) {
                 score += opponent_creature_reflection_penalty(
                     ctx.state,
@@ -706,13 +736,14 @@ fn score_target_object(ctx: &PolicyContext<'_>, object_id: ObjectId, beneficial:
 
                 if let Some(toughness) = object.toughness {
                     let remaining = toughness - object.damage_marked as i32;
-                    // Penalize targeting creatures that won't die to this damage.
-                    // Graduated: almost-lethal burn (leaves 1 toughness) is less
-                    // wasteful than burn that barely scratches a large creature.
-                    if damage < remaining {
-                        let survival_ratio = (remaining - damage) as f64 / remaining as f64;
-                        // Full penalty (-8.0) when damage is negligible relative to toughness,
-                        // reduced penalty (-4.0) when damage is almost lethal.
+                    // Graduated non-lethal penalty: almost-lethal burn (leaves 1
+                    // toughness) is less wasteful than burn that barely scratches a
+                    // large creature.
+                    if lethal == Some(false) && remaining > 0 {
+                        let survival_ratio =
+                            ((remaining - damage).max(0)) as f64 / remaining as f64;
+                        // Full penalty (-8.0) when damage is negligible relative to
+                        // toughness, reduced penalty (-4.0) when damage is almost lethal.
                         score -= 4.0 + 4.0 * survival_ratio;
                     }
                     // Penalize massive overkill (wasting damage capacity)
@@ -722,6 +753,10 @@ fn score_target_object(ctx: &PolicyContext<'_>, object_id: ObjectId, beneficial:
                         score += ctx.penalties().overkill_base_penalty * waste_ratio.sqrt();
                     }
                 }
+            } else if lethal == Some(false) {
+                // Non-damage shrink (-X/-X, -0/-X, -1/-1 counters) that won't kill
+                // the target wastes the spell, mirroring the burn-whiff penalty.
+                score -= 8.0;
             }
 
             // CR 702.16b + CR 702.16e: Protection prevents targeting and damage
@@ -733,9 +768,15 @@ fn score_target_object(ctx: &PolicyContext<'_>, object_id: ObjectId, beneficial:
                 }
             }
 
-            // Penalize targeting creatures with ward (must pay additional cost)
+            // Price the cost of an *affordable* ward (must pay an extra cost).
+            // An unaffordable ward is hard-rejected upstream by `tactical_gate`
+            // (CR 702.21a — the spell would just be countered), so this judgment
+            // layer never double-scores that case.
             for keyword in &object.keywords {
                 if let Keyword::Ward(ward_cost) = keyword {
+                    if !can_pay_ward_cost(ctx, ward_cost) {
+                        break;
+                    }
                     let severity = match ward_cost {
                         WardCost::Mana(cost) => (cost.mana_value() as f64 / 2.0).min(2.0),
                         WardCost::PayLife(amount) => (*amount as f64 / 3.0).min(2.0),

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -5,7 +5,9 @@ use engine::types::ability::{
     TargetFilter, TypeFilter,
 };
 use engine::types::counter::CounterType;
+use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
 use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
 use engine::types::triggers::TriggerMode;
@@ -250,6 +252,100 @@ pub(crate) fn extract_target_filter(effect: &Effect) -> Option<&TargetFilter> {
         // NOTE: SearchLibrary uses `filter`, not `target`.
         _ => None,
     }
+}
+
+/// Whether `effects`, all applied to the creature `object_id`, will kill it.
+///
+/// Models the three toughness-reducing removal modalities the AI must reason
+/// about when deciding whether a removal spell is worth casting:
+/// - direct damage (`Effect::DealDamage`),
+/// - negative `Pump` (covers `-X/-X` and `-0/-X`),
+/// - `-1/-1` (and other negative P/T) counters (`Effect::PutCounter`).
+///
+/// All such effects in the spell are assumed to hit this creature, which is the
+/// single-target removal case the callers care about.
+///
+/// Returns:
+/// - `Some(true)`  — provably lethal,
+/// - `Some(false)` — provably non-lethal (every relevant amount is fixed and
+///   the creature survives),
+/// - `None`        — not determinable: either no damage/shrink effect is present
+///   (e.g. `Destroy`, `Bounce`, `Exile`), or a relevant amount is variable (an
+///   `X` spell whose value the caster chooses). Callers fail open on `None`.
+pub(crate) fn lethal_to_creature(
+    state: &GameState,
+    object_id: ObjectId,
+    effects: &[&Effect],
+) -> Option<bool> {
+    let object = state.objects.get(&object_id)?;
+    let base_toughness = object.toughness?;
+
+    let mut toughness_reduction = 0i32; // from negative pumps and -1/-1 counters
+    let mut total_damage = 0i32;
+    let mut saw_relevant = false;
+
+    for effect in effects {
+        match effect {
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value },
+                ..
+            } => {
+                total_damage += *value;
+                saw_relevant = true;
+            }
+            // Variable (X) damage — the caster picks the amount, so lethality
+            // can't be decided here.
+            Effect::DealDamage { .. } => return None,
+            Effect::Pump { toughness, .. } => match toughness {
+                PtValue::Fixed(v) if *v < 0 => {
+                    toughness_reduction += -*v;
+                    saw_relevant = true;
+                }
+                PtValue::Fixed(_) => {}
+                // -X/-X: variable shrink, undecidable here.
+                PtValue::Variable(_) | PtValue::Quantity(_) => return None,
+            },
+            Effect::PutCounter {
+                counter_type,
+                count,
+                ..
+            } => {
+                if let Some((_, t_delta)) = counter_type.power_toughness_delta() {
+                    if t_delta < 0 {
+                        match count {
+                            QuantityExpr::Fixed { value } => {
+                                toughness_reduction += -t_delta * *value;
+                                saw_relevant = true;
+                            }
+                            _ => return None,
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if !saw_relevant {
+        return None;
+    }
+
+    let new_toughness = base_toughness - toughness_reduction;
+    // CR 704.5f: a creature with toughness 0 or less is put into its owner's
+    // graveyard. This is not destruction, so indestructible does not prevent it.
+    if new_toughness <= 0 {
+        return Some(true);
+    }
+    // CR 704.5g + CR 702.12b: lethal marked damage destroys the creature — but
+    // an indestructible permanent ignores that state-based action, so damage
+    // alone can never kill it.
+    if total_damage > 0 && !object.has_keyword(&Keyword::Indestructible) {
+        let marked = object.damage_marked as i32;
+        if marked + total_damage >= new_toughness {
+            return Some(true);
+        }
+    }
+    Some(false)
 }
 
 /// Returns true if the effect exclusively targets creatures (not "any target").
@@ -580,5 +676,163 @@ fn filter_excludes_parent_target(filter: &TargetFilter) -> bool {
         TargetFilter::Not { filter: inner } => matches!(inner.as_ref(), TargetFilter::ParentTarget),
         TargetFilter::And { filters } => filters.iter().any(filter_excludes_parent_target),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod lethality_tests {
+    use super::*;
+    use engine::game::scenario::{GameScenario, P1};
+    use engine::types::keywords::Keyword;
+
+    fn deal_damage(value: i32) -> Effect {
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value },
+            target: TargetFilter::Any,
+            damage_source: None,
+        }
+    }
+
+    fn shrink(power: i32, toughness: i32) -> Effect {
+        Effect::Pump {
+            power: PtValue::Fixed(power),
+            toughness: PtValue::Fixed(toughness),
+            target: TargetFilter::Any,
+        }
+    }
+
+    fn minus_counters(count: i32) -> Effect {
+        Effect::PutCounter {
+            counter_type: CounterType::Minus1Minus1,
+            count: QuantityExpr::Fixed { value: count },
+            target: TargetFilter::Any,
+        }
+    }
+
+    #[test]
+    fn damage_lethal_only_at_or_above_remaining_toughness() {
+        let mut scenario = GameScenario::new();
+        let bear = scenario.add_creature(P1, "Bear", 2, 2).id();
+        let runner = scenario.build();
+        let state = runner.state();
+        assert_eq!(
+            lethal_to_creature(state, bear, &[&deal_damage(2)]),
+            Some(true)
+        );
+        assert_eq!(
+            lethal_to_creature(state, bear, &[&deal_damage(1)]),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn abrade_on_zero_four_reads_non_lethal() {
+        // Regression: 3 damage on a 0/4 must not look lethal (the reported bug).
+        let mut scenario = GameScenario::new();
+        let wall = scenario.add_creature(P1, "Wall", 0, 4).id();
+        let runner = scenario.build();
+        assert_eq!(
+            lethal_to_creature(runner.state(), wall, &[&deal_damage(3)]),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn damage_accounts_for_marked_damage() {
+        // CR 704.5g: total marked damage (prior + this) vs toughness.
+        let mut scenario = GameScenario::new();
+        let wall = scenario.add_creature(P1, "Wall", 0, 4).id();
+        let mut runner = scenario.build();
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&wall)
+            .unwrap()
+            .damage_marked = 2;
+        let state = runner.state();
+        assert_eq!(
+            lethal_to_creature(state, wall, &[&deal_damage(2)]),
+            Some(true)
+        );
+        assert_eq!(
+            lethal_to_creature(state, wall, &[&deal_damage(1)]),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn negative_pump_kills_via_zero_toughness() {
+        // CR 704.5f: -0/-4 brings a 0/4 to 0 toughness -> dies; -0/-3 survives.
+        let mut scenario = GameScenario::new();
+        let wall = scenario.add_creature(P1, "Wall", 0, 4).id();
+        let runner = scenario.build();
+        let state = runner.state();
+        assert_eq!(
+            lethal_to_creature(state, wall, &[&shrink(0, -4)]),
+            Some(true)
+        );
+        assert_eq!(
+            lethal_to_creature(state, wall, &[&shrink(0, -3)]),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn minus_one_counters_kill_by_toughness() {
+        let mut scenario = GameScenario::new();
+        let bear = scenario.add_creature(P1, "Bear", 2, 2).id();
+        let runner = scenario.build();
+        let state = runner.state();
+        assert_eq!(
+            lethal_to_creature(state, bear, &[&minus_counters(2)]),
+            Some(true)
+        );
+        assert_eq!(
+            lethal_to_creature(state, bear, &[&minus_counters(1)]),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn indestructible_survives_damage_but_dies_to_zero_toughness() {
+        let mut scenario = GameScenario::new();
+        let wall = scenario
+            .add_creature(P1, "Wall", 0, 4)
+            .with_keyword(Keyword::Indestructible)
+            .id();
+        let runner = scenario.build();
+        let state = runner.state();
+        // CR 702.12b: damage never destroys an indestructible creature.
+        assert_eq!(
+            lethal_to_creature(state, wall, &[&deal_damage(10)]),
+            Some(false)
+        );
+        // CR 704.5f: toughness 0 bypasses indestructible.
+        assert_eq!(
+            lethal_to_creature(state, wall, &[&shrink(0, -4)]),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn variable_and_non_shrink_effects_are_undecidable() {
+        let mut scenario = GameScenario::new();
+        let bear = scenario.add_creature(P1, "Bear", 2, 2).id();
+        let runner = scenario.build();
+        let state = runner.state();
+        // Variable (X) shrink: the caster picks the amount -> undecidable.
+        let variable_shrink = Effect::Pump {
+            power: PtValue::Fixed(0),
+            toughness: PtValue::Variable("X".to_string()),
+            target: TargetFilter::Any,
+        };
+        assert_eq!(lethal_to_creature(state, bear, &[&variable_shrink]), None);
+        // Destroy has no toughness-reducing component -> undecidable here (the
+        // gate handles it; lethality math doesn't apply).
+        let destroy = Effect::Destroy {
+            target: TargetFilter::Any,
+            cant_regenerate: false,
+        };
+        assert_eq!(lethal_to_creature(state, bear, &[&destroy]), None);
     }
 }

--- a/crates/phase-ai/src/policies/strategy_helpers.rs
+++ b/crates/phase-ai/src/policies/strategy_helpers.rs
@@ -5,7 +5,7 @@ use engine::types::ability::{Effect, TargetFilter};
 use engine::types::card_type::CoreType;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
-use engine::types::keywords::Keyword;
+use engine::types::keywords::{Keyword, WardCost};
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 
@@ -270,6 +270,89 @@ pub(crate) fn count_counterspells_in_hand(state: &GameState, player: PlayerId) -
             })
         })
         .count()
+}
+
+/// Heuristic upper bound on the mana the AI could spend on a ward cost *after*
+/// paying for the spell it is currently casting. Counts untapped mana sources
+/// (lands, non-sick mana dorks, mana rocks) plus any floating mana, then
+/// subtracts the spell's own mana value. Colour requirements are approximated by
+/// total mana value, matching the engine's auto-tap heuristics used elsewhere in
+/// the AI (CR 302.6: a summoning-sick creature can't tap for mana).
+pub(crate) fn available_mana_after_spell(ctx: &PolicyContext<'_>) -> u32 {
+    let player = &ctx.state.players[ctx.ai_player.0 as usize];
+    let mut sources = player.mana_pool.total() as u32;
+    for &id in &ctx.state.battlefield {
+        let Some(obj) = ctx.state.objects.get(&id) else {
+            continue;
+        };
+        if obj.controller != ctx.ai_player || obj.tapped {
+            continue;
+        }
+        let is_creature = obj.card_types.core_types.contains(&CoreType::Creature);
+        // Untapped pure land counts unconditionally (auto-tap tier 0); other mana
+        // sources count only if they have a mana ability and — for creatures —
+        // aren't summoning-sick (CR 302.6).
+        let is_pure_land = obj.card_types.core_types.contains(&CoreType::Land) && !is_creature;
+        let is_usable_dork = obj
+            .abilities
+            .iter()
+            .any(engine::game::mana_abilities::is_mana_ability)
+            && !(is_creature && engine::game::combat::has_summoning_sickness(obj));
+        if is_pure_land || is_usable_dork {
+            sources += 1;
+        }
+    }
+    let spell_cost = ctx
+        .source_object()
+        .map_or(0, |source| source.mana_cost.mana_value());
+    sources.saturating_sub(spell_cost)
+}
+
+/// CR 702.21a: Whether the AI can pay `ward` after committing to the spell it is
+/// casting. Mana / Waterbend costs use the post-spell mana estimate; non-mana
+/// costs check the corresponding resource (life, a spare card, sacrificeable
+/// permanents). Conservative on the unknown: a cost we can't analyse returns
+/// `true` so the AI is never blocked from a cast we can't prove is wasted.
+pub(crate) fn can_pay_ward_cost(ctx: &PolicyContext<'_>, ward: &WardCost) -> bool {
+    match ward {
+        WardCost::Mana(cost) | WardCost::Waterbend(cost) => {
+            available_mana_after_spell(ctx) >= cost.mana_value()
+        }
+        // CR 119.4: life may be paid only if the life total is at least the
+        // amount. CR 704.5a: a player at 0 life loses, so the AI treats a payment
+        // that would drop it to 0 as unaffordable — it leaves at least 1 life.
+        WardCost::PayLife(amount) => ctx.state.players[ctx.ai_player.0 as usize].life > *amount,
+        WardCost::DiscardCard => {
+            let source_id = ctx.source_object().map(|source| source.id);
+            ctx.state.players[ctx.ai_player.0 as usize]
+                .hand
+                .iter()
+                .any(|&id| Some(id) != source_id)
+        }
+        WardCost::Sacrifice { count, filter } => {
+            let Some(source) = ctx.source_object() else {
+                return true;
+            };
+            let fctx = FilterContext::from_source(ctx.state, source.id);
+            let matching = ctx
+                .state
+                .battlefield
+                .iter()
+                .filter(|&&id| {
+                    ctx.state
+                        .objects
+                        .get(&id)
+                        .is_some_and(|obj| obj.controller == ctx.ai_player)
+                        && matches_target_filter(ctx.state, id, filter, &fctx)
+                })
+                .count();
+            matching as u32 >= *count
+        }
+        // CR 702.21a: every conjoined sub-cost must be payable. Mana contention
+        // between multiple mana sub-costs is approximated (each checked against
+        // the full post-spell pool) — rare enough not to warrant exact tracking.
+        WardCost::Compound(costs) => costs.iter().all(|cost| can_pay_ward_cost(ctx, cost)),
+    }
 }
 
 fn keyword_pressure(object: &GameObject) -> f64 {

--- a/crates/phase-ai/src/tactical_gate.rs
+++ b/crates/phase-ai/src/tactical_gate.rs
@@ -19,6 +19,7 @@ use crate::policies::effect_classify::{
     effect_polarity, extract_target_filter, targets_creatures_only, EffectPolarity,
 };
 use crate::policies::stack_awareness::{has_pending_removal, will_target_die_from_stack};
+use crate::policies::strategy_helpers::can_pay_ward_cost;
 #[cfg(test)]
 use engine::types::game_state::CastPaymentMode;
 
@@ -280,16 +281,64 @@ fn reject_futile_target(ctx: &PolicyContext<'_>, target: &TargetRef) -> Option<G
     let TargetRef::Object(object_id) = target else {
         return None;
     };
+    let object = ctx.state.objects.get(object_id)?;
     let effects = ctx.effects();
+
+    // CR 701.8 + CR 702.12b: destroy-based removal can't destroy an
+    // indestructible permanent.
     let is_destroy = effects.iter().any(|e| matches!(e, Effect::Destroy { .. }));
-    if is_destroy {
-        if let Some(object) = ctx.state.objects.get(object_id) {
-            if object.has_keyword(&Keyword::Indestructible) {
+    if is_destroy && object.has_keyword(&Keyword::Indestructible) {
+        return Some(GateDecision::Reject);
+    }
+
+    // CR 702.12b: an indestructible creature ignores the lethal-damage SBA
+    // (CR 704.5g), so a damage-only spell can NEVER kill it regardless of the
+    // amount — provably futile. Shrink effects are exempt: reducing toughness to
+    // 0 kills via CR 704.5f (which indestructible does not prevent), and two
+    // shrink spells can combine, so those stay in the judgment layer.
+    if object.has_keyword(&Keyword::Indestructible)
+        && deals_damage(&effects)
+        && !has_toughness_shrink(&effects)
+    {
+        return Some(GateDecision::Reject);
+    }
+
+    // CR 702.21a: targeting a warded permanent triggers ward; if the AI can't
+    // pay the cost, the spell is simply countered — a strict card-down. Never
+    // choose such a target.
+    for keyword in &object.keywords {
+        if let Keyword::Ward(ward) = keyword {
+            if !can_pay_ward_cost(ctx, ward) {
                 return Some(GateDecision::Reject);
             }
+            break;
         }
     }
+
     None
+}
+
+/// Whether any effect deals damage (fixed or variable).
+fn deals_damage(effects: &[&Effect]) -> bool {
+    effects
+        .iter()
+        .any(|e| matches!(e, Effect::DealDamage { .. }))
+}
+
+/// Whether any effect reduces toughness via a negative `Pump` or a negative P/T
+/// counter. Variable pump toughness is treated as possible shrink (conservative:
+/// never hard-reject a line that might reduce toughness to 0).
+fn has_toughness_shrink(effects: &[&Effect]) -> bool {
+    effects.iter().any(|e| match e {
+        Effect::Pump { toughness, .. } => match toughness {
+            PtValue::Fixed(v) => *v < 0,
+            PtValue::Variable(_) | PtValue::Quantity(_) => true,
+        },
+        Effect::PutCounter { counter_type, .. } => counter_type
+            .power_toughness_delta()
+            .is_some_and(|(_, t)| t < 0),
+        _ => false,
+    })
 }
 
 fn target_choice_penalty(ctx: &PolicyContext<'_>, target: &TargetRef) -> f64 {
@@ -639,6 +688,7 @@ mod tests {
         WaitingFor,
     };
     use engine::types::identifiers::CardId;
+    use engine::types::keywords::WardCost;
     use engine::types::mana::ManaCost;
 
     #[test]
@@ -895,5 +945,149 @@ mod tests {
         };
 
         assert_eq!(assess_candidate(&ctx), GateDecision::Reject);
+    }
+
+    /// Build a `ChooseTarget` decision for a damage spell aimed at `creature`.
+    fn damage_target_decision(creature: ObjectId, damage: i32) -> AiDecisionContext {
+        AiDecisionContext {
+            waiting_for: WaitingFor::TargetSelection {
+                player: P0,
+                pending_cast: Box::new(PendingCast::new(
+                    ObjectId(900),
+                    CardId(900),
+                    ResolvedAbility::new(
+                        Effect::DealDamage {
+                            amount: engine::types::ability::QuantityExpr::Fixed { value: damage },
+                            target: TargetFilter::Any,
+                            damage_source: None,
+                        },
+                        Vec::new(),
+                        ObjectId(900),
+                        P0,
+                    ),
+                    ManaCost::zero(),
+                )),
+                target_slots: vec![TargetSelectionSlot {
+                    legal_targets: vec![TargetRef::Object(creature)],
+                    optional: false,
+                }],
+                mode_labels: Vec::new(),
+                selection: TargetSelectionProgress::default(),
+            },
+            candidates: Vec::new(),
+        }
+    }
+
+    fn choose_target_candidate(creature: ObjectId) -> CandidateAction {
+        CandidateAction {
+            action: GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(creature)),
+            },
+            metadata: ActionMetadata {
+                actor: Some(P0),
+                tactical_class: TacticalClass::Target,
+            },
+        }
+    }
+
+    /// CR 702.12b: a damage-only spell can never kill an indestructible creature.
+    #[test]
+    fn rejects_damage_targeting_indestructible_creature() {
+        let mut scenario = GameScenario::new();
+        let creature = scenario
+            .add_creature(P1, "Darksteel Wall", 0, 4)
+            .with_keyword(Keyword::Indestructible)
+            .id();
+        let mut runner = scenario.build();
+        let state = runner.state_mut();
+        let decision = damage_target_decision(creature, 3);
+        let candidate = choose_target_candidate(creature);
+        let config = create_config(AiDifficulty::VeryHard, Platform::Wasm);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: P0,
+            config: &config,
+            context: &AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+        assert_eq!(assess_candidate(&ctx), GateDecision::Reject);
+    }
+
+    /// A normal creature targeted by damage is NOT gate-rejected — non-lethal
+    /// burn is a judgment-layer preference, not a provable futility.
+    #[test]
+    fn allows_damage_targeting_normal_creature() {
+        let mut scenario = GameScenario::new();
+        let creature = scenario.add_creature(P1, "Wall", 0, 4).id();
+        let mut runner = scenario.build();
+        let state = runner.state_mut();
+        let decision = damage_target_decision(creature, 3);
+        let candidate = choose_target_candidate(creature);
+        let config = create_config(AiDifficulty::VeryHard, Platform::Wasm);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: P0,
+            config: &config,
+            context: &AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+        assert_ne!(assess_candidate(&ctx), GateDecision::Reject);
+    }
+
+    /// CR 702.21a: never target a warded creature whose ward cost the AI can't
+    /// pay — the spell would just be countered.
+    #[test]
+    fn rejects_targeting_unpayable_ward() {
+        let mut scenario = GameScenario::new();
+        let creature = scenario
+            .add_creature(P1, "Warded", 2, 2)
+            .with_keyword(Keyword::Ward(WardCost::PayLife(100)))
+            .id();
+        let mut runner = scenario.build();
+        let state = runner.state_mut();
+        // P0 starts at 20 life — paying 100 is impossible.
+        let decision = damage_target_decision(creature, 3);
+        let candidate = choose_target_candidate(creature);
+        let config = create_config(AiDifficulty::VeryHard, Platform::Wasm);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: P0,
+            config: &config,
+            context: &AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+        assert_eq!(assess_candidate(&ctx), GateDecision::Reject);
+    }
+
+    /// A payable ward does not gate the target out — it's only priced (in the
+    /// judgment layer), not vetoed.
+    #[test]
+    fn allows_targeting_payable_ward() {
+        let mut scenario = GameScenario::new();
+        let creature = scenario
+            .add_creature(P1, "Warded", 2, 2)
+            .with_keyword(Keyword::Ward(WardCost::PayLife(2)))
+            .id();
+        let mut runner = scenario.build();
+        let state = runner.state_mut();
+        let decision = damage_target_decision(creature, 3);
+        let candidate = choose_target_candidate(creature);
+        let config = create_config(AiDifficulty::VeryHard, Platform::Wasm);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: P0,
+            config: &config,
+            context: &AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+        assert_ne!(assess_candidate(&ctx), GateDecision::Reject);
     }
 }


### PR DESCRIPTION
Burn, -X/-X, -0/-X and -1/-1 removal now require a lethal target before
the AI casts or aims it, and warded creatures it cannot pay for are never
targeted (CR 702.21a — the spell would just be countered).

- effect_classify::lethal_to_creature: unified lethality predicate over
  damage (CR 704.5g, blocked by indestructible), negative pumps incl. -0/-X
  (CR 704.5f, bypasses indestructible), and -1/-1 counters. Tri-state Option:
  None for variable-X and non-damage removal so callers fail open.
- anti_self_harm: cast-time guard now requires a killable + ward-affordable
  opponent creature; target-select whiff penalty generalized to all three
  shrink/burn modalities. Penalties, not vetoes — multi-spell kills still
  emerge from search.
- tactical_gate: hard-reject provably-futile targets — damage-only vs
  indestructible (CR 702.12b) and unpayable ward (CR 702.21a). Existing ward
  severity penalty narrowed to affordable-only (no double-scoring).
- strategy_helpers::can_pay_ward_cost: post-spell ward affordability.

Blocking ai-gate (--games 10) clean: 0 FAIL, red-mirror 60%->70%.
