### PR TITLE
feat(engine): hexproof if it hasn’t dealt damage yet

### DIFF
--- a/crates/engine/src/game/conditions.rs
+++ b/crates/engine/src/game/conditions.rs
@@ -110,6 +110,16 @@ pub(crate) fn eval_source_entered_this_turn(state: &GameState, source_id: Object
         .is_some_and(|obj| obj.entered_battlefield_turn == Some(state.turn_number))
 }
 
+/// CR 120.3 + CR 120.6 + CR 702.11b: True when the source permanent has actually
+/// dealt damage (combat or noncombat) since it entered the battlefield. Backs the
+/// `StaticCondition::SourceHasDealtDamage` predicate; the "hasn't dealt damage yet"
+/// negation wraps this via `StaticCondition::Not`. The flag is set in
+/// `deal_damage` on the first nonzero amount actually dealt and cleared on a
+/// battlefield exit (`apply_zone_exit_cleanup`).
+pub(crate) fn eval_source_has_dealt_damage(state: &GameState, source_id: ObjectId) -> bool {
+    state.objects_that_dealt_damage.contains(&source_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5708,6 +5708,7 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::DuringYourTurn => ("DuringYourTurn", Handled),
         StaticCondition::DayNightIs { .. } => ("DayNightIs", Handled),
         StaticCondition::SourceEnteredThisTurn => ("SourceEnteredThisTurn", Handled),
+        StaticCondition::SourceHasDealtDamage => ("SourceHasDealtDamage", Handled),
         StaticCondition::WasCast { .. } => ("WasCast", Handled),
         StaticCondition::IsRingBearer => ("IsRingBearer", Handled),
         StaticCondition::RingLevelAtLeast { .. } => ("RingLevelAtLeast", Handled),

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -584,6 +584,24 @@ pub(crate) fn apply_damage_after_replacement(
             record.source_zone = obj.zone;
         }
         state.damage_dealt_this_turn.push_back(record);
+        // CR 120.3 + CR 120.6 + CR 702.11b + CR 613.1f: Mark the source as having
+        // actually dealt damage (this branch is gated on `actual_amount > 0`, i.e.
+        // a nonzero amount actually dealt per CR 120.3/120.6, not the would-be
+        // amount of CR 120.1a). Only battlefield-resident sources carry this
+        // sticky flag, since the reset in `apply_zone_exit_cleanup` is gated on a
+        // battlefield exit. When the id is NEWLY inserted, mark layers fully dirty
+        // so `flush_layers` recomputes the materialized keyword set that
+        // `has_hexproof` reads — otherwise the conditional hexproof grant for
+        // "has hexproof if it hasn't dealt damage yet" would never drop at the
+        // targeting check (a Clean `layers_dirty` no-ops `flush_layers`).
+        if state
+            .objects
+            .get(&ctx.source_id)
+            .is_some_and(|obj| obj.zone == crate::types::zones::Zone::Battlefield)
+            && state.objects_that_dealt_damage.insert(ctx.source_id)
+        {
+            state.layers_dirty.mark_full();
+        }
     }
 
     // CR 702.15b / CR 120.3f: Lifelink — controller gains life equal to damage dealt.
@@ -1415,6 +1433,196 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, GameEvent::DamagePrevented { .. })),
             "a DamagePrevented event is emitted"
