### PR TITLE
fix(ui): render the Learn modal (CR 701.48a)

### DIFF
--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -80,6 +80,7 @@ type StationTarget = Extract<WaitingFor, { type: "StationTarget" }>;
 type SaddleMount = Extract<WaitingFor, { type: "SaddleMount" }>;
 type DamageSourceChoice = Extract<WaitingFor, { type: "DamageSourceChoice" }>;
 type ChooseRingBearer = Extract<WaitingFor, { type: "ChooseRingBearer" }>;
+type LearnChoice = Extract<WaitingFor, { type: "LearnChoice" }>;
 
 /**
  * Generic card choice modal for Scry, Dig, Surveil, Reveal, Search, and NamedChoice.
@@ -259,6 +260,9 @@ export function CardChoiceModal() {
     case "ChooseRingBearer":
       if (!canActForWaitingState) return null;
       return <RingBearerModal data={waitingFor.data} />;
+    case "LearnChoice":
+      if (!canActForWaitingState) return null;
+      return <LearnModal data={waitingFor.data} />;
     case "ChooseManaColor":
       if (!canActForWaitingState) return null;
       return <ManaColorChoiceModal data={waitingFor.data} />;
@@ -295,6 +299,91 @@ function RingBearerModal({ data }: { data: ChooseRingBearer["data"] }) {
     >
       <ScrollableCardStrip>
         {data.candidates.map((id, index) => {
+          const obj = objects[id];
+          if (!obj) return null;
+          const isSelected = selected === id;
+          return (
+            <motion.button
+              key={id}
+              type="button"
+              aria-label={obj.name}
+              className={`relative flex flex-col items-center gap-2 rounded-lg transition ${
+                isSelected
+                  ? "ring-2 ring-emerald-400/80"
+                  : "ring-1 ring-white/10 hover:ring-white/35"
+              }`}
+              initial={{ opacity: 0, y: 40, scale: 0.9 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              transition={{ delay: 0.1 + index * 0.08, duration: 0.35 }}
+              whileHover={{ scale: 1.05, y: -6 }}
+              onClick={() => setSelected(id)}
+              {...hoverProps(id)}
+            >
+              <CardImage {...objectImageProps(obj)} size="normal" />
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-bold transition ${
+                  isSelected
+                    ? "bg-emerald-500/80 text-white"
+                    : "bg-slate-800/90 text-slate-300"
+                }`}
+              >
+                {isSelected ? t("cardChoice.badges.selected") : t("cardChoice.badges.choose")}
+              </span>
+            </motion.button>
+          );
+        })}
+      </ScrollableCardStrip>
+    </ChoiceOverlay>
+  );
+}
+
+// ── Learn Modal ────────────────────────────────────────────────────────────
+
+// CR 701.48a: "Learn" means "You may discard a card. If you do, draw a card. If
+// you didn't discard a card, you may reveal a Lesson card you own from outside
+// the game and put it into your hand." The second mode (revealing a Lesson from
+// outside the game) is engine-deferred, so this modal renders only the rummage
+// (discard-then-draw) and skip branches. Selecting a card dispatches a Rummage
+// LearnOption (engine discards then draws); skipping dispatches Skip (no-op).
+function LearnModal({ data }: { data: LearnChoice["data"] }) {
+  const { t } = useTranslation("game");
+  const dispatch = useGameDispatch();
+  const objects = useGameStore((s) => s.gameState?.objects);
+  const hoverProps = useInspectHoverProps();
+  const [selected, setSelected] = useState<ObjectId | null>(null);
+
+  const handleRummage = useCallback(() => {
+    if (selected !== null) {
+      dispatch({
+        type: "LearnDecision",
+        data: { choice: { type: "Rummage", data: { card_id: selected } } },
+      });
+    }
+  }, [dispatch, selected]);
+
+  const handleSkip = useCallback(() => {
+    dispatch({ type: "LearnDecision", data: { choice: { type: "Skip" } } });
+  }, [dispatch]);
+
+  if (!objects) return null;
+
+  return (
+    <ChoiceOverlay
+      title={t("cardChoice.learn.title")}
+      subtitle={t("cardChoice.learn.subtitle")}
+      footer={
+        <div className="mx-auto flex w-full max-w-xl flex-col gap-2">
+          <ConfirmButton
+            onClick={handleRummage}
+            disabled={selected === null}
+            label={t("cardChoice.learn.labelRummage")}
+          />
+          <CancelButton onClick={handleSkip} label={t("cardChoice.learn.labelSkip")} />
+        </div>
+      }
+    >
+      <ScrollableCardStrip>
+        {data.hand_cards.map((id, index) => {
           const obj = objects[id];
           if (!obj) return null;
           const isSelected = selected === id;

--- a/client/src/components/modal/__tests__/LearnChoiceModal.test.tsx
+++ b/client/src/components/modal/__tests__/LearnChoiceModal.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameState, WaitingFor } from "../../../adapter/types.ts";
+import { CardChoiceModal } from "../CardChoiceModal.tsx";
+import { isWaitingForHandled } from "../../../game/waitingForRegistry.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useMultiplayerStore } from "../../../stores/multiplayerStore.ts";
+
+const dispatchMock = vi.fn();
+
+vi.mock("../../../hooks/useGameDispatch.ts", () => ({
+  useGameDispatch: () => dispatchMock,
+}));
+
+function makeHandCard(id: number, name: string) {
+  return {
+    id,
+    card_id: id,
+    owner: 0,
+    controller: 0,
+    zone: "Hand" as const,
+    tapped: false,
+    face_down: false,
+    flipped: false,
+    transformed: false,
+    damage_marked: 0,
+    dealt_deathtouch_damage: false,
+    attached_to: null,
+    attachments: [],
+    counters: {},
+    name,
+    power: null,
+    toughness: null,
+    loyalty: null,
+    card_types: { supertypes: [], core_types: ["Sorcery"], subtypes: [] },
+    mana_cost: { type: "NoCost" as const },
+    keywords: [],
+    abilities: [],
+    trigger_definitions: [],
+    replacement_definitions: [],
+    static_definitions: [],
+    color: [],
+    base_power: null,
+    base_toughness: null,
+    base_keywords: [],
+    base_color: [],
+    timestamp: 1,
+    entered_battlefield_turn: 1,
+  };
+}
+
+const learnChoice: WaitingFor = {
+  type: "LearnChoice",
+  data: { player: 0, hand_cards: [42, 43] },
+};
+
+function makeState(): GameState {
+  return {
+    turn_number: 1,
+    active_player: 0,
+    phase: "PreCombatMain",
+    players: [
+      { id: 0, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [42, 43], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+      { id: 1, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+    ],
+    priority_player: 0,
+    objects: {
+      42: makeHandCard(42, "Lightning Bolt"),
+      43: makeHandCard(43, "Counterspell"),
+    },
+    next_object_id: 100,
+    battlefield: [],
+    stack: [],
+    exile: [],
+    rng_seed: 1,
+    combat: null,
+    waiting_for: learnChoice,
+    has_pending_cast: false,
+    lands_played_this_turn: 0,
+    max_lands_per_turn: 1,
+    priority_pass_count: 0,
+    pending_replacement: null,
+    layers_dirty: false,
+    next_timestamp: 2,
+    eliminated_players: [],
+  } as unknown as GameState;
+}
+
+describe("LearnModal (via CardChoiceModal)", () => {
+  beforeEach(() => {
+    dispatchMock.mockClear();
+    useMultiplayerStore.setState({ activePlayerId: 0 });
+    useGameStore.setState({
+      gameMode: "online",
+      gameState: makeState(),
+      waitingFor: learnChoice,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders all hand cards offered for the learn rummage", () => {
+    render(<CardChoiceModal />);
+
+    expect(screen.getByRole("button", { name: "Lightning Bolt" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Counterspell" })).toBeInTheDocument();
+  });
+
+  it("keeps Discard & draw disabled until a card is selected, then dispatches Rummage", () => {
+    render(<CardChoiceModal />);
+
+    expect(screen.getByRole("button", { name: "Discard & draw" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Counterspell" }));
+    expect(screen.getByRole("button", { name: "Discard & draw" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard & draw" }));
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "LearnDecision",
+      data: { choice: { type: "Rummage", data: { card_id: 43 } } },
+    });
+  });
+
+  it("dispatches Skip when the player declines without selecting", () => {
+    render(<CardChoiceModal />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "LearnDecision",
+      data: { choice: { type: "Skip" } },
+    });
+  });
+
+  it("is registered as a handled waiting-for state (suppresses the orphan safety-net)", () => {
+    expect(isWaitingForHandled(learnChoice)).toBe(true);
+  });
+});

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -938,6 +938,12 @@
       "title": "Ringträger wählen",
       "subtitle": "Wähle eine Kreatur, die du kontrollierst"
     },
+    "learn": {
+      "title": "Learn",
+      "subtitle": "Discard a card to draw a card, or skip",
+      "labelRummage": "Discard & draw",
+      "labelSkip": "Skip"
+    },
     "reorderHint": "Zum Umsortieren ziehen · die oberste Karte wird zuerst gezogen",
     "scry": {
       "title": "Hellsicht",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -943,6 +943,12 @@
       "title": "Choose Ring-bearer",
       "subtitle": "Choose a creature you control"
     },
+    "learn": {
+      "title": "Learn",
+      "subtitle": "Discard a card to draw a card, or skip",
+      "labelRummage": "Discard & draw",
+      "labelSkip": "Skip"
+    },
     "reorderHint": "Drag to reorder · the top card is drawn first",
     "scry": {
       "title": "Scry",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -938,6 +938,12 @@
       "title": "Elegir Portador del Anillo",
       "subtitle": "Elige una criatura que controles"
     },
+    "learn": {
+      "title": "Learn",
+      "subtitle": "Discard a card to draw a card, or skip",
+      "labelRummage": "Discard & draw",
+      "labelSkip": "Skip"
+    },
     "reorderHint": "Arrastra para reordenar · la primera carta se roba antes",
     "scry": {
       "title": "Adivinar",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -938,6 +938,12 @@
       "title": "Choisir le porteur de l'Anneau",
       "subtitle": "Choisissez une créature que vous contrôlez"
     },
+    "learn": {
+      "title": "Learn",
+      "subtitle": "Discard a card to draw a card, or skip",
+      "labelRummage": "Discard & draw",
+      "labelSkip": "Skip"
+    },
     "reorderHint": "Glissez pour réorganiser · la première carte est piochée en premier",
     "scry": {
       "title": "Cartomancie",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -938,6 +938,12 @@
       "title": "Scegli il Portatore dell'Anello",
       "subtitle": "Scegli una creatura che controlli"
     },
+    "learn": {
+      "title": "Learn",
+      "subtitle": "Discard a card to draw a card, or skip",
+      "labelRummage": "Discard & draw",
+      "labelSkip": "Skip"
+    },
     "reorderHint": "Trascina per riordinare · la prima carta è pescata per prima",
     "scry": {
       "title": "Profetizzare",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -938,6 +938,12 @@
       "title": "Wybierz Nosiciela Pierścienia",
       "subtitle": "Wybierz stwora, którego kontrolujesz"
     },
+    "learn": {
+      "title": "Learn",
+      "subtitle": "Discard a card to draw a card, or skip",
+      "labelRummage": "Discard & draw",
+      "labelSkip": "Skip"
+    },
     "reorderHint": "Przeciągnij, aby zmienić kolejność · karta na wierzchu jest dobierana pierwsza",
     "scry": {
       "title": "Scry",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -938,6 +938,12 @@
       "title": "Escolher Portador do Anel",
       "subtitle": "Escolha uma criatura que você controla"
     },
+    "learn": {
+      "title": "Learn",
+      "subtitle": "Discard a card to draw a card, or skip",
+      "labelRummage": "Discard & draw",
+      "labelSkip": "Skip"
+    },
     "reorderHint": "Arraste para reordenar · a primeira carta é comprada primeiro",
     "scry": {
       "title": "Vidência",


### PR DESCRIPTION
WaitingFor::LearnChoice was in HANDLED_WAITING_FOR_TYPES (so the missing-handler
safety net was suppressed) but no modal rendered it and nothing dispatched
LearnDecision — a player reaching Learn got a silent hang. Add a LearnModal case
to CardChoiceModal that single-selects a hand card to discard-then-draw
(LearnDecision::Rummage) or Skip, plus cardChoice.learn.* i18n keys in all 7
locales. The Lesson-from-outside-the-game mode (CR 701.48a) is engine-deferred,
so only rummage/skip is rendered.
