### PR TITLE
feat(client): flex layout edit mode — drag widgets, resize zones, scale, presets

### DIFF
--- a/client/src/components/board/BattlefieldZoneOverflow.tsx
+++ b/client/src/components/board/BattlefieldZoneOverflow.tsx
@@ -9,6 +9,7 @@ import { ManaSymbol } from "../mana/ManaSymbol.tsx";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import type { GroupedPermanent } from "../../viewmodel/battlefieldProps.ts";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
@@ -281,6 +282,10 @@ interface ZoneSummaryTileProps {
 function ZoneSummaryTile({ groups, objectIds, zone, onOpen }: ZoneSummaryTileProps) {
   const { t } = useTranslation("game");
   const gameState = useGameStore((s) => s.gameState);
+  // Aspect-preserving size multiplier for the collapsed overflow pill (absent ⇒
+  // 1). Anchored to the column's outer edge so it grows toward the central
+  // corridor rather than off-screen: lands hug the left, support the right.
+  const summaryScale = usePreferencesStore((s) => s.flexLayout.scales?.summaryTile) ?? 1;
   const selectedAttackers = useUiStore((s) => s.selectedAttackers);
   const blockerAssignments = useUiStore((s) => s.blockerAssignments);
   const selectedCardIds = useUiStore((s) => s.selectedCardIds);
@@ -395,6 +400,14 @@ function ZoneSummaryTile({ groups, objectIds, zone, onOpen }: ZoneSummaryTilePro
       type="button"
       onClick={onOpen}
       data-grouped-ids={objectIds.join(" ")}
+      style={
+        summaryScale !== 1
+          ? {
+              transform: `scale(${summaryScale})`,
+              transformOrigin: zone === "support" ? "right center" : "left center",
+            }
+          : undefined
+      }
       className={`relative flex min-h-[3.25rem] min-w-[7.5rem] max-w-full flex-col justify-center rounded-lg border px-2 py-1.5 text-left shadow-[0_10px_24px_rgba(0,0,0,0.28)] backdrop-blur-md transition hover:border-white/30 hover:bg-slate-900/80 ${
         hasInteraction
           ? "border-cyan-300/60 bg-cyan-950/45 ring-1 ring-cyan-300/40"

--- a/client/src/components/board/BoardContextMenu.tsx
+++ b/client/src/components/board/BoardContextMenu.tsx
@@ -6,6 +6,7 @@ interface BoardContextMenuProps {
   y: number;
   onClose: () => void;
   onChangeBackground: () => void;
+  onCustomizeLayout: () => void;
   onToggleGameLog: () => void;
   onToggleDebugLog: () => void;
 }
@@ -15,6 +16,7 @@ export function BoardContextMenu({
   y,
   onClose,
   onChangeBackground,
+  onCustomizeLayout,
   onToggleGameLog,
   onToggleDebugLog,
 }: BoardContextMenuProps) {
@@ -65,6 +67,14 @@ export function BoardContextMenu({
         label={t("board.changeBackground")}
         onClick={() => {
           onChangeBackground();
+          onClose();
+        }}
+      />
+      <MenuItem
+        label={t("board.customizeLayout")}
+        shortcut="Ctrl+Shift+L"
+        onClick={() => {
+          onCustomizeLayout();
           onClose();
         }}
       />

--- a/client/src/components/board/GameBoard.tsx
+++ b/client/src/components/board/GameBoard.tsx
@@ -16,6 +16,7 @@ import {
 import { BoardInteractionContext } from "./BoardInteractionContext.tsx";
 import { CombatLine } from "./CombatLine.tsx";
 import { PlayerArea } from "./PlayerArea.tsx";
+import { DraggableWidget } from "../flexlayout/DraggableWidget.tsx";
 
 interface GameBoardProps {
   oppHud?: React.ReactNode;
@@ -242,8 +243,17 @@ export const GameBoard = memo(function GameBoard({ oppHud, playerHud }: GameBoar
           )
         ) : (
           <div className="flex min-h-0 flex-1 flex-col">
-            {/* Keep opponent controls above overflowing command-zone cards. */}
-            <div className="relative z-40 shrink-0">{oppHud}</div>
+            {/* Keep opponent controls above overflowing command-zone cards.
+                The multiplayer opponent HUD is the table-size-keyed widget —
+                repositioning it stores under the "multiplayer" slot, distinct
+                from the 1v1 opponent HUD (wired in PlayerArea). */}
+            <DraggableWidget
+              target={{ kind: "opponentHud", tableSize: "multiplayer" }}
+              flexZone="opponentHud"
+              className="relative z-40 shrink-0"
+            >
+              {oppHud}
+            </DraggableWidget>
             {focusedId != null ? (
               <PlayerArea
                 battlefieldView={focusedBattlefieldView ?? undefined}

--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import type { PlayerId } from "../../adapter/types.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { usePreferencesStore, DEFAULT_LAND_SUPPORT_RATIO } from "../../stores/preferencesStore.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import type { GroupedPermanent } from "../../viewmodel/battlefieldProps.ts";
 import type { PlayerBattlefieldView } from "../../viewmodel/gameStateView.ts";
@@ -10,6 +11,8 @@ import { BattlefieldRow } from "./BattlefieldRow.tsx";
 import { BattlefieldZoneOverflow } from "./BattlefieldZoneOverflow.tsx";
 import { CompactStrip } from "./CompactStrip.tsx";
 import { CommandDock } from "../zone/CommandDock.tsx";
+import { DraggableWidget } from "../flexlayout/DraggableWidget.tsx";
+import type { DraggableTarget } from "../../hooks/useDraggableWidget.ts";
 
 /** Base scales — used when few cards; shrinks as more are added.
  *  On compact-height (landscape phones), lands shrink hard so creatures
@@ -69,6 +72,10 @@ export function PlayerArea({
   const { t } = useTranslation("game");
   const gameState = useGameStore((s) => s.gameState);
   const isCompactHeight = useIsCompactHeight();
+  // Lands↔support split (lands' share of the middle row). One global ratio,
+  // applied symmetrically to every player area; absent ⇒ even halves.
+  const landSupportRatio =
+    usePreferencesStore((s) => s.flexLayout.landSupportRatio) ?? DEFAULT_LAND_SUPPORT_RATIO;
   // Combined support cluster: artifacts/enchantments then planeswalkers, in ONE
   // wrapping row (like the lands column) so it stays a single line until crowded.
   // Keeping it one row keeps the middle-row band ~one card tall so the flex-1
@@ -99,6 +106,10 @@ export function PlayerArea({
   // the same visual treatment as elimination for consistency.
   const isPhasedOut = player?.status?.type === "PhasedOut";
   const isMirrored = mode === "focused";
+  // The viewer's own area (mode "full"). Only this area exposes the lands↔support
+  // boundary markers so the editor grabs a single, predictable divider — the
+  // ratio it sets is global, so every area reflows in step.
+  const isOwnArea = mode === "full";
   const partitioned = battlefieldView;
 
   const creatures = creatureOverride ?? partitioned?.creatures ?? [];
@@ -134,8 +145,11 @@ export function PlayerArea({
     <div className="flex min-h-0 min-w-0 items-stretch justify-between gap-2" data-debug-label="Middle Row">
       <div
         className={`z-10 flex min-w-0 basis-0 flex-1 gap-2 pl-2 ${landAlignClass}`}
-        style={landStyle}
+        // `flexGrow` overrides `flex-1`'s grow so the lands/support boundary
+        // sits at the stored ratio; shrink/basis from `flex-1` are unchanged.
+        style={{ ...landStyle, flexGrow: landSupportRatio }}
         data-debug-label="Lands"
+        data-flex-zone={isOwnArea ? "lands-col" : undefined}
       >
         <BattlefieldZoneOverflow
           groups={partitioned?.lands ?? []}
@@ -151,8 +165,9 @@ export function PlayerArea({
           separates the two sub-clusters without stacking them onto a second row. */}
       <div
         className={`z-10 flex min-w-0 basis-0 flex-1 gap-2 ${supportAlignClass}`}
-        style={supportStyle}
+        style={{ ...supportStyle, flexGrow: 1 - landSupportRatio }}
         data-debug-label="Support"
+        data-flex-zone={isOwnArea ? "support-col" : undefined}
       >
         <BattlefieldZoneOverflow
           groups={supportGroups}
@@ -188,12 +203,26 @@ export function PlayerArea({
   // just above its middle row. z-20 keeps it
   // above resting cards (lands/support are z-10) but below a hovered card
   // (PermanentCard lifts to z-60), so a card slides over the HUD on hover.
+  // The player's own HUD is a shared-global widget; a HUD in `focused` mode is
+  // the 1v1 opponent (multiplayer routes its opponent HUD through GameBoard
+  // instead), keyed by the "oneVsOne" table size.
+  const hudTarget: DraggableTarget =
+    mode === "full"
+      ? { kind: "widget", key: "playerHud" }
+      : { kind: "opponentHud", tableSize: "oneVsOne" };
   const hudBand = hud ? (
     <div
       className={`absolute left-1/2 z-20 -translate-x-1/2 ${isMirrored ? "bottom-[130%] translate-y-full" : "top-[165%] -translate-y-full"}`}
       data-debug-label="HUD"
     >
-      {hud}
+      {/* Inner node owns the drag offset so the outer `-translate-x-1/2`
+          centering transform is never clobbered. */}
+      <DraggableWidget
+        target={hudTarget}
+        flexZone={mode === "full" ? "playerHud" : "opponentHud"}
+      >
+        {hud}
+      </DraggableWidget>
     </div>
   ) : null;
 

--- a/client/src/components/flexlayout/ColumnSplitter.tsx
+++ b/client/src/components/flexlayout/ColumnSplitter.tsx
@@ -1,0 +1,56 @@
+import { usePreferencesStore } from "../../stores/preferencesStore.ts";
+import { ratioFromPointerX } from "./gridBandMath.ts";
+
+interface ColumnSplitterProps {
+  /** Viewport X (px) of the lands↔support boundary this grabber straddles. */
+  x: number;
+  /** Viewport Y (px) of the top of the middle row the boundary spans. */
+  top: number;
+  /** Height (px) of the middle row, so the grabber matches the columns' extent. */
+  height: number;
+  /** Left/right viewport bounds of the combined two-column region — the fixed
+   *  outer edges the boundary slides between (lands.left / support.right). */
+  left: number;
+  right: number;
+}
+
+/**
+ * A thin vertical grabber on the lands↔support boundary. Dragging it sets the
+ * global `landSupportRatio` (lands' share of the row) from the pointer's
+ * absolute X via {@link ratioFromPointerX}; the support column takes the
+ * remainder. Positioned by {@link FlexEditOverlay} at the measured boundary, so
+ * it never needs to know the column geometry itself. The store clamps the ratio
+ * so neither column can starve.
+ */
+export function ColumnSplitter({ x, top, height, left, right }: ColumnSplitterProps) {
+  const setFlexLandSupportRatio = usePreferencesStore((s) => s.setFlexLandSupportRatio);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    // Only while a pointer is captured (a button is held during the drag).
+    if (e.buttons === 0) return;
+    setFlexLandSupportRatio(ratioFromPointerX(e.clientX, left, right));
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    (e.target as HTMLElement).releasePointerCapture?.(e.pointerId);
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      data-flex-splitter="lands-support"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      className="fixed z-[71] flex w-4 -translate-x-1/2 cursor-col-resize items-center justify-center"
+      style={{ left: x, top, height }}
+    >
+      <span className="h-16 w-1 rounded-full bg-sky-400/80 shadow-[0_0_8px_2px_rgba(56,189,248,0.6)]" />
+    </div>
+  );
+}

--- a/client/src/components/flexlayout/DraggableWidget.tsx
+++ b/client/src/components/flexlayout/DraggableWidget.tsx
@@ -1,0 +1,62 @@
+import { motion } from "framer-motion";
+
+import {
+  useDraggableWidget,
+  type DraggableTarget,
+} from "../../hooks/useDraggableWidget.ts";
+
+interface DraggableWidgetProps {
+  /** What this wrapper repositions (a shared widget, or the table-size-keyed
+   *  opponent HUD). */
+  target: DraggableTarget;
+  /** `data-flex-zone` value so {@link FlexEditOverlay} can anchor its outline. */
+  flexZone: string;
+  className?: string;
+  /** Positioning style carried from the original node (e.g. a zone rail's
+   *  CSS-var style). Merged under the motion `x`/`y` so the drag offset wins. */
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps a board widget's content in a Framer Motion node that applies its
+ * persisted offset at all times and becomes draggable in Flex Layout edit mode.
+ * This is the single integration point every call site uses — wrap the widget's
+ * CONTENT (not its positioned outer node), so an existing transform on the outer
+ * node (e.g. a HUD's `-translate-x-1/2`) is never clobbered.
+ */
+export function DraggableWidget({
+  target,
+  flexZone,
+  className,
+  style,
+  children,
+}: DraggableWidgetProps) {
+  const {
+    ref,
+    style: motionStyle,
+    drag,
+    dragMomentum,
+    dragElastic,
+    onDragEnd,
+    onClickCapture,
+  } = useDraggableWidget(target);
+  return (
+    <motion.div
+      ref={ref}
+      data-flex-zone={flexZone}
+      drag={drag}
+      dragMomentum={dragMomentum}
+      dragElastic={dragElastic}
+      onDragEnd={onDragEnd}
+      onClickCapture={onClickCapture}
+      // In edit mode force the node grabbable even if its normal className is
+      // `pointer-events-none` (e.g. a zone rail whose dead space must not block
+      // the board during play). Outside edit mode, defer to the className.
+      style={{ ...style, ...motionStyle, pointerEvents: drag ? "auto" : undefined }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/client/src/components/flexlayout/FlexEditOverlay.tsx
+++ b/client/src/components/flexlayout/FlexEditOverlay.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { useUiStore } from "../../stores/uiStore.ts";
+import { usePreferencesStore } from "../../stores/preferencesStore.ts";
+import { FLEX_PRESETS } from "./presets.ts";
+import { ZoneSplitter } from "./ZoneSplitter.tsx";
+import { ColumnSplitter } from "./ColumnSplitter.tsx";
+
+/** Widget zones the overlay outlines + labels (the `data-flex-zone` values that
+ *  map to a `settings:flexLayout.zones.*` key). The two board rows used only for
+ *  splitter placement ("opp-row"/"player-row") are intentionally excluded. */
+const LABELLED_ZONES = new Set([
+  "playerHud",
+  "opponentHud",
+  "stackPanel",
+  "logPanel",
+  "actionRail",
+  "playerPiles",
+  "opponentPiles",
+]);
+
+interface ZoneRect {
+  key: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** The lands↔support boundary the vertical {@link ColumnSplitter} straddles:
+ *  `x` is the current boundary, `left`/`right` the fixed outer edges of the
+ *  two-column region (lands.left / support.right). Null when the viewer's middle
+ *  row isn't measurable (no own-area columns rendered). */
+interface ColumnBoundary {
+  x: number;
+  top: number;
+  height: number;
+  left: number;
+  right: number;
+}
+
+interface Measured {
+  topBoundary: number | null;
+  bottomBoundary: number | null;
+  columnBoundary: ColumnBoundary | null;
+  zones: ZoneRect[];
+}
+
+const EMPTY: Measured = {
+  topBoundary: null,
+  bottomBoundary: null,
+  columnBoundary: null,
+  zones: [],
+};
+
+/** Read the live `data-flex-zone` element rects from the DOM. */
+function measure(): Measured {
+  const oppRow = document.querySelector('[data-flex-zone="opp-row"]');
+  const playerRow = document.querySelector('[data-flex-zone="player-row"]');
+  const landsCol = document.querySelector('[data-flex-zone="lands-col"]');
+  const supportCol = document.querySelector('[data-flex-zone="support-col"]');
+  const zones: ZoneRect[] = [];
+  for (const el of document.querySelectorAll<HTMLElement>("[data-flex-zone]")) {
+    const key = el.dataset.flexZone ?? "";
+    if (!LABELLED_ZONES.has(key)) continue;
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) continue; // not currently rendered
+    zones.push({ key, left: r.left, top: r.top, width: r.width, height: r.height });
+  }
+  let columnBoundary: ColumnBoundary | null = null;
+  if (landsCol && supportCol) {
+    const l = landsCol.getBoundingClientRect();
+    const s = supportCol.getBoundingClientRect();
+    if (l.width > 0 && s.width > 0) {
+      columnBoundary = {
+        x: (l.right + s.left) / 2, // midpoint of the gap between the columns
+        top: l.top,
+        height: l.height,
+        left: l.left,
+        right: s.right,
+      };
+    }
+  }
+  return {
+    topBoundary: oppRow ? oppRow.getBoundingClientRect().bottom : null,
+    bottomBoundary: playerRow ? playerRow.getBoundingClientRect().top : null,
+    columnBoundary,
+    zones,
+  };
+}
+
+/** The interactive Flex Layout editing surface. Mounted only while
+ *  `flexEditMode` is on. The root is `pointer-events-none` so it never blocks
+ *  the widget drags it enables — only the toolbar and the splitters capture
+ *  pointers. Sits at the top of the stack (z-[70]+) above the game log (z-[60])
+ *  and hovered cards (z-60) so it can annotate every target. */
+function FlexEditOverlayInner() {
+  const { t } = useTranslation("settings");
+  const setFlexEditMode = useUiStore((s) => s.setFlexEditMode);
+  const applyFlexPreset = usePreferencesStore((s) => s.applyFlexPreset);
+  const resetFlexLayout = usePreferencesStore((s) => s.resetFlexLayout);
+  const activePreset = usePreferencesStore((s) => s.flexLayout.activePreset);
+  const setFlexScale = usePreferencesStore((s) => s.setFlexScale);
+  const stackScale = usePreferencesStore((s) => s.flexLayout.scales?.stack) ?? 1;
+  const summaryScale = usePreferencesStore((s) => s.flexLayout.scales?.summaryTile) ?? 1;
+
+  const [m, setM] = useState<Measured>(EMPTY);
+
+  // Re-measure on every animation frame while editing so the outlines/labels
+  // and splitter positions track live: widget drags (which mutate the DOM but
+  // not the store until release), splitter drags, and window resizes. The key
+  // guard re-renders only when the measured geometry actually changes, so idle
+  // frames are a cheap measure + compare with no React work.
+  useEffect(() => {
+    let raf = 0;
+    let prevKey = "";
+    const loop = () => {
+      const next = measure();
+      const key = JSON.stringify(next);
+      if (key !== prevKey) {
+        prevKey = key;
+        setM(next);
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <>
+      {/* Decorative chrome — never captures pointers. */}
+      <div className="pointer-events-none fixed inset-0 z-[70]">
+        {m.zones.map((z) => (
+          <div
+            key={z.key}
+            className="absolute rounded-lg ring-2 ring-sky-400/70 shadow-[0_0_12px_rgba(56,189,248,0.35)]"
+            style={{ left: z.left, top: z.top, width: z.width, height: z.height }}
+          >
+            <span className="absolute left-0 top-0 -translate-y-full rounded-t-md bg-sky-400 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-950">
+              {t(`flexLayout.zones.${z.key}`)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Zone-resize grabbers (own their own pointer capture). */}
+      {m.topBoundary != null && <ZoneSplitter side="top" top={m.topBoundary} />}
+      {m.bottomBoundary != null && <ZoneSplitter side="bottom" top={m.bottomBoundary} />}
+      {m.columnBoundary != null && (
+        <ColumnSplitter
+          x={m.columnBoundary.x}
+          top={m.columnBoundary.top}
+          height={m.columnBoundary.height}
+          left={m.columnBoundary.left}
+          right={m.columnBoundary.right}
+        />
+      )}
+
+      {/* Toolbar. */}
+      <div className="pointer-events-auto fixed left-1/2 top-3 z-[72] flex -translate-x-1/2 flex-col items-center gap-1.5 rounded-xl border border-sky-400/40 bg-slate-950/90 px-3 py-2 shadow-xl backdrop-blur">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wider text-sky-300">
+            {t("flexLayout.title")}
+          </span>
+          <div className="flex items-center gap-1">
+            {FLEX_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={() => applyFlexPreset(preset.config)}
+                title={t(preset.descriptionKey)}
+                className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                  activePreset === preset.id
+                    ? "bg-sky-400 text-slate-950"
+                    : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+                }`}
+              >
+                {t(preset.labelKey)}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => resetFlexLayout()}
+            className="rounded-md bg-slate-800 px-2 py-1 text-xs font-medium text-slate-200 hover:bg-slate-700"
+          >
+            {t("flexLayout.reset")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setFlexEditMode(false)}
+            className="rounded-md bg-emerald-500 px-3 py-1 text-xs font-bold text-slate-950 hover:bg-emerald-400"
+          >
+            {t("flexLayout.done")}
+          </button>
+        </div>
+        <div className="flex items-center gap-3">
+          <ScaleStepper
+            label={t("flexLayout.scale.stack")}
+            value={stackScale}
+            onChange={(v) => setFlexScale("stack", v)}
+          />
+          <ScaleStepper
+            label={t("flexLayout.scale.tiles")}
+            value={summaryScale}
+            onChange={(v) => setFlexScale("summaryTile", v)}
+          />
+        </div>
+        <span className="text-[11px] text-slate-400">{t("flexLayout.hint")}</span>
+      </div>
+    </>
+  );
+}
+
+/** Step size for the scale steppers — one tenth, matching the store's clamp
+ *  granularity (0.5–2.0). */
+const SCALE_STEP = 0.1;
+
+/** A compact −/value/+ control for an aspect-preserving zone scale. The store
+ *  clamps the committed value, so the buttons can overshoot freely. */
+function ScaleStepper({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (next: number) => void;
+}) {
+  const { t } = useTranslation("settings");
+  return (
+    <span className="flex items-center gap-1">
+      <span className="text-[11px] text-slate-300">{label}</span>
+      <button
+        type="button"
+        onClick={() => onChange(value - SCALE_STEP)}
+        aria-label={t("flexLayout.scale.smaller", { label })}
+        className="flex h-5 w-5 items-center justify-center rounded bg-slate-800 text-sm font-bold text-slate-200 hover:bg-slate-700"
+      >
+        −
+      </button>
+      <span className="w-9 text-center text-[11px] tabular-nums text-slate-200">
+        {Math.round(value * 100)}%
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(value + SCALE_STEP)}
+        aria-label={t("flexLayout.scale.larger", { label })}
+        className="flex h-5 w-5 items-center justify-center rounded bg-slate-800 text-sm font-bold text-slate-200 hover:bg-slate-700"
+      >
+        +
+      </button>
+    </span>
+  );
+}
+
+/** Gate wrapper: render nothing (and run no measurement effects) outside edit
+ *  mode. Split so the hooks in {@link FlexEditOverlayInner} never run when the
+ *  feature is off. */
+export function FlexEditOverlay() {
+  const flexEditMode = useUiStore((s) => s.flexEditMode);
+  if (!flexEditMode) return null;
+  return <FlexEditOverlayInner />;
+}