+        );
+    }
+
+    /// CR 702.11b + CR 613.1f + CR 120.3: DISCRIMINATING runtime test for
+    /// "has hexproof if it hasn't dealt damage yet" (Palladia-Mors, the Ruiner;
+    /// Karakyk Guardian). Proves the gate is read AT THE TARGETING CHECK:
+    ///   1. Before dealing damage, an opponent's bolt CANNOT target the creature
+    ///      (hexproof active → not in `target_slots[0].legal_targets`).
+    ///   2. After the creature deals combat damage, the same bolt CAN target it
+    ///      (hexproof gone) — this passes only because the `mark_full()` in the
+    ///      damage chokepoint forces `flush_layers` to recompute the materialized
+    ///      keyword set `has_hexproof` reads. Reverting that `mark_full()` leaves
+    ///      `layers_dirty == Clean`, the keyword set stale, and this step FAILS.
+    ///   3. A noncombat-damage source separately sets the same sticky flag.
+    ///   4. After the creature leaves and re-enters the battlefield (flicker), the
+    ///      flag is cleared and hexproof is restored (illegal target again).
+    #[test]
+    fn hexproof_if_hasnt_dealt_damage_drops_at_targeting_after_damage_restored_on_flicker() {
+        use crate::game::keywords::has_hexproof;
+        use crate::game::layers::flush_layers;
+        use crate::game::scenario::GameScenario;
+        use crate::game::zones::move_to_zone;
+        use crate::types::actions::GameAction;
+        use crate::types::game_state::CastPaymentMode;
+        use crate::types::phase::Phase;
+
+        const P0: PlayerId = PlayerId(0);
+        const P1: PlayerId = PlayerId(1);
+
+        // P1 controls the conditional-hexproof creature; P0 is the opponent.
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let guardian = scenario
+            .add_creature_from_oracle(
+                P1,
+                "Karakyk Guardian",
+                3,
+                3,
+                "Flying, vigilance, trample\nThis creature has hexproof if it hasn't dealt damage yet.",
+            )
+            .id();
+        // A vanilla P1 creature for the guardian to deal noncombat-style damage to.
+        let victim = scenario.add_creature(P1, "Bear", 2, 2).id();
+        let bolt1 = scenario.add_bolt_to_hand(P0);
+        let bolt2 = scenario.add_bolt_to_hand(P0);
+        let mut runner = scenario.build();
+
+        // Layer 6 (CR 613.1f): the conditional grant is active while the gate
+        // (Not(SourceHasDealtDamage)) holds — i.e. before any damage is dealt.
+        flush_layers(runner.state_mut());
+        assert!(
+            has_hexproof(&runner.state().objects[&guardian]),
+            "guardian must have hexproof before it has dealt damage"
+        );
+
+        // STEP 1 — at the targeting check, an opponent's bolt cannot target it.
+        let bolt1_card = runner.state().objects[&bolt1].card_id;
+        let before = runner
+            .act(GameAction::CastSpell {
+                object_id: bolt1,
+                card_id: bolt1_card,
+                targets: vec![],
+                payment_mode: CastPaymentMode::Auto,
+            })
+            .expect("cast bolt 1 (players are still legal targets)");
+        if let WaitingFor::TargetSelection { target_slots, .. } = &before.waiting_for {
+            assert!(
+                !target_slots[0]
+                    .legal_targets
+                    .contains(&TargetRef::Object(guardian)),
+                "hexproof creature must NOT be a legal target before dealing damage"
+            );
+        } else {
+            panic!("expected TargetSelection, got {:?}", before.waiting_for);
+        }
+        // Resolve bolt 1 harmlessly at a player so it leaves the stack.
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![TargetRef::Player(P1)],
+            })
+            .expect("retarget bolt 1 at a player");
+
+        // STEP 2 — the guardian deals COMBAT damage. Drive the production
+        // chokepoint (`apply_damage_after_replacement`) so the BLOCKER-1
+        // `mark_full()` path executes.
+        {
+            let state = runner.state_mut();
+            let ctx = DamageContext::from_source(state, guardian).expect("guardian source ctx");
+            let event = ProposedEvent::Damage {
+                source_id: guardian,
+                target: TargetRef::Object(victim),
+                amount: 1,
+                is_combat: true,
+                applied: HashSet::new(),
+            };
+            let mut events = Vec::new();
+            apply_damage_after_replacement(state, &ctx, event, true, &mut events);
+            assert!(
+                state.objects_that_dealt_damage.contains(&guardian),
+                "sticky flag set after combat damage actually dealt"
+            );
+            // BLOCKER 1: the chokepoint marked layers fully dirty on first insert.
+            assert!(
+                state.layers_dirty.is_dirty(),
+                "deal_damage must mark layers dirty so the keyword set recomputes"
+            );
+        }
+
+        // The next action flushes layers; hexproof must now be gone AT the
+        // targeting check (the bolt can now target the guardian).
+        let bolt2_card = runner.state().objects[&bolt2].card_id;
+        let after = runner
+            .act(GameAction::CastSpell {
+                object_id: bolt2,
+                card_id: bolt2_card,
+                targets: vec![],
+                payment_mode: CastPaymentMode::Auto,
+            })
+            .expect("cast bolt 2");
+        if let WaitingFor::TargetSelection { target_slots, .. } = &after.waiting_for {
+            assert!(
+                target_slots[0]
+                    .legal_targets
+                    .contains(&TargetRef::Object(guardian)),
+                "hexproof must be GONE at the targeting check after the creature dealt damage"
+            );
+        } else {
+            panic!("expected TargetSelection, got {:?}", after.waiting_for);
+        }
+        assert!(
+            !has_hexproof(&runner.state().objects[&guardian]),
+            "materialized keywords must no longer include hexproof after damage"
+        );
+        // Clear the in-flight bolt 2 selection by retargeting at a player.
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![TargetRef::Player(P1)],
+            })
+            .expect("retarget bolt 2 at a player");
+
+        // STEP 3 — a NONCOMBAT-damage source also sets the sticky flag. Use a
+        // fresh creature so combat vs. noncombat is isolated.
+        {
+            let state = runner.state_mut();
+            let id = create_object(
+                state,
+                CardId(9001),
+                P1,
+                "Noncombat Pinger".to_string(),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+            let ctx = DamageContext::from_source(state, id).expect("pinger source ctx");
+            let event = ProposedEvent::Damage {
+                source_id: id,
+                target: TargetRef::Player(P0),
+                amount: 1,
+                is_combat: false,
+                applied: HashSet::new(),
+            };
+            let mut events = Vec::new();
+            apply_damage_after_replacement(state, &ctx, event, false, &mut events);
+            assert!(
+                state.objects_that_dealt_damage.contains(&id),
+                "noncombat damage also sets the sticky flag"
+            );
+        }
+
+        // STEP 4 — flicker the guardian (battlefield → exile → battlefield). The
+        // sticky flag is cleared on the battlefield exit, restoring hexproof.
+        {
+            let state = runner.state_mut();
+            let mut events = Vec::new();
+            move_to_zone(state, guardian, Zone::Exile, &mut events);
+            assert!(
+                !state.objects_that_dealt_damage.contains(&guardian),
+                "flag cleared when the guardian leaves the battlefield"
+            );
+            move_to_zone(state, guardian, Zone::Battlefield, &mut events);
+            flush_layers(state);
+        }
+        assert!(
+            has_hexproof(&runner.state().objects[&guardian]),
+            "hexproof restored after flicker (clean slate, no damage dealt yet)"
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -6,7 +6,8 @@ use crate::game::arithmetic::saturating_pt_add;
 use crate::game::conditions::{
     counter_condition_matches, eval_chosen_label_is, eval_class_level_ge, eval_has_city_blessing,
     eval_is_initiative, eval_is_monarch, eval_no_monarch, eval_source_entered_this_turn,
-    eval_source_in_zone, eval_source_is_attacking, eval_source_is_tapped_on_battlefield,
+    eval_source_has_dealt_damage, eval_source_in_zone, eval_source_is_attacking,
+    eval_source_is_tapped_on_battlefield,
 };
 use crate::game::devotion::count_devotion;
 use crate::game::filter::{matches_target_filter, FilterContext};
@@ -630,6 +631,7 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::UnlessPay { .. }
         | StaticCondition::DuringYourTurn
         | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::SourceHasDealtDamage
         | StaticCondition::WasCast { .. }
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
@@ -747,6 +749,7 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::UnlessPay { .. }
         | StaticCondition::DuringYourTurn
         | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::SourceHasDealtDamage
         | StaticCondition::WasCast { .. }
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
@@ -927,6 +930,10 @@ fn evaluate_condition_with_context(
         }
         // CR 400.7: True when the source permanent entered the battlefield this turn.
         StaticCondition::SourceEnteredThisTurn => eval_source_entered_this_turn(state, source_id),
+        // CR 120.3 + CR 120.6 + CR 702.11b: True once the source has actually dealt
+        // damage since entering the battlefield (sticky). The "hasn't dealt damage
+        // yet" hexproof grant wraps this in `StaticCondition::Not`.
+        StaticCondition::SourceHasDealtDamage => eval_source_has_dealt_damage(state, source_id),
         // CR 601.2 + CR 611.3a: True when the source permanent was cast.
         StaticCondition::WasCast { zone } => state
             .objects

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -323,6 +323,12 @@ pub(crate) fn apply_zone_exit_cleanup(
     if from == Zone::Battlefield {
         super::pairing::break_pair(state, object_id);
         crate::game::layers::mark_layers_full(state);
+        // CR 400.7 + CR 702.11b: The "has dealt damage since entering" sticky flag
+        // belongs to the old object. ObjectId persists across this zone change, so
+        // clear it on a battlefield exit (death/bounce/exile/flicker) — otherwise a
+        // flickered "has hexproof if it hasn't dealt damage yet" creature would
+        // re-enter still treated as having dealt damage and never regain hexproof.
+        state.objects_that_dealt_damage.remove(&object_id);
         super::layers::prune_host_left_effects(state, object_id);
         super::layers::prune_affected_object_left_effects(state, object_id);
         // CR 613.1 + CR 400.7: Copy effects are pruned above, but layer-derived

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2526,6 +2526,11 @@ pub(crate) fn static_condition_to_ability_condition(
         // CR 725.1: "there is no monarch" is a trigger-only intervening-if; no
         // `AbilityCondition` monarch variant beyond `IsMonarch` exists.
         | StaticCondition::NoMonarch
+        // CR 702.11b + CR 120.3: "has dealt damage since entering" is a static-only
+        // Layer-6 gate (the conditional hexproof grant) with no effect-resolution
+        // (`AbilityCondition`) equivalent. `Not(SourceHasDealtDamage)` is handled by
+        // the inner Not sub-match's `_ => None` arm above.
+        | StaticCondition::SourceHasDealtDamage
         | StaticCondition::None => None,
     }
 }

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1129,6 +1129,30 @@ fn parse_source_attached_to_creature(input: &str) -> OracleResult<'_, StaticCond
     .parse(rest)
 }
 
+/// CR 120.3 + CR 702.11b: Parse "<subject> hasn't dealt damage yet" into
+/// `Not(SourceHasDealtDamage)` — the negated form of the sticky "has dealt
+/// damage since entering" gate (Palladia-Mors, the Ruiner; Karakyk Guardian:
+/// "has hexproof if it hasn't dealt damage yet"). Accepts the self-referential
+/// subjects the conditional-keyword templates use ("it", "~", "this creature",
+/// "this permanent"). Only the negated "hasn't" idiom appears in Oracle text, so
+/// no affirmative form is produced here.
+fn parse_source_hasnt_dealt_damage(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = alt((
+        tag("it "),
+        tag("~ "),
+        tag("this creature "),
+        tag("this permanent "),
+    ))
+    .parse(input)?;
+    value(
+        StaticCondition::Not {
+            condition: Box::new(StaticCondition::SourceHasDealtDamage),
+        },
+        tag("hasn't dealt damage yet"),
+    )
+    .parse(rest)
+}
+
 /// CR 611.2b: Parse source-state conditions (tapped, untapped, entered this turn).
 fn parse_source_state_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
     alt((
@@ -1158,6 +1182,10 @@ fn parse_source_state_conditions(input: &str) -> OracleResult<'_, StaticConditio
         // Must precede `parse_source_is_type` so "has … counters on it" wins over
         // any other interpretation.
         parse_source_has_counters,
+        // CR 120.3 + CR 702.11b: "<subject> hasn't dealt damage yet" →
+        // Not(SourceHasDealtDamage). Specific full-phrase tag; placed before the
+        // generic predicates so it is not shadowed.
+        parse_source_hasnt_dealt_damage,
         // CR 400.7: Entered this turn.
         // Accept both the long "entered the battlefield this turn" and the abbreviated
         // "entered this turn" forms — Oracle templates vary between them for the same
@@ -7218,6 +7246,21 @@ mod tests {
             parse_inner_condition("this aura entered the battlefield this turn").unwrap();
         assert_eq!(rest, "");
         assert_eq!(c, StaticCondition::SourceEnteredThisTurn);
+    }
+
+    // CR 120.3 + CR 702.11b: "it hasn't dealt damage yet" (Palladia-Mors,
+    // Karakyk Guardian conditional hexproof) → Not(SourceHasDealtDamage),
+    // fully consumed.
+    #[test]
+    fn test_it_hasnt_dealt_damage_yet() {
+        let (rest, c) = parse_inner_condition("it hasn't dealt damage yet").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            c,
+            StaticCondition::Not {
+                condition: Box::new(StaticCondition::SourceHasDealtDamage),
+            }
+        );
     }
 
     // CR 400.7: Shardmage's Rescue — `~ entered this turn` (no "the battlefield").

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1189,6 +1189,43 @@ pub(crate) fn parse_static_line_inner(
         }
     }
 
+    // --- "<self> has <kw> if <cond>" single-pair conditional keyword grant ---
+    // CR 613.1f + CR 611.3a + CR 702.11b: A self-referential keyword grant gated
+    // on a typed source-state condition (Palladia-Mors, the Ruiner; Karakyk
+    // Guardian: "has hexproof if it hasn't dealt damage yet"). The MULTI-pair list
+    // (Multiclass Baldric) is owned by the attached-grant path
+    // (`parse_conditional_keyword_list`'s `len() > 1` gate); the SELF single-pair
+    // case has no other handler, so it is parsed here. `parse_self_reference`
+    // consumes every self-subject form ("~", "this creature", "this permanent",
+    // "it", ...) uniformly — including the "this creature" forms the generic
+    // `has`/`gets` arm below excludes via its `scan_contains(subject, "creature")`
+    // guard. Full consumption + the mandatory " if " in
+    // `parse_conditional_keyword_list` mean it cannot steal "has flying as long
+    // as", "has base power and toughness X", or "has all activated abilities".
+    // Placed BEFORE the generic `has`/`gets` arm so it owns the `if`-gated form
+    // first. Calls `parse_conditional_keyword_list` DIRECTLY so the multi-pair
+    // gate there is untouched.
+    if let Some((TargetFilter::SelfRef, after_subject)) =
+        nom_on_lower(&text, &lower, nom_target::parse_self_reference)
+    {
+        if let Some(after_has) = nom_tag_lower(after_subject, after_subject, " has ") {
+            let after_has_lower = after_has.to_lowercase();
+            if let Ok((rest, pairs)) = parse_conditional_keyword_list(&after_has_lower) {
+                if rest.trim().trim_end_matches('.').is_empty() && pairs.len() == 1 {
+                    if let Some((keyword, condition)) = pairs.into_iter().next() {
+                        return Some(
+                            StaticDefinition::continuous()
+                                .affected(TargetFilter::SelfRef)
+                                .modifications(vec![ContinuousModification::AddKeyword { keyword }])
+                                .condition(condition)
+                                .description(text.to_string()),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     // --- "~ has/gets ..." (self-referential) ---
     // Match lines like "CARDNAME has deathtouch" or "CARDNAME gets +1/+1"
     if let Some(pos) = tp

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -16694,3 +16694,121 @@ fn level_up_enchanted_creature_grant_attack_trigger_parses_multiply_counter() {
         draw.condition
     );
 }
+
+/// CR 702.11b + CR 613.1f + CR 120.3: "<self> has hexproof if it hasn't dealt
+/// damage yet" (Palladia-Mors, the Ruiner) must lower to a single Continuous
+/// `AddKeyword(Hexproof)` on `SelfRef`, gated on `Not(SourceHasDealtDamage)`.
+/// The card-name self-reference is normalized to `~` before `parse_static_line`
+/// (see `normalize_card_name_refs`), so the AST test feeds the `~` form.
+#[test]
+fn self_has_hexproof_if_it_hasnt_dealt_damage_palladia_mors() {
+    let def =
+        parse_static_line("~ has hexproof if it hasn't dealt damage yet.").expect("static def");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert_eq!(
+        def.modifications,
+        vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof
+        }]
+    );
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::Not {
+            condition: Box::new(StaticCondition::SourceHasDealtDamage),
+        }),
+        "hexproof must be gated on Not(SourceHasDealtDamage), got {:?}",
+        def.condition
+    );
+}
+
+/// CR 702.11b + CR 613.1f: Karakyk Guardian's "This creature has hexproof if it
+/// hasn't dealt damage yet" — the "this creature" subject form normalizes the
+/// same as the card-name form and lowers identically.
+#[test]
+fn self_has_hexproof_if_it_hasnt_dealt_damage_karakyk_guardian() {
+    let def = parse_static_line("This creature has hexproof if it hasn't dealt damage yet.")
+        .expect("static def");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert_eq!(
+        def.modifications,
+        vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof
+        }]
+    );
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::Not {
+            condition: Box::new(StaticCondition::SourceHasDealtDamage),
+        })
+    );
+}
+
+/// CR 702.11b + CR 613.1f: FULL-CARD flip — Palladia-Mors, the Ruiner and
+/// Karakyk Guardian must parse their conditional-hexproof line into a real
+/// Hexproof grant gated on `Not(SourceHasDealtDamage)`, with NO `Unimplemented`
+/// residual static and no swallowed-clause diagnostic.
+#[test]
+fn palladia_mors_and_karakyk_guardian_conditional_hexproof_full_card_flip() {
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
+    use crate::types::ability::Effect;
+
+    let cards = [
+        (
+            "Palladia-Mors, the Ruiner",
+            "Flying, vigilance, trample\nPalladia-Mors, the Ruiner has hexproof if it hasn't dealt damage yet.",
+        ),
+        (
+            "Karakyk Guardian",
+            "Flying, vigilance, trample\nThis creature has hexproof if it hasn't dealt damage yet.",
+        ),
+    ];
+    for (name, text) in cards {
+        let parsed = parse_oracle_text(
+            text,
+            name,
+            &[],
+            &["Creature".to_string()],
+            &["Dragon".to_string()],
+        );
+        // The conditional hexproof grant is present and correctly gated.
+        let hexproof = parsed.statics.iter().find(|d| {
+            d.modifications
+                .contains(&ContinuousModification::AddKeyword {
+                    keyword: Keyword::Hexproof,
+                })
+        });
+        let hexproof = hexproof.unwrap_or_else(|| panic!("{name}: missing hexproof static"));
+        assert_eq!(
+            hexproof.condition,
+            Some(StaticCondition::Not {
+                condition: Box::new(StaticCondition::SourceHasDealtDamage),
+            }),
+            "{name}: hexproof must be gated on Not(SourceHasDealtDamage)"
+        );
+        assert_eq!(hexproof.affected, Some(TargetFilter::SelfRef));
+        // No Unimplemented residual rode into a granted ability on any static.
+        for def in &parsed.statics {
+            for m in &def.modifications {
+                if let ContinuousModification::GrantAbility { definition } = m {
+                    assert!(
+                        !matches!(definition.effect.as_ref(), Effect::Unimplemented { .. }),
+                        "{name}: static carries an Unimplemented residual: {def:?}"
+                    );
+                }
+            }
+        }
+        // No clause was silently swallowed.
+        let swallowed: Vec<_> = parsed
+            .parse_warnings
+            .iter()
+            .filter(|w| matches!(w, OracleDiagnostic::SwallowedClause { .. }))
+            .collect();
+        assert!(
+            swallowed.is_empty(),
+            "{name}: unexpected swallowed-clause diagnostics: {swallowed:?}"
+        );
+    }
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -16812,3 +16812,38 @@ fn palladia_mors_and_karakyk_guardian_conditional_hexproof_full_card_flip() {
         );
     }
 }
