### PR TITLE
fix(parser): Escape to the Wilds play-permission + extra land

### DIFF
--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -1354,6 +1354,56 @@ pub fn additional_land_drops(state: &GameState, player: PlayerId) -> u8 {
         total = total.saturating_add(count);
     }
 
+    // CR 305.2 + CR 611.2c: A turn-scoped grant (Escape to the Wilds: "you may
+    // play an additional land this turn") is a transient continuous effect, not
+    // a battlefield static, so it is invisible to `battlefield_active_statics`.
+    // Sum it from the TCE table here.
+    total = total.saturating_add(transient_additional_land_drops(state, player));
+
+    total
+}
+
+/// CR 305.2 + CR 611.2c: Sum the additional land drops a player is granted by
+/// transient continuous effects (e.g. Escape to the Wilds' "play an additional
+/// land this turn"). The typed-summing twin of
+/// `transient_grants_other_static_to_context`: it mirrors that helper's
+/// player-pin and duration/condition gates but accumulates the land-drop count
+/// from each `AddStaticMode` modification rather than testing a named bool.
+fn transient_additional_land_drops(state: &GameState, player: PlayerId) -> u8 {
+    let mut total: u8 = 0;
+    for tce in &state.transient_continuous_effects {
+        // CR 611.2c: player-scoped registration fans `TargetFilter::Player`
+        // broadcasts into per-player `SpecificPlayer` TCEs; the bare `Player`
+        // variant is matched defensively for any raw all-players registration.
+        let pins_player = match &tce.affected {
+            TargetFilter::SpecificPlayer { id } => *id == player,
+            TargetFilter::Player => true,
+            _ => continue,
+        };
+        if !pins_player {
+            continue;
+        }
+        // CR 611.2b: ForAsLongAs durations re-evaluate their condition each cycle.
+        if let Duration::ForAsLongAs { ref condition } = tce.duration {
+            if !evaluate_condition(state, condition, tce.controller, tce.source_id) {
+                continue;
+            }
+        }
+        if let Some(ref condition) = tce.condition {
+            if !evaluate_condition(state, condition, tce.controller, tce.source_id) {
+                continue;
+            }
+        }
+        for m in &tce.modifications {
+            if let ContinuousModification::AddStaticMode { mode } = m {
+                total = total.saturating_add(match mode {
+                    StaticMode::MayPlayAdditionalLand => 1,
+                    StaticMode::AdditionalLandDrop { count } => *count,
+                    _ => 0,
+                });
+            }
+        }
+    }
     total
 }
 