--- a/client/src/components/flexlayout/ZoneSplitter.tsx
+++ b/client/src/components/flexlayout/ZoneSplitter.tsx
@@ -1,0 +1,61 @@
+import { useRef } from "react";
+
+import { usePreferencesStore, type CappedTrack } from "../../stores/preferencesStore.ts";
+import { resizeBand } from "./gridBandMath.ts";
+
+interface ZoneSplitterProps {
+  /** Which band this grabber resizes. "top" sits on the opponent/battlefield
+   *  boundary (drag down to grow); "bottom" on the battlefield/player boundary
+   *  (drag up to grow). */
+  side: "top" | "bottom";
+  /** Viewport Y (px) of the boundary this grabber straddles. */
+  top: number;
+}
+
+/**
+ * A thin horizontal grabber on a board row boundary. Dragging it resizes the
+ * adjacent {@link CappedTrack} via {@link resizeBand}; the `1fr` middle row
+ * absorbs the change. Positioned by {@link FlexEditOverlay} at the measured
+ * boundary, so it never needs to know the grid geometry itself.
+ */
+export function ZoneSplitter({ side, top }: ZoneSplitterProps) {
+  const setFlexBand = usePreferencesStore((s) => s.setFlexBand);
+  const startRef = useRef<{ y: number; track: CappedTrack } | null>(null);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    startRef.current = {
+      y: e.clientY,
+      track: usePreferencesStore.getState().flexLayout.gridBands[side],
+    };
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const start = startRef.current;
+    if (!start) return;
+    const dragY = e.clientY - start.y;
+    // Top boundary grows downward; bottom boundary grows upward.
+    const deltaPx = side === "top" ? dragY : -dragY;
+    setFlexBand(side, resizeBand(start.track, deltaPx, window.innerHeight));
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    startRef.current = null;
+    (e.target as HTMLElement).releasePointerCapture?.(e.pointerId);
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="horizontal"
+      data-flex-splitter={side}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      className="fixed inset-x-0 z-[71] flex h-4 -translate-y-1/2 cursor-row-resize items-center justify-center"
+      style={{ top }}
+    >
+      <span className="h-1 w-16 rounded-full bg-sky-400/80 shadow-[0_0_8px_2px_rgba(56,189,248,0.6)]" />
+    </div>
+  );
+}

