### PR TITLE
fix(parser): bind "untaps it" anaphor to trigger subject, not ParentTarget

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1165,9 +1165,24 @@ pub(super) fn parse_targeted_action_ast(
         alt((value("tap", tag("tap ")), value("untap", tag("untap ")))).parse(input)
     }) {
         let (target_text, _) = super::strip_optional_target_prefix(strip_article(rest));
-        let (target, _rem) = parse_target_with_ctx(target_text, ctx);
-        #[cfg(debug_assertions)]
-        assert_no_compound_remainder(_rem, text);
+        // CR 608.2k: A bare object pronoun ("untaps it") in a subject-bearing
+        // clause is an anaphor, not a parent-target chain. Route it through
+        // `resolve_it_pronoun` — identical to the sacrifice/counter clauses in
+        // the same instruction — so "that player gains control of ~, untaps it,
+        // and puts a +1/+1 counter on it" (Alexios, Deimos of Kosmos) binds the
+        // untap to `SelfRef` (the named source), and observer triggers like
+        // "whenever a permanent you control enters tapped, untap it" (Amulet of
+        // Vigor) bind to `TriggeringSource` (the entering permanent). Without a
+        // subject (a true parent-target chain, "tap target creature. untap it")
+        // the guard falls through to `parse_target_with_ctx` → `ParentTarget`.
+        let target = if ctx.subject.is_some() && is_bare_object_pronoun(target_text.trim()) {
+            resolve_it_pronoun(ctx)
+        } else {
+            let (target, _rem) = parse_target_with_ctx(target_text, ctx);
+            #[cfg(debug_assertions)]
+            assert_no_compound_remainder(_rem, text);
+            target
+        };
         return match verb {
             "tap" => Some(TargetedImperativeAst::Tap { target }),
             "untap" => Some(TargetedImperativeAst::Untap { target }),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -12678,6 +12678,71 @@ mod tests {
         );
     }
 
+    /// CR 608.2k: the "untap it"/"tap it" bare-object-pronoun anaphor binds by
+    /// the trigger SUBJECT, not to `ParentTarget` (which resolves against the
+    /// effect's empty target list on a primary, non-targeted trigger effect and
+    /// silently no-ops the untap). This is a parse-shape building-block test for
+    /// the whole class, exercised end-to-end by
+    /// `tests/integration/issue_2915_alexios.rs`:
+    ///   - typed/attached subject ("a permanent you control", "equipped
+    ///     creature") → `TriggeringSource` (the entering/attacking object),
+    ///     matching the sibling sacrifice/destroy/exile anaphor verbs;
+    ///   - self subject (the source named in the same instruction, Alexios's
+    ///     "gains control of ~, untaps it") → `SelfRef`.
+    #[test]
+    fn untap_it_anaphor_binds_to_trigger_subject_not_parent_target() {
+        fn find_untap_target(ability: &AbilityDefinition) -> &TargetFilter {
+            let mut node = Some(ability);
+            while let Some(current) = node {
+                if let Effect::SetTapState {
+                    target,
+                    state: TapStateChange::Untap,
+                    ..
+                } = current.effect.as_ref()
+                {
+                    return target;
+                }
+                node = current.sub_ability.as_deref();
+            }
+            panic!("expected an Untap SetTapState in the trigger chain");
+        }
+
+        // Typed subject: "it" is the entering permanent (the triggering object).
+        let amulet = parse_trigger_line(
+            "Whenever a permanent you control enters tapped, untap it.",
+            "Amulet of Vigor",
+        );
+        assert_eq!(
+            find_untap_target(amulet.execute.as_ref().expect("execute present")),
+            &TargetFilter::TriggeringSource,
+            "typed-subject 'untap it' must bind to the triggering object"
+        );
+
+        // Attached subject: "it" is the equipped (attacking) creature.
+        let genji = parse_trigger_line(
+            "Whenever equipped creature attacks, untap it.",
+            "Genji Glove",
+        );
+        assert_eq!(
+            find_untap_target(genji.execute.as_ref().expect("execute present")),
+            &TargetFilter::TriggeringSource,
+            "attached-subject 'untap it' must bind to the triggering object"
+        );
+
+        // Self subject: "it" is the source named earlier in the instruction.
+        let alexios = parse_trigger_line(
+            "At the beginning of each player's upkeep, that player gains control of \
+             Alexios, untaps it, and puts a +1/+1 counter on it. It gains haste until \
+             end of turn.",
+            "Alexios, Deimos of Kosmos",
+        );
+        assert_eq!(
+            find_untap_target(alexios.execute.as_ref().expect("execute present")),
+            &TargetFilter::SelfRef,
+            "self-subject 'untaps it' must bind to the named source"
+        );
+    }
+
     // CR 603.6a + CR 110.5b: "Whenever an artifact or creature an opponent
     // controls enters untapped, ..." — Charismatic Conqueror class. The
     // `enters untapped` rider must wrap `ZoneChangeObjectIsTapped` in `Not`,

--- a/crates/engine/tests/integration/issue_2915_alexios.rs
+++ b/crates/engine/tests/integration/issue_2915_alexios.rs
@@ -1,14 +1,40 @@
 //! Regression for GitHub issue #2915 — Alexios, Deimos of Kosmos must scope
 //! "can't attack its owner" to the owner player (not blanket CantAttack) and
 //! upkeep GiveControl must honor `ScopedPlayer`.
+//!
+//! Follow-up (post-#2915): the upkeep trigger's middle clause — "that player
+//! gains control of ~, **untaps it**, and puts a +1/+1 counter on it" — must
+//! actually untap Alexios when control moves to the new player. The "untaps it"
+//! anaphor previously parsed to `ParentTarget`, which resolves against the
+//! parent `GiveControl { target: SelfRef }`'s empty target list, so the untap
+//! silently no-op'd. The bug was latent until #2915 made control genuinely
+//! move: before that, Alexios reverted to its owner every upkeep and was
+//! untapped by that owner's normal untap step (CR 502), masking the dead
+//! trigger-untap. CR 608.2k: the bare object pronoun "it" binds to the named
+//! source (`SelfRef`), matching the sibling counter clause.
 
+use engine::game::scenario::{GameRunner, GameScenario};
 use engine::parser::oracle_static::parse_static_line_multi;
 use engine::types::ability::TargetFilter;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
 use engine::types::triggers::AttackTargetFilter;
 
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
 const ALEXIOS_ATTACK_LINE: &str =
     "This creature attacks each combat if able, can't be sacrificed, and can't attack its owner.";
+
+/// Alexios's full Oracle text (the upkeep trigger is what drives this test).
+const ALEXIOS_ORACLE: &str = "Trample\n\
+     Alexios attacks each combat if able, can't be sacrificed, and can't attack its owner.\n\
+     At the beginning of each player's upkeep, that player gains control of Alexios, untaps it, \
+     and puts a +1/+1 counter on it. It gains haste until end of turn.";
 
 #[test]
 fn alexios_cant_attack_owner_is_scoped_not_blanket() {
@@ -24,4 +50,94 @@ fn alexios_cant_attack_owner_is_scoped_not_blanket() {
     assert!(defs
         .iter()
         .all(|def| def.affected == Some(TargetFilter::SelfRef)));
+}
+
+/// Drive the engine forward, passing priority and declaring no
+/// attackers/blockers, until the turn rolls from P0's pre-combat main into P1's
+/// upkeep and the (non-targeted) Alexios trigger resolves — i.e. control flips
+/// to P1 — or a step budget is exhausted.
+fn advance_until_alexios_controlled_by_p1(
+    runner: &mut GameRunner,
+    alexios: engine::types::identifiers::ObjectId,
+) {
+    for _ in 0..240 {
+        if runner.state().objects[&alexios].controller == P1 {
+            return;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    return;
+                }
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                if runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                if runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            _ => return,
+        }
+    }
+}
+
+/// CR 608.2k + CR 701.26b (issue #2915 follow-up): on P1's upkeep the trigger
+/// gives P1 control of Alexios, untaps it, and adds a +1/+1 counter. A
+/// discriminating runtime test: Alexios enters tapped under P0; pre-fix the
+/// "untaps it" clause resolves to nothing and Alexios stays tapped after moving
+/// to P1; post-fix it is untapped.
+#[test]
+fn alexios_upkeep_trigger_untaps_when_control_moves() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Libraries so draw steps never deck anyone out before the assertion.
+    for &pid in &[P0, P1] {
+        scenario.with_library_top(pid, &["Lib A", "Lib B", "Lib C", "Lib D"]);
+    }
+
+    let alexios = scenario
+        .add_creature_from_oracle(P0, "Alexios, Deimos of Kosmos", 4, 4, ALEXIOS_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    // Alexios enters tapped (e.g. it attacked on P0's previous turn). Because it
+    // changes control on P1's upkeep, P1's own untap step (CR 502) does NOT
+    // untap it — only the trigger's "untaps it" clause can.
+    runner.state_mut().objects.get_mut(&alexios).unwrap().tapped = true;
+
+    advance_until_alexios_controlled_by_p1(&mut runner, alexios);
+
+    let obj = &runner.state().objects[&alexios];
+    assert_eq!(
+        obj.controller, P1,
+        "trigger must move control of Alexios to the upkeep player (P1)"
+    );
+    assert!(
+        !obj.tapped,
+        "the 'untaps it' clause must untap Alexios when control moves to P1"
+    );
+    assert_eq!(
+        obj.counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        1,
+        "the trigger must put one +1/+1 counter on Alexios"
+    );
 }


### PR DESCRIPTION
The tap/untap imperative verb was the lone object-affecting verb that did not
route a bare object pronoun ("it") through resolve_it_pronoun, so "untap it"
parsed to TargetFilter::ParentTarget. On a primary, non-targeted trigger
effect, ParentTarget resolves against an empty ability.targets and the untap
silently no-ops.

This broke Alexios, Deimos of Kosmos's upkeep trigger ("that player gains
control of ~, untaps it, and puts a +1/+1 counter on it") — latent until
#2915 made control genuinely move, since before that Alexios reverted to its
owner each upkeep and was untapped by that owner's normal untap step (CR 502).

Route the tap/untap "it" anaphor through resolve_it_pronoun when a subject is
present, mirroring sacrifice/destroy/exile/counter. This fixes the whole
class: Alexios -> SelfRef; Amulet of Vigor / Genji Glove / Raggadragga ->
TriggeringSource. Subjectless parent-target chains keep ParentTarget.

CR 608.2k.
