### PR TITLE
Fix Song of the Dryads ability loss per CR 305.7

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -8791,6 +8791,88 @@ mod tests {
     }
 
     #[test]
+    fn song_style_set_card_types_and_basic_land_type_makes_nonland_a_forest() {
+        // CR 205.1a + CR 305.7: Song of the Dryads both makes the enchanted
+        // permanent a land and sets its basic land subtype, which removes its
+        // rules-text abilities and grants the Forest intrinsic mana ability.
+        let mut state = setup();
+        let p0 = PlayerId(0);
+
+        let creature_id = create_object(
+            &mut state,
+            CardId(0),
+            p0,
+            "Test Creature".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let ts = state.next_timestamp();
+            let obj = state.objects.get_mut(&creature_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+            Arc::make_mut(&mut obj.base_abilities).push(AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            ));
+            obj.abilities = Arc::new((*obj.base_abilities).clone());
+        }
+
+        let aura_id = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "Song of the Dryads".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let ts = state.next_timestamp();
+            let obj = state.objects.get_mut(&aura_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::new(TypeFilter::Card)
+                            .properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                    .modifications(vec![
+                        ContinuousModification::SetCardTypes {
+                            core_types: vec![CoreType::Land],
+                        },
+                        ContinuousModification::SetBasicLandType {
+                            land_type: BasicLandType::Forest,
+                        },
+                    ]),
+            );
+        }
+
+        state.objects.get_mut(&aura_id).unwrap().attached_to = Some(creature_id.into());
+
+        evaluate_layers(&mut state);
+
+        let creature = state.objects.get(&creature_id).unwrap();
+        assert_eq!(creature.card_types.core_types, vec![CoreType::Land]);
+        assert!(creature.card_types.subtypes.contains(&"Forest".to_string()));
+        assert!(
+            !creature
+                .abilities
+                .iter()
+                .any(|ability| matches!(&*ability.effect, Effect::GainLife { .. })),
+            "CR 305.7: rules-text abilities should be removed"
+        );
+        assert_eq!(
+            count_mana_abilities(creature, ManaColor::Green),
+            1,
+            "CR 305.7: Forest subtype should grant the intrinsic green mana ability"
+        );
+    }
+
+    #[test]
     fn set_chosen_basic_land_type_reads_source_choice() {
         // CR 305.7 + CR 305.6: Phantasmal Terrain / Convincing Mirage. The Aura
         // (source) recorded a chosen basic land type as it entered; its

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10422,6 +10422,33 @@ fn gain_all_creature_types_produces_add_keyword_changeling() {
 }
 
 #[test]
+fn enchanted_permanent_is_colorless_forest_land_produces_set_basic_land_type() {
+    // CR 305.7: Song of the Dryads pattern - should use SetBasicLandType to trigger ability removal
+    let def = parse_static_line("Enchanted permanent is a colorless Forest land.").unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(def
+        .modifications
+        .contains(&ContinuousModification::SetBasicLandType {
+            land_type: crate::types::ability::BasicLandType::Forest,
+        }));
+    assert!(def
+        .modifications
+        .contains(&ContinuousModification::SetColor { colors: vec![] }));
+}
+
+#[test]
+fn enchanted_permanent_is_forest_land_produces_set_basic_land_type() {
+    // CR 305.7: Without color prefix, should still use SetBasicLandType
+    let def = parse_static_line("Enchanted permanent is a Forest land.").unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(def
+        .modifications
+        .contains(&ContinuousModification::SetBasicLandType {
+            land_type: crate::types::ability::BasicLandType::Forest,
+        }));
+}
+
+#[test]
 fn static_condition_source_in_graveyard() {
     let cond = parse_static_condition("this card is in your graveyard");
     assert!(

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10426,6 +10426,14 @@ fn enchanted_permanent_is_colorless_forest_land_produces_set_basic_land_type() {
     // CR 305.7: Song of the Dryads pattern - should use SetBasicLandType to trigger ability removal
     let def = parse_static_line("Enchanted permanent is a colorless Forest land.").unwrap();
     assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::SetCardTypes {
+                core_types: vec![crate::types::card_type::CoreType::Land],
+            }),
+        "Song-style type change must make the permanent a land: {:?}",
+        def.modifications
+    );
     assert!(def
         .modifications
         .contains(&ContinuousModification::SetBasicLandType {
@@ -10441,6 +10449,14 @@ fn enchanted_permanent_is_forest_land_produces_set_basic_land_type() {
     // CR 305.7: Without color prefix, should still use SetBasicLandType
     let def = parse_static_line("Enchanted permanent is a Forest land.").unwrap();
     assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::SetCardTypes {
+                core_types: vec![crate::types::card_type::CoreType::Land],
+            }),
+        "Song-style type change must make the permanent a land: {:?}",
+        def.modifications
+    );
     assert!(def
         .modifications
         .contains(&ContinuousModification::SetBasicLandType {

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -641,6 +641,33 @@ pub(crate) fn parse_enchanted_is_type(
             }
         }
 
+        // CR 305.7: If the only core type is Land and there's exactly one basic land subtype,
+        // use SetBasicLandType instead of SetCardTypes + AddSubtype to trigger ability removal.
+        if granted_core_types == vec![CoreType::Land] && granted_subtypes.len() == 1 {
+            if let Some(basic_type) = parse_basic_land_type(&granted_subtypes[0].to_lowercase()) {
+                let affected = TargetFilter::Typed(
+                    TypedFilter::new(perm_tf).properties(vec![FilterProp::EnchantedBy]),
+                );
+                let mut mods = modifications;
+                if let Some(color) = opt_color {
+                    mods.push(ContinuousModification::SetColor {
+                        colors: vec![color],
+                    });
+                } else if is_colorless {
+                    mods.push(ContinuousModification::SetColor { colors: vec![] });
+                }
+                mods.push(ContinuousModification::SetBasicLandType {
+                    land_type: basic_type,
+                });
+                return Some(
+                    StaticDefinition::continuous()
+                        .affected(affected)
+                        .modifications(mods)
+                        .description(description.to_string()),
+                );
+            }
+        }
+
         // This branch handles type-*changing* auras that grant at least one
         // core card type ("is an Insect artifact creature ..."). A bare
         // "is a [land subtype]" ("Enchanted land is a Mountain") grants no

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -641,14 +641,20 @@ pub(crate) fn parse_enchanted_is_type(
             }
         }
 
-        // CR 305.7: If the only core type is Land and there's exactly one basic land subtype,
-        // use SetBasicLandType instead of SetCardTypes + AddSubtype to trigger ability removal.
-        if granted_core_types == vec![CoreType::Land] && granted_subtypes.len() == 1 {
+        // CR 305.7: If a non-additive type-changing Aura sets exactly one
+        // basic land subtype, keep the card-type replacement ("is a ... land")
+        // and use SetBasicLandType instead of AddSubtype so the land-subtype
+        // change removes rules-text abilities and old land subtypes.
+        if !is_additive && granted_core_types == vec![CoreType::Land] && granted_subtypes.len() == 1
+        {
             if let Some(basic_type) = parse_basic_land_type(&granted_subtypes[0].to_lowercase()) {
                 let affected = TargetFilter::Typed(
                     TypedFilter::new(perm_tf).properties(vec![FilterProp::EnchantedBy]),
                 );
                 let mut mods = modifications;
+                mods.push(ContinuousModification::SetCardTypes {
+                    core_types: granted_core_types,
+                });
                 if let Some(color) = opt_color {
                     mods.push(ContinuousModification::SetColor {
                         colors: vec![color],


### PR DESCRIPTION
## Summary
 
Fix Song of the Dryads to correctly cause the enchanted permanent to lose its rules-text abilities when it becomes a Forest land, as required by CR 305.7.
 
## Implementation method (required)
 
How was the engine/parser logic in this PR produced? Check exactly one:
 
- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below
 
If you did **not** use `/engine-implementer`, state why (e.g. frontend-only change, docs/CI/tooling change, release chore, or a fix too small to warrant the pipeline):
 
> This is a targeted parser fix (~35 lines across 2 files) that modifies a single function to emit the correct ContinuousModification for a well-understood CR 305.7 case. The change leverages existing infrastructure (parse_basic_land_type, set_land_subtype_replacing) and doesn't require architectural planning or new engine primitives.
 
> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.
 
## CR references
 
CR 305.7
 
## Verification
 
Ran `cargo test -p engine --lib parser::oracle_static::tests` — all 722 tests pass, including new tests:
- [enchanted_permanent_is_colorless_forest_land_produces_set_basic_land_type](cci:1://file:///d:/Projects/gittensor/phase/crates/engine/src/parser/oracle_static/tests.rs:10423:0-10436:1)
- [enchanted_permanent_is_forest_land_produces_set_basic_land_type](cci:1://file:///d:/Projects/gittensor/phase/crates/engine/src/parser/oracle_static/tests.rs:10438:0-10448:1)
 
Existing test [enchanted_permanent_loses_abilities_becomes_land](cci:1://file:///d:/Projects/gittensor/phase/crates/engine/src/parser/oracle_static/tests.rs:10997:0-11017:1) still passes, confirming no regression for the "colorless land" case without a subtype.
