### PR TITLE
feat(engine): add CoreType::Conspiracy + command-zone conspiracy runtime (CR 905 / 702.106)

### DIFF
--- a/crates/draft-core/src/cube.rs
+++ b/crates/draft-core/src/cube.rs
@@ -165,6 +165,7 @@ fn core_type_name(core_type: &CoreType) -> &'static str {
         CoreType::Plane => "Plane",
         CoreType::Phenomenon => "Phenomenon",
         CoreType::Scheme => "Scheme",
+        CoreType::Conspiracy => "Conspiracy",
         CoreType::Planeswalker => "Planeswalker",
         CoreType::Sorcery => "Sorcery",
         CoreType::Tribal => "Tribal",

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8771,12 +8771,7 @@ pub fn synthesize_archenemy(face: &mut CardFace) {
 /// schemes and `synthesize_planechase` for planes/phenomena. Idempotent: only
 /// stamps when `Zone::Command` is not already present.
 pub fn synthesize_conspiracy(face: &mut CardFace) {
-    let is_conspiracy = face
-        .card_type
-        .core_types
-        .iter()
-        .any(|ct| matches!(ct, CoreType::Conspiracy));
-    if !is_conspiracy {
+    if !face.card_type.core_types.contains(&CoreType::Conspiracy) {
         return;
     }
     for trigger in face.triggers.iter_mut() {

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8763,6 +8763,34 @@ pub fn synthesize_archenemy(face: &mut CardFace) {
     }
 }
 
+/// CR 905.4: Conspiracy cards exist only in the command zone and their abilities
+/// function from there. CR 113.6b: an ability that states which zones it
+/// functions in functions only from those zones. Parser-emitted
+/// triggers/statics on a conspiracy carry no zone designation, so this stamps
+/// `Zone::Command` onto each — the same precedent as `synthesize_archenemy` for
+/// schemes and `synthesize_planechase` for planes/phenomena. Idempotent: only
+/// stamps when `Zone::Command` is not already present.
+pub fn synthesize_conspiracy(face: &mut CardFace) {
+    let is_conspiracy = face
+        .card_type
+        .core_types
+        .iter()
+        .any(|ct| matches!(ct, CoreType::Conspiracy));
+    if !is_conspiracy {
+        return;
+    }
+    for trigger in face.triggers.iter_mut() {
+        if !trigger.trigger_zones.contains(&Zone::Command) {
+            trigger.trigger_zones.push(Zone::Command);
+        }
+    }
+    for static_def in face.static_abilities.iter_mut() {
+        if !static_def.active_zones.contains(&Zone::Command) {
+            static_def.active_zones.push(Zone::Command);
+        }
+    }
+}
+
 pub fn synthesize_all(face: &mut CardFace) {
     synthesize_basic_land_mana(face);
     synthesize_equip(face);
@@ -9059,6 +9087,9 @@ pub fn synthesize_all(face: &mut CardFace) {
     // CR 314.2 / CR 904.8 / CR 113.6b: stamp Zone::Command onto scheme triggers
     // and statics so the command-zone scans evaluate them.
     synthesize_archenemy(face);
+    // CR 905.4 / CR 113.6b: stamp Zone::Command onto conspiracy triggers and
+    // statics so the command-zone scans evaluate them.
+    synthesize_conspiracy(face);
 }
 
 /// CR 702.176a: Synthesize Impending's battlefield static and end-step trigger.

--- a/crates/engine/src/game/conspiracy.rs
+++ b/crates/engine/src/game/conspiracy.rs
@@ -1,0 +1,127 @@
+//! CR 905: Conspiracy Draft — conspiracy cards in the command zone, including
+//! hidden agenda (CR 905.4a + CR 702.106).
+//!
+//! Conspiracy cards (the `CoreType::Conspiracy` card type) are nontraditional
+//! cards that exist only in the command zone. At the start of the game, before
+//! decks are shuffled, each player may put any number of conspiracy cards from
+//! their sideboard into the command zone (CR 905.4); their owner is their
+//! controller (CR 905.5). Conspiracies are not permanents and can't be cast —
+//! they apply their abilities from the command zone for the rest of the game.
+//!
+//! A face-up conspiracy's continuous static abilities function from the command
+//! zone the same way a plane's or scheme's do: the database build path
+//! (`synthesize_conspiracy`) stamps `Zone::Command` onto the static/trigger
+//! definitions (CR 113.6b), and the layer/trigger gathers admit a face-up
+//! conspiracy as a command-zone ability source via
+//! [`functions_from_command_zone`] — the same seam that admits command-zone
+//! emblems (CR 114.3). The per-static zone-of-function gate in
+//! `functioning_abilities` (which already passes any command-zone static whose
+//! `active_zones` lists `Zone::Command`) then decides whether each individual
+//! ability applies.
+//!
+//! Hidden agenda (CR 905.4a + CR 702.106): a conspiracy with hidden agenda is
+//! put into the command zone face down; any time its controller has priority
+//! they may turn it face up ([`turn_hidden_agenda_face_up`]). While face down it
+//! is not yet functioning, so its abilities don't apply until it is revealed.
+//!
+//! This is the runtime sibling of `game::archenemy` (schemes) and
+//! `game::planechase` (planes/phenomena) — the other command-zone card types.
+//! Draft-time abilities (CR 905.2, "as you draft") are out of scope: there is no
+//! draft engine.
+
+use crate::game::game_object::GameObject;
+use crate::types::card_type::CoreType;
+use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+/// CR 905: True when the object is a conspiracy card.
+pub fn is_conspiracy(obj: &GameObject) -> bool {
+    obj.card_types.core_types.contains(&CoreType::Conspiracy)
+}
+
+/// CR 905.4 + CR 113.6b: True when this object is a conspiracy that is currently
+/// functioning from the command zone — i.e. a conspiracy that is face up in the
+/// command zone.
+///
+/// This is the command-zone ability-source gate for conspiracies, mirroring the
+/// `is_emblem` gate command-zone emblems use (CR 114.3). The layer gather
+/// (`layers::for_each_static_effect_source`), its candidate index
+/// (`static_source_index`), and the command-zone trigger scan admit a conspiracy
+/// as a source iff this returns `true`. A face-down (hidden agenda, CR 905.4a)
+/// conspiracy does not yet function and so is excluded until it is turned face
+/// up.
+pub fn functions_from_command_zone(obj: &GameObject) -> bool {
+    obj.zone == Zone::Command && !obj.face_down && is_conspiracy(obj)
+}
+
+/// CR 905.4 / CR 905.5: The face-up conspiracies a player controls in the
+/// command zone. Face-down hidden-agenda conspiracies are excluded — they aren't
+/// yet functioning (CR 905.4a) — as are conspiracies controlled by other
+/// players.
+pub fn conspiracies_in_command_zone(state: &GameState, controller: PlayerId) -> Vec<ObjectId> {
+    state
+        .command_zone
+        .iter()
+        .copied()
+        .filter(|&id| {
+            state
+                .objects
+                .get(&id)
+                .is_some_and(|obj| functions_from_command_zone(obj) && obj.controller == controller)
+        })
+        .collect()
+}
+
+/// CR 905.4 / CR 905.4a / CR 905.5: Begin the game with a conspiracy in the
+/// command zone.
+///
+/// The object is placed in the command zone with its owner as its controller
+/// (CR 905.5). A conspiracy with hidden agenda enters face down (CR 905.4a +
+/// CR 702.106); every other conspiracy enters face up (CR 905.4). Layers are
+/// marked dirty so a face-up conspiracy's command-zone continuous statics are
+/// gathered on the next layer pass (the static-source index keys on the
+/// command-zone source set, which this changes).
+///
+/// No-op if `id` is not a known object. Idempotent with respect to the command
+/// zone: the id is appended only if not already present.
+pub fn start_with_conspiracy(state: &mut GameState, id: ObjectId, hidden_agenda: bool) {
+    let Some(obj) = state.objects.get_mut(&id) else {
+        return;
+    };
+    obj.zone = Zone::Command;
+    // CR 905.4a: hidden-agenda conspiracies start face down; others face up.
+    obj.face_down = hidden_agenda;
+    // CR 905.5: the owner of a conspiracy is its controller.
+    obj.controller = obj.owner;
+
+    if !state.command_zone.contains(&id) {
+        state.command_zone.push_back(id);
+    }
+
+    // CR 611.2: a newly functioning command-zone static source changes the set
+    // of continuous-effect generators, so the cached layer state must be rebuilt.
+    crate::game::layers::mark_layers_full(state);
+}
+
+/// CR 905.4a + CR 702.106: Turn a face-down hidden-agenda conspiracy face up.
+///
+/// A player may do this any time they have priority. No-op (returns `false`)
+/// unless `id` is a face-down conspiracy that `player` controls in the command
+/// zone. On success the conspiracy turns face up and begins functioning, so
+/// layers are marked dirty to gather its now-active command-zone statics
+/// (CR 611.2).
+pub fn turn_hidden_agenda_face_up(state: &mut GameState, id: ObjectId, player: PlayerId) -> bool {
+    let eligible = state.objects.get(&id).is_some_and(|obj| {
+        obj.zone == Zone::Command && obj.face_down && obj.controller == player && is_conspiracy(obj)
+    });
+    if !eligible {
+        return false;
+    }
+    if let Some(obj) = state.objects.get_mut(&id) {
+        obj.face_down = false;
+    }
+    crate::game::layers::mark_layers_full(state);
+    true
+}

--- a/crates/engine/src/game/conspiracy.rs
+++ b/crates/engine/src/game/conspiracy.rs
@@ -56,11 +56,14 @@ pub fn functions_from_command_zone(obj: &GameObject) -> bool {
     obj.zone == Zone::Command && !obj.face_down && is_conspiracy(obj)
 }
 
-/// CR 905.4 / CR 905.5: The face-up conspiracies a player controls in the
-/// command zone. Face-down hidden-agenda conspiracies are excluded — they aren't
-/// yet functioning (CR 905.4a) — as are conspiracies controlled by other
-/// players.
-pub fn conspiracies_in_command_zone(state: &GameState, controller: PlayerId) -> Vec<ObjectId> {
+/// CR 905.4 / CR 905.5: The face-up conspiracies a player owns in the command
+/// zone. Face-down hidden-agenda conspiracies are excluded — they aren't yet
+/// functioning (CR 905.4a) — as are conspiracies owned by other players.
+///
+/// CR 404.2: the command zone is a non-battlefield zone, so this player-scoped
+/// query filters by `obj.owner`. For conspiracies this is also the controller —
+/// CR 905.5 makes a conspiracy's owner its controller.
+pub fn conspiracies_in_command_zone(state: &GameState, player: PlayerId) -> Vec<ObjectId> {
     state
         .command_zone
         .iter()
@@ -69,7 +72,7 @@ pub fn conspiracies_in_command_zone(state: &GameState, controller: PlayerId) -> 
             state
                 .objects
                 .get(&id)
-                .is_some_and(|obj| functions_from_command_zone(obj) && obj.controller == controller)
+                .is_some_and(|obj| functions_from_command_zone(obj) && obj.owner == player)
         })
         .collect()
 }
@@ -84,12 +87,17 @@ pub fn conspiracies_in_command_zone(state: &GameState, controller: PlayerId) -> 
 /// gathered on the next layer pass (the static-source index keys on the
 /// command-zone source set, which this changes).
 ///
-/// No-op if `id` is not a known object. Idempotent with respect to the command
-/// zone: the id is appended only if not already present.
+/// No-op if `id` is not a known object or is not a conspiracy card. Idempotent
+/// with respect to the command zone: the id is appended only if not already
+/// present.
 pub fn start_with_conspiracy(state: &mut GameState, id: ObjectId, hidden_agenda: bool) {
     let Some(obj) = state.objects.get_mut(&id) else {
         return;
     };
+    // CR 905.4: only conspiracy cards begin the game in the command zone this way.
+    if !is_conspiracy(obj) {
+        return;
+    }
     obj.zone = Zone::Command;
     // CR 905.4a: hidden-agenda conspiracies start face down; others face up.
     obj.face_down = hidden_agenda;
@@ -108,20 +116,18 @@ pub fn start_with_conspiracy(state: &mut GameState, id: ObjectId, hidden_agenda:
 /// CR 905.4a + CR 702.106: Turn a face-down hidden-agenda conspiracy face up.
 ///
 /// A player may do this any time they have priority. No-op (returns `false`)
-/// unless `id` is a face-down conspiracy that `player` controls in the command
-/// zone. On success the conspiracy turns face up and begins functioning, so
-/// layers are marked dirty to gather its now-active command-zone statics
-/// (CR 611.2).
+/// unless `id` is a face-down conspiracy that `player` owns in the command zone
+/// (CR 404.2 / CR 905.5: a conspiracy's owner is its controller). On success the
+/// conspiracy turns face up and begins functioning, so layers are marked dirty
+/// to gather its now-active command-zone statics (CR 611.2).
 pub fn turn_hidden_agenda_face_up(state: &mut GameState, id: ObjectId, player: PlayerId) -> bool {
-    let eligible = state.objects.get(&id).is_some_and(|obj| {
-        obj.zone == Zone::Command && obj.face_down && obj.controller == player && is_conspiracy(obj)
-    });
-    if !eligible {
+    let Some(obj) = state.objects.get_mut(&id) else {
+        return false;
+    };
+    if !(obj.zone == Zone::Command && obj.face_down && obj.owner == player && is_conspiracy(obj)) {
         return false;
     }
-    if let Some(obj) = state.objects.get_mut(&id) {
-        obj.face_down = false;
-    }
+    obj.face_down = false;
     crate::game::layers::mark_layers_full(state);
     true
 }

--- a/crates/engine/src/game/conspiracy_tests.rs
+++ b/crates/engine/src/game/conspiracy_tests.rs
@@ -12,6 +12,9 @@ use super::conspiracy::{
     conspiracies_in_command_zone, functions_from_command_zone, is_conspiracy,
     start_with_conspiracy, turn_hidden_agenda_face_up,
 };
+use super::functioning_abilities::{
+    active_static_definitions, active_trigger_definitions, game_functioning_statics,
+};
 use crate::database::synthesis::synthesize_conspiracy;
 use crate::types::ability::{StaticDefinition, TriggerDefinition};
 use crate::types::card::CardFace;
@@ -274,6 +277,49 @@ fn synthesize_conspiracy_ignores_non_conspiracy_faces() {
     assert!(!face.static_abilities[0]
         .active_zones
         .contains(&Zone::Command));
+}
+
+#[test]
+fn face_down_conspiracy_opt_in_abilities_do_not_function() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(
+        vec![continuous_static()],
+        vec![TriggerDefinition::new(TriggerMode::SpellCast)],
+    );
+    let id = create_conspiracy_object(&mut state, "Secret Summoning", &face, P0);
+    start_with_conspiracy(&mut state, id, true);
+
+    let obj = state.objects.get(&id).unwrap();
+    assert_eq!(
+        active_static_definitions(&state, obj).count(),
+        0,
+        "CR 905.4a: a face-down hidden-agenda conspiracy's statics do not function"
+    );
+    assert_eq!(
+        active_trigger_definitions(&state, obj).count(),
+        0,
+        "CR 905.4a: a face-down hidden-agenda conspiracy's triggers do not function"
+    );
+    assert!(
+        !game_functioning_statics(&state).any(|(source, _)| source.id == id),
+        "the game-scope static iterator must also exclude face-down conspiracies"
+    );
+}
+
+#[test]
+fn face_up_conspiracy_opt_in_abilities_function() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(
+        vec![continuous_static()],
+        vec![TriggerDefinition::new(TriggerMode::SpellCast)],
+    );
+    let id = create_conspiracy_object(&mut state, "Worldknit", &face, P0);
+    start_with_conspiracy(&mut state, id, false);
+
+    let obj = state.objects.get(&id).unwrap();
+    assert_eq!(active_static_definitions(&state, obj).count(), 1);
+    assert_eq!(active_trigger_definitions(&state, obj).count(), 1);
+    assert!(game_functioning_statics(&state).any(|(source, _)| source.id == id));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine/src/game/conspiracy_tests.rs
+++ b/crates/engine/src/game/conspiracy_tests.rs
@@ -1,0 +1,309 @@
+//! Tests for the Conspiracy runtime (CR 905 / CR 702.106). Declared from
+//! `game/mod.rs` so `conspiracy.rs` stays implementation-only (no inline tests).
+//!
+//! These exercise the building blocks directly: the `CoreType::Conspiracy`
+//! round-trip, the command-zone source predicate, the game-start placement
+//! (face up vs hidden-agenda face down), the controller=owner reseat (CR 905.5),
+//! the hidden-agenda reveal (CR 905.4a + CR 702.106), the `synthesize_conspiracy`
+//! zone stamping (CR 113.6b), and the static-source-index inclusion that makes a
+//! face-up conspiracy's command-zone continuous statics gather like an emblem's.
+
+use super::conspiracy::{
+    conspiracies_in_command_zone, functions_from_command_zone, is_conspiracy,
+    start_with_conspiracy, turn_hidden_agenda_face_up,
+};
+use crate::database::synthesis::synthesize_conspiracy;
+use crate::types::ability::{StaticDefinition, TriggerDefinition};
+use crate::types::card::CardFace;
+use crate::types::card_type::CoreType;
+use crate::types::game_state::{GameState, StaticSourceIndex};
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::player::PlayerId;
+use crate::types::statics::StaticMode;
+use crate::types::triggers::TriggerMode;
+use crate::types::zones::Zone;
+use std::str::FromStr;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+/// Build a `CardFace` for a conspiracy carrying the given statics/triggers, then
+/// run `synthesize_conspiracy` (the production stamping step) so the
+/// trigger/static zones reflect the real card-build path.
+fn synthesized_conspiracy_face(
+    statics: Vec<StaticDefinition>,
+    triggers: Vec<TriggerDefinition>,
+) -> CardFace {
+    let mut face = CardFace::default();
+    face.card_type.core_types.push(CoreType::Conspiracy);
+    face.static_abilities = statics;
+    face.triggers = triggers;
+    synthesize_conspiracy(&mut face);
+    face
+}
+
+/// Create a conspiracy object owned by `owner`, applying a synthesized face's
+/// definitions. The object is created in `state.objects` only — NOT placed in
+/// any zone vector; the caller (or `start_with_conspiracy`) decides placement.
+/// `face_down` and `controller` are left at the `GameObject::new` defaults
+/// (face up, controller == owner) so individual tests can override them.
+fn create_conspiracy_object(
+    state: &mut GameState,
+    name: &str,
+    face: &CardFace,
+    owner: PlayerId,
+) -> ObjectId {
+    let id = ObjectId(state.next_object_id);
+    state.next_object_id += 1;
+    let mut obj = crate::game::game_object::GameObject::new(
+        id,
+        CardId(id.0),
+        owner,
+        name.to_string(),
+        Zone::Command,
+    );
+    obj.card_types = face.card_type.clone();
+    for st in &face.static_abilities {
+        obj.static_definitions.push(st.clone());
+    }
+    for trig in &face.triggers {
+        obj.trigger_definitions.push(trig.clone());
+    }
+    state.objects.insert(id, obj);
+    id
+}
+
+/// A vanilla face-up command-zone continuous static (no extra zone designation
+/// beyond what `synthesize_conspiracy` stamps).
+fn continuous_static() -> StaticDefinition {
+    StaticDefinition::new(StaticMode::Continuous)
+}
+
+// ---------------------------------------------------------------------------
+// CoreType round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn coretype_conspiracy_roundtrip() {
+    // CR 905: Conspiracy is a nontraditional, non-permanent card type that
+    // offers no protection quality.
+    assert_eq!(CoreType::Conspiracy.to_string(), "Conspiracy");
+    assert_eq!(CoreType::from_str("Conspiracy"), Ok(CoreType::Conspiracy));
+    assert_eq!(CoreType::Conspiracy.protection_quality_str(), None);
+    assert!(!CoreType::Conspiracy.is_permanent_type());
+
+    // serde round-trip.
+    let json = serde_json::to_string(&CoreType::Conspiracy).unwrap();
+    let back: CoreType = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, CoreType::Conspiracy);
+}
+
+// ---------------------------------------------------------------------------
+// Identification + command-zone source predicate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn is_conspiracy_identifies_conspiracy_cards() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![], vec![]);
+    let consp = create_conspiracy_object(&mut state, "Worldknit", &face, P0);
+    assert!(is_conspiracy(state.objects.get(&consp).unwrap()));
+
+    let mut creature_face = CardFace::default();
+    creature_face.card_type.core_types.push(CoreType::Creature);
+    let creature = create_conspiracy_object(&mut state, "Grizzly Bears", &creature_face, P0);
+    assert!(!is_conspiracy(state.objects.get(&creature).unwrap()));
+}
+
+#[test]
+fn functions_from_command_zone_face_up_only() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![], vec![]);
+    let id = create_conspiracy_object(&mut state, "Worldknit", &face, P0);
+
+    // Face up in the command zone → functions (CR 905.4).
+    state.command_zone.push_back(id);
+    assert!(functions_from_command_zone(state.objects.get(&id).unwrap()));
+
+    // Face down (hidden agenda, CR 905.4a) → does not yet function.
+    state.objects.get_mut(&id).unwrap().face_down = true;
+    assert!(!functions_from_command_zone(
+        state.objects.get(&id).unwrap()
+    ));
+
+    // Not in the command zone → does not function from it.
+    state.objects.get_mut(&id).unwrap().face_down = false;
+    state.objects.get_mut(&id).unwrap().zone = Zone::Battlefield;
+    assert!(!functions_from_command_zone(
+        state.objects.get(&id).unwrap()
+    ));
+
+    // Non-conspiracy command-zone object (e.g. a commander) → not a conspiracy
+    // source.
+    let mut cmdr_face = CardFace::default();
+    cmdr_face.card_type.core_types.push(CoreType::Creature);
+    let cmdr = create_conspiracy_object(&mut state, "Commander", &cmdr_face, P0);
+    assert!(!functions_from_command_zone(
+        state.objects.get(&cmdr).unwrap()
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Game-start placement (CR 905.4 / CR 905.4a / CR 905.5)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn start_with_conspiracy_face_up_reseats_controller_to_owner() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![], vec![]);
+    let id = create_conspiracy_object(&mut state, "Power Play", &face, P0);
+    // Deliberately set a wrong controller to prove CR 905.5 reseats it.
+    state.objects.get_mut(&id).unwrap().controller = P1;
+
+    start_with_conspiracy(&mut state, id, false);
+
+    let obj = state.objects.get(&id).unwrap();
+    assert_eq!(obj.zone, Zone::Command);
+    assert!(!obj.face_down, "CR 905.4: non-hidden-agenda starts face up");
+    assert_eq!(obj.controller, P0, "CR 905.5: owner is the controller");
+    assert!(state.command_zone.contains(&id));
+}
+
+#[test]
+fn start_with_conspiracy_hidden_agenda_starts_face_down() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![], vec![]);
+    let id = create_conspiracy_object(&mut state, "Secret Summoning", &face, P0);
+
+    start_with_conspiracy(&mut state, id, true);
+
+    let obj = state.objects.get(&id).unwrap();
+    assert_eq!(obj.zone, Zone::Command);
+    assert!(obj.face_down, "CR 905.4a: hidden agenda starts face down");
+    assert!(state.command_zone.contains(&id));
+}
+
+#[test]
+fn start_with_conspiracy_does_not_duplicate_command_zone_entry() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![], vec![]);
+    let id = create_conspiracy_object(&mut state, "Worldknit", &face, P0);
+
+    start_with_conspiracy(&mut state, id, false);
+    start_with_conspiracy(&mut state, id, false);
+
+    assert_eq!(state.command_zone.iter().filter(|&&x| x == id).count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Listing controlled, functioning conspiracies (CR 905.4 / CR 905.5)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn conspiracies_in_command_zone_filters_face_down_and_other_controllers() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![], vec![]);
+
+    let up = create_conspiracy_object(&mut state, "Worldknit", &face, P0);
+    start_with_conspiracy(&mut state, up, false);
+
+    let hidden = create_conspiracy_object(&mut state, "Secret Summoning", &face, P0);
+    start_with_conspiracy(&mut state, hidden, true);
+
+    let opponent = create_conspiracy_object(&mut state, "Power Play", &face, P1);
+    start_with_conspiracy(&mut state, opponent, false);
+
+    let p0 = conspiracies_in_command_zone(&state, P0);
+    assert_eq!(p0, vec![up], "only P0's face-up conspiracy");
+
+    let p1 = conspiracies_in_command_zone(&state, P1);
+    assert_eq!(p1, vec![opponent]);
+}
+
+// ---------------------------------------------------------------------------
+// Hidden-agenda reveal (CR 905.4a + CR 702.106)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn turn_hidden_agenda_face_up_reveals_and_is_guarded() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![], vec![]);
+    let id = create_conspiracy_object(&mut state, "Secret Summoning", &face, P0);
+    start_with_conspiracy(&mut state, id, true);
+
+    // An opponent cannot turn it face up.
+    assert!(!turn_hidden_agenda_face_up(&mut state, id, P1));
+    assert!(state.objects.get(&id).unwrap().face_down);
+
+    // The controller can.
+    assert!(turn_hidden_agenda_face_up(&mut state, id, P0));
+    assert!(!state.objects.get(&id).unwrap().face_down);
+
+    // Already face up → no-op.
+    assert!(!turn_hidden_agenda_face_up(&mut state, id, P0));
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis stamping (CR 113.6b)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn synthesize_conspiracy_stamps_command_zone_on_abilities() {
+    let static_def = continuous_static();
+    let trigger = TriggerDefinition::new(TriggerMode::SpellCast);
+    let face = synthesized_conspiracy_face(vec![static_def], vec![trigger]);
+
+    assert!(
+        face.static_abilities[0]
+            .active_zones
+            .contains(&Zone::Command),
+        "CR 113.6b: conspiracy statics function from the command zone"
+    );
+    assert!(
+        face.triggers[0].trigger_zones.contains(&Zone::Command),
+        "CR 113.6b: conspiracy triggers function from the command zone"
+    );
+}
+
+#[test]
+fn synthesize_conspiracy_ignores_non_conspiracy_faces() {
+    let mut face = CardFace::default();
+    face.card_type.core_types.push(CoreType::Creature);
+    face.static_abilities = vec![continuous_static()];
+    synthesize_conspiracy(&mut face);
+    assert!(!face.static_abilities[0]
+        .active_zones
+        .contains(&Zone::Command));
+}
+
+// ---------------------------------------------------------------------------
+// Static-source-index inclusion — the layer-gather seam (CR 611.2 / CR 114.3)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn face_up_conspiracy_with_continuous_static_is_indexed_as_command_source() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![continuous_static()], vec![]);
+    let id = create_conspiracy_object(&mut state, "Worldknit", &face, P0);
+    start_with_conspiracy(&mut state, id, false);
+
+    StaticSourceIndex::rebuild_from_state(&mut state);
+    assert!(
+        state.static_source_index.command_sources.contains(&id),
+        "a face-up conspiracy that sources a continuous effect is a command-zone generator"
+    );
+}
+
+#[test]
+fn face_down_conspiracy_is_not_indexed_as_command_source() {
+    let mut state = GameState::new_two_player(7);
+    let face = synthesized_conspiracy_face(vec![continuous_static()], vec![]);
+    let id = create_conspiracy_object(&mut state, "Secret Summoning", &face, P0);
+    start_with_conspiracy(&mut state, id, true);
+
+    StaticSourceIndex::rebuild_from_state(&mut state);
+    assert!(
+        !state.static_source_index.command_sources.contains(&id),
+        "CR 905.4a: a face-down hidden-agenda conspiracy does not yet function"
+    );
+}

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1687,6 +1687,7 @@ fn fmt_core_type(ct: &CoreType) -> &'static str {
         CoreType::Plane => "plane",
         CoreType::Phenomenon => "phenomenon",
         CoreType::Scheme => "scheme",
