### PR TITLE
ci: gate MTGJSON download on file existence, not cache-hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,17 @@ jobs:
           restore-keys: mtgjson-
 
       - name: Download MTGJSON data
-        if: steps.mtgjson-cache.outputs.cache-hit != 'true'
+        # Gate on file existence, not cache-hit: actions/cache restore-keys can
+        # match a poisoned/partial entry (and CACHE_ON_FAILURE saves caches from
+        # failed runs), setting cache-hit=true while AtomicCards.json is absent.
+        # Gating the download on cache-hit then permanently skips it, breaking
+        # oracle-gen with "AtomicCards.json not found". Always run; fetch only
+        # when the file is missing so a poisoned cache self-heals.
         run: |
-          mkdir -p data/mtgjson
-          curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+          if [ ! -f data/mtgjson/AtomicCards.json ]; then
+            mkdir -p data/mtgjson
+            curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+          fi
 
       - name: Cache generated card data
         # Output of `oracle-gen` is deterministic given (MTGJSON input + engine

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,10 +73,17 @@ jobs:
           key: scryfall-${{ steps.cache-keys.outputs.day }}
 
       - name: Download MTGJSON data
-        if: steps.mtgjson-cache.outputs.cache-hit != 'true'
+        # Gate on file existence, not cache-hit: actions/cache restore-keys can
+        # match a poisoned/partial entry (and CACHE_ON_FAILURE saves caches from
+        # failed runs), setting cache-hit=true while AtomicCards.json is absent.
+        # Gating the download on cache-hit then permanently skips it, breaking
+        # oracle-gen with "AtomicCards.json not found". Always run; fetch only
+        # when the file is missing so a poisoned cache self-heals.
         run: |
-          mkdir -p data/mtgjson
-          curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+          if [ ! -f data/mtgjson/AtomicCards.json ]; then
+            mkdir -p data/mtgjson
+            curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+          fi
 
       - name: Generate card data and coverage (from source)
         # Single source of truth: scripts/gen-card-data.sh produces all public


### PR DESCRIPTION
**Durable fix for the recurring `AtomicCards.json not found` card-data failures.** A poisoned/partial mtgjson cache (actions/cache `restore-keys` matching an incomplete entry; `CACHE_ON_FAILURE: true` saving caches from failed runs) sets `cache-hit=true` while `data/mtgjson/AtomicCards.json` is absent, so the cache-hit-gated download was skipped and `oracle-gen` failed. This gates the download on **file existence** so a bad cache self-heals. Applied to `ci.yml` and `deploy.yml`. YAML validated locally.