### PR TITLE
feat(ui): surface player conditions, ring benefits, mana availability & creature overflow

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -727,6 +727,9 @@ export interface GameObject {
   class_level?: number;
   devotion?: number;
   available_mana_pips?: ManaPip[];
+  /** CR 701.15c: players who have goaded this creature (it must attack a
+   *  player other than them, if able). Empty/omitted when not goaded. */
+  goaded_by?: PlayerId[];
   casting_permissions?: CastingPermission[];
   is_emblem?: boolean;
   /**
@@ -1726,6 +1729,33 @@ export interface CommanderDamageView {
 }
 
 /**
+ * Presentation-only discriminant for a player-affecting continuous condition.
+ * Mirrors `engine::game::derived_views::PlayerConditionKind` (serde
+ * tag="type", content="data"). The FE maps each kind to an icon + i18n label
+ * and never re-derives the condition from static abilities — the engine
+ * aggregates the authoritative state into `DerivedViews.player_status`.
+ */
+export type PlayerConditionKind =
+  | { type: "CantWin" }
+  | { type: "CantGainLife" }
+  | { type: "CantLoseLife" }
+  | { type: "CantPayLifeAsCost" }
+  | { type: "CantCastSpells" }
+  | { type: "CantActivateAbilities" }
+  | { type: "CastOnlyFromZones"; data: { allowed_zones: Zone[] } };
+
+/**
+ * One player-status row. Mirrors `engine::game::derived_views::PlayerStatusView`.
+ * `source` is the imposing permanent when the engine surfaces it (stored
+ * restrictions / epic locks); absent for statics-scanned life/cost conditions.
+ */
+export interface PlayerStatusView {
+  player: PlayerId;
+  kind: PlayerConditionKind;
+  source?: ObjectId | null;
+}
+
+/**
  * Engine-authored projections computed at each state snapshot. Rides
  * alongside GameState through every adapter path. Frontend components
  * consume this shape directly and never compute grouping/filtering
@@ -1762,7 +1792,49 @@ export interface DerivedViews {
    *  own hand (incl. granted). Keyed by hand ObjectId (string). Mirrors
    *  engine::game::derived_views::DerivedViews::web_slinging_costs. */
   web_slinging_costs?: Record<string, ManaCost>;
+  /**
+   * Player-affecting continuous conditions (can't gain life, can't cast, etc.)
+   * the HUD renders as status icons. Engine-aggregated from static abilities +
+   * stored restrictions/epic locks so the FE never re-scans statics. Empty/
+   * omitted when no player is afflicted. Mirrors
+   * `engine::game::derived_views::DerivedViews::player_status`.
+   */
+  player_status?: PlayerStatusView[];
 }