@@ -1777,6 +1827,82 @@ mod tests {
 
         // CR 305.2: Two Explorations = +2 additional land drops
         assert_eq!(additional_land_drops(&state, PlayerId(0)), 2);
+    }
+
+    /// Issue #2879 + CR 305.2 + CR 611.2c: a turn-scoped transient grant (Escape
+    /// to the Wilds: "you may play an additional land this turn") must be summed
+    /// into `additional_land_drops` for the affected player only.
+    #[test]
+    fn transient_additional_land_drops_counted() {
+        use crate::types::ability::{ContinuousModification, Duration};
+
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Escape to the Wilds".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Baseline: no extra land drops.
+        assert_eq!(additional_land_drops(&state, PlayerId(0)), 0);
+
+        state.add_transient_continuous_effect(
+            source,
+            PlayerId(0),
+            Duration::UntilEndOfTurn,
+            TargetFilter::SpecificPlayer { id: PlayerId(0) },
+            vec![ContinuousModification::AddStaticMode {
+                mode: StaticMode::MayPlayAdditionalLand,
+            }],
+            None,
+        );
+
+        assert_eq!(
+            additional_land_drops(&state, PlayerId(0)),
+            1,
+            "PlayerId(0) must get the transient extra land drop"
+        );
+        assert_eq!(
+            additional_land_drops(&state, PlayerId(1)),
+            0,
+            "PlayerId(1) must not get it — per-player scoping"
+        );
+    }
+
+    /// Issue #2879 (count >= 2 branch): a transient `AdditionalLandDrop { count }`
+    /// sums its full count into `additional_land_drops`.
+    #[test]
+    fn transient_additional_land_drops_counts_multiple() {
+        use crate::types::ability::{ContinuousModification, Duration};
+
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Multi-land Grant".to_string(),
+            Zone::Battlefield,
+        );
+
+        state.add_transient_continuous_effect(
+            source,
+            PlayerId(0),
+            Duration::UntilEndOfTurn,
+            TargetFilter::SpecificPlayer { id: PlayerId(0) },
+            vec![ContinuousModification::AddStaticMode {
+                mode: StaticMode::AdditionalLandDrop { count: 2 },
+            }],
+            None,
+        );
+
+        assert_eq!(
+            additional_land_drops(&state, PlayerId(0)),
+            2,
+            "AdditionalLandDrop count 2 must sum to 2"
+        );
+        assert_eq!(additional_land_drops(&state, PlayerId(1)), 0);
     }
 
     #[test]

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -282,12 +282,14 @@ fn parse_additional_land_head(input: &str) -> nom::IResult<&str, (), OracleError
     use nom::combinator::value;
     alt((
         value((), tag("play an additional land")),
-        value((), |i| -> nom::IResult<&str, (), OracleError<'_>> {
-            let (i, _) = tag("play ").parse(i)?;
-            let (i, _) = crate::parser::oracle_nom::primitives::parse_number(i)?;
-            let (i, _) = tag(" additional lands").parse(i)?;
-            Ok((i, ()))
-        }),
+        value(
+            (),
+            (
+                tag("play "),
+                crate::parser::oracle_nom::primitives::parse_number,
+                tag(" additional lands"),
+            ),
+        ),
     ))
     .parse(input)
 }

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -242,6 +242,13 @@ fn is_specialized_duration_carrier(text_lower: &str) -> bool {
         value((), tag("cast those ")),
         value((), tag("cast it")),
         value((), tag("cast one of ")),
+        // CR 400.7i — Escape to the Wilds impulse-set anaphor. The trailing
+        // duration ("until the end of your next turn") must reach
+        // `try_parse_play_from_exile` to disambiguate vs. `Effect::CastFromZone`.
+        value((), tag("play cards exiled this way")),
+        value((), tag("play the cards exiled this way")),
+        value((), tag("cast cards exiled this way")),
+        value((), tag("cast the cards exiled this way")),
         // Full impulse-draw form (when the optional strip didn't fire
         // because we're a recursive sub-clause). Mirrors the alternatives
         // at `oracle_effect/mod.rs:2701`.
@@ -256,9 +263,33 @@ fn is_specialized_duration_carrier(text_lower: &str) -> bool {
         // specialized parser at `oracle_effect/mod.rs:571` requires
         // "this turn" to be present in the input.
         value((), tag("the next ")),
+        // CR 305.2 — "play an additional land this turn" / "play <n> additional
+        // lands this turn" (Escape to the Wilds). `try_parse_additional_land_this_turn`
+        // requires the " this turn" suffix to discriminate the turn-scoped
+        // grant from the printed static ("on each of your turns") form.
+        parse_additional_land_head,
     ))
     .parse(text_lower);
     head.is_ok()
+}
+
+/// CR 305.2: Head matcher for the turn-scoped additional-land grant, used by
+/// `is_specialized_duration_carrier` so the trailing duration is deferred to
+/// `try_parse_additional_land_this_turn`.
+fn parse_additional_land_head(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
+    use nom::branch::alt;
+    use nom::bytes::complete::tag;
+    use nom::combinator::value;
+    alt((
+        value((), tag("play an additional land")),
+        value((), |i| -> nom::IResult<&str, (), OracleError<'_>> {
+            let (i, _) = tag("play ").parse(i)?;
+            let (i, _) = crate::parser::oracle_nom::primitives::parse_number(i)?;
+            let (i, _) = tag(" additional lands").parse(i)?;
+            Ok((i, ()))
+        }),
+    ))
+    .parse(input)
 }
 
 /// CR 608.2d: Suffixes after "you may " that have specialized parsing elsewhere

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4518,6 +4518,14 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return clause;
     }
 