--- a/client/src/components/flexlayout/__tests__/ZoneSplitter.test.ts
+++ b/client/src/components/flexlayout/__tests__/ZoneSplitter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { ratioFromPointerX, resizeBand } from "../gridBandMath.ts";
+
+const VH = 1000; // round viewport height for easy arithmetic
+
+describe("resizeBand", () => {
+  it("grows the band by the drag delta and keeps pct/pxCap in agreement", () => {
+    // Default top band: min(12% of 1000 = 120, cap 100) => 100px effective.
+    const next = resizeBand({ pct: 12, pxCap: 100 }, 50, VH);
+    expect(next.pxCap).toBe(150); // 100 + 50
+    expect(next.pct).toBeCloseTo(15, 5); // 150 / 1000 * 100
+  });
+
+  it("shrinks the band on a negative delta", () => {
+    const next = resizeBand({ pct: 18, pxCap: 150 }, -50, VH);
+    expect(next.pxCap).toBe(100); // 150 - 50
+    expect(next.pct).toBeCloseTo(10, 5);
+  });
+
+  it("never shrinks a band below the minimum pixel floor", () => {
+    const next = resizeBand({ pct: 12, pxCap: 100 }, -500, VH);
+    expect(next.pxCap).toBe(40); // MIN_PX floor
+  });
+
+  it("never grows a band past 40% of the viewport (battlefield protection)", () => {
+    const next = resizeBand({ pct: 18, pxCap: 150 }, 5000, VH);
+    expect(next.pxCap).toBe(400); // MAX_FRACTION * VH
+    expect(next.pct).toBeCloseTo(35, 5); // clamped to MAX_PCT
+  });
+
+  it("clamps the percentage to its ceiling even when px would allow more", () => {
+    // On a very tall viewport, 40% px would imply >35% — pct must still cap.
+    const next = resizeBand({ pct: 18, pxCap: 150 }, 100, VH);
+    expect(next.pct).toBeLessThanOrEqual(35);
+  });
+});
+
+describe("ratioFromPointerX", () => {
+  it("returns lands' share from the pointer position in the region", () => {
+    // Region [200, 1000]: a pointer at 600 is exactly halfway.
+    expect(ratioFromPointerX(600, 200, 1000)).toBeCloseTo(0.5, 5);
+    // Three-quarters across ⇒ lands take 0.75 (support 0.25).
+    expect(ratioFromPointerX(800, 200, 1000)).toBeCloseTo(0.75, 5);
+  });
+
+  it("is drift-free (depends only on absolute position, not a delta)", () => {
+    // Same pointer X always yields the same ratio regardless of call history.
+    expect(ratioFromPointerX(450, 200, 1000)).toEqual(ratioFromPointerX(450, 200, 1000));
+  });
+
+  it("falls back to an even split for a degenerate region", () => {
+    expect(ratioFromPointerX(500, 600, 600)).toBe(0.5);
+    expect(ratioFromPointerX(500, 700, 600)).toBe(0.5);
+  });
+});

--- a/client/src/components/flexlayout/gridBandMath.ts
+++ b/client/src/components/flexlayout/gridBandMath.ts
@@ -1,0 +1,43 @@
+import type { CappedTrack } from "../../stores/preferencesStore.ts";
+
+/** Per-band clamps so a resize can never collapse a zone to nothing or starve
+ *  the battlefield (the `1fr` middle). A band may not exceed `MAX_FRACTION` of
+ *  the viewport height. */
+const MIN_PCT = 6;
+const MAX_PCT = 35;
+const MIN_PX = 40;
+const MAX_FRACTION = 0.4;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Pure resize math: given a band's current {@link CappedTrack}, a pixel delta
+ * (positive = grow the band), and the viewport height, return the new track.
+ * Both `pct` and `pxCap` are set to agree at the current viewport so the band
+ * renders at exactly the dragged height now and still scales with the window.
+ */
+export function resizeBand(
+  current: CappedTrack,
+  deltaPx: number,
+  viewportH: number,
+): CappedTrack {
+  const currentPx = Math.min((current.pct / 100) * viewportH, current.pxCap);
+  const maxPx = viewportH * MAX_FRACTION;
+  const nextPx = clamp(currentPx + deltaPx, MIN_PX, maxPx);
+  const pct = clamp((nextPx / viewportH) * 100, MIN_PCT, MAX_PCT);
+  return { pct: Math.round(pct * 10) / 10, pxCap: Math.round(nextPx) };
+}
+
+/**
+ * Pure lands↔support split math: given the absolute pointer X and the left/right
+ * viewport bounds of the combined two-column region, return lands' share (0..1).
+ * Drift-free — derived from the pointer's absolute position rather than an
+ * accumulated delta. The store applies the safety clamp; a degenerate region
+ * (right ≤ left) falls back to an even split.
+ */
+export function ratioFromPointerX(pointerX: number, left: number, right: number): number {
+  if (right <= left) return 0.5;
+  return (pointerX - left) / (right - left);
+}

--- a/client/src/components/flexlayout/presets.ts
+++ b/client/src/components/flexlayout/presets.ts
@@ -1,0 +1,51 @@
+import {
+  defaultFlexLayout,
+  type FlexLayoutConfig,
+} from "../../stores/preferencesStore.ts";
+
+/** A selectable layout preset (excludes the synthetic "custom"). Each carries a
+ *  COMPLETE config — applying one replaces the layout wholesale, including the
+ *  opponent HUD. `labelKey` is an i18n key under the `settings` namespace. */
+export interface FlexPreset {
+  id: "default" | "layout2" | "layout3";
+  labelKey: string;
+  descriptionKey: string;
+  config: FlexLayoutConfig;
+}
+
+/** The built-in presets shown in the Flex Layout toolbar/settings picker.
+ *  `default` reuses the store's canonical default so the reset target and the
+ *  "Default" preset can never drift apart. */
+export const FLEX_PRESETS: readonly FlexPreset[] = [
+  {
+    id: "default",
+    labelKey: "flexLayout.presets.default.label",
+    descriptionKey: "flexLayout.presets.default.description",
+    config: defaultFlexLayout(),
+  },
+  {
+    // Layout 2 — a larger battlefield: smaller hand/opponent bands free
+    // vertical space. (Shape-only; no principled use-case rationale.)
+    id: "layout2",
+    labelKey: "flexLayout.presets.layout2.label",
+    descriptionKey: "flexLayout.presets.layout2.description",
+    config: {
+      gridBands: { top: { pct: 10, pxCap: 80 }, bottom: { pct: 14, pxCap: 120 } },
+      widgets: {},
+      opponentHudByTableSize: {},
+      activePreset: "layout2",
+    },
+  },
+  {
+    // Layout 3 — a taller lower third. (Shape-only; no principled rationale.)
+    id: "layout3",
+    labelKey: "flexLayout.presets.layout3.label",
+    descriptionKey: "flexLayout.presets.layout3.description",
+    config: {
+      gridBands: { top: { pct: 12, pxCap: 100 }, bottom: { pct: 22, pxCap: 180 } },
+      widgets: {},
+      opponentHudByTableSize: {},
+      activePreset: "layout3",
+    },
+  },
+];

--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -328,7 +328,9 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
     // avatar + name + life when the row is squeezed by additional opponents on
     // a narrow (mobile) viewport. `max-w` on each tab caps its size so one or
     // two opponents don't balloon on desktop. KickConfirmDialog is a fixed
