### PR TITLE
Fix #1025: cast Expertise free spells during resolution

### DIFF
--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -288,6 +288,80 @@ fn target_is_in_other_players_graveyard(
         .is_some_and(|obj| obj.zone == Zone::Graveyard && obj.owner != controller)
 }
 
+/// CR 608.2g + CR 601.2a: After a resolution-time hand pick for a free
+/// `CastFromZone` (Expertise cycle, Electrodominance), cast the chosen spell
+/// during resolution instead of granting a lingering hand permission.
+pub(crate) fn complete_hand_pick_cast_from_zone(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    card: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> Result<bool, EffectError> {
+    let (without_paying, cast_transformed, alt_ability_cost, constraint, driver) =
+        match &ability.effect {
+            Effect::CastFromZone {
+                without_paying_mana_cost,
+                cast_transformed,
+                alt_ability_cost,
+                constraint,
+                driver,
+                ..
+            } => (
+                *without_paying_mana_cost,
+                *cast_transformed,
+                alt_ability_cost.as_ref(),
+                constraint.clone(),
+                *driver,
+            ),
+            _ => return Err(EffectError::MissingParam("CastFromZone".to_string())),
+        };
+
+    let during_resolution = driver.is_during_resolution()
+        || (without_paying
+            && alt_ability_cost.is_none()
+            && matches!(
+                &ability.effect,
+                Effect::CastFromZone { target, .. }
+                    if target.extract_in_zone() == Some(Zone::Hand)
+            ));
+
+    if during_resolution {
+        cast_single_target_during_resolution(
+            state,
+            ability,
+            card,
+            constraint.or_else(|| effective_cast_from_zone_constraint(ability)),
+            cast_transformed,
+            events,
+        )?;
+        return Ok(true);
+    }
+
+    grant_lingering_permissions(state, ability, std::slice::from_ref(&card), events)?;
+    Ok(false)
+}
+
+fn effective_cast_from_zone_constraint(
+    ability: &ResolvedAbility,
+) -> Option<crate::types::ability::CastPermissionConstraint> {
+    let Effect::CastFromZone { target, .. } = &ability.effect else {
+        return None;
+    };
+    let TargetFilter::Typed(filter) = target else {
+        return None;
+    };
+    filter.properties.iter().find_map(|prop| {
+        if let crate::types::ability::FilterProp::Cmc { comparator, value } = prop {
+            Some(crate::types::ability::CastPermissionConstraint::ManaValue {
+                comparator: *comparator,
+                value: value.clone(),
+            })
+        } else {
+            None
+        }
+    })
+}
+
 /// CR 608.2g + CR 601.2a–i: Cast a single targeted card DURING the resolution of
 /// this effect, for free, via the same authority Cascade/Discover/Suspend use.
 ///
@@ -1087,7 +1161,7 @@ mod tests {
     }
 
     #[test]
-    fn hand_cast_selection_grants_zero_cost_permission_in_hand() {
+    fn hand_cast_selection_casts_during_resolution_without_lingering_permission() {
         let mut state = make_test_state();
         let cheap = add_card_to_hand(&mut state, PlayerId(0), CardId(505));
         let ability = electrodominance_hand_ability(3);
@@ -1096,27 +1170,10 @@ mod tests {
         resolve(&mut state, &ability, &mut events).unwrap();
         apply_as_current(&mut state, GameAction::SelectCards { cards: vec![cheap] }).unwrap();
 
-        assert_eq!(state.objects[&cheap].zone, Zone::Hand);
-        assert!(state.objects[&cheap]
-            .casting_permissions
-            .iter()
-            .any(|p| matches!(
-                p,
-                CastingPermission::ExileWithAltCost {
-                    cost,
-                    granted_to: Some(PlayerId(0)),
-                    ..
-                } if *cost == ManaCost::zero()
-            )));
+        assert_eq!(state.objects[&cheap].zone, Zone::Stack);
+        assert!(state.objects[&cheap].casting_permissions.is_empty());
     }
 
-    /// CR 611.2a: A hand-origin in-place "you may cast it without paying its
-    /// mana cost" grant (Sunforger searches a card to hand, then casts it from
-    /// there) is a one-resolution offer. It must default to `UntilEndOfTurn` so
-    /// that if the cast is *declined* the grant is pruned at cleanup — otherwise
-    /// a `duration: None` grant lingers on the hand card and
-    /// `has_hand_alt_cost_permission` re-offers the free cast forever. Mirrors
-    /// the graveyard-origin (Emry) default.
     #[test]
     fn hand_in_place_grant_defaults_to_until_end_of_turn() {
         let mut state = make_test_state();
@@ -1124,8 +1181,7 @@ mod tests {
         let ability = electrodominance_hand_ability(3);
 
         let mut events = vec![];
-        resolve(&mut state, &ability, &mut events).unwrap();
-        apply_as_current(&mut state, GameAction::SelectCards { cards: vec![cheap] }).unwrap();
+        grant_lingering_permissions(&mut state, &ability, &[cheap], &mut events).unwrap();
 
         assert_eq!(state.objects[&cheap].zone, Zone::Hand);
         assert!(

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2664,13 +2664,29 @@ pub(super) fn handle_resolution_choice(
                         ));
                     };
                     let ability = *cont.chain;
-                    effects::cast_from_zone::grant_lingering_permissions(
-                        &mut *state,
-                        &ability,
-                        &chosen,
-                        events,
-                    )
-                    .map_err(|e| EngineError::InvalidAction(e.to_string()))?;
+                    if chosen.len() == 1 {
+                        let used_during_resolution =
+                            effects::cast_from_zone::complete_hand_pick_cast_from_zone(
+                                &mut *state,
+                                &ability,
+                                chosen[0],
+                                events,
+                            )
+                            .map_err(|e| EngineError::InvalidAction(e.to_string()))?;
+                        if used_during_resolution {
+                            return Ok(ResolutionChoiceOutcome::WaitingFor(
+                                state.waiting_for.clone(),
+                            ));
+                        }
+                    } else {
+                        effects::cast_from_zone::grant_lingering_permissions(
+                            &mut *state,
+                            &ability,
+                            &chosen,
+                            events,
+                        )
+                        .map_err(|e| EngineError::InvalidAction(e.to_string()))?;
+                    }
                 }
                 // CR 701.68a: Place `count_param` -1/-1 counters on the creature
                 // the controller chose. The choice is non-targeted; the pool was

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12481,7 +12481,7 @@ fn try_parse_cast_effect(lower: &str) -> Option<Effect> {
             without_paying_mana_cost: without_paying,
             mode,
             cast_transformed: false,
-            alt_ability_cost: None,
+            alt_ability_cost,
             constraint,
             duration: None,
             driver,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12463,6 +12463,19 @@ fn try_parse_cast_effect(lower: &str) -> Option<Effect> {
         .unwrap_or_else(|| super::oracle_target::parse_type_phrase(cast_target_rest).0);
     if cast_filter_has_typed_leaf(&filter) {
         apply_cast_target_suffixes(&mut filter, rest);
+        let alt_ability_cost = parse_alt_ability_cost_rider(lower);
+        let hand_origin = matches!(
+            &filter,
+            TargetFilter::Typed(tf)
+                if tf.properties.iter().any(|prop| {
+                    matches!(prop, FilterProp::InZone { zone: Zone::Hand })
+                })
+        );
+        let driver = if without_paying && alt_ability_cost.is_none() && hand_origin {
+            crate::types::ability::CastFromZoneDriver::DuringResolution
+        } else {
+            crate::types::ability::CastFromZoneDriver::LingeringPermission
+        };
         return Some(Effect::CastFromZone {
             target: filter,
             without_paying_mana_cost: without_paying,
@@ -12471,7 +12484,7 @@ fn try_parse_cast_effect(lower: &str) -> Option<Effect> {
             alt_ability_cost: None,
             constraint,
             duration: None,
-            driver: crate::types::ability::CastFromZoneDriver::LingeringPermission,
+            driver,
         });
     }
 

--- a/crates/engine/tests/integration/issue_1025_rishkars_expertise.rs
+++ b/crates/engine/tests/integration/issue_1025_rishkars_expertise.rs
@@ -1,0 +1,136 @@
+//! Issue #1025 — Rishkar's Expertise must cast the free spell during resolution
+//! instead of stalling in a non-actionable waiting state after the hand pick.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{CastingPermission, Effect};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const RISHKAR_EXPERTISE: &str = "Draw cards equal to the greatest power among creatures you control. \
+You may cast a spell with mana value 5 or less from your hand without paying its mana cost.";
+
+fn floating_mana(generic: usize, green: usize) -> Vec<ManaUnit> {
+    let mut pool = Vec::new();
+    for _ in 0..generic {
+        pool.push(ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    }
+    for _ in 0..green {
+        pool.push(ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]));
+    }
+    pool
+}
+
+#[test]
+fn rishkars_expertise_free_cast_completes_during_resolution() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario.with_library_top(
+        P0,
+        &["Library One", "Library Two", "Library Three", "Library Four", "Library Five"],
+    );
+    scenario.add_creature(P0, "Elf", 1, 1);
+    let expertise = scenario
+        .add_spell_to_hand_from_oracle(P0, "Rishkar's Expertise", false, RISHKAR_EXPERTISE)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 4,
+            shards: vec![ManaCostShard::Green, ManaCostShard::Green],
+        })
+        .id();
+    let free_spell = scenario
+        .add_spell_to_hand(P0, "Free Bolt", true)
+        .with_mana_cost(ManaCost::generic(2))
+        .from_oracle_text("Draw a card.")
+        .id();
+
+    scenario.with_mana_pool(P0, floating_mana(4, 2));
+
+    let mut runner = scenario.build();
+    let expertise_card_id = runner.state().objects[&expertise].card_id;
+
+    let parsed = &runner.state().objects[&expertise].abilities[0];
+    let cast = parsed
+        .sub_ability
+        .as_ref()
+        .expect("free cast sub-ability");
+    assert!(matches!(
+        cast.effect.as_ref(),
+        Effect::CastFromZone {
+            without_paying_mana_cost: true,
+            ..
+        }
+    ));
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: expertise,
+            card_id: expertise_card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Rishkar's Expertise");
+
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { player, .. } if player == P0
+        ),
+        "expected optional free-cast prompt, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept free cast");
+
+    match &runner.state().waiting_for {
+        WaitingFor::EffectZoneChoice { cards, .. } => {
+            assert!(cards.contains(&free_spell));
+        }
+        other => panic!("expected hand pick for free cast, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![free_spell],
+        })
+        .expect("pick free spell");
+
+    assert_eq!(
+        runner.state().objects[&free_spell].zone,
+        Zone::Stack,
+        "free spell must reach the stack during resolution"
+    );
+    assert!(
+        !runner.state().objects[&free_spell]
+            .casting_permissions
+            .iter()
+            .any(|p| matches!(
+                p,
+                CastingPermission::ExileWithAltCost {
+                    resolution_cleanup: None,
+                    ..
+                }
+            )),
+        "must not leave a lingering hand free-cast permission"
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "game must return to actionable priority, got {:?}",
+        runner.state().waiting_for
+    );
+}

