### PR TITLE
fix(parser): Per-opponent 'they' anaphor in 'each opponent ... the life they lost this turn' emits L

### DIFF
--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -1192,6 +1192,64 @@ mod tests {
         );
     }
 
+    /// CR 115.10a + CR 119.3 + CR 608.2c (Wound Reflection / Archfiend of Despair /
+    /// Warlock Class L3): "each opponent loses life equal to the life they lost
+    /// this turn" resolves with a `LifeLostThisTurn { ScopedPlayer }` amount under
+    /// `player_scope: Opponent`. Each iterated opponent must lose its OWN life lost
+    /// this turn — NOT the source controller's. The controller's count is seeded
+    /// high (99) as a trap: the prior `Controller`-scoped encoding drained every
+    /// opponent by 99. This is the canonical runtime regression guard for the
+    /// reported bug; the parser fix is covered in oracle_effect/mod.rs.
+    #[test]
+    fn each_opponent_loses_own_life_lost_uses_scoped_player() {
+        use crate::game::effects::resolve_ability_chain;
+        use crate::types::ability::{PlayerFilter, PlayerScope};
+
+        // 3-player game so two distinct opponents prove per-iteration scoping.
+        let mut state = GameState::new(crate::types::FormatConfig::standard(), 3, 42);
+        state.players[0].life_lost_this_turn = 99; // controller — trap, must be ignored
+        state.players[1].life_lost_this_turn = 3; // opponent A
+        state.players[2].life_lost_this_turn = 5; // opponent B
+        let p0_life_before = state.players[0].life;
+        let p1_life_before = state.players[1].life;
+        let p2_life_before = state.players[2].life;
+
+        let mut ability = ResolvedAbility::new(
+            Effect::LoseLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::LifeLostThisTurn {
+                        player: PlayerScope::ScopedPlayer,
+                    },
+                },
+                target: None,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        ability.player_scope = Some(PlayerFilter::Opponent);
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        // Controller untouched — it is the source, not an affected opponent.
+        assert_eq!(
+            state.players[0].life, p0_life_before,
+            "controller must not lose life — the trap value (99) must be ignored"
+        );
+        // Each opponent loses ITS OWN life lost this turn (3 and 5), not 99.
+        assert_eq!(
+            state.players[1].life,
+            p1_life_before - 3,
+            "opponent A must lose its own life lost (3), not the controller's 99"
+        );
+        assert_eq!(
+            state.players[2].life,
+            p2_life_before - 5,
+            "opponent B must lose its own life lost (5), not the controller's 99"
+        );
+    }
+
     /// Issue #317 (Lich): "If you would gain life, draw that many cards
     /// instead." The replacement substitutes a *different* event type
     /// (`Effect::Draw`) for the original `LifeGain` event. CR 614.1a +

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -348,12 +348,14 @@ fn parse_life_verb_remainder<'a>(
 /// player the surrounding LoseLife/GainLife affects, so a target opponent loses
 /// life equal to *their own* life lost this turn.
 ///