+    // CR 305.2 + CR 611.2c: "you may play an additional land this turn" — a
+    // turn-scoped extra-land-drop grant (Escape to the Wilds). Must win before
+    // the generic CastFromZone parser, which would otherwise misread "play …"
+    // as a card pick.
+    if let Some(clause) = try_parse_additional_land_this_turn(tp) {
+        return clause;
+    }
+
     // CR 701.57a: "discover N" / "discover X" — effect variant.
     let (discover_tp, discover_where_x) = strip_trailing_where_x(tp);
     if let Some((limit, rest_orig)) =
@@ -6450,10 +6458,17 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
 
     if let Some(rest) = full_rest {
         // Full form: rest must start with a card reference
+        // CR 400.7i + CR 603.7: "(the) cards exiled this way" is the impulse-set
+        // anaphor used by Escape to the Wilds — semantically identical to "those
+        // cards" but phrased relative to the exiling effect rather than a
+        // demonstrative. Longer-first so "the cards exiled this way" wins over
+        // the bare "cards exiled this way".
         if alt((
             tag::<_, _, OracleError<'_>>("that card"),
             tag("that spell"),
             tag("those cards"),
+            tag("the cards exiled this way"),
+            tag("cards exiled this way"),
             tag("it "),
         ))
         .parse(rest.lower)
@@ -6484,11 +6499,17 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
         if scan_contains_phrase(tp.lower, "without paying") {
             return None;
         }
+        // CR 400.7i + CR 603.7: "(the) cards exiled this way" bare anaphor
+        // (Escape to the Wilds, after `you may ` is peeled by the chunk loop).
         if alt((
             tag::<_, _, OracleError<'_>>("play that card"),
             tag("cast that card"),
             tag("play it"),
             tag("cast it"),
+            tag("play the cards exiled this way"),
+            tag("play cards exiled this way"),
+            tag("cast the cards exiled this way"),
+            tag("cast cards exiled this way"),
         ))
         .parse(tp.lower)
         .is_err()
@@ -6576,6 +6597,58 @@ fn try_parse_play_the_exiled_card_grant(tp: TextPair) -> Option<ParsedEffectClau
         target: tracked_set_filter(),
         grantee: Default::default(),
     }))