+
+/// CR 611.3a + CR 613.1f + CR 509.1b + CR 702.11b: Ratonhnhaké꞉ton uses the
+/// inverted condition form and gates two sibling statics with the same "hasn't
+/// dealt damage yet" condition. The multi-static path must preserve both the
+/// Hexproof grant and the CantBeBlocked mode under `Not(SourceHasDealtDamage)`.
+#[test]
+fn ratonhnhaketon_hasnt_dealt_damage_gates_hexproof_and_cant_be_blocked() {
+    let defs = parse_static_line_multi(
+        "As long as ~ hasn't dealt damage yet, it has hexproof and can't be blocked.",
+    );
+    assert_eq!(defs.len(), 2, "expected hexproof grant plus evasion static");
+
+    let expected_condition = Some(StaticCondition::Not {
+        condition: Box::new(StaticCondition::SourceHasDealtDamage),
+    });
+
+    let hexproof = defs
+        .iter()
+        .find(|def| {
+            def.modifications
+                .contains(&ContinuousModification::AddKeyword {
+                    keyword: Keyword::Hexproof,
+                })
+        })
+        .expect("missing conditional hexproof grant");
+    assert_eq!(hexproof.affected, Some(TargetFilter::SelfRef));
+    assert_eq!(hexproof.condition, expected_condition);
+
+    let evasion = defs
+        .iter()
+        .find(|def| def.mode == StaticMode::CantBeBlocked)
+        .expect("missing conditional can't-be-blocked static");
+    assert_eq!(evasion.affected, Some(TargetFilter::SelfRef));
+    assert_eq!(evasion.condition, expected_condition);
+}

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2740,6 +2740,9 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
 
         // Variants with no TriggerCondition equivalent (combat-only / source-state / cost).
         StaticCondition::SourceEnteredThisTurn
