### PR TITLE
fix(engine): constrained library search must allow fail-to-find (#2722)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -941,9 +941,12 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             constraint,
             ..
         } => {
-            // CR 107.1c + CR 701.23d: "any number of" / "up to N" searches enumerate
-            // combination sizes 0..=count; exact-count searches enumerate only `count`.
-            let sizes: Vec<usize> = if *up_to {
+            // CR 701.23b/d: constrained (stated-quality) searches enumerate 0..=count
+            // so the legal-action set always contains the empty fail-to-find plus
+            // valid partials; pure-quantity exact-count searches enumerate only
+            // `count`. `combinations(_, 0)` returns `vec![vec![]]`, so the empty
+            // decline survives the constraint filter below.
+            let sizes: Vec<usize> = if *up_to || constraint.permits_partial_find() {
                 (0..=*count).collect()
             } else {
                 vec![*count]

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -5550,7 +5550,11 @@ mod tests {
     /// duplicate-named entry is collapsed to its canonical id before
     /// combinations are generated (a duplicate cannot legally appear in any
     /// chosen set with its twin), so a 5-card pool with one duplicate
-    /// collapses to 4 unique-name ids → C(4,2) = 6 combinations.
+    /// collapses to 4 unique-name ids. Because a stated-quality constraint
+    /// permits partial finds (CR 701.23b/d — a player may find fewer than the
+    /// stated number, including none), the enumeration covers every size
+    /// 0..=count, i.e. C(4,0)+C(4,1)+C(4,2) = 1+4+6 = 11 combinations — each of
+    /// which is still name-unique.
     #[test]
     fn search_choice_candidates_filter_distinct_names() {
         use crate::types::ability::{SearchSelectionConstraint, SharedQuality};
@@ -5589,9 +5593,10 @@ mod tests {
         );
 
         // With distinct names the engine pool cap collapses the duplicate
-        // Alpha to a single canonical id (5 → 4 ids), and the post-hoc
-        // selection-constraint filter then enumerates C(4,2) = 6 combos —
-        // every one of which contains two distinct names.
+        // Alpha to a single canonical id (5 → 4 ids). The constraint permits
+        // partial finds (CR 701.23b/d), so the enumeration covers sizes
+        // 0..=count = C(4,0)+C(4,1)+C(4,2) = 1+4+6 = 11 combos — every one of
+        // which is name-unique (no combo contains two cards sharing a name).
         state.waiting_for = WaitingFor::SearchChoice {
             player: PlayerId(0),
             cards: ids,
@@ -5606,8 +5611,9 @@ mod tests {
         let filtered = candidate_actions_broad(&state);
         assert_eq!(
             filtered.len(),
-            6,
-            "distinct names must collapse duplicate-named ids before enumeration"
+            11,
+            "distinct names collapse duplicate-named ids (5→4) before enumeration; \
+             partial finds permitted (CR 701.23b/d) so sizes 0..=2 → 1+4+6 = 11"
         );
         for action in &filtered {
             let GameAction::SelectCards { cards } = &action.action else {

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -337,12 +337,19 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
                 cards,
                 count,
                 up_to,
+                constraint,
                 ..
             },
             GameAction::SelectCards { cards: chosen },
         ) => {
-            let exact = if *up_to { None } else { Some(*count) };
-            selection_mismatch(chosen, cards, exact) || (*up_to && chosen.len() > *count)
+            // CR 701.23b vs CR 701.23d: a stated-quality search (MatchEachFilter,
+            // etc.) may legally find fewer cards than requested — including none.
+            // Mirror the submission guard / candidate generation lower bound so
+            // the validated legal-action path does not drop the legal short/empty
+            // fail-to-find candidate and freeze the AI.
+            let lower_bounded = *up_to || constraint.permits_partial_find();
+            let exact = if lower_bounded { None } else { Some(*count) };
+            selection_mismatch(chosen, cards, exact) || (lower_bounded && chosen.len() > *count)
         }
         (
             WaitingFor::ChooseFromZoneChoice {
@@ -2004,6 +2011,53 @@ mod tests {
         assert!(!cheap_reject_candidate(
             &state,
             &GameAction::SelectCards { cards: choices }
+        ));
+    }
+
+    #[test]
+    fn cheap_reject_candidate_permits_partial_constrained_search() {
+        // CR 701.23b: a stated-quality (MatchEachFilter) search may legally find
+        // fewer cards than requested — including none. The validated legal-action
+        // path must NOT cheap-reject a short/empty pick, or the AI freezes.
+        let mut state = GameState::new_two_player(42);
+        let choices = vec![ObjectId(1), ObjectId(2)];
+        state.waiting_for = WaitingFor::SearchChoice {
+            player: PlayerId(0),
+            cards: choices.clone(),
+            count: 2,
+            reveal: false,
+            up_to: false,
+            constraint: SearchSelectionConstraint::MatchEachFilter {
+                filters: vec![TargetFilter::Any, TargetFilter::Any],
+            },
+            split: None,
+        };
+
+        // Empty (full fail-to-find) is legal and must survive cheap-reject.
+        assert!(!cheap_reject_candidate(
+            &state,
+            &GameAction::SelectCards { cards: vec![] }
+        ));
+        // Partial pick (one of two) is legal and must survive cheap-reject.
+        assert!(!cheap_reject_candidate(
+            &state,
+            &GameAction::SelectCards {
+                cards: vec![choices[0]]
+            }
+        ));
+        // The full pick is still legal.
+        assert!(!cheap_reject_candidate(
+            &state,
+            &GameAction::SelectCards {
+                cards: choices.clone()
+            }
+        ));
+        // Over the requested count remains rejected.
+        assert!(cheap_reject_candidate(
+            &state,
+            &GameAction::SelectCards {
+                cards: vec![choices[0], choices[1], ObjectId(3)]
+            }
         ));
     }
 

--- a/crates/engine/src/game/effects/search_library.rs
+++ b/crates/engine/src/game/effects/search_library.rs
@@ -133,34 +133,45 @@ fn selection_matches_each_filter(
     chosen: &[crate::types::identifiers::ObjectId],
     filters: &[TargetFilter],
 ) -> bool {
-    if chosen.len() != filters.len() {
+    // CR 701.23b: stated-quality search may fail to find some or all cards.
+    // A short (or empty) selection is legal as long as every chosen card can
+    // claim a distinct, matching, unused filter slot — leftover slots stay
+    // unfilled. Over-selection (more cards than slots) is still illegal.
+    if chosen.len() > filters.len() {
         return false;
     }
-    let mut used = vec![false; chosen.len()];
-    assign_filter_slot(state, chosen, filters, &mut used, 0)
+    let mut used = vec![false; filters.len()];
+    assign_each_chosen_to_distinct_slot(state, chosen, filters, &mut used, 0)
 }
 
-fn assign_filter_slot(
+/// Card-anchored backtracking matcher: each chosen card must claim a distinct,
+/// matching, still-unused filter slot. Leftover slots may go unfilled — the
+/// fail-to-find case (CR 701.23b). Backtracking (not greedy) is
+/// required: for filters `[basic-or-Shrine, Shrine]` and chosen `[shrine, basic]`,
+/// a greedy first-match would bind shrine→slot0 then fail basic→slot1, falsely
+/// rejecting the legal assignment shrine→slot1, basic→slot0.
+fn assign_each_chosen_to_distinct_slot(
     state: &GameState,
     chosen: &[crate::types::identifiers::ObjectId],
     filters: &[TargetFilter],
     used: &mut [bool],
-    filter_idx: usize,
+    card_idx: usize,
 ) -> bool {
-    if filter_idx == filters.len() {
+    if card_idx == chosen.len() {
         return true;
     }
 
     let filter_ctx = FilterContext::neutral();
-    chosen.iter().enumerate().any(|(card_idx, card_id)| {
-        if used[card_idx]
-            || !matches_target_filter(state, *card_id, &filters[filter_idx], &filter_ctx)
+    let card_id = chosen[card_idx];
+    (0..filters.len()).any(|slot_idx| {
+        if used[slot_idx] || !matches_target_filter(state, card_id, &filters[slot_idx], &filter_ctx)
         {
             return false;
         }
-        used[card_idx] = true;
-        let matched = assign_filter_slot(state, chosen, filters, used, filter_idx + 1);
-        used[card_idx] = false;
+        used[slot_idx] = true;
+        let matched =
+            assign_each_chosen_to_distinct_slot(state, chosen, filters, used, card_idx + 1);
+        used[slot_idx] = false;
         matched
     })
 }
@@ -424,7 +435,9 @@ pub fn resolve(
 mod tests {
     use super::*;
     use crate::game::zones::create_object;
-    use crate::types::ability::{Comparator, FilterProp, QuantityExpr, QuantityRef, TypedFilter};
+    use crate::types::ability::{
+        Comparator, FilterProp, QuantityExpr, QuantityRef, TypeFilter, TypedFilter,
+    };
     use crate::types::card_type::CoreType;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::ManaCost;
@@ -1567,6 +1580,163 @@ mod tests {
             &[black_green, green, blue],
             &constraint
         ));
+    }
+
+    /// CR 701.23b: a stated-quality MatchEachFilter search may find FEWER cards
+    /// than there are filter slots — including none — when the library can't
+    /// supply one card per slot (Aang's Journey kicked: basic land + Shrine, but
+    /// the deck has no Shrine). Exercises the building-block legality authority
+    /// across the full short/over/distinct-slot range, including the overlapping-
+    /// filter backtracking case a greedy matcher silently breaks.
+    #[test]
+    fn match_each_filter_permits_partial_and_empty_fail_to_find() {
+        let mut state = GameState::new_two_player(42);
+
+        // A basic land and a Shrine enchantment in the library.
+        let basic = add_library_land(&mut state, 1, PlayerId(0), "Forest", true);
+        let shrine = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Honden".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&shrine).unwrap();
+            obj.card_types.core_types = vec![CoreType::Enchantment];
+            obj.card_types.subtypes.push("Shrine".to_string());
+        }
+
+        let basic_filter = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Land],
+            controller: None,
+            properties: vec![FilterProp::HasSupertype {
+                value: crate::types::card_type::Supertype::Basic,
+            }],
+        });
+        let shrine_filter = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Subtype("Shrine".to_string())],
+            controller: None,
+            properties: vec![],
+        });
+        let constraint = SearchSelectionConstraint::MatchEachFilter {
+            filters: vec![basic_filter.clone(), shrine_filter.clone()],
+        };
+
+        // Empty selection: always legal (full fail-to-find).
+        assert!(selection_satisfies_constraint(&state, &[], &constraint));
+
+        // Partial: a single basic fills the distinct basic slot, Shrine slot
+        // left unfilled — legal.
+        assert!(selection_satisfies_constraint(
+            &state,
+            &[basic],
+            &constraint
+        ));
+        // A single Shrine fills the Shrine slot — legal.
+        assert!(selection_satisfies_constraint(
+            &state,
+            &[shrine],
+            &constraint
+        ));
+
+        // Full selection still legal.
+        assert!(selection_satisfies_constraint(
+            &state,
+            &[basic, shrine],
+            &constraint
+        ));
+
+        // A card matching NO slot is illegal even as a singleton: a vanilla
+        // creature satisfies neither the basic-land nor the Shrine filter.
+        let creature = add_library_creature(&mut state, 3, PlayerId(0), "Bear");
+        assert!(!selection_satisfies_constraint(
+            &state,
+            &[creature],
+            &constraint
+        ));
+
+        // Over-selection: more cards than filter slots is illegal.
+        let basic2 = add_library_land(&mut state, 4, PlayerId(0), "Island", true);
+        assert!(!selection_satisfies_constraint(
+            &state,
+            &[basic, shrine, basic2],
+            &constraint
+        ));
+
+        // Two cards both matching only the same single slot is illegal: two
+        // basics against [basic, Shrine] cannot both claim the lone basic slot.
+        assert!(!selection_satisfies_constraint(
+            &state,
+            &[basic, basic2],
+            &constraint
+        ));
+    }
+
+    /// CR 701.23b: the card-anchored matcher MUST backtrack, not greedily bind
+    /// the first matching slot. For overlapping filters `[basic-or-Shrine, Shrine]`
+    /// and chosen `[shrine, basic]`, a greedy matcher binds shrine→slot0 then
+    /// fails basic→slot1 (Shrine-only), falsely rejecting the legal assignment
+    /// shrine→slot1, basic→slot0. This case is the regression sentinel for a
+    /// greedy rewrite.
+    #[test]
+    fn match_each_filter_backtracks_on_overlapping_slots() {
+        let mut state = GameState::new_two_player(42);
+        let basic = add_library_land(&mut state, 1, PlayerId(0), "Forest", true);
+        let shrine = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Honden".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&shrine).unwrap();
+            obj.card_types.core_types = vec![CoreType::Enchantment];
+            obj.card_types.subtypes.push("Shrine".to_string());
+        }
+
+        // slot0 matches a basic land OR a Shrine; slot1 matches only a Shrine.
+        let basic_or_shrine = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::AnyOf(vec![
+                TypeFilter::Land,
+                TypeFilter::Subtype("Shrine".to_string()),
+            ])],
+            controller: None,
+            properties: vec![],
+        });
+        let shrine_only = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Subtype("Shrine".to_string())],
+            controller: None,
+            properties: vec![],
+        });
+        let constraint = SearchSelectionConstraint::MatchEachFilter {
+            filters: vec![basic_or_shrine, shrine_only],
+        };
+
+        // Chosen order [shrine, basic]: only the backtracking assignment
+        // (shrine→slot1, basic→slot0) is valid. A greedy first-match returns
+        // false here.
+        assert!(selection_satisfies_constraint(
+            &state,
+            &[shrine, basic],
+            &constraint
+        ));
+    }
+
+    /// CR 701.23d: a pure-quantity (`None`) search is unaffected by the partial-
+    /// find relaxation — any size remains legal there, as before, because the
+    /// count bound is enforced separately at the submission guard.
+    #[test]
+    fn none_constraint_unaffected_by_partial_find_relaxation() {
+        let mut state = GameState::new_two_player(42);
+        let a = add_library_creature(&mut state, 1, PlayerId(0), "A");
+        let b = add_library_creature(&mut state, 2, PlayerId(0), "B");
+        let constraint = SearchSelectionConstraint::None;
+        assert!(selection_satisfies_constraint(&state, &[], &constraint));
+        assert!(selection_satisfies_constraint(&state, &[a], &constraint));
+        assert!(selection_satisfies_constraint(&state, &[a, b], &constraint));
+        assert!(!constraint.permits_partial_find());
     }
 
     /// CR 107.3a + CR 601.2b: Nature's Rhythm — search for a creature card with mana

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1651,8 +1651,13 @@ pub(super) fn handle_resolution_choice(
             },
             GameAction::SelectCards { cards: chosen },
         ) => {
-            // CR 107.1c + CR 701.23d: "up to N" / "any number of" accept 0..=count picks.
-            let valid = if up_to {
+            // CR 701.23b/d: "up to N" OR a stated-quality constraint accepts a
+            // short/empty pick (fail-to-find); a pure quantity search needs
+            // exactly `count`. The subsequent `selection_satisfies_constraint`
+            // re-check validates the distinct-slot consistency of whatever was
+            // chosen, so widening the count bound here is safe.
+            let lower_bounded = up_to || constraint.permits_partial_find();
+            let valid = if lower_bounded {
                 chosen.len() <= count
             } else {
                 chosen.len() == count
@@ -1660,7 +1665,7 @@ pub(super) fn handle_resolution_choice(
             if !valid {
                 return Err(EngineError::InvalidAction(format!(
                     "Must select {}{} card(s), got {}",
-                    if up_to { "up to " } else { "exactly " },
+                    if lower_bounded { "up to " } else { "exactly " },
                     count,
                     chosen.len()
                 )));

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -109,6 +109,16 @@ pub enum SearchSelectionConstraint {
     MatchEachFilter { filters: Vec<TargetFilter> },
 }
 
+impl SearchSelectionConstraint {
+    /// CR 701.23b vs CR 701.23d: a *stated-quality* search (any constrained
+    /// variant) may find fewer cards than requested — including none. A pure
+    /// *quantity* search (`None`) must find as many as possible. Drives the
+    /// SearchChoice lower bound in the submission guard and AI candidate gen.
+    pub fn permits_partial_find(&self) -> bool {
+        !matches!(self, SearchSelectionConstraint::None)
+    }
+}
+
 /// CR 400.11 + CR 406.3: Candidate pool for outside-game searches. The
 /// baseline pool is the player's sideboard; Karn/Coax-class text widens that
 /// pool to include owned face-up exile cards that match the same filter.

--- a/crates/engine/tests/aang_journey_partial_fail_to_find_2722.rs
+++ b/crates/engine/tests/aang_journey_partial_fail_to_find_2722.rs
@@ -1,0 +1,288 @@
+//! Regression (issue #2722): a `MatchEachFilter` library search must not
+//! DEADLOCK (game freeze) when the library can't supply one card per filter
+//! slot.
+//!
+//! Aang's Journey, kicked, searches the library for "a basic land card and a
+//! Shrine card". A deck with basics but NO Shrine cannot fill the Shrine slot.
+//! Pre-fix, the `SearchChoice` submission guard required EXACTLY `count` cards
+//! satisfying `MatchEachFilter`, and the AI candidate generator only enumerated
+//! `count`-sized combinations — so against a no-Shrine library every candidate
+//! was filtered out, the legal-action set was EMPTY, and the game froze with no
+//! submittable action.
+//!
+//! CR 701.23b: when searching a hidden zone for cards with a stated quality, a
+//! player "isn't required to find some or all of those cards even if they're
+//! present" — a stated-quality search may ALWAYS fail to find some or all of the
+//! described cards (CR 701.23b), distinct from a pure-quantity search which must
+//! find as many as possible (CR 701.23d).
+//!
+//! This drives the REAL pipeline: `search_library::resolve` parks the live
+//! `WaitingFor::SearchChoice`, the AI candidate enumerator (`candidate_actions_
+//! broad`) must return a non-empty legal-action set, and the real engine
+//! submission handler (`apply_as_current` → `engine_resolution_choices`) accepts
+//! both a single-basic partial pick and the empty full-fail-to-find. The
+//! `SearchLibrary → ChangeZone(Hand) → Shuffle` continuation moves the found
+//! card to hand and shuffles, mirroring the real card's resolution chain.
+//!
+//! This is NOT an AST-shape test. Pre-fix it fails at the `candidate_actions_
+//! broad` non-empty assertion (empty legal-action set == freeze) and at the
+//! submission `.expect(...)` (the guard rejects the short pick).
+
+use engine::ai_support::candidate_actions_broad;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    Effect, FilterProp, QuantityExpr, ResolvedAbility, SearchSelectionConstraint, TargetFilter,
+    TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::{CoreType, Supertype};
+use engine::types::events::{GameEvent, PlayerActionKind};
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+/// A basic land in P0's library.
+fn add_basic_land(state: &mut GameState, card: u64, name: &str) -> ObjectId {
+    let id = create_object(state, CardId(card), P0, name.to_string(), Zone::Library);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Land];
+    obj.card_types.supertypes.push(Supertype::Basic);
+    id
+}
+
+/// The kicked Aang's-Journey search: find one basic land AND one Shrine, then
+/// move the found card(s) to hand and shuffle. `count: 2` (two filter slots).
+fn aangs_journey_search(source: ObjectId) -> ResolvedAbility {
+    let basic_filter = TargetFilter::Typed(TypedFilter {
+        type_filters: vec![TypeFilter::Land],
+        controller: None,
+        properties: vec![FilterProp::HasSupertype {
+            value: Supertype::Basic,
+        }],
+    });
+    let shrine_filter = TargetFilter::Typed(TypedFilter {
+        type_filters: vec![TypeFilter::Subtype("Shrine".to_string())],
+        controller: None,
+        properties: vec![],
+    });
+
+    // Continuation link 2: shuffle the searcher's library.
+    let shuffle = ResolvedAbility::new(
+        Effect::Shuffle {
+            target: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    // Continuation link 1: move the found card(s) to hand.
+    let mut to_hand = ResolvedAbility::new(
+        Effect::ChangeZone {
+            origin: Some(Zone::Library),
+            destination: Zone::Hand,
+            target: TargetFilter::Any,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: Default::default(),
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            face_down_profile: None,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    to_hand.sub_ability = Some(Box::new(shuffle));
+
+    // Head: search for [basic, Shrine].
+    let mut search = ResolvedAbility::new(
+        Effect::SearchLibrary {
+            filter: TargetFilter::Any,
+            count: QuantityExpr::Fixed { value: 2 },
+            reveal: false,
+            target_player: None,
+            selection_constraint: SearchSelectionConstraint::MatchEachFilter {
+                filters: vec![basic_filter, shrine_filter],
+            },
+            split: None,
+            source_zones: vec![Zone::Library],
+        },
+        vec![],
+        source,
+        P0,
+    );
+    search.sub_ability = Some(Box::new(to_hand));
+    search
+}
+
+/// Build a no-Shrine library: three basics. Returns (state, source, basics).
+fn setup_no_shrine_library() -> (GameState, ObjectId, Vec<ObjectId>) {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = P0;
+
+    let source = create_object(
+        &mut state,
+        CardId(99),
+        P0,
+        "Aang's Journey".to_string(),
+        Zone::Battlefield,
+    );
+
+    // No Shrine in the deck — only basics, so the Shrine slot can never fill.
+    let basics = vec![
+        add_basic_land(&mut state, 1, "Forest"),
+        add_basic_land(&mut state, 2, "Island"),
+        add_basic_land(&mut state, 3, "Mountain"),
+    ];
+
+    (state, source, basics)
+}
+
+/// CR 701.23b: a kicked Aang's-Journey search against a no-Shrine library must
+/// NOT freeze. The live SearchChoice must offer a non-empty legal-action set
+/// (the empty fail-to-find decline plus single-basic partial picks), and the
+/// real submission handler must accept a single-basic pick — moving that basic
+/// to hand and shuffling.
+#[test]
+fn match_each_filter_partial_find_does_not_freeze_and_submits_partial() {
+    let (mut state, source, basics) = setup_no_shrine_library();
+    let forest = basics[0];
+    let ability = aangs_journey_search(source);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).expect("search resolves");
+
+    // The search parks at a SearchChoice over the three basics (the matching
+    // candidate set). Pre-fix this state is unsubmittable.
+    let WaitingFor::SearchChoice { cards, count, .. } = &state.waiting_for else {
+        panic!("expected SearchChoice, got {:?}", state.waiting_for);
+    };
+    assert_eq!(*count, 2, "two filter slots → count 2");
+    assert_eq!(
+        cards.len(),
+        3,
+        "all three basics match the search filter union"
+    );
+
+    // CR 701.23b: the legal-action set must be NON-EMPTY (anti-freeze). Pre-fix
+    // it is empty because every count-sized combination of basics fails the
+    // MatchEachFilter constraint (no Shrine for slot 2).
+    let candidates = candidate_actions_broad(&state);
+    assert!(
+        !candidates.is_empty(),
+        "deadlock: the SearchChoice produced no legal actions (game freeze)"
+    );
+
+    // The empty fail-to-find decline must be among the legal actions.
+    assert!(
+        candidates
+            .iter()
+            .any(|c| matches!(&c.action, GameAction::SelectCards { cards } if cards.is_empty())),
+        "the empty fail-to-find decline must be a legal action"
+    );
+    // A single-basic partial pick must be among the legal actions.
+    assert!(
+        candidates.iter().any(|c| matches!(
+            &c.action,
+            GameAction::SelectCards { cards } if cards.len() == 1 && basics.contains(&cards[0])
+        )),
+        "a single-basic partial pick must be a legal action"
+    );
+
+    // CR 701.23b — AI-VALIDATED path (issue #2722 Finding 1). The broad
+    // enumerator above bypasses `cheap_reject_candidate`; the AI actually
+    // consumes `validated_candidate_actions` (FilterPipeline →
+    // BasicLegalityFilter → cheap_reject_candidate). If the SearchChoice
+    // cheap-reject arm uses up_to-only logic, it rejects the legal empty/partial
+    // pick → the validated set is EMPTY → the AI freezes at the same
+    // SearchChoice. This assertion FAILS pre-Finding-1-fix and PASSES after.
+    let validated = engine::ai_support::validated_candidate_actions(&state);
+    assert!(
+        !validated.is_empty(),
+        "deadlock: the AI-validated legal-action set is empty (game freeze)"
+    );
+    assert!(
+        validated
+            .iter()
+            .any(|c| matches!(&c.action, GameAction::SelectCards { cards } if cards.is_empty())),
+        "the empty fail-to-find decline must survive the AI-validated pipeline"
+    );
+
+    // Submit a single-basic pick through the REAL submission handler.
+    let result = engine::game::apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: vec![forest],
+        },
+    )
+    .expect("submitting a single-basic partial pick must succeed (fail-to-find for the Shrine)");
+
+    // The continuation moved the Forest to hand and shuffled the library.
+    assert_eq!(
+        state.objects[&forest].zone,
+        Zone::Hand,
+        "the found basic must move to hand"
+    );
+    assert!(
+        !state.players[0].library.contains(&forest),
+        "the found basic must leave the library"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            GameEvent::PlayerPerformedAction {
+                action: PlayerActionKind::ShuffledLibrary,
+                ..
+            }
+        )),
+        "the library must be shuffled after the search"
+    );
+}
+
+/// CR 701.23b: the FULL fail-to-find (empty selection) is also legal and
+/// completes — the searcher finds neither described card, then shuffles.
+#[test]
+fn match_each_filter_full_fail_to_find_empty_selection_completes() {
+    let (mut state, source, _basics) = setup_no_shrine_library();
+    let ability = aangs_journey_search(source);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).expect("search resolves");
+    assert!(
+        matches!(state.waiting_for, WaitingFor::SearchChoice { .. }),
+        "expected SearchChoice, got {:?}",
+        state.waiting_for
+    );
+
+    // Submit the empty fail-to-find through the REAL submission handler.
+    let result =
+        engine::game::apply_as_current(&mut state, GameAction::SelectCards { cards: vec![] })
+            .expect("submitting the empty full fail-to-find must succeed");
+
+    // No card left the library, but the library was still shuffled.
+    assert_eq!(
+        state.players[0].library.len(),
+        3,
+        "no card is found, so all three basics remain in the library"
+    );
+    assert!(
+        result.events.iter().any(|e| matches!(
+            e,
+            GameEvent::PlayerPerformedAction {
+                action: PlayerActionKind::ShuffledLibrary,
+                ..
+            }
+        )),
+        "the library must be shuffled even on a full fail-to-find"
+    );
+    assert!(
+        !matches!(state.waiting_for, WaitingFor::SearchChoice { .. }),
+        "the search must have completed (no lingering SearchChoice)"
+    );
+}


### PR DESCRIPTION
CR 701.23b: a player searching a hidden zone for cards with a stated quality is
never required to find them. A MatchEachFilter search (e.g. Aang's Journey kicked
= 'a basic land card and a Shrine card') deadlocked whenever the library could
not supply one card per filter slot: the Or-filter still matched (so the empty
fail-to-find escape was skipped), but selection_matches_each_filter required one
card per slot, so every candidate was rejected and the legal-action set was empty
— a freeze. Affects ~11 MatchEachFilter cards.

Allow partial and empty selections for constrained stated-quality searches:
- selection_matches_each_filter -> card-anchored backtracking matcher: each
  chosen card claims a distinct matching slot, leftover slots may go unfound,
  empty is legal, over-selection rejected.
- SearchSelectionConstraint::permits_partial_find() (false only for None, the
  pure-quantity CR 701.23d case which must still find as many as possible).
- Submission guard, raw candidate enumerator (0..=count), and the AI
  cheap_reject_candidate validated path all lower-bound on
  up_to || permits_partial_find(), so every consumer offers the fail-to-find.

Closes #2722.
