### PR TITLE
fix(client): PairChoice is modal-resolved, drop its board-glow seed

### DIFF
--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -87,6 +87,19 @@ describe("getWaitingForObjectChoiceIds", () => {
       }),
     ).toEqual([10, 11]);
   });
+
+  // PairChoice is modal-resolved (PairChoiceModal dispatches ChoosePair), so it
+  // must NOT seed board-clickable object glow. The engine rejects ChooseTarget
+  // for PairChoice, so a board click would dead-end. Mirrors CrewVehicle /
+  // StationTarget / SaddleMount, which are likewise absent here.
+  it("returns [] for PairChoice (modal-only, not board-clickable)", () => {
+    expect(
+      getWaitingForObjectChoiceIds({
+        type: "PairChoice",
+        data: { player: 0, source_id: 1, choices: [20, 21, 22] },
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe("getCastableZoneViewerTarget", () => {

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -130,8 +130,6 @@ export function getWaitingForObjectChoiceIds(
       return waitingFor.data.legal_targets.flatMap((target) =>
         "Object" in target ? [target.Object] : [],
       );
-    case "PairChoice":
-      return waitingFor.data.choices;
     default:
       return [];
   }


### PR DESCRIPTION
PairChoice is resolved by PairChoiceModal (dispatches ChoosePair), but it was
also seeded into getWaitingForObjectChoiceIds, glowing board objects whose click
dispatches ChooseTarget — which the engine rejects for PairChoice. Remove the
PairChoice case so it falls through to [] like the other modal-only variants
(CrewVehicle/StationTarget/SaddleMount). Eliminates the misleading dead glow.
