### PR TITLE
fix(engine): consume one-shot in-place cast grants when the spell leaves the stack

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -24489,6 +24489,121 @@ mod tests {
             .expect("bauble must be castable from graveyard");
     }
 
+    /// Regression (Sunforger infinite recast): a `CastFromZone` "cast it
+    /// without paying its mana cost" grant attached *in place* to a card the
+    /// effect routed through the hand (Sunforger: search → to hand → cast from
+    /// hand) leaves a zero-cost `ExileWithAltCost { duration: None }` on the
+    /// card. The card never visits exile, so the exile-exit cleanup never fires.
+    /// Before the fix, after the spell resolved to the graveyard the spent grant
+    /// persisted there, and `has_graveyard_timed_alt_cost_permission` re-offered
+    /// the free cast on every priority — the AI cast Abrade from its graveyard
+    /// endlessly. CR 400.7 + CR 601.2a: the one-shot grant must be consumed when
+    /// the card leaves the stack after its single cast.
+    ///
+    /// This test seeds the post-resolution graveyard state directly (the bug's
+    /// observed surface) and drives the real cast+resolve pipeline through the
+    /// fixed `apply_zone_exit_cleanup` seam. Grant *creation* provenance (the
+    /// hand-origin `CastFromZone` resolve and its `UntilEndOfTurn` default) is
+    /// covered by `cast_from_zone::tests::hand_in_place_grant_defaults_to_until_end_of_turn`.
+    #[test]
+    fn graveyard_in_place_alt_cost_grant_is_consumed_after_one_cast() {
+        let mut state = setup_game_at_main_phase();
+        // Seed library so the resolving Draw does not hit an empty library.
+        for i in 0..3 {
+            create_object(
+                &mut state,
+                CardId(7100 + i),
+                PlayerId(0),
+                format!("Library Card {i}"),
+                Zone::Library,
+            );
+        }
+
+        let spell = create_object(
+            &mut state,
+            CardId(7000),
+            PlayerId(0),
+            "Abrade".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            ));
+            // Printed cost is real; the only way this casts is the free grant.
+            obj.mana_cost = ManaCost::generic(3);
+            // Hand-origin in-place grant: `duration: None` (graveyard-origin
+            // grants default to UntilEndOfTurn — the leak class is the one that
+            // never expires).
+            obj.casting_permissions
+                .push(CastingPermission::ExileWithAltCost {
+                    cost: ManaCost::zero(),
+                    cast_transformed: false,
+                    constraint: None,
+                    granted_to: Some(PlayerId(0)),
+                    resolution_cleanup: None,
+                    duration: None,
+                    exile_instead_of_graveyard_on_resolve: false,
+                });
+        }
+
+        // Precondition (the bug's trigger): the stale grant makes the free
+        // graveyard cast available even with no mana in the pool.
+        assert!(
+            spell_objects_available_to_cast(&state, PlayerId(0)).contains(&spell),
+            "stale in-place grant should surface the free graveyard cast"
+        );
+
+        // Cast it for free and resolve it back to the graveyard.
+        apply_as_current(
+            &mut state,
+            GameAction::CastSpell {
+                object_id: spell,
+                card_id: CardId(7000),
+                targets: vec![],
+                payment_mode: CastPaymentMode::Auto,
+            },
+        )
+        .expect("free graveyard cast should be accepted");
+        assert_eq!(state.stack.len(), 1, "spell should be on the stack");
+
+        for _ in 0..4 {
+            if state.stack.is_empty() {
+                break;
+            }
+            apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+        }
+
+        assert_eq!(
+            state.objects[&spell].zone,
+            Zone::Graveyard,
+            "instant should resolve back to the graveyard"
+        );
+        // The fix: the spent one-shot grant is gone.
+        assert!(
+            !state.objects[&spell]
+                .casting_permissions
+                .iter()
+                .any(|p| matches!(
+                    p,
+                    CastingPermission::ExileWithAltCost { .. }
+                        | CastingPermission::ExileWithAltAbilityCost { .. }
+                )),
+            "the consumed CastFromZone grant must be cleared on leaving the stack"
+        );
+        // And the infinite-recast surface is closed.
+        assert!(
+            !spell_objects_available_to_cast(&state, PlayerId(0)).contains(&spell),
+            "the spell must not be re-offered from the graveyard after its single cast"
+        );
+    }
+
     #[test]
     fn hand_alt_cost_permission_overrides_printed_mana_cost() {
         let mut state = setup_game_at_main_phase();

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -439,11 +439,21 @@ pub(crate) fn grant_lingering_permissions(
                     // durational grants (Rebound's `UntilEndOfTurn` upkeep
                     // recast offer) are pruned at the correct boundary.
                     // `None` (the common case) preserves the standing
-                    // semantics used by Discover, Suspend, Nashi, etc.
-                    // Emry-class graveyard grants default to UntilEndOfTurn
-                    // when the parser did not carry an explicit duration.
+                    // semantics used by Discover, Suspend, Nashi, etc., whose
+                    // cards are exiled and stay castable until they leave exile
+                    // (cleared by `zones::apply_zone_exit_cleanup`).
+                    // CR 611.2a: An *in-place* grant on a card left in the hand
+                    // or graveyard (Emry, Sunforger searching to hand,
+                    // Electrodominance) is a continuous effect from this
+                    // ability's resolution; it must expire at cleanup if the
+                    // cast is declined, since the card never leaves a zone that
+                    // would trigger permission cleanup.
+                    // Default both in-place origins to UntilEndOfTurn when the
+                    // parser carried no explicit duration. (Exile-origin grants
+                    // keep `None` — they are pruned on leaving exile instead.)
                     duration: duration.clone().or_else(|| {
-                        (current_zone == Some(Zone::Graveyard)).then_some(Duration::UntilEndOfTurn)
+                        matches!(current_zone, Some(Zone::Graveyard | Zone::Hand))
+                            .then_some(Duration::UntilEndOfTurn)
                     }),
                     exile_instead_of_graveyard_on_resolve,
                 }
@@ -1098,6 +1108,42 @@ mod tests {
                     ..
                 } if *cost == ManaCost::zero()
             )));