+
+/** Mirrors `engine::types::game_state::NextSpellModifier` (serde tag="type"). */
+export type NextSpellModifier =
+  | { type: "CantBeCountered" }
+  | { type: "HasKeyword"; keyword: Keyword }
+  | { type: "CastAsThoughFlash" }
+  | { type: "WithoutPayingManaCost" };
+
+/** CR 601.2f: a one-shot modifier applied to a player's next qualifying spell.
+ *  Mirrors `engine::types::game_state::PendingNextSpellModifier`. */
+export interface PendingNextSpellModifier {
+  player: PlayerId;
+  modifier: NextSpellModifier;
+  spell_filter?: TargetFilter | null;
+}
+
+/** CR 601.2f: a one-shot mana reduction for a player's next qualifying spell.
+ *  Mirrors `engine::types::game_state::PendingSpellCostReduction`. */
+export interface PendingSpellCostReduction {
+  player: PlayerId;
+  amount: number;
+  spell_filter?: TargetFilter | null;
+}
+
+/** CR 702.50a: a rest-of-game Epic effect locking its controller out of
+ *  casting. Mirrors `engine::types::game_state::EpicEffect` (`spell` omitted —
+ *  the FE only needs the controller + prototype for display). */
+export interface EpicEffect {
+  controller: PlayerId;
+  prototype_id: ObjectId;
+}
+
+/** CR 731: the day/night designation, absent when neither is in effect. */
+export type DayNight = "Day" | "Night";
 
 export interface GameState {
   turn_number: number;
@@ -1859,6 +1931,17 @@ export interface GameState {
   /** CR 701.20e: the player to whom `private_look_ids` is visible (the looker). */
   private_look_player?: PlayerId;
   restrictions?: GameRestriction[];
+  /** CR 601.2f: pending one-shot modifiers for each player's next qualifying
+   *  spell (copy, flash, can't-be-countered, free cast). Surfaced as a HUD
+   *  "next spell" badge. Empty/omitted when none pending. */
+  pending_next_spell_modifiers?: PendingNextSpellModifier[];
+  /** CR 601.2f: pending one-shot cost reductions for each player's next
+   *  qualifying spell. */
+  pending_next_spell_cost_reductions?: PendingSpellCostReduction[];
+  /** CR 702.50a: active rest-of-game Epic locks (controller can't cast). */
+  epic_effects?: EpicEffect[];
+  /** CR 731: current day/night designation, absent when neither is in effect. */
+  day_night?: DayNight | null;
   command_zone?: ObjectId[];
   auto_pass?: Record<number, AutoPassMode>;
   phase_stops?: Record<number, Phase[]>;

--- a/client/src/components/board/BattlefieldRow.tsx
+++ b/client/src/components/board/BattlefieldRow.tsx
@@ -23,6 +23,11 @@ interface BattlefieldRowProps {
    *  keeping two sub-clusters (e.g. enchantments|planeswalkers) on one wrapping
    *  line while visually separating them. Omit for no divider. */
   dividerBeforeIndex?: number;
+  /** Creatures only: render at the card size inherited from the parent's CSS
+   *  vars and wrap top-down, skipping the measure-based shrink-to-fit. Lets a
+   *  scrollable parent present a fixed, readable size and scroll the overflow
+   *  (used by the crowded-creature overview) instead of cramming the row. */
+  fixedSize?: boolean;
 }
 
 const ROW_JUSTIFY: Record<string, string> = {
@@ -61,7 +66,7 @@ function getCreatureScale(groupCount: number, display: "art_crop" | "full_card")
   return Math.max(min, 1 / Math.sqrt(1 + excess * 0.15));
 }
 
-export function BattlefieldRow({ groups, rowType, className, dividerBeforeIndex }: BattlefieldRowProps) {
+export function BattlefieldRow({ groups, rowType, className, dividerBeforeIndex, fixedSize = false }: BattlefieldRowProps) {
   const { t } = useTranslation("game");
   const battlefieldCardDisplay = usePreferencesStore((s) => s.battlefieldCardDisplay);
   const isCompactHeight = useIsCompactHeight();
@@ -75,7 +80,9 @@ export function BattlefieldRow({ groups, rowType, className, dividerBeforeIndex 
   // non-empty render (the early return below means the ref is null when empty).
   const hasGroups = groups.length > 0;
   useEffect(() => {
-    if (rowType !== "creatures" || !hasGroups) return;
+    // fixedSize inherits its card dimensions from the parent's CSS vars and lets
+    // the parent scroll, so the measure-based sizing observer is unnecessary.
+    if (rowType !== "creatures" || !hasGroups || fixedSize) return;
     const el = containerRef.current?.parentElement;
     if (!el) return;
     const observer = new ResizeObserver(([entry]) => {
@@ -86,7 +93,7 @@ export function BattlefieldRow({ groups, rowType, className, dividerBeforeIndex 
     });
     observer.observe(el);
     return () => observer.disconnect();
-  }, [rowType, hasGroups]);
+  }, [rowType, hasGroups, fixedSize]);
 
   useEffect(() => {
     const currentGroupIds = new Set(groups.map((group) => group.ids[0]));
@@ -142,7 +149,11 @@ export function BattlefieldRow({ groups, rowType, className, dividerBeforeIndex 
     0,
   );
 
-  if (rowType === "creatures") {
+  if (rowType === "creatures" && fixedSize) {
+    // Inherit card size from the parent's CSS vars; wrap top-down and let the
+    // parent scroll. No rowStyle override.
+    creatureWrap = true;
+  } else if (rowType === "creatures") {
     if (containerSize && containerSize.height > 0) {
       // Measure-based sizing: fill available space
       const { width: cw, height: ch } = containerSize;
@@ -208,9 +219,11 @@ export function BattlefieldRow({ groups, rowType, className, dividerBeforeIndex 
     }
   }
 
-  const creatureClass = creatureWrap
-    ? "flex-wrap items-end content-end"
-    : "flex-nowrap items-end";
+  const creatureClass = fixedSize
+    ? "flex-wrap items-start content-start"
+    : creatureWrap
+      ? "flex-wrap items-end content-end"
+      : "flex-nowrap items-end";
 
   // Planeswalkers stay on a single horizontal line — wrapping them stacks
   // vertically and warps the surrounding board rows. Every other non-creature

--- a/client/src/components/board/BattlefieldZoneOverflow.tsx
+++ b/client/src/components/board/BattlefieldZoneOverflow.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, RefObject } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
@@ -15,7 +15,7 @@ import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
 import { useBoardInteractionState } from "./BoardInteractionContext.tsx";
 import { BattlefieldRow } from "./BattlefieldRow.tsx";
 
-type OverflowZone = "lands" | "support";
+type OverflowZone = "lands" | "support" | "creatures";
 type DrawerSide = "left" | "right";
 
 interface BattlefieldZoneOverflowProps {
@@ -28,6 +28,12 @@ interface BattlefieldZoneOverflowProps {
 
 const MOBILE_COLLAPSE_GROUPS = 4;
 const DESKTOP_COLLAPSE_GROUPS = 8;
+// Creatures own the full board width (lands/support each share a half-row), so
+// they tolerate more cards before crowding. Identical tokens already stack into
+// one group, so the creature threshold counts GROUPS (distinct stacks), not
+// bodies — a lone 20-token Saproling swarm shouldn't trip the overflow.
+const MOBILE_COLLAPSE_CREATURE_GROUPS = 6;
+const DESKTOP_COLLAPSE_CREATURE_GROUPS = 12;
 const MANA_COLOR_ORDER: Array<ManaColor | "Colorless"> = [
   "White",
   "Blue",
@@ -57,11 +63,16 @@ export function BattlefieldZoneOverflow({
   const panelRef = useRef<HTMLDivElement | null>(null);
   const isMobile = useIsMobile();
   const isCompactHeight = useIsCompactHeight();
-  const threshold = isMobile || isCompactHeight
-    ? MOBILE_COLLAPSE_GROUPS
-    : DESKTOP_COLLAPSE_GROUPS;
+  const isCreatures = zone === "creatures";
+  const compact = isMobile || isCompactHeight;
+  const threshold = isCreatures
+    ? (compact ? MOBILE_COLLAPSE_CREATURE_GROUPS : DESKTOP_COLLAPSE_CREATURE_GROUPS)
+    : (compact ? MOBILE_COLLAPSE_GROUPS : DESKTOP_COLLAPSE_GROUPS);
   const objectIds = useMemo(() => groups.flatMap((group) => group.ids), [groups]);
-  const collapsed = objectIds.length > threshold;
+  // Creatures collapse by stack count (token swarms already group); lands and
+  // support collapse by body count, preserving their established behaviour.
+  const collapseMetric = isCreatures ? groups.length : objectIds.length;
+  const collapsed = collapseMetric > threshold;
 
   useEffect(() => {
     if (!open) return;
@@ -101,12 +112,23 @@ export function BattlefieldZoneOverflow({
 
   return (
     <>
-      <ZoneSummaryTile
-        groups={groups}
-        objectIds={objectIds}
-        zone={zone}
-        onOpen={() => setOpen(true)}
-      />
+      {isCreatures ? (
+        // Creatures fill the whole band: a scrollable grid of readable cards
+        // (full P/T, keywords, counters, tapped state) rather than a summary
+        // pill — combat-selected creatures float to the top for priority sight.
+        <CreatureOverview
+          groups={groups}
+          objectIds={objectIds}
+          onOpen={() => setOpen(true)}
+        />
+      ) : (
+        <ZoneSummaryTile
+          groups={groups}
+          objectIds={objectIds}
+          zone={zone}
+          onOpen={() => setOpen(true)}
+        />
+      )}
       {open && createPortal(
         <BattlefieldZoneDrawer
           panelRef={panelRef}
@@ -120,6 +142,132 @@ export function BattlefieldZoneOverflow({
         document.body,
       )}
     </>
+  );
+}
+
+// Fixed, readable card size for the scrollable creature grid. Big enough to
+// read P/T, keywords, and counters; the parent scrolls the overflow.
+const CREATURE_GRID_VARS: CSSProperties = {
+  "--art-crop-w": "6.4rem",
+  "--art-crop-h": "4.8rem",
+  "--card-w": "4.4rem",
+  "--card-h": "6.16rem",
+} as CSSProperties;
+
+interface CreatureOverviewProps {
+  groups: GroupedPermanent[];
+  objectIds: ObjectId[];
+  onOpen: () => void;
+}
+
+/**
+ * Crowded-creature view: a scrollable grid of full, readable cards (real board
+ * cards via BattlefieldRow, so attack/block/activate/inspect all work inline).
+ * Two affordances the design calls for:
+ *  - Combat-selected creatures (chosen attackers, committed attackers, assigned
+ *    blockers) sort to the FRONT so they're visible without scrolling.
+ *  - Scrollability is made obvious with top/bottom fades, a bouncing chevron,
+ *    and a header hint whenever there's more below the fold.
+ */
+function CreatureOverview({ groups, objectIds, onOpen }: CreatureOverviewProps) {
+  const { t } = useTranslation("game");
+  const gameState = useGameStore((s) => s.gameState);
+  const selectedAttackers = useUiStore((s) => s.selectedAttackers);
+  const blockerAssignments = useUiStore((s) => s.blockerAssignments);
+  const { committedAttackerIds, incomingAttackerCounts } = useBoardInteractionState();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [edges, setEdges] = useState({ top: false, bottom: false });
+
+  const objects = useMemo(
+    () => objectIds
+      .map((id) => gameState?.objects[id])
+      .filter((obj): obj is GameObject => obj != null),
+    [gameState?.objects, objectIds],
+  );
+
+  // Float every combat participant to the front for priority visibility: chosen
+  // and committed attackers, assigned blockers, and creatures with incoming
+  // attacks (so a blocked/attacked creature is visible without scrolling). A
+  // stable sort keeps everything else in its incoming order.
+  const sortedGroups = useMemo(() => {
+    const priority = new Set<ObjectId>([
+      ...selectedAttackers,
+      ...committedAttackerIds,
+      ...blockerAssignments.keys(),
+      ...incomingAttackerCounts.keys(),
+    ]);
+    if (priority.size === 0) return groups;
+    const isPriority = (group: GroupedPermanent) => group.ids.some((id) => priority.has(id));
+    return groups
+      .map((group, index) => ({ group, index, priority: isPriority(group) }))
+      .sort((a, b) => Number(b.priority) - Number(a.priority) || a.index - b.index)
+      .map((entry) => entry.group);
+  }, [groups, selectedAttackers, committedAttackerIds, blockerAssignments, incomingAttackerCounts]);
+
+  const updateEdges = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setEdges({
+      top: el.scrollTop > 4,
+      bottom: el.scrollTop + el.clientHeight < el.scrollHeight - 4,
+    });
+  }, []);
+
+  useEffect(() => {
+    updateEdges();
+    const el = scrollRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(updateEdges);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [updateEdges, sortedGroups]);
+
+  return (
+    <div className="flex h-full w-full flex-col gap-1">
+      <div className="flex shrink-0 flex-wrap items-center justify-center gap-2 px-2 pt-0.5">
+        <span className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-200">
+          {t("battlefieldOverflow.creatures.label")}
+        </span>
+        <span className="rounded-full bg-white/10 px-2 py-0.5 text-[11px] font-black tabular-nums text-white">
+          {objectIds.length}
+        </span>
+        <CreatureSummary objects={objects} />
+        {edges.bottom && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-cyan-400/15 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-cyan-200 ring-1 ring-cyan-300/40">
+            <span aria-hidden className="animate-bounce">↓</span>
+            {t("battlefieldOverflow.creatures.scrollHint")}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={onOpen}
+          aria-label={t("battlefieldOverflow.creatures.open", { count: objectIds.length })}
+          className="rounded-md bg-white/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-slate-200 transition hover:bg-white/20 hover:text-white"
+        >
+          {t("battlefieldOverflow.creatures.viewAll")}
+        </button>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        <div
+          aria-hidden
+          className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-5 bg-gradient-to-b from-slate-950 to-transparent transition-opacity ${edges.top ? "opacity-100" : "opacity-0"}`}
+        />
+        <div
+          ref={scrollRef}
+          onScroll={updateEdges}
+          className="thin-scrollbar h-full overflow-y-auto overscroll-contain px-1 pb-1"
+          style={CREATURE_GRID_VARS}
+        >
+          <BattlefieldRow groups={sortedGroups} rowType="creatures" fixedSize />
+        </div>
+        <div
+          aria-hidden
+          className={`pointer-events-none absolute inset-x-0 bottom-0 z-10 flex h-8 items-end justify-center bg-gradient-to-t from-slate-950 to-transparent text-base text-cyan-200 transition-opacity ${edges.bottom ? "opacity-100" : "opacity-0"}`}
+        >
+          <span className="animate-bounce">⌄</span>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -206,23 +354,32 @@ function ZoneSummaryTile({ groups, objectIds, zone, onOpen }: ZoneSummaryTilePro
     const commanderIdentityByPlayer = new Map(
       gameState.players.map((player) => [player.id, player.commander_color_identity]),
     );
-    const colorCounts = new Map<ManaColor | "Colorless", number>();
+    // Per-color land counts split by availability. `total` counts every land
+    // that can produce the color; `untapped` counts only those usable now.
+    // CR 106.1: a tapped land can't produce mana, so `!tapped` is the
+    // available-now signal (controller-agnostic — correct for own and
+    // opponent boxes alike, unlike the viewer-scoped manaTappableObjectIds).
+    const total = new Map<ManaColor | "Colorless", number>();
+    const untapped = new Map<ManaColor | "Colorless", number>();
     for (const object of objects) {
       const identity = commanderIdentityByPlayer.get(object.controller);
+      const usableNow = !object.tapped;
       for (const pip of object.available_mana_pips ?? []) {
         for (const color of manaPipToDisplayColors(pip, identity)) {
           const manaColor = color as ManaColor | "Colorless";
-          colorCounts.set(manaColor, (colorCounts.get(manaColor) ?? 0) + 1);
+          total.set(manaColor, (total.get(manaColor) ?? 0) + 1);
+          if (usableNow) untapped.set(manaColor, (untapped.get(manaColor) ?? 0) + 1);
         }
       }
     }
     return MANA_COLOR_ORDER
       .map((color) => ({
         color,
-        count: colorCounts.get(color) ?? 0,
+        total: total.get(color) ?? 0,
+        untapped: untapped.get(color) ?? 0,
         shard: MANA_COLOR_SHARD[color],
       }))
-      .filter((entry) => entry.count > 0);
+      .filter((entry) => entry.total > 0);
   }, [gameState, objects, zone]);
   const hasInteraction =
     interaction.activatable > 0
@@ -256,16 +413,24 @@ function ZoneSummaryTile({ groups, objectIds, zone, onOpen }: ZoneSummaryTilePro
       <span className="mt-1 flex items-center gap-1">
         {zone === "lands" ? (
           manaOptions.length > 0 ? (
-            manaOptions.map(({ color, count, shard }) => (
+            manaOptions.map(({ color, total, untapped, shard }) => (
               <span
                 key={color}
-                className="group relative inline-flex h-5 items-center gap-0.5 rounded-full bg-black/45 px-1.5 text-[10px] font-black tabular-nums text-slate-100 ring-1 ring-white/12"
+                className={`group relative inline-flex h-5 items-center gap-0.5 rounded-full bg-black/45 px-1.5 text-[10px] font-black tabular-nums ring-1 ring-white/12 ${
+                  untapped === 0 ? "text-slate-400 opacity-60" : "text-slate-100"
+                }`}
               >
-                <span>{count}×</span>
+                {/* untapped (available now) bright; tapped remainder as a dim
+                    "/total" so the box reads "available of how many lands". */}
+                <span>{untapped}</span>
+                {untapped !== total ? (
+                  <span className="font-bold text-slate-400">/{total}</span>
+                ) : null}
+                <span>×</span>
                 <ManaSymbol shard={shard} size="xs" className="drop-shadow-[0_1px_1px_rgba(0,0,0,0.65)]" />
                 <GameplayTooltip className="left-0 right-auto w-56">
                   <span className="inline-flex items-center gap-1.5">
-                    <span>{t("battlefieldOverflow.lands.pipTooltip", { count })}</span>
+                    <span>{t("battlefieldOverflow.lands.pipAvailability", { untapped, total })}</span>
                     <ManaSymbol shard={shard} size="sm" className="shrink-0" />
                   </span>
                 </GameplayTooltip>
@@ -374,6 +539,30 @@ function supportTypeCounts(objects: GameObject[]): SupportTypeCounts {
   }
 
   return counts;
+}
+
+/** Aggregate power/toughness across the collapsed creatures, so the tile still
+ *  conveys board presence at a glance. Null P/T (e.g. unset characteristic-
+ *  defining values) counts as 0. */
+function CreatureSummary({ objects }: { objects: GameObject[] }) {
+  const { t } = useTranslation("game");
+  const { power, toughness } = objects.reduce(
+    (totals, object) => ({
+      power: totals.power + (object.power ?? 0),
+      toughness: totals.toughness + (object.toughness ?? 0),
+    }),
+    { power: 0, toughness: 0 },
+  );
+
+  return (
+    <span className="group relative inline-flex h-5 items-center gap-1 rounded-full bg-black/45 px-2 text-[10px] font-black tabular-nums text-slate-100 ring-1 ring-white/12">
+      <span aria-hidden>⚔</span>
+      <span>{`${power}/${toughness}`}</span>
+      <GameplayTooltip className="left-0 right-auto w-52">
+        {t("battlefieldOverflow.creatures.totalPower", { power, toughness })}
+      </GameplayTooltip>
+    </span>
+  );
 }
 
 function SupportCounts({ counts }: { counts: SupportTypeCounts }) {
@@ -489,7 +678,7 @@ function BattlefieldZoneDrawer({
             groups={groups}
             rowType={zone}
             dividerBeforeIndex={dividerBeforeIndex}
-            className={`${zone === "lands" ? "justify-start" : "justify-end"} ${className ?? ""}`}
+            className={`${zone === "lands" ? "justify-start" : zone === "creatures" ? "justify-center" : "justify-end"} ${className ?? ""}`}
           />
         </div>
       </div>

--- a/client/src/components/board/CompactStrip.tsx
+++ b/client/src/components/board/CompactStrip.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { PlayerId } from "../../adapter/types.ts";
+import type { GameObject, PlayerId } from "../../adapter/types.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { partitionByType } from "../../viewmodel/battlefieldProps.ts";
+import { LandManaRail } from "../mana/LandManaRail.tsx";
 
 interface CompactStripProps {
   playerId: PlayerId;
@@ -16,8 +17,13 @@ export function CompactStrip({ playerId, onClick, isActive }: CompactStripProps)
   const gameState = useGameStore((s) => s.gameState);
   const isTheirTurn = gameState?.active_player === playerId;
 
-  const { player, counts } = useMemo(() => {
-    if (!gameState) return { player: null, counts: { creatures: 0, lands: 0, other: 0 } };
+  const { player, counts, landObjects } = useMemo(() => {
+    const empty = {
+      player: null,
+      counts: { creatures: 0, other: 0 },
+      landObjects: [] as GameObject[],
+    };
+    if (!gameState) return empty;
 
     const p = gameState.players[playerId];
     const battlefieldObjects = gameState.battlefield
@@ -26,14 +32,19 @@ export function CompactStrip({ playerId, onClick, isActive }: CompactStripProps)
       .filter((obj) => obj.controller === playerId);
 
     const partition = partitionByType(battlefieldObjects);
+    // partitionByType returns ObjectIds; resolve the land ids back to objects
+    // for the mana rail (it reads each land's available_mana_pips + tapped).
+    const landObjects = partition.lands
+      .map((id) => gameState.objects[id])
+      .filter((obj): obj is GameObject => Boolean(obj));
 
     return {
       player: p,
       counts: {
         creatures: partition.creatures.length,
-        lands: partition.lands.length,
         other: partition.support.length + partition.planeswalkers.length + partition.other.length,
       },
+      landObjects,
     };
   }, [gameState, playerId]);
 
@@ -77,8 +88,13 @@ export function CompactStrip({ playerId, onClick, isActive }: CompactStripProps)
       {counts.creatures > 0 && (
         <PermanentCount label={t("player.creaturesAbbr")} count={counts.creatures} color="text-red-400" />
       )}
-      {counts.lands > 0 && (
-        <PermanentCount label={t("player.landsAbbr")} count={counts.lands} color="text-green-400" />
+      {/* Lands surface as a per-source mana rail (untapped bright, tapped dimmed)
+          rather than a bare count — see LandManaRail / manaAvailability. */}
+      {landObjects.length > 0 && (
+        <div className="flex flex-col items-center">
+          <span className="text-[10px] text-gray-500">{t("player.landsAbbr")}</span>
+          <LandManaRail lands={landObjects} />
+        </div>
       )}
       {counts.other > 0 && (
         <PermanentCount label={t("player.otherAbbr")} count={counts.other} color="text-blue-400" />

--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -182,15 +182,15 @@ export function PlayerArea({
   // than wedged into its own column or lane. As a content-width absolute overlay
   // it consumes zero vertical space, so the flex-1 creature row keeps its full
   // height, and the box hugs the HUD instead of spanning the row. Centered
-  // horizontally (`left-1/2 -translate-x-1/2`) and dropped just below the middle
-  // row for the player (`top-[130%] -translate-y-full`); the focused opponent
+  // horizontally (`left-1/2 -translate-x-1/2`) and dropped below the middle
+  // row for the player (`top-[165%] -translate-y-full`); the focused opponent
   // uses the vertical mirror (`bottom-[130%] translate-y-full`) so the HUD sits
   // just above its middle row. z-20 keeps it
   // above resting cards (lands/support are z-10) but below a hovered card
   // (PermanentCard lifts to z-60), so a card slides over the HUD on hover.
   const hudBand = hud ? (
     <div
-      className={`absolute left-1/2 z-20 -translate-x-1/2 ${isMirrored ? "bottom-[130%] translate-y-full" : "top-[130%] -translate-y-full"}`}
+      className={`absolute left-1/2 z-20 -translate-x-1/2 ${isMirrored ? "bottom-[130%] translate-y-full" : "top-[165%] -translate-y-full"}`}
       data-debug-label="HUD"
     >
       {hud}
@@ -222,13 +222,22 @@ export function PlayerArea({
               {hudBand}
             </div>
             <div className="flex min-h-0 flex-1 items-end px-2" data-debug-label="Opp Creatures">
-              <BattlefieldRow groups={creatures} rowType="creatures" className="w-full" />
+              <BattlefieldZoneOverflow
+                groups={creatures}
+                zone="creatures"
+                side="left"
+                className="w-full"
+              />
             </div>
           </>
         ) : (
           <>
             <div className="min-h-0 flex-1 px-2" data-debug-label="Creatures">
-              <BattlefieldRow groups={creatures} rowType="creatures" />
+              <BattlefieldZoneOverflow
+                groups={creatures}
+                zone="creatures"
+                side="left"
+              />
             </div>
             <div className={`relative ${isCompactHeight ? "min-h-0 max-h-[40%]" : "shrink-0"}`}>
               {middleRow}

--- a/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
+++ b/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
@@ -102,11 +102,17 @@ function makeGroups(count: number): GroupedPermanentType[] {
   });
 }
 
+function makeCreature(id: number, power = 2, toughness = 2): GameObject {
+  return { ...makeObject(id, ["Creature"]), power, toughness };
+}
+
 function renderOverflow(options: {
   groups?: GroupedPermanentType[];
   includePreview?: boolean;
   objects?: Record<number, GameObject>;
   validTargetObjectIds?: Set<number>;
+  committedAttackerIds?: Set<number>;
+  zone?: "lands" | "support" | "creatures";
 } = {}) {
   const groups = options.groups ?? makeGroups(9);
   const objects = options.objects ?? Object.fromEntries(
@@ -117,7 +123,7 @@ function renderOverflow(options: {
     <BoardInteractionContext.Provider
       value={{
         activatableObjectIds: new Set(),
-        committedAttackerIds: new Set(),
+        committedAttackerIds: options.committedAttackerIds ?? new Set(),
         incomingAttackerCounts: new Map(),
         manaTappableObjectIds: new Set([1]),
         selectableManaCostCreatureIds: new Set(),
@@ -126,7 +132,11 @@ function renderOverflow(options: {
         validTargetObjectIds: options.validTargetObjectIds ?? new Set(),
       }}
     >
-      <BattlefieldZoneOverflow groups={groups} zone="lands" side="left" />
+      <BattlefieldZoneOverflow
+        groups={groups}
+        zone={options.zone ?? "lands"}
+        side="left"
+      />
       {options.includePreview ? <GameCardPreview /> : null}
     </BoardInteractionContext.Provider>,
   );
@@ -134,6 +144,13 @@ function renderOverflow(options: {
 
 describe("BattlefieldZoneOverflow", () => {
   beforeEach(() => {
+    // BattlefieldRow instantiates a ResizeObserver for the creatures row; jsdom
+    // has no implementation, so a no-op stub keeps inline creature renders alive.
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
     Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
     window.matchMedia = ((query: string) => ({
@@ -181,9 +198,11 @@ describe("BattlefieldZoneOverflow", () => {
   it("summarizes available land mana with counted pips", () => {
     renderOverflow();
 
-    expect(screen.getByText("9×")).toBeInTheDocument();
+    // Pill shows the untapped count and a "×" multiplier in separate spans.
+    expect(screen.getByText("×")).toBeInTheDocument();
     expect(screen.getAllByAltText("G").length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText(/hidden lands can currently produce/i)).toBeInTheDocument();
+    // Tooltip now reports tapped-vs-untapped availability (all 9 untapped here).
+    expect(screen.getByText("9 of 9 untapped")).toBeInTheDocument();
   });
 
   it("opens and closes the drawer from the summary tile", () => {
@@ -254,5 +273,43 @@ describe("BattlefieldZoneOverflow", () => {
 
     expect(useUiStore.getState().inspectedObjectId).toBe(1);
     expect(screen.getAllByAltText("Permanent 1").length).toBeGreaterThan(0);
+  });
+
+  describe("creatures zone", () => {
+    function renderCreatures(count: number, extra: { power?: number; toughness?: number } = {}) {
+      const groups = makeGroups(count);
+      const objects = Object.fromEntries(
+        groups.flatMap((group) => group.ids).map((id) => [id, makeCreature(id, extra.power, extra.toughness)]),
+      );
+      return renderOverflow({ groups, objects, zone: "creatures" });
+    }
+
+    it("collapses to the scrollable overview only past the higher creature threshold", () => {
+      renderCreatures(13);
+      expect(screen.getByRole("button", { name: /open creatures drawer/i })).toBeInTheDocument();
+    });
+
+    it("keeps a moderate creature count inline (does not reuse the lower land threshold)", () => {
+      // 9 groups would collapse a lands zone, but creatures get more room.
+      renderCreatures(9);
+      expect(screen.queryByRole("button", { name: /open creatures drawer/i })).not.toBeInTheDocument();
+    });
+
+    it("summarizes aggregate power/toughness in the overview header", () => {
+      renderCreatures(13, { power: 2, toughness: 3 });
+      expect(screen.getByText("26/39")).toBeInTheDocument();
+    });
+
+    it("floats combat participants to the front for priority visibility", () => {
+      const groups = makeGroups(13);
+      const objects = Object.fromEntries(
+        groups.flatMap((group) => group.ids).map((id) => [id, makeCreature(id)]),
+      );
+      // Commit the last creature as an attacker; it should sort to the front.
+      renderOverflow({ groups, objects, zone: "creatures", committedAttackerIds: new Set([13]) });
+      const renderedIds = Array.from(document.querySelectorAll("[data-object-id]"))
+        .map((el) => el.getAttribute("data-object-id"));
+      expect(renderedIds[0]).toBe("13");
+    });
   });
 });

--- a/client/src/components/hud/HudBadges.tsx
+++ b/client/src/components/hud/HudBadges.tsx
@@ -1,6 +1,18 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { DungeonId } from "../../adapter/types.ts";
+import { RingBenefitsPopover } from "./RingBenefitsPopover.tsx";
+import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
+import type {
+  DungeonId,
+  NextSpellModifier,
+  PendingNextSpellModifier,
+  PendingSpellCostReduction,
+  PlayerConditionKind,
+  PlayerStatusView,
+} from "../../adapter/types.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import { getKeywordDisplayText } from "../../viewmodel/keywordProps.ts";
 
 interface StatusBadgeProps {
   label: string;
@@ -30,62 +42,65 @@ export function StatusBadge({
 export function MonarchBadge() {
   const { t } = useTranslation("game");
   return (
-    <span
-      role="img"
-      aria-label={t("badges.monarch")}
-      title={t("badges.monarchTooltip")}
-      className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[12px] leading-none ring-1 bg-amber-400 ring-amber-200/80 shadow-[0_0_14px_rgba(251,191,36,0.55)]"
-    >
+    <BadgeTip text={t("badges.monarchTooltip")}>
       <span
-        aria-hidden
-        className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_10%,transparent_12%),radial-gradient(circle_at_68%_30%,rgba(254,243,199,0.95)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(180,83,9,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#fffbeb_0%,#fcd34d_36%,#b45309_72%,#451a03_100%)]"
-      />
-      <span
-        aria-hidden
-        className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-amber-950/30 blur-[1px]"
-      />
-      <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.45)]">👑</span>
-    </span>
+        role="img"
+        aria-label={t("badges.monarch")}
+        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[12px] leading-none ring-1 bg-amber-400 ring-amber-200/80 shadow-[0_0_14px_rgba(251,191,36,0.55)]"
+      >
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_10%,transparent_12%),radial-gradient(circle_at_68%_30%,rgba(254,243,199,0.95)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(180,83,9,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#fffbeb_0%,#fcd34d_36%,#b45309_72%,#451a03_100%)]"
+        />
+        <span
+          aria-hidden
+          className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-amber-950/30 blur-[1px]"
+        />
+        <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.45)]">👑</span>
+      </span>
+    </BadgeTip>
   );
 }
 
 export function InitiativeBadge() {
   const { t } = useTranslation("game");
   return (
-    <span
-      role="img"
-      aria-label={t("badges.initiative")}
-      title={t("badges.initiativeTooltip")}
-      className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[12px] leading-none ring-1 bg-cyan-500 ring-cyan-200/80 shadow-[0_0_14px_rgba(34,211,238,0.55)]"
-    >
+    <BadgeTip text={t("badges.initiativeTooltip")}>
       <span
-        aria-hidden
-        className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_10%,transparent_12%),radial-gradient(circle_at_68%_30%,rgba(207,250,254,0.95)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(14,116,144,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#ecfeff_0%,#67e8f9_36%,#0e7490_72%,#083344_100%)]"
-      />
-      <span
-        aria-hidden
-        className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-cyan-950/30 blur-[1px]"
-      />
-      <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]">🛡</span>
-    </span>
+        role="img"
+        aria-label={t("badges.initiative")}
+        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[12px] leading-none ring-1 bg-cyan-500 ring-cyan-200/80 shadow-[0_0_14px_rgba(34,211,238,0.55)]"
+      >
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_10%,transparent_12%),radial-gradient(circle_at_68%_30%,rgba(207,250,254,0.95)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(14,116,144,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#ecfeff_0%,#67e8f9_36%,#0e7490_72%,#083344_100%)]"
+        />
+        <span
+          aria-hidden
+          className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-cyan-950/30 blur-[1px]"
+        />
+        <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]">🛡</span>
+      </span>
+    </BadgeTip>
   );
 }
 
 export function CityBlessingBadge() {
   const { t } = useTranslation("game");
   return (
-    <span
-      role="img"
-      aria-label={t("badges.cityBlessing")}
-      title={t("badges.cityBlessingTooltip")}
-      className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[12px] leading-none ring-1 bg-yellow-400 ring-yellow-200/80 shadow-[0_0_14px_rgba(250,204,21,0.6)]"
-    >
+    <BadgeTip text={t("badges.cityBlessingTooltip")}>
       <span
-        aria-hidden
-        className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_50%_40%,rgba(255,255,255,0.95)_0_18%,transparent_22%),radial-gradient(circle_at_50%_50%,rgba(254,240,138,0.85)_0_36%,transparent_42%),linear-gradient(135deg,#fefce8_0%,#fde047_36%,#ca8a04_72%,#422006_100%)]"
-      />
-      <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.4)]">☀</span>
-    </span>
+        role="img"
+        aria-label={t("badges.cityBlessing")}
+        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[12px] leading-none ring-1 bg-yellow-400 ring-yellow-200/80 shadow-[0_0_14px_rgba(250,204,21,0.6)]"
+      >
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_50%_40%,rgba(255,255,255,0.95)_0_18%,transparent_22%),radial-gradient(circle_at_50%_50%,rgba(254,240,138,0.85)_0_36%,transparent_42%),linear-gradient(135deg,#fefce8_0%,#fde047_36%,#ca8a04_72%,#422006_100%)]"
+        />
+        <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.4)]">☀</span>
+      </span>
+    </BadgeTip>
   );
 }
 
@@ -107,16 +122,17 @@ export function DungeonBadge({ dungeonName, roomIndex }: DungeonBadgeProps) {
   const display = DUNGEON_DISPLAY_NAMES[dungeonName];
   const room = roomIndex + 1;
   return (
-    <span
-      role="img"
-      aria-label={t("badges.dungeonAriaLabel", { name: display, room })}
-      title={t("badges.dungeonTooltip", { name: display, room })}
-      className="relative inline-flex h-6 shrink-0 items-center gap-1 overflow-hidden rounded-full bg-violet-500/85 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-violet-50 ring-1 ring-violet-300/70 shadow-[0_0_12px_rgba(139,92,246,0.45)]"
-    >
-      <span aria-hidden className="text-[12px] leading-none drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]">🏰</span>
-      <span className="relative truncate">{display}</span>
-      <span className="relative tabular-nums text-white">{room}</span>
-    </span>
+    <BadgeTip text={t("badges.dungeonTooltip", { name: display, room })}>
+      <span
+        role="img"
+        aria-label={t("badges.dungeonAriaLabel", { name: display, room })}
+        className="relative inline-flex h-6 shrink-0 items-center gap-1 overflow-hidden rounded-full bg-violet-500/85 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-violet-50 ring-1 ring-violet-300/70 shadow-[0_0_12px_rgba(139,92,246,0.45)]"
+      >
+        <span aria-hidden className="text-[12px] leading-none drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]">🏰</span>
+        <span className="relative truncate">{display}</span>
+        <span className="relative tabular-nums text-white">{room}</span>
+      </span>
+    </BadgeTip>
   );
 }
 
@@ -132,47 +148,52 @@ export function CounterBadge({ kind, value, ringBearerName }: CounterBadgeProps)
   const { t } = useTranslation("game");
   if (kind === "poison") {
     return (
-      <span
-        role="img"
-        aria-label={t("badges.poisonAriaLabel", { count: value })}
-        title={t("badges.poisonTooltip", { count: value })}
-        className={`relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-lime-950 ring-1 ${
-          value >= 8
-            ? "bg-lime-300 ring-lime-100 shadow-[0_0_16px_rgba(217,249,157,0.55)]"
-            : "bg-lime-400 ring-lime-200/70 shadow-[0_0_12px_rgba(190,242,100,0.34)]"
-        }`}
-      >
+      <BadgeTip text={t("badges.poisonTooltip", { count: value })}>
         <span
-          aria-hidden
-          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.9)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(254,240,138,0.95)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(132,204,22,0.72)_0_11%,transparent_13%),linear-gradient(135deg,#f7fee7_0%,#bef264_36%,#65a30d_72%,#1a2e05_100%)]"
-        />
-        <span
-          aria-hidden
-          className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-lime-950/28 blur-[1px]"
-        />
-        <span className="relative">{value}</span>
-      </span>
+          role="img"
+          aria-label={t("badges.poisonAriaLabel", { count: value })}
+          className={`relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-lime-950 ring-1 ${
+            value >= 8
+              ? "bg-lime-300 ring-lime-100 shadow-[0_0_16px_rgba(217,249,157,0.55)]"
+              : "bg-lime-400 ring-lime-200/70 shadow-[0_0_12px_rgba(190,242,100,0.34)]"
+          }`}
+        >
+          <span
+            aria-hidden
+            className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.9)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(254,240,138,0.95)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(132,204,22,0.72)_0_11%,transparent_13%),linear-gradient(135deg,#f7fee7_0%,#bef264_36%,#65a30d_72%,#1a2e05_100%)]"
+          />
+          <span
+            aria-hidden
+            className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-lime-950/28 blur-[1px]"
+          />
+          <span className="relative">{value}</span>
+        </span>
+      </BadgeTip>
     );
   }
 
   if (kind === "energy") {
     return (
-      <span
-        role="img"
-        aria-label={t("badges.energyAriaLabel", { count: value })}
-        title={t("badges.energyTooltip", { count: value })}
-        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-cyan-950 ring-1 bg-cyan-300 ring-cyan-100 shadow-[0_0_12px_rgba(103,232,249,0.5)]"
-      >
+      <BadgeTip text={t("badges.energyTooltip", { count: value })}>
         <span
-          aria-hidden
-          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(207,250,254,0.9)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(8,145,178,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#ecfeff_0%,#67e8f9_36%,#0891b2_72%,#083344_100%)]"
-        />
-        <span className="relative">⚡{value}</span>
-      </span>
+          role="img"
+          aria-label={t("badges.energyAriaLabel", { count: value })}
+          className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-cyan-950 ring-1 bg-cyan-300 ring-cyan-100 shadow-[0_0_12px_rgba(103,232,249,0.5)]"
+        >
+          <span
+            aria-hidden
+            className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(207,250,254,0.9)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(8,145,178,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#ecfeff_0%,#67e8f9_36%,#0891b2_72%,#083344_100%)]"
+          />
+          <span className="relative">⚡{value}</span>
+        </span>
+      </BadgeTip>
     );
   }
 
   if (kind === "ring") {
+    // Static fallback tooltip (opponents): all four levels as plain text. The
+    // player's OWN ring gets the richer active-highlight popover via
+    // <RingBenefitsBadge> instead.
     const ringTitle = [
       t("badges.ringTooltip", { level: value }),
       ringBearerName
@@ -184,46 +205,40 @@ export function CounterBadge({ kind, value, ringBearerName }: CounterBadgeProps)
       t("badges.ringLevel4"),
     ].join("\n");
     return (
-      <span
-        role="img"
-        aria-label={t("badges.ringAriaLabel", {
+      <RingChip
+        value={value}
+        ariaLabel={t("badges.ringAriaLabel", {
           level: value,
           bearer: ringBearerName ?? t("badges.noRingBearer"),
         })}
         title={ringTitle}
-        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-amber-950 ring-1 bg-yellow-600 ring-yellow-300/70 shadow-[0_0_12px_rgba(202,138,4,0.55)]"
-      >
-        <span
-          aria-hidden
-          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_50%_50%,transparent_0_30%,rgba(0,0,0,0.45)_32%,transparent_38%),linear-gradient(135deg,#fde68a_0%,#d97706_45%,#78350f_100%)]"
-        />
-        <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.6)]">{value}</span>
-      </span>
+      />
     );
   }
 
   if (kind === "rad") {
     return (
-      <span
-        role="img"
-        aria-label={t("badges.radAriaLabel", { count: value })}
-        title={t("badges.radTooltip", { count: value })}
-        className={`relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-amber-950 ring-1 ${
-          value >= 8
-            ? "bg-amber-300 ring-amber-100 shadow-[0_0_16px_rgba(252,211,77,0.55)]"
-            : "bg-amber-500 ring-amber-300/70 shadow-[0_0_12px_rgba(245,158,11,0.4)]"
-        }`}
-      >
+      <BadgeTip text={t("badges.radTooltip", { count: value })}>
         <span
-          aria-hidden
-          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.85)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(254,243,199,0.9)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(217,119,6,0.72)_0_11%,transparent_13%),linear-gradient(135deg,#fffbeb_0%,#fbbf24_36%,#b45309_72%,#451a03_100%)]"
-        />
-        <span
-          aria-hidden
-          className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-amber-950/28 blur-[1px]"
-        />
-        <span className="relative">☢{value}</span>
-      </span>
+          role="img"
+          aria-label={t("badges.radAriaLabel", { count: value })}
+          className={`relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-amber-950 ring-1 ${
+            value >= 8
+              ? "bg-amber-300 ring-amber-100 shadow-[0_0_16px_rgba(252,211,77,0.55)]"
+              : "bg-amber-500 ring-amber-300/70 shadow-[0_0_12px_rgba(245,158,11,0.4)]"
+          }`}
+        >
+          <span
+            aria-hidden
+            className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.85)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(254,243,199,0.9)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(217,119,6,0.72)_0_11%,transparent_13%),linear-gradient(135deg,#fffbeb_0%,#fbbf24_36%,#b45309_72%,#451a03_100%)]"
+          />
+          <span
+            aria-hidden
+            className="absolute -bottom-1 left-1/2 h-3 w-5 -translate-x-1/2 rounded-[45%] bg-amber-950/28 blur-[1px]"
+          />
+          <span className="relative">☢{value}</span>
+        </span>
+      </BadgeTip>
     );
   }
 
@@ -231,34 +246,270 @@ export function CounterBadge({ kind, value, ringBearerName }: CounterBadgeProps)
     // CR 122.1: Experience counters are player counters; surfaced so the player can
     // see their total without activating an ability that consumes them.
     return (
-      <span
-        role="img"
-        aria-label={t("badges.experienceAriaLabel", { count: value })}
-        title={t("badges.experienceTooltip", { count: value })}
-        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-indigo-950 ring-1 bg-indigo-300 ring-indigo-100 shadow-[0_0_12px_rgba(165,180,252,0.5)]"
-      >
+      <BadgeTip text={t("badges.experienceTooltip", { count: value })}>
         <span
-          aria-hidden
-          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(224,231,255,0.9)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(79,70,229,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#eef2ff_0%,#a5b4fc_36%,#4f46e5_72%,#1e1b4b_100%)]"
-        />
-        <span className="relative">✦{value}</span>
-      </span>
+          role="img"
+          aria-label={t("badges.experienceAriaLabel", { count: value })}
+          className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-indigo-950 ring-1 bg-indigo-300 ring-indigo-100 shadow-[0_0_12px_rgba(165,180,252,0.5)]"
+        >
+          <span
+            aria-hidden
+            className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.95)_0_9%,transparent_11%),radial-gradient(circle_at_68%_30%,rgba(224,231,255,0.9)_0_7%,transparent_9%),radial-gradient(circle_at_38%_74%,rgba(79,70,229,0.7)_0_11%,transparent_13%),linear-gradient(135deg,#eef2ff_0%,#a5b4fc_36%,#4f46e5_72%,#1e1b4b_100%)]"
+          />
+          <span className="relative">✦{value}</span>
+        </span>
+      </BadgeTip>
     );
   }
 
   return (
+    <BadgeTip text={t("badges.speedTooltip", { value })}>
+      <span
+        role="img"
+        aria-label={t("badges.speedAriaLabel", { value })}
+        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-[6px] px-1 text-[11px] font-black leading-none tabular-nums text-white ring-1 ring-slate-100/60 shadow-[0_0_10px_rgba(226,232,240,0.22)]"
+      >
+        <span
+          aria-hidden
+          className="absolute inset-0 bg-[linear-gradient(90deg,rgba(15,23,42,0.82)_0_2px,transparent_2px),linear-gradient(45deg,#f8fafc_25%,#020617_25%,#020617_50%,#f8fafc_50%,#f8fafc_75%,#020617_75%,#020617_100%)] bg-[length:100%_100%,7px_7px]"
+        />
+        <span aria-hidden className="absolute inset-0 bg-cyan-300/10" />
+        <span className="relative rounded-sm bg-black/62 px-0.5">{value}</span>
+      </span>
+    </BadgeTip>
+  );
+}
+
+// CR 104.2b / 119.7 / 119.8 / 118.3 / 101.2 / 601.2a: glyph + i18n label-key per
+// player-affecting condition. Exhaustive over PlayerConditionKind["type"] so a
+// new engine variant forces an entry here.
+const CONDITION_GLYPH: Record<PlayerConditionKind["type"], string> = {
+  CantWin: "⛔",
+  CantGainLife: "💔",
+  CantLoseLife: "💚",
+  CantPayLifeAsCost: "🩸",
+  CantCastSpells: "🚫",
+  CantActivateAbilities: "🛑",
+  CastOnlyFromZones: "📤",
+};
+
+const CONDITION_LABEL_KEY: Record<PlayerConditionKind["type"], string> = {
+  CantWin: "badges.condCantWin",
+  CantGainLife: "badges.condCantGainLife",
+  CantLoseLife: "badges.condCantLoseLife",
+  CantPayLifeAsCost: "badges.condCantPayLife",
+  CantCastSpells: "badges.condCantCast",
+  CantActivateAbilities: "badges.condCantActivate",
+  CastOnlyFromZones: "badges.condCastOnlyFromZones",
+};
+
+/**
+ * Renders tooltip content in the project's custom <GameplayTooltip> rather than
+ * a native `title`. The wrapper supplies the `group relative` hover context and
+ * is deliberately NOT `overflow-hidden`, so the absolutely-positioned tooltip
+ * escapes the badge's own rounded `overflow-hidden` clip. Newline-separated text
+ * becomes stacked rows (native `title` line breaks have no inline-HTML analog).
+ */
+function BadgeTip({ text, children }: { text: string; children: ReactNode }) {
+  const lines = text.split("\n");
+  return (
+    <span className="group relative inline-flex">
+      {children}
+      <GameplayTooltip>
+        {lines.length === 1
+          ? lines[0]
+          : lines.map((line, i) => (
+              <span key={i} className="block">
+                {line}
+              </span>
+            ))}
+      </GameplayTooltip>
+    </span>
+  );
+}
+
+/**
+ * A single player-affecting condition (afflictions like "can't gain life" /
+ * "can't cast spells"), rendered as a red glossy chip. Reads its source card
+ * name (when the engine surfaced one) for the tooltip; never re-derives the
+ * condition itself — `condition` comes straight from `DerivedViews.player_status`.
+ */
+export function ConditionBadge({ condition }: { condition: PlayerStatusView }) {
+  const { t } = useTranslation("game");
+  const sourceName = useGameStore((s) =>
+    condition.source != null
+      ? (s.gameState?.objects[String(condition.source)]?.name ?? null)
+      : null,
+  );
+  const kind = condition.kind.type;
+  const label = t(CONDITION_LABEL_KEY[kind]);
+  const title = sourceName ? t("badges.condFromSource", { condition: label, name: sourceName }) : label;
+  return (
+    <BadgeTip text={title}>
+      <span
+        role="img"
+        aria-label={title}
+        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[12px] leading-none ring-1 bg-red-500/85 ring-red-300/70 shadow-[0_0_12px_rgba(239,68,68,0.45)]"
+      >
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.85)_0_9%,transparent_11%),linear-gradient(135deg,#fee2e2_0%,#ef4444_42%,#7f1d1d_100%)]"
+        />
+        <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]">{CONDITION_GLYPH[kind]}</span>
+      </span>
+    </BadgeTip>
+  );
+}
+
+/** One human-readable line for a pending next-spell modifier. */
+function describeNextSpellModifier(
+  t: ReturnType<typeof useTranslation>["t"],
+  modifier: NextSpellModifier,
+): string {
+  switch (modifier.type) {
+    case "CantBeCountered":
+      return t("badges.pendingCantBeCountered");
+    case "HasKeyword":
+      return t("badges.pendingHasKeyword", { keyword: getKeywordDisplayText(modifier.keyword) });
+    case "CastAsThoughFlash":
+      return t("badges.pendingFlash");
+    case "WithoutPayingManaCost":
+      return t("badges.pendingFree");
+  }
+}
+
+/**
+ * CR 601.2f: badge surfacing pending one-shot modifiers/reductions for the
+ * player's next spell (copy, flash, can't-be-countered, cheaper, free). Glyph
+ * + a multi-line tooltip enumerating each pending effect.
+ */
+export function PendingSpellBadge({
+  modifiers,
+  reductions,
+}: {
+  modifiers: PendingNextSpellModifier[];
+  reductions: PendingSpellCostReduction[];
+}) {
+  const { t } = useTranslation("game");
+  const lines = [
+    ...modifiers.map((m) => describeNextSpellModifier(t, m.modifier)),
+    ...reductions.map((r) => t("badges.pendingCheaper", { amount: r.amount })),
+  ];
+  const title = [t("badges.pendingSpell"), ...lines].join("\n");
+  return (
+    <BadgeTip text={title}>
+      <span
+        role="img"
+        aria-label={t("badges.pendingSpell")}
+        className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-full px-1 text-[12px] leading-none ring-1 bg-indigo-500/85 ring-indigo-300/70 shadow-[0_0_12px_rgba(99,102,241,0.5)]"
+      >
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_24%,rgba(255,255,255,0.9)_0_9%,transparent_11%),linear-gradient(135deg,#e0e7ff_0%,#6366f1_42%,#312e81_100%)]"
+        />
+        <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.5)]">✨</span>
+      </span>
+    </BadgeTip>
+  );
+}
+
+// Shared ring-chip visual (gold disc + level number). Used by both the
+// opponent `CounterBadge` ring branch (static tooltip) and `RingBenefitsBadge`
+// (hover popover) so the chip styling lives in exactly one place.
+function RingChip({
+  value,
+  ariaLabel,
+  title,
+  chipRef,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  value: number;
+  ariaLabel: string;
+  title?: string;
+  chipRef?: React.Ref<HTMLSpanElement>;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}) {
+  const chip = (
     <span
+      ref={chipRef}
       role="img"
-      aria-label={t("badges.speedAriaLabel", { value })}
-      title={t("badges.speedTooltip", { value })}
-      className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center overflow-hidden rounded-[6px] px-1 text-[11px] font-black leading-none tabular-nums text-white ring-1 ring-slate-100/60 shadow-[0_0_10px_rgba(226,232,240,0.22)]"
+      aria-label={ariaLabel}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className="relative inline-flex h-6 min-w-6 shrink-0 items-center justify-center gap-px overflow-hidden rounded-full px-1 text-[11px] font-black leading-none tabular-nums text-amber-950 ring-1 bg-yellow-600 ring-yellow-300/70 shadow-[0_0_12px_rgba(202,138,4,0.55)]"
     >
       <span
         aria-hidden
-        className="absolute inset-0 bg-[linear-gradient(90deg,rgba(15,23,42,0.82)_0_2px,transparent_2px),linear-gradient(45deg,#f8fafc_25%,#020617_25%,#020617_50%,#f8fafc_50%,#f8fafc_75%,#020617_75%,#020617_100%)] bg-[length:100%_100%,7px_7px]"
+        className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_50%_50%,transparent_0_30%,rgba(0,0,0,0.45)_32%,transparent_38%),linear-gradient(135deg,#fde68a_0%,#d97706_45%,#78350f_100%)]"
       />
-      <span aria-hidden className="absolute inset-0 bg-cyan-300/10" />
-      <span className="relative rounded-sm bg-black/62 px-0.5">{value}</span>
+      <span className="relative drop-shadow-[0_1px_1px_rgba(0,0,0,0.6)]">{value}</span>
     </span>
+  );
+  // Opponent ring badge: static multi-line tooltip. The player's own ring omits
+  // `title` and gets the richer hover popover via <RingBenefitsBadge> instead.
+  return title ? <BadgeTip text={title}>{chip}</BadgeTip> : chip;
+}
+
+// Brief dismiss delay smoothing cursor jitter on the chip edge (mirrors
+// EnchantmentsBadge's HOVER_CLOSE_DELAY_MS).
+const RING_HOVER_CLOSE_DELAY_MS = 80;
+
+/**
+ * The player's OWN Ring badge: the gold level chip plus a hover popover
+ * (<RingBenefitsPopover>) listing the four CR 701.54 abilities with those
+ * active at the current `level` highlighted. The ability TEXT comes from the
+ * existing `badges.ringLevelN` i18n strings (the project's convention for
+ * fixed rules text, like keyword reminder text); only the active/inactive
+ * split is state-driven — a comparison against `level`, not game logic.
+ */
+export function RingBenefitsBadge({
+  level,
+  ringBearerName,
+}: {
+  level: number;
+  ringBearerName: string | null;
+}) {
+  const { t } = useTranslation("game");
+  const chipRef = useRef<HTMLSpanElement>(null);
+  const [hoverOpen, setHoverOpen] = useState(false);
+  const closeTimerRef = useRef<number | null>(null);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current != null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+  const onEnter = useCallback(() => {
+    cancelClose();
+    setHoverOpen(true);
+  }, [cancelClose]);
+  const onLeave = useCallback(() => {
+    cancelClose();
+    closeTimerRef.current = window.setTimeout(() => {
+      setHoverOpen(false);
+      closeTimerRef.current = null;
+    }, RING_HOVER_CLOSE_DELAY_MS);
+  }, [cancelClose]);
+  useEffect(() => () => cancelClose(), [cancelClose]);
+
+  return (
+    <>
+      <RingChip
+        value={level}
+        chipRef={chipRef}
+        ariaLabel={t("badges.ringAriaLabel", {
+          level,
+          bearer: ringBearerName ?? t("badges.noRingBearer"),
+        })}
+        onMouseEnter={onEnter}
+        onMouseLeave={onLeave}
+      />
+      {hoverOpen && chipRef.current ? (
+        <RingBenefitsPopover anchorEl={chipRef.current} level={level} bearerName={ringBearerName} />
+      ) : null}
+    </>
   );
 }

--- a/client/src/components/hud/PlayerHud.tsx
+++ b/client/src/components/hud/PlayerHud.tsx
@@ -12,7 +12,7 @@ import { ScoreBadge } from "../draft/ScoreBadge.tsx";
 import { LifeTotal } from "../controls/LifeTotal.tsx";
 import { ManaPoolSummary } from "./ManaPoolSummary.tsx";
 import { PhaseIndicatorLeft, PhaseIndicatorRight } from "../controls/PhaseStopBar.tsx";
-import { CityBlessingBadge, CounterBadge, DungeonBadge, InitiativeBadge, MonarchBadge, StatusBadge } from "./HudBadges.tsx";
+import { CityBlessingBadge, ConditionBadge, CounterBadge, DungeonBadge, InitiativeBadge, MonarchBadge, PendingSpellBadge, RingBenefitsBadge, StatusBadge } from "./HudBadges.tsx";
 import { EnchantmentsBadge } from "./EnchantmentsBadge.tsx";
 import { HudPlate } from "./HudPlate.tsx";
 
@@ -107,9 +107,8 @@ export function PlayerHud() {
             ) : null}
             {isPhasedOut ? <StatusBadge label={t("player.phasedOut")} tone="neutral" /> : null}
             {designations.ringLevel > 0 ? (
-              <CounterBadge
-                kind="ring"
-                value={designations.ringLevel}
+              <RingBenefitsBadge
+                level={designations.ringLevel}
                 ringBearerName={designations.ringBearerName}
               />
             ) : null}
@@ -118,6 +117,19 @@ export function PlayerHud() {
             {radCounters > 0 ? <CounterBadge kind="rad" value={radCounters} /> : null}
             {experienceCounters > 0 ? <CounterBadge kind="experience" value={experienceCounters} /> : null}
             {speed > 0 ? <CounterBadge kind="speed" value={speed} /> : null}
+            {designations.pendingSpellModifiers.length > 0
+            || designations.pendingSpellReductions.length > 0 ? (
+              <PendingSpellBadge
+                modifiers={designations.pendingSpellModifiers}
+                reductions={designations.pendingSpellReductions}
+              />
+            ) : null}
+            {designations.statusConditions.map((condition, i) => (
+              <ConditionBadge
+                key={`${condition.kind.type}-${condition.source ?? "x"}-${i}`}
+                condition={condition}
+              />
+            ))}
           </>
         }
       >

--- a/client/src/components/hud/RingBenefitsPopover.tsx
+++ b/client/src/components/hud/RingBenefitsPopover.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  anchorEl: HTMLElement;
+  /** Current ring level (0–4); levels ≤ this are active/unlocked. */
+  level: number;
+  bearerName: string | null;
+}
+
+const ANCHOR_GAP_PX = 10;
+const RING_LEVELS = [1, 2, 3, 4] as const;
+
+/**
+ * Passive hover popover for the player's OWN Ring: lists the four CR 701.54
+ * level abilities and highlights those active at the current `level`. The
+ * ability TEXT comes from the existing `badges.ringLevelN` i18n strings (the
+ * project's convention for fixed rules text); the only state-driven decision
+ * is the active/inactive split — `lv <= level` — which is formatting, not game
+ * logic (`ring_level` is engine-provided).
+ *
+ * Mirrors `AurasHoverPreview`: `pointer-events-none`, portaled to
+ * `document.body` (HudPlate's `transform` would otherwise clip it), and
+ * auto-flipped above/below based on the anchor's viewport half.
+ */
+export function RingBenefitsPopover({ anchorEl, level, bearerName }: Props) {
+  const { t } = useTranslation("game");
+  const [pos, setPos] = useState<{
+    left: number;
+    top: number;
+    placement: "above" | "below";
+  } | null>(null);
+
+  useEffect(() => {
+    function recompute() {
+      const rect = anchorEl.getBoundingClientRect();
+      const placement: "above" | "below" =
+        rect.top < window.innerHeight / 2 ? "below" : "above";
+      const left = rect.left + rect.width / 2;
+      const top = placement === "above" ? rect.top - ANCHOR_GAP_PX : rect.bottom + ANCHOR_GAP_PX;
+      setPos({ left, top, placement });
+    }
+    recompute();
+    window.addEventListener("resize", recompute);
+    window.addEventListener("scroll", recompute, true);
+    return () => {
+      window.removeEventListener("resize", recompute);
+      window.removeEventListener("scroll", recompute, true);
+    };
+  }, [anchorEl]);
+
+  if (!pos) return null;
+
+  const transform =
+    pos.placement === "above" ? "translate(-50%, -100%)" : "translate(-50%, 0)";
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed z-50"
+      style={{ left: pos.left, top: pos.top, transform }}
+      aria-hidden
+    >
+      <div className="w-72 rounded-2xl border border-amber-300/40 bg-slate-950/95 p-3 text-left shadow-[0_18px_36px_rgba(0,0,0,0.55)] backdrop-blur-md">
+        <div className="mb-1 text-[12px] font-bold tracking-wide text-amber-200">
+          {t("badges.ringTooltip", { level })}
+        </div>
+        <div className="mb-2 text-[11px] text-slate-300">
+          {bearerName
+            ? t("badges.ringBearerTooltip", { name: bearerName })
+            : t("badges.noRingBearerTooltip")}
+        </div>
+        <ul className="flex flex-col gap-1">
+          {RING_LEVELS.map((lv) => {
+            const active = lv <= level;
+            return (
+              <li
+                key={lv}
+                className={`flex gap-1.5 text-[11px] leading-snug ${
+                  active ? "text-amber-100" : "text-slate-500"
+                }`}
+              >
+                <span aria-hidden className={active ? "text-amber-300" : "text-slate-600"}>
+                  {active ? "◆" : "◇"}
+                </span>
+                <span>{t(`badges.ringLevel${lv}`)}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/client/src/components/hud/__tests__/OpponentHud.test.tsx
+++ b/client/src/components/hud/__tests__/OpponentHud.test.tsx
@@ -232,15 +232,18 @@ describe("OpponentHud", () => {
 
     render(<OpponentHud />);
 
-    expect(screen.getByTitle("Poison counters: 3")).toHaveAttribute("aria-label", "3 poison counters");
-    expect(screen.getByTitle("Speed: 2")).toHaveAttribute("aria-label", "Speed 2");
+    // Custom GameplayTooltip text in the DOM replaces the native `title`.
+    expect(screen.getByLabelText("3 poison counters")).toBeInTheDocument();
+    expect(screen.getByText("Poison counters: 3")).toBeInTheDocument();
+    expect(screen.getByLabelText("Speed 2")).toBeInTheDocument();
+    expect(screen.getByText("Speed: 2")).toBeInTheDocument();
     expect(screen.queryByText("Speed")).toBeNull();
   });
 
   it("hides zero poison counters", () => {
     render(<OpponentHud />);
 
-    expect(screen.queryByTitle(/Poison counters:/)).toBeNull();
+    expect(screen.queryByText(/Poison counters:/)).toBeNull();
   });
 
   describe("FFA targeting intent disambiguation", () => {
@@ -377,8 +380,10 @@ describe("OpponentHud", () => {
 
     render(<OpponentHud />);
 
-    expect(screen.getByTitle("Poison counters: 4")).toHaveAttribute("aria-label", "4 poison counters");
-    expect(screen.getByTitle("Speed: 1")).toHaveAttribute("aria-label", "Speed 1");
+    expect(screen.getByLabelText("4 poison counters")).toBeInTheDocument();
+    expect(screen.getByText("Poison counters: 4")).toBeInTheDocument();
+    expect(screen.getByLabelText("Speed 1")).toBeInTheDocument();
+    expect(screen.getByText("Speed: 1")).toBeInTheDocument();
     expect(screen.queryByText("Speed")).toBeNull();
   });
 

--- a/client/src/components/hud/__tests__/PlayerHud.test.tsx
+++ b/client/src/components/hud/__tests__/PlayerHud.test.tsx
@@ -74,14 +74,18 @@ describe("PlayerHud", () => {
 
     render(<PlayerHud />);
 
-    expect(screen.getByTitle("Poison counters: 8")).toHaveAttribute("aria-label", "8 poison counters");
-    expect(screen.getByTitle("Speed: 3")).toHaveAttribute("aria-label", "Speed 3");
+    // Badges now use the custom GameplayTooltip (text rendered in the DOM)
+    // rather than a native `title`; the aria-label stays on the badge element.
+    expect(screen.getByLabelText("8 poison counters")).toBeInTheDocument();
+    expect(screen.getByText("Poison counters: 8")).toBeInTheDocument();
+    expect(screen.getByLabelText("Speed 3")).toBeInTheDocument();
+    expect(screen.getByText("Speed: 3")).toBeInTheDocument();
     expect(screen.queryByText("Speed")).toBeNull();
   });
 
   it("hides local zero poison counters", () => {
     render(<PlayerHud />);
 
-    expect(screen.queryByTitle(/Poison counters:/)).toBeNull();
+    expect(screen.queryByText(/Poison counters:/)).toBeNull();
   });
 });

--- a/client/src/components/mana/LandManaRail.tsx
+++ b/client/src/components/mana/LandManaRail.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { GameObject } from "../../adapter/types.ts";
+import { landManaAvailability, type LandManaSource } from "../../viewmodel/manaAvailability.ts";
+import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
+import { ManaSymbol } from "./ManaSymbol.tsx";
+
+// Cap the rail width on crowded boards; the trailing "untapped/total" count
+// stays exact even when individual pips overflow into a "+N".
+const MAX_PIPS = 12;
+
+interface LandManaRailProps {
+  lands: GameObject[];
+  className?: string;
+}
+
+/**
+ * Per-source mana rail: one pip-group per land, untapped (available) sources
+ * first and bright, tapped sources dimmed. Communicates "what mana is
+ * available now" without summing per color — see `manaAvailability`.
+ */
+export function LandManaRail({ lands, className = "" }: LandManaRailProps) {
+  const { t } = useTranslation("game");
+
+  const { shown, overflow, total, untapped } = useMemo(() => {
+    const availability = landManaAvailability(lands);
+    // Untapped sources lead so the actionable (available) mana reads first.
+    const ordered = [...availability.sources].sort(
+      (a, b) => Number(a.tapped) - Number(b.tapped),
+    );
+    return {
+      total: availability.total,
+      untapped: availability.untapped,
+      shown: ordered.slice(0, MAX_PIPS),
+      overflow: Math.max(0, ordered.length - MAX_PIPS),
+    };
+  }, [lands]);
+
+  if (total === 0) return null;
+
+  return (
+    <div className={`group relative flex items-center gap-1 ${className}`}>
+      <div className="flex items-center gap-[2px]">
+        {shown.map((source, i) => (
+          <SourcePips key={i} source={source} />
+        ))}
+        {overflow > 0 && (
+          <span className="text-[10px] font-medium tabular-nums text-gray-400">+{overflow}</span>
+        )}
+      </div>
+      <span className="text-[10px] tabular-nums text-gray-500">
+        {untapped}/{total}
+      </span>
+      <GameplayTooltip>{t("player.manaAvailable", { untapped, total })}</GameplayTooltip>
+    </div>
+  );
+}
+
+/** One land rendered as a single tight pip-group (lettered, rainbow, or neutral). */
+function SourcePips({ source }: { source: LandManaSource }) {
+  const dim = source.tapped ? "opacity-40 grayscale" : "";
+
+  if (source.shards.length > 0) {
+    return (
+      <span className={`flex items-center ${dim}`}>
+        {source.shards.map((shard, i) => (
+          <ManaSymbol key={i} shard={shard} size="xs" />
+        ))}
+      </span>
+    );
+  }
+
+  if (source.rainbow) {
+    // Flexible output with no single Scryfall symbol → a WUBRG rainbow swatch.
+    return (
+      <span
+        className={`inline-block h-3.5 w-3.5 rounded-full ring-1 ring-black/30 ${dim}`}
+        style={{
+          background:
+            "conic-gradient(#f8e7b3 0deg 72deg, #a8d4f0 72deg 144deg, #c4bcb4 144deg 216deg, #f0a9a0 216deg 288deg, #acd6b0 288deg 360deg)",
+        }}
+      />
+    );
+  }
+
+  // No mana ability (e.g. Maze of Ith): a neutral dot keeps the land count
+  // honest without implying it taps for mana.
+  return <span className={`inline-block h-3.5 w-3.5 rounded-full bg-gray-600 ${dim}`} />;
+}

--- a/client/src/components/targeting/TargetingOverlay.tsx
+++ b/client/src/components/targeting/TargetingOverlay.tsx
@@ -120,8 +120,11 @@ export function TargetingOverlay() {
         {/* Semi-transparent overlay (click-through so board cards remain clickable) */}
         <div className="absolute inset-0 bg-black/30" />
 
-        {/* Instruction text */}
-        <div className="absolute left-0 right-0 top-4 flex flex-col items-center gap-1">
+        {/* Instruction text. Pinned to the very top so it overlaps only the
+            opponent's face-down hand (low-value space) and clears the
+            opponent-HUD tab rail below it — the rail carries life/creature/land
+            counts that must stay readable and clickable during targeting. */}
+        <div className="absolute left-0 right-0 top-1 flex flex-col items-center gap-1">
           {sourceName && (
             <div className="rounded-md bg-gray-800/90 px-4 py-1 text-sm font-medium text-amber-300 shadow">
               {sourceName}

--- a/client/src/hooks/useAttackerArrowPositions.ts
+++ b/client/src/hooks/useAttackerArrowPositions.ts
@@ -153,11 +153,16 @@ export function useAttackerArrowPositions(
     restartPolling();
     window.addEventListener("resize", restartPolling);
     window.visualViewport?.addEventListener("resize", restartPolling);
+    // Capture-phase `scroll` catches scrolling inside inner containers (e.g. the
+    // crowded-creature overflow grid) where attacker/target cards move but
+    // `resize` never fires; without it, stabilized arrow endpoints desync.
+    window.addEventListener("scroll", restartPolling, true);
 
     return () => {
       if (rafId !== 0) cancelAnimationFrame(rafId);
       window.removeEventListener("resize", restartPolling);
       window.visualViewport?.removeEventListener("resize", restartPolling);
+      window.removeEventListener("scroll", restartPolling, true);
     };
   }, [arrows]);
 

--- a/client/src/hooks/usePlayerDesignations.ts
+++ b/client/src/hooks/usePlayerDesignations.ts
@@ -1,6 +1,13 @@
 import { useShallow } from "zustand/react/shallow";
 
-import type { DungeonId, ObjectId, PlayerId } from "../adapter/types.ts";
+import type {
+  DungeonId,
+  ObjectId,
+  PendingNextSpellModifier,
+  PendingSpellCostReduction,
+  PlayerId,
+  PlayerStatusView,
+} from "../adapter/types.ts";
 import { useGameStore } from "../stores/gameStore.ts";
 
 export interface PlayerDesignations {
@@ -16,6 +23,14 @@ export interface PlayerDesignations {
    *  after a dungeon is completed, so this is the only safe presence signal. */
   activeDungeon: DungeonId | null;
   currentRoom: number;
+  /** Engine-aggregated continuous conditions afflicting this player (can't gain
+   *  life, can't cast, etc.). Shared empty array when none, so `useShallow`
+   *  stays stable in the dominant case. */
+  statusConditions: PlayerStatusView[];
+  /** CR 601.2f: pending one-shot modifiers for this player's next spell. */
+  pendingSpellModifiers: PendingNextSpellModifier[];
+  /** CR 601.2f: pending one-shot cost reductions for this player's next spell. */
+  pendingSpellReductions: PendingSpellCostReduction[];
   hasAny: boolean;
 }
 
@@ -23,6 +38,13 @@ export interface PlayerDesignations {
 // Equality checks (monarch === playerId) and array indexing (players[playerId])
 // use the raw number; map lookups (ring_level, dungeon_progress) need the string.
 const playerKey = (id: PlayerId): string => String(id);
+
+// Shared empty arrays: returned by reference when a player has no conditions /
+// pending modifiers (the common case) so `useShallow` sees a stable value and
+// skips re-render. A fresh `.filter([])` result would defeat that.
+const NO_CONDITIONS: PlayerStatusView[] = [];
+const NO_MODIFIERS: PendingNextSpellModifier[] = [];
+const NO_REDUCTIONS: PendingSpellCostReduction[] = [];
 
 const EMPTY: PlayerDesignations = {
   isMonarch: false,
@@ -34,8 +56,22 @@ const EMPTY: PlayerDesignations = {
   energy: 0,
   activeDungeon: null,
   currentRoom: 0,
+  statusConditions: NO_CONDITIONS,
+  pendingSpellModifiers: NO_MODIFIERS,
+  pendingSpellReductions: NO_REDUCTIONS,
   hasAny: false,
 };
+
+/** Filter a per-player wire list to `playerId`, returning the shared empty
+ *  constant (stable ref) when nothing matches. */
+function forPlayer<T extends { player: PlayerId }>(
+  all: T[] | undefined,
+  playerId: PlayerId,
+  empty: T[],
+): T[] {
+  if (!all || !all.some((entry) => entry.player === playerId)) return empty;
+  return all.filter((entry) => entry.player === playerId);
+}
 
 export function usePlayerDesignations(playerId: PlayerId): PlayerDesignations {
   return useGameStore(
@@ -51,13 +87,27 @@ export function usePlayerDesignations(playerId: PlayerId): PlayerDesignations {
       const ringBearerId = gs.ring_bearer?.[playerKey(playerId)] ?? null;
       const ringBearerName = ringBearerId != null ? (gs.objects[String(ringBearerId)]?.name ?? null) : null;
       const energy = gs.players[playerId]?.energy ?? 0;
+      const statusConditions = forPlayer(gs.derived?.player_status, playerId, NO_CONDITIONS);
+      const pendingSpellModifiers = forPlayer(
+        gs.pending_next_spell_modifiers,
+        playerId,
+        NO_MODIFIERS,
+      );
+      const pendingSpellReductions = forPlayer(
+        gs.pending_next_spell_cost_reductions,
+        playerId,
+        NO_REDUCTIONS,
+      );
       const hasAny =
         isMonarch
         || hasInitiative
         || hasCityBlessing
         || activeDungeon != null
         || ringLevel > 0
-        || energy > 0;
+        || energy > 0
+        || statusConditions.length > 0
+        || pendingSpellModifiers.length > 0
+        || pendingSpellReductions.length > 0;
       return {
         isMonarch,
         hasInitiative,
@@ -68,6 +118,9 @@ export function usePlayerDesignations(playerId: PlayerId): PlayerDesignations {
         energy,
         activeDungeon,
         currentRoom: dungeon?.current_room ?? 0,
+        statusConditions,
+        pendingSpellModifiers,
+        pendingSpellReductions,
         hasAny,
       };
     }),

--- a/client/src/hooks/useRafPositions.ts
+++ b/client/src/hooks/useRafPositions.ts
@@ -24,7 +24,7 @@ export function useRafPositions(pairs: Map<ObjectId, ObjectId>): Map<ObjectId, L
 
     stableCountRef.current = 0;
     prevRectsRef.current = new Map();
-    let rafId: number;
+    let rafId = 0;
 
     function poll() {
       const currentRects = new Map<string, DOMRect>();
@@ -80,11 +80,32 @@ export function useRafPositions(pairs: Map<ObjectId, ObjectId>): Map<ObjectId, L
       // Stop polling after 10 stable frames
       if (stableCountRef.current < 10) {
         rafId = requestAnimationFrame(poll);
+      } else {
+        rafId = 0;
       }
     }
 
-    rafId = requestAnimationFrame(poll);
-    return () => cancelAnimationFrame(rafId);
+    const restartPolling = () => {
+      if (rafId !== 0) cancelAnimationFrame(rafId);
+      stableCountRef.current = 0;
+      prevRectsRef.current = new Map();
+      rafId = requestAnimationFrame(poll);
+    };
+
+    restartPolling();
+    // Capture-phase `scroll` catches scrolling inside inner containers (e.g. the
+    // crowded-creature overflow grid) where cards move but `resize` never fires;
+    // without it, the stabilized line endpoints freeze and desync from the cards.
+    window.addEventListener("resize", restartPolling);
+    window.visualViewport?.addEventListener("resize", restartPolling);
+    window.addEventListener("scroll", restartPolling, true);
+
+    return () => {
+      if (rafId !== 0) cancelAnimationFrame(rafId);
+      window.removeEventListener("resize", restartPolling);
+      window.visualViewport?.removeEventListener("resize", restartPolling);
+      window.removeEventListener("scroll", restartPolling, true);
+    };
   }, [pairs]);
 
   return positions;

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -98,8 +98,19 @@
       "open_other": "Open lands drawer ({{count}} lands)",
       "pipTooltip_one": "{{count}} hidden land can currently produce",
       "pipTooltip_other": "{{count}} hidden lands can currently produce",
+      "pipAvailability": "{{untapped}} von {{total}} ungetappt",
       "title_one": "Lands ({{count}})",
       "title_other": "Lands ({{count}})"
+    },
+    "creatures": {
+      "label": "Creatures",
+      "open_one": "Open creatures drawer ({{count}} creature)",
+      "open_other": "Open creatures drawer ({{count}} creatures)",
+      "title_one": "Creatures ({{count}})",
+      "title_other": "Creatures ({{count}})",
+      "totalPower": "{{power}}/{{toughness}} total power and toughness",
+      "viewAll": "Click to view all",
+      "scrollHint": "Scroll"
     },
     "support": {
       "label": "Support",
@@ -163,6 +174,7 @@
     "creaturesAbbr": "Krt",
     "landsAbbr": "Lnd",
     "otherAbbr": "Snst",
+    "manaAvailable": "{{untapped}} von {{total}} Ländern ungetappt",
     "out": "RAUS",
     "eliminated": "Ausgeschieden",
     "phasedOut": "Ausgephast",
@@ -293,6 +305,20 @@
     "experienceTooltip": "Erfahrungsmarken: {{count}}",
     "speedAriaLabel": "Tempo {{value}}",
     "speedTooltip": "Tempo: {{value}}",
+    "condCantWin": "Kann das Spiel nicht gewinnen",
+    "condCantGainLife": "Kann keine Lebenspunkte dazugewinnen",
+    "condCantLoseLife": "Kann keine Lebenspunkte verlieren",
+    "condCantPayLife": "Kann keine Lebenspunkte als Kosten bezahlen",
+    "condCantCast": "Kann keine Zauber wirken",
+    "condCantActivate": "Kann keine Fähigkeiten aktivieren",
+    "condCastOnlyFromZones": "Kann nur aus bestimmten Zonen wirken",
+    "condFromSource": "{{condition}} — von {{name}}",
+    "pendingSpell": "Nächster Zauber",
+    "pendingCantBeCountered": "Nächster Zauber kann nicht neutralisiert werden",
+    "pendingHasKeyword": "Nächster Zauber hat {{keyword}}",
+    "pendingFlash": "Nächster Zauber kann gewirkt werden, als hätte er Blitz",
+    "pendingFree": "Nächster Zauber, ohne seine Manakosten zu bezahlen",
+    "pendingCheaper": "Nächster Zauber kostet {{amount}} weniger",
     "companion": "Gefährte"
   },
   "avatar": {

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -98,8 +98,19 @@
       "open_other": "Open lands drawer ({{count}} lands)",
       "pipTooltip_one": "{{count}} hidden land can currently produce",
       "pipTooltip_other": "{{count}} hidden lands can currently produce",
+      "pipAvailability": "{{untapped}} of {{total}} untapped",
       "title_one": "Lands ({{count}})",
       "title_other": "Lands ({{count}})"
+    },
+    "creatures": {
+      "label": "Creatures",
+      "open_one": "Open creatures drawer ({{count}} creature)",
+      "open_other": "Open creatures drawer ({{count}} creatures)",
+      "title_one": "Creatures ({{count}})",
+      "title_other": "Creatures ({{count}})",
+      "totalPower": "{{power}}/{{toughness}} total power and toughness",
+      "viewAll": "Click to view all",
+      "scrollHint": "Scroll"
     },
     "support": {
       "label": "Support",
@@ -163,6 +174,7 @@
     "creaturesAbbr": "Crt",
     "landsAbbr": "Lnd",
     "otherAbbr": "Oth",
+    "manaAvailable": "{{untapped}} of {{total}} lands untapped",
     "out": "OUT",
     "eliminated": "Eliminated",
     "phasedOut": "Phased Out",
@@ -293,6 +305,20 @@
     "experienceTooltip": "Experience counters: {{count}}",
     "speedAriaLabel": "Speed {{value}}",
     "speedTooltip": "Speed: {{value}}",
+    "condCantWin": "Can't win the game",
+    "condCantGainLife": "Can't gain life",
+    "condCantLoseLife": "Can't lose life",
+    "condCantPayLife": "Can't pay life",
+    "condCantCast": "Can't cast spells",
+    "condCantActivate": "Can't activate abilities",
+    "condCastOnlyFromZones": "Can cast only from limited zones",
+    "condFromSource": "{{condition}} — from {{name}}",
+    "pendingSpell": "Next spell",
+    "pendingCantBeCountered": "Next spell can't be countered",
+    "pendingHasKeyword": "Next spell has {{keyword}}",
+    "pendingFlash": "Next spell can be cast as though it had flash",
+    "pendingFree": "Next spell without paying its mana cost",
+    "pendingCheaper": "Next spell costs {{amount}} less",
     "companion": "Companion"
   },
   "avatar": {

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -98,8 +98,19 @@
       "open_other": "Open lands drawer ({{count}} lands)",
       "pipTooltip_one": "{{count}} hidden land can currently produce",
       "pipTooltip_other": "{{count}} hidden lands can currently produce",
+      "pipAvailability": "{{untapped}} de {{total}} desenderezadas",
       "title_one": "Lands ({{count}})",
       "title_other": "Lands ({{count}})"
+    },
+    "creatures": {
+      "label": "Creatures",
+      "open_one": "Open creatures drawer ({{count}} creature)",
+      "open_other": "Open creatures drawer ({{count}} creatures)",
+      "title_one": "Creatures ({{count}})",
+      "title_other": "Creatures ({{count}})",
+      "totalPower": "{{power}}/{{toughness}} total power and toughness",
+      "viewAll": "Click to view all",
+      "scrollHint": "Scroll"
     },
     "support": {
       "label": "Support",
@@ -163,6 +174,7 @@
     "creaturesAbbr": "Crt",
     "landsAbbr": "Trr",
     "otherAbbr": "Otr",
+    "manaAvailable": "{{untapped}} de {{total}} tierras enderezadas",
     "out": "FUERA",
     "eliminated": "Eliminado",
     "phasedOut": "Fuera de fase",
@@ -293,6 +305,20 @@
     "experienceTooltip": "Contadores de experiencia: {{count}}",
     "speedAriaLabel": "Velocidad {{value}}",
     "speedTooltip": "Velocidad: {{value}}",
+    "condCantWin": "No puede ganar la partida",
+    "condCantGainLife": "No puede ganar vidas",
+    "condCantLoseLife": "No puede perder vidas",
+    "condCantPayLife": "No puede pagar vidas",
+    "condCantCast": "No puede lanzar hechizos",
+    "condCantActivate": "No puede activar habilidades",
+    "condCastOnlyFromZones": "Solo puede lanzar desde zonas limitadas",
+    "condFromSource": "{{condition}} — de {{name}}",
+    "pendingSpell": "Próximo hechizo",
+    "pendingCantBeCountered": "El próximo hechizo no puede ser contrarrestado",
+    "pendingHasKeyword": "El próximo hechizo tiene {{keyword}}",
+    "pendingFlash": "El próximo hechizo puede lanzarse como si tuviera destello",
+    "pendingFree": "El próximo hechizo sin pagar su coste de maná",
+    "pendingCheaper": "El próximo hechizo cuesta {{amount}} menos",
     "companion": "Compañero"
   },
   "avatar": {

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -98,8 +98,19 @@
       "open_other": "Open lands drawer ({{count}} lands)",
       "pipTooltip_one": "{{count}} hidden land can currently produce",
       "pipTooltip_other": "{{count}} hidden lands can currently produce",
+      "pipAvailability": "{{untapped}} sur {{total}} dégagés",
       "title_one": "Lands ({{count}})",
       "title_other": "Lands ({{count}})"
+    },
+    "creatures": {
+      "label": "Creatures",
+      "open_one": "Open creatures drawer ({{count}} creature)",
+      "open_other": "Open creatures drawer ({{count}} creatures)",
+      "title_one": "Creatures ({{count}})",
+      "title_other": "Creatures ({{count}})",
+      "totalPower": "{{power}}/{{toughness}} total power and toughness",
+      "viewAll": "Click to view all",
+      "scrollHint": "Scroll"
     },
     "support": {
       "label": "Support",
@@ -163,6 +174,7 @@
     "creaturesAbbr": "Cré",
     "landsAbbr": "Ter",
     "otherAbbr": "Aut",
+    "manaAvailable": "{{untapped}} sur {{total}} terrains dégagés",
     "out": "ÉLIM",
     "eliminated": "Éliminé",
     "phasedOut": "Déphasé",
@@ -293,6 +305,20 @@
     "experienceTooltip": "Marqueurs d'expérience : {{count}}",
     "speedAriaLabel": "Vitesse {{value}}",
     "speedTooltip": "Vitesse : {{value}}",
+    "condCantWin": "Ne peut pas gagner la partie",
+    "condCantGainLife": "Ne peut pas gagner de points de vie",
+    "condCantLoseLife": "Ne peut pas perdre de points de vie",
+    "condCantPayLife": "Ne peut pas payer de points de vie",
+    "condCantCast": "Ne peut pas lancer de sorts",
+    "condCantActivate": "Ne peut pas activer de capacités",
+    "condCastOnlyFromZones": "Ne peut lancer que depuis certaines zones",
+    "condFromSource": "{{condition}} — de {{name}}",
+    "pendingSpell": "Prochain sort",
+    "pendingCantBeCountered": "Le prochain sort ne peut pas être contrecarré",
+    "pendingHasKeyword": "Le prochain sort a {{keyword}}",
+    "pendingFlash": "Le prochain sort peut être lancé comme s'il avait la flash",
+    "pendingFree": "Le prochain sort sans payer son coût de mana",
+    "pendingCheaper": "Le prochain sort coûte {{amount}} de moins",
     "companion": "Compagnon"
   },
   "avatar": {

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -98,8 +98,19 @@
       "open_other": "Open lands drawer ({{count}} lands)",
       "pipTooltip_one": "{{count}} hidden land can currently produce",
       "pipTooltip_other": "{{count}} hidden lands can currently produce",
+      "pipAvailability": "{{untapped}} di {{total}} raddrizzate",
       "title_one": "Lands ({{count}})",
       "title_other": "Lands ({{count}})"
+    },
+    "creatures": {
+      "label": "Creatures",
+      "open_one": "Open creatures drawer ({{count}} creature)",
+      "open_other": "Open creatures drawer ({{count}} creatures)",
+      "title_one": "Creatures ({{count}})",
+      "title_other": "Creatures ({{count}})",
+      "totalPower": "{{power}}/{{toughness}} total power and toughness",
+      "viewAll": "Click to view all",
+      "scrollHint": "Scroll"
     },
     "support": {
       "label": "Support",
@@ -163,6 +174,7 @@
     "creaturesAbbr": "Crt",
     "landsAbbr": "Ter",
     "otherAbbr": "Alt",
+    "manaAvailable": "{{untapped}} di {{total}} terre raddrizzate",
     "out": "FUORI",
     "eliminated": "Eliminato",
     "phasedOut": "In dissolvenza",
@@ -293,6 +305,20 @@
     "experienceTooltip": "Segnalini esperienza: {{count}}",
     "speedAriaLabel": "Velocità {{value}}",
     "speedTooltip": "Velocità: {{value}}",
+    "condCantWin": "Non può vincere la partita",
+    "condCantGainLife": "Non può guadagnare punti vita",
+    "condCantLoseLife": "Non può perdere punti vita",
+    "condCantPayLife": "Non può pagare punti vita",
+    "condCantCast": "Non può lanciare magie",
+    "condCantActivate": "Non può attivare abilità",
+    "condCastOnlyFromZones": "Può lanciare solo da zone limitate",
+    "condFromSource": "{{condition}} — da {{name}}",
+    "pendingSpell": "Prossima magia",
+    "pendingCantBeCountered": "La prossima magia non può essere neutralizzata",
+    "pendingHasKeyword": "La prossima magia ha {{keyword}}",
+    "pendingFlash": "La prossima magia può essere lanciata come se avesse lampo",
+    "pendingFree": "La prossima magia senza pagare il suo costo di mana",
+    "pendingCheaper": "La prossima magia costa {{amount}} in meno",
     "companion": "Compagno"
   },
   "avatar": {

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -98,8 +98,19 @@
       "open_other": "Open lands drawer ({{count}} lands)",
       "pipTooltip_one": "{{count}} hidden land can currently produce",
       "pipTooltip_other": "{{count}} hidden lands can currently produce",
+      "pipAvailability": "{{untapped}} z {{total}} odtapowanych",
       "title_one": "Lands ({{count}})",
       "title_other": "Lands ({{count}})"
+    },
+    "creatures": {
+      "label": "Creatures",
+      "open_one": "Open creatures drawer ({{count}} creature)",
+      "open_other": "Open creatures drawer ({{count}} creatures)",
+      "title_one": "Creatures ({{count}})",
+      "title_other": "Creatures ({{count}})",
+      "totalPower": "{{power}}/{{toughness}} total power and toughness",
+      "viewAll": "Click to view all",
+      "scrollHint": "Scroll"
     },
     "support": {
       "label": "Support",
@@ -163,6 +174,7 @@
     "creaturesAbbr": "Stw",
     "landsAbbr": "Ziem",
     "otherAbbr": "Inne",
+    "manaAvailable": "{{untapped}} z {{total}} ziem odtapowanych",
     "out": "POZA GRĄ",
     "eliminated": "Wyeliminowany",
     "phasedOut": "Przefazowany",
@@ -293,6 +305,20 @@
     "experienceTooltip": "Znaczniki doświadczenia: {{count}}",
     "speedAriaLabel": "Prędkość {{value}}",
     "speedTooltip": "Prędkość: {{value}}",
+    "condCantWin": "Nie może wygrać gry",
+    "condCantGainLife": "Nie może zyskiwać życia",
+    "condCantLoseLife": "Nie może tracić życia",
+    "condCantPayLife": "Nie może płacić życiem",
+    "condCantCast": "Nie może rzucać czarów",
+    "condCantActivate": "Nie może aktywować zdolności",
+    "condCastOnlyFromZones": "Może rzucać tylko z określonych stref",
+    "condFromSource": "{{condition}} — od {{name}}",
+    "pendingSpell": "Następny czar",
+    "pendingCantBeCountered": "Następny czar nie może zostać skontrowany",
+    "pendingHasKeyword": "Następny czar ma {{keyword}}",
+    "pendingFlash": "Następny czar można rzucić tak, jakby miał błysk",
+    "pendingFree": "Następny czar bez płacenia jego kosztu many",
+    "pendingCheaper": "Następny czar kosztuje {{amount}} mniej",
     "companion": "Towarzysz"
   },
   "avatar": {

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -98,8 +98,19 @@
       "open_other": "Open lands drawer ({{count}} lands)",
       "pipTooltip_one": "{{count}} hidden land can currently produce",
       "pipTooltip_other": "{{count}} hidden lands can currently produce",
+      "pipAvailability": "{{untapped}} de {{total}} desviradas",
       "title_one": "Lands ({{count}})",
       "title_other": "Lands ({{count}})"
+    },
+    "creatures": {
+      "label": "Creatures",
+      "open_one": "Open creatures drawer ({{count}} creature)",
+      "open_other": "Open creatures drawer ({{count}} creatures)",
+      "title_one": "Creatures ({{count}})",
+      "title_other": "Creatures ({{count}})",
+      "totalPower": "{{power}}/{{toughness}} total power and toughness",
+      "viewAll": "Click to view all",
+      "scrollHint": "Scroll"
     },
     "support": {
       "label": "Support",
@@ -163,6 +174,7 @@
     "creaturesAbbr": "Crt",
     "landsAbbr": "Trr",
     "otherAbbr": "Out",
+    "manaAvailable": "{{untapped}} de {{total}} terrenos desvirados",
     "out": "FORA",
     "eliminated": "Eliminado",
     "phasedOut": "Em Fase Inativa",
@@ -293,6 +305,20 @@
     "experienceTooltip": "Contadores de experiência: {{count}}",
     "speedAriaLabel": "Velocidade {{value}}",
     "speedTooltip": "Velocidade: {{value}}",
+    "condCantWin": "Não pode vencer o jogo",
+    "condCantGainLife": "Não pode ganhar vida",
+    "condCantLoseLife": "Não pode perder vida",
+    "condCantPayLife": "Não pode pagar vida",
+    "condCantCast": "Não pode conjurar mágicas",
+    "condCantActivate": "Não pode ativar habilidades",
+    "condCastOnlyFromZones": "Só pode conjurar de zonas limitadas",
+    "condFromSource": "{{condition}} — de {{name}}",
+    "pendingSpell": "Próxima mágica",
+    "pendingCantBeCountered": "A próxima mágica não pode ser anulada",
+    "pendingHasKeyword": "A próxima mágica tem {{keyword}}",
+    "pendingFlash": "A próxima mágica pode ser conjurada como se tivesse lampejo",
+    "pendingFree": "A próxima mágica sem pagar seu custo de mana",
+    "pendingCheaper": "A próxima mágica custa {{amount}} a menos",
     "companion": "Companheiro"
   },
   "avatar": {

--- a/client/src/viewmodel/__tests__/manaAvailability.test.ts
+++ b/client/src/viewmodel/__tests__/manaAvailability.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import type { GameObject, ManaPip } from "../../adapter/types";
+import { landManaAvailability } from "../manaAvailability";
+
+function makeLand(overrides: Partial<GameObject>): GameObject {
+  return {
+    id: 1,
+    card_id: 0,
+    owner: 0,
+    controller: 0,
+    zone: "Battlefield",
+    tapped: false,
+    face_down: false,
+    flipped: false,
+    transformed: false,
+    damage_marked: 0,
+    dealt_deathtouch_damage: false,
+    attached_to: null,
+    attachments: [],
+    counters: {},
+    name: "Land",
+    power: null,
+    toughness: null,
+    loyalty: null,
+    card_types: { supertypes: [], core_types: ["Land"], subtypes: [] },
+    mana_cost: { type: "NoCost" },
+    keywords: [],
+    abilities: [],
+    trigger_definitions: [],
+    replacement_definitions: [],
+    static_definitions: [],
+    color: [],
+    base_power: null,
+    base_toughness: null,
+    base_keywords: [],
+    base_color: [],
+    timestamp: 1,
+    entered_battlefield_turn: null,
+    ...overrides,
+  };
+}
+
+const forest: ManaPip = { type: "Color", data: "Green" };
+const wasteland: ManaPip = { type: "Colorless" };
+const dual: ManaPip = { type: "OneOfColors", data: ["White", "Blue"] };
+const triome: ManaPip = { type: "OneOfColors", data: ["White", "Blue", "Black"] };
+
+describe("landManaAvailability", () => {
+  it("counts total and untapped lands", () => {
+    const result = landManaAvailability([
+      makeLand({ id: 1, available_mana_pips: [forest] }),
+      makeLand({ id: 2, tapped: true, available_mana_pips: [forest] }),
+      makeLand({ id: 3, available_mana_pips: [forest] }),
+    ]);
+    expect(result.total).toBe(3);
+    expect(result.untapped).toBe(2);
+    expect(result.sources).toHaveLength(3);
+  });
+
+  it("maps a single color to its shard, untapped", () => {
+    const [source] = landManaAvailability([
+      makeLand({ available_mana_pips: [forest] }),
+    ]).sources;
+    expect(source).toEqual({ shards: ["G"], rainbow: false, tapped: false });
+  });
+
+  it("renders a tapped source as dimmed (tapped) without dropping it", () => {
+    const [source] = landManaAvailability([
+      makeLand({ tapped: true, available_mana_pips: [wasteland] }),
+    ]).sources;
+    expect(source).toEqual({ shards: ["C"], rainbow: false, tapped: true });
+  });
+
+  it("collapses a two-color choice into ONE hybrid pip (no overcounting)", () => {
+    const [source] = landManaAvailability([
+      makeLand({ available_mana_pips: [dual] }),
+    ]).sources;
+    // A dual makes W OR U — one hybrid shard, never one W + one U.
+    expect(source.shards).toEqual(["W/U"]);
+    expect(source.rainbow).toBe(false);
+  });
+
+  it("falls back to a rainbow swatch for 3+ color choices (no hybrid symbol)", () => {
+    const [source] = landManaAvailability([
+      makeLand({ available_mana_pips: [triome] }),
+    ]).sources;
+    expect(source.shards).toEqual([]);
+    expect(source.rainbow).toBe(true);
+  });
+
+  it("treats a no-mana land (no pips) as neither lettered nor rainbow", () => {
+    // Maze of Ith: a land with no mana ability still counts toward total but
+    // renders as a neutral dot, never implying it taps for mana.
+    const [source] = landManaAvailability([makeLand({ available_mana_pips: [] })]).sources;
+    expect(source).toEqual({ shards: [], rainbow: false, tapped: false });
+  });
+});

--- a/client/src/viewmodel/manaAvailability.ts
+++ b/client/src/viewmodel/manaAvailability.ts
@@ -1,0 +1,96 @@
+import type { GameObject, ManaColor, ManaPip } from "../adapter/types.ts";
+import { SHARD_ABBREVIATION } from "./costLabel.ts";
+
+// Renders a player's land mana as a "per-source pip rail": one tight pip-group
+// per source, never per-color totals. This preserves the engine's flexible-
+// source modeling — a dual that taps for "{W} or {U}" is ONE pip
+// (`ManaPip::OneOfColors`), not one white + one blue — so the rail can't
+// overcount available mana (the matching problem stays in the engine).
+//
+// Tapped vs untapped is the user-facing signal: `available_mana_pips` is the
+// engine's color projection (NOT tapped-aware — see `display_land_mana_pips`),
+// so the `tapped` flag drives whether a source renders bright or dimmed.
+
+/** One source rendered as a single tight pip-group in the rail. */
+export interface LandManaSource {
+  /**
+   * Scryfall shard strings for `ManaSymbol` (e.g. `"W"`, `"C"`, `"W/U"`).
+   * A source producing two colors simultaneously contributes two shards
+   * (still one group); a two-color *choice* contributes one hybrid shard.
+   * Empty when the source's output can't map to mana symbols — see `rainbow`
+   * and the neutral fallback in the renderer.
+   */
+  shards: string[];
+  /**
+   * True when the source produces flexible mana with no single Scryfall
+   * symbol (3+ color choice, any-combination, or commander-identity); the
+   * rail shows a rainbow swatch instead of a lettered pip.
+   */
+  rainbow: boolean;
+  /** CR 106.1: a tapped source can't produce mana now → rendered dimmed. */
+  tapped: boolean;
+}
+
+export interface LandManaAvailability {
+  /** One entry per land, in battlefield order. */
+  sources: LandManaSource[];
+  /** Total lands (matches the prior bare count). */
+  total: number;
+  /** Lands that are currently untapped (their mana is available now). */
+  untapped: number;
+}
+
+/** Map one `ManaPip` to render shards, flagging flexible output as rainbow. */
+function pipToShards(pip: ManaPip): { shards: string[]; rainbow: boolean } {
+  switch (pip.type) {
+    case "Color":
+      return { shards: [colorShard(pip.data)], rainbow: false };
+    case "Colorless":
+      return { shards: ["C"], rainbow: false };
+    case "OneOfColors":
+      // CR 106.4: a two-color choice has a Scryfall hybrid symbol ("W/U");
+      // a 3+-color choice does not, so fall back to a rainbow swatch.
+      return pip.data.length === 2
+        ? { shards: [pip.data.map(colorShard).join("/")], rainbow: false }
+        : { shards: [], rainbow: true };
+    case "CombinationOfColors":
+    case "AnyInCommandersIdentity":
+      return { shards: [], rainbow: true };
+  }
+}
+
+function colorShard(color: ManaColor): string {
+  // SHARD_ABBREVIATION is keyed by shard-variant name; the five single-color
+  // names overlap ManaColor exactly ("White" → "W", …).
+  return SHARD_ABBREVIATION[color] ?? "C";
+}
+
+/**
+ * Build the per-source rail descriptor for a player's lands. `lands` should be
+ * the player's battlefield lands (e.g. `partitionByType(...).lands`); each
+ * carries the engine-derived `available_mana_pips` + `tapped` already on the
+ * wire, so this is pure presentation aggregation — no game logic.
+ */
+export function landManaAvailability(lands: GameObject[]): LandManaAvailability {
+  const sources: LandManaSource[] = [];
+  let untapped = 0;
+
+  for (const land of lands) {
+    const tapped = land.tapped ?? false;
+    if (!tapped) untapped += 1;
+
+    const shards: string[] = [];
+    let rainbow = false;
+    for (const pip of land.available_mana_pips ?? []) {
+      const mapped = pipToShards(pip);
+      shards.push(...mapped.shards);
+      rainbow = rainbow || mapped.rainbow;
+    }
+    // A land with no pip projection (e.g. Maze of Ith) makes no mana — it is
+    // neither lettered nor rainbow; the renderer shows a neutral dot so the
+    // land count stays honest without implying it taps for mana.
+    sources.push({ shards, rainbow, tapped });
+  }
+
+  return { sources, total: lands.length, untapped };
+}

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -17,7 +17,9 @@ use std::collections::{BTreeMap, HashMap};
 use crate::game::ability_utils::flatten_targets_in_chain;
 use crate::game::game_object::AttachTarget;
 use crate::game::stack::{stack_display_groups, StackDisplayGroup};
-use crate::types::ability::{KeywordAction, TargetRef};
+use crate::types::ability::{
+    GameRestriction, KeywordAction, ProhibitedActivity, RestrictionPlayerScope, TargetRef,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
     CastingVariant, GameState, StackEntry, StackEntryKind, StackPaidSnapshot,
@@ -80,6 +82,54 @@ pub struct StackEntryDisplay {
     pub trigger_context: Vec<TriggerContextDisplay>,
 }
 
+/// A single player-affecting condition the HUD surfaces as a status icon.
+///
+/// **Presentation-only discriminant.** `kind` selects an icon + i18n key; it
+/// deliberately spans multiple CR sections (CR 104.2b, CR 119.7/.8, CR 118.3,
+/// CR 101.2 / CR 702.50b) because the display layer groups "conditions
+/// afflicting a player" regardless of which rules section produced them. The
+/// categorical-boundary rule governs *rules-primitive* enums; this lives in
+/// the `DerivedViews` presentation layer alongside `StackPaidFactView`, so
+/// the cross-section span is correct here, not a sibling-cluster smell. The
+/// authoritative rules state remains in `StaticMode`, `GameRestriction`, and
+/// `EpicEffect` — this enum never feeds game logic, only rendering.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum PlayerConditionKind {
+    /// CR 104.2b: effect-based win attempts targeting this player are no-ops.
+    CantWin,
+    /// CR 119.7: life-gain events affecting this player are replaced with nothing.
+    CantGainLife,
+    /// CR 119.8: life-loss events affecting this player are replaced with nothing.
+    CantLoseLife,
+    /// CR 118.3: this player can't pay life as a cost.
+    CantPayLifeAsCost,
+    /// CR 101.2 / CR 702.50b: this player can't cast spells (Epic lock or a
+    /// temporary `ProhibitActivity::CastSpells`, possibly spell-filtered — the
+    /// `source` card identifies the specifics for the tooltip).
+    CantCastSpells,
+    /// CR 101.2 + CR 602.5: this player can't activate abilities (mana abilities
+    /// may still be exempt — the `source` card identifies the specifics).
+    CantActivateAbilities,
+    /// CR 101.2 + CR 601.2a: this player may cast spells only from the listed zones.
+    CastOnlyFromZones { allowed_zones: Vec<Zone> },
+}
+
+/// One rendered row of player status: which `player` is under a `kind` of
+/// condition, and the permanent `source` imposing it (when known).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlayerStatusView {
+    pub player: PlayerId,
+    pub kind: PlayerConditionKind,
+    /// The permanent imposing the condition, when the engine surfaces it.
+    /// `None` for the statics-scanned life/cost conditions whose authority
+    /// predicate returns a bare `bool` — recovering the granting permanent
+    /// would require a second scan, so the FE tooltip falls back to the
+    /// condition name. `Some` for stored `GameRestriction`/`EpicEffect` rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<ObjectId>,
+}
+
 /// Engine-authored projections used by the display layer. Keep this struct
 /// small — every field becomes mandatory payload on every state snapshot
 /// the client receives. Add a new field only when the frontend would
@@ -127,6 +177,15 @@ pub struct DerivedViews {
     /// no granting static, or no qualifying card.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub web_slinging_costs: HashMap<ObjectId, ManaCost>,
+
+    /// Player-affecting continuous conditions (CR 104.2b / 119.7 / 119.8 /
+    /// 118.3 / 101.2 / 702.50b) the HUD renders as status icons. Aggregates
+    /// the statics-scanned `player_has_*` authorities and the stored
+    /// `restrictions`/`epic_effects` so the frontend never re-scans static
+    /// abilities to learn that a player "can't gain life" or "can't cast".
+    /// Empty (and omitted) in the dominant case where no player is afflicted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub player_status: Vec<PlayerStatusView>,
 }
 
 /// Serialize-only wrapper: the WASM getter passes `&GameState` by reference
@@ -229,6 +288,12 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
         }
     }
 
+    // CR 104.2b / 119.7 / 119.8 / 118.3 / 101.2 / 702.50b: aggregate
+    // player-affecting conditions so the HUD can render status icons without
+    // re-scanning static abilities. Runs in every format (not gated by the
+    // Commander short-circuit below).
+    views.player_status = player_status_views(state);
+
     if state.format_config.commander_damage_threshold.is_none() {
         return views;
     }
@@ -250,6 +315,138 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
         }
     }
     views
+}
+
+/// Aggregate player-affecting conditions into render-ready rows.
+///
+/// Two sources, neither of which introduces new game logic:
+/// 1. **Statics-scanned** life/cost conditions — delegate verbatim to the
+///    single-authority `player_has_*` predicates in `static_abilities`
+///    (CR 104.2b / 119.7 / 119.8 / 118.3). `source` is `None` because those
+///    predicates return a bare `bool`.
+/// 2. **Stored state** — read `restrictions` and `epic_effects` as-is
+///    (CR 101.2 / 602.5 / 601.2a / 702.50b); `source` is the imposing card.
+///
+/// Deliberately excluded: `GameRestriction::DamagePreventionDisabled` has no
+/// per-player axis (it scopes by source/target, CR 614.16) so it is not a
+/// player condition; `player_ignores_hexproof` / `player_has_protection_from_everything`
+/// are beneficial capabilities, not afflictions; `player_cant_sacrifice_as_cost`
+/// is an object-parameterized per-payment query, not a player-level status.
+fn player_status_views(state: &GameState) -> Vec<PlayerStatusView> {
+    use crate::game::static_abilities::{
+        player_cant_pay_life_as_cost, player_has_cant_gain_life, player_has_cant_lose_life,
+        player_has_cant_win,
+    };
+
+    let mut views = Vec::new();
+
+    // Source 1: statics-scanned, player-scoped life/cost conditions. Each
+    // predicate is the sole authority for its CR rule; calling them keeps the
+    // logic single-sourced. Cost is O(players × active statics) — bounded by
+    // the (typically tiny) set of permanents with static abilities.
+    for player in &state.players {
+        let pid = player.id;
+        let conditions = [
+            (
+                player_has_cant_win(state, pid),
+                PlayerConditionKind::CantWin,
+            ),
+            (
+                player_has_cant_gain_life(state, pid),
+                PlayerConditionKind::CantGainLife,
+            ),
+            (
+                player_has_cant_lose_life(state, pid),
+                PlayerConditionKind::CantLoseLife,
+            ),
+            (
+                player_cant_pay_life_as_cost(state, pid),
+                PlayerConditionKind::CantPayLifeAsCost,
+            ),
+        ];
+        for (active, kind) in conditions {
+            if active {
+                views.push(PlayerStatusView {
+                    player: pid,
+                    kind,
+                    source: None,
+                });
+            }
+        }
+    }
+
+    // Source 2a: stored activity prohibitions, read as-is from GameState.
+    for restriction in &state.restrictions {
+        let GameRestriction::ProhibitActivity {
+            source,
+            affected_players,
+            activity,
+            ..
+        } = restriction
+        else {
+            // DamagePreventionDisabled has no per-player axis — see fn docs.
+            continue;
+        };
+        let kind = match activity {
+            ProhibitedActivity::CastSpells { .. } => PlayerConditionKind::CantCastSpells,
+            ProhibitedActivity::ActivateAbilities { .. } => {
+                PlayerConditionKind::CantActivateAbilities
+            }
+            ProhibitedActivity::CastOnlyFromZones { allowed_zones } => {
+                PlayerConditionKind::CastOnlyFromZones {
+                    allowed_zones: allowed_zones.clone(),
+                }
+            }
+        };
+        for pid in restriction_affected_players(state, affected_players, *source) {
+            views.push(PlayerStatusView {
+                player: pid,
+                kind: kind.clone(),
+                source: Some(*source),
+            });
+        }
+    }
+
+    // Source 2b: CR 702.50b — a resolved Epic locks its controller out of casting.
+    for epic in &state.epic_effects {
+        views.push(PlayerStatusView {
+            player: epic.controller,
+            kind: PlayerConditionKind::CantCastSpells,
+            source: Some(epic.prototype_id),
+        });
+    }
+
+    views
+}
+
+/// Resolve a restriction's `RestrictionPlayerScope` to the concrete players it
+/// afflicts at display time. The `TargetedPlayer` / `ParentTargetedPlayer`
+/// placeholders are resolved to `SpecificPlayer` at resolution time
+/// (CR 608.2c); if one survives to the display layer it can't be attributed,
+/// so it contributes no rows.
+fn restriction_affected_players(
+    state: &GameState,
+    scope: &RestrictionPlayerScope,
+    source: ObjectId,
+) -> Vec<PlayerId> {
+    match scope {
+        RestrictionPlayerScope::AllPlayers => state.players.iter().map(|p| p.id).collect(),
+        RestrictionPlayerScope::SpecificPlayer(pid) => vec![*pid],
+        RestrictionPlayerScope::OpponentsOfSourceController => {
+            match state.objects.get(&source).map(|obj| obj.controller) {
+                Some(controller) => state
+                    .players
+                    .iter()
+                    .map(|p| p.id)
+                    .filter(|&pid| pid != controller)
+                    .collect(),
+                None => Vec::new(),
+            }
+        }
+        RestrictionPlayerScope::TargetedPlayer | RestrictionPlayerScope::ParentTargetedPlayer => {
+            Vec::new()
+        }
+    }
 }
 
 fn stack_entry_details(state: &GameState) -> HashMap<ObjectId, StackEntryDisplay> {
@@ -551,12 +748,13 @@ fn zone_label(zone: Option<Zone>) -> &'static str {
 mod tests {
     use super::*;
     use crate::game::zones::create_object;
-    use crate::types::ability::{Effect, ResolvedAbility, TargetRef};
+    use crate::types::ability::{Effect, ResolvedAbility, RestrictionExpiry, TargetRef};
     use crate::types::format::FormatConfig;
     use crate::types::game_state::{
         CommanderDamageEntry, StackEntry, StackEntryKind, StackPaidSnapshot, ZoneChangeRecord,
     };
     use crate::types::identifiers::CardId;
+    use crate::types::statics::ActivationExemption;
     use crate::types::zones::Zone;
 
     fn setup_commander_game(num_players: u8) -> GameState {
@@ -1017,6 +1215,121 @@ mod tests {
         assert!(
             !views.auras_attached_to_player.contains_key(&PlayerId(0)),
             "P0 has no Aura host — must not get an empty entry",
+        );
+    }
+
+    /// CR 101.2 / CR 614.16 / CR 702.50b: stored restrictions and epic locks
+    /// project into per-player status rows; the scope is resolved to concrete
+    /// players, kinds map correctly, and `DamagePreventionDisabled` (no
+    /// per-player axis) contributes nothing.
+    #[test]
+    fn derive_views_projects_stored_player_conditions() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        // A source permanent controlled by P0 (imposes the restrictions).
+        let source = create_object(
+            &mut state,
+            CardId(7),
+            PlayerId(0),
+            "Restrictor".into(),
+            Zone::Battlefield,
+        );
+
+        // CR 101.2: P1 specifically can't cast spells.
+        state.restrictions.push(GameRestriction::ProhibitActivity {
+            source,
+            affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(1)),
+            expiry: RestrictionExpiry::EndOfTurn,
+            activity: ProhibitedActivity::CastSpells { spell_filter: None },
+        });
+        // CR 602.5: all players can't activate non-mana abilities.
+        state.restrictions.push(GameRestriction::ProhibitActivity {
+            source,
+            affected_players: RestrictionPlayerScope::AllPlayers,
+            expiry: RestrictionExpiry::EndOfTurn,
+            activity: ProhibitedActivity::ActivateAbilities {
+                exemption: ActivationExemption::ManaAbilities,
+            },
+        });
+        // CR 614.16: no per-player axis — must NOT produce a status row.
+        state
+            .restrictions
+            .push(GameRestriction::DamagePreventionDisabled {
+                source,
+                expiry: RestrictionExpiry::EndOfTurn,
+                scope: None,
+            });
+
+        let status = derive_views(&state, None).player_status;
+
+        // P1 can't cast (SpecificPlayer), attributed to the source.
+        assert!(
+            status.contains(&PlayerStatusView {
+                player: PlayerId(1),
+                kind: PlayerConditionKind::CantCastSpells,
+                source: Some(source),
+            }),
+            "P1's cast prohibition should project with its source",
+        );
+        // Both players can't activate abilities (AllPlayers).
+        for pid in [PlayerId(0), PlayerId(1)] {
+            assert!(
+                status.contains(&PlayerStatusView {
+                    player: pid,
+                    kind: PlayerConditionKind::CantActivateAbilities,
+                    source: Some(source),
+                }),
+                "AllPlayers scope should project to {pid:?}",
+            );
+        }
+        // P0 is NOT cast-locked (the cast prohibition was P1-specific).
+        assert!(
+            !status
+                .iter()
+                .any(|v| v.player == PlayerId(0) && v.kind == PlayerConditionKind::CantCastSpells),
+            "P0 must not inherit P1's specific cast prohibition",
+        );
+        // DamagePreventionDisabled contributes no rows.
+        assert_eq!(
+            status.len(),
+            3,
+            "exactly 3 rows: P1 can't-cast + both players can't-activate; \
+             DamagePreventionDisabled excluded",
+        );
+    }
+
+    /// CR 101.2: `OpponentsOfSourceController` resolves to every player except
+    /// the source's controller.
+    #[test]
+    fn derive_views_resolves_opponents_of_source_controller() {
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        let source = create_object(
+            &mut state,
+            CardId(8),
+            PlayerId(1),
+            "Silence Engine".into(),
+            Zone::Battlefield,
+        );
+        state.restrictions.push(GameRestriction::ProhibitActivity {
+            source,
+            affected_players: RestrictionPlayerScope::OpponentsOfSourceController,
+            expiry: RestrictionExpiry::EndOfTurn,
+            activity: ProhibitedActivity::CastSpells { spell_filter: None },
+        });
+
+        let afflicted: Vec<PlayerId> = derive_views(&state, None)
+            .player_status
+            .into_iter()
+            .filter(|v| v.kind == PlayerConditionKind::CantCastSpells)
+            .map(|v| v.player)
+            .collect();
+
+        assert!(
+            !afflicted.contains(&PlayerId(1)),
+            "the source's controller (P1) is not their own opponent",
+        );
+        assert!(
+            afflicted.contains(&PlayerId(0)) && afflicted.contains(&PlayerId(2)),
+            "both opponents (P0, P2) should be cast-locked",
         );
     }
 


### PR DESCRIPTION
Frontend status-surfacing pass plus the engine projection it renders:

- engine: DerivedViews.player_status projection (PlayerStatusView / PlayerConditionKind) aggregating existing authorities (cant-gain-life, epic, restrictions); CR-annotated, no new game logic.
- HUD: ConditionBadge, PendingSpellBadge, and a Ring-benefits hover popover; migrated all HUD badges from native title= to the custom GameplayTooltip via a shared BadgeTip wrapper.
- mana: per-source tapped/untapped land mana availability (LandManaRail + manaAvailability viewmodel) and untapped/total in the collapsed lands overflow box.
- creatures: BattlefieldZoneOverflow gains a 'creatures' zone — a scrollable readable card grid (BattlefieldRow fixedSize) with combat participants sorted to the front for priority visibility and explicit scroll affordances.
- combat: re-arm attack/block arrow polling on inner-container scroll so lines track cards in the scrollable grid.
- targeting: pin the prompt to the top so it clears the multiplayer opponent-HUD rail; drop the player HUD lower.
- i18n: new keys across all 7 locales.