+}
+
+/// CR 305.2 + CR 611.2c: "You may play an additional land this turn" — a
+/// one-shot land-drop grant scoped to the current turn (Escape to the Wilds,
+/// Explore, Rampaging Baloths' landfall). Distinct from the STATIC "on each of
+/// your turns" form (Exploration/Azusa), which `should_defer_spell_to_effect`
+/// routes to the static parser; the `this turn` discriminator keeps this
+/// resolution-time `GenericEffect` from colliding with that printed static.
+/// "an additional land" => count 1 (`MayPlayAdditionalLand`); "<n> additional
+/// lands" => count n (`AdditionalLandDrop { count: n }`). The granted mode is
+/// applied to the controller for the rest of the turn via a transient
+/// continuous effect (`Duration::UntilEndOfTurn`), summed at land-drop time by
+/// `static_abilities::additional_land_drops`.
+fn try_parse_additional_land_this_turn(tp: TextPair) -> Option<ParsedEffectClause> {
+    let (count, rest_orig) = nom_on_lower(tp.original, tp.lower, |input| {
+        let (input, _) = opt(alt((tag("you may "), tag("may ")))).parse(input)?;
+        let (input, _) = tag("play ").parse(input)?;
+        // "an additional land" (count 1) or "<number> additional lands".
+        let (input, count) = alt((
+            value(1u8, tag("an additional land")),
+            map(
+                (nom_primitives::parse_number, tag(" additional lands")),
+                |(n, _)| n as u8,
+            ),
+        ))
+        .parse(input)?;
+        let (input, _) = tag(" this turn").parse(input)?;
+        let (input, _) = opt(tag(".")).parse(input)?;
+        let (input, _) = eof.parse(input)?;
+        Ok((input, count))
+    })?;
+    let _ = rest_orig;
+
+    let mode = if count == 1 {
+        StaticMode::MayPlayAdditionalLand
+    } else {
+        StaticMode::AdditionalLandDrop { count }
+    };
+    let def = StaticDefinition::new(mode.clone())
+        .affected(TargetFilter::Controller)
+        .modifications(vec![ContinuousModification::AddStaticMode { mode }]);
+
+    let mut clause = parsed_clause(Effect::GenericEffect {
+        static_abilities: vec![def],
+        duration: Some(Duration::UntilEndOfTurn),
+        target: None,
+    });
+    // CR 305.2: The grant lapses at end of turn — set the clause duration so
+    // `register_transient_effect` builds a UntilEndOfTurn transient continuous
+    // effect (mirrors the Pardic Miner restriction idiom in subject.rs).
+    clause.duration = Some(Duration::UntilEndOfTurn);
+    Some(clause)
 }
 
 pub(crate) fn try_parse_exile_top_each_library_with_collection_counter(
@@ -12892,6 +12965,14 @@ fn parse_imperative_effect_inner(tp: TextPair, ctx: &mut ParseContext) -> Parsed
     // just exiled by the preceding clause. It is not an immediate cast/play
     // instruction, so it must win before the generic CastFromZone parser.
     if let Some(clause) = try_parse_play_from_exile(tp, ctx) {
+        return clause;
+    }
+
+    // CR 305.2 + CR 611.2c: "you may play an additional land this turn" — a
+    // turn-scoped extra-land-drop grant (Escape to the Wilds). Must win before
+    // the generic CastFromZone parser, which would otherwise misread "play …"
+    // as a card pick.
+    if let Some(clause) = try_parse_additional_land_this_turn(tp) {
         return clause;
     }
 
@@ -31950,6 +32031,196 @@ mod tests {
             "Expected PlayFromExile(UntilEndOfNextTurnOf) on TrackedSet(0), got {:?}",
             sub.effect
         );
+    }
+
+    /// Issue #2879: Escape to the Wilds' "cards exiled this way" anaphor must
+    /// parse to the same impulse-set grant shape as "those cards" (Light Up the
+    /// Stage), not to a `CastFromZone`.
+    #[test]
+    fn escape_to_the_wilds_play_clause() {
+        let def = parse_effect_chain(
+            "Exile the top five cards of your library. You may play cards exiled this way until the end of your next turn.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::ExileTop {
+                    player: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 5 },
+                    face_down: false,
+                }
+            ),
+            "Expected ExileTop(Controller, 5), got {:?}",
+            def.effect
+        );
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("Expected sub_ability grant");
+        assert!(!sub.optional, "grant sub-ability must not be optional");
+        assert!(
+            matches!(
+                &*sub.effect,
+                Effect::GrantCastingPermission {
+                    permission: CastingPermission::PlayFromExile {
+                        duration: Duration::UntilEndOfNextTurnOf {
+                            player: PlayerScope::Controller,
+                        },
+                        ..
+                    },
+                    target: TargetFilter::TrackedSet {
+                        id: TrackedSetId(0)
+                    },
+                    ..
+                }
+            ),
+            "Expected PlayFromExile(UntilEndOfNextTurnOf) on TrackedSet(0), got {:?}",
+            sub.effect
+        );
+        // No CastFromZone / Unimplemented anywhere in the chain.
+        assert!(
+            !matches!(
+                &*sub.effect,
+                Effect::CastFromZone { .. } | Effect::Unimplemented { .. }
+            ),
+            "grant must not be CastFromZone/Unimplemented, got {:?}",
+            sub.effect
+        );
+        assert!(
+            !matches!(&*def.effect, Effect::Unimplemented { .. }),
+            "root must not be Unimplemented"
+        );
+    }
+
+    /// Issue #2879: the turn-scoped additional-land grant must parse to a
+    /// `GenericEffect` carrying `MayPlayAdditionalLand` for the controller,
+    /// NOT a `CastFromZone`.
+    #[test]
+    fn escape_to_the_wilds_additional_land() {
+        let def = parse_effect_chain(
+            "You may play an additional land this turn.",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::GenericEffect {
+                static_abilities,
+                duration,
+                ..
+            } => {
+                assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+                let s = &static_abilities[0];
+                assert_eq!(s.mode, StaticMode::MayPlayAdditionalLand);
+                assert_eq!(s.affected, Some(TargetFilter::Controller));
+                assert!(
+                    s.modifications.iter().any(|m| matches!(
+                        m,
+                        ContinuousModification::AddStaticMode {
+                            mode: StaticMode::MayPlayAdditionalLand
+                        }
+                    )),
+                    "expected AddStaticMode(MayPlayAdditionalLand), got {:?}",
+                    s.modifications
+                );
+            }
+            other => panic!("expected GenericEffect, got {other:?}"),
+        }
+    }
+
+    /// Issue #2879 (count >= 2 branch): "play two additional lands this turn"
+    /// must carry `AdditionalLandDrop { count: 2 }`, not the count-1
+    /// `MayPlayAdditionalLand` shape.
+    #[test]
+    fn play_two_additional_lands_this_turn_parses_count() {
+        let def = parse_effect_chain(
+            "You may play two additional lands this turn.",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::GenericEffect {
+                static_abilities,
+                duration,
+                ..
+            } => {
+                assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+                let s = &static_abilities[0];
+                assert_eq!(s.mode, StaticMode::AdditionalLandDrop { count: 2 });
+                assert!(
+                    s.modifications.iter().any(|m| matches!(
+                        m,
+                        ContinuousModification::AddStaticMode {
+                            mode: StaticMode::AdditionalLandDrop { count: 2 }
+                        }
+                    )),
+                    "expected AddStaticMode(AdditionalLandDrop count 2), got {:?}",
+                    s.modifications
+                );
+            }
+            other => panic!("expected GenericEffect, got {other:?}"),
+        }
+    }
+
+    /// Issue #2879: the complete Escape to the Wilds oracle text parses to a
+    /// 3-link chain (ExileTop -> PlayFromExile grant -> additional-land
+    /// GenericEffect) with no Unimplemented / CastFromZone{Any}.
+    #[test]
+    fn escape_to_the_wilds_full_card_chain() {
+        let def = parse_effect_chain(
+            "Exile the top five cards of your library. You may play cards exiled this way until the end of your next turn. You may play an additional land this turn.",
+            AbilityKind::Spell,
+        );
+        // Link 1: ExileTop.
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::ExileTop {
+                    count: QuantityExpr::Fixed { value: 5 },
+                    ..
+                }
+            ),
+            "Expected ExileTop(5) root, got {:?}",
+            def.effect
+        );
+        // Link 2: PlayFromExile grant.
+        let grant = def
+            .sub_ability
+            .as_ref()
+            .expect("Expected grant sub_ability");
+        assert!(
+            matches!(
+                &*grant.effect,
+                Effect::GrantCastingPermission {
+                    permission: CastingPermission::PlayFromExile { .. },
+                    ..
+                }
+            ),
+            "Expected PlayFromExile grant, got {:?}",
+            grant.effect
+        );
+        // Link 3: additional-land GenericEffect.
+        let land = grant
+            .sub_ability
+            .as_ref()
+            .expect("Expected additional-land sub_ability");
+        assert!(
+            matches!(&*land.effect, Effect::GenericEffect { .. }),
+            "Expected GenericEffect for additional land, got {:?}",
+            land.effect
+        );
+        // No Unimplemented / CastFromZone anywhere in the chain.
+        for (label, eff) in [
+            ("root", &*def.effect),
+            ("grant", &*grant.effect),
+            ("land", &*land.effect),
+        ] {
+            assert!(
+                !matches!(
+                    eff,
+                    Effect::Unimplemented { .. } | Effect::CastFromZone { .. }
+                ),
+                "{label} must not be Unimplemented/CastFromZone, got {eff:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -3353,6 +3353,16 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
             }
             return clause;
         }
