### PR TITLE
fix(engine): type StaticMode::LinkedCollectionCounterPlayPermission (Evelyn coverage)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1618,12 +1618,8 @@ fn source_has_collection_counter_play_permission(
     state.objects.get(&source).is_some_and(|source_obj| {
         source_obj.zone == Zone::Battlefield
             && source_obj.controller == player
-            && active_static_definitions(state, source_obj).any(|def| {
-                matches!(
-                    &def.mode,
-                    StaticMode::Other(name) if name == "LinkedCollectionCounterPlayPermission"
-                )
-            })
+            && active_static_definitions(state, source_obj)
+                .any(|def| matches!(&def.mode, StaticMode::LinkedCollectionCounterPlayPermission))
     })
 }
 
@@ -24770,9 +24766,9 @@ mod tests {
             .get_mut(&source)
             .unwrap()
             .static_definitions
-            .push(StaticDefinition::new(StaticMode::Other(
-                "LinkedCollectionCounterPlayPermission".to_string(),
-            )));
+            .push(StaticDefinition::new(
+                StaticMode::LinkedCollectionCounterPlayPermission,
+            ));
 
         let obj_id = create_object(
             &mut state,
@@ -24838,9 +24834,9 @@ mod tests {
             .get_mut(&source)
             .unwrap()
             .static_definitions
-            .push(StaticDefinition::new(StaticMode::Other(
-                "LinkedCollectionCounterPlayPermission".to_string(),
-            )));
+            .push(StaticDefinition::new(
+                StaticMode::LinkedCollectionCounterPlayPermission,
+            ));
 
         // An opponent-owned (PlayerId(1)) exiled spell with a collection counter,
         // exiled by an ability PlayerId(0) controlled — the reported scenario.

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -67,6 +67,12 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             // enforcement is in casting.rs::exile_objects_castable_by_permission
             // and casting_costs.rs.
             | StaticMode::ExileCastPermission { .. }
+            // CR 113.6 + CR 601.2a: LinkedCollectionCounterPlayPermission is a
+            // nullary marker static — runtime enforcement is in
+            // casting.rs::source_has_collection_counter_play_permission, which
+            // gates the per-card `CastingPermission::PlayFromExile` on a live
+            // source. Not registry-keyed (mirrors the cast-permission cluster).
+            | StaticMode::LinkedCollectionCounterPlayPermission
             | StaticMode::CastWithKeyword { .. }
             // CR 118.9: CastWithAlternativeCost carries an `AbilityCost` — runtime
             // data, not registry-keyable (Rooftop Storm, Fist of Suns, Jodah).

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -12614,10 +12614,7 @@ fn parser_shape_evelyn_collection_counter_play_permission_static_is_not_unimplem
             "Once each turn, you may play a card from exile with a collection counter on it if it was exiled by an ability you controlled, and you may spend mana as though it were mana of any color to cast it.",
         )
         .unwrap();
-    assert_eq!(
-        def.mode,
-        StaticMode::Other("LinkedCollectionCounterPlayPermission".to_string())
-    );
+    assert_eq!(def.mode, StaticMode::LinkedCollectionCounterPlayPermission);
 }
 
 // --- Group B: Generic activated ability cost reduction ---

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -211,10 +211,8 @@ pub(crate) fn parse_collection_counter_play_permission_static(
     })?;
 
     Some(
-        StaticDefinition::new(StaticMode::Other(
-            "LinkedCollectionCounterPlayPermission".to_string(),
-        ))
-        .description(description.to_string()),
+        StaticDefinition::new(StaticMode::LinkedCollectionCounterPlayPermission)
+            .description(description.to_string()),
     )
 }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -625,6 +625,13 @@ fn static_mode_is_optional_permission(mode: &StaticMode) -> bool {
             // may cast …" exile-cast permission — structurally opt-in by
             // the same "you may cast" surface as the graveyard sibling.
             | StaticMode::ExileCastPermission { .. }
+            // CR 601.2a + CR 113.6: Evelyn-class "Once each turn, you may
+            // play a card from exile … if it was exiled by an ability you
+            // controlled" — opt-in "you may play" permission whose "if"
+            // provenance clause is enforced at runtime via the per-card
+            // `PlayFromExile { exiled_by_ability_controller }` grant, not a
+            // dropped condition.
+            | StaticMode::LinkedCollectionCounterPlayPermission
             // CR 601.2f: Defiler-style cost reductions encode the optional
             // life payment inside the static cost-modification primitive.
             | StaticMode::DefilerCostReduction { .. }
@@ -1968,6 +1975,14 @@ fn detect_condition_if(
         // CR 117.3a: TopOfLibraryCastPermission with `alt_cost` IS the "if
         // you cast a spell this way, pay X" gate (Bolas's Citadel etc.).
         "TopOfLibraryCastPermission",
+        // CR 113.6 + CR 601.2a: Evelyn's "you may play a card from exile … if
+        // it was exiled by an ability you controlled" — the "if" provenance
+        // clause is represented structurally by the
+        // LinkedCollectionCounterPlayPermission live-source marker static plus
+        // the per-card `PlayFromExile { exiled_by_ability_controller }` grant
+        // the ETB trigger attaches (set in grant_permission.rs, enforced in
+        // casting.rs / layers.rs), not a swallowed condition.
+        "LinkedCollectionCounterPlayPermission",
         // CR 614.1a: GraveyardCastPermission with this flag carries the "if
         // a spell cast this way would be put into your graveyard, exile it
         // instead" replacement rider.

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -965,6 +965,29 @@ pub enum StaticMode {
         #[serde(default)]
         timing: ExileCastTiming,
     },
+    /// CR 113.6 + CR 601.2a: Marker static identifying a source whose linked
+    /// "play a card from exile with a collection counter on it" permission is
+    /// live (Evelyn, the Covetous). Per CR 113.6, that play permission is a
+    /// static ability of the source and functions only while the source is on
+    /// the battlefield under the player's control; this marker is what
+    /// `casting.rs::source_has_collection_counter_play_permission` consults so
+    /// the per-card `CastingPermission::PlayFromExile` (collection-counter +
+    /// controller provenance) is honored only while a live source remains.
+    /// CR 601.2a: the permission authorizes moving a matching exiled card to
+    /// the stack / battlefield (playing it).
+    ///
+    /// Distinct from `ExileCastPermission`: that static is self-contained and
+    /// grants the cast itself, keyed on a source-identity exile pool. This is a
+    /// nullary marker; the actual permission lives on each exiled card as a
+    /// `CastingPermission::PlayFromExile`, linked by the collection counter
+    /// (not source identity), so the authority winks out if every source
+    /// leaves but the counter persists.
+    ///
+    /// RUNTIME: handled by direct match in
+    /// `casting.rs::source_has_collection_counter_play_permission`; coverage
+    /// support is via `is_data_carrying_static()` (mirrors the cast-permission
+    /// cluster, which is also runtime-by-direct-match, not registry-keyed).
+    LinkedCollectionCounterPlayPermission,
     /// CR 101.2: This spell/permanent can't be countered.
     CantBeCountered,
     /// CR 101.2 + CR 707.10: This spell can't be copied by spells or abilities.
@@ -1578,6 +1601,7 @@ impl StaticMode {
             | StaticMode::AssignNoCombatDamage
             | StaticMode::UntapsDuringEachOtherPlayersUntapStep
             | StaticMode::EntersWithAdditionalCounters { .. }
+            | StaticMode::LinkedCollectionCounterPlayPermission
             | StaticMode::Other(_) => None,
         }
     }
@@ -1870,6 +1894,9 @@ impl fmt::Display for StaticMode {
             } => {
                 write!(f, "EntersWithAdditionalCounters({counter_type:?},{count})")
             }
+            StaticMode::LinkedCollectionCounterPlayPermission => {
+                write!(f, "LinkedCollectionCounterPlayPermission")
+            }
             // Fallback
             StaticMode::Other(s) => write!(f, "{s}"),
         }