+    }
+
+    /// CR 611.2a: A hand-origin in-place "you may cast it without paying its
+    /// mana cost" grant (Sunforger searches a card to hand, then casts it from
+    /// there) is a one-resolution offer. It must default to `UntilEndOfTurn` so
+    /// that if the cast is *declined* the grant is pruned at cleanup — otherwise
+    /// a `duration: None` grant lingers on the hand card and
+    /// `has_hand_alt_cost_permission` re-offers the free cast forever. Mirrors
+    /// the graveyard-origin (Emry) default.
+    #[test]
+    fn hand_in_place_grant_defaults_to_until_end_of_turn() {
+        let mut state = make_test_state();
+        let cheap = add_card_to_hand(&mut state, PlayerId(0), CardId(515));
+        let ability = electrodominance_hand_ability(3);
+
+        let mut events = vec![];
+        resolve(&mut state, &ability, &mut events).unwrap();
+        apply_as_current(&mut state, GameAction::SelectCards { cards: vec![cheap] }).unwrap();
+
+        assert_eq!(state.objects[&cheap].zone, Zone::Hand);
+        assert!(
+            state.objects[&cheap]
+                .casting_permissions
+                .iter()
+                .any(|p| matches!(
+                    p,
+                    CastingPermission::ExileWithAltCost {
+                        duration: Some(Duration::UntilEndOfTurn),
+                        granted_to: Some(PlayerId(0)),
+                        ..
+                    }
+                )),
+            "hand-origin in-place grant must default to UntilEndOfTurn so a \
+             declined offer expires at cleanup; got {:?}",
+            state.objects[&cheap].casting_permissions
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -188,6 +188,38 @@ pub(crate) fn apply_zone_exit_cleanup(
             state.exile_links.retain(|link| link.exiled_id != object_id);
         }
 
+        // CR 400.7 + CR 601.2a + CR 118.9 + CR 701.17d: An object-tagged cast/play
+        // grant ("you may cast it without paying its mana cost", a milled card's
+        // "you may play that card") attaches an `ExileWithAltCost` /
+        // `ExileWithAltAbilityCost` / `PlayFromExile` permission *in place* on a
+        // card picked from the hand or graveyard (Sunforger searches a card to
+        // hand and casts it from there; Electrodominance / Emry cast in place;
+        // Ark of Hunger / Tablet of Discovery mill-grant in the graveyard) — see
+        // `effects::cast_from_zone` and the #751 graveyard `PlayFromExile` path.
+        // Such a card never passes through exile, so the exile-exit clear above
+        // never fires for it. Each grant authorizes exactly one cast of *that*
+        // card; once it has been cast and is leaving the stack (resolved or
+        // countered), the spent grant must be dropped so CR 400.7's new object
+        // does not inherit it. Without this, a stale grant lands back in the
+        // graveyard where `has_graveyard_timed_alt_cost_permission` /
+        // `graveyard_spell_objects_available_to_cast` re-offer the free cast on
+        // every priority — an unbounded recast loop. Exile-origin grants are
+        // already cleared at the Exile→Stack move, so this is a no-op for them
+        // (impulse draw, Suspend, Discover, Cascade). Other exile-scoped
+        // permissions (AdventureCreature, Plotted, Foretold, WarpExile) are left
+        // untouched: an Adventure spell, for instance, gains `AdventureCreature`
+        // precisely as it resolves to exile.
+        if from == Zone::Stack {
+            obj_mut.casting_permissions.retain(|p| {
+                !matches!(
+                    p,
+                    crate::types::ability::CastingPermission::ExileWithAltCost { .. }
+                        | crate::types::ability::CastingPermission::ExileWithAltAbilityCost { .. }
+                        | crate::types::ability::CastingPermission::PlayFromExile { .. }
+                )
+            });
+        }
+
         if from == Zone::Battlefield {
             obj_mut.reset_for_battlefield_exit();
         }


### PR DESCRIPTION
An AI repeatedly cast Abrade from its graveyard for free, every priority,
effectively forever. Sunforger ("search your library for a red or white
instant ... and you may cast it without paying its mana cost") is modeled
as SearchLibrary -> ChangeZone{Library->Hand} -> CastFromZone{without
paying} -> Shuffle. The found card is moved to hand, then
`effects::cast_from_zone` stamps `ExileWithAltCost { cost: 0 }` IN PLACE
(it only relocates to exile for cards that aren't already in
hand/graveyard/exile). The card is cast from hand and resolves to the
graveyard.

`apply_zone_exit_cleanup` only cleared `ExileWithAltCost`-class casting
permissions when leaving exile, so the spent grant persisted on the
graveyard card. `has_graveyard_timed_alt_cost_permission` then re-offered
the free cast on every priority -> unbounded recast loop.

CR 400.7 + CR 601.2a: a one-shot in-place grant authorizes exactly one
cast of that card. Clear `ExileWithAltCost`, `ExileWithAltAbilityCost`,
and object-tagged `PlayFromExile` when the card leaves the stack after its
single cast (resolved or countered). This also closes the same latent
recast for milled `PlayFromExile` cards (#751) without affecting the
once-only #751 creature flow. Exile-origin grants are untouched (already
cleared at Exile->Stack); Adventure/Plotted/Foretold/WarpExile are
untouched.

Also default hand-origin in-place grants to `Duration::UntilEndOfTurn`
(mirroring graveyard-origin grants), so a *declined* "you may cast it"
offer is pruned at cleanup instead of lingering forever on the hand card.

Tests: graveyard recast surface is consumed after one cast (real cast+
resolve pipeline); hand-origin grant provenance defaults to UntilEndOfTurn.