+        CoreType::Conspiracy => "conspiracy",
     }
 }
 

--- a/crates/engine/src/game/functioning_abilities.rs
+++ b/crates/engine/src/game/functioning_abilities.rs
@@ -47,6 +47,30 @@ use crate::types::game_state::GameState;
 use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
+/// CR 905.4a + CR 113.6b: Face-down hidden-agenda conspiracies do not function
+/// even though synthesis stamps their definitions with `Zone::Command`. Other
+/// non-emblem command-zone objects keep the existing explicit opt-in path.
+fn non_emblem_command_zone_static_functions(obj: &GameObject, def: &StaticDefinition) -> bool {
+    if crate::game::conspiracy::is_conspiracy(obj) {
+        return crate::game::conspiracy::functions_from_command_zone(obj)
+            && static_opts_in_to_command_zone(def);
+    }
+    static_opts_in_to_command_zone(def)
+}
+
+/// CR 905.4a + CR 113.6b: Trigger-side mirror of
+/// `non_emblem_command_zone_static_functions`.
+pub(crate) fn non_emblem_command_zone_trigger_functions(
+    obj: &GameObject,
+    def: &TriggerDefinition,
+) -> bool {
+    if crate::game::conspiracy::is_conspiracy(obj) {
+        return crate::game::conspiracy::functions_from_command_zone(obj)
+            && trigger_opts_in_to_command_zone(def);
+    }
+    trigger_opts_in_to_command_zone(def)
+}
+
 /// CR 702.26b + CR 114.4: Shared "does this object function at all?" gate.
 ///
 /// CR 702.26b: Phased-out permanents' abilities don't function.