-/// Kept distinct from the shared `parse_life_lost_ref` "they lost" arms (which
-/// map to `Controller` for the per-iteration rebind of "each opponent" effects
-/// and to which Astarion's phrase never reaches because that combinator's
-/// `opt("the amount of ")` strip makes its "amount of …" tag unreachable). This
-/// recognizer requires the "amount of" gloss, so the article-only each-opponent
-/// phrasing ("the life they lost this turn", Archfiend of Despair) is untouched.
+/// The shared `parse_life_lost_ref` "they lost"/"that player lost" arms now also
+/// emit `PlayerScope::Target` (not `Controller`), so the bare article-only
+/// each-opponent phrasing ("the life they lost this turn", Archfiend of Despair /
+/// Wound Reflection) is `Target`-scoped at the leaf and then rebound to
+/// `ScopedPlayer` by `rewrite_player_scope_refs` under the per-opponent
+/// `player_scope` loop. This recognizer still runs first for the "amount of"
+/// gloss (Astarion), yielding the identical `Target` mapping, so both phrasings
+/// resolve to the affected player's own life lost this turn.
 fn parse_target_relative_life_change_this_turn(qty_text: &str) -> Option<QuantityExpr> {
     let (rest, _) = opt(tag::<_, _, OracleError<'_>>("the "))
         .parse(qty_text)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14478,6 +14478,22 @@ fn rewrite_player_scope_refs(def: &mut AbilityDefinition) {
                         player: PlayerScope::ScopedPlayer,
                     }
                 }
+                // CR 119.3 + CR 109.5 + CR 608.2c: "the life they/that player lost
+                // this turn" under a per-opponent `player_scope` loop binds to the
+                // iterating player, the same rebind the analogous
+                // `LifeTotal`/`HandSize` arms above perform for "their life"/"their
+                // hand". The leaf combinator emits `Target`; this walker (run only
+                // on `player_scope`-bearing defs) maps it to `ScopedPlayer`. A
+                // purely targeted clause (Blitzwing — no `player_scope`) never
+                // reaches this walker, so its `Target` survives to read the
+                // targeted opponent's own life lost.
+                QuantityRef::LifeLostThisTurn {
+                    player: PlayerScope::Target,
+                } => {
+                    *qty = QuantityRef::LifeLostThisTurn {
+                        player: PlayerScope::ScopedPlayer,
+                    }
+                }
                 QuantityRef::TargetZoneCardCount { zone } => match zone {
                     crate::types::ability::ZoneRef::Hand => {
                         *qty = QuantityRef::HandSize {
@@ -33724,6 +33740,93 @@ mod tests {
                 rounding: RoundingMode::Up,
             },
             "nested each-opponent 'their life' must rebind to ScopedPlayer, got {amount:?}",
+        );
+    }
+
+    /// CR 115.10a + CR 119.3 + CR 608.2c (Wound Reflection / Warlock Class L3):
+    /// "each opponent loses life equal to the life they lost this turn" lifts the
+    /// each-opponent subject onto `player_scope: Opponent` and the third-person
+    /// "they" anaphor must rebind to `ScopedPlayer` so each iterated opponent
+    /// loses its OWN life lost this turn (not the source's controller's). Before
+    /// the fix the leaf emitted `Controller`, draining the controller's count for
+    /// every opponent.
+    #[test]
+    fn each_opponent_loses_life_equal_to_life_they_lost_uses_scoped_player() {
+        let def = parse_effect_chain(
+            "Each opponent loses life equal to the life they lost this turn.",
+            AbilityKind::Spell,
+        );
+        assert_eq!(def.player_scope, Some(PlayerFilter::Opponent));
+        let Effect::LoseLife { amount, .. } = &*def.effect else {
+            panic!("expected LoseLife, got {:?}", def.effect);
+        };
+        assert_eq!(
+            *amount,
+            QuantityExpr::Ref {
+                qty: QuantityRef::LifeLostThisTurn {
+                    player: PlayerScope::ScopedPlayer,
+                },
+            },
+            "per-opponent 'they lost' must rebind to ScopedPlayer, got {amount:?}",
+        );
+    }
+
+    /// CR 115.10a + CR 119.3 (Archfiend of Despair): the "that player" phrasing of
+    /// the per-opponent anaphor must rebind to `ScopedPlayer` identically to the
+    /// "they" phrasing above.
+    #[test]
+    fn each_opponent_loses_life_equal_to_life_that_player_lost_uses_scoped_player() {
+        let def = parse_effect_chain(
+            "Each opponent loses life equal to the life that player lost this turn.",
+            AbilityKind::Spell,
+        );
+        assert_eq!(def.player_scope, Some(PlayerFilter::Opponent));
+        let Effect::LoseLife { amount, .. } = &*def.effect else {
+            panic!("expected LoseLife, got {:?}", def.effect);
+        };
+        assert_eq!(
+            *amount,
+            QuantityExpr::Ref {
+                qty: QuantityRef::LifeLostThisTurn {
+                    player: PlayerScope::ScopedPlayer,
+                },
+            },
+            "per-opponent 'that player lost' must rebind to ScopedPlayer, got {amount:?}",
+        );
+    }
+
+    /// CR 115.1 + CR 119.3 (Blitzwing, Cruel Tormentor): a TARGETED clause —
+    /// "target opponent loses life equal to the life that player lost this turn" —
+    /// has no `player_scope`, so the rewrite walker never runs and the leaf's
+    /// `Target` scope survives, reading the targeted opponent's own life lost.
+    #[test]
+    fn target_opponent_loses_life_equal_to_life_that_player_lost_uses_target() {
+        let def = parse_effect_chain(
+            "Target opponent loses life equal to the life that player lost this turn.",
+            AbilityKind::Spell,
+        );
+        assert_eq!(
+            def.player_scope, None,
+            "targeted clause must not carry a per-opponent player_scope",
+        );
+        let Effect::LoseLife { amount, target } = &*def.effect else {
+            panic!("expected LoseLife, got {:?}", def.effect);
+        };
+        // The "target opponent" subject yields a real opponent player target
+        // (`Typed { controller: Opponent }`); the precise encoding is incidental —
+        // what matters is the loss is directed at a target, not the controller.
+        assert!(
+            matches!(target, Some(TargetFilter::Player | TargetFilter::Typed(_))),
+            "expected a player target, got {target:?}",
+        );
+        assert_eq!(
+            *amount,
+            QuantityExpr::Ref {
+                qty: QuantityRef::LifeLostThisTurn {
+                    player: PlayerScope::Target,
+                },
+            },
+            "targeted 'that player lost' must stay Target-scoped, got {amount:?}",
         );
     }
 

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1627,41 +1627,49 @@ fn parse_life_lost_ref(input: &str) -> OracleResult<'_, QuantityRef> {
             },
             tag("life you lost"),
         ),
