### PR TITLE
fix(parser): RevealUntil filter collapses to Any (dropping 'a Time Lord creature card') when parsed 

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -40713,6 +40713,41 @@ mod tests {
         assert!(def.sub_ability.is_none(), "should have no sub_ability");
     }
 
+    /// CR 701.20a + CR 205.3m: "reveal cards ... until you reveal a Time Lord
+    /// creature card" must dig to a Time Lord creature, not the first card of any
+    /// type. Regression (Time Lord Regeneration): the filter collapsed to
+    /// `TargetFilter::Any` because "Time Lord" (CR 205.3m: the only two-word
+    /// creature type) was missing from the SUBTYPES registry, so the typed
+    /// "Time Lord creature card" noun phrase failed to parse.
+    #[test]
+    fn reveal_until_time_lord_creature_keeps_typed_filter() {
+        let def = parse_effect_chain(
+            "Reveal cards from the top of your library until you reveal a Time Lord creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
+            AbilityKind::Activated,
+        );
+        match &*def.effect {
+            Effect::RevealUntil { filter, .. } => {
+                let tf = match filter {
+                    TargetFilter::Typed(tf) => tf,
+                    other => panic!("expected Typed filter, got {other:?}"),
+                };
+                assert!(
+                    tf.type_filters.contains(&TypeFilter::Creature),
+                    "expected Creature in type_filters, got {:?}",
+                    tf.type_filters
+                );
+                assert!(
+                    tf.type_filters
+                        .iter()
+                        .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Time Lord")),
+                    "expected Subtype(\"Time Lord\") in type_filters, got {:?}",
+                    tf.type_filters
+                );
+            }
+            other => panic!("expected RevealUntil, got {other:?}"),
+        }
+    }
+
     /// CR 109.5 + CR 701.20a: Third-person form ("Its controller reveals cards
     /// from the top of their library until they reveal a creature card.") —
     /// must dispatch to RevealUntil with player=ParentTargetController, not to

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5796,6 +5796,23 @@ mod tests {
     }
 
     #[test]
+    fn time_lord_target_keeps_subtype_and_controller() {
+        // CR 205.3m + CR 115.1: "target Time Lord you control" must keep both the
+        // two-word subtype (CR 205.3m: the only two-word creature type) and the
+        // controller restriction (CR 115.1: declared target). Regression: when
+        // "Time Lord" was absent from the SUBTYPES registry this collapsed to
+        // Typed{type_filters:[], controller:None} (Time Lord Regeneration).
+        let (filter, rest) = parse_target("target Time Lord you control");
+        assert_eq!(rest, "");
+        let tf = typed_leg(&filter).expect("expected Typed filter");
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(tf
+            .type_filters
+            .iter()
+            .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Time Lord")));
+    }
+
+    #[test]
     fn bare_commander_they_control_uses_relative_player_scope() {
         let mut ctx = ParseContext {
             relative_player_scope: Some(ControllerRef::TargetPlayer),

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1170,6 +1170,11 @@ const SUBTYPES: &[&str] = &[
     "Thopter",
     "Thrull",
     "Tiefling",
+    // CR 205.3m: "Time Lord" is the only two-word creature type. Multi-word
+    // matching is handled by `parse_subtype_entry`/`starts_with_word_ci`
+    // (full-entry match + word boundary); no SUBTYPE_PLURALS entry is needed
+    // because the regular plural "Time Lords" is covered by the +"s" branch.
+    "Time Lord",
     "Treefolk",
     "Trilobite",
     "Troll",
@@ -2319,6 +2324,29 @@ mod tests {
         // Not a subtype.
         assert!(!is_subtype_word("sharuum"));
         assert!(!is_subtype_word("flying")); // that's a keyword, not a subtype
+    }
+
+    #[test]
+    fn parse_subtype_recognizes_two_word_time_lord() {
+        // CR 205.3m: "Time Lord" is the only two-word creature type. The
+        // two-word match is handled by `parse_subtype_entry`/`starts_with_word_ci`
+        // (full-entry match + word boundary), so the registry entry alone is
+        // sufficient — no SUBTYPE_PLURALS or canonicalization change is needed.
+        assert_eq!(
+            parse_subtype("Time Lord"),
+            Some(("Time Lord".to_string(), 9))
+        );
+        assert_eq!(
+            parse_subtype("time lord creature card"),
+            Some(("Time Lord".to_string(), 9))
+        );
+        // Regular plural via the +"s" branch — no SUBTYPE_PLURALS entry.
+        assert_eq!(
+            parse_subtype("Time Lords"),
+            Some(("Time Lord".to_string(), 10))
+        );
+        // Negative: a bare single word must NOT match the two-word subtype.
+        assert_eq!(parse_subtype("time you control"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** RevealUntil filter collapses to Any (dropping 'a Time Lord creature card') when parsed inside a granted-quote trigger, and the granted-ability target loses its 'target Time Lord you control' subtype + controller restriction.

## Cards corrected
- Time Lord Regeneration

## Fix
Implemented the approved single-registry fix for WHO misparse cluster #10 (Time Lord Regeneration). Root cause: the creature subtype "Time Lord" was missing from the parser's SUBTYPES registry in oracle_util.rs. Adding it fixes both reported bugs transparently via the existing parse_subtype -> parse_subtype_entry -> starts_with_word_ci path (no try_parse_reveal_until or oracle_static change needed; the spec's two-bug hypothesis was one shared root cause). Added "Time Lord" to the SUBTYPES const (alphabetical, between Tiefling and Treefolk) with a CR 205.3m comment, plus three building-block-level regression tests. Verified directly (worktree not under Tilt): cargo fmt clean, cargo clippy -p engine --all-targets -D warnings clean (exit 0), cargo test -p engine all 53 result lines pass with 0 failures (3 new tests pass), gen-card-data.sh succeeded. oracle-gen on the card confirms both fixes: spell target now Typed{[Subtype("Time Lord")], controller:You} (was Typed{[], None}); granted RevealUntil filter now Typed{[Creature, Subtype("Time Lord")]} (was Any). TARDIS now recognizes the subtype too (class-level win). Parser diff gate passes on my added lines (the only flagged line, tf.type_filters.contains(&TypeFilter::Creature), is typed Vec membership in a test, identical to the sibling test idiom, not string dispatch). The repo-wide check-parser-combinators.sh failure is entirely pre-existing drift in files I never touched (it diffs against old merge-base ff799f899). Did NOT commit or push.

## Files changed
- crates/engine/src/parser/oracle_util.rs
- crates/engine/src/parser/oracle_target.rs
- crates/engine/src/parser/oracle_effect/mod.rs

## CR references
- CR 205.3m (docs/MagicCompRules.txt:1437 — 'One creature type is two words long: Time Lord'; verified via grep -n '^205.3m')
- CR 205.3b (docs/MagicCompRules.txt:1414 — creature subtypes are one or two words; verified via grep -n '^205.3b')
- CR 115.1 (docs/MagicCompRules.txt:836 — targets declared on the stack; verified via grep -n '^115.1')
- CR 701.20a (docs/MagicCompRules.txt:3432 — reveal a card; verified via grep -n '^701.20a')

## Verification
- `cargo fmt --all` — clean (no changes)
- `check-parser-combinators.sh <upstream/main merge-base 2fcf9eeb4>` — pass (exit 0)
- `cargo clippy -p engine --all-targets -- -D warnings` — pass (exit 0)
- `cargo test -p engine` — pass (exit 0, 0 failed)
- `oracle-gen data --filter "time lord regeneration"` — pass (AST matches oracle text)
Cards confirmed re-parsed correctly: time lord regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