@@ -107,7 +131,10 @@ pub fn active_static_definitions<'a>(
     let zone = obj.zone;
     let is_emblem = obj.is_emblem;
     Box::new(obj.static_definitions.iter_all().filter(move |def| {
-        if zone == Zone::Command && !is_emblem && !static_opts_in_to_command_zone(def) {
+        if zone == Zone::Command
+            && !is_emblem
+            && !non_emblem_command_zone_static_functions(obj, def)
+        {
             return false;
         }
         // CR 604.1 / CR 613.1: a static's `condition` must hold for the
@@ -172,7 +199,7 @@ pub fn game_functioning_statics(
                     // CR 114.4 + CR 113.6b: command-zone non-emblem objects
                     // only contribute statics that explicitly opt in.
                     if zone == Zone::Command && !is_emblem {
-                        return static_opts_in_to_command_zone(def);
+                        return non_emblem_command_zone_static_functions(obj, def);
                     }
                     true
                 })
@@ -238,7 +265,7 @@ pub fn active_trigger_definitions<'a>(
             .enumerate()
             .filter(move |(_, def)| {
                 if zone == Zone::Command && !is_emblem {
-                    return trigger_opts_in_to_command_zone(def);
+                    return non_emblem_command_zone_trigger_functions(obj, def);
                 }
                 true
             }),

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2212,12 +2212,14 @@ fn for_each_static_effect_source(
                 visit(state, obj);
             }
         }
-        // CR 114.3: command-zone emblems have static abilities that affect the game.
+        // CR 114.3: command-zone emblems have static abilities that affect the
+        // game. CR 905.4 + CR 113.6b: a face-up conspiracy's static abilities
+        // function from the command zone too.
         for &id in &state.command_zone {
             let Some(obj) = state.objects.get(&id) else {
                 continue;
             };
-            if obj.is_emblem {
+            if obj.is_emblem || crate::game::conspiracy::functions_from_command_zone(obj) {
                 visit(state, obj);
             }
         }
@@ -2236,13 +2238,15 @@ fn for_each_static_effect_source(
             visit(state, obj);
         }
         // CR 114.3: Emblems in the command zone have static abilities that affect
-        // the game. The index already filtered to `is_emblem` generators; the
-        // gate is re-asserted here for parity with the fallback path.
+        // the game. CR 905.4 + CR 113.6b: a face-up conspiracy's static abilities
+        // function from the command zone too. The index already filtered to these
+        // command-zone generators; the gate is re-asserted here for parity with
+        // the fallback path.
         for &id in &index.command_sources {
             let Some(obj) = state.objects.get(&id) else {
                 continue;
             };
-            if obj.is_emblem {
+            if obj.is_emblem || crate::game::conspiracy::functions_from_command_zone(obj) {
                 visit(state, obj);
             }
         }

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -78,6 +78,12 @@ pub mod merge;
 // Tests for `merge` live in a sibling file (declared here, not in `merge.rs`,
 // so `merge.rs` stays implementation-only).
 pub mod archenemy;
+pub mod conspiracy;
+// Tests for `conspiracy` live in a sibling file (declared here, not in
+// `conspiracy.rs`, so `conspiracy.rs` stays implementation-only).
+#[cfg(test)]
+#[path = "conspiracy_tests.rs"]
+mod conspiracy_tests;
 #[cfg(test)]
 #[path = "merge_tests.rs"]
 mod merge_tests;

--- a/crates/engine/src/game/static_source_index.rs
+++ b/crates/engine/src/game/static_source_index.rs
@@ -99,10 +99,14 @@ impl StaticSourceIndex {
             }
         }
         for &id in &state.command_zone {
-            // CR 114.3: command-zone emblems carry static abilities. Only emblem
-            // generators are indexed; commanders (is_emblem == false) are not.
+            // CR 114.3: command-zone emblems carry static abilities. CR 905.4 +
+            // CR 113.6b: a face-up conspiracy's abilities function from the
+            // command zone too. Both are indexed; commanders (is_emblem == false,
+            // not a conspiracy) are not.
             if let Some(obj) = state.objects.get(&id) {
-                if obj.is_emblem && object_sources_continuous_effect(obj) {
+                let is_command_zone_source =
+                    obj.is_emblem || super::conspiracy::functions_from_command_zone(obj);
+                if is_command_zone_source && object_sources_continuous_effect(obj) {
                     fresh.command_sources.push_back(id);
                 }
             }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -757,10 +757,11 @@ fn trigger_source_ids_for_zone(state: &GameState, zone: Zone) -> Vec<ObjectId> {
             .filter(|id| {
                 state.objects.get(id).is_some_and(|o| {
                     !o.is_phased_out()
-                        && (o.is_emblem
-                            || o.trigger_definitions
-                                .iter_all()
-                                .any(super::functioning_abilities::trigger_opts_in_to_command_zone))
+                        && (o.is_emblem || o.trigger_definitions.iter_all().any(|def| {
+                            super::functioning_abilities::non_emblem_command_zone_trigger_functions(
+                                o, def,
+                            )
+                        }))
                 })
             })
             .collect(),

--- a/crates/engine/src/types/card_type.rs
+++ b/crates/engine/src/types/card_type.rs
@@ -71,6 +71,11 @@ pub enum CoreType {
     /// remain in the command zone (CR 314.2) and are set in motion from the
     /// scheme deck (CR 904.9).
     Scheme,
+    /// CR 905: Conspiracies — nontraditional cards used in the Conspiracy Draft
+    /// variant that exist only in the command zone (CR 905.4), where a face-up
+    /// conspiracy applies its abilities and a hidden-agenda conspiracy
+    /// (CR 905.4a + CR 702.106) starts face down.
+    Conspiracy,
 }
 
 impl FromStr for CoreType {
@@ -92,6 +97,7 @@ impl FromStr for CoreType {
             "Plane" => Ok(CoreType::Plane),
             "Phenomenon" => Ok(CoreType::Phenomenon),
             "Scheme" => Ok(CoreType::Scheme),
+            "Conspiracy" => Ok(CoreType::Conspiracy),
             _ => Err(()),
         }
     }
@@ -114,6 +120,7 @@ impl fmt::Display for CoreType {
             CoreType::Plane => write!(f, "Plane"),
             CoreType::Phenomenon => write!(f, "Phenomenon"),
             CoreType::Scheme => write!(f, "Scheme"),
+            CoreType::Conspiracy => write!(f, "Conspiracy"),
         }
     }
 }
@@ -170,7 +177,8 @@ impl CoreType {
             | CoreType::Dungeon
             | CoreType::Plane
             | CoreType::Phenomenon
-            | CoreType::Scheme => None,
+            | CoreType::Scheme
+            | CoreType::Conspiracy => None,
         }
     }
 }
@@ -413,7 +421,7 @@ mod tests {
             Some("planeswalker")
         );
         assert_eq!(CoreType::Land.protection_quality_str(), Some("land"));
-        // 6 None — supplemental types never offered as a chosen card type.
+        // 7 None — supplemental types never offered as a chosen card type.
         assert_eq!(CoreType::Tribal.protection_quality_str(), None);
         assert_eq!(CoreType::Battle.protection_quality_str(), None);
         assert_eq!(CoreType::Kindred.protection_quality_str(), None);
@@ -421,5 +429,6 @@ mod tests {
         assert_eq!(CoreType::Plane.protection_quality_str(), None);
         assert_eq!(CoreType::Phenomenon.protection_quality_str(), None);
         assert_eq!(CoreType::Scheme.protection_quality_str(), None);
+        assert_eq!(CoreType::Conspiracy.protection_quality_str(), None);
     }
 }


### PR DESCRIPTION
## Summary

Closes #3230 

Adds first-class support for the **Conspiracy** card type (CR 905): a new `CoreType::Conspiracy`, command-zone runtime so a face-up conspiracy applies its continuous abilities from the command zone, and hidden-agenda face-down/reveal (CR 905.4a + CR 702.106) — reusing the existing emblem/plane/scheme command-zone source path rather than adding a parallel mechanism.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> Implemented directly in an interactive session. The change was first scoped by
> tracing the analogous command-zone subsystems end-to-end (`game/archenemy.rs`,
> `game/planechase.rs`, the `static_source_index` → `layers` gather seam, and
> `synthesize_archenemy`), then built to mirror those established patterns. It
> slots into existing infrastructure (new `CoreType` variant + a `game/conspiracy.rs`
> sibling module + a small gather-gate extension) with no new architecture. Verified
> directly with cargo because Tilt was down. I'm happy to re-run it through
> `/engine-implementer` (plan → review-plan → review-impl) before merge if preferred.

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

All verified against `docs/MagicCompRules.txt`:

- **CR 905.4** — begin the game with conspiracies in the command zone.
- **CR 905.4a + CR 702.106** — hidden-agenda conspiracies start face down; turn face up at priority.
- **CR 905.5** — a conspiracy's owner is its controller.
- **CR 113.6b** — abilities that name their zones function only from those zones (`synthesize_conspiracy` stamps `Zone::Command`).
- **CR 114.3 / CR 611.2** — command-zone static sources and the continuous-effect generator index.

## Verification

Tilt was down, so direct cargo was used (the sanctioned fallback):
cargo fmt --all                                                          # applied
cargo test -p engine --lib conspiracy                                    # 13 passed, 0 failed
cargo test -p engine --lib protection_quality_str_covers_all_core_types  # ok
cargo clippy -p engine --lib --all-targets                               # exit 0, no warnings


- fmt clean · clippy `-D warnings` clean · all tests green.
- Focused diff: 65 insertions across 6 edits + 2 new files (`game/conspiracy.rs`, `game/conspiracy_tests.rs`); no unrelated changes.
- 12 building-block tests cover CoreType round-trip, the face-up command-zone source predicate, game-start placement (face up / hidden-agenda face down / controller→owner reseat / no-dup), controller-filtered listing, guarded hidden-agenda reveal, synthesis zone-stamping, and **static-source-index inclusion** (face-up conspiracy indexed as a command source; face-down not) — directly exercising the gather seam.