-        // CR 119.3 + CR 608.2k: Third-person variants resolve against the
-        // per-target player during effect iteration. The runtime's
-        // `LifeLostThisTurn` reads `player.life_lost_this_turn` where
-        // `player` is the resolution context's bound player — for
-        // `LoseLife { target: EachOpponent }` this rebinds per-opponent,
-        // so "they lost" / "that player lost" resolve correctly without
-        // a new typed variant. Archfiend of Despair, Wound Reflection,
-        // Astarion (Feed mode), Blitzwing, Warlock Class.
+        // CR 115.1 + CR 115.10 + CR 119.3 + CR 608.2c: Third-person "they" / "that
+        // player" anaphor in a life-change clause refers to the player the
+        // surrounding LoseLife/GainLife AFFECTS, never the source's controller. In
+        // a TARGETED clause ("target opponent loses life equal to the life that
+        // player lost this turn" — Blitzwing, Cruel Tormentor; Astarion Feed) that
+        // is the player TARGET (CR 115.1), read from `ability.targets`. In a
+        // per-opponent ITERATION ("each opponent loses life equal to the life they
+        // lost this turn" — Wound Reflection, Archfiend of Despair, Warlock Class
+        // L3) the affected player is not a target (CR 115.10a);
+        // `rewrite_player_scope_refs` rebinds this `Target` form to `ScopedPlayer`
+        // under the lifted `player_scope` loop, mirroring the "each opponent loses
+        // half their life" (Betor / Blood Tribute) `LifeTotal` rewrite. Emitting
+        // `Target` here (not `Controller`) is what lets both the targeted and the
+        // iterated context resolve to each affected player's OWN life lost this
+        // turn. (`LifeGainedThisTurn` has no third-person printing today; this is
+        // its symmetric extension point should one appear.)
         value(
             QuantityRef::LifeLostThisTurn {
-                player: PlayerScope::Controller,
+                player: PlayerScope::Target,
             },
             tag("the life that player lost this turn"),
         ),
         value(
             QuantityRef::LifeLostThisTurn {
-                player: PlayerScope::Controller,
+                player: PlayerScope::Target,
             },
             tag("the life they lost this turn"),
         ),
         value(
             QuantityRef::LifeLostThisTurn {
-                player: PlayerScope::Controller,
+                player: PlayerScope::Target,
             },
             tag("the amount of life they lost this turn"),
         ),
         value(
             QuantityRef::LifeLostThisTurn {
-                player: PlayerScope::Controller,
+                player: PlayerScope::Target,
             },
             tag("the life that player lost"),
         ),
         value(
             QuantityRef::LifeLostThisTurn {
-                player: PlayerScope::Controller,
+                player: PlayerScope::Target,
             },
             tag("the life they lost"),
         ),