+        // CR 702.11b + CR 120.3: "has dealt damage since entering" is a static-only
+        // Layer-6 gate with no intervening-if (`TriggerCondition`) equivalent.
+        | StaticCondition::SourceHasDealtDamage
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
         | StaticCondition::DevotionGE { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4814,6 +4814,15 @@ pub enum StaticCondition {
     /// CR 400.7: True when the source permanent entered the battlefield this turn.
     /// Used for "as long as this [permanent] entered this turn" conditional statics.
     SourceEnteredThisTurn,
+    /// CR 120.1 + CR 120.3/120.6 + CR 702.11b + CR 613.1f: True once the source
+    /// permanent has actually dealt damage (combat or noncombat) since it entered
+    /// the battlefield. Sticky per-object flag (set on the first nonzero amount of
+    /// damage actually dealt per CR 120.3/120.6, not the would-be amount of CR
+    /// 120.1a; reset when the object leaves the battlefield). Used as a Layer 6
+    /// (CR 613.1f) ability-adding gate for "has hexproof if it hasn't dealt damage
+    /// yet" (Palladia-Mors, the Ruiner; Karakyk Guardian). The "hasn't" negation
+    /// wraps this in `StaticCondition::Not`.
+    SourceHasDealtDamage,
     /// CR 601.2 + CR 611.3a: True when the source permanent was cast (its
     /// `cast_from_zone` is `Some`). `zone: None` = cast from any zone; `Some(z)`
     /// = cast specifically from zone `z`. Used for "as long as it was cast"

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5485,6 +5485,16 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub commander_declined_zone_return: HashSet<ObjectId>,
 
+    /// CR 120.3 + CR 120.6 + CR 702.11b: Battlefield objects that have actually
+    /// dealt damage (combat or noncombat) since entering the battlefield. Sticky
+    /// per-object flag backing the `StaticCondition::SourceHasDealtDamage`
+    /// predicate (e.g. "has hexproof if it hasn't dealt damage yet"). Set only
+    /// when a nonzero amount of damage is actually dealt (CR 120.3/120.6, not the
+    /// would-deal amount of CR 120.1a); cleared when the object leaves the
+    /// battlefield so a flickered object starts with a clean slate.
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub objects_that_dealt_damage: HashSet<ObjectId>,
+
     /// CR 500.7: Extra turns granted by effects, stored as a LIFO stack.
     /// Most recently created extra turn is taken first (pop from end).
     #[serde(default)]
@@ -6940,6 +6950,7 @@ impl GameState {
             cancelled_casts: Vec::new(),
             pending_activations: Vec::new(),
             commander_declined_zone_return: HashSet::new(),
+            objects_that_dealt_damage: HashSet::new(),
             debug_mode: false,
             debug_permitted: BTreeSet::new(),
             debug_infinite_mana: BTreeSet::new(),
@@ -7217,6 +7228,7 @@ impl PartialEq for GameState {
             && self.commander_cast_count == other.commander_cast_count
             && self.commander_cast_owners == other.commander_cast_owners
             && self.commander_declined_zone_return == other.commander_declined_zone_return
+            && self.objects_that_dealt_damage == other.objects_that_dealt_damage
             && self.extra_turns == other.extra_turns
             && self.turns_to_skip == other.turns_to_skip
             && self.steps_to_skip == other.steps_to_skip


### PR DESCRIPTION
Closes #3225.

## Problem
The conditional keyword grant **"[creature] has hexproof if it hasn't dealt damage yet"** was dropped as an `Unimplemented` static — Palladia-Mors, the Ruiner; Karakyk Guardian; and Oyaminartok, Polar Werebear never gained (or correctly lost) hexproof. Two gaps: the self-static `has <kw> if <cond>` line was not routed to the conditional-keyword machinery, and the condition "it hasn't dealt damage yet" was unmodeled.

## Fix
- New `StaticCondition::SourceHasDealtDamage`, gated by a **sticky per-object flag** (`objects_that_dealt_damage`): set the first time a battlefield source actually deals damage (combat or noncombat), cleared on leaving the battlefield so a flickered creature regains hexproof with a clean slate (CR 400.7). The `"hasn't"` form composes the existing `StaticCondition::Not` combinator — no new negation variant.
- Setting the flag marks the layer system dirty so the materialized keyword set recomputes and the creature stops being hexproof **at the next target-legality check** (this is the load-bearing correctness piece).
- The self-static `~ has <keyword> if <condition>` line is routed through the existing `parse_conditional_keyword_list` machinery (single source of truth); the condition is parsed by a new nom combinator.

## Result
Palladia-Mors, the Ruiner and Karakyk Guardian flip to **fully supported**; Oyaminartok partially (it has an unrelated spellbook-draft gap).

## Verification
- **Discriminating runtime test** drives the real pipeline: the creature **cannot** be targeted by an opponent before dealing damage, **can** after it deals damage (combat and noncombat), and is protected again after a flicker round-trip. Proven fail-if-reverted (removing the layer-dirty mark fails the targeting assertion).
- Parser AST + full-card flip tests; engine lib suite (11846) + full integration suite (1028) green; `cargo fmt`, parser-combinator gate, and `clippy --workspace` clean.
- Coverage regen vs same-commit baseline: **supported +3, swallowed-clause delta 0** (no flip-trap).

CR 702.11a/702.11b (hexproof static ability), CR 613.1f (Layer 6 ability-adding), CR 120.1/120.3/120.6 (damage dealt), CR 400.7 (new object on zone change).