+        if let Some(mut clause) =
+            try_parse_additional_land_this_turn(TextPair::new(text, &original_lower))
+        {
+            if clause.condition.is_none() {
+                if let Some(cond) = peel_ctx.condition().cloned() {
+                    clause.condition = Some(cond);
+                }
+            }
+            return clause;
+        }
     }
     let mut clause = parse_effect_clause_inner(&peeled_text, ctx);
     // Trial-parse fallback: peeling may have removed disambiguation signal
@@ -6648,7 +6658,23 @@ fn try_parse_additional_land_this_turn(tp: TextPair) -> Option<ParsedEffectClaus
     // `register_transient_effect` builds a UntilEndOfTurn transient continuous
     // effect (mirrors the Pardic Miner restriction idiom in subject.rs).
     clause.duration = Some(Duration::UntilEndOfTurn);
+    // CR 305.2: The printed "may" grants permission to play the extra land
+    // later; it is not an optional choice to apply this continuous effect now.
+    clause.optional = false;
     Some(clause)
+}
+
+fn clause_is_additional_land_permission(clause: &ParsedEffectClause) -> bool {
+    matches!(
+        &clause.effect,
+        Effect::GenericEffect {
+            static_abilities,
+            ..
+        } if static_abilities.iter().any(|definition| matches!(
+            definition.mode,
+            StaticMode::MayPlayAdditionalLand | StaticMode::AdditionalLandDrop { .. }
+        ))
+    )
 }
 
 pub(crate) fn try_parse_exile_top_each_library_with_collection_counter(
@@ -17220,9 +17246,15 @@ pub(crate) fn parse_effect_chain_ir(
         // CR 608.2g + CR 601.2: The "may" in a free-cast window belongs to the
         // interactive CastOffer itself ("up to N" includes choosing zero casts),
         // not to the generic OptionalEffectChoice wrapper around the whole
-        // effect. Keep the actor context derived from the printed "you may", but
-        // lower the effect as mandatory so resolution opens the FreeCastWindow.
-        let is_optional = if matches!(&clause.effect, Effect::FreeCastFromZones { .. }) {
+        // effect.
+        //
+        // CR 305.2: The "may" in an additional-land grant is likewise the later
+        // play permission, not a choice to apply the continuous effect now. Keep
+        // the actor context derived from the printed "you may", but lower both
+        // permission grants as mandatory so resolution installs the permission.
+        let is_optional = if matches!(&clause.effect, Effect::FreeCastFromZones { .. })
+            || clause_is_additional_land_permission(&clause)
+        {
             false
         } else {
             is_optional
@@ -32102,6 +32134,10 @@ mod tests {
             "You may play an additional land this turn.",
             AbilityKind::Spell,
         );
+        assert!(
+            !def.optional,
+            "permission grant must not become an optional resolution choice"
+        );
         match &*def.effect {
             Effect::GenericEffect {
                 static_abilities,
@@ -32135,6 +32171,10 @@ mod tests {
         let def = parse_effect_chain(
             "You may play two additional lands this turn.",
             AbilityKind::Spell,
+        );
+        assert!(
+            !def.optional,
+            "permission grant must not become an optional resolution choice"
         );
         match &*def.effect {
             Effect::GenericEffect {
@@ -32202,6 +32242,10 @@ mod tests {
             .sub_ability
             .as_ref()
             .expect("Expected additional-land sub_ability");
+        assert!(
+            !land.optional,
+            "additional-land permission grant must resolve without an optional prompt"
+        );
         assert!(
             matches!(&*land.effect, Effect::GenericEffect { .. }),
             "Expected GenericEffect for additional land, got {:?}",

--- a/crates/engine/tests/escape_to_wilds_2879.rs
+++ b/crates/engine/tests/escape_to_wilds_2879.rs
@@ -1,0 +1,68 @@
+//! Runtime regression for #2879 — Escape to the Wilds must grant both the
+//! tracked exile play permission and the extra land drop through the real spell
+//! resolution pipeline.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::static_abilities::additional_land_drops;
+use engine::types::ability::{CastingPermission, Duration, PlayerScope};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const ESCAPE_TO_THE_WILDS: &str = "Exile the top five cards of your library. \
+You may play cards exiled this way until the end of your next turn. \
+You may play an additional land this turn.";
+
+#[test]
+fn escape_to_the_wilds_runtime_grants_exile_play_and_extra_land() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let exiled_cards: Vec<_> = ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]
+        .into_iter()
+        .map(|name| scenario.add_card_to_library_top(P0, name))
+        .collect();
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Escape to the Wilds", false, ESCAPE_TO_THE_WILDS)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let outcome = scenario.build().cast(spell).resolve();
+
+    for id in &exiled_cards {
+        assert_eq!(
+            outcome.zone_of(*id),
+            Zone::Exile,
+            "Escape to the Wilds must exile the top five library cards"
+        );
+
+        let object = &outcome.state().objects[id];
+        assert!(
+            object.casting_permissions.iter().any(|permission| matches!(
+                permission,
+                CastingPermission::PlayFromExile {
+                    granted_to: P0,
+                    duration: Duration::UntilEndOfNextTurnOf {
+                        player: PlayerScope::Controller
+                    },
+                    ..
+                }
+            )),
+            "exiled card must carry the controller's until-next-turn PlayFromExile permission, got {:?}",
+            object.casting_permissions
+        );
+    }
+
+    assert_eq!(
+        additional_land_drops(outcome.state(), P0),
+        1,
+        "the parser-produced GenericEffect must register a controller-scoped transient extra land drop; TCEs: {:?}",
+        outcome.state().transient_continuous_effects
+    );
+    assert_eq!(
+        additional_land_drops(outcome.state(), P1),
+        0,
+        "the transient extra land drop must not fan out to opponents"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2879 — Escape to the Wilds ("Exile the top five cards of your library. You may play cards exiled this way until the end of your next turn. You may play an additional land this turn.") was misparsed in two ways:

1. **"You may play cards exiled this way …"** parsed to an optional `CastFromZone{ParentTarget}` that prompted a yes/no at resolution instead of granting standing permission (and exiled lands weren't playable).
2. **"You may play an additional land this turn"** was misparsed as `CastFromZone{Any}`, so no extra land play was granted.

## Fix

- Recognize the **"cards exiled this way"** anaphor in `try_parse_play_from_exile` and defer its trailing duration in `is_specialized_duration_carrier`, so it lowers to the same `GrantCastingPermission{ PlayFromExile{ UntilEndOfNextTurnOf }, TrackedSet }` shape **Light Up the Stage** already produces — a standing permission with no prompt.
- Add a this-turn additional-land effect parser producing `GenericEffect{ AddStaticMode(AdditionalLandDrop/MayPlayAdditionalLand), duration: UntilEndOfTurn }` (modeled on the Pardic Miner `CantPlayLand` twin), and extend `additional_land_drops` to also honor transient grants so the extra land drop is actually usable. The ` this turn` suffix distinguishes it from the static "on each of your turns" form (Exploration/Azusa), which stays a `StaticDefinition`.

**No new engine variants** — reuses `GrantCastingPermission`/`PlayFromExile`/`TrackedSet`/`GenericEffect`/`AddStaticMode`/`AdditionalLandDrop`.

## Verification

Discriminating tests drive the real parse/runtime (and reproduce the exact #2879 misparse when reverted): Escape parses to the 3-link chain (ExileTop → PlayFromExile grant → additional-land GenericEffect, no CastFromZone/Unimplemented); the transient grant raises `additional_land_drops`; count≥2 ("two additional lands") covered. Non-regression: Light Up the Stage, Act on Impulse, Exploration/Azusa unchanged. clippy `-D warnings` clean, integration suite green, parser-combinator + engine-authorities gates pass.

Note: distinct from #999 (the top-five exile not triggering); here the exile works.