-    // overlay, so its position in the flow is irrelevant.
+    // overlay portaled to document.body: this rail can sit inside a Flex Layout
+    // DraggableWidget whose transform would otherwise become the containing
+    // block for the dialog's `fixed` positioning and clip it to the rail box.
     <div className="flex w-full items-center justify-center gap-1.5 px-2 py-1">
       {allOpponents.map((opId) => (
         <OpponentTab
@@ -364,15 +366,18 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
         enabled={followActiveOpponent}
         onToggle={handleToggleFollowActiveOpponent}
       />
-      <KickConfirmDialog
-        isOpen={kickTarget !== null}
-        playerLabel={targetLabel}
-        onConfirm={() => {
-          if (kickTarget !== null && onKickPlayer) onKickPlayer(kickTarget);
-          setKickTarget(null);
-        }}
-        onCancel={() => setKickTarget(null)}
-      />
+      {createPortal(
+        <KickConfirmDialog
+          isOpen={kickTarget !== null}
+          playerLabel={targetLabel}
+          onConfirm={() => {
+            if (kickTarget !== null && onKickPlayer) onKickPlayer(kickTarget);
+            setKickTarget(null);
+          }}
+          onCancel={() => setKickTarget(null)}
+        />,
+        document.body,
+      )}
     </div>
   );
 }

--- a/client/src/components/log/GameLogPanel.tsx
+++ b/client/src/components/log/GameLogPanel.tsx
@@ -14,6 +14,7 @@ import {
   uniqueTurns,
 } from "../../viewmodel/logSearch.ts";
 import { LogEntry } from "./LogEntry.tsx";
+import { useDraggableWidget } from "../../hooks/useDraggableWidget.ts";
 
 const EMPTY_LOG: GameLogEntry[] = [];
 
@@ -57,6 +58,10 @@ export function GameLogPanel() {
   const [categoryFilter, setCategoryFilter] = useState<Set<LogCategory>>(new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  // Flex Layout reposition. The hook's own ref is left unused here (panelRef
+  // owns the node for outside-click detection), so its viewport clamp no-ops
+  // for the log — acceptable; the drag offset still applies and persists.
+  const logDrag = useDraggableWidget({ kind: "widget", key: "logPanel" });
 
   const verbosityFiltered = useMemo(
     () => filterLogByVerbosity(logHistory, verbosity),
@@ -98,6 +103,9 @@ export function GameLogPanel() {
 
   const handleOutsideClick = useCallback(
     (e: MouseEvent) => {
+      // Don't close while Flex Layout edit mode is active: the user may be
+      // clicking the edit toolbar (outside the panel) or repositioning the log.
+      if (useUiStore.getState().flexEditMode) return;
       if (isOpen && !isGameOver && panelRef.current && !panelRef.current.contains(e.target as Node)) {
         setLogPanelOpen(false);
       }
@@ -156,10 +164,20 @@ export function GameLogPanel() {
         {isOpen && (
           <motion.div
             ref={panelRef}
+            data-flex-zone="logPanel"
+            drag={logDrag.drag}
+            dragMomentum={logDrag.dragMomentum}
+            dragElastic={logDrag.dragElastic}
+            onDragEnd={logDrag.onDragEnd}
+            onClickCapture={logDrag.onClickCapture}
             className="fixed bottom-0 right-0 top-0 z-[60] flex w-80 flex-col border-l border-gray-700 bg-gray-900/95 shadow-2xl"
-            initial={{ x: "100%" }}
-            animate={{ x: 0 }}
-            exit={{ x: "100%" }}
+            // Opacity (not an x-slide) so the Flex Layout drag offset, which
+            // owns the x/y transform on this same fixed node, isn't fought by
+            // the open/close animation.
+            style={logDrag.style}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
             transition={{ type: "spring", stiffness: 300, damping: 30 }}
           >
             <div className="flex items-center justify-between border-b border-gray-700 px-3 py-2">

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -13,6 +13,7 @@ import {
   usePreferencesStore,
 } from "../../stores/preferencesStore.ts";
 import { useMultiplayerStore } from "../../stores/multiplayerStore.ts";
+import { useUiStore } from "../../stores/uiStore.ts";
 import {
   ANIMATION_SPEED_DEFAULT,
   ANIMATION_SPEED_MAX,
@@ -127,6 +128,7 @@ export function PreferencesModal({
   highlight,
 }: PreferencesModalProps) {
   const { t } = useTranslation("settings");
+  const setFlexEditMode = useUiStore((s) => s.setFlexEditMode);
   const boardBackgroundRef = useRef<HTMLDivElement | null>(null);
   const [highlightFlash, setHighlightFlash] = useState(highlight === "board-background");
 
@@ -470,6 +472,24 @@ export function PreferencesModal({
                         {t("visual.clearArtOverrides", { count: artOverrideCount })}
                       </button>
                     )}
+                  </SettingGroup>
+
+                  <SettingGroup label={t("flexLayout.title")}>
+                    <p className="mb-2 text-xs text-slate-400">
+                      {t("flexLayout.description")}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        // Launch edit mode and close settings so the board is
+                        // visible; the overlay toolbar owns presets/reset/done.
+                        setFlexEditMode(true);
+                        onClose();
+                      }}
+                      className="rounded-[14px] border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-slate-200 transition hover:bg-white/10"
+                    >
+                      {t("flexLayout.edit")}
+                    </button>
                   </SettingGroup>
                 </SettingsSection>
               )}

--- a/client/src/components/stack/StackDisplay.tsx
+++ b/client/src/components/stack/StackDisplay.tsx
@@ -12,6 +12,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import type { ObjectId, StackDisplayGroup, StackEntry as StackEntryType, StackEntryDisplay, WaitingFor } from "../../adapter/types.ts";
 import { getStackCardSize } from "../board/boardSizing.ts";
+import { DraggableWidget } from "../flexlayout/DraggableWidget.tsx";
 
 const EMPTY_STACK: StackEntryType[] = [];
 const EMPTY_GROUPS: StackDisplayGroup[] = [];
@@ -97,6 +98,9 @@ export function StackDisplay() {
   const stackDockSide = usePreferencesStore((s) => s.stackDockSide);
   const setStackDockSide = usePreferencesStore((s) => s.setStackDockSide);
   const dockedLeft = stackDockSide === "left";
+  // User size multiplier over the viewport-derived auto-scale (absent ⇒ 1).
+  // Cards derive width AND height from one scale, so this stays aspect-correct.
+  const userStackScale = usePreferencesStore((s) => s.flexLayout.scales?.stack) ?? 1;
 
   useEffect(() => {
     function handleResize() {
@@ -151,7 +155,7 @@ export function StackDisplay() {
       viewport.width < 1024 ? 0.72 :
         viewport.width < 1440 ? 0.86 : 1;
   const heightScale = viewport.height < 820 ? 0.9 : 1;
-  const responsiveScale = widthScale * heightScale;
+  const responsiveScale = widthScale * heightScale * userStackScale;
   const cardSize = {
     width: Math.max(112, Math.round(rawCardSize.width * responsiveScale)),
     height: Math.max(156, Math.round(rawCardSize.height * responsiveScale)),
@@ -210,25 +214,31 @@ export function StackDisplay() {
   }));
 
   return (
-    <AnimatePresence>
-      <motion.div
-        key="stack-container"
-        initial={{ opacity: 0, x: dockedLeft ? -60 : 60 }}
-        animate={{ opacity: 1, x: 0 }}
-        exit={{ opacity: 0, x: dockedLeft ? -60 : 60 }}
-        transition={{ type: "spring", stiffness: 300, damping: 30 }}
-        // `pointer-events-none`: the outer box keeps its full panel width even
-        // when the inner panel is transform-collapsed offscreen, so a
-        // transparent region would otherwise hover over (and swallow clicks
-        // meant for) battlefield objects. Click-through here; the real
-        // interactive surfaces below opt back in with `pointer-events-auto`.
-        // Vertical position comes entirely from the clamped pixel `top` in
-        // `panelAnchorStyle` — no `top-1/2`/`-translate-y-1/2` centering, which
-        // would let a tall panel's header slide above the viewport top edge.
-        className="pointer-events-none fixed z-[35]"
-        style={panelAnchorStyle}
-      >
+    // The DraggableWidget owns the fixed dock anchor so its Flex Layout offset
+    // composes with the panel's own entry/collapse animations below. Its
+    // `pointer-events-none`: the outer box keeps its full panel width even when
+    // the inner panel is transform-collapsed offscreen, so a transparent region
+    // would otherwise hover over (and swallow clicks meant for) battlefield
+    // objects. Click-through here; the real interactive surfaces below opt back
+    // in with `pointer-events-auto`. Vertical position comes entirely from the
+    // clamped pixel `top` in `panelAnchorStyle` — no `top-1/2`/`-translate-y-1/2`
+    // centering, which would let a tall panel's header slide above the viewport.
+    <DraggableWidget
+      target={{ kind: "widget", key: "stackPanel" }}
+      flexZone="stackPanel"
+      className="pointer-events-none fixed z-[35]"
+      style={panelAnchorStyle}
+    >
+      <AnimatePresence>
         <motion.div
+          key="stack-container"
+          initial={{ opacity: 0, x: dockedLeft ? -60 : 60 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: dockedLeft ? -60 : 60 }}
+          transition={{ type: "spring", stiffness: 300, damping: 30 }}
+          className="pointer-events-none"
+        >
+          <motion.div
           animate={{ x: isCollapsed ? collapsedX : 0 }}
           transition={{ type: "spring", stiffness: 340, damping: 34 }}
           className="relative"
@@ -339,5 +349,6 @@ export function StackDisplay() {
         />
       </motion.div>
     </AnimatePresence>
+    </DraggableWidget>
   );
 }

--- a/client/src/hooks/__tests__/useResolvedGridRows.test.ts
+++ b/client/src/hooks/__tests__/useResolvedGridRows.test.ts
@@ -1,0 +1,168 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveGridRows } from "../useResolvedGridRows.ts";
+import {
+  defaultFlexLayout,
+  usePreferencesStore,
+  type FlexLayoutConfig,
+} from "../../stores/preferencesStore.ts";
+
+// The exact literals the board grid used before Flex Layout existed. Any drift
+// here is a visible layout regression for every user who never opens edit mode.
+const LEGACY_DESKTOP_ROWS = "minmax(0,min(12%,100px)) 1fr minmax(0,min(18%,150px))";
+const LEGACY_COMPACT_ROWS = "minmax(0,12%) 1fr minmax(0,18%)";
+
+describe("resolveGridRows", () => {
+  it("reproduces the prior hardcoded desktop layout byte-for-byte", () => {
+    expect(resolveGridRows(defaultFlexLayout().gridBands, false)).toBe(LEGACY_DESKTOP_ROWS);
+  });
+
+  it("reproduces the prior hardcoded compact layout byte-for-byte", () => {
+    expect(resolveGridRows(defaultFlexLayout().gridBands, true)).toBe(LEGACY_COMPACT_ROWS);
+  });
+
+  it("keeps the middle row 1fr and only varies the top/bottom bands", () => {
+    const rows = resolveGridRows(
+      { top: { pct: 8, pxCap: 60 }, bottom: { pct: 30, pxCap: 240 } },
+      false,
+    );
+    expect(rows).toBe("minmax(0,min(8%,60px)) 1fr minmax(0,min(30%,240px))");
+  });
+});
+
+describe("preferencesStore flex layout actions", () => {
+  beforeEach(() => {
+    act(() => usePreferencesStore.getState().resetFlexLayout());
+  });
+
+  it("defaults to the zero-offset 'default' preset", () => {
+    expect(usePreferencesStore.getState().flexLayout).toEqual(defaultFlexLayout());
+  });
+
+  it("flips activePreset to 'custom' on a manual band resize", () => {
+    act(() => usePreferencesStore.getState().setFlexBand("top", { pct: 9, pxCap: 80 }));
+    const { flexLayout } = usePreferencesStore.getState();
+    expect(flexLayout.gridBands.top).toEqual({ pct: 9, pxCap: 80 });
+    expect(flexLayout.activePreset).toBe("custom");
+  });
+
+  it("flips activePreset to 'custom' on a manual widget drag", () => {
+    act(() => usePreferencesStore.getState().setFlexWidgetOffset("stackPanel", { dx: 10, dy: -20 }));
+    const { flexLayout } = usePreferencesStore.getState();
+    expect(flexLayout.widgets.stackPanel).toEqual({ dx: 10, dy: -20 });
+    expect(flexLayout.activePreset).toBe("custom");
+  });
+
+  it("keys opponent-HUD offsets per table size and leaves the other size untouched", () => {
+    act(() => usePreferencesStore.getState().setFlexOpponentHudOffset("multiplayer", { dx: 5, dy: 5 }));
+    const { flexLayout } = usePreferencesStore.getState();
+    expect(flexLayout.opponentHudByTableSize.multiplayer).toEqual({ dx: 5, dy: 5 });
+    expect(flexLayout.opponentHudByTableSize.oneVsOne).toBeUndefined();
+    expect(flexLayout.activePreset).toBe("custom");
+  });
+
+  it("sets the lands↔support ratio and flips to 'custom'", () => {
+    act(() => usePreferencesStore.getState().setFlexLandSupportRatio(0.65));
+    const { flexLayout } = usePreferencesStore.getState();
+    expect(flexLayout.landSupportRatio).toBeCloseTo(0.65, 5);
+    expect(flexLayout.activePreset).toBe("custom");
+  });
+
+  it("clamps the lands↔support ratio so neither column starves", () => {
+    act(() => usePreferencesStore.getState().setFlexLandSupportRatio(0.95));
+    expect(usePreferencesStore.getState().flexLayout.landSupportRatio).toBe(0.8);
+    act(() => usePreferencesStore.getState().setFlexLandSupportRatio(0.05));
+    expect(usePreferencesStore.getState().flexLayout.landSupportRatio).toBe(0.2);
+  });
+
+  it("sets a per-zone scale, clamps it to the readable range, and flips to 'custom'", () => {
+    act(() => usePreferencesStore.getState().setFlexScale("stack", 1.4));
+    let { flexLayout } = usePreferencesStore.getState();
+    expect(flexLayout.scales?.stack).toBeCloseTo(1.4, 5);
+    expect(flexLayout.activePreset).toBe("custom");
+    // Over- and under-shoots clamp to [0.5, 2].
+    act(() => usePreferencesStore.getState().setFlexScale("summaryTile", 5));
+    act(() => usePreferencesStore.getState().setFlexScale("stack", 0.1));
+    flexLayout = usePreferencesStore.getState().flexLayout;
+    expect(flexLayout.scales?.summaryTile).toBe(2);
+    expect(flexLayout.scales?.stack).toBe(0.5);
+  });
+
+  it("reset clears the ratio and scales back to defaults", () => {
+    act(() => {
+      usePreferencesStore.getState().setFlexLandSupportRatio(0.7);
+      usePreferencesStore.getState().setFlexScale("stack", 1.5);
+    });
+    act(() => usePreferencesStore.getState().resetFlexLayout());
+    const { flexLayout } = usePreferencesStore.getState();
+    expect(flexLayout.landSupportRatio).toBe(0.5);
+    expect(flexLayout.scales).toEqual({});
+    expect(flexLayout.activePreset).toBe("default");
+  });
+
+  it("applies a preset wholesale, including the opponent HUD, and sets its id", () => {
+    // Seed a manual opponent-HUD offset, then apply a preset that doesn't carry one.
+    act(() => usePreferencesStore.getState().setFlexOpponentHudOffset("oneVsOne", { dx: 40, dy: 0 }));
+    const preset: FlexLayoutConfig = {
+      gridBands: { top: { pct: 10, pxCap: 80 }, bottom: { pct: 14, pxCap: 120 } },
+      widgets: {},
+      opponentHudByTableSize: {},
+      activePreset: "layout2",
+    };
+    act(() => usePreferencesStore.getState().applyFlexPreset(preset));
+    const { flexLayout } = usePreferencesStore.getState();
+    expect(flexLayout.activePreset).toBe("layout2");
+    // Preset is authoritative: it wiped the manual opponent-HUD offset.
+    expect(flexLayout.opponentHudByTableSize).toEqual({});
+    expect(flexLayout.gridBands.top).toEqual({ pct: 10, pxCap: 80 });
+  });
+
+  it("deep-clones an applied preset so the constant can't be mutated through the store", () => {
+    const preset: FlexLayoutConfig = {
+      gridBands: { top: { pct: 10, pxCap: 80 }, bottom: { pct: 14, pxCap: 120 } },
+      widgets: {},
+      opponentHudByTableSize: {},
+      activePreset: "layout2",
+    };
+    act(() => usePreferencesStore.getState().applyFlexPreset(preset));
+    act(() => usePreferencesStore.getState().setFlexBand("top", { pct: 99, pxCap: 99 }));
+    // The preset constant is unchanged despite the post-apply store mutation.
+    expect(preset.gridBands.top).toEqual({ pct: 10, pxCap: 80 });
+  });
+
+  it("reset returns to the default preset and clears every offset", () => {
+    act(() => {
+      usePreferencesStore.getState().setFlexWidgetOffset("logPanel", { dx: 1, dy: 1 });
+      usePreferencesStore.getState().setFlexBand("bottom", { pct: 25, pxCap: 200 });
+    });
+    act(() => usePreferencesStore.getState().resetFlexLayout());
+    expect(usePreferencesStore.getState().flexLayout).toEqual(defaultFlexLayout());
+  });
+});
+
+describe("preferencesStore v15→v16 migration", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("seeds the default flexLayout for a legacy store that lacks it", async () => {
+    // A v15 blob with no flexLayout key, in the shape zustand/persist writes.
+    localStorage.setItem(
+      "phase-preferences",
+      JSON.stringify({ state: { cardSize: "large", stackDockSide: "left" }, version: 15 }),
+    );
+
+    await act(async () => {
+      await usePreferencesStore.persist.rehydrate();
+    });
+
+    const state = usePreferencesStore.getState();
+    // The pre-existing field survived migration...
+    expect(state.cardSize).toBe("large");
+    // ...and the absent flexLayout was seeded to the default, resolving to the
+    // identical grid as before the feature existed.
+    expect(state.flexLayout).toEqual(defaultFlexLayout());
+    expect(resolveGridRows(state.flexLayout.gridBands, false)).toBe(LEGACY_DESKTOP_ROWS);
+  });
+});

--- a/client/src/hooks/useDraggableWidget.ts
+++ b/client/src/hooks/useDraggableWidget.ts
@@ -1,0 +1,122 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+import { type MotionStyle, type PanInfo, useMotionValue } from "framer-motion";
+
+import { useUiStore } from "../stores/uiStore.ts";
+import {
+  usePreferencesStore,
+  type FlexTableSize,
+  type FlexWidgetKey,
+  type WidgetOffset,
+} from "../stores/preferencesStore.ts";
+
+/** Keep at least this many pixels of a widget on-screen when clamping a
+ *  cross-monitor offset back into view. */
+const VIEWPORT_MARGIN = 24;
+
+/** What a draggable wrapper repositions. A shared-global widget, or the opponent
+ *  HUD whose offset is keyed by table size (1v1 vs multiplayer). */
+export type DraggableTarget =
+  | { kind: "widget"; key: FlexWidgetKey }
+  | { kind: "opponentHud"; tableSize: FlexTableSize };
+
+/** Props to spread onto the inner `motion.div` that wraps a widget's content.
+ *  `x`/`y` apply the persisted offset at all times (so a customized layout
+ *  survives normal play); `drag` is enabled only in Flex Layout edit mode. */
+export interface DraggableWidgetProps {
+  ref: React.RefObject<HTMLDivElement | null>;
+  style: MotionStyle;
+  drag: boolean;
+  dragMomentum: false;
+  dragElastic: 0;
+  onDragEnd: () => void;
+  onClickCapture?: (e: React.MouseEvent) => void;
+}
+
+function useTargetOffset(target: DraggableTarget): WidgetOffset | undefined {
+  // Scoped selector: returns the same reference until THIS target's offset
+  // changes, so dragging one widget never re-renders the others.
+  return usePreferencesStore((s) =>
+    target.kind === "widget"
+      ? s.flexLayout.widgets[target.key]
+      : s.flexLayout.opponentHudByTableSize[target.tableSize],
+  );
+}
+
+/**
+ * Makes a board widget drag-repositionable in Flex Layout edit mode, persisting
+ * its offset to `preferencesStore`. Net-new infrastructure built directly on
+ * Framer Motion's `drag` (it is NOT a wrapper over `useDragToCast`, which only
+ * exposes a threshold `onDragEnd`). Returns props for an inner `motion.div`;
+ * the call site decides which node to wrap so existing transforms (e.g. a HUD's
+ * `-translate-x-1/2`) on the outer node are never clobbered.
+ */
+export function useDraggableWidget(target: DraggableTarget): DraggableWidgetProps {
+  const flexEditMode = useUiStore((s) => s.flexEditMode);
+  const offset = useTargetOffset(target);
+  const ref = useRef<HTMLDivElement>(null);
+  const x = useMotionValue(offset?.dx ?? 0);
+  const y = useMotionValue(offset?.dy ?? 0);
+
+  // Seed/re-sync the motion values from the persisted offset (a preset apply or
+  // reset returns the widget home), THEN visually clamp into the viewport so a
+  // cloud-synced offset from a larger monitor can't strand it off-screen. Both
+  // steps must live in ONE layout effect: a separate passive re-sync would run
+  // after this and overwrite the clamp. The clamp adjusts the motion values
+  // only — it must NOT persist, or it would wrongly flip activePreset to
+  // "custom" on load.
+  useLayoutEffect(() => {
+    x.set(offset?.dx ?? 0);
+    y.set(offset?.dy ?? 0);
+    const el = ref.current;
+    if (!el || offset == null) return;
+    const rect = el.getBoundingClientRect();
+    let cx = x.get();
+    let cy = y.get();
+    if (rect.left > window.innerWidth - VIEWPORT_MARGIN) {
+      cx -= rect.left - (window.innerWidth - VIEWPORT_MARGIN);
+    }
+    if (rect.top > window.innerHeight - VIEWPORT_MARGIN) {
+      cy -= rect.top - (window.innerHeight - VIEWPORT_MARGIN);
+    }
+    if (rect.right < VIEWPORT_MARGIN) cx += VIEWPORT_MARGIN - rect.right;
+    if (rect.bottom < VIEWPORT_MARGIN) cy += VIEWPORT_MARGIN - rect.bottom;
+    if (cx !== x.get()) x.set(cx);
+    if (cy !== y.get()) y.set(cy);
+  }, [offset?.dx, offset?.dy, offset, x, y]);
+
+  const persist = useCallback(
+    (next: WidgetOffset) => {
+      const store = usePreferencesStore.getState();
+      if (target.kind === "widget") {
+        store.setFlexWidgetOffset(target.key, next);
+      } else {
+        store.setFlexOpponentHudOffset(target.tableSize, next);
+      }
+    },
+    [target],
+  );
+
+  const onDragEnd = useCallback(() => {
+    persist({ dx: Math.round(x.get()), dy: Math.round(y.get()) });
+  }, [persist, x, y]);
+
+  // In edit mode, a functional control (rail button, pile, stack/log) is
+  // drag-only — swallow the click so a reposition tap can't also fire its action.
+  const onClickCapture = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  return {
+    ref,
+    style: { x, y },
+    drag: flexEditMode,
+    dragMomentum: false,
+    dragElastic: 0,
+    onDragEnd,
+    onClickCapture: flexEditMode ? onClickCapture : undefined,
+  };
+}
+
+/** Re-export for call sites that wire `onDragEnd`-style handlers themselves. */
+export type { PanInfo };

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -23,6 +23,8 @@ import {
  * - D: Copy game state JSON to clipboard (debug)
  * - Ctrl+D: Export game state JSON as a compressed ZIP (debug)
  * - `: Toggle debug panel
+ * - Ctrl+Shift+L: Toggle Flex Layout edit mode
+ * - Escape (in Flex Layout): Exit edit mode
  * - Triple-tap (touch): Toggle debug panel (iPad/mobile)
  */
 export function useKeyboardShortcuts(): void {
@@ -71,6 +73,14 @@ export function useKeyboardShortcuts(): void {
       const { gameState, waitingFor, dispatch, undo, stateHistory, gameMode } =
         useGameStore.getState();
       const uiState = useUiStore.getState();
+
+      // Flex Layout edit mode owns Escape while active so it can't fall through
+      // to game-action cancellation.
+      if (uiState.flexEditMode && e.key === "Escape") {
+        e.preventDefault();
+        uiState.setFlexEditMode(false);
+        return;
+      }
 
       if (uiState.helpSheetOpen) {
         if (e.key === "Escape") {
@@ -188,6 +198,14 @@ export function useKeyboardShortcuts(): void {
         case "`":
           e.preventDefault();
           uiState.toggleDebugPanel();
+          break;
+
+        case "l":
+        case "L":
+          if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey) {
+            e.preventDefault();
+            uiState.toggleFlexEditMode();
+          }
           break;
       }
     };

--- a/client/src/hooks/useResolvedGridRows.ts
+++ b/client/src/hooks/useResolvedGridRows.ts
@@ -1,0 +1,33 @@
+import { useIsCompactHeight } from "./useIsCompactHeight.ts";
+import {
+  usePreferencesStore,
+  type CappedTrack,
+  type GridBands,
+} from "../stores/preferencesStore.ts";
+
+/** Render one grid band as a CSS track. Desktop caps the band at
+ *  `min(pct%, pxCap px)` (mirroring the prior hardcoded `minmax(0,min(12%,100px))`);
+ *  compact-height mode drops the px cap, matching the prior compact layout. */
+function band(track: CappedTrack, isCompactHeight: boolean): string {
+  return isCompactHeight
+    ? `minmax(0,${track.pct}%)`
+    : `minmax(0,min(${track.pct}%,${track.pxCap}px))`;
+}
+
+/** Pure resolver: {@link GridBands} → a CSS `grid-template-rows` value. The
+ *  middle (battlefield) row is always `1fr` and absorbs the remainder, so only
+ *  the top/bottom bands are configurable. Exported so the byte-identical-to-today
+ *  regression can be asserted directly in tests. */
+export function resolveGridRows(bands: GridBands, isCompactHeight: boolean): string {
+  return `${band(bands.top, isCompactHeight)} 1fr ${band(bands.bottom, isCompactHeight)}`;
+}
+
+/** Hook form: reads the persisted bands and the live compact-height media query,
+ *  returning the `grid-template-rows` string for the board grid. Mirrors the
+ *  `useResolvedCommandZoneDisplay` resolve-at-use-site precedent. The default
+ *  layout resolves byte-identical to the prior hardcoded value. */
+export function useResolvedGridRows(): string {
+  const bands = usePreferencesStore((s) => s.flexLayout.gridBands);
+  const isCompactHeight = useIsCompactHeight();
+  return resolveGridRows(bands, isCompactHeight);
+}

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -81,6 +81,7 @@
   "board": {
     "regroupCreatures": "Doppelte Kreaturengruppen neu gruppieren",
     "changeBackground": "Hintergrund ändern…",
+    "customizeLayout": "Layout anpassen…",
     "gameLog": "Spielprotokoll",
     "debugLog": "Debug-Protokoll",
     "waitingForGame": "Warten auf Spiel...",

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -81,6 +81,35 @@
       "minimal": "Minimal"
     }
   },
+  "flexLayout": {
+    "title": "Flexibles Layout",
+    "description": "Ziehe Panels und HUDs beliebig und ändere die Größe der Spielfeldzonen.",
+    "edit": "Layout anpassen…",
+    "done": "Fertig",
+    "reset": "Layout zurücksetzen",
+    "preset": "Vorlage",
+    "hint": "Ziehe ein Panel, um es zu verschieben. Ziehe die leuchtenden Balken, um Zonen zu skalieren.",
+    "scale": {
+      "stack": "Stapel",
+      "tiles": "Kacheln",
+      "smaller": "{{label}} verkleinern",
+      "larger": "{{label}} vergrößern"
+    },
+    "presets": {
+      "default": { "label": "Layout 1", "description": "Das ausgewogene Standardlayout." },
+      "layout2": { "label": "Layout 2", "description": "Ein größeres Spielfeld mit eingeklappten Händen." },
+      "layout3": { "label": "Layout 3", "description": "Ein höheres unteres Drittel." }
+    },
+    "zones": {
+      "playerHud": "Dein HUD",
+      "opponentHud": "Gegner-HUD",
+      "stackPanel": "Stapel",
+      "logPanel": "Spielprotokoll",
+      "actionRail": "Aktionen",
+      "playerPiles": "Deine Zonen",
+      "opponentPiles": "Gegnerzonen"
+    }
+  },
   "audio": {
     "title": "Audio",
     "muteAll": "Alles stummschalten",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -81,6 +81,7 @@
   "board": {
     "regroupCreatures": "Regroup duplicate creature groups",
     "changeBackground": "Change background…",
+    "customizeLayout": "Customize layout…",
     "gameLog": "Game log",
     "debugLog": "Debug log",
     "waitingForGame": "Waiting for game...",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -81,6 +81,35 @@
       "minimal": "Minimal"
     }
   },
+  "flexLayout": {
+    "title": "Flex Layout",
+    "description": "Drag panels and HUDs anywhere, and resize the board zones.",
+    "edit": "Customize layout…",
+    "done": "Done",
+    "reset": "Reset layout",
+    "preset": "Preset",
+    "hint": "Drag any panel to move it. Drag the glowing bars to resize zones.",
+    "scale": {
+      "stack": "Stack",
+      "tiles": "Tiles",
+      "smaller": "Decrease {{label}} size",
+      "larger": "Increase {{label}} size"
+    },
+    "presets": {
+      "default": { "label": "Layout 1", "description": "The standard balanced layout." },
+      "layout2": { "label": "Layout 2", "description": "A larger battlefield with tucked-away hands." },
+      "layout3": { "label": "Layout 3", "description": "A taller lower third." }
+    },
+    "zones": {
+      "playerHud": "Your HUD",
+      "opponentHud": "Opponent HUD",
+      "stackPanel": "Stack",
+      "logPanel": "Game Log",
+      "actionRail": "Actions",
+      "playerPiles": "Your Zones",
+      "opponentPiles": "Opponent Zones"
+    }
+  },
   "audio": {
     "title": "Audio",
     "muteAll": "Mute All",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -81,6 +81,7 @@
   "board": {
     "regroupCreatures": "Reagrupar grupos de criaturas duplicadas",
     "changeBackground": "Cambiar fondo…",
+    "customizeLayout": "Personalizar diseño…",
     "gameLog": "Registro de la partida",
     "debugLog": "Registro de depuración",
     "waitingForGame": "Esperando la partida...",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -81,6 +81,35 @@
       "minimal": "Mínima"
     }
   },
+  "flexLayout": {
+    "title": "Diseño flexible",
+    "description": "Arrastra los paneles y HUD a cualquier lugar y cambia el tamaño de las zonas del tablero.",
+    "edit": "Personalizar diseño…",
+    "done": "Listo",
+    "reset": "Restablecer diseño",
+    "preset": "Preajuste",
+    "hint": "Arrastra cualquier panel para moverlo. Arrastra las barras brillantes para redimensionar zonas.",
+    "scale": {
+      "stack": "Pila",
+      "tiles": "Mosaicos",
+      "smaller": "Reducir tamaño de {{label}}",
+      "larger": "Aumentar tamaño de {{label}}"
+    },
+    "presets": {
+      "default": { "label": "Diseño 1", "description": "El diseño equilibrado estándar." },
+      "layout2": { "label": "Diseño 2", "description": "Un campo de batalla más grande con las manos recogidas." },
+      "layout3": { "label": "Diseño 3", "description": "Un tercio inferior más alto." }
+    },
+    "zones": {
+      "playerHud": "Tu HUD",
+      "opponentHud": "HUD del rival",
+      "stackPanel": "Pila",
+      "logPanel": "Registro",
+      "actionRail": "Acciones",
+      "playerPiles": "Tus zonas",
+      "opponentPiles": "Zonas del rival"
+    }
+  },
   "audio": {
     "title": "Audio",
     "muteAll": "Silenciar todo",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -81,6 +81,7 @@
   "board": {
     "regroupCreatures": "Regrouper les groupes de créatures en double",
     "changeBackground": "Changer l'arrière-plan…",
+    "customizeLayout": "Personnaliser la disposition…",
     "gameLog": "Journal de partie",
     "debugLog": "Journal de débogage",
     "waitingForGame": "En attente de la partie...",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -81,6 +81,35 @@
       "minimal": "Minimale"
     }
   },
+  "flexLayout": {
+    "title": "Disposition flexible",
+    "description": "Déplacez les panneaux et HUD où vous voulez et redimensionnez les zones du plateau.",
+    "edit": "Personnaliser la disposition…",
+    "done": "Terminé",
+    "reset": "Réinitialiser la disposition",
+    "preset": "Préréglage",
+    "hint": "Faites glisser un panneau pour le déplacer. Faites glisser les barres lumineuses pour redimensionner les zones.",
+    "scale": {
+      "stack": "Pile",
+      "tiles": "Tuiles",
+      "smaller": "Réduire la taille de {{label}}",
+      "larger": "Augmenter la taille de {{label}}"
+    },
+    "presets": {
+      "default": { "label": "Disposition 1", "description": "La disposition équilibrée standard." },
+      "layout2": { "label": "Disposition 2", "description": "Un champ de bataille plus grand avec les mains repliées." },
+      "layout3": { "label": "Disposition 3", "description": "Un tiers inférieur plus haut." }
+    },
+    "zones": {
+      "playerHud": "Votre HUD",
+      "opponentHud": "HUD de l'adversaire",
+      "stackPanel": "Pile",
+      "logPanel": "Journal",
+      "actionRail": "Actions",
+      "playerPiles": "Vos zones",
+      "opponentPiles": "Zones de l'adversaire"
+    }
+  },
   "audio": {
     "title": "Audio",
     "muteAll": "Tout couper",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -81,6 +81,7 @@
   "board": {
     "regroupCreatures": "Raggruppa i gruppi di creature duplicate",
     "changeBackground": "Cambia sfondo…",
+    "customizeLayout": "Personalizza layout…",
     "gameLog": "Registro di gioco",
     "debugLog": "Registro di debug",
     "waitingForGame": "In attesa della partita...",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -81,6 +81,35 @@
       "minimal": "Minima"
     }
   },
+  "flexLayout": {
+    "title": "Layout flessibile",
+    "description": "Trascina pannelli e HUD ovunque e ridimensiona le zone del campo.",
+    "edit": "Personalizza layout…",
+    "done": "Fatto",
+    "reset": "Reimposta layout",
+    "preset": "Preimpostazione",
+    "hint": "Trascina un pannello per spostarlo. Trascina le barre luminose per ridimensionare le zone.",
+    "scale": {
+      "stack": "Pila",
+      "tiles": "Riquadri",
+      "smaller": "Riduci dimensione di {{label}}",
+      "larger": "Aumenta dimensione di {{label}}"
+    },
+    "presets": {
+      "default": { "label": "Layout 1", "description": "Il layout bilanciato standard." },
+      "layout2": { "label": "Layout 2", "description": "Un campo di battaglia più grande con le mani ridotte." },
+      "layout3": { "label": "Layout 3", "description": "Un terzo inferiore più alto." }
+    },
+    "zones": {
+      "playerHud": "Il tuo HUD",
+      "opponentHud": "HUD avversario",
+      "stackPanel": "Pila",
+      "logPanel": "Registro",
+      "actionRail": "Azioni",
+      "playerPiles": "Le tue zone",
+      "opponentPiles": "Zone avversario"
+    }
+  },
   "audio": {
     "title": "Audio",
     "muteAll": "Disattiva tutto",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -81,6 +81,7 @@
   "board": {
     "regroupCreatures": "Pogrupuj zduplikowane grupy stworów",
     "changeBackground": "Zmień tło…",
+    "customizeLayout": "Dostosuj układ…",
     "gameLog": "Dziennik gry",
     "debugLog": "Dziennik debugowania",
     "waitingForGame": "Oczekiwanie na grę...",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -81,6 +81,35 @@
       "minimal": "Minimalna"
     }
   },
+  "flexLayout": {
+    "title": "Elastyczny układ",
+    "description": "Przeciągaj panele i HUD w dowolne miejsce i zmieniaj rozmiar stref planszy.",
+    "edit": "Dostosuj układ…",
+    "done": "Gotowe",
+    "reset": "Zresetuj układ",
+    "preset": "Ustawienie",
+    "hint": "Przeciągnij panel, aby go przesunąć. Przeciągnij świecące paski, aby zmienić rozmiar stref.",
+    "scale": {
+      "stack": "Stos",
+      "tiles": "Kafelki",
+      "smaller": "Zmniejsz rozmiar: {{label}}",
+      "larger": "Zwiększ rozmiar: {{label}}"
+    },
+    "presets": {
+      "default": { "label": "Układ 1", "description": "Standardowy, zrównoważony układ." },
+      "layout2": { "label": "Układ 2", "description": "Większe pole bitwy ze schowanymi rękami." },
+      "layout3": { "label": "Układ 3", "description": "Wyższa dolna część." }
+    },
+    "zones": {
+      "playerHud": "Twój HUD",
+      "opponentHud": "HUD przeciwnika",
+      "stackPanel": "Stos",
+      "logPanel": "Dziennik",
+      "actionRail": "Akcje",
+      "playerPiles": "Twoje strefy",
+      "opponentPiles": "Strefy przeciwnika"
+    }
+  },
   "audio": {
     "title": "Dźwięk",
     "muteAll": "Wycisz wszystko",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -81,6 +81,7 @@
   "board": {
     "regroupCreatures": "Reagrupar grupos de criaturas duplicadas",
     "changeBackground": "Alterar plano de fundo…",
+    "customizeLayout": "Personalizar layout…",
     "gameLog": "Registro do jogo",
     "debugLog": "Registro de depuração",
     "waitingForGame": "Aguardando o jogo...",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -81,6 +81,35 @@
       "minimal": "Mínima"
     }
   },
+  "flexLayout": {
+    "title": "Layout flexível",
+    "description": "Arraste painéis e HUDs para qualquer lugar e redimensione as zonas do tabuleiro.",
+    "edit": "Personalizar layout…",
+    "done": "Concluído",
+    "reset": "Redefinir layout",
+    "preset": "Predefinição",
+    "hint": "Arraste qualquer painel para movê-lo. Arraste as barras brilhantes para redimensionar zonas.",
+    "scale": {
+      "stack": "Pilha",
+      "tiles": "Blocos",
+      "smaller": "Diminuir tamanho de {{label}}",
+      "larger": "Aumentar tamanho de {{label}}"
+    },
+    "presets": {
+      "default": { "label": "Layout 1", "description": "O layout equilibrado padrão." },
+      "layout2": { "label": "Layout 2", "description": "Um campo de batalha maior com as mãos recolhidas." },
+      "layout3": { "label": "Layout 3", "description": "Um terço inferior mais alto." }
+    },
+    "zones": {
+      "playerHud": "Seu HUD",
+      "opponentHud": "HUD do oponente",
+      "stackPanel": "Pilha",
+      "logPanel": "Registro",
+      "actionRail": "Ações",
+      "playerPiles": "Suas zonas",
+      "opponentPiles": "Zonas do oponente"
+    }
+  },
   "audio": {
     "title": "Áudio",
     "muteAll": "Silenciar Tudo",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -15,8 +15,10 @@ import type { DeckCardCount, GameFormat, MatchConfig, SerializedAbilityCost } fr
 import { useDraftStore } from "../stores/draftStore";
 import { loadActiveQuickDraft } from "../services/quickDraftPersistence";
 import type { DraftMatchResult } from "../services/quickDraftPersistence";
-import { useIsCompactHeight } from "../hooks/useIsCompactHeight.ts";
+import { useResolvedGridRows } from "../hooks/useResolvedGridRows.ts";
 import { useIsMobile } from "../hooks/useIsMobile.ts";
+import { FlexEditOverlay } from "../components/flexlayout/FlexEditOverlay.tsx";
+import { DraggableWidget } from "../components/flexlayout/DraggableWidget.tsx";
 import { BetweenGamesSideboardModal } from "../components/multiplayer/BetweenGamesSideboardModal.tsx";
 import { audioManager } from "../audio/AudioManager.ts";
 import { useAudioContext } from "../audio/useAudioContext.ts";
@@ -716,7 +718,7 @@ function GamePageContent({
   const lobbyProgress = useGameStore((s) => s.lobbyProgress);
   const dispatch = useGameDispatch();
   const isMobile = useIsMobile();
-  const isCompactHeight = useIsCompactHeight();
+  const gridTemplateRows = useResolvedGridRows();
   const objects = useGameStore((s) => s.gameState?.objects);
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
   const seatOrder = useGameStore((s) => s.gameState?.seat_order);
@@ -1129,18 +1131,21 @@ function GamePageContent({
         className={`relative z-10 grid min-w-0 h-full${isReconnecting ? " pointer-events-none" : ""}`}
         style={{
           paddingTop: "var(--game-top-overlay-offset, 0px)",
-          gridTemplateRows: isCompactHeight
-            ? "minmax(0,12%) 1fr minmax(0,18%)"
-            : "minmax(0,min(12%,100px)) 1fr minmax(0,min(18%,150px))",
+          gridTemplateRows,
           gridTemplateColumns: "1fr",
         }}
       >
         {/* Row 1: Opponent hand + zone piles (flow layout — piles take real space) */}
-        <div className="relative z-20 min-w-0 flex w-full overflow-visible">
+        <div
+          className="relative z-20 min-w-0 flex w-full overflow-visible"
+          data-flex-zone="opp-row"
+        >
           <div className="min-w-0 flex-1">
             <OpponentHand showCards={showAiHand} />
           </div>
-          <div
+          <DraggableWidget
+            target={{ kind: "widget", key: "opponentPiles" }}
+            flexZone="opponentPiles"
             className="flex shrink-0 items-start gap-1.5 px-1 py-1"
             style={playerZoneRailStyle}
           >
@@ -1161,7 +1166,7 @@ function GamePageContent({
                 setViewingZone({ zone: "graveyard", playerId: activeOpponentId })
               }
             />
-          </div>
+          </DraggableWidget>
         </div>
 
         {/* Row 2: Battlefield — takes remaining space; HUDs passed inline to PlayerAreas */}
@@ -1170,13 +1175,15 @@ function GamePageContent({
         </div>
 
         {/* Row 3: Player hand + zones */}
-        <div className="relative min-w-0 overflow-visible">
+        <div className="relative min-w-0 overflow-visible" data-flex-zone="player-row">
           <div className="flex items-end justify-center">
             <ZoneHand zone="exile" />
             <PlayerHand />
             <ZoneHand zone="graveyard" />
           </div>
-          <div
+          <DraggableWidget
+            target={{ kind: "widget", key: "playerPiles" }}
+            flexZone="playerPiles"
             className="pointer-events-none absolute left-0 top-0 bottom-0 z-10 flex w-fit flex-col items-start justify-end gap-0.5 p-1 lg:gap-1 lg:p-3 [&>*]:pointer-events-auto [&>div>*]:pointer-events-auto"
             style={playerZoneRailStyle}
           >
@@ -1197,7 +1204,7 @@ function GamePageContent({
                 onView={() => setViewingZone({ zone: "library", playerId: perspectivePlayerId })}
               />
             </div>
-          </div>
+          </DraggableWidget>
           <div
             className="pointer-events-none absolute right-0 top-0 bottom-0 z-10 flex w-fit flex-col items-end justify-end gap-0.5 p-1 lg:gap-1 lg:p-3 [&>*]:pointer-events-auto"
             style={playerZoneRailStyle}
@@ -1208,7 +1215,9 @@ function GamePageContent({
       </div>
 
       {/* Right-side fixed UI stack: combat phases → full control → action buttons → log */}
-      <div
+      <DraggableWidget
+        target={{ kind: "widget", key: "actionRail" }}
+        flexZone="actionRail"
         className="fixed z-30 flex flex-col items-end gap-1.5"
         style={{
           bottom: "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
@@ -1227,10 +1236,11 @@ function GamePageContent({
             <ActionButton />
           </>
         )}
-      </div>
+      </DraggableWidget>
 
       <GameLogPanel />
       <MobileHandDrawer />
+      <FlexEditOverlay />
 
       {/* Game menu — top-left hamburger */}
       <GameMenu
@@ -1390,6 +1400,7 @@ function GamePageContent({
           onChangeBackground={() =>
             setPreferencesOpen({ tab: "gameplay", highlight: "board-background" })
           }
+          onCustomizeLayout={() => useUiStore.getState().setFlexEditMode(true)}
           onToggleGameLog={() => useUiStore.getState().toggleLogPanel()}
           onToggleDebugLog={() => useUiStore.getState().toggleDebugPanel()}
         />

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -93,6 +93,107 @@ export type OpponentHudDensity = "comfortable" | "compact";
  *  Any other string is a battlefield or plain-color ID. */
 export type BoardBackground = "auto-wubrg" | "random" | "none" | "custom" | (string & {});
 
+// ── Flex layout ──────────────────────────────────────────────────────────────
+/** A pixel delta from a widget's docked default position. The *absence* of an
+ *  entry means the widget sits exactly where it does today, so a fresh store and
+ *  every legacy store render byte-identically (zero-regression default). */
+export interface WidgetOffset {
+  dx: number;
+  dy: number;
+}
+/** Draggable widgets whose position is shared across all table sizes. The
+ *  opponent HUD is intentionally absent here — it's the one element whose
+ *  structure differs by table size, so it's keyed separately (see
+ *  {@link FlexTableSize}). */
+export type FlexWidgetKey =
+  | "playerHud"
+  | "stackPanel"
+  | "logPanel"
+  | "actionRail"
+  | "playerPiles"
+  | "opponentPiles";
+/** Table sizes the opponent HUD position is keyed by: 1v1 renders a single pill,
+ *  multiplayer a tab strip, so a shared offset wouldn't fit both. */
+export type FlexTableSize = "oneVsOne" | "multiplayer";
+/** A board grid row capped at `min(pct%, pxCap px)` — mirrors today's
+ *  `minmax(0,min(12%,100px))` track. The middle (battlefield) row is always
+ *  `1fr` and absorbs the remainder, so only the top/bottom bands are stored. */
+export interface CappedTrack {
+  pct: number;
+  pxCap: number;
+}
+export interface GridBands {
+  top: CappedTrack;
+  bottom: CappedTrack;
+}
+/** Preset ids are intentionally neutral ("Layout N"): the alternative layouts
+ *  carry no principled design rationale, so naming them by use-case ("Streamer")
+ *  would overclaim. `default` is load-bearing — it is the {@link defaultFlexLayout}
+ *  seed and the Reset target — so only the two editorial slots are neutralized. */
+export type FlexPresetId = "default" | "layout2" | "layout3" | "custom";
+/** An aspect-preserving size multiplier over a zone's existing auto-scale.
+ *  `stack` scales the stack's cards (over the viewport `responsiveScale`);
+ *  `summaryTile` scales the collapsed lands/support overflow pills. Absent ⇒ 1. */
+export type FlexScaleKey = "stack" | "summaryTile";
+/** Persisted board layout. One shared global config; only the opponent HUD is
+ *  table-size-keyed. Presets are authoritative — applying one replaces every
+ *  field wholesale. Any manual edit flips `activePreset` to "custom".
+ *
+ *  `landSupportRatio` and `scales` are optional so a config persisted before
+ *  they existed (or cloud-synced from an older client) reads as the neutral
+ *  default rather than `undefined`; consumers apply `?? 0.5` / `?? 1`. */
+export interface FlexLayoutConfig {
+  gridBands: GridBands;
+  /** Lands' share of the lands↔support middle row, 0..1. Support takes the
+   *  remainder (`1 - ratio`). Absent ⇒ 0.5 (the prior equal `flex-1` split). */
+  landSupportRatio?: number;
+  /** Per-zone aspect-preserving size multipliers. Absent key ⇒ 1.0. */
+  scales?: Partial<Record<FlexScaleKey, number>>;
+  widgets: Partial<Record<FlexWidgetKey, WidgetOffset>>;
+  opponentHudByTableSize: Partial<Record<FlexTableSize, WidgetOffset>>;
+  activePreset: FlexPresetId;
+}
+
+/** Neutral default for the lands↔support split — equal halves, matching the
+ *  prior hardcoded `flex-1` / `flex-1`. */
+export const DEFAULT_LAND_SUPPORT_RATIO = 0.5;
+
+/** Factory for the default layout. This IS the "default" preset baseline and the
+ *  reset target; `presets.ts` imports it rather than redefining it. The band
+ *  values reproduce today's desktop `gridTemplateRows` exactly (see
+ *  {@link useResolvedGridRows}). Returned as a function so nested objects are
+ *  never shared between the store and the defaults snapshot. */
+export function defaultFlexLayout(): FlexLayoutConfig {
+  return {
+    gridBands: { top: { pct: 12, pxCap: 100 }, bottom: { pct: 18, pxCap: 150 } },
+    landSupportRatio: DEFAULT_LAND_SUPPORT_RATIO,
+    scales: {},
+    widgets: {},
+    opponentHudByTableSize: {},
+    activePreset: "default",
+  };
+}
+
+/** Deep-clone a layout config so applying a preset constant can never let a
+ *  later in-store mutation corrupt the shared preset object. */
+function cloneFlexLayout(config: FlexLayoutConfig): FlexLayoutConfig {
+  return {
+    gridBands: {
+      top: { ...config.gridBands.top },
+      bottom: { ...config.gridBands.bottom },
+    },
+    landSupportRatio: config.landSupportRatio,
+    scales: { ...config.scales },
+    widgets: Object.fromEntries(
+      Object.entries(config.widgets).map(([k, v]) => [k, { ...v }]),
+    ),
+    opponentHudByTableSize: Object.fromEntries(
+      Object.entries(config.opponentHudByTableSize).map(([k, v]) => [k, { ...v }]),
+    ),
+    activePreset: config.activePreset,
+  };
+}
+
 function defaultAiSeat(): AiSeatPref {
   return { difficulty: DEFAULT_AI_DIFFICULTY, deckId: AI_DECK_RANDOM };
 }
@@ -167,6 +268,7 @@ function buildDefaultPreferences(): PreferencesState {
     dismissedSandboxToolsNudge: false,
     artChain: [] as ArtChainEntry[],
     artOverrides: {} as Record<string, CardArtOverride>,
+    flexLayout: defaultFlexLayout(),
   };
 }
 
@@ -236,6 +338,9 @@ interface PreferencesState {
   dismissedSandboxToolsNudge: boolean;
   artChain: ArtChainEntry[];
   artOverrides: Record<string, CardArtOverride>;
+  /** Persisted board layout (grid bands + per-widget offsets + active preset).
+   *  See {@link FlexLayoutConfig}. Edited only in Flex Layout mode. */
+  flexLayout: FlexLayoutConfig;
 }
 
 interface PreferencesActions {
@@ -298,6 +403,26 @@ interface PreferencesActions {
   setArtOverride: (oracleId: string, override: CardArtOverride) => void;
   clearArtOverride: (oracleId: string) => void;
   clearAllArtOverrides: () => void;
+  /** Resize one board grid band (top or bottom); the `1fr` middle absorbs the
+   *  change. Flips `activePreset` to "custom". */
+  setFlexBand: (side: "top" | "bottom", track: CappedTrack) => void;
+  /** Reposition a shared-global widget. Flips `activePreset` to "custom". */
+  setFlexWidgetOffset: (key: FlexWidgetKey, offset: WidgetOffset) => void;
+  /** Reposition the opponent HUD for the current table size only (so 1v1 and
+   *  multiplayer keep distinct spots). Flips `activePreset` to "custom". */
+  setFlexOpponentHudOffset: (tableSize: FlexTableSize, offset: WidgetOffset) => void;
+  /** Set the lands↔support split (lands' share, clamped 0..1). The support
+   *  column takes the remainder. Flips `activePreset` to "custom". */
+  setFlexLandSupportRatio: (ratio: number) => void;
+  /** Set a zone's aspect-preserving size multiplier. Flips `activePreset` to
+   *  "custom". */
+  setFlexScale: (key: FlexScaleKey, scale: number) => void;
+  /** Apply a preset wholesale — replaces every field, including the opponent
+   *  HUD, and sets `activePreset` to the preset's id. Caller resolves the id to
+   *  a config (from `presets.ts`) to keep the store free of a preset import. */
+  applyFlexPreset: (config: FlexLayoutConfig) => void;
+  /** Reset the layout to the default preset (clears all offsets). */
+  resetFlexLayout: () => void;
 }
 
 type LegacyFlatAiPrefs = Partial<{
@@ -476,10 +601,57 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
           return { artOverrides: rest };
         }),
       clearAllArtOverrides: () => set({ artOverrides: {} }),
+      setFlexBand: (side, track) =>
+        set((state) => ({
+          flexLayout: {
+            ...state.flexLayout,
+            gridBands: { ...state.flexLayout.gridBands, [side]: track },
+            activePreset: "custom",
+          },
+        })),
+      setFlexWidgetOffset: (key, offset) =>
+        set((state) => ({
+          flexLayout: {
+            ...state.flexLayout,
+            widgets: { ...state.flexLayout.widgets, [key]: offset },
+            activePreset: "custom",
+          },
+        })),
+      setFlexOpponentHudOffset: (tableSize, offset) =>
+        set((state) => ({
+          flexLayout: {
+            ...state.flexLayout,
+            opponentHudByTableSize: {
+              ...state.flexLayout.opponentHudByTableSize,
+              [tableSize]: offset,
+            },
+            activePreset: "custom",
+          },
+        })),
+      setFlexLandSupportRatio: (ratio) =>
+        set((state) => ({
+          flexLayout: {
+            ...state.flexLayout,
+            // Clamp so neither column starves (each keeps ≥20% of the row).
+            landSupportRatio: Math.min(0.8, Math.max(0.2, ratio)),
+            activePreset: "custom",
+          },
+        })),
+      setFlexScale: (key, scale) =>
+        set((state) => ({
+          flexLayout: {
+            ...state.flexLayout,
+            // Clamp to a sane, readable range (half to double the auto-size).
+            scales: { ...state.flexLayout.scales, [key]: Math.min(2, Math.max(0.5, scale)) },
+            activePreset: "custom",
+          },
+        })),
+      applyFlexPreset: (config) => set({ flexLayout: cloneFlexLayout(config) }),
+      resetFlexLayout: () => set({ flexLayout: defaultFlexLayout() }),
     }),
     {
       name: "phase-preferences",
-      version: 15,
+      version: 16,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -504,6 +676,10 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          (instant — the prior behavior) via the shallow merge.
       // v14 → v15: Add commandZoneDisplay; legacy stores default to "auto"
       //          via the shallow merge.
+      // v15 → v16: Add flexLayout; legacy stores default to defaultFlexLayout()
+      //          via the shallow merge. The default bands reproduce today's
+      //          gridTemplateRows exactly, so this is a zero-regression seed —
+      //          no explicit migration block needed.
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -163,6 +163,11 @@ interface UiStoreState {
   debugHighlightedObjectId: ObjectId | null;
   debugHighlightedPlayerId: number | null;
   logPanelOpen: boolean;
+  /** Whether Flex Layout edit mode is active. Ephemeral (never persisted) — the
+   *  layout DATA lives in `preferencesStore.flexLayout`; this is just the
+   *  transient "the user is currently rearranging the board" toggle that gates
+   *  the edit overlay, widget dragging, and resize grabbers. */
+  flexEditMode: boolean;
 }
 
 interface UiStoreActions {
@@ -223,6 +228,8 @@ interface UiStoreActions {
   setDebugHighlightedPlayerId: (id: number | null) => void;
   setLogPanelOpen: (open: boolean) => void;
   toggleLogPanel: () => void;
+  setFlexEditMode: (active: boolean) => void;
+  toggleFlexEditMode: () => void;
 }
 
 export type UiStore = UiStoreState & UiStoreActions;
@@ -262,6 +269,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   debugHighlightedObjectId: null,
   debugHighlightedPlayerId: null,
   logPanelOpen: false,
+  flexEditMode: false,
 
   selectObject: (id) => set({ selectedObjectId: id }),
   hoverObject: (id) => set({ hoveredObjectId: id }),
@@ -514,4 +522,6 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   toggleHelpSheet: () => set((state) => ({ helpSheetOpen: !state.helpSheetOpen })),
   setLogPanelOpen: (open) => set({ logPanelOpen: open }),
   toggleLogPanel: () => set((state) => ({ logPanelOpen: !state.logPanelOpen })),
+  setFlexEditMode: (active) => set({ flexEditMode: active }),
+  toggleFlexEditMode: () => set((state) => ({ flexEditMode: !state.flexEditMode })),
 }));


### PR DESCRIPTION
Adds a toggleable Flex Layout edit mode (Ctrl+Shift+L, board right-click
'Customize layout…', or Preferences → Visual) that lets players tailor the
table and persists it in preferencesStore (v16 flexLayout; zero-regression
defaults reproduce today's layout byte-for-byte).

Capabilities:
- Drag-reposition the player HUD, both opponent HUD variants (1v1 + the
  multiplayer tab strip, position remembered per table size), stack, game
  log, action rail, and zone piles — via one reusable useDraggableWidget +
  DraggableWidget built on Framer Motion's drag, with a load-time viewport
  clamp for cloud-synced offsets from a larger monitor.
- Resize the three board bands (ZoneSplitter over an asymmetric capped-track
  grid model; the 1fr middle absorbs the change) and the lands↔support
  divider (ColumnSplitter → global landSupportRatio, drift-free pointer math,
  clamped so neither column starves).
- Aspect-preserving size multipliers (scales: stack + summary tiles) exposed
  as toolbar steppers, clamped 0.5–2.0.
- Presets (Layout 1/2/3) are authoritative — applying one replaces the layout
  wholesale; Reset returns to the default baseline. Neutral names since the
  alternative shapes carry no principled design rationale.

Engine/transport untouched: this is display-layer state only. i18n added
across all 7 locales (parity gate green). Tests cover the byte-identical grid
resolver, v16 migration, splitter/ratio/scale math, and store-action
transitions.