--- a/crates/engine/tests/integration/issue_1025_rishkars_expertise.rs
+++ b/crates/engine/tests/integration/issue_1025_rishkars_expertise.rs
@@ -10,7 +10,8 @@ use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
-const RISHKAR_EXPERTISE: &str = "Draw cards equal to the greatest power among creatures you control. \
+const RISHKAR_EXPERTISE: &str =
+    "Draw cards equal to the greatest power among creatures you control. \
 You may cast a spell with mana value 5 or less from your hand without paying its mana cost.";
 
 fn floating_mana(generic: usize, green: usize) -> Vec<ManaUnit> {
@@ -36,7 +37,13 @@ fn rishkars_expertise_free_cast_completes_during_resolution() {
 
     scenario.with_library_top(
         P0,
-        &["Library One", "Library Two", "Library Three", "Library Four", "Library Five"],
+        &[
+            "Library One",
+            "Library Two",
+            "Library Three",
+            "Library Four",
+            "Library Five",
+        ],
     );
     scenario.add_creature(P0, "Elf", 1, 1);
     let expertise = scenario
@@ -58,10 +65,7 @@ fn rishkars_expertise_free_cast_completes_during_resolution() {
     let expertise_card_id = runner.state().objects[&expertise].card_id;
 
     let parsed = &runner.state().objects[&expertise].abilities[0];
-    let cast = parsed
-        .sub_ability
-        .as_ref()
-        .expect("free cast sub-ability");
+    let cast = parsed.sub_ability.as_ref().expect("free cast sub-ability");
     assert!(matches!(
         cast.effect.as_ref(),
         Effect::CastFromZone {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -92,6 +92,7 @@ mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;
 mod invoke_calamity_free_cast;
+mod issue_1025_rishkars_expertise;
 mod issue_1202_prepared_spell_cast_timing;
 mod issue_1206_shelob_spider_death_tokens;
 mod issue_1297_venture_initiative_triggers;


### PR DESCRIPTION
## Summary

- Route `CastFromZone` hand picks (Rishkar's Expertise, Baral's Expertise, Electrodominance) through `initiate_cast_during_resolution` instead of granting lingering hand permissions that stall in a non-actionable waiting state.
- Parse hand-origin "cast a spell ... without paying its mana cost" effects with `CastFromZoneDriver::DuringResolution`.

## Test plan

- [x] `cargo test -p engine --test integration issue_1025`
- [x] `cargo test -p engine --lib hand_cast`
- [x] `cargo clippy -p engine -- -D warnings`
- [x] `./scripts/check-parser-combinators.sh upstream/main`

Fixes #1025

Made with [Cursor](https://cursor.com)