### PR TITLE
feat(parser): parse {TK} ticket-counter symbols

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6989,16 +6989,59 @@ fn try_parse_lose_all_player_counters(text: &str, lower: &str) -> Option<Effect>
     None
 }
 
+/// CR 107.17: Count a leading run of consecutive `{tk}` ticket symbols, each of
+/// which represents one ticket counter. Returns the count when the input begins
+/// with at least one `{tk}` glyph and the only remaining text is a sentence
+/// terminator (so "{tk}{tk}" and "{tk}{tk}." match, but "{tk} for each ..." or
+/// a `{tk}` activation cost does not — those carry trailing clauses this player
+/// counter parser must not swallow). Mirrors the `{tk}`-counting idiom in
+/// `oracle_keyword::strip_ticket_activation_cost_prefix`.
+fn count_ticket_symbols(rest: &str) -> Option<u32> {
+    let mut remaining = rest;
+    let mut count = 0u32;
+    while let Ok((next, _)) = tag::<_, _, OracleError<'_>>("{tk}").parse(remaining) {
+        count += 1;
+        remaining = next;
+    }
+    if count == 0 {
+        return None;
+    }
+    // Only a trailing terminator may remain; any other text means this is not a
+    // bare "you get {TK}…" instruction (e.g. an activation cost or larger clause).
+    let tail = remaining
+        .trim_start()
+        .trim_end_matches(['.', ';', ','])
+        .trim();
+    tail.is_empty().then_some(count)
+}
+
 /// CR 122.1: Parse "get/gets a/an/N [type] counter(s)" into a GivePlayerCounter AST.
 /// Handles patterns like:
 /// - "get a poison counter"
 /// - "gets two experience counters"
 /// - "get ten rad counters"
