### PR TITLE
Fix #1202: enforce prepared spell mana cost and sorcery timing

### DIFF
--- a/crates/engine/src/game/effects/prepare.rs
+++ b/crates/engine/src/game/effects/prepare.rs
@@ -384,7 +384,8 @@ mod tests {
     use crate::types::card_type::CoreType;
     use crate::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
     use crate::types::identifiers::CardId;
-    use crate::types::mana::{ManaCost, ManaCostShard};
+    use crate::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+    use crate::types::phase::Phase;
     use crate::types::player::PlayerId;
     use crate::types::replacements::ReplacementEvent;
     use crate::types::zones::Zone;
@@ -1028,6 +1029,64 @@ mod tests {
         assert!(
             state.stack.iter().all(|entry| entry.id != copy_id),
             "cancelled cast must remove stack placeholder for synthesized copy"
+        );
+    }
+
+    #[test]
+    fn prepared_sorcery_not_castable_during_opponents_main_phase() {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(0);
+        state.phase = Phase::PreCombatMain;
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let source_id = setup_creature(&mut state);
+        {
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.prepared = Some(PreparedState);
+            source.back_face = Some(BackFaceForTest::prepare_with_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 0,
+            }));
+        }
+        state.players[0].mana_pool.mana.push(ManaUnit::new(
+            ManaType::Red,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+
+        assert!(
+            !can_cast_prepared_copy_now(&state, PlayerId(0), source_id),
+            "prepared sorcery must not be castable during the opponent's main phase"
+        );
+    }
+
+    #[test]
+    fn prepared_sorcery_requires_payable_mana_even_at_sorcery_speed() {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.phase = Phase::PreCombatMain;
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let source_id = setup_creature(&mut state);
+        {
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.prepared = Some(PreparedState);
+            source.back_face = Some(BackFaceForTest::prepare_with_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 1,
+            }));
+        }
+
+        assert!(
+            !can_cast_prepared_copy_now(&state, PlayerId(0), source_id),
+            "prepared copy must not be castable without payable mana"
         );
     }
 

--- a/crates/engine/tests/integration/issue_1202_prepared_spell_cast_timing.rs
+++ b/crates/engine/tests/integration/issue_1202_prepared_spell_cast_timing.rs
@@ -1,0 +1,59 @@
+//! Issue #1202 — Prepared copies must pay the prepare spell's mana cost and obey
+//! sorcery timing (not instant speed on the opponent's turn).
+
+use engine::game::effects::prepare::can_cast_prepared_copy_now;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::actions::GameAction;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use crate::support::shared_card_db as load_db;
+
+#[test]
+fn issue_1202_prepared_sorcery_requires_mana_and_sorcery_timing() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let emeritus = scenario.add_real_card(P0, "Emeritus of Truce", Zone::Battlefield, db);
+
+    let mut runner = scenario.build();
+    runner.state_mut().debug_mode = true;
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    let back = runner
+        .state()
+        .objects
+        .get(&emeritus)
+        .and_then(|o| o.back_face.clone())
+        .expect("Emeritus must hydrate a prepare spell back face");
+    assert!(
+        !matches!(back.mana_cost, engine::types::mana::ManaCost::NoCost),
+        "prepare spell back face must carry a payable mana cost, got {:?}",
+        back.mana_cost
+    );
+
+    runner
+        .act(GameAction::Debug(
+            engine::types::actions::DebugAction::SetPrepared {
+                object_id: emeritus,
+                prepared: true,
+            },
+        ))
+        .expect("mark Emeritus prepared");
+
+    assert!(
+        !can_cast_prepared_copy_now(runner.state(), P0, emeritus),
+        "prepared sorcery must not be castable without mana in pool"
+    );
+
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P0;
+    assert!(
+        !can_cast_prepared_copy_now(runner.state(), P0, emeritus),
+        "prepared sorcery must not be castable during the opponent's turn"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -92,6 +92,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod invoke_calamity_free_cast;
+mod issue_1202_prepared_spell_cast_timing;
 mod issue_1297_venture_initiative_triggers;
 mod issue_1302_final_parting;
 mod issue_1305_thalisse_tokens_created_this_turn;


### PR DESCRIPTION
## Summary
- Add unit tests on `can_cast_prepared_copy_now` proving prepared sorcery copies are not offered without payable mana and not during the opponent's main phase.
- Add integration coverage with Emeritus of Truce (prepare DFC in the fixture DB) verifying the prepare-spell back face carries a non-zero mana cost after rehydration.

## Root cause
Engine casting already routes prepared copies through the normal spell pipeline with `ExileWithAltCost` using the prepare face mana cost and sorcery-speed timing checks. This PR locks that behavior in with regression tests so future changes cannot reintroduce free or instant-speed prepared casts.

Fixes #1202

## Test plan
- [x] `cargo test -p engine --lib prepared_sorcery`
- [x] `cargo test -p engine --test integration issue_1202`
- [x] `cargo clippy -p engine -- -D warnings`

Made with [Cursor](https://cursor.com)