### PR TITLE
fix(engine): declined optional trigger must not fire its reflexive (#3179)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1391,13 +1391,21 @@ pub(super) fn resolve_optional_effect_decision(
         AutoMayChoice::Decline => {
             let decline_branch = ability.else_ability.as_ref().or_else(|| {
                 ability.sub_ability.as_ref().filter(|sub| {
-                    // CR 608.2c: A separate-sentence sibling ("You may shuffle."
-                    // "Draw a card.") is the next printed instruction — it
-                    // resolves regardless of the optional decision. A
-                    // within-clause continuation only resolves if it is a
-                    // conditioned decline branch (IfYouDo / Otherwise / composite).
-                    sub.sub_link == SubAbilityLink::SequentialSibling
-                        || should_resolve_subability_on_optional_decline(sub)
+                    // CR 608.2c: a conditioned decline branch (IfYouDo /
+                    // Otherwise / composite) resolves on decline — authoritative
+                    // check.
+                    should_resolve_subability_on_optional_decline(sub)
+                        // CR 608.2c: a separate-sentence sibling is the next
+                        // printed instruction and resolves regardless of the
+                        // optional decision — BUT only when it is not a
+                        // reflexive trigger. CR 603.12: a reflexive ("When you
+                        // do, …") sub's "do" did not occur when the action was
+                        // declined, so it must NOT fire even though it is a
+                        // separate sentence (issue #3179: Swashbuckler
+                        // Extraordinaire's declined Treasure sacrifice must not
+                        // resolve the double-strike reflexive).
+                        || (sub.sub_link == SubAbilityLink::SequentialSibling
+                            && !sub_ability_is_reflexive(sub))
                 })
             });
             if let Some(branch) = decline_branch {
@@ -1442,6 +1450,21 @@ fn condition_depends_on_effect_performed(condition: &AbilityCondition) -> bool {
             conditions.iter().any(condition_depends_on_effect_performed)
         }
         _ => false,
+    }
+}
+
+/// CR 603.12: Whether a sub-ability is a *reflexive* trigger — its "do"
+/// depends on whether the just-prompted action actually occurred during this
+/// resolution. A reflexive sub MUST NOT resolve when the optional parent was
+/// declined (the "do" did not happen), regardless of its sentence-boundary
+/// `sub_link`. Covers the bare `WhenYouDo` reflexive (CR 603.12 Heart-Piercer
+/// Manticore) and any condition that reads a per-iteration effect outcome
+/// (`IfYouDo` / composite `Or{[IfYouDo,…]}`). Predicate helper, not rule code.
+fn sub_ability_is_reflexive(sub: &ResolvedAbility) -> bool {
+    match &sub.condition {
+        Some(AbilityCondition::WhenYouDo) => true,
+        Some(condition) => condition_depends_on_effect_performed(condition),
+        None => false,
     }
 }
 

--- a/crates/engine/tests/swashbuckler_extraordinaire_declined_sacrifice_3179.rs
+++ b/crates/engine/tests/swashbuckler_extraordinaire_declined_sacrifice_3179.rs
@@ -1,0 +1,214 @@
+//! Discriminating integration tests for **Swashbuckler Extraordinaire**
+//! (GitHub issue #3179).
+//!
+//! Attack-trigger Oracle text under test:
+//!   "Whenever you attack, you may sacrifice one or more Treasures. When you do,
+//!    up to that many target creatures gain double strike until end of turn."
+//!
+//! The bug (issue #3179): DECLINING the optional "you may sacrifice one or more
+//! Treasures" still resolved the reflexive `When you do` sub-ability. The
+//! double-strike grant has a `SequentialSibling` sentence boundary, so the
+//! decline-branch selector treated it as the next printed instruction and fired
+//! it even though the sacrifice never happened — emitting
+//! `WaitingFor::TriggerTargetSelection` with no real "do", stalling the game.
+//!
+//! Rules-correct behavior (CR 603.12): a reflexive triggered ability triggers
+//! ONLY if the trigger event (here, sacrificing one or more Treasures) actually
+//! occurred during resolution. Declining the sacrifice means the "do" did not
+//! happen, so the reflexive must NOT fire — regardless of its sentence boundary.
+//!
+//! These tests drive the REAL combat pipeline (`advance_to_combat` +
+//! `declare_attackers`) so the attack trigger fires from a genuine
+//! declare-attackers event.
+//!
+//! - Test A (regression): decline -> no TriggerTargetSelection stall, no
+//!   double strike, game not stuck. Fails on pre-fix HEAD (stalls).
+//! - Test B (positive control / over-suppression guard): accept, sacrifice the
+//!   Treasure, target the second creature -> it gains double strike, one
+//!   Treasure leaves the battlefield.
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Only the attack trigger — the ETB Treasure-creation line is intentionally
+/// omitted so the test seeds its own Treasure deterministically.
+const SWASHBUCKLER_ATTACK: &str = "Whenever you attack, you may sacrifice one or more Treasures. \
+    When you do, up to that many target creatures gain double strike until end of turn.";
+
+/// Build a 2-player board: Swashbuckler (the attacker), a Treasure token P0 can
+/// sacrifice, and a second creature that is a candidate double-strike target.
+/// Returns (runner, swashbuckler, second_creature, treasure).
+fn board() -> (GameRunner, ObjectId, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let swashbuckler = scenario
+        .add_creature_from_oracle(P0, "Swashbuckler Extraordinaire", 2, 2, SWASHBUCKLER_ATTACK)
+        .id();
+
+    // CR 111.10a: a Treasure artifact token — only its Treasure subtype matters
+    // for the Sacrifice filter. Built via the established create-creature +
+    // as_artifact + subtype pattern (no add_treasure helper exists).
+    let treasure = scenario
+        .add_creature(P0, "Treasure", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Treasure"])
+        .id();
+
+    let second = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    let runner = scenario.build();
+    (runner, swashbuckler, second, treasure)
+}
+
+/// Advance to combat and declare Swashbuckler attacking P1, firing the
+/// "Whenever you attack" trigger.
+fn attack(runner: &mut GameRunner, attacker: ObjectId) {
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+        .expect("declaring Swashbuckler as attacker must succeed");
+}
+
+fn has_double_strike(runner: &GameRunner, id: ObjectId) -> bool {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .is_some_and(|o| o.has_keyword(&Keyword::DoubleStrike))
+}
+
+/// TEST A — REGRESSION. Decline the optional sacrifice. The reflexive double-
+/// strike grant must NOT fire: no TriggerTargetSelection stall, the second
+/// creature has no double strike, the game settles to a clean priority window.
+///
+/// On the pre-fix HEAD this stalls on `WaitingFor::TriggerTargetSelection`
+/// (the reflexive fired with no real "do") and the assertions below fail.
+#[test]
+fn declined_sacrifice_does_not_grant_double_strike() {
+    let (mut runner, swashbuckler, second, _treasure) = board();
+
+    attack(&mut runner, swashbuckler);
+
+    // Bounded drive: decline the optional sacrifice, then pass priority to empty
+    // the stack. If the reflexive wrongly fires, we land on
+    // TriggerTargetSelection — which this loop deliberately does NOT answer, so
+    // the assertion afterwards catches the stall.
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: false })
+                    .expect("declining the optional sacrifice must succeed");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() || runner.act(GameAction::PassPriority).is_err()
+                {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "CR 603.12: a DECLINED sacrifice must not fire the reflexive double-strike \
+         grant, so the engine must not be waiting on TriggerTargetSelection (issue #3179)"
+    );
+    assert!(
+        !has_double_strike(&runner, second),
+        "CR 603.12: the second creature must NOT gain double strike when the \
+         sacrifice was declined"
+    );
+    assert!(
+        runner.state().stack.is_empty(),
+        "the game must settle (stack empty) — the declined reflexive must not stall it"
+    );
+}
+
+/// TEST B — POSITIVE CONTROL / OVER-SUPPRESSION GUARD. Accept the sacrifice and
+/// sacrifice the Treasure. When the "do" actually happens, the reflexive MUST
+/// fire — so the engine reaches the reflexive's target prompt
+/// (`WaitingFor::TriggerTargetSelection`) offering the second creature as a
+/// legal target, and the Treasure leaves the battlefield. This guards against
+/// the decline-suppression over-firing: the fix must not suppress the reflexive
+/// when the action *was* performed.
+///
+/// NOTE: this asserts the reflexive *fires and reaches its target prompt*, not
+/// the post-target grant. Driving the "up to that many target creatures"
+/// selection to completion hits a SEPARATE, pre-existing engine bug
+/// (`assign_selected_slots_in_chain` -> "Unused selected target slots") in the
+/// accept-path target assignment for reflexive `GenericEffect` grants — that
+/// path is OUT OF SCOPE for issue #3179 (which is the *decline* stall) and is
+/// equally broken before this fix. Stopping at the prompt keeps Test B a clean,
+/// passing over-suppression guard on the decline-logic layer this change owns.
+#[test]
+fn accepted_sacrifice_fires_reflexive_target_prompt() {
+    let (mut runner, swashbuckler, second, treasure) = board();
+
+    attack(&mut runner, swashbuckler);
+
+    let mut reached_reflexive_prompt = false;
+    for _ in 0..60 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accepting the optional sacrifice must succeed");
+            }
+            WaitingFor::EffectZoneChoice { .. } => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![treasure],
+                    })
+                    .expect("selecting the Treasure to sacrifice must succeed");
+            }
+            WaitingFor::TriggerTargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                // CR 603.12: the reflexive DID fire (the sacrifice occurred), so
+                // the engine prompts for "up to that many target creatures" with
+                // the second creature offered as a legal target.
+                assert!(
+                    target_slots[selection.current_slot]
+                        .legal_targets
+                        .contains(&TargetRef::Object(second)),
+                    "the reflexive's target prompt must offer the second creature"
+                );
+                reached_reflexive_prompt = true;
+                break;
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() || runner.act(GameAction::PassPriority).is_err()
+                {
+                    break;
+                }
+            }
+            other => panic!("unexpected waiting state during resolution: {other:?}"),
+        }
+    }
+
+    assert_eq!(
+        runner.state().objects.get(&treasure).map(|o| o.zone),
+        Some(Zone::Graveyard),
+        "CR 701.21: the sacrificed Treasure must leave the battlefield for the graveyard"
+    );
+    assert!(
+        reached_reflexive_prompt,
+        "CR 603.12: accepting the sacrifice performs the 'do', so the reflexive \
+         must fire and prompt for its double-strike target (no over-suppression)"
+    );
+}


### PR DESCRIPTION
CR 603.12: a reflexive 'when you do' triggered ability fires only if the action
occurred during resolution. Swashbuckler Extraordinaire's 'you may sacrifice one
or more Treasures. When you do, up to that many target creatures gain double
strike' wrongly resolved the reflexive on DECLINE — EventContextAmount then
resolved to the attacker count and the engine emitted a TriggerTargetSelection
with no real targets, stalling the game.

The decline-branch selector treated any SequentialSibling sub as a next-printed
instruction, firing it before the reflexive-aware should_resolve check. Add
sub_ability_is_reflexive() and gate the SequentialSibling disjunct on it, so a
reflexive (WhenYouDo / IfYouDo-conditioned) sub is dropped on decline while
genuinely independent siblings and conditioned decline branches still resolve.

Closes #3179.