+/// - "get {TK}{TK}" (CR 107.17 ticket symbol form; see `count_ticket_symbols`)
 fn try_parse_player_counter(lower: &str) -> Option<ImperativeFamilyAst> {
     // Strip "get/gets " prefix
     let (rest, _) = alt((tag::<_, _, OracleError<'_>>("gets "), tag("get ")))
         .parse(lower)
         .ok()?;
+
+    // CR 107.17: The ticket symbol is {TK}; it represents one ticket counter.
+    // Unfinity cards write "you get N ticket counters" as N repeated `{TK}`
+    // glyphs (e.g. "you get {TK}{TK}{TK}"). Each glyph is one ticket counter, so
+    // count the run of consecutive `{tk}` symbols and emit a Ticket player
+    // counter of that size. This must precede the word-form "counter(s)" suffix
+    // check below because the symbol form carries no "counter" noun. The branch
+    // returns None on the no-symbol case and falls through to the word form.
+    if let Some(count) = count_ticket_symbols(rest) {
+        return Some(ImperativeFamilyAst::GivePlayerCounter {
+            counter_kind: PlayerCounterKind::Ticket,
+            count: QuantityExpr::Fixed {
+                value: count as i32,
+            },
+        });
+    }
 
     // Must end with "counter" or "counters"
     let (before_counter, plural) = if let Some(s) = rest.strip_suffix(" counters") {
@@ -10374,6 +10417,83 @@ mod tests {
             result.is_none(),
             "Should NOT parse unknown counter type as player counter"
         );
+    }
+
+    /// CR 107.17: Each `{TK}` glyph is one ticket counter. "get {tk}{tk}" → 2.
+    /// Building-block test: exercises the symbol-counting branch across counts.
+    #[test]
+    fn parse_player_counter_ticket_symbols() {
+        for (text, expected) in [
+            ("get {tk}", 1),
+            ("get {tk}{tk}", 2),
+            ("get {tk}{tk}{tk}", 3),
+            ("gets {tk}{tk}.", 2),
+        ] {
+            match try_parse_player_counter(text) {
+                Some(ImperativeFamilyAst::GivePlayerCounter {
+                    counter_kind,
+                    count,
+                }) => {
+                    assert_eq!(
+                        counter_kind,
+                        PlayerCounterKind::Ticket,
+                        "{text:?} should be a Ticket counter"
+                    );
+                    assert!(
+                        matches!(count, QuantityExpr::Fixed { value } if value == expected),
+                        "{text:?} should give {expected} ticket counters, got {count:?}"
+                    );
+                }
+                other => panic!("Expected GivePlayerCounter for {text:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// The symbol branch must not swallow a `{TK}` activation cost or a larger
+    /// clause: only a bare "get {TK}…" with an optional terminator may match.
+    #[test]
+    fn parse_player_counter_ticket_symbols_reject_trailing_clause() {
+        assert!(
+            try_parse_player_counter("get {tk} for each creature you control").is_none(),
+            "Trailing 'for each ...' clause must not parse as a bare ticket grant"
+        );
+        // No leading ticket symbol — falls through to the word form (and fails
+        // there, since there is no counter noun), so the symbol branch is inert.
+        assert!(
+            count_ticket_symbols("a poison counter").is_none(),
+            "Non-symbol input must not be counted as ticket symbols"
+        );
+    }
+
+    /// End-to-end (CR 107.17): real Unfinity oracle text that was previously
+    /// Unimplemented now parses to a Ticket player counter. Representative cards:
+    /// Blorbian Buddy ("you get {TK}"), Stiltstrider/Prize Wall ("you get
+    /// {TK}{TK}"), Ticketomaton ("you get {TK}{TK}{TK}").
+    #[test]
+    fn parse_effect_you_get_ticket_symbols_end_to_end() {
+        for (oracle, expected) in [
+            ("You get {TK}", 1),
+            ("You get {TK}{TK}", 2),
+            ("You get {TK}{TK}{TK}", 3),
+        ] {
+            match super::super::parse_effect(oracle) {
+                Effect::GivePlayerCounter {
+                    counter_kind,
+                    count,
+                    target,
+                } => {
+                    assert_eq!(counter_kind, PlayerCounterKind::Ticket);
+                    assert_eq!(target, TargetFilter::Controller);
+                    assert!(
+                        matches!(count, QuantityExpr::Fixed { value } if value == expected),
+                        "{oracle:?} should give {expected} tickets, got {count:?}"
+                    );
+                }
+                other => panic!(
+                    "{oracle:?} should parse to GivePlayerCounter, not {other:?} (regression: was Unimplemented)"
+                ),
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`try_parse_player_counter` (`crates/engine/src/parser/oracle_effect/imperative.rs`) parses the **word** form of player-counter grants ("you get two rad counters", "you get a ticket counter") but not the **symbol** form. Unfinity writes "you get N ticket counters" as N repeated `{TK}` glyphs — e.g. `you get {TK}{TK}{TK}` — with no "counter" noun. Because the parser required the clause to end in "counter"/"counters", every `{TK}`-symbol grant fell through to `Effect::Unimplemented`.

## Fix

Add a `{TK}`-repetition branch to `try_parse_player_counter`. A new `count_ticket_symbols` helper counts the leading run of consecutive `{tk}` symbols (reusing the existing `while tag("{tk}")` counting idiom already used by `oracle_keyword::strip_ticket_activation_cost_prefix`) and emits `Effect::GivePlayerCounter { kind: Ticket, count: N }`. nom combinators only — no string dispatch.

- **Built for the class:** any "you get {TK}×N" grant, for any N, parses to N ticket counters. Each `{TK}` glyph is one ticket counter per CR 107.17.
- **Subject routing reused:** the branch lowers to `TargetFilter::Controller` (default "you"). For non-controller subjects ("target player gets {TK}"), the existing `inject_subject_target` path (`mod.rs`, which already handles `GivePlayerCounter`) remaps the target — identical to the word form.
- **Doesn't over-match:** the branch requires that only a sentence terminator follow the symbol run, so `{TK}` activation costs (`{TK}{TK} — {T}`) and larger clauses (`{TK} for each ...`) are not swallowed and fall through correctly.

## Cards unlocked

Previously-`Unimplemented` Unfinity cards whose grant text is the `{TK}`-symbol form now parse, including:

- Ticketomaton (`you get {TK}{TK}{TK}`)
- Prize Wall (`you get {TK}{TK}`)
- Stiltstrider (`you get {TK}{TK}`)
- Blorbian Buddy (`you get {TK}`)
- Ambassador Blorpityblorpboop (`you get {TK}…`)

…and the rest of the "you get {TK}×N" class (~19 cards total).

## Tests

- `parse_player_counter_ticket_symbols` — building-block test: `get {tk}`, `get {tk}{tk}`, `get {tk}{tk}{tk}`, `gets {tk}{tk}.` all map to `GivePlayerCounter { Ticket, N }`.
- `parse_player_counter_ticket_symbols_reject_trailing_clause` — discriminating: `get {tk} for each creature you control` does **not** parse as a bare ticket grant; non-symbol input is not counted.
- `parse_effect_you_get_ticket_symbols_end_to_end` — full `parse_effect` over real card oracle text (`You get {TK}` / `{TK}{TK}` / `{TK}{TK}{TK}`), asserting `GivePlayerCounter { Ticket, N, Controller }` and not `Unimplemented`.

`cargo fmt --all -- --check` clean; `cargo clippy -p engine --lib -- -D warnings` clean; `cargo test -p engine --lib` 11924 passed / 0 failed; parser combinator gate clean.

## CR

- **CR 107.17:** "The ticket symbol is {TK}. It represents one ticket counter." — each glyph is one counter.
- **CR 122.1:** counter definition (a counter is a marker placed on an object or player).