@@ -4777,6 +4785,57 @@ mod tests {
             }
         );
         assert_eq!(rest, "");
+    }
+
+    /// CR 115.1 + CR 119.3 + CR 608.2c: the third-person "they" / "that player"
+    /// life-lost anaphor must emit `PlayerScope::Target` at the leaf — the player
+    /// the surrounding LoseLife affects — so a targeted clause (Blitzwing) reads
+    /// the target's own loss and a per-opponent loop (Wound Reflection) can be
+    /// rebound to `ScopedPlayer` by `rewrite_player_scope_refs`. Guards against
+    /// the prior `Controller` mapping that drained the source's controller.
+    #[test]
+    fn parse_quantity_ref_third_person_life_lost_is_target_scoped() {
+        // The article-only forms are the exact Wound Reflection / Archfiend /
+        // Warlock / Blitzwing phrasings. The "amount of life they lost" gloss
+        // (Astarion Feed) is consumed by `parse_life_lost_ref`'s leading
+        // `opt("the amount of ")` strip and routed through the imperative-level
+        // `parse_target_relative_life_change_this_turn` recognizer instead, which
+        // also yields `Target` — so it is asserted at that layer, not here.
+        for phrase in [
+            "the life they lost this turn",
+            "the life that player lost this turn",
+        ] {
+            let (rest, q) = parse_quantity_ref(phrase).unwrap();
+            assert_eq!(
+                q,
+                QuantityRef::LifeLostThisTurn {
+                    player: PlayerScope::Target
+                },
+                "{phrase:?} must be Target-scoped, got {q:?}"
+            );
+            assert_eq!(rest, "", "{phrase:?} left remainder {rest:?}");
+        }
+    }
+
+    /// Over-broadening guard: the first-person "you"/"you've" arms must stay
+    /// `Controller`-scoped (CR 109.5 — "you" is the controller, never a target).
+    #[test]
+    fn parse_quantity_ref_first_person_life_lost_stays_controller() {
+        for phrase in [
+            "the life you lost this turn",
+            "the life you've lost this turn",
+            "total life you lost this turn",
+        ] {
+            let (rest, q) = parse_quantity_ref(phrase).unwrap();
+            assert_eq!(
+                q,
+                QuantityRef::LifeLostThisTurn {
+                    player: PlayerScope::Controller
+                },
+                "{phrase:?} must stay Controller-scoped, got {q:?}"
+            );
+            assert_eq!(rest, "", "{phrase:?} left remainder {rest:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** Per-opponent 'they' anaphor in 'each opponent ... the life they lost this turn' emits LifeLostThisTurn{player:Controller} instead of ScopedPlayer, so resolve_quantity reads the printed controller's life loss for every iterated opponent.

## Cards corrected
- Wound Reflection

## Fix
Implemented the approved plan for WHO cluster #11 (per-opponent / targeted "the life they lost this turn" anaphor) with two surgical leaf changes plus tests, exactly as specified.

Change A (crates/engine/src/parser/oracle_nom/quantity.rs): the five bare third-person life-lost anaphor arms in parse_life_lost_ref ("the life that player lost this turn", "the life they lost this turn", "the amount of life they lost this turn", "the life that player lost", "the life they lost") now emit PlayerScope::Target instead of PlayerScope::Controller. Replaced the stale comment (which cited the nonexistent "CR 608.2k") with a verified CR block citing CR 115.1 + CR 115.10 + CR 119.3 + CR 608.2c. First-person ("you"/"you've") and "your opponents" aggregate arms left unchanged.

Change B (crates/engine/src/parser/oracle_effect/mod.rs): added one QuantityRef::LifeLostThisTurn { Target } -> ScopedPlayer rewrite arm in rewrite_player_scope_refs, immediately after the analogous HandSize { Target } arm, so under a lifted per-opponent player_scope the Target form rebinds to ScopedPlayer (mirroring the existing LifeTotal/HandSize Betor/Blood Tribute path). A purely targeted clause (Blitzwing, no player_scope) never reaches this walker, so its Target survives.

imperative.rs: doc-comment correction only (the comment claimed the bare arms map to Controller; they now map to Target). No logic change.

Tests added at three levels: leaf (quantity.rs), rewrite-walker (oracle_effect/mod.rs, 3 tests modeled on nested_each_opponent_loses_half_life_uses_scoped_player), and runtime end-to-end (life.rs, 3-player per-opponent ScopedPlayer with a controller trap value).

Verification: cargo fmt clean; cargo clippy -p engine --all-targets -D warnings exit 0 (no warnings); full cargo test -p engine green (0 failures across all binaries); 6 new tests pass; 63 life_lost/scoped_player tests pass. Regenerated card-data.json (35373 cards). Spot-check confirms all 5 cards: Wound Reflection / Archfiend of Despair / Warlock Class -> LifeLostThisTurn{ScopedPlayer}; Blitzwing -> LifeLostThisTurn{Target}; Astarion (Feed) -> LifeLostThisTurn{Target} unchanged. Scope tally across all cards is healthy (Controller 6, Opponent 21, AllPlayers 2, ScopedPlayer 4, Target 2) with no Controller-form regression; False Cure still has no LifeLostThisTurn ref (untouched). The fix corrected a fourth previously-broken sibling beyond the three named, a build-for-the-class win.

Parser diff gate: PASS on my changes (zero contains/starts_with/find/ends_with introduced in any modified file).

One test-shape correction vs the plan (not a logic deviation): the plan's leaf test for "the amount of life they lost this turn" is unreachable via parse_quantity_ref because parse_life_lost_ref's leading opt("the amount of ") strip consumes the gloss and there is no bare "life they lost" arm (the "amount of" tag arm is pre-existing dead code). That form was and remains routed through parse_target_relative_life_change_this_turn (imperative.rs), which already yields Target. I scoped the leaf test to the two reachable article-only forms (the actual card phrasings) and documented why. Runtime behavior matches the plan exactly. No code logic differs from the plan.

## Files changed
- crates/engine/src/parser/oracle_nom/quantity.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/parser/oracle_effect/imperative.rs
- crates/engine/src/game/effects/life.rs

## CR references
- CR 115.1 (target declared as part of putting ability on stack; read from ability.targets) - verified docs/MagicCompRules.txt:836
- CR 115.10 (spells/abilities can affect players they don't target) - verified docs/MagicCompRules.txt:884
- CR 115.10a (being affected does not make a player a target unless identified by 'target') - verified docs/MagicCompRules.txt:886
- CR 119.3 (gain/lose life adjusts that player's life total) - verified docs/MagicCompRules.txt:1063
- CR 608.2c (read the whole text and apply the rules of English; corrects the plan's nonexistent 'CR 608.2k') - verified docs/MagicCompRules.txt:2789
- CR 109.5 ('you'/'your' = the object's controller) - verified docs/MagicCompRules.txt:610

## Verification
- `cargo fmt --all` — clean (no changes)
- `./scripts/check-parser-combinators.sh <upstream/main merge-base cb4990504>` — clean (exit 0)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean (exit 0, no warnings)
- `cargo test -p engine` — clean (exit 0, 0 failed)
- `cargo run --profile tool --features cli --bin oracle-gen -- data --filter "wound reflection"` — passed (after freeing disk space by removing regenerable target/debug/incremental cache)
Cards confirmed re-parsed correctly: Wound Reflection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