@@ -1885,6 +1912,9 @@ impl FromStr for StaticMode {
             "CantAttack" => StaticMode::CantAttack,
             "CantBlock" => StaticMode::CantBlock,
             "CantAttackOrBlock" => StaticMode::CantAttackOrBlock,
+            "LinkedCollectionCounterPlayPermission" => {
+                StaticMode::LinkedCollectionCounterPlayPermission
+            }
             s if parse_static_mode_u32_arg(s, "MaxAttackersEachCombat").is_some() => {
                 StaticMode::MaxAttackersEachCombat {
                     max: parse_static_mode_u32_arg(s, "MaxAttackersEachCombat").unwrap(),


### PR DESCRIPTION
Evelyn, the Covetous read coverage supported:false despite working correctly
at runtime. Its "Once each turn, you may play a card from exile ..." play
permission was modeled via the StaticMode::Other("LinkedCollectionCounter...")
escape hatch, which the coverage classifier counts as an unmodeled gap by
construction (Other(_) is neither registry-keyed nor in is_data_carrying_static).
A second false-positive Swallow:Condition_If warning flagged the "if it was
exiled by an ability you controlled" clause, which is actually enforced at
runtime via the per-card PlayFromExile { exiled_by_ability_controller } grant.

Promote the marker to a first-class typed unit variant
StaticMode::LinkedCollectionCounterPlayPermission (CR 113.6 + CR 601.2a) and
make it visible to the coverage and swallowed-clause tooling. No runtime
behavior change: the runtime path was already a direct match on the same marker.

- types/statics.rs: new unit variant + as_keyword/Display/FromStr arms
- parser/oracle_static/type_change.rs: emit the typed variant
- game/casting.rs: match the typed variant (drop string compare) + test fixtures
- game/coverage.rs: add to is_data_carrying_static (closes Static: gap)
- parser/swallow_check.rs: cond_markers + optional-permission classification
  (closes Swallow:Condition_If gap)

Evelyn now reads supported:true, gap_count 0.
