### PR TITLE
feat(engine): add Momir Basic format

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -47,7 +47,8 @@ export type GameFormat =
   | "HistoricBrawl"
   | "FreeForAll"
   | "TwoHeadedGiant"
-  | "Limited";
+  | "Limited"
+  | "Momir";
 
 export type FormatGroup = "Constructed" | "Commander" | "Multiplayer" | "Limited";
 

--- a/client/src/data/formatRegistry.ts
+++ b/client/src/data/formatRegistry.ts
@@ -384,6 +384,27 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       allow_debug_actions: false,
     },
   },
+  {
+    format: "Momir",
+    label: "Momir Basic",
+    short_label: "MOM",
+    description: "60 basic lands, random creature tokens",
+    group: "Multiplayer",
+    default_config: {
+      format: "Momir",
+      starting_life: 24,
+      min_players: 2,
+      max_players: 2,
+      deck_size: 60,
+      singleton: false,
+      command_zone: true,
+      commander_damage_threshold: null,
+      range_of_influence: null,
+      team_based: false,
+      uses_commander: false,
+      allow_debug_actions: false,
+    },
+  },
 ];
 
 export function formatMetadata(format: GameFormat): FormatMetadata | undefined {

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2778,6 +2778,37 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
             }
         }
 
+        // CR 114.4 + CR 602.1: Command-zone activated abilities (Momir Basic
+        // emblem). Mirrors the battlefield loop above; `can_activate_ability_now`
+        // honors each ability's `activation_zone` (casting.rs), so legality is
+        // unchanged. Gated on the format's command-zone capability so non-Momir
+        // games pay no extra scan.
+        if state.format_config.command_zone {
+            for &obj_id in &state.command_zone {
+                if let Some(obj) = state.objects.get(&obj_id) {
+                    if obj.controller == player {
+                        for (i, ability_def) in
+                            casting::activated_ability_definitions(state, obj_id)
+                        {
+                            if ability_def.kind == crate::types::ability::AbilityKind::Activated
+                                && !crate::game::mana_abilities::is_mana_ability(&ability_def)
+                                && casting::can_activate_ability_now(state, player, obj_id, i)
+                            {
+                                actions.push(candidate(
+                                    GameAction::ActivateAbility {
+                                        source_id: obj_id,
+                                        ability_index: i,
+                                    },
+                                    TacticalClass::Ability,
+                                    Some(player),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         if is_main_phase && stack_empty && is_active {
             for &obj_id in &state.battlefield {
                 let Some(obj) = state.objects.get(&obj_id) else {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -10733,7 +10733,9 @@ pub(super) fn find_non_self_sacrifice_cost(cost: &AbilityCost) -> Option<(u32, &
     }
 }
 
-fn find_non_self_discard(cost: &AbilityCost) -> Option<(&QuantityExpr, Option<&TargetFilter>)> {
+pub(crate) fn find_non_self_discard(
+    cost: &AbilityCost,
+) -> Option<(&QuantityExpr, Option<&TargetFilter>)> {
     match cost {
         AbilityCost::Discard {
             count,
@@ -10783,7 +10785,9 @@ pub(crate) fn stamp_self_ref_discard_cost_paid_object(
 /// Self-ref exile (Scavenge, Suspend) returns `None` — that shape is auto-paid
 /// by `pay_ability_cost`'s self-ref exile arm and never back-referenced as a
 /// cost-paid object. Recurses into `Composite`.
-fn find_non_self_exile(cost: &AbilityCost) -> Option<(u32, Zone, Option<&TargetFilter>)> {
+pub(super) fn find_non_self_exile(
+    cost: &AbilityCost,
+) -> Option<(u32, Zone, Option<&TargetFilter>)> {
     match cost {
         AbilityCost::Exile {
             filter: Some(TargetFilter::SelfRef),
@@ -11686,6 +11690,31 @@ pub fn handle_activate_ability(
             return casting_costs::enter_payment_step(state, player, None, events);
         }
 
+        // CR 107.1b + CR 601.2f: When an activated ability's cost includes a mana
+        // cost containing X — either directly (`Mana { cost }`) or as a sub-cost
+        // of a Composite (e.g., `{X} + Discard a card`, `Tap + Pay {X}`) — divert
+        // to ChooseXValue so X is chosen in step 601.2f BEFORE any cost is paid.
+        // This MUST run before the non-self sacrifice/discard/exile detours below:
+        // those return a `PayCost` `WaitingFor` and never resume into the X
+        // announcement, so a `{X}`-plus-discard cost (Momir Basic emblem) would
+        // otherwise pay the discard and treat X as 0. The remaining non-mana
+        // sub-costs stay in `activation_cost` and are paid after ManaPayment via
+        // the residual-cost handler (`finish_pending_cost_or_cast`), which already
+        // surfaces a `PayCost::Discard` / `Sacrifice` / `Composite` for them.
+        if let Some((mana_cost, remaining)) = casting_costs::extract_x_mana_cost(cost) {
+            let mut pending_x = PendingCast::new(source_id, CardId(0), resolved, mana_cost);
+            pending_x.activation_cost = remaining;
+            pending_x.activation_ability_index = Some(ability_index);
+            // CR 601.2f + CR 601.2h: POSITIVE signal — the residual non-mana tail
+            // in `activation_cost` is still OUTSTANDING after mana payment, so
+            // `push_activated_ability_to_stack` must re-surface a non-self discard
+            // sub-cost. Only THIS path sets it; the discard-first detour below
+            // already pays the discard and resumes with the flag unset.
+            pending_x.x_residual_activation = true;
+            state.pending_cast = Some(Box::new(pending_x));
+            return casting_costs::enter_payment_step(state, player, None, events);
+        }
+
         if let Some((count, sac_filter)) = find_non_self_sacrifice_cost(cost) {
             let eligible = find_eligible_sacrifice_targets(state, player, source_id, sac_filter);
             let (min_count, max_count) = sacrifice_cost_bounds(count, eligible.len());
@@ -11949,19 +11978,6 @@ pub fn handle_activate_ability(
                 Some(ConvokeMode::Waterbend),
                 events,
             );
-        }
-
-        // CR 107.1b + CR 601.2f: When an activated ability's cost includes a mana
-        // cost containing X — either directly (`Mana { cost }`) or as a sub-cost
-        // of a Composite (e.g., `Tap + Pay {X}`) — divert to ChooseXValue so X is
-        // chosen before mana payment. The remaining non-mana sub-costs (Tap,
-        // Sacrifice, etc.) are paid after ManaPayment via `activation_cost`.
-        if let Some((mana_cost, remaining)) = casting_costs::extract_x_mana_cost(cost) {
-            let mut pending_x = PendingCast::new(source_id, CardId(0), resolved, mana_cost);
-            pending_x.activation_cost = remaining;
-            pending_x.activation_ability_index = Some(ability_index);
-            state.pending_cast = Some(Box::new(pending_x));
-            return casting_costs::enter_payment_step(state, player, None, events);
         }
     }
 
@@ -17508,6 +17524,106 @@ mod tests {
         assert!(matches!(
             state.stack[0].kind,
             StackEntryKind::ActivatedAbility { source_id, .. } if source_id == blood
+        ));
+    }
+
+    /// CR 601.2h + CR 701.9a (MED-1 regression): an activated ability whose ONLY
+    /// cost is a BARE non-self `Discard` (no mana, no X) takes the discard-FIRST
+    /// detour. After the discard is paid and the activation resumes through
+    /// `push_activated_ability_to_stack`, the X-residual discard detour MUST NOT
+    /// re-fire. Before the fix, that detour was gated on the cost SHAPE
+    /// (`matches!(cost, Discard)`), which is true for a bare `Discard` resumed
+    /// from EITHER path, so it would prompt for a SECOND discard. With exactly one
+    /// card in hand, the second prompt finds an empty hand and the activation
+    /// errors. The fix gates on the positive `x_residual` signal (false on the
+    /// discard-first path), so the single discard pays the cost and the ability
+    /// lands on the stack.
+    ///
+    /// Discriminating assertion: `state.stack.len() == 1` (the activated ability
+    /// reached the stack). If MED-1 is reverted, `apply_as_current` returns `Err`
+    /// (not enough cards to discard the second time) and the stack stays empty.
+    #[test]
+    fn bare_non_self_discard_activation_does_not_double_prompt() {
+        use super::super::engine::apply_as_current;
+        use crate::types::ability::{AbilityCost, AbilityKind, Effect};
+
+        let mut state = setup_game_at_main_phase();
+        let source = create_object(
+            &mut state,
+            CardId(973),
+            PlayerId(0),
+            "Bare Discard Source".to_string(),
+            Zone::Battlefield,
+        );
+        // Exactly ONE card in hand — a second (erroneous) discard prompt would
+        // have nothing to discard and fail.
+        let only_card = create_object(
+            &mut state,
+            CardId(974),
+            PlayerId(0),
+            "Sole Hand Card".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
+                )
+                .cost(AbilityCost::Discard {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    filter: None,
+                    selection: crate::types::ability::CardSelectionMode::Chosen,
+                    self_scope: crate::types::ability::DiscardSelfScope::FromHand,
+                }),
+            );
+        }
+
+        apply_as_current(
+            &mut state,
+            GameAction::ActivateAbility {
+                source_id: source,
+                ability_index: 0,
+            },
+        )
+        .unwrap();
+
+        // Discard-first detour surfaces a single Discard prompt for the one card.
+        match &state.waiting_for {
+            WaitingFor::PayCost {
+                kind: PayCostKind::Discard,
+                choices,
+                count,
+                ..
+            } => {
+                assert_eq!(*count, 1);
+                assert_eq!(choices, &vec![only_card]);
+            }
+            other => panic!("expected PayCost Discard, got {other:?}"),
+        }
+
+        apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![only_card],
+            },
+        )
+        .expect("single discard must pay the cost without a second prompt");
+
+        assert_eq!(state.objects[&only_card].zone, Zone::Graveyard);
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "ability must reach the stack after exactly one discard"
+        );
+        assert!(matches!(
+            state.stack[0].kind,
+            StackEntryKind::ActivatedAbility { source_id, .. } if source_id == source
         ));
     }
 

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -870,6 +870,7 @@ fn finish_pending_cost_or_cast(
             ability_index,
             pending.ability,
             pending.activation_cost.as_ref(),
+            pending.x_residual_activation,
             events,
         )?;
         return Ok(drain_deferred_triggers_after_stack_object_announcement(
@@ -1177,6 +1178,7 @@ pub(crate) fn resume_interrupted_cost_payment(
             activation_ability_index,
             pending.ability,
             pending.activation_cost.as_ref(),
+            pending.x_residual_activation,
             events,
         );
     }
@@ -2037,6 +2039,7 @@ pub(crate) fn handle_exile_materials_for_cost(
 /// Push an activated ability to the stack after costs are paid.
 /// Shared by: direct path in `handle_activate_ability`, sacrifice detour, and
 /// waterbend/ManaPayment finalization in the PassPriority handler.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn push_activated_ability_to_stack(
     state: &mut GameState,
     player: PlayerId,
@@ -2044,12 +2047,85 @@ pub(super) fn push_activated_ability_to_stack(
     ability_index: usize,
     mut resolved: ResolvedAbility,
     remaining_cost: Option<&crate::types::ability::AbilityCost>,
+    // CR 601.2f + CR 601.2h: POSITIVE signal that the caller took the `{X}`-mana
+    // detour, so `remaining_cost` is the unpaid residual non-mana tail. Threaded
+    // from `PendingCast::x_residual_activation` — set ONLY by that detour.
+    x_residual: bool,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     // Pay any activation-cost tail still outstanding. Cost-selection flows may
     // pass the original full cost; choice-based sub-costs already paid by a
     // WaitingFor handler are no-ops here.
     if let Some(cost) = remaining_cost {
+        // CR 601.2f + CR 601.2h + CR 701.9a: When the X-mana detour ran first
+        // (e.g. the Momir Basic emblem's `{X}, Discard a card` cost), the non-self
+        // "discard a card" sub-cost is still OUTSTANDING here AFTER mana payment,
+        // signalled by `x_residual`. In contrast, the discard-FIRST pre-check
+        // detour in `handle_activate_ability` already paid the discard and resumes
+        // with `x_residual == false` and the ORIGINAL cost — its discard sub-cost
+        // is correctly no-op'd by `pay_ability_cost_for_activation` below. Gating
+        // on the positive `x_residual` signal (not the cost shape) avoids
+        // double-charging the discard on that pre-check path even when the cost is
+        // a BARE `Discard` (which would otherwise fail with an empty hand).
+        if let Some((count, filter)) =
+            super::casting::find_non_self_discard(cost).filter(|_| x_residual)
+        {
+            let count =
+                super::quantity::resolve_quantity(state, count, player, source_id).max(0) as usize;
+            let eligible =
+                super::casting::find_eligible_discard_targets(state, player, source_id, filter);
+            if eligible.len() < count {
+                return Err(EngineError::ActionNotAllowed(
+                    "Not enough cards in hand to discard".into(),
+                ));
+            }
+            let mut pending_discard =
+                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+            pending_discard.activation_ability_index = Some(ability_index);
+            return Ok(WaitingFor::PayCost {
+                player,
+                kind: PayCostKind::Discard,
+                choices: eligible,
+                count,
+                min_count: 0,
+                resume: CostResume::Spell {
+                    spell: Box::new(pending_discard),
+                },
+            });
+        }
+
+        // CR 118.3 + CR 601.2h: The `{X}`-mana detour (`extract_x_mana_cost` in
+        // `handle_activate_ability`) hoists X-first and leaves the residual tail
+        // here, but ONLY the non-self `Discard` arm above re-surfaces an
+        // interactive cost. A residual non-self SACRIFICE or non-self EXILE would
+        // otherwise fall through to `pay_ability_cost_for_activation`, where both
+        // are silent `Paid` no-ops (they rely on the pre-payment
+        // SacrificeForCost / ExileForCost WaitingFor interception that the X-first
+        // hoist bypassed) — silently SKIPPING the cost. No current card has an
+        // `{X} + non-self-sacrifice/exile` activated ability (corpus scan = zero),
+        // and this was already broken pre-hoist (X→0), so this is not a
+        // regression — but a silent cost-swallow must not ship. Fail LOUDLY here.
+        // A future `{X} + non-self-sacrifice/exile` activated ability must extend
+        // this residual detour with Sacrifice/Exile arms mirroring the Discard arm
+        // above (route to `WaitingFor::PayCost { kind: Sacrifice | ExileFromZone }`
+        // with the residual stored in the resumed pending).
+        if x_residual
+            && (super::casting::find_non_self_sacrifice_cost(cost).is_some()
+                || super::casting::find_non_self_exile(cost).is_some())
+        {
+            debug_assert!(
+                false,
+                "X-residual activation left a non-self sacrifice/exile cost unhandled \
+                 (cost: {cost:?}); extend the residual detour in \
+                 push_activated_ability_to_stack"
+            );
+            return Err(EngineError::ActionNotAllowed(
+                "Unsupported activated-ability cost: {X} combined with a non-self \
+                 sacrifice/exile is not yet implemented"
+                    .into(),
+            ));
+        }
+
         // CR 606.3 + CR 606.5: Capture the symbolic `[−X]` loyalty shape before
         // chosen-X concretization turns it into a fixed counter-removal count.
         let should_record_loyalty = crate::types::ability::is_loyalty_ability_cost(cost);
@@ -6963,6 +7039,7 @@ pub fn finalize_mana_payment(
             ability_index,
             pending.ability,
             pending.activation_cost.as_ref(),
+            pending.x_residual_activation,
             events,
         );
     }
@@ -7127,6 +7204,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
             ability_index,
             pending.ability,
             pending.activation_cost.as_ref(),
+            pending.x_residual_activation,
             events,
         );
     }
@@ -7770,6 +7848,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         }
     }
 
@@ -11881,6 +11960,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         };
 
         let result = pay_additional_cost(
@@ -12005,6 +12085,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         };
 
         let mut events = Vec::new();
@@ -12098,6 +12179,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         };
 
         // Exactly one card is required. Selecting two must fail.
@@ -12180,6 +12262,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         };
 
         // `red` is not in the legal-cards list, so the cost handler must reject
@@ -12295,6 +12378,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         };
 
         let result = pay_additional_cost(
@@ -14889,6 +14973,66 @@ its replicate cost was paid.)\nDraw a card.";
                 generic: 3,
             },
             "declined offering must leave cost at full {{3}}{{W}}"
+        );
+    }
+
+    /// CR 118.3 + CR 601.2h: A `{X}` + non-self SACRIFICE activated-ability cost
+    /// takes the X-mana detour, leaving the non-self sacrifice as the unpaid
+    /// residual in `push_activated_ability_to_stack`. That function only
+    /// re-surfaces the non-self DISCARD arm; a non-self sacrifice/exile residual
+    /// would otherwise fall through to `pay_ability_cost_for_activation` and be a
+    /// SILENT `Paid` no-op (the cost would be skipped). The guard must instead
+    /// fail LOUDLY. No real card has this cost shape; this guards the shared
+    /// pipeline against a future one. In debug builds the `debug_assert!` panics
+    /// (asserted here); in release builds it is compiled out and the function
+    /// returns `EngineError::ActionNotAllowed` instead, so the cost is never
+    /// silently skipped on either profile.
+    #[test]
+    #[should_panic(expected = "non-self sacrifice/exile cost unhandled")]
+    fn x_residual_non_self_sacrifice_fails_loudly() {
+        let mut state = GameState::new_two_player(42);
+        // A permanent the player could sacrifice — present so the failure is the
+        // unhandled-cost guard, not an empty eligible set.
+        let source = create_object(
+            &mut state,
+            CardId(7_700),
+            PlayerId(0),
+            "X-Sacrifice Source".to_string(),
+            Zone::Battlefield,
+        );
+        let _victim = create_object(
+            &mut state,
+            CardId(7_701),
+            PlayerId(0),
+            "Sac Fodder".to_string(),
+            Zone::Battlefield,
+        );
+        let resolved = ResolvedAbility::new(
+            Effect::Scry {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            Vec::new(),
+            source,
+            PlayerId(0),
+        );
+        // The X-mana sub-cost has already been extracted/paid by the detour; the
+        // residual handed to `push_activated_ability_to_stack` is the non-self
+        // sacrifice, flagged as the X-residual path (`x_residual = true`).
+        let residual = AbilityCost::Sacrifice(SacrificeCost::count(
+            TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+            1,
+        ));
+        let mut events = Vec::new();
+        let _ = push_activated_ability_to_stack(
+            &mut state,
+            PlayerId(0),
+            source,
+            0,
+            resolved,
+            Some(&residual),
+            true,
+            &mut events,
         );
     }
 }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2629,6 +2629,15 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 d.push(("attacking".into(), "yes".into()));
             }
         }
+        Effect::CreateTokenCopyFromPool {
+            mv,
+            mv_bound,
+            selection,
+            ..
+        } => {
+            d.push(("mv".into(), format!("{mv:?} {}", fmt_quantity(mv_bound))));
+            d.push(("selection".into(), format!("{selection:?}")));
+        }
         Effect::ExploreAll { filter } => {
             d.push(("filter".into(), fmt_target(filter)));
         }

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -186,6 +186,71 @@ pub fn create_object_from_card_face(
     obj_id
 }
 
+/// Build the Momir Basic emblem's activated ability programmatically (no Oracle
+/// text — emblems have no card to parse). CR 113.1b + CR 114.4:
+/// "{X}, Discard a card: Create a token that's a copy of a creature card with
+/// mana value X chosen at random. Activate only any time you could cast a sorcery
+/// and only once each turn."
+pub fn momir_emblem_ability() -> crate::types::ability::AbilityDefinition {
+    use crate::types::ability::{
+        AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, CardSelectionMode,
+        Comparator, DiscardSelfScope, Effect, QuantityExpr, QuantityRef, TargetFilter,
+    };
+    use crate::types::mana::{ManaCost, ManaCostShard};
+
+    // CR 707.2 + CR 202.3 + CR 701.9a (analogous): random copy of a creature card
+    // whose mana value equals the X paid.
+    let effect = Effect::CreateTokenCopyFromPool {
+        owner: TargetFilter::Controller,
+        type_filter: TargetFilter::Any,
+        mv: Comparator::EQ,
+        mv_bound: QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        },
+        selection: CardSelectionMode::Random,
+        count: QuantityExpr::Fixed { value: 1 },
+        tapped: false,
+        enters_attacking: false,
+    };
+
+    // Cost: {X} + discard a card. CR 107.3 (X) + CR 701.9a (discard).
+    let cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::X],
+                    generic: 0,
+                },
+            },
+            AbilityCost::Discard {
+                count: QuantityExpr::Fixed { value: 1 },
+                filter: None,
+                selection: CardSelectionMode::Chosen,
+                self_scope: DiscardSelfScope::FromHand,
+            },
+        ],
+    };
+
+    let mut ability = AbilityDefinition::new(AbilityKind::Activated, effect)
+        .cost(cost)
+        // CR 307.5 (sorcery speed) + CR 602.5b (once each turn).
+        .activation_restrictions(vec![
+            ActivationRestriction::AsSorcery,
+            ActivationRestriction::OnlyOnceEachTurn,
+        ])
+        .description(
+            "{X}, Discard a card: Create a token that's a copy of a creature card \
+             with mana value X chosen at random. Activate only as a sorcery and \
+             only once each turn."
+                .to_string(),
+        );
+    // CR 114.4: the ability functions (and is activated) from the command zone.
+    ability.activation_zone = Some(Zone::Command);
+    ability
+}
+
 /// Create a commander GameObject from a CardFace, placing it in the command zone.
 pub fn create_commander_from_card_face(
     state: &mut GameState,
@@ -407,6 +472,25 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
             for _ in 0..entry.count {
                 create_signature_spell_from_card_face(state, &entry.card, owner);
             }
+        }
+    }
+
+    // Momir Basic: grant each player a game-start command-zone emblem carrying
+    // the random-creature-token activated ability (CR 114.1 / CR 113.1b). The
+    // grant runs BEFORE `rehydrate_game_from_card_db` populates the Momir pool
+    // (in `load_and_hydrate_decks`); this ordering is correct ONLY because
+    // `grant_emblem` does not read `momir_pool` / `momir_pool_faces` — those are
+    // resolution-time-only reads inside the effect resolver.
+    if state.format_config.format == crate::types::format::GameFormat::Momir {
+        for i in 0..state.players.len() {
+            let player = PlayerId(i as u8);
+            crate::game::effects::create_emblem::grant_emblem(
+                state,
+                player,
+                Vec::new(),
+                Vec::new(),
+                vec![momir_emblem_ability()],
+            );
         }
     }
 

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -1318,6 +1318,74 @@ fn evaluate_oathbreaker(
     }
 }
 
+/// Momir Basic deck legality: exactly 60 cards in the main deck, every one a
+/// basic land (CR 205.4 Basic supertype + CR 305 Land core type), no sideboard,
+/// no command-zone cards. CR 100.2a's basic-land exception means the 60 copies
+/// of basics are legal despite the four-copy default.
+fn evaluate_momir(
+    db: &CardDatabase,
+    request: &DeckCompatibilityRequest,
+    unknown_cards: &BTreeSet<String>,
+) -> CompatibilityCheck {
+    let mut reasons = Vec::new();
+
+    if !unknown_cards.is_empty() {
+        reasons.push(summarize_cards("Unknown cards", unknown_cards, 6));
+    }
+
+    if request.main_deck.len() != 60 {
+        reasons.push(format!(
+            "Momir Basic decks must have exactly 60 cards (found {})",
+            request.main_deck.len()
+        ));
+    }
+
+    // CR 205.4 + CR 305: every main-deck card must be a basic land.
+    let mut non_basic = BTreeSet::new();
+    for name in request.main_deck.iter().map(String::as_str) {
+        if unknown_cards.contains(name) {
+            continue;
+        }
+        let resolved = resolve_card_name(db, name);
+        let Some(face) = db.get_face_by_name(resolved) else {
+            continue;
+        };
+        let is_basic_land = face.card_type.supertypes.contains(&Supertype::Basic)
+            && face.card_type.core_types.contains(&CoreType::Land);
+        if !is_basic_land {
+            non_basic.insert(face.name.clone());
+        }
+    }
+    if !non_basic.is_empty() {
+        reasons.push(summarize_cards(
+            "Momir Basic decks may only contain basic lands",
+            &non_basic,
+            6,
+        ));
+    }
+
+    if !request.sideboard.is_empty() {
+        reasons.push("Momir Basic does not use a sideboard".to_string());
+    }
+    if !request.commander.is_empty() || !request.signature_spell.is_empty() {
+        reasons.push("Momir Basic does not use command-zone cards".to_string());
+    }
+
+    CompatibilityCheck {
+        compatible: reasons.is_empty(),
+        reasons,
+    }
+}
+
+fn quick_momir_check(db: &CardDatabase, request: &DeckCompatibilityRequest) -> QuickCheckResult {
+    let unknown_cards = collect_unknown_cards(db, request);
+    let check = evaluate_momir(db, request, &unknown_cards);
+    QuickCheckResult {
+        reason: check.reasons.into_iter().next(),
+        unknown_cards,
+    }
+}
+
 fn quick_oathbreaker_check(
     db: &CardDatabase,
     request: &DeckCompatibilityRequest,
@@ -1382,6 +1450,7 @@ fn evaluate_selected_format_summary(
         ),
         GameFormat::TinyLeaders => quick_tiny_leaders_check(db, request),
         GameFormat::Oathbreaker => quick_oathbreaker_check(db, request),
+        GameFormat::Momir => quick_momir_check(db, request),
         GameFormat::Brawl | GameFormat::HistoricBrawl => quick_brawl_check(
             db,
             request,
@@ -1744,6 +1813,13 @@ fn evaluate_selected_format(
         }
         GameFormat::Oathbreaker => {
             let check = evaluate_oathbreaker(db, request, unknown_cards);
+            if !check.compatible {
+                reasons.extend(check.reasons);
+            }
+            check.compatible
+        }
+        GameFormat::Momir => {
+            let check = evaluate_momir(db, request, unknown_cards);
             if !check.compatible {
                 reasons.extend(check.reasons);
             }
@@ -4809,5 +4885,69 @@ mod tests {
             "restricted card must not be flagged as illegal; reasons: {:?}",
             result.selected_format_reasons
         );
+    }
+
+    fn momir_request(main: Vec<String>) -> DeckCompatibilityRequest {
+        DeckCompatibilityRequest {
+            main_deck: main,
+            sideboard: Vec::new(),
+            commander: Vec::new(),
+            signature_spell: Vec::new(),
+            selected_format: Some(GameFormat::Momir),
+            selected_match_type: None,
+            summary_only: false,
+        }
+    }
+
+    #[test]
+    fn momir_sixty_basics_passes() {
+        let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
+        let request = momir_request(expand("Plains", 60));
+        let check = evaluate_momir(&db, &request, &BTreeSet::new());
+        assert!(
+            check.compatible,
+            "60 basic lands must be a legal Momir deck, reasons: {:?}",
+            check.reasons
+        );
+    }
+
+    #[test]
+    fn momir_wrong_count_fails() {
+        let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
+        for count in [59usize, 61] {
+            let check = evaluate_momir(
+                &db,
+                &momir_request(expand("Plains", count)),
+                &BTreeSet::new(),
+            );
+            assert!(
+                !check.compatible,
+                "a {count}-card Momir deck must be rejected"
+            );
+            assert!(check.reasons.iter().any(|r| r.contains("exactly 60")));
+        }
+    }
+
+    #[test]
+    fn momir_non_basic_fails() {
+        let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
+        let mut deck = expand("Plains", 59);
+        deck.push("Legal Standard".to_string()); // non-basic
+        let check = evaluate_momir(&db, &momir_request(deck), &BTreeSet::new());
+        assert!(!check.compatible, "a non-basic card must be rejected");
+        assert!(check
+            .reasons
+            .iter()
+            .any(|r| r.contains("only contain basic lands")));
+    }
+
+    #[test]
+    fn momir_non_empty_sideboard_fails() {
+        let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
+        let mut request = momir_request(expand("Plains", 60));
+        request.sideboard = vec!["Plains".to_string()];
+        let check = evaluate_momir(&db, &request, &BTreeSet::new());
+        assert!(!check.compatible, "Momir has no sideboard");
+        assert!(check.reasons.iter().any(|r| r.contains("sideboard")));
     }
 }

--- a/crates/engine/src/game/effects/create_emblem.rs
+++ b/crates/engine/src/game/effects/create_emblem.rs
@@ -1,11 +1,60 @@
 use crate::game::game_object::EmblemSource;
 use crate::game::zones::create_object;
-use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::types::ability::{
+    AbilityDefinition, Effect, EffectError, EffectKind, ResolvedAbility, StaticDefinition,
+    TriggerDefinition,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
-use crate::types::identifiers::CardId;
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 use std::sync::Arc;
+
+/// CR 114.1 + CR 114.4: Single authority for emblem-object construction. Creates
+/// an emblem in `owner`'s command zone and installs the given static, triggered,
+/// and activated abilities so they function from the command zone (CR 114.4).
+///
+/// Returns the new emblem's `ObjectId` so callers can set display-only
+/// `emblem_source` provenance. `grant_emblem` does NOT set `emblem_source`
+/// because it has no ability source of its own.
+///
+/// This helper does NOT read any format pool fields (`momir_pool`,
+/// `momir_pool_faces`); those are resolution-time-only reads, which is why
+/// `deck_loading` can grant the Momir emblem before the pool is built.
+pub fn grant_emblem(
+    state: &mut GameState,
+    owner: PlayerId,
+    statics: Vec<StaticDefinition>,
+    triggers: Vec<TriggerDefinition>,
+    abilities: Vec<AbilityDefinition>,
+) -> ObjectId {
+    // CR 114.1: Create emblem in command zone owned by `owner`.
+    let emblem_id = create_object(state, CardId(0), owner, "Emblem".to_string(), Zone::Command);
+    let obj = state.objects.get_mut(&emblem_id).unwrap();
+    // CR 114.5: An emblem is neither a card nor a permanent. Setting `is_emblem`
+    // BEFORE installing ability definitions is load-bearing:
+    // `functioning_abilities::object_functions` uses this flag to admit
+    // command-zone objects, so the first trigger/static scan after creation
+    // sees the emblem's abilities.
+    obj.is_emblem = true;
+    // CR 114.4 + CR 611.1: static abilities function from the command zone.
+    obj.static_definitions = statics.clone().into();
+    obj.base_static_definitions = Arc::new(statics);
+    // CR 113.1c + CR 114.4: install triggered abilities so
+    // `active_trigger_definitions` yields them during command-zone scans.
+    obj.trigger_definitions = triggers.clone().into();
+    obj.base_trigger_definitions = Arc::new(triggers);
+    // CR 113.1b + CR 114.4: install activated abilities so they can be activated
+    // from the command zone (e.g. the Momir Basic emblem ability).
+    obj.abilities = Arc::new(abilities.clone());
+    obj.base_abilities = Arc::new(abilities);
+
+    // CR 114.1 + CR 611.1: An emblem can source continuous effects; conservatively
+    // request a full layer re-evaluation.
+    crate::game::layers::mark_layers_full(state);
+    emblem_id
+}
 
 /// CR 114.1 + CR 114.4: Create an emblem in the command zone with the given
 /// abilities (statics and triggers). Emblems are not permanents — they cannot
@@ -34,32 +83,19 @@ pub fn resolve(
             printed_ref: src.printed_ref.clone(),
         });
 
-    // CR 114.1: Create emblem in command zone owned by the ability's controller
-    let emblem_id = create_object(
+    // CR 114.1: Create the emblem via the single-authority helper. No activated
+    // abilities for the planeswalker/spell emblem path — only statics + triggers.
+    let emblem_id = grant_emblem(
         state,
-        CardId(0),
         ability.controller,
-        "Emblem".to_string(),
-        Zone::Command,
+        statics.clone(),
+        triggers.clone(),
+        Vec::new(),
     );
-    let obj = state.objects.get_mut(&emblem_id).unwrap();
-    // CR 114.5: An emblem is neither a card nor a permanent. Emblem isn't a
-    // card type. Setting `is_emblem` BEFORE installing ability definitions is
-    // load-bearing: `functioning_abilities::object_functions` uses this flag
-    // to admit command-zone objects, so the first trigger/static scan after
-    // creation sees the emblem's abilities.
-    obj.is_emblem = true;
-    obj.emblem_source = emblem_source;
-    obj.static_definitions = statics.clone().into();
-    obj.base_static_definitions = Arc::new(statics.clone());
-    // CR 113.1c + CR 114.4: Install triggered abilities on the emblem so
-    // `active_trigger_definitions` yields them during command-zone scans.
-    obj.trigger_definitions = triggers.clone().into();
-    obj.base_trigger_definitions = Arc::new(triggers.clone());
+    // CR 114: set display-only provenance captured above (grant_emblem leaves it
+    // unset because it has no ability source of its own).
+    state.objects.get_mut(&emblem_id).unwrap().emblem_source = emblem_source;
 
-    // CR 114.1 + CR 611.1: An emblem can source continuous effects; conservatively
-    // request a full layer re-evaluation.
-    crate::game::layers::mark_layers_full(state);
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::from(&ability.effect),
         source_id: ability.source_id,

--- a/crates/engine/src/game/effects/create_token_copy_from_pool.rs
+++ b/crates/engine/src/game/effects/create_token_copy_from_pool.rs
@@ -1,0 +1,197 @@
+//! CR 707.2 + CR 111.1 + CR 701.9a (analogous): `Effect::CreateTokenCopyFromPool`
+//! resolver. Creates a token that's a copy of a creature card chosen from the
+//! format-defined pool (`GameState::momir_pool` / `momir_pool_faces`) whose mana
+//! value satisfies the effect's comparator against `mv_bound`. The canonical card
+//! is the Momir Basic emblem; the comparator makes the same primitive express
+//! "copy a creature card with mana value N or less" (Oko-style) via `LE`.
+//!
+//! The copy source exists only as a `CardFace` (no battlefield object), so the
+//! resolver builds `CopiableValues` directly from the face via
+//! `copiable_values_from_face`, then routes the result through the SHARED copy-
+//! token apply path (`token_copy::drive_copy_token_batches`) so the replacement
+//! pipeline and token construction are never duplicated.
+
+use crate::game::effects::token::resolve_token_owner;
+use crate::game::effects::token_copy::drive_copy_token_batches;
+use crate::game::filter::matches_target_filter_against_face;
+use crate::game::game_object::DisplaySource;
+use crate::game::printed_cards::{copiable_values_from_face, printed_ref_from_face};
+use crate::game::quantity::resolve_quantity_with_targets;
+use crate::types::ability::{Comparator, EffectError, EffectKind, ResolvedAbility};
+use crate::types::card::CardFace;
+use crate::types::card_type::CoreType;
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+use crate::types::game_state::PendingCopyTokenBatch;
+use crate::types::proposed_event::CopyTokenSpec;
+use rand::seq::IndexedRandom;
+use std::collections::VecDeque;
+
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    // 1. Destructure the typed fields from the effect.
+    let crate::types::ability::Effect::CreateTokenCopyFromPool {
+        owner,
+        type_filter,
+        mv,
+        mv_bound,
+        selection,
+        count,
+        tapped,
+        enters_attacking,
+    } = &ability.effect
+    else {
+        return Err(EffectError::MissingParam(
+            "CreateTokenCopyFromPool".to_string(),
+        ));
+    };
+    let (mv, selection, tapped, enters_attacking) = (*mv, *selection, *tapped, *enters_attacking);
+    let owner_filter = owner.clone();
+    let type_filter = type_filter.clone();
+
+    // 2. CR 202.3: Resolve the mana-value bound. `resolve_quantity_with_targets`
+    // threads `ability.chosen_x`, so the Momir `Variable { "X" }` bound reads the
+    // X the activator paid.
+    let bound = resolve_quantity_with_targets(state, mv_bound, ability);
+
+    // 3. Gather candidate names from the pool by the comparator. `EQ` is the
+    // direct keyed lookup (Momir); other comparators range over the BTreeMap.
+    let candidates: Vec<String> = match mv {
+        Comparator::EQ => state.momir_pool.get(&bound).cloned().unwrap_or_default(),
+        Comparator::LE => state
+            .momir_pool
+            .range(..=bound)
+            .flat_map(|(_, names)| names.iter().cloned())
+            .collect(),
+        Comparator::LT => state
+            .momir_pool
+            .range(..bound)
+            .flat_map(|(_, names)| names.iter().cloned())
+            .collect(),
+        Comparator::GE => state
+            .momir_pool
+            .range(bound..)
+            .flat_map(|(_, names)| names.iter().cloned())
+            .collect(),
+        Comparator::GT => state
+            .momir_pool
+            .range((std::ops::Bound::Excluded(bound), std::ops::Bound::Unbounded))
+            .flat_map(|(_, names)| names.iter().cloned())
+            .collect(),
+        Comparator::NE => state
+            .momir_pool
+            .iter()
+            .filter(|(mv, _)| **mv != bound)
+            .flat_map(|(_, names)| names.iter().cloned())
+            .collect(),
+    };
+
+    // 4. CR 205 + CR 111.5: Hydrate each candidate's face and keep only those
+    // ELIGIBLE for copying — a creature card (CR 111.5: instants/sorceries make no
+    // token; the pool is creature-only, but a future caller's filter may admit
+    // others, so guard defensively) that ALSO satisfies the effect's
+    // `type_filter` ("additional filter applied to the hydrated face"). Filtering
+    // here, during candidate gathering, ensures the random pick (step 6) respects
+    // `type_filter`. For Momir `type_filter` is `Any`, so this is a no-op narrowing.
+    // Faces missing from the hydration map are dropped (cannot be copied).
+    let eligible_faces: Vec<(String, CardFace)> = candidates
+        .into_iter()
+        .filter_map(|name| {
+            let face = state.momir_pool_faces.get(&name.to_lowercase()).cloned()?;
+            let is_creature = face.card_type.core_types.contains(&CoreType::Creature);
+            let is_instant_or_sorcery = face
+                .card_type
+                .core_types
+                .iter()
+                .any(|t| matches!(t, CoreType::Instant | CoreType::Sorcery));
+            (is_creature
+                && !is_instant_or_sorcery
+                && matches_target_filter_against_face(&face, &type_filter))
+            .then_some((name, face))
+        })
+        .collect();
+
+    // 5. CR 609.3: "Do as much as possible" — no eligible face creates no token
+    // (a mana value with no qualifying creatures). Not an error.
+    if eligible_faces.is_empty() {
+        state.last_created_token_ids = Vec::new();
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
+    // 6. CR 608.2d: the effect selects an eligible candidate's face (at random
+    //    for Momir; "chosen at random" has no dedicated CR, so the selection
+    //    rule CR 608.2d governs here).
+    let face = match selection {
+        crate::types::ability::CardSelectionMode::Random => eligible_faces
+            .choose(&mut state.rng)
+            .map(|(_, face)| face.clone())
+            .expect("non-empty eligible set"),
+        crate::types::ability::CardSelectionMode::Chosen => {
+            // RUNTIME: Momir Basic never uses `Chosen` selection. Interactive
+            // "choose a creature card from the pool" is not built; this typed-but-
+            // unhandled arm is a benign no-op so the primitive stays total.
+            state.last_created_token_ids = Vec::new();
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::from(&ability.effect),
+                source_id: ability.source_id,
+            });
+            return Ok(());
+        }
+    };
+
+    // 7. CR 707.2: Build copiable values directly from the face (no battlefield
+    // source object exists for a pool pick).
+    let values = copiable_values_from_face(&face);
+    let printed_ref = printed_ref_from_face(&face);
+
+    // 8. CR 109.4 + CR 111.2: Resolve the token's creator/owner and
+    // the token count. NOTE: `count > 1` replicates the SINGLE random pick above
+    // `count` times (all N tokens copy the same chosen face), NOT N independent
+    // random picks. Momir Basic uses `count = 1`, so this is inert today.
+    // Independent per-token picks ("create N random creature tokens") are a future
+    // change: loop the step-4/6 selection `count` times, consuming `state.rng` in
+    // order for determinism, and enqueue one `PendingCopyTokenBatch { count: 1 }`
+    // per pick.
+    let token_owner = resolve_token_owner(state, ability, &owner_filter);
+    let count = resolve_quantity_with_targets(state, count, ability).max(0) as u32;
+
+    // 9. Emit the copy through the SHARED replacement + apply path. The drain
+    // (`drive_copy_token_batches` -> `drain_copy_token_resolution`) rebuilds the
+    // probe `TokenSpec` from `copy.values` via `copy_probe_spec_for` internally,
+    // so we only assemble the `PendingCopyTokenBatch` here.
+    let mut remaining = VecDeque::with_capacity(1);
+    remaining.push_back(PendingCopyTokenBatch {
+        owner: token_owner,
+        count,
+        copy: Box::new(CopyTokenSpec {
+            values: Box::new(values),
+            display_source: DisplaySource::Card,
+            printed_ref,
+            token_image_ref: None,
+            extra_keywords: Vec::new(),
+            additional_modifications: Vec::new(),
+            tapped,
+            enters_attacking,
+            sacrifice_at: ability.duration.clone(),
+            source_id: ability.source_id,
+            controller: ability.controller,
+        }),
+    });
+
+    drive_copy_token_batches(
+        state,
+        remaining,
+        EffectKind::from(&ability.effect),
+        ability.source_id,
+        events,
+    );
+
+    Ok(())
+}

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -64,6 +64,7 @@ pub mod counter;
 pub mod counters;
 pub mod create_damage_replacement;
 pub mod create_emblem;
+pub mod create_token_copy_from_pool;
 pub mod deal_damage;
 pub mod delayed_trigger;
 pub mod destroy;
@@ -2337,6 +2338,9 @@ pub fn resolve_effect(
         Effect::EpicCopy { .. } => epic::resolve(state, ability, events),
         Effect::CastCopyOfCard { .. } => cast_copy_of_card::resolve(state, ability, events),
         Effect::CopyTokenOf { .. } => token_copy::resolve(state, ability, events),
+        Effect::CreateTokenCopyFromPool { .. } => {
+            create_token_copy_from_pool::resolve(state, ability, events)
+        }
         Effect::Myriad => myriad::resolve(state, ability, events),
         Effect::ExileHaunting { .. } => crate::game::haunt::resolve(state, ability, events),
         Effect::Encore => encore::resolve(state, ability, events),

--- a/crates/engine/src/game/effects/search_outside_game.rs
+++ b/crates/engine/src/game/effects/search_outside_game.rs
@@ -2,10 +2,8 @@ use crate::game::effects::change_zone::{self, ZoneMoveResult};
 use crate::game::printed_cards::apply_card_face_to_object;
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::game::zones;
-use crate::types::ability::{Effect, EffectError, EffectKind, FilterProp, ResolvedAbility};
-use crate::types::ability::{TargetFilter, TypeFilter};
-use crate::types::card::CardFace;
-use crate::types::card_type::CoreType;
+use crate::types::ability::TargetFilter;
+use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
     GameState, OutsideGameCardUse, OutsideGameChoiceEntry, OutsideGameChoiceSource, WaitingFor,
@@ -50,15 +48,19 @@ pub fn resolve(
                         sideboard_index,
                         entry.count,
                     );
-                    (available_count > 0 && sideboard_entry_matches_filter(&entry.card, filter))
-                        .then(|| OutsideGameChoiceEntry {
-                            source: OutsideGameChoiceSource::Sideboard {
-                                sideboard_index,
-                                card: entry.card.clone(),
-                            },
-                            count: available_count,
-                            name: entry.card.name.clone(),
-                        })
+                    (available_count > 0
+                        && crate::game::filter::matches_target_filter_against_face(
+                            &entry.card,
+                            filter,
+                        ))
+                    .then(|| OutsideGameChoiceEntry {
+                        source: OutsideGameChoiceSource::Sideboard {
+                            sideboard_index,
+                            card: entry.card.clone(),
+                        },
+                        count: available_count,
+                        name: entry.card.name.clone(),
+                    })
                 })
                 .collect()
         })
@@ -243,55 +245,10 @@ fn available_sideboard_count(
     sideboard_count.saturating_sub(used)
 }
 
-fn sideboard_entry_matches_filter(card: &CardFace, filter: &TargetFilter) -> bool {
-    match filter {
-        TargetFilter::Any => true,
-        TargetFilter::None => false,
-        TargetFilter::Typed(typed) => {
-            typed.controller.is_none()
-                && typed
-                    .type_filters
-                    .iter()
-                    .all(|type_filter| card_matches_type_filter(card, type_filter))
-                && typed.properties.iter().all(|property| match property {
-                    FilterProp::HasSupertype { value } => card.card_type.supertypes.contains(value),
-                    _ => false,
-                })
-        }
-        TargetFilter::Or { filters } => filters
-            .iter()
-            .any(|inner| sideboard_entry_matches_filter(card, inner)),
-        TargetFilter::And { filters } => filters
-            .iter()
-            .all(|inner| sideboard_entry_matches_filter(card, inner)),
-        TargetFilter::Not { filter } => !sideboard_entry_matches_filter(card, filter),
-        _ => false,
-    }
-}
-
-fn card_matches_type_filter(card: &CardFace, filter: &TypeFilter) -> bool {
-    match filter {
-        TypeFilter::Creature => card.card_type.core_types.contains(&CoreType::Creature),
-        TypeFilter::Land => card.card_type.core_types.contains(&CoreType::Land),
-        TypeFilter::Artifact => card.card_type.core_types.contains(&CoreType::Artifact),
-        TypeFilter::Enchantment => card.card_type.core_types.contains(&CoreType::Enchantment),
-        TypeFilter::Instant => card.card_type.core_types.contains(&CoreType::Instant),
-        TypeFilter::Sorcery => card.card_type.core_types.contains(&CoreType::Sorcery),
-        TypeFilter::Planeswalker => card.card_type.core_types.contains(&CoreType::Planeswalker),
-        TypeFilter::Battle => card.card_type.core_types.contains(&CoreType::Battle),
-        TypeFilter::Permanent => card
-            .card_type
-            .core_types
-            .iter()
-            .any(|card_type| card_type.is_permanent_type()),
-        TypeFilter::Card | TypeFilter::Any => true,
-        TypeFilter::Non(inner) => !card_matches_type_filter(card, inner),
-        TypeFilter::Subtype(subtype) => card.card_type.subtypes.contains(subtype),
-        TypeFilter::AnyOf(filters) => filters
-            .iter()
-            .any(|inner| card_matches_type_filter(card, inner)),
-    }
-}
+// CR 205: card-type/face filtering for sideboard entries now delegates to the
+// shared `crate::game::filter::matches_target_filter_against_face` building block
+// (used here and by `Effect::CreateTokenCopyFromPool`), so face-vs-filter logic
+// lives in exactly one place.
 
 #[cfg(test)]
 mod tests {
@@ -301,9 +258,10 @@ mod tests {
     use crate::game::deck_loading::DeckEntry;
     use crate::game::effects;
     use crate::game::zones::create_object;
-    use crate::types::ability::{OutsideGameSourcePool, QuantityExpr, TypedFilter};
+    use crate::types::ability::{OutsideGameSourcePool, QuantityExpr, TypeFilter, TypedFilter};
     use crate::types::actions::{GameAction, OutsideGameSelection};
-    use crate::types::card_type::CardType;
+    use crate::types::card::CardFace;
+    use crate::types::card_type::{CardType, CoreType};
     use crate::types::game_state::PlayerDeckPool;
 
     fn face(name: &str, core_type: CoreType) -> CardFace {

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -221,18 +221,40 @@ pub fn resolve(
         });
     }
 
+    drive_copy_token_batches(
+        state,
+        remaining,
+        EffectKind::from(&ability.effect),
+        ability.source_id,
+        events,
+    );
+
+    Ok(())
+}
+
+/// CR 707.2 + CR 614.1a: Route a queue of `PendingCopyTokenBatch`es through the
+/// `CreateToken` replacement pipeline and apply path. Single authority shared by
+/// `CopyTokenOf` (battlefield-sourced copies) and `CreateTokenCopyFromPool`
+/// (format-pool-sourced copies) so the replacement + apply path is never
+/// duplicated. The drain can pause and resume when a CR 616.1 replacement choice
+/// is required.
+pub(crate) fn drive_copy_token_batches(
+    state: &mut GameState,
+    remaining: VecDeque<PendingCopyTokenBatch>,
+    effect_kind: EffectKind,
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) {
     drain_copy_token_resolution(
         state,
         PendingCopyTokenResolution {
             created_ids: Vec::new(),
             remaining,
-            effect_kind: EffectKind::from(&ability.effect),
-            source_id: ability.source_id,
+            effect_kind,
+            source_id,
         },
         events,
     );
-
-    Ok(())
 }
 
 pub(crate) fn drain_pending_copy_token_resolution(

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -11662,6 +11662,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: crate::types::game_state::CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         }));
         state.waiting_for = WaitingFor::ManaPayment {
             player: PlayerId(0),
@@ -12047,6 +12048,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: crate::types::game_state::CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         }));
         state.waiting_for = WaitingFor::ManaPayment {
             player: PlayerId(0),

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2953,6 +2953,7 @@ pub(super) fn handle_resolution_choice(
                         ability_index,
                         pending.ability,
                         pending.activation_cost.as_ref(),
+                        pending.x_residual_activation,
                         events,
                     )?;
                 } else {

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -15,6 +15,7 @@ use crate::types::ability::{
     PtStat, PtValueScope, QuantityExpr, ResolvedAbility, SharedQuality, SharedQualityRelation,
     TargetFilter, TargetRef, TypeFilter, TypedFilter,
 };
+use crate::types::card::CardFace;
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterMatch;
 use crate::types::game_state::{
@@ -849,6 +850,67 @@ pub fn matches_target_filter_including_phased_out(
         ctx.scoped_iteration_player,
         ControllerLookup::LiveOnly,
     )
+}
+
+/// CR 205: Evaluate a `TargetFilter`'s STATIC characteristics against a bare
+/// `CardFace` — a printed card definition with no battlefield object, controller,
+/// or game-state context (e.g. a card outside the game, or a pool entry hydrated
+/// for `Effect::CreateTokenCopyFromPool`). Only context-free predicates are
+/// honored (card types, subtypes, supertypes); any filter component that needs a
+/// live object (controller scope, counters, combat state, LKI) cannot match a
+/// face and yields `false`. Use the object-based `matches_target_filter` family
+/// instead whenever an `ObjectId` exists.
+pub(crate) fn matches_target_filter_against_face(face: &CardFace, filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Any => true,
+        TargetFilter::None => false,
+        TargetFilter::Typed(typed) => {
+            typed.controller.is_none()
+                && typed
+                    .type_filters
+                    .iter()
+                    .all(|type_filter| matches_type_filter_against_face(face, type_filter))
+                && typed.properties.iter().all(|property| match property {
+                    FilterProp::HasSupertype { value } => face.card_type.supertypes.contains(value),
+                    _ => false,
+                })
+        }
+        TargetFilter::Or { filters } => filters
+            .iter()
+            .any(|inner| matches_target_filter_against_face(face, inner)),
+        TargetFilter::And { filters } => filters
+            .iter()
+            .all(|inner| matches_target_filter_against_face(face, inner)),
+        TargetFilter::Not { filter } => !matches_target_filter_against_face(face, filter),
+        _ => false,
+    }
+}
+
+/// CR 205: Evaluate a single `TypeFilter` against a bare `CardFace`'s printed
+/// card type line (core types, subtypes, supertypes). Context-free counterpart
+/// to the object-based type checks in `filter_inner_for_object`.
+pub(crate) fn matches_type_filter_against_face(face: &CardFace, filter: &TypeFilter) -> bool {
+    match filter {
+        TypeFilter::Creature => face.card_type.core_types.contains(&CoreType::Creature),
+        TypeFilter::Land => face.card_type.core_types.contains(&CoreType::Land),
+        TypeFilter::Artifact => face.card_type.core_types.contains(&CoreType::Artifact),
+        TypeFilter::Enchantment => face.card_type.core_types.contains(&CoreType::Enchantment),
+        TypeFilter::Instant => face.card_type.core_types.contains(&CoreType::Instant),
+        TypeFilter::Sorcery => face.card_type.core_types.contains(&CoreType::Sorcery),
+        TypeFilter::Planeswalker => face.card_type.core_types.contains(&CoreType::Planeswalker),
+        TypeFilter::Battle => face.card_type.core_types.contains(&CoreType::Battle),
+        TypeFilter::Permanent => face
+            .card_type
+            .core_types
+            .iter()
+            .any(|card_type| card_type.is_permanent_type()),
+        TypeFilter::Card | TypeFilter::Any => true,
+        TypeFilter::Non(inner) => !matches_type_filter_against_face(face, inner),
+        TypeFilter::Subtype(subtype) => face.card_type.subtypes.contains(subtype),
+        TypeFilter::AnyOf(filters) => filters
+            .iter()
+            .any(|inner| matches_type_filter_against_face(face, inner)),
+    }
 }
 
 /// CR 109.5 + CR 400.3: In owner-scoped zones (hand, library, graveyard),

--- a/crates/engine/src/game/meld.rs
+++ b/crates/engine/src/game/meld.rs
@@ -15,7 +15,7 @@
 //! LAYER-ONLY: it NEVER calls `apply_card_face_to_object` on the survivor (that
 //! would overwrite the survivor's `base_*`, permanently replacing Gisela's
 //! printed identity with Brisela). Instead it builds a [`CopiableValues`] from
-//! the result `CardFace` via [`meld_copiable_values`] and installs it as a
+//! the result `CardFace` via [`copiable_values_from_face`] and installs it as a
 //! layer-1 `CopyValues` continuous effect through
 //! [`merge::install_merge_layer_effect`] — exactly mirroring `merge_object_onto`'s
 //! never-touch-base discipline. On leave, `split_merged_permanent_on_leave`
@@ -34,7 +34,7 @@
 
 use crate::game::game_object::MergeKind;
 use crate::game::merge;
-use crate::game::printed_cards::{meld_copiable_values, printed_ref_from_face};
+use crate::game::printed_cards::{copiable_values_from_face, printed_ref_from_face};
 use crate::game::zone_pipeline::{self, ZoneMoveRequest};
 use crate::types::ability::{Effect, EffectError, ResolvedAbility};
 use crate::types::events::GameEvent;
@@ -155,7 +155,7 @@ pub fn perform_meld(
     // characteristics BEFORE the ETB-emitting entry below — mirroring
     // `merge_object_onto`'s install-then-observe ordering and the conjure entry
     // path, so the ETB scan sees the melded permanent.
-    let values = meld_copiable_values(&result_face);
+    let values = copiable_values_from_face(&result_face);
     let printed_ref = printed_ref_from_face(&result_face);
     merge::install_merge_layer_effect(
         state,

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -414,7 +414,11 @@ pub fn intrinsic_copiable_values(obj: &GameObject) -> CopiableValues {
 /// `base_*` — each component returns as its own front face on leave (CR 712.21).
 /// Parameterized over any result face (a building block, not a per-card path);
 /// mirrors `apply_card_face_to_object`'s field derivations without writing base.
-pub(crate) fn meld_copiable_values(result_face: &CardFace) -> CopiableValues {
+///
+/// Also used by `CreateTokenCopyFromPool` (Momir Basic) to build copiable values
+/// for a creature card chosen from the format pool, which exists only as a
+/// `CardFace` (no battlefield object to read via `compute_current_copiable_values`).
+pub(crate) fn copiable_values_from_face(result_face: &CardFace) -> CopiableValues {
     CopiableValues {
         name: result_face.name.clone(),
         mana_cost: result_face.mana_cost.clone(),
@@ -855,6 +859,10 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::EpicCopy { .. }
         | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
+        // owner/type_filter are TargetFilters; no nested ability carrier and the
+        // copy source comes from the format pool, so this is a leaf for conjure
+        // collection.
+        | Effect::CreateTokenCopyFromPool { .. }
         | Effect::Myriad
         | Effect::Encore
         | Effect::ExileHaunting { .. }
@@ -1158,6 +1166,37 @@ fn rehydrate_card_db_metadata(state: &mut GameState, db: &CardDatabase) {
     // game is restored from a persisted snapshot, deadlocking the session.
     if state.all_card_names.is_empty() {
         state.all_card_names = db.card_names().into();
+    }
+
+    // CR 707.2 + CR 202.3: Build the Momir Basic random-token pool. Gated on the
+    // format AND emptiness: `rehydrate_card_db_metadata` also runs on the
+    // mid-game debug-spawn path (engine-wasm), so without the emptiness guard we
+    // would rescan the full creature corpus on every spawn. The deserialize case
+    // is covered — `format_config` is serialized, so a peer deserializing a Momir
+    // game sees `format == Momir && momir_pool.is_empty()` and rebuilds the same
+    // pool from its own copy of the card DB (the keys are sorted, so the index is
+    // deterministic across peers).
+    if state.format_config.format == crate::types::format::GameFormat::Momir
+        && state.momir_pool.is_empty()
+    {
+        let mut pool: std::collections::BTreeMap<i32, Vec<String>> =
+            std::collections::BTreeMap::new();
+        let mut faces: HashMap<String, CardFace> = HashMap::new();
+        for face in db
+            .face_index
+            .values()
+            .filter(|face| face.card_type.core_types.contains(&CoreType::Creature))
+        {
+            let mv = face.mana_cost.mana_value() as i32;
+            pool.entry(mv).or_default().push(face.name.clone());
+            faces.insert(face.name.to_lowercase(), face.clone());
+        }
+        // Deterministic selection order regardless of DB iteration order.
+        for names in pool.values_mut() {
+            names.sort();
+        }
+        state.momir_pool = pool;
+        state.momir_pool_faces = std::sync::Arc::new(faces);
     }
 }
 

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -728,6 +728,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::CopySpell
         | EffectKind::EpicCopy
         | EffectKind::CopyTokenOf
+        | EffectKind::CreateTokenCopyFromPool
         | EffectKind::Myriad
         | EffectKind::Encore
         | EffectKind::Meld

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -773,6 +773,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: crate::types::game_state::AssistState::NotOffered,
+            x_residual_activation: false,
         })
     }
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -3770,6 +3770,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::CopySpell { .. }
         | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
+        | Effect::CreateTokenCopyFromPool { .. }
         | Effect::Myriad
         | Effect::Encore
         | Effect::Meld { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7355,6 +7355,45 @@ pub enum Effect {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         additional_modifications: Vec<ContinuousModification>,
     },
+    /// CR 707.2 + CR 111.1 + CR 701.9a (analogous): Create a token that's a copy
+    /// of a creature card chosen from a format-defined pool whose mana value
+    /// satisfies `mv <comparator> mv_bound`. The canonical card is the Momir
+    /// Basic emblem ("Create a token that's a copy of a creature card with mana
+    /// value X chosen at random"). The pool is the engine's creature corpus
+    /// (`GameState::momir_pool` / `momir_pool_faces`). `selection` chooses how a
+    /// candidate is picked from the matching set: `Random` (CR 701.9a is the
+    /// discard keyword action; the random *selection* here is analogous to the
+    /// random-choice idiom) or `Chosen`. Built as a reusable primitive so the
+    /// `mv` comparator also expresses "copy a creature card with mana value N or
+    /// less" (Oko-style) via `Comparator::LE`.
+    CreateTokenCopyFromPool {
+        /// CR 109.4: player who creates (and controls) the token. Defaults to
+        /// the resolving ability's controller. Mirrors `CopyTokenOf.owner`.
+        #[serde(default = "default_target_filter_controller")]
+        owner: TargetFilter,
+        /// Additional filter applied to the hydrated face beyond "is a creature
+        /// card" (the pool is already creature-only). Defaults to `Any`.
+        #[serde(default = "default_target_filter_any")]
+        type_filter: TargetFilter,
+        /// CR 202.3: comparator relating a candidate's mana value to `mv_bound`.
+        /// Momir uses `EQ` (exact match); `LE`/`GE` express threshold variants.
+        mv: Comparator,
+        /// CR 202.3: the mana-value bound. For Momir this is `Variable { "X" }`
+        /// (the chosen X paid for the ability).
+        mv_bound: QuantityExpr,
+        /// CR 701.9a (analogous) / CR 608.2d: how a candidate is selected from
+        /// the matching set — `Random` (Momir) or `Chosen`.
+        selection: CardSelectionMode,
+        /// CR 707.10: number of tokens to create. Defaults to one.
+        #[serde(default = "default_quantity_one")]
+        count: QuantityExpr,
+        /// Token enters the battlefield tapped.
+        #[serde(default)]
+        tapped: bool,
+        /// CR 508.4: token enters the battlefield attacking.
+        #[serde(default)]
+        enters_attacking: bool,
+    },
     /// CR 702.116a: Myriad creates one tapped attacking copy token for each
     /// opponent other than the defending player for the source creature, then
     /// exiles those tokens at end of combat.
@@ -9664,6 +9703,10 @@ impl Effect {
             // --- Effects with no player-selectable target field ---
             // These use filters, zone-level operations, or have no targeting at all.
             Effect::StartYourEngines { .. }
+            // CR 109.4: owner/type_filter are non-targeting resolution-time
+            // filters; the copy source is chosen from the format pool, not
+            // declared as a target.
+            | Effect::CreateTokenCopyFromPool { .. }
             | Effect::Myriad
             // CR 702.141a: opponents and per-opponent attack binding are chosen
             // by the effect, not declared as targets.
@@ -9829,6 +9872,7 @@ impl Effect {
             | Effect::Dig { count, .. }
             | Effect::Surveil { count, .. }
             | Effect::CopyTokenOf { count, .. }
+            | Effect::CreateTokenCopyFromPool { count, .. }
             | Effect::PutCounter { count, .. }
             | Effect::PutCounterAll { count, .. }
             | Effect::Discard { count, .. }
@@ -10029,6 +10073,7 @@ impl Effect {
             | Effect::Dig { count, .. }
             | Effect::Surveil { count, .. }
             | Effect::CopyTokenOf { count, .. }
+            | Effect::CreateTokenCopyFromPool { count, .. }
             | Effect::PutCounter { count, .. }
             | Effect::PutCounterAll { count, .. }
             | Effect::Discard { count, .. }
@@ -10279,6 +10324,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::EpicCopy { .. } => "EpicCopy",
         Effect::CastCopyOfCard { .. } => "CastCopyOfCard",
         Effect::CopyTokenOf { .. } => "CopyTokenOf",
+        Effect::CreateTokenCopyFromPool { .. } => "CreateTokenCopyFromPool",
         Effect::Myriad => "Myriad",
         Effect::Encore => "Encore",
         Effect::Meld { .. } => "Meld",
@@ -10482,6 +10528,7 @@ pub enum EffectKind {
     EpicCopy,
     CastCopyOfCard,
     CopyTokenOf,
+    CreateTokenCopyFromPool,
     Myriad,
     Encore,
     Meld,
@@ -10686,6 +10733,7 @@ impl From<&Effect> for EffectKind {
             Effect::EpicCopy { .. } => EffectKind::EpicCopy,
             Effect::CastCopyOfCard { .. } => EffectKind::CastCopyOfCard,
             Effect::CopyTokenOf { .. } => EffectKind::CopyTokenOf,
+            Effect::CreateTokenCopyFromPool { .. } => EffectKind::CreateTokenCopyFromPool,
             Effect::Myriad => EffectKind::Myriad,
             Effect::Encore => EffectKind::Encore,
             Effect::Meld { .. } => EffectKind::Meld,

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -52,6 +52,10 @@ pub enum GameFormat {
     HistoricBrawl,
     FreeForAll,
     TwoHeadedGiant,
+    /// Momir Basic: 60 basic lands, 24 life, a game-start command-zone emblem
+    /// granting "{X}, Discard a card: Create a token that's a copy of a creature
+    /// card with mana value X chosen at random."
+    Momir,
 }
 
 /// CR 100.4 / CR 100.4a: Per-format sideboard rules.
@@ -143,6 +147,8 @@ impl GameFormat {
             | GameFormat::Oathbreaker
             | GameFormat::FreeForAll
             | GameFormat::TwoHeadedGiant
+            // Momir's pool is the entire creature corpus — no legality restriction.
+            | GameFormat::Momir
             | GameFormat::Limited => None,
         }
     }
@@ -168,6 +174,8 @@ impl GameFormat {
             | GameFormat::DuelCommander
             | GameFormat::Oathbreaker
             | GameFormat::Brawl
+            // Momir has no sideboard — the deck is exactly 60 basic lands.
+            | GameFormat::Momir
             | GameFormat::HistoricBrawl => SideboardPolicy::Forbidden,
             GameFormat::TinyLeaders => SideboardPolicy::Limited(10),
             GameFormat::FreeForAll | GameFormat::TwoHeadedGiant | GameFormat::Limited => {
@@ -235,6 +243,7 @@ impl GameFormat {
             GameFormat::HistoricBrawl => "Historic Brawl",
             GameFormat::FreeForAll => "Free-for-All",
             GameFormat::TwoHeadedGiant => "Two-Headed Giant",
+            GameFormat::Momir => "Momir Basic",
         }
     }
 
@@ -388,6 +397,14 @@ impl GameFormat {
                 description: "Draft or sealed, 40-card deck",
                 group: FormatGroup::Limited,
                 default_config: FormatConfig::limited(),
+            },
+            FormatMetadata {
+                format: GameFormat::Momir,
+                label: "Momir Basic",
+                short_label: "MOM",
+                description: "60 basic lands, random creature tokens",
+                group: FormatGroup::Multiplayer,
+                default_config: FormatConfig::momir(),
             },
         ]
     }
@@ -616,6 +633,27 @@ impl FormatConfig {
         }
     }
 
+    /// Momir Basic: 60 basic lands, 24 life, 2-player. A game-start command-zone
+    /// emblem grants the random-creature-token activated ability. No sideboard,
+    /// no commander. `command_zone: true` so the command-zone activation surface
+    /// and pool rehydration are enabled.
+    pub fn momir() -> Self {
+        FormatConfig {
+            format: GameFormat::Momir,
+            starting_life: 24,
+            min_players: 2,
+            max_players: 2,
+            deck_size: 60,
+            singleton: false,
+            command_zone: true,
+            commander_damage_threshold: None,
+            range_of_influence: None,
+            team_based: false,
+            uses_commander: false,
+            allow_debug_actions: false,
+        }
+    }
+
     pub fn two_headed_giant() -> Self {
         FormatConfig {
             format: GameFormat::TwoHeadedGiant,
@@ -669,6 +707,7 @@ impl FormatConfig {
             GameFormat::HistoricBrawl => Self::historic_brawl(),
             GameFormat::FreeForAll => Self::free_for_all(),
             GameFormat::TwoHeadedGiant => Self::two_headed_giant(),
+            GameFormat::Momir => Self::momir(),
         }
     }
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use rand::SeedableRng;
@@ -1630,6 +1630,17 @@ pub struct PendingCast {
     /// the generic amount they will pay at `finalize_cast`.
     #[serde(default)]
     pub assist_state: AssistState,
+    /// CR 601.2f + CR 601.2h: POSITIVE signal that this pending activation took
+    /// the `{X}`-mana detour (`extract_x_mana_cost` ran first), so its
+    /// `activation_cost` is the RESIDUAL non-mana tail that has NOT yet been
+    /// paid. `push_activated_ability_to_stack` re-surfaces a non-self discard
+    /// sub-cost only when this is set — the discard-FIRST detour leaves it
+    /// `false` because it already paid the discard before resuming. Set ONLY by
+    /// the X-residual detour in `handle_activate_ability`. Skipped on the wire
+    /// only when `false`; serialized when `true` so an activation paused
+    /// mid-payment keeps the signal across a multiplayer save/restore.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub x_residual_activation: bool,
 }
 
 fn default_origin_zone() -> Zone {
@@ -1681,6 +1692,7 @@ impl PendingCast {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         }
     }
 
@@ -6135,6 +6147,22 @@ pub struct GameState {
     #[serde(skip)]
     pub card_face_registry: Arc<HashMap<String, CardFace>>,
 
+    /// Momir Basic selection index: mana value -> sorted creature face names.
+    /// CR 707.2 + CR 202.3: the random-token pool, keyed by mana value so the
+    /// emblem's `{X}` ability can pick a creature with mana value X. Built only
+    /// when `format == Momir` (see `rehydrate_card_db_metadata`); empty
+    /// otherwise. Skipped in serialization and rebuilt deterministically per peer
+    /// from the loaded card DB.
+    #[serde(skip)]
+    pub momir_pool: BTreeMap<i32, Vec<String>>,
+
+    /// Momir Basic hydration map: lowercase creature name -> `CardFace`. The
+    /// resolver reads this (NEVER `card_face_registry`, which is conjure-scoped
+    /// and misses most creatures) to build the copy token. Skipped in
+    /// serialization; rebuilt with `momir_pool`.
+    #[serde(skip)]
+    pub momir_pool_faces: Arc<HashMap<String, CardFace>>,
+
     /// Display names for log resolution. Set by server; WASM leaves empty (defaults to "Player N").
     /// Skipped in serialization — runtime context only.
     #[serde(skip)]
@@ -6917,6 +6945,8 @@ impl GameState {
             all_creature_types: Vec::new(),
             all_card_names: Arc::from([]),
             card_face_registry: Arc::new(HashMap::new()),
+            momir_pool: BTreeMap::new(),
+            momir_pool_faces: Arc::new(HashMap::new()),
             log_player_names: Vec::new(),
             last_created_token_ids: Vec::new(),
             last_revealed_ids: Vec::new(),
@@ -7688,6 +7718,7 @@ mod tests {
                 cancel_restore_prepared_source: None,
                 payment_mode: CastPaymentMode::Auto,
                 assist_state: AssistState::NotOffered,
+                x_residual_activation: false,
             })
         }
 
@@ -8019,6 +8050,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
+            x_residual_activation: false,
         });
         let choose_x = WaitingFor::ChooseXValue {
             player: PlayerId(0),

--- a/crates/engine/tests/momir_basic_emblem.rs
+++ b/crates/engine/tests/momir_basic_emblem.rs
@@ -1,0 +1,567 @@
+//! Momir Basic format integration tests.
+//!
+//! These drive the REAL activation + resolution pipeline (`GameAction::
+//! ActivateAbility` -> `ChooseX` -> discard cost -> mana payment -> resolve)
+//! through `GameRunner`, asserting on state deltas. The primary test
+//! (`momir_emblem_creates_creature_token_with_matching_mv`) would fail if the
+//! `CreateTokenCopyFromPool` resolver or the emblem grant were reverted.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use engine::game::deck_loading::momir_emblem_ability;
+use engine::game::scenario::GameRunner;
+use engine::types::ability::{
+    CardSelectionMode, Comparator, Effect, PtValue, QuantityExpr, ResolvedAbility, TargetFilter,
+    TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card::CardFace;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::format::FormatConfig;
+use engine::types::game_state::{GameState, PayCostKind, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+/// A synthetic creature face with the given name and mana value (paid as
+/// generic mana for simplicity).
+fn creature_face(name: &str, mana_value: u32) -> CardFace {
+    CardFace {
+        name: name.to_string(),
+        mana_cost: ManaCost::Cost {
+            shards: vec![],
+            generic: mana_value,
+        },
+        card_type: CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec!["Beast".to_string()],
+        },
+        power: Some(PtValue::Fixed(mana_value as i32)),
+        toughness: Some(PtValue::Fixed(mana_value as i32)),
+        ..Default::default()
+    }
+}
+
+/// Build a Momir Basic game state at precombat main with P0 holding priority.
+/// The pool is populated directly (mirroring `rehydrate_card_db_metadata`) so
+/// the test does not depend on the full card database.
+fn momir_state(pool: &[(u32, &str)]) -> (GameState, ObjectId) {
+    let mut state = GameState::new(FormatConfig::momir(), 2, 42);
+    state.phase = Phase::PreCombatMain;
+    state.turn_number = 2;
+    state.active_player = P0;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+
+    // Populate the Momir pool directly.
+    let mut by_mv: BTreeMap<i32, Vec<String>> = BTreeMap::new();
+    let mut faces = std::collections::HashMap::new();
+    for (mv, name) in pool {
+        by_mv.entry(*mv as i32).or_default().push(name.to_string());
+        faces.insert(name.to_lowercase(), creature_face(name, *mv));
+    }
+    for names in by_mv.values_mut() {
+        names.sort();
+    }
+    state.momir_pool = by_mv;
+    state.momir_pool_faces = Arc::new(faces);
+
+    // Grant the Momir emblem to P0.
+    let emblem_id = engine::game::effects::create_emblem::grant_emblem(
+        &mut state,
+        P0,
+        Vec::new(),
+        Vec::new(),
+        vec![momir_emblem_ability()],
+    );
+
+    (state, emblem_id)
+}
+
+/// Give P0 `amount` colorless mana in their pool (pays generic costs) and one
+/// disposable card in hand.
+fn fund_and_card(state: &mut GameState, amount: u32) -> ObjectId {
+    for _ in 0..amount {
+        state.players[0].mana_pool.add(ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    }
+    // A disposable card to discard for the cost.
+    engine::game::zones::create_object(state, CardId(999), P0, "Plains".to_string(), Zone::Hand)
+}
+
+/// Drive `GameAction::ActivateAbility` on the emblem with X = `x`, paying the
+/// discard with `discard_card` and the mana from the pool. Returns the runner
+/// after resolution.
+fn activate_emblem(
+    state: GameState,
+    emblem_id: ObjectId,
+    x: u32,
+    discard_card: ObjectId,
+) -> GameRunner {
+    let mut runner = GameRunner::from_state(state);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: emblem_id,
+            ability_index: 0,
+        })
+        .expect("activating the Momir emblem must be accepted");
+
+    for _ in 0..32 {
+        match &runner.state().waiting_for {
+            WaitingFor::ChooseXValue { .. } => {
+                runner
+                    .act(GameAction::ChooseX { value: x })
+                    .expect("ChooseX must be accepted");
+            }
+            WaitingFor::PayCost {
+                kind: PayCostKind::Discard,
+                ..
+            } => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![discard_card],
+                    })
+                    .expect("discarding to pay the cost must be accepted");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalizing mana payment must be accepted");
+            }
+            WaitingFor::Priority { .. } => break,
+            other => panic!("unexpected WaitingFor during activation: {other:?}"),
+        }
+    }
+
+    // Resolve the ability off the stack.
+    for _ in 0..16 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        runner
+            .act(GameAction::PassPriority)
+            .expect("passing priority to resolve the emblem ability must be accepted");
+    }
+    runner
+}
+
+/// PRIMARY DISCRIMINATING TEST. Reverting either the emblem grant or the
+/// `CreateTokenCopyFromPool` resolver makes the asserted token absent and this
+/// fails. The flipping assertion is `token_count == 1` with mana value 3.
+#[test]
+fn momir_emblem_creates_creature_token_with_matching_mv() {
+    let (mut state, emblem_id) =
+        momir_state(&[(3, "Hill Giant"), (2, "Gray Ogre"), (5, "Air Elemental")]);
+    let card = fund_and_card(&mut state, 3);
+
+    let runner = activate_emblem(state, emblem_id, 3, card);
+
+    // A creature token with mana value 3 exists on the battlefield.
+    let tokens: Vec<&engine::game::game_object::GameObject> = runner
+        .state()
+        .battlefield
+        .iter()
+        .filter_map(|id| runner.state().objects.get(id))
+        .filter(|o| o.is_token)
+        .collect();
+    assert_eq!(
+        tokens.len(),
+        1,
+        "exactly one creature token must be created, got {}",
+        tokens.len()
+    );
+    let token = tokens[0];
+    assert!(
+        token.card_types.core_types.contains(&CoreType::Creature),
+        "the token must be a creature"
+    );
+    assert_eq!(
+        token.mana_cost.mana_value(),
+        3,
+        "the token's mana value must equal the X paid (3), got {}",
+        token.mana_cost.mana_value()
+    );
+    assert_eq!(
+        token.name, "Hill Giant",
+        "with only one MV-3 creature in the pool, that creature must be copied"
+    );
+
+    // The discarded card moved hand -> graveyard.
+    assert_eq!(
+        runner.state().objects[&card].zone,
+        Zone::Graveyard,
+        "the cost card must be discarded to the graveyard"
+    );
+}
+
+/// Determinism: identical seed + setup yields the same chosen creature name.
+#[test]
+fn momir_selection_is_deterministic_under_seed() {
+    let pool = &[(4, "Air Elemental"), (4, "Wind Drake"), (4, "Cloud Sprite")];
+
+    let run_once = || {
+        let (mut state, emblem_id) = momir_state(pool);
+        let card = fund_and_card(&mut state, 4);
+        let runner = activate_emblem(state, emblem_id, 4, card);
+        runner
+            .state()
+            .battlefield
+            .iter()
+            .filter_map(|id| runner.state().objects.get(id))
+            .find(|o| o.is_token)
+            .map(|o| o.name.clone())
+            .expect("a token must be created")
+    };
+
+    assert_eq!(
+        run_once(),
+        run_once(),
+        "same seed + setup must select the same creature"
+    );
+}
+
+/// Once-per-turn: a second activation in the same turn is rejected.
+#[test]
+fn momir_emblem_only_once_each_turn() {
+    let (mut state, emblem_id) = momir_state(&[(3, "Hill Giant")]);
+    let _card = fund_and_card(&mut state, 6);
+    // A second discard fodder card for the (rejected) second attempt.
+    let card2 = engine::game::zones::create_object(
+        &mut state,
+        CardId(998),
+        P0,
+        "Island".to_string(),
+        Zone::Hand,
+    );
+
+    let mut runner = activate_emblem(state, emblem_id, 3, card2);
+
+    // After one activation this turn, the ability is no longer activatable.
+    let legal = engine::game::casting::can_activate_ability_now(runner.state(), P0, emblem_id, 0);
+    assert!(
+        !legal,
+        "CR 602.5b: the once-each-turn emblem ability must be unavailable after one use"
+    );
+
+    // Direct re-activation is rejected by the engine.
+    let err = runner.act(GameAction::ActivateAbility {
+        source_id: emblem_id,
+        ability_index: 0,
+    });
+    assert!(
+        err.is_err(),
+        "re-activating the once-each-turn emblem ability in the same turn must be rejected"
+    );
+}
+
+/// Sorcery-speed: the ability is not activatable outside the controller's main
+/// phase (CR 307.5 requires main phase + empty stack + priority).
+#[test]
+fn momir_emblem_is_sorcery_speed() {
+    let (mut state, emblem_id) = momir_state(&[(3, "Hill Giant")]);
+    // Move to the upkeep step (not a main phase) — sorcery-speed timing fails.
+    state.phase = Phase::Upkeep;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+
+    let legal = engine::game::casting::can_activate_ability_now(&state, P0, emblem_id, 0);
+    assert!(
+        !legal,
+        "CR 307.5: a sorcery-speed ability must not be activatable outside the main phase"
+    );
+}
+
+/// Building-block test: the `CreateTokenCopyFromPool` primitive with
+/// `Comparator::LE` exercises the BTreeMap range path (distinct from Momir's
+/// EQ keyed lookup) and creates a creature token of MV <= bound.
+#[test]
+fn create_token_copy_from_pool_le_bound_oko_style() {
+    let (mut state, emblem_id) =
+        momir_state(&[(2, "Gray Ogre"), (4, "Air Elemental"), (9, "Big Thing")]);
+    // Set chosen_x irrelevant; we drive the resolver directly with a Fixed bound.
+    let _ = emblem_id;
+    let card = fund_and_card(&mut state, 0);
+    let _ = card;
+
+    let effect = Effect::CreateTokenCopyFromPool {
+        owner: TargetFilter::Controller,
+        type_filter: TargetFilter::Any,
+        mv: Comparator::LE,
+        mv_bound: QuantityExpr::Fixed { value: 8 },
+        selection: CardSelectionMode::Random,
+        count: QuantityExpr::Fixed { value: 1 },
+        tapped: false,
+        enters_attacking: false,
+    };
+    let ability = ResolvedAbility::new(effect, vec![], emblem_id, P0);
+    let mut events = Vec::new();
+    engine::game::effects::create_token_copy_from_pool::resolve(&mut state, &ability, &mut events)
+        .expect("LE-bound pool copy must resolve");
+
+    let token = state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .find(|o| o.is_token)
+        .expect("a token must be created for an MV<=8 pool with eligible creatures");
+    assert!(
+        token.mana_cost.mana_value() <= 8,
+        "LE bound must only copy creatures with mana value <= 8, got {}",
+        token.mana_cost.mana_value()
+    );
+    assert_ne!(
+        token.name, "Big Thing",
+        "the MV-9 creature must be excluded by the LE-8 bound"
+    );
+}
+
+/// LOW-1 regression: the effect's `type_filter` ("additional filter applied to
+/// the hydrated face") MUST exclude non-matching candidates from the random pool.
+/// Pool has three MV-3 creatures sharing one mana value: two `Goblin`s and one
+/// `Wizard`. With `type_filter = Subtype(Wizard)` and `selection = Random`, the
+/// ONLY eligible candidate is the Wizard, so the created token must be the Wizard
+/// regardless of RNG. Before the fix, `type_filter` was only checked for `== None`
+/// (never applied to the face), so the random pick ranged over all three and
+/// could produce a Goblin.
+///
+/// Positive correctness check: `token.name == "Pool Wizard"`. The fully
+/// deterministic discriminator for LOW-1 is
+/// `create_token_copy_from_pool_type_filter_no_match_is_noop` below (this one's
+/// revert-detection depends on the RNG happening to pick a Goblin).
+#[test]
+fn create_token_copy_from_pool_applies_type_filter() {
+    let (mut state, emblem_id) = momir_state(&[]);
+    // Seed a custom MV-3 pool: two Goblins and one Wizard, all at the same mana
+    // value so the comparator alone cannot disambiguate them.
+    let mut by_mv: BTreeMap<i32, Vec<String>> = BTreeMap::new();
+    by_mv.insert(
+        3,
+        vec![
+            "Pool Goblin A".to_string(),
+            "Pool Goblin B".to_string(),
+            "Pool Wizard".to_string(),
+        ],
+    );
+    let mut faces = std::collections::HashMap::new();
+    for name in ["Pool Goblin A", "Pool Goblin B"] {
+        let mut face = creature_face(name, 3);
+        face.card_type.subtypes = vec!["Goblin".to_string()];
+        faces.insert(name.to_lowercase(), face);
+    }
+    let mut wizard = creature_face("Pool Wizard", 3);
+    wizard.card_type.subtypes = vec!["Wizard".to_string()];
+    faces.insert("pool wizard".to_string(), wizard);
+    state.momir_pool = by_mv;
+    state.momir_pool_faces = Arc::new(faces);
+
+    let effect = Effect::CreateTokenCopyFromPool {
+        owner: TargetFilter::Controller,
+        type_filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype(
+            "Wizard".to_string(),
+        ))),
+        mv: Comparator::EQ,
+        mv_bound: QuantityExpr::Fixed { value: 3 },
+        selection: CardSelectionMode::Random,
+        count: QuantityExpr::Fixed { value: 1 },
+        tapped: false,
+        enters_attacking: false,
+    };
+    let ability = ResolvedAbility::new(effect, vec![], emblem_id, P0);
+    let mut events = Vec::new();
+    engine::game::effects::create_token_copy_from_pool::resolve(&mut state, &ability, &mut events)
+        .expect("type-filtered pool copy must resolve");
+
+    let token = state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .find(|o| o.is_token)
+        .expect("a token must be created when an eligible Wizard exists");
+    assert_eq!(
+        token.name, "Pool Wizard",
+        "type_filter = Subtype(Wizard) must exclude the Goblins from the pool"
+    );
+}
+
+/// LOW-1 corollary: when NO candidate satisfies `type_filter`, the random pool is
+/// empty and no token is created (CR 609.3 do-as-much-as-possible), rather than
+/// the filter being ignored and a non-matching creature being copied.
+#[test]
+fn create_token_copy_from_pool_type_filter_no_match_is_noop() {
+    let (mut state, emblem_id) = momir_state(&[(3, "Gray Ogre")]); // subtype Beast
+    let effect = Effect::CreateTokenCopyFromPool {
+        owner: TargetFilter::Controller,
+        type_filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype(
+            "Wizard".to_string(),
+        ))),
+        mv: Comparator::EQ,
+        mv_bound: QuantityExpr::Fixed { value: 3 },
+        selection: CardSelectionMode::Random,
+        count: QuantityExpr::Fixed { value: 1 },
+        tapped: false,
+        enters_attacking: false,
+    };
+    let ability = ResolvedAbility::new(effect, vec![], emblem_id, P0);
+    let mut events = Vec::new();
+    engine::game::effects::create_token_copy_from_pool::resolve(&mut state, &ability, &mut events)
+        .expect("a type_filter with no matches must be a clean no-op");
+
+    let token_count = state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|o| o.is_token)
+        .count();
+    assert_eq!(
+        token_count, 0,
+        "no token may be created when type_filter excludes every candidate"
+    );
+}
+
+/// Empty-pool: a mana value with no creatures creates no token and does not panic.
+#[test]
+fn create_token_copy_from_pool_empty_candidates_is_noop() {
+    let (mut state, emblem_id) = momir_state(&[(2, "Gray Ogre")]);
+
+    let effect = Effect::CreateTokenCopyFromPool {
+        owner: TargetFilter::Controller,
+        type_filter: TargetFilter::Any,
+        mv: Comparator::EQ,
+        mv_bound: QuantityExpr::Fixed { value: 7 }, // no MV-7 creatures
+        selection: CardSelectionMode::Random,
+        count: QuantityExpr::Fixed { value: 1 },
+        tapped: false,
+        enters_attacking: false,
+    };
+    let ability = ResolvedAbility::new(effect, vec![], emblem_id, P0);
+    let mut events = Vec::new();
+    engine::game::effects::create_token_copy_from_pool::resolve(&mut state, &ability, &mut events)
+        .expect("empty candidate set must be a clean no-op");
+
+    let token_count = state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|o| o.is_token)
+        .count();
+    assert_eq!(
+        token_count, 0,
+        "no token may be created from an empty pool key"
+    );
+}
+
+/// Format config: Momir Basic is 24 life, 60-card deck, command zone enabled.
+#[test]
+fn momir_format_config_values() {
+    let config = FormatConfig::momir();
+    assert_eq!(config.starting_life, 24);
+    assert_eq!(config.deck_size, 60);
+    assert!(config.command_zone, "Momir needs the command zone enabled");
+    assert!(!config.uses_commander);
+}
+
+/// grant_emblem installs a command-zone-activatable ability on the emblem.
+#[test]
+fn grant_emblem_installs_command_zone_activated_ability() {
+    let mut state = GameState::new(FormatConfig::momir(), 2, 42);
+    let emblem_id = engine::game::effects::create_emblem::grant_emblem(
+        &mut state,
+        P0,
+        Vec::new(),
+        Vec::new(),
+        vec![momir_emblem_ability()],
+    );
+    let emblem = &state.objects[&emblem_id];
+    assert!(emblem.is_emblem);
+    assert_eq!(emblem.zone, Zone::Command);
+    assert_eq!(emblem.abilities.len(), 1);
+    assert_eq!(
+        emblem.abilities[0].activation_zone,
+        Some(Zone::Command),
+        "the Momir ability must be command-zone-activatable"
+    );
+}
+
+/// MP serialization: the pool fields are `#[serde(skip)]` — they must not appear
+/// in the serialized form and are rebuilt on rehydrate.
+#[test]
+fn momir_pool_is_not_serialized() {
+    let (state, _emblem) = momir_state(&[(3, "Hill Giant"), (5, "Air Elemental")]);
+    assert!(!state.momir_pool.is_empty(), "precondition: pool populated");
+
+    let json = serde_json::to_string(&state).expect("serialize Momir state");
+    assert!(
+        !json.contains("momir_pool"),
+        "momir_pool / momir_pool_faces must be #[serde(skip)] and absent from the wire form"
+    );
+
+    let de: GameState = serde_json::from_str(&json).expect("deserialize Momir state");
+    assert!(
+        de.momir_pool.is_empty(),
+        "a deserialized peer starts with an empty pool (rebuilt on rehydrate)"
+    );
+    // format_config survives, so the peer knows to rebuild the Momir pool.
+    assert_eq!(
+        de.format_config.format,
+        engine::types::format::GameFormat::Momir
+    );
+}
+
+/// CR 111.5 guard: a synthetic instant/sorcery pool entry yields no token.
+#[test]
+fn create_token_copy_from_pool_instant_sorcery_guard() {
+    let mut state = GameState::new(FormatConfig::momir(), 2, 42);
+    let mut faces = std::collections::HashMap::new();
+    let mut sorcery_face = creature_face("Sorcery Sham", 3);
+    sorcery_face.card_type.core_types = vec![CoreType::Sorcery];
+    sorcery_face.power = None;
+    sorcery_face.toughness = None;
+    faces.insert("sorcery sham".to_string(), sorcery_face);
+    let mut by_mv: BTreeMap<i32, Vec<String>> = BTreeMap::new();
+    by_mv.insert(3, vec!["Sorcery Sham".to_string()]);
+    state.momir_pool = by_mv;
+    state.momir_pool_faces = Arc::new(faces);
+
+    let emblem_id = engine::game::effects::create_emblem::grant_emblem(
+        &mut state,
+        P0,
+        Vec::new(),
+        Vec::new(),
+        vec![momir_emblem_ability()],
+    );
+
+    let effect = Effect::CreateTokenCopyFromPool {
+        owner: TargetFilter::Controller,
+        type_filter: TargetFilter::Any,
+        mv: Comparator::EQ,
+        mv_bound: QuantityExpr::Fixed { value: 3 },
+        selection: CardSelectionMode::Random,
+        count: QuantityExpr::Fixed { value: 1 },
+        tapped: false,
+        enters_attacking: false,
+    };
+    let ability = ResolvedAbility::new(effect, vec![], emblem_id, P0);
+    let mut events = Vec::new();
+    engine::game::effects::create_token_copy_from_pool::resolve(&mut state, &ability, &mut events)
+        .expect("instant/sorcery guard must be a clean no-op");
+
+    let token_count = state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|o| o.is_token)
+        .count();
+    assert_eq!(
+        token_count, 0,
+        "CR 111.5: a token that's a copy of an instant/sorcery is not created"
+    );
+}

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -408,6 +408,9 @@ fn redundancy_delta(
         | Effect::EpicCopy { .. }
         | Effect::CastCopyOfCard { .. }
         | Effect::CopyTokenOf { .. }
+        // Random pool copy (Momir Basic) — not a "redundant if already
+        // controlled" effect; the token's identity is chosen at resolution.
+        | Effect::CreateTokenCopyFromPool { .. }
         | Effect::Myriad
         // CR 702.141a: Encore makes per-opponent copy tokens — like Myriad, it is
         // not a "redundant if already controlled" effect.

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -1,32 +1,32 @@
 {
   "sources": [
-    "crates/engine/src/types/identifiers.rs",
-    "crates/engine/src/types/game_state.rs",
-    "crates/engine/src/types/definitions.rs",
-    "crates/engine/src/types/phase.rs",
+    "crates/engine/src/types/format.rs",
+    "crates/engine/src/types/actions.rs",
     "crates/engine/src/types/replacements.rs",
-    "crates/engine/src/types/mana.rs",
+    "crates/engine/src/types/identifiers.rs",
+    "crates/engine/src/types/events.rs",
+    "crates/engine/src/types/proposed_event.rs",
+    "crates/engine/src/types/keywords.rs",
     "crates/engine/src/types/statics.rs",
     "crates/engine/src/types/triggers.rs",
+    "crates/engine/src/types/definitions.rs",
+    "crates/engine/src/types/ability.rs",
     "crates/engine/src/types/log.rs",
-    "crates/engine/src/types/events.rs",
-    "crates/engine/src/types/actions.rs",
+    "crates/engine/src/types/game_state.rs",
+    "crates/engine/src/types/phase.rs",
     "crates/engine/src/types/counter.rs",
-    "crates/engine/src/types/keywords.rs",
-    "crates/engine/src/types/format.rs",
     "crates/engine/src/types/mod.rs",
+    "crates/engine/src/types/layers.rs",
     "crates/engine/src/types/match_config.rs",
+    "crates/engine/src/types/card.rs",
+    "crates/engine/src/types/player.rs",
+    "crates/engine/src/types/mana.rs",
     "crates/engine/src/types/zones.rs",
     "crates/engine/src/types/attribution.rs",
-    "crates/engine/src/types/ability.rs",
-    "crates/engine/src/types/card_type.rs",
-    "crates/engine/src/types/proposed_event.rs",
-    "crates/engine/src/types/player.rs",
-    "crates/engine/src/types/layers.rs",
-    "crates/engine/src/types/card.rs"
+    "crates/engine/src/types/card_type.rs"
   ],
   "enum_count": 295,
-  "variant_count": 3116,
+  "variant_count": 3126,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -338,6 +338,17 @@
       }
     },
     {
+      "enum_name": "ObjectScope",
+      "cluster": {
+        "shared_root": "Event",
+        "members": [
+          "EventSource",
+          "EventTarget"
+        ],
+        "smell_score": "LOW"
+      }
+    },
+    {
       "enum_name": "PlayerFilter",
       "cluster": {
         "shared_root": "Player",
@@ -490,13 +501,13 @@
     },
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11815,
+      "line": 11904,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 11833,
+          "line": 11922,
           "kind": "struct",
           "field_names": [
             "source",
@@ -516,7 +527,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 11853,
+          "line": 11942,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -527,7 +538,7 @@
         },
         {
           "name": "AlternativeManaCostPaid",
-          "line": 11857,
+          "line": 11946,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9 + CR 608.2c: \"If the {COST} cost was paid\" on spells with an alternative *mana* cost (e.g. Baleful Mastery). Evaluates against `SpellContext.alternative_mana_cost_paid`, not `additional_cost_paid`.",
@@ -538,7 +549,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 11862,
+          "line": 11951,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -552,7 +563,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 11867,
+          "line": 11956,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -562,7 +573,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 11875,
+          "line": 11964,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -572,7 +583,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 11878,
+          "line": 11967,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -584,7 +595,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 11882,
+          "line": 11971,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -597,7 +608,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 11885,
+          "line": 11974,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -610,7 +621,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 11888,
+          "line": 11977,
           "kind": "struct",
           "field_names": [
             "color",
@@ -624,7 +635,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 11898,
+          "line": 11987,
           "kind": "struct",
           "field_names": [
             "card_types",
@@ -638,7 +649,7 @@
         },
         {
           "name": "ObjectsShareQuality",
-          "line": 11920,
+          "line": 12009,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -653,7 +664,7 @@
         },
         {
           "name": "TargetSharesNameWithOtherExiledThisWay",
-          "line": 11928,
+          "line": 12017,
           "kind": "struct",
           "field_names": [
             "target"
@@ -666,7 +677,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 11932,
+          "line": 12021,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -677,7 +688,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 11935,
+          "line": 12024,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -690,7 +701,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 11940,
+          "line": 12029,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -704,7 +715,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 11944,
+          "line": 12033,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -718,7 +729,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 11953,
+          "line": 12042,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -732,7 +743,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 11958,
+          "line": 12047,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -742,7 +753,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 11960,
+          "line": 12049,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -752,7 +763,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 11963,
+          "line": 12052,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: \"if you have the initiative\" is true when the ability controller has the initiative designation.",
@@ -762,7 +773,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 11966,
+          "line": 12055,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -772,7 +783,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 11970,
+          "line": 12059,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -784,7 +795,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 11975,
+          "line": 12064,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -798,7 +809,7 @@
         },
         {
           "name": "TriggeringSpellTargetsFilter",
-          "line": 11987,
+          "line": 12076,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -811,7 +822,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 11991,
+          "line": 12080,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -823,7 +834,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 11996,
+          "line": 12085,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -839,7 +850,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 12008,
+          "line": 12097,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -852,7 +863,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 12012,
+          "line": 12101,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -865,7 +876,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 12016,
+          "line": 12105,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -875,7 +886,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 12024,
+          "line": 12113,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -888,7 +899,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 12029,
+          "line": 12118,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -901,7 +912,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 12034,
+          "line": 12123,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -913,7 +924,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 12040,
+          "line": 12129,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -925,7 +936,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 12044,
+          "line": 12133,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -939,7 +950,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 12047,
+          "line": 12136,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -949,7 +960,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 12056,
+          "line": 12145,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -962,7 +973,7 @@
         },
         {
           "name": "And",
-          "line": 12061,
+          "line": 12150,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -974,7 +985,7 @@
         },
         {
           "name": "Or",
-          "line": 12066,
+          "line": 12155,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -986,7 +997,7 @@
         },
         {
           "name": "Not",
-          "line": 12074,
+          "line": 12163,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -998,7 +1009,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 12078,
+          "line": 12167,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -1008,7 +1019,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 12080,
+          "line": 12169,
           "kind": "struct",
           "field_names": [
             "state"
@@ -1020,7 +1031,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 12090,
+          "line": 12179,
           "kind": "struct",
           "field_names": [
             "n"
@@ -1032,7 +1043,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 12093,
+          "line": 12182,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -1044,7 +1055,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 12113,
+          "line": 12202,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -1070,13 +1081,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5494,
+      "line": 5535,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 5495,
+          "line": 5536,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1086,7 +1097,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 5504,
+          "line": 5545,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -1099,7 +1110,7 @@
         },
         {
           "name": "Tap",
-          "line": 5507,
+          "line": 5548,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1107,7 +1118,7 @@
         },
         {
           "name": "Untap",
-          "line": 5508,
+          "line": 5549,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1115,7 +1126,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 5509,
+          "line": 5550,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1125,7 +1136,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5512,
+          "line": 5553,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -1133,7 +1144,7 @@
         },
         {
           "name": "PayLife",
-          "line": 5518,
+          "line": 5559,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1145,7 +1156,7 @@
         },
         {
           "name": "Discard",
-          "line": 5521,
+          "line": 5562,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1158,7 +1169,7 @@
         },
         {
           "name": "Exile",
-          "line": 5532,
+          "line": 5573,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1170,7 +1181,7 @@
         },
         {
           "name": "ExileMaterials",
-          "line": 5546,
+          "line": 5587,
           "kind": "struct",
           "field_names": [
             "materials",
@@ -1183,7 +1194,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 5553,
+          "line": 5594,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1196,7 +1207,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 5556,
+          "line": 5597,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1207,7 +1218,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5566,
+          "line": 5607,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1223,7 +1234,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 5574,
+          "line": 5615,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1233,7 +1244,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 5578,
+          "line": 5619,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1246,7 +1257,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 5586,
+          "line": 5627,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1260,7 +1271,7 @@
         },
         {
           "name": "Unattach",
-          "line": 5595,
+          "line": 5636,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1270,7 +1281,7 @@
         },
         {
           "name": "Mill",
-          "line": 5596,
+          "line": 5637,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1280,7 +1291,7 @@
         },
         {
           "name": "Exert",
-          "line": 5599,
+          "line": 5640,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1288,7 +1299,7 @@
         },
         {
           "name": "Blight",
-          "line": 5602,
+          "line": 5643,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1298,7 +1309,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5605,
+          "line": 5646,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1309,7 +1320,7 @@
         },
         {
           "name": "Behold",
-          "line": 5613,
+          "line": 5654,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1321,7 +1332,7 @@
         },
         {
           "name": "Composite",
-          "line": 5619,
+          "line": 5660,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1331,7 +1342,7 @@
         },
         {
           "name": "OneOf",
-          "line": 5636,
+          "line": 5677,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1344,7 +1355,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 5640,
+          "line": 5681,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1354,7 +1365,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 5645,
+          "line": 5686,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1367,7 +1378,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 5652,
+          "line": 5693,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1379,7 +1390,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 5668,
+          "line": 5709,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1393,7 +1404,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 5673,
+          "line": 5714,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1406,13 +1417,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10789,
+      "line": 10878,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 10791,
+          "line": 10880,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1420,7 +1431,7 @@
         },
         {
           "name": "Activated",
-          "line": 10792,
+          "line": 10881,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1428,7 +1439,7 @@
         },
         {
           "name": "Database",
-          "line": 10793,
+          "line": 10882,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1436,7 +1447,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 10796,
+          "line": 10885,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1444,7 +1455,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 10802,
+          "line": 10891,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1457,7 +1468,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10955,
+      "line": 11044,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1465,7 +1476,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 10957,
+          "line": 11046,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1475,7 +1486,7 @@
         },
         {
           "name": "Evolve",
-          "line": 10959,
+          "line": 11048,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1485,7 +1496,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 10961,
+          "line": 11050,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1495,7 +1506,7 @@
         },
         {
           "name": "Outlast",
-          "line": 10963,
+          "line": 11052,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1505,7 +1516,7 @@
         },
         {
           "name": "Cycling",
-          "line": 10968,
+          "line": 11057,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29a + CR 702.29e: This ability originated from a Cycling (or Typecycling) keyword definition. Used so the activation pipeline can emit a `GameEvent::Cycled` (CR 702.29c) that \"When you cycle this card\" triggers match.",
@@ -1517,7 +1528,7 @@
         },
         {
           "name": "Backup",
-          "line": 10970,
+          "line": 11059,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.165a: ability originated from a Backup keyword definition.",
@@ -1559,13 +1570,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10978,
+      "line": 11067,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 10979,
+          "line": 11068,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1573,7 +1584,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 10980,
+          "line": 11069,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1581,7 +1592,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 10981,
+          "line": 11070,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1589,7 +1600,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 10982,
+          "line": 11071,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1597,7 +1608,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 10983,
+          "line": 11072,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1605,7 +1616,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 10984,
+          "line": 11073,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1613,7 +1624,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 10985,
+          "line": 11074,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1621,7 +1632,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 10986,
+          "line": 11075,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1629,7 +1640,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 10987,
+          "line": 11076,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1637,7 +1648,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 10988,
+          "line": 11077,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1647,7 +1658,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 10991,
+          "line": 11080,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1657,7 +1668,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 10995,
+          "line": 11084,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1667,7 +1678,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 10997,
+          "line": 11086,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1679,7 +1690,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 11002,
+          "line": 11091,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1693,7 +1704,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 11013,
+          "line": 11102,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1707,7 +1718,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 11026,
+          "line": 11115,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1720,13 +1731,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5898,
+      "line": 5939,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 5904,
+          "line": 5945,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1737,7 +1748,7 @@
         },
         {
           "name": "Kicker",
-          "line": 5919,
+          "line": 5960,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1753,7 +1764,7 @@
         },
         {
           "name": "Choice",
-          "line": 5931,
+          "line": 5972,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1761,7 +1772,7 @@
         },
         {
           "name": "Required",
-          "line": 5933,
+          "line": 5974,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1772,7 +1783,7 @@
     },
     "AdditionalCostOrigin": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5941,
+      "line": 5982,
       "doc": "CR 113.2c + CR 601.2b/f: Linked identity for one independently functioning additional-cost keyword instance. Cast-time copy triggers read their own Casualty/Replicate payments via CR 702.153b / CR 702.56b; ETB-linked Squad/Offspring triggers read their own payments via CR 607.2g.",
       "cr_refs": [
         "CR 113.2c",
@@ -1784,7 +1795,7 @@
       "variants": [
         {
           "name": "Kicker",
-          "line": 5942,
+          "line": 5983,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1792,7 +1803,7 @@
         },
         {
           "name": "Casualty",
-          "line": 5943,
+          "line": 5984,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1800,7 +1811,7 @@
         },
         {
           "name": "Offspring",
-          "line": 5944,
+          "line": 5985,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1808,7 +1819,7 @@
         },
         {
           "name": "Squad",
-          "line": 5945,
+          "line": 5986,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1816,7 +1827,7 @@
         },
         {
           "name": "Replicate",
-          "line": 5946,
+          "line": 5987,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1824,7 +1835,7 @@
         },
         {
           "name": "Other",
-          "line": 5948,
+          "line": 5989,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1835,7 +1846,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6053,
+      "line": 6094,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1843,7 +1854,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 6055,
+          "line": 6096,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1851,7 +1862,7 @@
         },
         {
           "name": "Kicker",
-          "line": 6056,
+          "line": 6097,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1859,7 +1870,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 6057,
+          "line": 6098,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1914,15 +1925,16 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3964,
-      "doc": "CR 107.3e: Aggregate function applied over a set of objects.",
+      "line": 3996,
+      "doc": "Reduction applied when collapsing a set of per-object values (CR 208.1 power/ toughness, CR 202.3 mana value) into a single number. The Comprehensive Rules define no standalone \"aggregate function\" rule; this enum names the reduction kind used by the various property-aggregate `QuantityRef` variants.",
       "cr_refs": [
-        "CR 107.3e"
+        "CR 202.3",
+        "CR 208.1"
       ],
       "variants": [
         {
           "name": "Max",
-          "line": 3965,
+          "line": 3997,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1930,7 +1942,7 @@
         },
         {
           "name": "Min",
-          "line": 3966,
+          "line": 3998,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1938,7 +1950,7 @@
         },
         {
           "name": "Sum",
-          "line": 3967,
+          "line": 3999,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2212,7 +2224,7 @@
     },
     "AttackScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4073,
+      "line": 4105,
       "doc": "CR 508.6: The time window over which \"attacked [a player]\" is measured.",
       "cr_refs": [
         "CR 508.6"
@@ -2220,7 +2232,7 @@
       "variants": [
         {
           "name": "ThisTurn",
-          "line": 4075,
+          "line": 4107,
           "kind": "unit",
           "field_names": [],
           "doc": "Across the whole turn, accumulated over every combat (CR 508.5).",
@@ -2230,7 +2242,7 @@
         },
         {
           "name": "ThisCombat",
-          "line": 4077,
+          "line": 4109,
           "kind": "unit",
           "field_names": [],
           "doc": "Within the current combat only (CR 702.121a Melee).",
@@ -2243,7 +2255,7 @@
     },
     "AttackSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4064,
+      "line": 4096,
       "doc": "CR 506.2 + CR 508.1b: Whose attacks the \"opponents attacked\" player set is measured over.",
       "cr_refs": [
         "CR 506.2",
@@ -2252,7 +2264,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 4066,
+          "line": 4098,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's controller — \"opponents you attacked\".",
@@ -2260,7 +2272,7 @@
         },
         {
           "name": "Source",
-          "line": 4068,
+          "line": 4100,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source creature — \"opponents this creature attacked\".",
@@ -2319,13 +2331,24 @@
             "CR 506.2",
             "CR 508.1a"
           ]
+        },
+        {
+          "name": "OwnerOrPlaneswalker",
+          "line": 189,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 506.2 + CR 508.1c: \"can't attack its owner or planeswalkers its owner controls\" restricts attacks against the owning player and planeswalkers that player controls.",
+          "cr_refs": [
+            "CR 506.2",
+            "CR 508.1c"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "AttackersDeclaredCountSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4502,
+      "line": 4534,
       "doc": "CR 508.1 / CR 508.1b: Subject axis for counting members of a triggering `AttackersDeclared` event.",
       "cr_refs": [
         "CR 508.1",
@@ -2334,7 +2357,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 4510,
+          "line": 4542,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -2347,7 +2370,7 @@
         },
         {
           "name": "AttackTarget",
-          "line": 4517,
+          "line": 4549,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -2591,13 +2614,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5244,
+      "line": 5285,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 5245,
+          "line": 5286,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2605,7 +2628,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 5246,
+          "line": 5287,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2745,7 +2768,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6484,
+      "line": 6525,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2753,7 +2776,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 6487,
+          "line": 6528,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2761,7 +2784,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 6489,
+          "line": 6530,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2955,13 +2978,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3369,
+      "line": 3378,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 3371,
+          "line": 3380,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -2975,7 +2998,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 3373,
+          "line": 3382,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -2986,7 +3009,7 @@
         },
         {
           "name": "Objects",
-          "line": 3375,
+          "line": 3384,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -3143,7 +3166,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3380,
+      "line": 3389,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -3151,7 +3174,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 3382,
+          "line": 3391,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -3159,7 +3182,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 3384,
+          "line": 3393,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -3170,7 +3193,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3390,
+      "line": 3399,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -3179,7 +3202,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 3392,
+          "line": 3401,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -3187,7 +3210,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 3394,
+          "line": 3403,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -3195,7 +3218,7 @@
         },
         {
           "name": "FromSource",
-          "line": 3396,
+          "line": 3405,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -3382,7 +3405,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5214,
+      "line": 5255,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -3391,7 +3414,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 5217,
+          "line": 5258,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -3399,7 +3422,7 @@
         },
         {
           "name": "Offering",
-          "line": 5221,
+          "line": 5262,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.48a: The spell was cast at instant speed by paying an Offering additional cost. When this permission is set, the Offering sacrifice is required (the player used the offering to unlock instant-speed timing).",
@@ -3412,7 +3435,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5163,
+      "line": 5204,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -3423,7 +3446,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 5165,
+          "line": 5206,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -3434,7 +3457,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 5168,
+          "line": 5209,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -3444,7 +3467,7 @@
         },
         {
           "name": "Sneak",
-          "line": 5170,
+          "line": 5211,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -3454,7 +3477,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 5172,
+          "line": 5213,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -3464,7 +3487,7 @@
         },
         {
           "name": "Evoke",
-          "line": 5175,
+          "line": 5216,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -3474,7 +3497,7 @@
         },
         {
           "name": "Suspend",
-          "line": 5181,
+          "line": 5222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -3484,7 +3507,7 @@
         },
         {
           "name": "Escape",
-          "line": 5186,
+          "line": 5227,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -3495,7 +3518,7 @@
         },
         {
           "name": "Foretell",
-          "line": 5189,
+          "line": 5230,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -3505,7 +3528,7 @@
         },
         {
           "name": "Bestow",
-          "line": 5194,
+          "line": 5235,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -3516,7 +3539,7 @@
         },
         {
           "name": "Impending",
-          "line": 5199,
+          "line": 5240,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: The spell was cast for its impending alternative cost. The permanent entered with N time counters and is not a creature while any remain. Read by the end-step counter-removal trigger and the \"not a creature\" layer fixup.",
@@ -3526,7 +3549,7 @@
         },
         {
           "name": "Surge",
-          "line": 5203,
+          "line": 5244,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.117a: Surge alternative cast cost was paid from hand. Read by the \"if its surge cost was paid\" intervening-if (Reckless Bushwhacker, Tyrant of Valakut).",
@@ -3536,7 +3559,7 @@
         },
         {
           "name": "Spectacle",
-          "line": 5207,
+          "line": 5248,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.137a: Spectacle alternative cast cost was paid from hand. Read by the \"if its spectacle cost was paid\" intervening-if (Rafter Demon) and the \"...if its spectacle cost was paid, instead\" clause (Rix Maadi Reveler).",
@@ -3735,13 +3758,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11034,
+      "line": 11123,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 11035,
+          "line": 11124,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3749,7 +3772,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 11036,
+          "line": 11125,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3757,7 +3780,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 11037,
+          "line": 11126,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3765,7 +3788,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 11038,
+          "line": 11127,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3773,7 +3796,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 11039,
+          "line": 11128,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3781,7 +3804,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 11040,
+          "line": 11129,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3789,7 +3812,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 11041,
+          "line": 11130,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3797,7 +3820,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 11042,
+          "line": 11131,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3805,7 +3828,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 11043,
+          "line": 11132,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3813,7 +3836,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 11044,
+          "line": 11133,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3821,7 +3844,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 11045,
+          "line": 11134,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3829,7 +3852,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 11046,
+          "line": 11135,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3837,7 +3860,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 11047,
+          "line": 11136,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3845,7 +3868,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 11048,
+          "line": 11137,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3853,7 +3876,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 11049,
+          "line": 11138,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3861,7 +3884,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 11050,
+          "line": 11139,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -4815,7 +4838,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13087,
+      "line": 13183,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -4823,7 +4846,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 13088,
+          "line": 13184,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4831,7 +4854,7 @@
         },
         {
           "name": "Lost",
-          "line": 13089,
+          "line": 13185,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4948,7 +4971,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13626,
+      "line": 13722,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -4956,7 +4979,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 13627,
+          "line": 13723,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4964,7 +4987,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 13628,
+          "line": 13724,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5080,7 +5103,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4623,
+      "line": 4655,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -5088,7 +5111,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 4626,
+          "line": 4658,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -5099,7 +5122,7 @@
         },
         {
           "name": "Any",
-          "line": 4630,
+          "line": 4662,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -5203,13 +5226,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4463,
+      "line": 4495,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 4464,
+          "line": 4496,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5217,7 +5240,7 @@
         },
         {
           "name": "LT",
-          "line": 4465,
+          "line": 4497,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5225,7 +5248,7 @@
         },
         {
           "name": "GE",
-          "line": 4466,
+          "line": 4498,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5233,7 +5256,7 @@
         },
         {
           "name": "LE",
-          "line": 4467,
+          "line": 4499,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5241,7 +5264,7 @@
         },
         {
           "name": "EQ",
-          "line": 4468,
+          "line": 4500,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5249,7 +5272,7 @@
         },
         {
           "name": "NE",
-          "line": 4469,
+          "line": 4501,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5260,7 +5283,7 @@
     },
     "ConjureSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6391,
+      "line": 6432,
       "doc": "CR 707.2: Where a conjured card's identity is taken from. Untagged so the legacy named form (`{\"name\": \"X\"}`) and the duplicate form (`{\"duplicate_of\": <filter>}`) are distinguished by their disjoint keys.",
       "cr_refs": [
         "CR 707.2"
@@ -5268,7 +5291,7 @@
       "variants": [
         {
           "name": "Named",
-          "line": 6393,
+          "line": 6434,
           "kind": "struct",
           "field_names": [
             "name"
@@ -5278,7 +5301,7 @@
         },
         {
           "name": "Duplicate",
-          "line": 6397,
+          "line": 6438,
           "kind": "struct",
           "field_names": [
             "duplicate_of"
@@ -5293,13 +5316,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14068,
+      "line": 14175,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 14069,
+          "line": 14176,
           "kind": "struct",
           "field_names": [
             "values",
@@ -5312,7 +5335,7 @@
         },
         {
           "name": "SetName",
-          "line": 14101,
+          "line": 14208,
           "kind": "struct",
           "field_names": [
             "name"
@@ -5326,7 +5349,7 @@
         },
         {
           "name": "AddPower",
-          "line": 14104,
+          "line": 14211,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5336,7 +5359,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 14107,
+          "line": 14214,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5346,7 +5369,7 @@
         },
         {
           "name": "SetPower",
-          "line": 14110,
+          "line": 14217,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5356,7 +5379,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 14113,
+          "line": 14220,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5366,7 +5389,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 14116,
+          "line": 14223,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -5376,7 +5399,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 14119,
+          "line": 14226,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -5386,7 +5409,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 14122,
+          "line": 14229,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -5396,7 +5419,7 @@
         },
         {
           "name": "GrantAllActivatedAbilitiesOf",
-          "line": 14134,
+          "line": 14241,
           "kind": "struct",
           "field_names": [
             "source"
@@ -5409,7 +5432,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 14141,
+          "line": 14248,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -5421,7 +5444,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 14144,
+          "line": 14251,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5429,7 +5452,7 @@
         },
         {
           "name": "AddType",
-          "line": 14145,
+          "line": 14252,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -5439,7 +5462,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 14148,
+          "line": 14255,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -5449,7 +5472,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 14151,
+          "line": 14258,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -5459,7 +5482,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 14154,
+          "line": 14261,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -5469,7 +5492,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 14161,
+          "line": 14268,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -5482,7 +5505,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 14167,
+          "line": 14274,
           "kind": "struct",
           "field_names": [
             "set"
@@ -5495,7 +5518,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 14171,
+          "line": 14278,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5505,7 +5528,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 14175,
+          "line": 14282,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5515,7 +5538,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 14182,
+          "line": 14289,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5527,7 +5550,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 14187,
+          "line": 14294,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5539,7 +5562,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 14191,
+          "line": 14298,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5551,7 +5574,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 14195,
+          "line": 14302,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5563,7 +5586,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 14200,
+          "line": 14307,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -5576,7 +5599,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 14206,
+          "line": 14313,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -5584,7 +5607,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 14209,
+          "line": 14316,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -5595,7 +5618,7 @@
         },
         {
           "name": "AddAllLandTypes",
-          "line": 14213,
+          "line": 14320,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and their mana abilities, additive. Distinct from AddAllBasicLandTypes (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.",
@@ -5607,7 +5630,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 14216,
+          "line": 14323,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -5617,7 +5640,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 14221,
+          "line": 14328,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -5627,7 +5650,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 14228,
+          "line": 14335,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -5638,7 +5661,7 @@
         },
         {
           "name": "SetColor",
-          "line": 14229,
+          "line": 14336,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -5648,7 +5671,7 @@
         },
         {
           "name": "AddColor",
-          "line": 14232,
+          "line": 14339,
           "kind": "struct",
           "field_names": [
             "color"
@@ -5658,7 +5681,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 14237,
+          "line": 14344,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -5668,7 +5691,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 14252,
+          "line": 14359,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -5683,7 +5706,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 14256,
+          "line": 14363,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -5693,7 +5716,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 14259,
+          "line": 14366,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -5703,7 +5726,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 14261,
+          "line": 14368,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -5713,7 +5736,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 14263,
+          "line": 14370,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -5723,7 +5746,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 14266,
+          "line": 14373,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -5733,7 +5756,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 14269,
+          "line": 14376,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -5745,7 +5768,7 @@
         },
         {
           "name": "SetChosenBasicLandType",
-          "line": 14283,
+          "line": 14390,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.7 + CR 305.6: Sets a land's subtype to the basic land type CHOSEN by the granting source (e.g. Phantasmal Terrain, Convincing Mirage: \"As this Aura enters, choose a basic land type.\" + \"Enchanted land is the chosen type.\"). Mirrors `SetBasicLandType`'s replacement semantics — removes the land's old land subtypes and clears the abilities generated from its rules text — but reads the concrete subtype from the source object's `chosen_attributes` (`ChosenSubtypeKind::BasicLandType`) at layer evaluation time rather than carrying a fixed type. Unit variant: the kind is implicitly `BasicLandType`. The intrinsic mana ability for the new type is derived from the subtype in `mana_sources.rs` (CR 305.6), so no explicit mana grant is needed here.",
@@ -5756,7 +5779,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 14295,
+          "line": 14402,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -5768,7 +5791,7 @@
         },
         {
           "name": "RetainPrintedAbilityFromSource",
-          "line": 14308,
+          "line": 14415,
           "kind": "struct",
           "field_names": [
             "source_ability_index"
@@ -5780,7 +5803,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 14316,
+          "line": 14423,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -5795,7 +5818,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 14325,
+          "line": 14432,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -5810,7 +5833,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 14339,
+          "line": 14446,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -5825,7 +5848,7 @@
         },
         {
           "name": "RemoveManaCost",
-          "line": 14355,
+          "line": 14462,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.9 + CR 202.1b: Strip a copy's mana cost — the \"has no mana cost\" copy exception used by Embalm (CR 702.128a) and Eternalize (CR 702.129a). Like `AddCounterOnEnter`, this is consumed at copy resolution, never evaluated through the layer system, so `ContinuousModification::layer()` treats it as unreachable: `token_copy.rs` bakes it into the new token's base mana cost, and `become_copy.rs` strips it from the copied values so the continuous copy carries mana value 0.",
@@ -6014,7 +6037,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14426,
+      "line": 14533,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -6024,7 +6047,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 14429,
+          "line": 14536,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -6032,7 +6055,7 @@
         },
         {
           "name": "Finalized",
-          "line": 14431,
+          "line": 14538,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -6043,13 +6066,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6428,
+      "line": 6469,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 6429,
+          "line": 6470,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6060,7 +6083,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 8948,
+      "line": 9028,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -6069,7 +6092,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 8950,
+          "line": 9030,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -6077,7 +6100,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 8952,
+          "line": 9032,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -6229,13 +6252,26 @@
             "CR 314.2",
             "CR 904.9"
           ]
+        },
+        {
+          "name": "Conspiracy",
+          "line": 78,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 905: Conspiracies — nontraditional cards used in the Conspiracy Draft variant that exist only in the command zone (CR 905.4), where a face-up conspiracy applies its abilities and a hidden-agenda conspiracy (CR 905.4a + CR 702.106) starts face down.",
+          "cr_refs": [
+            "CR 702.106",
+            "CR 905",
+            "CR 905.4",
+            "CR 905.4a"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5687,
+      "line": 5728,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice(_)` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -6243,7 +6279,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 5688,
+          "line": 5729,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6251,7 +6287,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 5689,
+          "line": 5730,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6259,7 +6295,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 5690,
+          "line": 5731,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6267,7 +6303,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 5691,
+          "line": 5732,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6275,7 +6311,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 5692,
+          "line": 5733,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6283,7 +6319,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 5693,
+          "line": 5734,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6291,7 +6327,7 @@
         },
         {
           "name": "Discards",
-          "line": 5694,
+          "line": 5735,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6299,7 +6335,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 5695,
+          "line": 5736,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6307,7 +6343,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 5696,
+          "line": 5737,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6315,7 +6351,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 5697,
+          "line": 5738,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6323,7 +6359,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 5698,
+          "line": 5739,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6331,7 +6367,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 5699,
+          "line": 5740,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6339,7 +6375,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 5700,
+          "line": 5741,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6347,7 +6383,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 5701,
+          "line": 5742,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6355,7 +6391,7 @@
         },
         {
           "name": "Mills",
-          "line": 5702,
+          "line": 5743,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6363,7 +6399,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 5703,
+          "line": 5744,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6371,7 +6407,7 @@
         },
         {
           "name": "Reveals",
-          "line": 5704,
+          "line": 5745,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6379,7 +6415,7 @@
         },
         {
           "name": "Exerts",
-          "line": 5705,
+          "line": 5746,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6387,7 +6423,7 @@
         },
         {
           "name": "KeywordCost",
-          "line": 5706,
+          "line": 5747,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6435,7 +6471,7 @@
     },
     "CostObjectCount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5253,
+      "line": 5294,
       "doc": "CR 702.167a: Object-count requirement for costs whose text may ask for an exact number (\"two creatures\") or a minimum (\"one or more creatures\").",
       "cr_refs": [
         "CR 702.167a"
@@ -6443,7 +6479,7 @@
       "variants": [
         {
           "name": "Exactly",
-          "line": 5254,
+          "line": 5295,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6453,7 +6489,7 @@
         },
         {
           "name": "AtLeast",
-          "line": 5255,
+          "line": 5296,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6613,13 +6649,13 @@
     },
     "CounterCostSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5349,
+      "line": 5390,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "SingleObject",
-          "line": 5351,
+          "line": 5392,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6627,7 +6663,7 @@
         },
         {
           "name": "AmongObjects",
-          "line": 5352,
+          "line": 5393,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7068,7 +7104,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3976,
+      "line": 4008,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -7076,7 +7112,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 3979,
+          "line": 4011,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -7128,7 +7164,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13499,
+      "line": 13595,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -7136,7 +7172,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 13501,
+          "line": 13597,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -7144,7 +7180,7 @@
         },
         {
           "name": "Triple",
-          "line": 13503,
+          "line": 13599,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -7152,7 +7188,7 @@
         },
         {
           "name": "Plus",
-          "line": 13505,
+          "line": 13601,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7162,7 +7198,7 @@
         },
         {
           "name": "Minus",
-          "line": 13512,
+          "line": 13608,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7175,7 +7211,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 13516,
+          "line": 13612,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -7185,7 +7221,7 @@
         },
         {
           "name": "SetTo",
-          "line": 13522,
+          "line": 13618,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7197,7 +7233,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 13528,
+          "line": 13624,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -7247,7 +7283,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6363,
+      "line": 6404,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -7255,7 +7291,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 6365,
+          "line": 6406,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -7263,7 +7299,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 6368,
+          "line": 6409,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -7277,7 +7313,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13614,
+      "line": 13710,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -7285,7 +7321,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 13616,
+          "line": 13712,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -7293,7 +7329,7 @@
         },
         {
           "name": "Player",
-          "line": 13618,
+          "line": 13714,
           "kind": "struct",
           "field_names": [
             "player"
@@ -7303,7 +7339,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 13621,
+          "line": 13717,
           "kind": "struct",
           "field_names": [
             "player"
@@ -7316,7 +7352,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13598,
+      "line": 13694,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -7324,7 +7360,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 13599,
+          "line": 13695,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7332,7 +7368,7 @@
         },
         {
           "name": "Opponent",
-          "line": 13600,
+          "line": 13696,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7340,7 +7376,7 @@
         },
         {
           "name": "Controller",
-          "line": 13603,
+          "line": 13699,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -7348,7 +7384,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 13607,
+          "line": 13703,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 614.1a: Damage recipient is the player chosen for the replacement source by a linked persisted choice, or a permanent that player controls for `PlayerOrPermanentsControlledBy`.",
@@ -7359,7 +7395,7 @@
         },
         {
           "name": "Specific",
-          "line": 13608,
+          "line": 13704,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -7784,7 +7820,7 @@
     },
     "DeckCopyLimit": {
       "file": "crates/engine/src/types/format.rs",
-      "line": 90,
+      "line": 94,
       "doc": "Per-card override to the default constructed copy limit.  CR 100.2a sets the default constructed limit to four of any card with a particular English name (basic lands excepted). A handful of cards print an explicit deck-construction override in their rules text:  - `Unlimited`: \"A deck can have any number of cards named ~.\" (Relentless   Rats, Shadowborn Apostle, etc.) — no upper bound on copies. - `UpTo(n)`: \"A deck can have up to <n> cards named ~.\" (Seven Dwarves → 7,   Nazgûl → 9) and the Commander/companion singleton override \"Your deck can   have only one copy of this card\" (Vazal, the Compleat → `UpTo(1)`).  CR 903.5b's Commander singleton rule exempts basic lands; an `UpTo(n>1)` override likewise raises the cap above the format default for that card.",
       "cr_refs": [
         "CR 100.2a",
@@ -7793,7 +7829,7 @@
       "variants": [
         {
           "name": "Unlimited",
-          "line": 91,
+          "line": 95,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7801,7 +7837,7 @@
         },
         {
           "name": "UpTo",
-          "line": 92,
+          "line": 96,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8287,13 +8323,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6608,
+      "line": 6649,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 6610,
+          "line": 6651,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -8305,7 +8341,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 6616,
+          "line": 6657,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -8320,7 +8356,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 6627,
+          "line": 6668,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8332,7 +8368,7 @@
         },
         {
           "name": "Draw",
-          "line": 6647,
+          "line": 6688,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8348,7 +8384,7 @@
         },
         {
           "name": "Pump",
-          "line": 6653,
+          "line": 6694,
           "kind": "struct",
           "field_names": [
             "power",
@@ -8360,7 +8396,7 @@
         },
         {
           "name": "PairWith",
-          "line": 6664,
+          "line": 6705,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8373,7 +8409,7 @@
         },
         {
           "name": "Destroy",
-          "line": 6667,
+          "line": 6708,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8384,7 +8420,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 6675,
+          "line": 6716,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8396,7 +8432,7 @@
         },
         {
           "name": "Counter",
-          "line": 6679,
+          "line": 6720,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8407,7 +8443,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 6700,
+          "line": 6741,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8421,7 +8457,7 @@
         },
         {
           "name": "Token",
-          "line": 6704,
+          "line": 6745,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8444,7 +8480,7 @@
         },
         {
           "name": "GainLife",
-          "line": 6742,
+          "line": 6783,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8455,7 +8491,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 6753,
+          "line": 6794,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8466,7 +8502,7 @@
         },
         {
           "name": "SetTapState",
-          "line": 6771,
+          "line": 6812,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8481,7 +8517,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 6782,
+          "line": 6823,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8493,7 +8529,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 6790,
+          "line": 6831,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8505,7 +8541,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 6811,
+          "line": 6852,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8516,7 +8552,7 @@
         },
         {
           "name": "Mill",
-          "line": 6817,
+          "line": 6858,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8528,7 +8564,7 @@
         },
         {
           "name": "Scry",
-          "line": 6834,
+          "line": 6875,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8543,7 +8579,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 6840,
+          "line": 6881,
           "kind": "struct",
           "field_names": [
             "power",
@@ -8555,7 +8591,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 6854,
+          "line": 6895,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8572,7 +8608,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 6878,
+          "line": 6919,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8585,7 +8621,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 6882,
+          "line": 6923,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8596,7 +8632,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 6889,
+          "line": 6930,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -8616,7 +8652,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 6934,
+          "line": 6975,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -8634,7 +8670,7 @@
         },
         {
           "name": "Dig",
-          "line": 6979,
+          "line": 7020,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8655,7 +8691,7 @@
         },
         {
           "name": "GainControl",
-          "line": 7012,
+          "line": 7053,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8665,7 +8701,7 @@
         },
         {
           "name": "GainControlAll",
-          "line": 7024,
+          "line": 7065,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8677,7 +8713,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 7028,
+          "line": 7069,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8688,7 +8724,7 @@
         },
         {
           "name": "Attach",
-          "line": 7034,
+          "line": 7075,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -8699,7 +8735,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 7046,
+          "line": 7087,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -8712,7 +8748,7 @@
         },
         {
           "name": "Surveil",
-          "line": 7058,
+          "line": 7099,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8727,7 +8763,7 @@
         },
         {
           "name": "Fight",
-          "line": 7064,
+          "line": 7105,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8738,7 +8774,7 @@
         },
         {
           "name": "Bounce",
-          "line": 7072,
+          "line": 7113,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8750,7 +8786,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 7091,
+          "line": 7132,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8765,7 +8801,7 @@
         },
         {
           "name": "Explore",
-          "line": 7099,
+          "line": 7140,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8773,7 +8809,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 7103,
+          "line": 7144,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8785,7 +8821,7 @@
         },
         {
           "name": "Investigate",
-          "line": 7108,
+          "line": 7149,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Investigate — create a Clue token.",
@@ -8795,7 +8831,7 @@
         },
         {
           "name": "Tribute",
-          "line": 7115,
+          "line": 7156,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8808,7 +8844,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 7121,
+          "line": 7162,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -8818,7 +8854,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 7123,
+          "line": 7164,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -8828,7 +8864,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 7124,
+          "line": 7165,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8836,7 +8872,7 @@
         },
         {
           "name": "ProliferateTarget",
-          "line": 7131,
+          "line": 7172,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8849,7 +8885,7 @@
         },
         {
           "name": "Populate",
-          "line": 7136,
+          "line": 7177,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -8859,7 +8895,7 @@
         },
         {
           "name": "Clash",
-          "line": 7138,
+          "line": 7179,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -8869,7 +8905,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 7143,
+          "line": 7184,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.1: End the turn. Exile every object on the stack, check state-based actions, remove everything from combat, then skip straight to the cleanup step. Time Stop, Sundial of the Infinite, Obeka, Glorious End, Discontinuity, Day's Undoing.",
@@ -8879,7 +8915,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 7148,
+          "line": 7189,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase. Exile every object on the stack, check state-based actions, remove everything from combat, expire \"until end of combat\" effects, and skip straight to the postcombat main phase. Does nothing outside a combat phase (CR 724.2g). Mandate of Peace.",
@@ -8890,7 +8926,7 @@
         },
         {
           "name": "Vote",
-          "line": 7163,
+          "line": 7204,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -8906,7 +8942,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7207,
+          "line": 7248,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -8926,7 +8962,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7226,
+          "line": 7267,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8938,7 +8974,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 7230,
+          "line": 7271,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8950,7 +8986,7 @@
         },
         {
           "name": "EpicCopy",
-          "line": 7255,
+          "line": 7296,
           "kind": "struct",
           "field_names": [
             "spell"
@@ -8963,7 +8999,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 7260,
+          "line": 7301,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8976,7 +9012,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 7271,
+          "line": 7312,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8995,8 +9031,29 @@
           ]
         },
         {
+          "name": "CreateTokenCopyFromPool",
+          "line": 7367,
+          "kind": "struct",
+          "field_names": [
+            "owner",
+            "type_filter",
+            "mv",
+            "mv_bound",
+            "selection",
+            "count",
+            "tapped",
+            "enters_attacking"
+          ],
+          "doc": "CR 707.2 + CR 111.1 + CR 701.9a (analogous): Create a token that's a copy of a creature card chosen from a format-defined pool whose mana value satisfies `mv <comparator> mv_bound`. The canonical card is the Momir Basic emblem (\"Create a token that's a copy of a creature card with mana value X chosen at random\"). The pool is the engine's creature corpus (`GameState::momir_pool` / `momir_pool_faces`). `selection` chooses how a candidate is picked from the matching set: `Random` (CR 701.9a is the discard keyword action; the random *selection* here is analogous to the random-choice idiom) or `Chosen`. Built as a reusable primitive so the `mv` comparator also expresses \"copy a creature card with mana value N or less\" (Oko-style) via `Comparator::LE`.",
+          "cr_refs": [
+            "CR 111.1",
+            "CR 701.9a",
+            "CR 707.2"
+          ]
+        },
+        {
           "name": "Myriad",
-          "line": 7318,
+          "line": 7398,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -9006,7 +9063,7 @@
         },
         {
           "name": "Encore",
-          "line": 7325,
+          "line": 7405,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.141a: Encore — for each opponent, create a token that's a copy of the (exiled) source card that must attack that opponent this turn if able. The tokens gain haste and are sacrificed at the beginning of the next end step. Resolver: `game/effects/encore.rs`. No player-selectable target (opponents and per-opponent attack binding are chosen by the effect, like `Myriad`).",
@@ -9016,7 +9073,7 @@
         },
         {
           "name": "Meld",
-          "line": 7333,
+          "line": 7413,
           "kind": "struct",
           "field_names": [
             "source",
@@ -9031,7 +9088,7 @@
         },
         {
           "name": "ExileHaunting",
-          "line": 7343,
+          "line": 7423,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9043,7 +9100,7 @@
         },
         {
           "name": "HideawayConceal",
-          "line": 7352,
+          "line": 7432,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9055,7 +9112,7 @@
         },
         {
           "name": "CopyTokenBlockingAttacker",
-          "line": 7364,
+          "line": 7444,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -9070,7 +9127,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 7376,
+          "line": 7456,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9086,7 +9143,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 7386,
+          "line": 7466,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -9097,7 +9154,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 7400,
+          "line": 7480,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9111,7 +9168,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 7408,
+          "line": 7488,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9125,7 +9182,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 7415,
+          "line": 7495,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9137,7 +9194,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 7423,
+          "line": 7503,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -9150,7 +9207,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 7429,
+          "line": 7509,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -9163,7 +9220,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 7437,
+          "line": 7517,
           "kind": "struct",
           "field_names": [
             "source",
@@ -9181,7 +9238,7 @@
         },
         {
           "name": "Animate",
-          "line": 7457,
+          "line": 7537,
           "kind": "struct",
           "field_names": [
             "power",
@@ -9196,7 +9253,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 7495,
+          "line": 7575,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -9220,7 +9277,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 7511,
+          "line": 7591,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -9230,7 +9287,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 7515,
+          "line": 7595,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -9242,7 +9299,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 7523,
+          "line": 7603,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -9259,7 +9316,7 @@
         },
         {
           "name": "Mana",
-          "line": 7541,
+          "line": 7621,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -9273,7 +9330,7 @@
         },
         {
           "name": "Discard",
-          "line": 7564,
+          "line": 7644,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9287,7 +9344,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 7591,
+          "line": 7671,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9297,7 +9354,7 @@
         },
         {
           "name": "Transform",
-          "line": 7595,
+          "line": 7675,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9307,7 +9364,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 7601,
+          "line": 7681,
           "kind": "struct",
           "field_names": [
             "source_zones",
@@ -9323,7 +9380,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 7658,
+          "line": 7738,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9341,7 +9398,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 7669,
+          "line": 7749,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9355,7 +9412,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 7698,
+          "line": 7778,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9368,7 +9425,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7709,
+          "line": 7789,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9381,7 +9438,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 7714,
+          "line": 7794,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9394,7 +9451,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 7723,
+          "line": 7803,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9406,7 +9463,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 7746,
+          "line": 7826,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9416,7 +9473,7 @@
         },
         {
           "name": "Choose",
-          "line": 7752,
+          "line": 7832,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -9427,7 +9484,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 7763,
+          "line": 7843,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -9440,7 +9497,7 @@
         },
         {
           "name": "Suspect",
-          "line": 7768,
+          "line": 7848,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9452,7 +9509,7 @@
         },
         {
           "name": "Connive",
-          "line": 7778,
+          "line": 7858,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9466,7 +9523,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 7786,
+          "line": 7866,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9478,7 +9535,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 7793,
+          "line": 7873,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9490,7 +9547,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 7798,
+          "line": 7878,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9502,7 +9559,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 7803,
+          "line": 7883,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9516,7 +9573,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 7812,
+          "line": 7892,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -9526,7 +9583,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 7819,
+          "line": 7899,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9538,7 +9595,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 7826,
+          "line": 7906,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9550,7 +9607,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 7831,
+          "line": 7911,
           "kind": "struct",
           "field_names": [
             "level"
@@ -9562,7 +9619,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 7836,
+          "line": 7916,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -9576,7 +9633,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 7866,
+          "line": 7946,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -9590,7 +9647,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 7872,
+          "line": 7952,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -9602,7 +9659,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 7877,
+          "line": 7957,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9615,7 +9672,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 7884,
+          "line": 7964,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -9628,7 +9685,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 7893,
+          "line": 7973,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9641,7 +9698,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 7901,
+          "line": 7981,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -9655,7 +9712,7 @@
         },
         {
           "name": "PayCost",
-          "line": 7916,
+          "line": 7996,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -9669,7 +9726,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 7934,
+          "line": 8014,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9689,7 +9746,7 @@
         },
         {
           "name": "FreeCastFromZones",
-          "line": 8002,
+          "line": 8082,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9709,7 +9766,7 @@
         },
         {
           "name": "ExileResolvingSpellInsteadOfGraveyard",
-          "line": 8037,
+          "line": 8117,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 608.2n + CR 607.2b: \"Exile it instead of putting it into a graveyard as it resolves\" — the self-replacement rider applied by a `WhenAPlayerCasts` trigger to the *triggering spell* (Rod of Absorption).  At resolution this effect does NOT move the spell (it is still on the stack); it stamps the per-object linked-source marker so the stack-resolution router sends the spell to exile (CR 614.1a replaces the normal CR 608.2n graveyard destination) when it finishes resolving. When the spell reaches exile, it is recorded as \"exiled with\" the trigger source so a linked ability (CR 607.2b — \"cards exiled with this artifact\") can later refer to the accumulating set.  Distinct from `ChangeZone { destination: Exile }` (which moves a card that is already in a zone) and from `FreeCastFromZones { exile_instead… }` (which stamps the same rider on a spell *cast during resolution*, with no linked-exile payoff). This effect is the trigger-driven, link-establishing form for the resolving spell itself.",
@@ -9721,7 +9778,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 8039,
+          "line": 8119,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9738,7 +9795,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 8084,
+          "line": 8164,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -9760,7 +9817,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 8125,
+          "line": 8205,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9772,7 +9829,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 8134,
+          "line": 8214,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9784,7 +9841,7 @@
         },
         {
           "name": "RollDie",
-          "line": 8147,
+          "line": 8227,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9802,7 +9859,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 8157,
+          "line": 8237,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -9815,7 +9872,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 8169,
+          "line": 8249,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9829,7 +9886,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 8178,
+          "line": 8258,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -9841,7 +9898,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 8183,
+          "line": 8263,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -9851,7 +9908,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 8186,
+          "line": 8266,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -9861,7 +9918,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 8188,
+          "line": 8268,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -9873,7 +9930,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 8193,
+          "line": 8273,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -9884,7 +9941,7 @@
         },
         {
           "name": "Planeswalk",
-          "line": 8198,
+          "line": 8278,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 901.8 / CR 901.9c: The synthetic \"planeswalking ability.\" When a player rolls the Planeswalker symbol on the planar die, this ability triggers and is put on the stack; on resolution its controller (the roller, CR 901.8) planeswalks (CR 701.31).",
@@ -9896,7 +9953,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 8201,
+          "line": 8281,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9908,7 +9965,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 8205,
+          "line": 8285,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.52: Roll to visit your Attractions.",
@@ -9918,7 +9975,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 8208,
+          "line": 8288,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -9928,7 +9985,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 8211,
+          "line": 8291,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -9940,7 +9997,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 8228,
+          "line": 8308,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9959,7 +10016,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 8261,
+          "line": 8341,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -9974,7 +10031,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 8274,
+          "line": 8354,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -9990,7 +10047,7 @@
         },
         {
           "name": "Exploit",
-          "line": 8289,
+          "line": 8369,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10002,7 +10059,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 8294,
+          "line": 8374,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10014,7 +10071,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 8299,
+          "line": 8379,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -10029,7 +10086,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 8311,
+          "line": 8391,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10041,7 +10098,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 8323,
+          "line": 8403,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10057,7 +10114,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 8334,
+          "line": 8414,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10075,7 +10132,7 @@
         },
         {
           "name": "Discover",
-          "line": 8372,
+          "line": 8452,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -10087,7 +10144,7 @@
         },
         {
           "name": "Cascade",
-          "line": 8384,
+          "line": 8464,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -10097,7 +10154,7 @@
         },
         {
           "name": "Ripple",
-          "line": 8389,
+          "line": 8469,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10109,7 +10166,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 8395,
+          "line": 8475,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -10121,7 +10178,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 8400,
+          "line": 8480,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -10133,7 +10190,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 8413,
+          "line": 8493,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10145,7 +10202,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 8422,
+          "line": 8502,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10157,7 +10214,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 8431,
+          "line": 8511,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10167,7 +10224,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 8436,
+          "line": 8516,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -10177,7 +10234,7 @@
         },
         {
           "name": "Goad",
-          "line": 8442,
+          "line": 8522,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10189,7 +10246,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 8449,
+          "line": 8529,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10201,7 +10258,7 @@
         },
         {
           "name": "Detain",
-          "line": 8456,
+          "line": 8536,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10213,7 +10270,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 8467,
+          "line": 8547,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -10227,7 +10284,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 8478,
+          "line": 8558,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10241,7 +10298,7 @@
         },
         {
           "name": "Manifest",
-          "line": 8493,
+          "line": 8573,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10254,7 +10311,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 8499,
+          "line": 8579,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -10264,7 +10321,7 @@
         },
         {
           "name": "Cloak",
-          "line": 8506,
+          "line": 8586,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10278,7 +10335,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 8518,
+          "line": 8598,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10291,7 +10348,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 8525,
+          "line": 8605,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10303,7 +10360,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 8539,
+          "line": 8619,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -10316,7 +10373,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 8550,
+          "line": 8630,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10329,7 +10386,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 8560,
+          "line": 8640,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10343,7 +10400,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 8576,
+          "line": 8656,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10360,7 +10417,7 @@
         },
         {
           "name": "Double",
-          "line": 8589,
+          "line": 8669,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -10374,7 +10431,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 8597,
+          "line": 8677,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -10386,7 +10443,7 @@
         },
         {
           "name": "Incubate",
-          "line": 8603,
+          "line": 8683,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10398,7 +10455,7 @@
         },
         {
           "name": "Amass",
-          "line": 8611,
+          "line": 8691,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -10411,7 +10468,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 8619,
+          "line": 8699,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10423,7 +10480,7 @@
         },
         {
           "name": "Specialize",
-          "line": 8625,
+          "line": 8705,
           "kind": "unit",
           "field_names": [],
           "doc": "Digital-only Specialize: permanently become a color-specific face after paying the synthesized activation cost (mana + discard). Not in CR text.",
@@ -10431,7 +10488,7 @@
         },
         {
           "name": "Renown",
-          "line": 8628,
+          "line": 8708,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10443,7 +10500,7 @@
         },
         {
           "name": "Bolster",
-          "line": 8634,
+          "line": 8714,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10455,7 +10512,7 @@
         },
         {
           "name": "Adapt",
-          "line": 8640,
+          "line": 8720,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10467,7 +10524,7 @@
         },
         {
           "name": "Learn",
-          "line": 8646,
+          "line": 8726,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -10477,7 +10534,7 @@
         },
         {
           "name": "Forage",
-          "line": 8648,
+          "line": 8728,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.61a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -10487,7 +10544,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 8650,
+          "line": 8730,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10499,7 +10556,7 @@
         },
         {
           "name": "Endure",
-          "line": 8657,
+          "line": 8737,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10512,7 +10569,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 8662,
+          "line": 8742,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10524,7 +10581,7 @@
         },
         {
           "name": "Seek",
-          "line": 8667,
+          "line": 8747,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -10538,7 +10595,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 8684,
+          "line": 8764,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10551,7 +10608,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 8699,
+          "line": 8779,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10567,7 +10624,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 8706,
+          "line": 8786,
           "kind": "struct",
           "field_names": [
             "to"
@@ -10579,7 +10636,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 8711,
+          "line": 8791,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10592,7 +10649,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 8720,
+          "line": 8800,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10604,7 +10661,7 @@
         },
         {
           "name": "Conjure",
-          "line": 8727,
+          "line": 8807,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -10616,7 +10673,7 @@
         },
         {
           "name": "Intensify",
-          "line": 8739,
+          "line": 8819,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -10627,7 +10684,7 @@
         },
         {
           "name": "DraftFromSpellbook",
-          "line": 8753,
+          "line": 8833,
           "kind": "struct",
           "field_names": [
             "destination",
@@ -10638,7 +10695,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 8772,
+          "line": 8852,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -10652,7 +10709,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 8783,
+          "line": 8863,
           "kind": "struct",
           "field_names": [
             "name",
@@ -10755,13 +10812,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14902,
+      "line": 15009,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 14904,
+          "line": 15011,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10769,7 +10826,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 14906,
+          "line": 15013,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10777,7 +10834,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 14908,
+          "line": 15015,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10785,7 +10842,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 14910,
+          "line": 15017,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10793,7 +10850,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 14912,
+          "line": 15019,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10801,7 +10858,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 14914,
+          "line": 15021,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10812,13 +10869,13 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10381,
+      "line": 10468,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 10382,
+          "line": 10469,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10826,7 +10883,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 10383,
+          "line": 10470,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10834,7 +10891,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 10384,
+          "line": 10471,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10842,7 +10899,7 @@
         },
         {
           "name": "Draw",
-          "line": 10385,
+          "line": 10472,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10850,7 +10907,7 @@
         },
         {
           "name": "Pump",
-          "line": 10386,
+          "line": 10473,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10858,7 +10915,7 @@
         },
         {
           "name": "PairWith",
-          "line": 10387,
+          "line": 10474,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10866,7 +10923,7 @@
         },
         {
           "name": "Destroy",
-          "line": 10388,
+          "line": 10475,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10874,7 +10931,7 @@
         },
         {
           "name": "Counter",
-          "line": 10389,
+          "line": 10476,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10882,7 +10939,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 10390,
+          "line": 10477,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10890,7 +10947,7 @@
         },
         {
           "name": "Token",
-          "line": 10391,
+          "line": 10478,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10898,7 +10955,7 @@
         },
         {
           "name": "GainLife",
-          "line": 10392,
+          "line": 10479,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10906,7 +10963,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 10393,
+          "line": 10480,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10914,7 +10971,7 @@
         },
         {
           "name": "Tap",
-          "line": 10394,
+          "line": 10481,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10922,7 +10979,7 @@
         },
         {
           "name": "Untap",
-          "line": 10395,
+          "line": 10482,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10930,7 +10987,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 10396,
+          "line": 10483,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10938,7 +10995,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 10397,
+          "line": 10484,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10946,7 +11003,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 10398,
+          "line": 10485,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10954,7 +11011,7 @@
         },
         {
           "name": "Mill",
-          "line": 10399,
+          "line": 10486,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10962,7 +11019,7 @@
         },
         {
           "name": "Scry",
-          "line": 10400,
+          "line": 10487,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10970,7 +11027,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 10401,
+          "line": 10488,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10978,7 +11035,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 10402,
+          "line": 10489,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10986,7 +11043,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 10403,
+          "line": 10490,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10994,7 +11051,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 10404,
+          "line": 10491,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11002,7 +11059,7 @@
         },
         {
           "name": "TapAll",
-          "line": 10405,
+          "line": 10492,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11010,7 +11067,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 10406,
+          "line": 10493,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11018,7 +11075,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 10407,
+          "line": 10494,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11026,7 +11083,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 10408,
+          "line": 10495,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11034,7 +11091,7 @@
         },
         {
           "name": "Dig",
-          "line": 10409,
+          "line": 10496,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11042,7 +11099,7 @@
         },
         {
           "name": "GainControl",
-          "line": 10410,
+          "line": 10497,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11050,7 +11107,7 @@
         },
         {
           "name": "GainControlAll",
-          "line": 10411,
+          "line": 10498,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11058,7 +11115,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 10412,
+          "line": 10499,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11066,7 +11123,7 @@
         },
         {
           "name": "Attach",
-          "line": 10413,
+          "line": 10500,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11074,7 +11131,7 @@
         },
         {
           "name": "AttachAll",
-          "line": 10414,
+          "line": 10501,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11082,7 +11139,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 10415,
+          "line": 10502,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11090,7 +11147,7 @@
         },
         {
           "name": "Surveil",
-          "line": 10416,
+          "line": 10503,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11098,7 +11155,7 @@
         },
         {
           "name": "Fight",
-          "line": 10417,
+          "line": 10504,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11106,7 +11163,7 @@
         },
         {
           "name": "Bounce",
-          "line": 10418,
+          "line": 10505,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11114,7 +11171,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 10419,
+          "line": 10506,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11122,7 +11179,7 @@
         },
         {
           "name": "Explore",
-          "line": 10420,
+          "line": 10507,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11130,7 +11187,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 10421,
+          "line": 10508,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11138,7 +11195,7 @@
         },
         {
           "name": "Investigate",
-          "line": 10422,
+          "line": 10509,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11146,7 +11203,7 @@
         },
         {
           "name": "Tribute",
-          "line": 10423,
+          "line": 10510,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11154,7 +11211,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 10424,
+          "line": 10511,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11162,7 +11219,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 10425,
+          "line": 10512,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11170,7 +11227,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 10426,
+          "line": 10513,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11178,7 +11235,7 @@
         },
         {
           "name": "ProliferateTarget",
-          "line": 10427,
+          "line": 10514,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11186,7 +11243,7 @@
         },
         {
           "name": "Populate",
-          "line": 10428,
+          "line": 10515,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11194,7 +11251,7 @@
         },
         {
           "name": "Clash",
-          "line": 10429,
+          "line": 10516,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11202,7 +11259,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 10430,
+          "line": 10517,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11210,7 +11267,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 10432,
+          "line": 10519,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase — skip to the postcombat main phase.",
@@ -11220,7 +11277,7 @@
         },
         {
           "name": "Vote",
-          "line": 10434,
+          "line": 10521,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -11230,7 +11287,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 10436,
+          "line": 10523,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -11240,7 +11297,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 10437,
+          "line": 10524,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11248,7 +11305,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 10438,
+          "line": 10525,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11256,7 +11313,7 @@
         },
         {
           "name": "EpicCopy",
-          "line": 10439,
+          "line": 10526,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11264,7 +11321,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 10440,
+          "line": 10527,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11272,7 +11329,15 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 10441,
+          "line": 10528,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CreateTokenCopyFromPool",
+          "line": 10529,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11280,7 +11345,7 @@
         },
         {
           "name": "Myriad",
-          "line": 10442,
+          "line": 10530,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11288,7 +11353,7 @@
         },
         {
           "name": "Encore",
-          "line": 10443,
+          "line": 10531,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11296,7 +11361,7 @@
         },
         {
           "name": "Meld",
-          "line": 10444,
+          "line": 10532,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11304,7 +11369,7 @@
         },
         {
           "name": "ExileHaunting",
-          "line": 10445,
+          "line": 10533,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11312,7 +11377,7 @@
         },
         {
           "name": "HideawayConceal",
-          "line": 10446,
+          "line": 10534,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11320,7 +11385,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 10447,
+          "line": 10535,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11328,7 +11393,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 10448,
+          "line": 10536,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11336,7 +11401,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 10449,
+          "line": 10537,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11344,7 +11409,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 10450,
+          "line": 10538,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11352,7 +11417,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 10451,
+          "line": 10539,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11360,7 +11425,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 10452,
+          "line": 10540,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11368,7 +11433,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 10453,
+          "line": 10541,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11376,7 +11441,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 10454,
+          "line": 10542,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11384,7 +11449,7 @@
         },
         {
           "name": "Animate",
-          "line": 10455,
+          "line": 10543,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11392,7 +11457,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 10456,
+          "line": 10544,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11400,7 +11465,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 10457,
+          "line": 10545,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11408,7 +11473,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 10458,
+          "line": 10546,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11416,7 +11481,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 10459,
+          "line": 10547,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11424,7 +11489,7 @@
         },
         {
           "name": "Mana",
-          "line": 10460,
+          "line": 10548,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11432,7 +11497,7 @@
         },
         {
           "name": "Discard",
-          "line": 10461,
+          "line": 10549,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11440,7 +11505,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 10462,
+          "line": 10550,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11448,7 +11513,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 10463,
+          "line": 10551,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11456,7 +11521,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 10464,
+          "line": 10552,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11464,7 +11529,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 10465,
+          "line": 10553,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11472,7 +11537,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 10466,
+          "line": 10554,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11480,7 +11545,7 @@
         },
         {
           "name": "Choose",
-          "line": 10467,
+          "line": 10555,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11488,7 +11553,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 10468,
+          "line": 10556,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11496,7 +11561,7 @@
         },
         {
           "name": "Suspect",
-          "line": 10469,
+          "line": 10557,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11504,7 +11569,7 @@
         },
         {
           "name": "Connive",
-          "line": 10470,
+          "line": 10558,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11512,7 +11577,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 10471,
+          "line": 10559,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11520,7 +11585,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 10472,
+          "line": 10560,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11528,7 +11593,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 10473,
+          "line": 10561,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11536,7 +11601,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 10474,
+          "line": 10562,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11544,7 +11609,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 10475,
+          "line": 10563,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11552,7 +11617,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 10477,
+          "line": 10565,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -11562,7 +11627,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 10479,
+          "line": 10567,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -11572,7 +11637,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 10480,
+          "line": 10568,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11580,7 +11645,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 10481,
+          "line": 10569,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11588,7 +11653,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 10482,
+          "line": 10570,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11596,7 +11661,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 10483,
+          "line": 10571,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11604,7 +11669,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 10484,
+          "line": 10572,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11612,7 +11677,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 10485,
+          "line": 10573,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11620,7 +11685,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 10486,
+          "line": 10574,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11628,7 +11693,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 10487,
+          "line": 10575,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11636,7 +11701,7 @@
         },
         {
           "name": "PayCost",
-          "line": 10488,
+          "line": 10576,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11644,7 +11709,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 10489,
+          "line": 10577,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11652,7 +11717,7 @@
         },
         {
           "name": "FreeCastFromZones",
-          "line": 10490,
+          "line": 10578,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11660,7 +11725,7 @@
         },
         {
           "name": "ExileResolvingSpellInsteadOfGraveyard",
-          "line": 10491,
+          "line": 10579,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11668,7 +11733,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 10492,
+          "line": 10580,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11676,7 +11741,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 10493,
+          "line": 10581,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11684,7 +11749,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 10494,
+          "line": 10582,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11692,7 +11757,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 10495,
+          "line": 10583,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11700,7 +11765,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 10496,
+          "line": 10584,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11708,7 +11773,7 @@
         },
         {
           "name": "RollDie",
-          "line": 10497,
+          "line": 10585,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11716,7 +11781,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 10498,
+          "line": 10586,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11724,7 +11789,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 10499,
+          "line": 10587,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11732,7 +11797,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 10500,
+          "line": 10588,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11740,7 +11805,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 10501,
+          "line": 10589,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11748,7 +11813,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 10502,
+          "line": 10590,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11756,7 +11821,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 10503,
+          "line": 10591,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11764,7 +11829,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 10504,
+          "line": 10592,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11772,7 +11837,7 @@
         },
         {
           "name": "Planeswalk",
-          "line": 10505,
+          "line": 10593,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11780,7 +11845,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 10506,
+          "line": 10594,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11788,7 +11853,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 10507,
+          "line": 10595,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11796,7 +11861,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 10508,
+          "line": 10596,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11804,7 +11869,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 10509,
+          "line": 10597,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11812,7 +11877,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 10510,
+          "line": 10598,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11820,7 +11885,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 10511,
+          "line": 10599,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11828,7 +11893,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 10512,
+          "line": 10600,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11836,7 +11901,7 @@
         },
         {
           "name": "Exploit",
-          "line": 10513,
+          "line": 10601,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11844,7 +11909,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 10514,
+          "line": 10602,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11852,7 +11917,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 10515,
+          "line": 10603,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11860,7 +11925,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 10516,
+          "line": 10604,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11868,7 +11933,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 10517,
+          "line": 10605,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11876,7 +11941,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 10518,
+          "line": 10606,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11884,7 +11949,7 @@
         },
         {
           "name": "Discover",
-          "line": 10519,
+          "line": 10607,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11892,7 +11957,7 @@
         },
         {
           "name": "Cascade",
-          "line": 10520,
+          "line": 10608,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11900,7 +11965,7 @@
         },
         {
           "name": "Ripple",
-          "line": 10521,
+          "line": 10609,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11908,7 +11973,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 10522,
+          "line": 10610,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11916,7 +11981,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 10523,
+          "line": 10611,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11924,7 +11989,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 10524,
+          "line": 10612,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11932,7 +11997,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 10525,
+          "line": 10613,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11940,7 +12005,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 10526,
+          "line": 10614,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11948,7 +12013,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 10527,
+          "line": 10615,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11956,7 +12021,7 @@
         },
         {
           "name": "Goad",
-          "line": 10528,
+          "line": 10616,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11964,7 +12029,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 10529,
+          "line": 10617,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11972,7 +12037,7 @@
         },
         {
           "name": "Detain",
-          "line": 10530,
+          "line": 10618,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11980,7 +12045,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 10531,
+          "line": 10619,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11988,7 +12053,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 10532,
+          "line": 10620,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11996,7 +12061,7 @@
         },
         {
           "name": "Incubate",
-          "line": 10533,
+          "line": 10621,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12004,7 +12069,7 @@
         },
         {
           "name": "Amass",
-          "line": 10534,
+          "line": 10622,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12012,7 +12077,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 10535,
+          "line": 10623,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12020,7 +12085,7 @@
         },
         {
           "name": "Specialize",
-          "line": 10536,
+          "line": 10624,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12028,7 +12093,7 @@
         },
         {
           "name": "Renown",
-          "line": 10537,
+          "line": 10625,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12036,7 +12101,7 @@
         },
         {
           "name": "Bolster",
-          "line": 10538,
+          "line": 10626,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12044,7 +12109,7 @@
         },
         {
           "name": "Adapt",
-          "line": 10539,
+          "line": 10627,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12052,7 +12117,7 @@
         },
         {
           "name": "Manifest",
-          "line": 10540,
+          "line": 10628,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12060,7 +12125,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 10541,
+          "line": 10629,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12068,7 +12133,7 @@
         },
         {
           "name": "Cloak",
-          "line": 10543,
+          "line": 10631,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.58a: Cloak (face-down 2/2 with ward {2}).",
@@ -12078,7 +12143,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 10544,
+          "line": 10632,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12086,7 +12151,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 10545,
+          "line": 10633,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12094,7 +12159,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 10546,
+          "line": 10634,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12102,7 +12167,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 10547,
+          "line": 10635,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12110,7 +12175,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 10548,
+          "line": 10636,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12118,7 +12183,7 @@
         },
         {
           "name": "Double",
-          "line": 10549,
+          "line": 10637,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12126,7 +12191,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 10550,
+          "line": 10638,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12134,7 +12199,7 @@
         },
         {
           "name": "Learn",
-          "line": 10551,
+          "line": 10639,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12142,7 +12207,7 @@
         },
         {
           "name": "Forage",
-          "line": 10552,
+          "line": 10640,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12150,7 +12215,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 10553,
+          "line": 10641,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12158,7 +12223,7 @@
         },
         {
           "name": "Endure",
-          "line": 10554,
+          "line": 10642,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12166,7 +12231,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 10555,
+          "line": 10643,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12174,7 +12239,7 @@
         },
         {
           "name": "Seek",
-          "line": 10556,
+          "line": 10644,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12182,7 +12247,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 10557,
+          "line": 10645,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12190,7 +12255,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 10558,
+          "line": 10646,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12198,7 +12263,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 10559,
+          "line": 10647,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12206,7 +12271,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 10560,
+          "line": 10648,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12214,7 +12279,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 10561,
+          "line": 10649,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12222,7 +12287,7 @@
         },
         {
           "name": "Conjure",
-          "line": 10562,
+          "line": 10650,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12230,7 +12295,7 @@
         },
         {
           "name": "Intensify",
-          "line": 10563,
+          "line": 10651,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12238,7 +12303,7 @@
         },
         {
           "name": "DraftFromSpellbook",
-          "line": 10564,
+          "line": 10652,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12246,7 +12311,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 10565,
+          "line": 10653,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12254,7 +12319,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 10566,
+          "line": 10654,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12262,7 +12327,7 @@
         },
         {
           "name": "Equip",
-          "line": 10568,
+          "line": 10656,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -12270,7 +12335,7 @@
         },
         {
           "name": "Crew",
-          "line": 10570,
+          "line": 10658,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -12280,7 +12345,7 @@
         },
         {
           "name": "Station",
-          "line": 10572,
+          "line": 10660,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -12290,7 +12355,7 @@
         },
         {
           "name": "Saddle",
-          "line": 10574,
+          "line": 10662,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -12300,7 +12365,7 @@
         },
         {
           "name": "Reveal",
-          "line": 10576,
+          "line": 10664,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -12308,7 +12373,7 @@
         },
         {
           "name": "Transform",
-          "line": 10577,
+          "line": 10665,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12316,7 +12381,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 10578,
+          "line": 10666,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12324,7 +12389,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 10579,
+          "line": 10667,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12440,13 +12505,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11799,
+      "line": 11888,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 11803,
+          "line": 11892,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -12457,7 +12522,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 11806,
+          "line": 11895,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -12865,7 +12930,7 @@
     },
     "FaceDownBody": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6509,
+      "line": 6550,
       "doc": "CR 708.2a: Whether a face-down permanent is a creature or a non-creature.  CR 708.2a sentence 1 gives the manifest/morph default: a face-down permanent is a 2/2 *creature*. Sentence 2 (\"...unless otherwise specified by the effect that put it onto the battlefield face down\") lets an effect specify a non-creature body instead — e.g. Yedora, Grave Gardener's \"It's a Forest land.\" (It has no other types or abilities.)\". This typed discriminant replaces an implicit \"Creature is always present\" assumption so the same face-down machinery covers both classes without a raw bool.",
       "cr_refs": [
         "CR 708.2a"
@@ -12873,7 +12938,7 @@
       "variants": [
         {
           "name": "Creature",
-          "line": 6515,
+          "line": 6556,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2a (sentence 1): the morph/manifest default — the face-down permanent has the Creature core type (always present) and defaults to 2/2 power/toughness. Any `extra_core_types` are layered on top of Creature (e.g. \"artifact creatures\").",
@@ -12883,7 +12948,7 @@
         },
         {
           "name": "Noncreature",
-          "line": 6520,
+          "line": 6561,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2a (sentence 2): the effect fully specifies the core types and the permanent is NOT a creature — so it has no power/toughness (CR 208.1) and gains no implicit Creature type. Used for \"It's a Forest land.\" The profile's `extra_core_types` are the complete core-type set.",
@@ -15407,14 +15472,15 @@
           "kind": "struct",
           "field_names": [
             "player_id",
-            "object_id"
+            "object_id",
+            "source_id"
           ],
           "doc": "",
           "cr_refs": []
         },
         {
           "name": "DamageCleared",
-          "line": 337,
+          "line": 344,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15424,7 +15490,7 @@
         },
         {
           "name": "GameOver",
-          "line": 340,
+          "line": 347,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -15434,7 +15500,7 @@
         },
         {
           "name": "ResolutionHalted",
-          "line": 351,
+          "line": 358,
           "kind": "struct",
           "field_names": [
             "involved"
@@ -15447,7 +15513,7 @@
         },
         {
           "name": "DamageDealt",
-          "line": 354,
+          "line": 361,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -15461,7 +15527,7 @@
         },
         {
           "name": "DamagePrevented",
-          "line": 365,
+          "line": 372,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -15475,7 +15541,7 @@
         },
         {
           "name": "SpellCountered",
-          "line": 370,
+          "line": 377,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15487,7 +15553,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 378,
+          "line": 385,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15499,7 +15565,7 @@
         },
         {
           "name": "ObjectIntensified",
-          "line": 386,
+          "line": 393,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15510,7 +15576,7 @@
         },
         {
           "name": "Evolved",
-          "line": 392,
+          "line": 399,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15522,7 +15588,7 @@
         },
         {
           "name": "CounterRemoved",
-          "line": 395,
+          "line": 402,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15534,7 +15600,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 400,
+          "line": 407,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15546,7 +15612,7 @@
         },
         {
           "name": "ObjectConjured",
-          "line": 411,
+          "line": 418,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15557,7 +15623,7 @@
         },
         {
           "name": "CreatureDestroyed",
-          "line": 415,
+          "line": 422,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15567,7 +15633,7 @@
         },
         {
           "name": "PermanentSacrificed",
-          "line": 418,
+          "line": 425,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15578,7 +15644,7 @@
         },
         {
           "name": "ControllerChanged",
-          "line": 423,
+          "line": 430,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15592,7 +15658,7 @@
         },
         {
           "name": "EffectResolved",
-          "line": 428,
+          "line": 435,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -15603,7 +15669,7 @@
         },
         {
           "name": "Unattached",
-          "line": 434,
+          "line": 441,
           "kind": "struct",
           "field_names": [
             "attachment_id",
@@ -15616,7 +15682,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 438,
+          "line": 445,
           "kind": "struct",
           "field_names": [
             "attacker_ids",
@@ -15628,7 +15694,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 445,
+          "line": 452,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -15638,7 +15704,7 @@
         },
         {
           "name": "CombatTaxPaid",
-          "line": 450,
+          "line": 457,
           "kind": "struct",
           "field_names": [
             "player",
@@ -15652,7 +15718,7 @@
         },
         {
           "name": "CombatTaxDeclined",
-          "line": 456,
+          "line": 463,
           "kind": "struct",
           "field_names": [
             "player",
@@ -15666,7 +15732,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 460,
+          "line": 467,
           "kind": "struct",
           "field_names": [
             "target",
@@ -15677,7 +15743,7 @@
         },
         {
           "name": "VehicleCrewed",
-          "line": 466,
+          "line": 473,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -15690,7 +15756,7 @@
         },
         {
           "name": "Stationed",
-          "line": 476,
+          "line": 483,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -15704,7 +15770,7 @@
         },
         {
           "name": "Saddled",
-          "line": 486,
+          "line": 493,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -15717,7 +15783,7 @@
         },
         {
           "name": "ReplacementApplied",
-          "line": 490,
+          "line": 497,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -15728,7 +15794,7 @@
         },
         {
           "name": "Transformed",
-          "line": 494,
+          "line": 501,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15738,7 +15804,7 @@
         },
         {
           "name": "Specialized",
-          "line": 498,
+          "line": 505,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15749,7 +15815,7 @@
         },
         {
           "name": "DayNightChanged",
-          "line": 502,
+          "line": 509,
           "kind": "struct",
           "field_names": [
             "new_state"
@@ -15759,7 +15825,7 @@
         },
         {
           "name": "TurnedFaceUp",
-          "line": 505,
+          "line": 512,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15769,7 +15835,7 @@
         },
         {
           "name": "CardsRevealed",
-          "line": 508,
+          "line": 515,
           "kind": "struct",
           "field_names": [
             "player",
@@ -15781,7 +15847,7 @@
         },
         {
           "name": "CombatDamageDealtToPlayer",
-          "line": 514,
+          "line": 521,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15793,7 +15859,7 @@
         },
         {
           "name": "PlayerEliminated",
-          "line": 540,
+          "line": 547,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15803,7 +15869,7 @@
         },
         {
           "name": "CrimeCommitted",
-          "line": 543,
+          "line": 550,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15813,7 +15879,7 @@
         },
         {
           "name": "Cycled",
-          "line": 546,
+          "line": 553,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15824,7 +15890,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 550,
+          "line": 557,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15835,7 +15901,7 @@
         },
         {
           "name": "Regenerated",
-          "line": 555,
+          "line": 562,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15847,7 +15913,7 @@
         },
         {
           "name": "CreatureSuspected",
-          "line": 559,
+          "line": 566,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15859,7 +15925,7 @@
         },
         {
           "name": "Detained",
-          "line": 566,
+          "line": 573,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15871,7 +15937,7 @@
         },
         {
           "name": "BecamePrepared",
-          "line": 572,
+          "line": 579,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15883,7 +15949,7 @@
         },
         {
           "name": "BecameUnprepared",
-          "line": 578,
+          "line": 585,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15895,7 +15961,7 @@
         },
         {
           "name": "CaseSolved",
-          "line": 582,
+          "line": 589,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15907,7 +15973,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 586,
+          "line": 593,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15920,7 +15986,7 @@
         },
         {
           "name": "MonarchChanged",
-          "line": 591,
+          "line": 598,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15932,7 +15998,7 @@
         },
         {
           "name": "CityBlessingGained",
-          "line": 595,
+          "line": 602,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15944,7 +16010,7 @@
         },
         {
           "name": "DieRolled",
-          "line": 601,
+          "line": 608,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15960,7 +16026,7 @@
         },
         {
           "name": "StartingPlayerContest",
-          "line": 614,
+          "line": 621,
           "kind": "struct",
           "field_names": [
             "rounds",
@@ -15974,7 +16040,7 @@
         },
         {
           "name": "CoinFlipped",
-          "line": 619,
+          "line": 626,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15987,7 +16053,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 624,
+          "line": 631,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15999,7 +16065,7 @@
         },
         {
           "name": "RoomEntered",
-          "line": 628,
+          "line": 635,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16014,7 +16080,7 @@
         },
         {
           "name": "RoomDoorUnlocked",
-          "line": 635,
+          "line": 642,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16029,7 +16095,7 @@
         },
         {
           "name": "BecomesPlotted",
-          "line": 642,
+          "line": 649,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -16042,7 +16108,7 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 647,
+          "line": 654,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16055,7 +16121,7 @@
         },
         {
           "name": "Planeswalked",
-          "line": 654,
+          "line": 661,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16070,7 +16136,7 @@
         },
         {
           "name": "ChaosEnsued",
-          "line": 661,
+          "line": 668,
           "kind": "struct",
           "field_names": [
             "plane_id"
@@ -16083,7 +16149,7 @@
         },
         {
           "name": "PlanarDieRolled",
-          "line": 665,
+          "line": 672,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16096,7 +16162,7 @@
         },
         {
           "name": "SchemeSetInMotion",
-          "line": 671,
+          "line": 678,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16110,7 +16176,7 @@
         },
         {
           "name": "SchemeAbandoned",
-          "line": 677,
+          "line": 684,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16124,7 +16190,7 @@
         },
         {
           "name": "InitiativeTaken",
-          "line": 682,
+          "line": 689,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -16136,7 +16202,7 @@
         },
         {
           "name": "AttractionOpened",
-          "line": 686,
+          "line": 693,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16149,7 +16215,7 @@
         },
         {
           "name": "AttractionsRolledToVisit",
-          "line": 691,
+          "line": 698,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16162,7 +16228,7 @@
         },
         {
           "name": "AttractionVisited",
-          "line": 696,
+          "line": 703,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16177,7 +16243,7 @@
         },
         {
           "name": "Firebend",
-          "line": 702,
+          "line": 709,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16188,7 +16254,7 @@
         },
         {
           "name": "Airbend",
-          "line": 707,
+          "line": 714,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16199,7 +16265,7 @@
         },
         {
           "name": "Earthbend",
-          "line": 712,
+          "line": 719,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16210,7 +16276,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 717,
+          "line": 724,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16221,7 +16287,7 @@
         },
         {
           "name": "CompanionRevealed",
-          "line": 722,
+          "line": 729,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16234,7 +16300,7 @@
         },
         {
           "name": "CompanionMovedToHand",
-          "line": 727,
+          "line": 734,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16247,7 +16313,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 734,
+          "line": 741,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16260,7 +16326,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 744,
+          "line": 751,
           "kind": "struct",
           "field_names": [
             "ability_tag",
@@ -16277,7 +16343,7 @@
         },
         {
           "name": "CreatureExploited",
-          "line": 752,
+          "line": 759,
           "kind": "struct",
           "field_names": [
             "exploiter",
@@ -16290,7 +16356,7 @@
         },
         {
           "name": "EnergyChanged",
-          "line": 757,
+          "line": 764,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16303,7 +16369,7 @@
         },
         {
           "name": "SpeedChanged",
-          "line": 762,
+          "line": 769,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16317,7 +16383,7 @@
         },
         {
           "name": "PlayerCounterChanged",
-          "line": 768,
+          "line": 775,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16331,7 +16397,7 @@
         },
         {
           "name": "ManaExpended",
-          "line": 774,
+          "line": 781,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16345,7 +16411,7 @@
         },
         {
           "name": "Clash",
-          "line": 780,
+          "line": 787,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -16361,7 +16427,7 @@
         },
         {
           "name": "VoteCast",
-          "line": 791,
+          "line": 798,
           "kind": "struct",
           "field_names": [
             "voter",
@@ -16375,7 +16441,7 @@
         },
         {
           "name": "VoteResolved",
-          "line": 799,
+          "line": 806,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16388,7 +16454,7 @@
         },
         {
           "name": "PowerToughnessChanged",
-          "line": 805,
+          "line": 812,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -16402,7 +16468,7 @@
         },
         {
           "name": "CascadeMissed",
-          "line": 816,
+          "line": 823,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -16416,7 +16482,7 @@
         },
         {
           "name": "DebugActionUsed",
-          "line": 824,
+          "line": 831,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16427,7 +16493,7 @@
         },
         {
           "name": "DebugPermissionGranted",
-          "line": 830,
+          "line": 837,
           "kind": "struct",
           "field_names": [
             "host",
@@ -16438,7 +16504,7 @@
         },
         {
           "name": "DebugPermissionRevoked",
-          "line": 835,
+          "line": 842,
           "kind": "struct",
           "field_names": [
             "host",
@@ -16606,6 +16672,14 @@
           "kind": "unit",
           "field_names": [],
           "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Momir",
+          "line": 58,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Momir Basic: 60 basic lands, 24 life, a game-start command-zone emblem granting \"{X}, Discard a card: Create a token that's a copy of a creature card with mana value X chosen at random.\"",
           "cr_refs": []
         }
       ],
@@ -16776,13 +16850,13 @@
     },
     "IntensityScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6415,
+      "line": 6456,
       "doc": "Digital-only Alchemy: which cards an `Effect::Intensify` applies to. Every scope resolves across ALL zones (a card's intensity follows it everywhere).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 6418,
+          "line": 6459,
           "kind": "unit",
           "field_names": [],
           "doc": "\"this creature/artifact/… intensifies\" — the source object only.",
@@ -16790,7 +16864,7 @@
         },
         {
           "name": "OwnedSameName",
-          "line": 6421,
+          "line": 6462,
           "kind": "unit",
           "field_names": [],
           "doc": "\"cards you own named [this card] intensify\" — every card the source's controller owns with the source's name.",
@@ -16798,7 +16872,7 @@
         },
         {
           "name": "OwnedSubtype",
-          "line": 6424,
+          "line": 6465,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -16811,7 +16885,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11585,
+      "line": 11674,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -16820,7 +16894,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 11588,
+          "line": 11677,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -18592,7 +18666,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14382,
+      "line": 14489,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -18601,7 +18675,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 14384,
+          "line": 14491,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -18614,7 +18688,7 @@
         },
         {
           "name": "Crew",
-          "line": 14390,
+          "line": 14497,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -18627,7 +18701,7 @@
         },
         {
           "name": "Saddle",
-          "line": 14396,
+          "line": 14503,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -18640,7 +18714,7 @@
         },
         {
           "name": "Station",
-          "line": 14404,
+          "line": 14511,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -19807,7 +19881,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12228,
+      "line": 12317,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -19817,7 +19891,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 12230,
+          "line": 12319,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -19827,7 +19901,7 @@
         },
         {
           "name": "Second",
-          "line": 12233,
+          "line": 12322,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -20111,13 +20185,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6349,
+      "line": 6390,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 6350,
+          "line": 6391,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20125,7 +20199,7 @@
         },
         {
           "name": "Bottom",
-          "line": 6351,
+          "line": 6392,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20133,7 +20207,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 6353,
+          "line": 6394,
           "kind": "struct",
           "field_names": [
             "n"
@@ -20985,7 +21059,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13569,
+      "line": 13665,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -20994,7 +21068,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 13572,
+          "line": 13668,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -21006,7 +21080,7 @@
         },
         {
           "name": "Multiply",
-          "line": 13575,
+          "line": 13671,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -21268,7 +21342,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13581,
+      "line": 13677,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -21277,7 +21351,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 13584,
+          "line": 13680,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -21285,7 +21359,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 13586,
+          "line": 13682,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -21811,13 +21885,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10868,
+      "line": 10957,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 10870,
+          "line": 10959,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -21829,7 +21903,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 10873,
+          "line": 10962,
           "kind": "struct",
           "field_names": [
             "source",
@@ -21850,13 +21924,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10848,
+      "line": 10937,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 10849,
+          "line": 10938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21864,7 +21938,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 10852,
+          "line": 10941,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -21879,7 +21953,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 10859,
+          "line": 10948,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -21889,7 +21963,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 10862,
+          "line": 10951,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -21990,7 +22064,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5145,
+      "line": 5186,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -22000,7 +22074,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 5147,
+          "line": 5188,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -22010,7 +22084,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 5149,
+          "line": 5190,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -22023,13 +22097,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3984,
+      "line": 4016,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 3985,
+          "line": 4017,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22037,7 +22111,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3986,
+          "line": 4018,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22045,7 +22119,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 3987,
+          "line": 4019,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22135,9 +22209,30 @@
             "CR 608.2c",
             "CR 608.2k"
           ]
+        },
+        {
+          "name": "EventTarget",
+          "line": 3372,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 603.2 + CR 120.1: The object that **received** the damage referenced by the current trigger event — the recipient counterpart to [`ObjectScope::EventSource`]. This is \"that creature\" in \"deals noncombat damage to a creature equal to that creature's toughness\": the antecedent is the damaged object carried by the `DamageDealt` event, not the ability source or a target. Resolved at both trigger detection and resolution (CR 603.4 intervening-if) via `extract_target_object_from_event`.",
+          "cr_refs": [
+            "CR 120.1",
+            "CR 603.2",
+            "CR 603.4"
+          ]
         }
       ],
-      "sibling_clusters": []
+      "sibling_clusters": [
+        {
+          "shared_root": "Event",
+          "members": [
+            "EventSource",
+            "EventTarget"
+          ],
+          "smell_score": "LOW"
+        }
+      ]
     },
     "OpeningHandBottomReason": {
       "file": "crates/engine/src/types/game_state.rs",
@@ -22179,7 +22274,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13019,
+      "line": 13115,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -22189,7 +22284,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 13021,
+          "line": 13117,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -22197,7 +22292,7 @@
         },
         {
           "name": "Equals",
-          "line": 13023,
+          "line": 13119,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -22205,7 +22300,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 13026,
+          "line": 13122,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -22213,7 +22308,7 @@
         },
         {
           "name": "OneOf",
-          "line": 13028,
+          "line": 13124,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -22355,7 +22450,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4909,
+      "line": 4950,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -22364,7 +22459,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 4910,
+          "line": 4951,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22374,7 +22469,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 4914,
+          "line": 4955,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -22384,7 +22479,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 4915,
+          "line": 4956,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22392,7 +22487,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 4917,
+          "line": 4958,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -22402,7 +22497,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 4918,
+          "line": 4959,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -22412,7 +22507,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 4921,
+          "line": 4962,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -22423,7 +22518,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 4925,
+          "line": 4966,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -22433,7 +22528,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 4929,
+          "line": 4970,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -22443,7 +22538,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 4931,
+          "line": 4972,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -22453,7 +22548,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 4932,
+          "line": 4973,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22461,7 +22556,7 @@
         },
         {
           "name": "SourceAttachedTo",
-          "line": 4936,
+          "line": 4977,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -22474,7 +22569,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 4939,
+          "line": 4980,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -22484,7 +22579,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 4942,
+          "line": 4983,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -22494,7 +22589,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 4945,
+          "line": 4986,
           "kind": "struct",
           "field_names": [
             "color"
@@ -22504,7 +22599,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 4948,
+          "line": 4989,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22512,7 +22607,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 4949,
+          "line": 4990,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22520,7 +22615,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 4950,
+          "line": 4991,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22528,7 +22623,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 4951,
+          "line": 4992,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22539,7 +22634,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 4955,
+          "line": 4996,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22550,7 +22645,7 @@
         },
         {
           "name": "ZoneCoreTypeCardCountAtLeast",
-          "line": 4959,
+          "line": 5000,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22562,7 +22657,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 4964,
+          "line": 5005,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22574,7 +22669,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 4969,
+          "line": 5010,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22584,7 +22679,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 4972,
+          "line": 5013,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22594,7 +22689,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 4975,
+          "line": 5016,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -22604,7 +22699,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 4980,
+          "line": 5021,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22616,7 +22711,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4989,
+          "line": 5030,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22631,7 +22726,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 4994,
+          "line": 5035,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -22641,7 +22736,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 4997,
+          "line": 5038,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22651,7 +22746,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 5000,
+          "line": 5041,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -22662,7 +22757,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 5004,
+          "line": 5045,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -22673,7 +22768,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 5008,
+          "line": 5049,
           "kind": "struct",
           "field_names": [
             "color",
@@ -22684,7 +22779,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 5012,
+          "line": 5053,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -22694,7 +22789,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 5015,
+          "line": 5056,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22702,7 +22797,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 5016,
+          "line": 5057,
           "kind": "struct",
           "field_names": [
             "name"
@@ -22712,7 +22807,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 5023,
+          "line": 5064,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -22725,7 +22820,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 5027,
+          "line": 5068,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -22735,7 +22830,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 5030,
+          "line": 5071,
           "kind": "struct",
           "field_names": [
             "power",
@@ -22746,7 +22841,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 5034,
+          "line": 5075,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22754,7 +22849,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 5035,
+          "line": 5076,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22764,7 +22859,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 5038,
+          "line": 5079,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22774,7 +22869,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 5041,
+          "line": 5082,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22784,7 +22879,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 5044,
+          "line": 5085,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22792,7 +22887,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 5045,
+          "line": 5086,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22800,7 +22895,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 5046,
+          "line": 5087,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22810,7 +22905,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 5052,
+          "line": 5093,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -22818,7 +22913,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 5055,
+          "line": 5096,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22831,7 +22926,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 5059,
+          "line": 5100,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22839,7 +22934,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 5060,
+          "line": 5101,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22849,7 +22944,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 5063,
+          "line": 5104,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22857,7 +22952,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 5064,
+          "line": 5105,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22865,7 +22960,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 5065,
+          "line": 5106,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22873,7 +22968,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 5066,
+          "line": 5107,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22881,7 +22976,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 5068,
+          "line": 5109,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -22891,7 +22986,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 5069,
+          "line": 5110,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22899,7 +22994,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 5070,
+          "line": 5111,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22907,7 +23002,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 5071,
+          "line": 5112,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22915,7 +23010,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 5072,
+          "line": 5113,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22926,7 +23021,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 5076,
+          "line": 5117,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22936,7 +23031,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 5081,
+          "line": 5122,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -22949,7 +23044,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 5086,
+          "line": 5127,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -22959,7 +23054,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 5094,
+          "line": 5135,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -22969,7 +23064,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 5107,
+          "line": 5148,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22983,7 +23078,7 @@
         },
         {
           "name": "And",
-          "line": 5115,
+          "line": 5156,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -22996,7 +23091,7 @@
         },
         {
           "name": "Or",
-          "line": 5121,
+          "line": 5162,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23009,7 +23104,7 @@
         },
         {
           "name": "Not",
-          "line": 5128,
+          "line": 5169,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -23894,13 +23989,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4083,
+      "line": 4115,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 4087,
+          "line": 4119,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -23910,7 +24005,7 @@
         },
         {
           "name": "Opponent",
-          "line": 4089,
+          "line": 4121,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -23918,7 +24013,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 4091,
+          "line": 4123,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -23928,7 +24023,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 4093,
+          "line": 4125,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -23936,7 +24031,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 4095,
+          "line": 4127,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -23944,7 +24039,7 @@
         },
         {
           "name": "HasLostTheGame",
-          "line": 4100,
+          "line": 4132,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3 + CR 104.5: Each player who has lost the game (`is_eliminated`). Quantity-only: players who lost have left the game, so this is not a live effect recipient filter. Rampant Frogantua class: \"+10/+10 for each player who has lost the game\".",
@@ -23955,7 +24050,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 4110,
+          "line": 4142,
           "kind": "struct",
           "field_names": [
             "source"
@@ -23970,7 +24065,7 @@
         },
         {
           "name": "OpponentAttacked",
-          "line": 4124,
+          "line": 4156,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -23986,7 +24081,7 @@
         },
         {
           "name": "All",
-          "line": 4129,
+          "line": 4161,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -23994,7 +24089,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 4131,
+          "line": 4163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -24004,7 +24099,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 4134,
+          "line": 4166,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -24012,7 +24107,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 4138,
+          "line": 4170,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24026,7 +24121,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 4144,
+          "line": 4176,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -24034,7 +24129,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 4148,
+          "line": 4180,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -24045,7 +24140,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 4157,
+          "line": 4189,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -24056,7 +24151,7 @@
         },
         {
           "name": "OpponentOfTriggeringPlayerNotAttacked",
-          "line": 4163,
+          "line": 4195,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 508.6 + CR 603.4: Each opponent of the *triggering/attacking* player (resolved from the active AttackersDeclared trigger event) who is NOT in that player's attacked-this-combat set. Models \"that player has another opponent who isn't being attacked\" (Suppressor Skyguard); counted via QuantityRef::PlayerCount, gated as count >= 1.",
@@ -24068,7 +24163,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 4174,
+          "line": 4206,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -24081,7 +24176,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 4186,
+          "line": 4218,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -24092,7 +24187,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 4208,
+          "line": 4240,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24108,7 +24203,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 4234,
+          "line": 4266,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24126,7 +24221,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 4250,
+          "line": 4282,
           "kind": "struct",
           "field_names": [
             "index"
@@ -24139,7 +24234,7 @@
         },
         {
           "name": "ParentObjectTargetOwner",
-          "line": 4260,
+          "line": 4292,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 109.4: The owner of the first object target of the resolving ability. The owner-axis sibling of `ParentObjectTargetController`, completing the owner/controller pair that `PlayerScope` (`ParentObjectTargetController`) and `TargetFilter` (`ParentTargetOwner` / `ParentTargetController`) already carry. Resolved via `ability_utils::parent_target_owner`. Powers the \"[target's owner] …, then faces a villainous choice — …\" class (This Is How It Ends) where the player facing the choice is the owner of the targeted permanent named in the prior clause, not the ability controller.",
@@ -24162,7 +24257,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4052,
+      "line": 4084,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -24172,7 +24267,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 4054,
+          "line": 4086,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -24180,7 +24275,7 @@
         },
         {
           "name": "Opponent",
-          "line": 4056,
+          "line": 4088,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -24188,7 +24283,7 @@
         },
         {
           "name": "All",
-          "line": 4058,
+          "line": 4090,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -24343,7 +24438,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13689,
+      "line": 13785,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -24352,7 +24447,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 13690,
+          "line": 13786,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24360,7 +24455,7 @@
         },
         {
           "name": "Resolved",
-          "line": 13691,
+          "line": 13787,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24984,7 +25079,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4528,
+      "line": 4560,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -24992,7 +25087,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 4530,
+          "line": 4562,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -25002,7 +25097,7 @@
         },
         {
           "name": "Toughness",
-          "line": 4532,
+          "line": 4564,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -25012,7 +25107,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 4534,
+          "line": 4566,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -25058,7 +25153,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4543,
+      "line": 4575,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -25067,7 +25162,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 4546,
+          "line": 4578,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -25077,7 +25172,7 @@
         },
         {
           "name": "Base",
-          "line": 4549,
+          "line": 4581,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -25090,13 +25185,13 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4267,
+      "line": 4299,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Ref",
-          "line": 4269,
+          "line": 4301,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -25106,7 +25201,7 @@
         },
         {
           "name": "Fixed",
-          "line": 4271,
+          "line": 4303,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25116,7 +25211,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 4275,
+          "line": 4307,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25130,7 +25225,7 @@
         },
         {
           "name": "Offset",
-          "line": 4282,
+          "line": 4314,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25143,7 +25238,7 @@
         },
         {
           "name": "ClampMin",
-          "line": 4291,
+          "line": 4323,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25156,7 +25251,7 @@
         },
         {
           "name": "Multiply",
-          "line": 4296,
+          "line": 4328,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -25167,7 +25262,7 @@
         },
         {
           "name": "Sum",
-          "line": 4305,
+          "line": 4337,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -25177,7 +25272,7 @@
         },
         {
           "name": "UpTo",
-          "line": 4330,
+          "line": 4362,
           "kind": "struct",
           "field_names": [
             "max"
@@ -25190,7 +25285,7 @@
         },
         {
           "name": "Power",
-          "line": 4336,
+          "line": 4368,
           "kind": "struct",
           "field_names": [
             "base",
@@ -25203,7 +25298,7 @@
         },
         {
           "name": "Difference",
-          "line": 4351,
+          "line": 4383,
           "kind": "struct",
           "field_names": [
             "left",
@@ -25219,7 +25314,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13535,
+      "line": 13631,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -25227,7 +25322,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 13537,
+          "line": 13633,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
@@ -25235,7 +25330,7 @@
         },
         {
           "name": "Plus",
-          "line": 13539,
+          "line": 13635,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25245,7 +25340,7 @@
         },
         {
           "name": "Minus",
-          "line": 13541,
+          "line": 13637,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25255,7 +25350,7 @@
         },
         {
           "name": "Prevent",
-          "line": 13561,
+          "line": 13657,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -25272,13 +25367,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3402,
+      "line": 3411,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 3406,
+          "line": 3415,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25290,7 +25385,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 3409,
+          "line": 3418,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25302,7 +25397,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 3415,
+          "line": 3424,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25314,7 +25409,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 3418,
+          "line": 3427,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -25322,7 +25417,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 3420,
+          "line": 3429,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -25332,7 +25427,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 3423,
+          "line": 3432,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25342,7 +25437,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 3440,
+          "line": 3449,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25356,7 +25451,7 @@
         },
         {
           "name": "ObjectCountBySharedQuality",
-          "line": 3450,
+          "line": 3459,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25371,7 +25466,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 3457,
+          "line": 3466,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25381,7 +25476,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 3478,
+          "line": 3487,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25394,7 +25489,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 3487,
+          "line": 3496,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -25407,7 +25502,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 3506,
+          "line": 3515,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -25424,7 +25519,7 @@
         },
         {
           "name": "Variable",
-          "line": 3511,
+          "line": 3520,
           "kind": "struct",
           "field_names": [
             "name"
@@ -25434,7 +25529,7 @@
         },
         {
           "name": "Power",
-          "line": 3518,
+          "line": 3527,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25448,7 +25543,7 @@
         },
         {
           "name": "Intensity",
-          "line": 3522,
+          "line": 3531,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25458,7 +25553,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3527,
+          "line": 3536,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25472,7 +25567,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 3533,
+          "line": 3542,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25485,7 +25580,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 3539,
+          "line": 3548,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25498,7 +25593,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 3544,
+          "line": 3553,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25511,7 +25606,7 @@
         },
         {
           "name": "ObjectTypelineComponentCount",
-          "line": 3548,
+          "line": 3557,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25525,7 +25620,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 3555,
+          "line": 3564,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25539,7 +25634,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 3567,
+          "line": 3576,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -25551,7 +25646,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 3569,
+          "line": 3578,
           "kind": "struct",
           "field_names": [
             "function",
@@ -25565,7 +25660,7 @@
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 3586,
+          "line": 3595,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25579,7 +25674,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 3593,
+          "line": 3602,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -25589,7 +25684,7 @@
         },
         {
           "name": "Devotion",
-          "line": 3595,
+          "line": 3604,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -25601,7 +25696,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 3599,
+          "line": 3608,
           "kind": "struct",
           "field_names": [
             "source"
@@ -25613,7 +25708,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 3604,
+          "line": 3613,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -25624,7 +25719,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 3608,
+          "line": 3617,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -25639,7 +25734,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 3617,
+          "line": 3626,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -25651,7 +25746,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 3621,
+          "line": 3630,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -25661,7 +25756,7 @@
         },
         {
           "name": "FilteredTrackedSetSize",
-          "line": 3636,
+          "line": 3645,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25676,7 +25771,7 @@
         },
         {
           "name": "ExiledFromHandThisResolution",
-          "line": 3646,
+          "line": 3655,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -25687,7 +25782,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 3650,
+          "line": 3659,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -25697,7 +25792,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 3665,
+          "line": 3674,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25710,7 +25805,7 @@
         },
         {
           "name": "PartySize",
-          "line": 3674,
+          "line": 3683,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25723,7 +25818,7 @@
         },
         {
           "name": "UnspentMana",
-          "line": 3683,
+          "line": 3692,
           "kind": "struct",
           "field_names": [
             "color"
@@ -25735,7 +25830,7 @@
         },
         {
           "name": "Speed",
-          "line": 3690,
+          "line": 3699,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25747,7 +25842,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 3693,
+          "line": 3702,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -25757,7 +25852,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 3701,
+          "line": 3710,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -25771,7 +25866,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 3713,
+          "line": 3722,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -25783,7 +25878,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 3716,
+          "line": 3725,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25796,7 +25891,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 3723,
+          "line": 3732,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25806,7 +25901,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 3729,
+          "line": 3738,
           "kind": "struct",
           "field_names": [
             "player",
@@ -25819,7 +25914,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 3734,
+          "line": 3743,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -25829,7 +25924,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 3740,
+          "line": 3749,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25841,7 +25936,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 3745,
+          "line": 3754,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25853,7 +25948,7 @@
         },
         {
           "name": "LandsPlayedThisTurn",
-          "line": 3750,
+          "line": 3759,
           "kind": "struct",
           "field_names": [
             "player",
@@ -25867,7 +25962,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 3757,
+          "line": 3766,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -25877,7 +25972,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 3761,
+          "line": 3770,
           "kind": "struct",
           "field_names": [
             "from",
@@ -25891,8 +25986,29 @@
           ]
         },
         {
+          "name": "ZoneChangeAggregateThisTurn",
+          "line": 3788,
+          "kind": "struct",
+          "field_names": [
+            "from",
+            "to",
+            "filter",
+            "function",
+            "property"
+          ],
+          "doc": "CR 400.7 + CR 603.10a + CR 700.4: Aggregate (sum/max/min via `function`) of an object `property` over this turn's zone-change records matching `from`/`to` and `filter`, using each moved object's last-known characteristics. The COUNT of the same population is `ZoneChangeCountThisTurn`; this is the value-aggregate sibling. CR 208.1 supplies each record's power/toughness; CR 202.3 its mana value. (The Comprehensive Rules define no general \"sum/max/min of a property\" rule — the reduction is a derived computation over the per-record CR 208.1/202.3 values, consumed by the surrounding effect's own rule, e.g. CR 119 for life loss.) Used by \"[loses life / draws / deals damage] equal to the total power of [type] that died this turn\" (Genesis of the Daleks).",
+          "cr_refs": [
+            "CR 119",
+            "CR 202.3",
+            "CR 208.1",
+            "CR 400.7",
+            "CR 603.10a",
+            "CR 700.4"
+          ]
+        },
+        {
           "name": "DamageDealtThisTurn",
-          "line": 3781,
+          "line": 3810,
           "kind": "struct",
           "field_names": [
             "source",
@@ -25910,7 +26026,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 3800,
+          "line": 3829,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -25918,7 +26034,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 3810,
+          "line": 3839,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25931,7 +26047,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 3817,
+          "line": 3846,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -25941,7 +26057,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 3825,
+          "line": 3854,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25955,7 +26071,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 3828,
+          "line": 3857,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -25965,7 +26081,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 3842,
+          "line": 3871,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25979,7 +26095,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 3853,
+          "line": 3882,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -25994,7 +26110,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 3862,
+          "line": 3891,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26007,7 +26123,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 3867,
+          "line": 3896,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26021,7 +26137,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 3875,
+          "line": 3904,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26035,7 +26151,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 3880,
+          "line": 3909,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -26045,7 +26161,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 3887,
+          "line": 3916,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -26055,7 +26171,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 3890,
+          "line": 3919,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -26066,7 +26182,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 3894,
+          "line": 3923,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -26078,7 +26194,7 @@
         },
         {
           "name": "AdditionalCostPaymentCountFor",
-          "line": 3898,
+          "line": 3927,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -26092,7 +26208,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 3906,
+          "line": 3935,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -26102,7 +26218,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 3911,
+          "line": 3940,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26116,7 +26232,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 3922,
+          "line": 3951,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -26127,7 +26243,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 3927,
+          "line": 3956,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -26137,7 +26253,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 3934,
+          "line": 3963,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26151,7 +26267,7 @@
         },
         {
           "name": "DistinctCounterKindsAmong",
-          "line": 3943,
+          "line": 3972,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26165,7 +26281,7 @@
         },
         {
           "name": "VoteCount",
-          "line": 3950,
+          "line": 3979,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -26248,7 +26364,7 @@
     },
     "RenownSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12421,
+      "line": 12510,
       "doc": "CR 702.112: Which creature's renowned designation an `IsRenowned` condition reads.  Renowned (CR 702.112b) is a per-permanent designation other spells and abilities can identify, so a condition may reference either the ability's own permanent or a different (event-subject) creature.   - `Source` — the ability's own permanent (\"~\"), as in Renown's own     intervening-if (CR 702.112a, \"if it isn't renowned\" where \"it\" == this creature).   - `EventSubject` — the creature named by the triggering event (\"it\"), a creature     other than the source (CR 702.112b).",
       "cr_refs": [
         "CR 702.112",
@@ -26258,7 +26374,7 @@
       "variants": [
         {
           "name": "Source",
-          "line": 12422,
+          "line": 12511,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26266,7 +26382,7 @@
         },
         {
           "name": "EventSubject",
-          "line": 12423,
+          "line": 12512,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26277,7 +26393,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11561,
+      "line": 11650,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -26286,7 +26402,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 11565,
+          "line": 11654,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -26296,7 +26412,7 @@
         },
         {
           "name": "UntilStopConditions",
-          "line": 11571,
+          "line": 11660,
           "kind": "struct",
           "field_names": [
             "stop_on_put_to_hand",
@@ -26313,13 +26429,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12798,
+      "line": 12887,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 12801,
+          "line": 12890,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -26331,7 +26447,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 12807,
+          "line": 12896,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -26341,7 +26457,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 12814,
+          "line": 12903,
           "kind": "struct",
           "field_names": [
             "count",
@@ -26354,7 +26470,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 12819,
+          "line": 12908,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26366,7 +26482,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 12824,
+          "line": 12913,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26379,7 +26495,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 12827,
+          "line": 12916,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -26391,7 +26507,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 12830,
+          "line": 12919,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -26401,7 +26517,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 12833,
+          "line": 12922,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -26412,7 +26528,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 12841,
+          "line": 12930,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26425,7 +26541,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 12855,
+          "line": 12944,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26438,7 +26554,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 12864,
+          "line": 12953,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -26449,7 +26565,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 12867,
+          "line": 12956,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -26459,7 +26575,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 12873,
+          "line": 12962,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26471,7 +26587,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 12878,
+          "line": 12967,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -26483,7 +26599,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 12883,
+          "line": 12972,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -26494,7 +26610,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 12892,
+          "line": 12981,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -26506,7 +26622,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 12899,
+          "line": 12988,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -26520,7 +26636,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 12907,
+          "line": 12996,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -26530,7 +26646,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 12912,
+          "line": 13001,
           "kind": "struct",
           "field_names": [
             "source"
@@ -26544,7 +26660,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 12916,
+          "line": 13005,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26557,7 +26673,7 @@
         },
         {
           "name": "EffectCausedDiscard",
-          "line": 12921,
+          "line": 13010,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 701.9a: Replacement applies only when the discard was caused by resolving a spell or ability effect, not by paying a cost or by a turn-based action (cleanup hand-size discard). Used by Library of Leng (\"If an effect causes you to discard a card...\").",
@@ -26568,7 +26684,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 12926,
+          "line": 13015,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -26579,7 +26695,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 12937,
+          "line": 13026,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -26592,7 +26708,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 12948,
+          "line": 13037,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -26604,7 +26720,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 12956,
+          "line": 13045,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26617,7 +26733,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 12966,
+          "line": 13055,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26629,7 +26745,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 12971,
+          "line": 13060,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27045,13 +27161,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13655,
+      "line": 13751,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 13658,
+          "line": 13754,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -27059,7 +27175,7 @@
         },
         {
           "name": "Optional",
-          "line": 13660,
+          "line": 13756,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -27069,7 +27185,7 @@
         },
         {
           "name": "MayCost",
-          "line": 13667,
+          "line": 13763,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -27086,7 +27202,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13643,
+      "line": 13739,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source player. For permanents/spells this is the source's controller; for cards outside the battlefield/stack, CR 109.4 + CR 108.4a make this the owner. `valid_player: None` keeps the source-player default; `Some(You)` is the explicit source-player scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 108.4a",
@@ -27096,7 +27212,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 13645,
+          "line": 13741,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source player.",
@@ -27104,7 +27220,7 @@
         },
         {
           "name": "Opponent",
-          "line": 13647,
+          "line": 13743,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source player.",
@@ -27112,7 +27228,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 13649,
+          "line": 13745,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -27368,7 +27484,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3957,
+      "line": 3986,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -27376,7 +27492,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 3958,
+          "line": 3987,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27384,7 +27500,7 @@
         },
         {
           "name": "Down",
-          "line": 3959,
+          "line": 3988,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27395,7 +27511,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5238,
+      "line": 5279,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -27403,7 +27519,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 5240,
+          "line": 5281,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -27414,7 +27530,7 @@
     },
     "SacrificeAggregateStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5357,
+      "line": 5398,
       "doc": "CR 701.21: Aggregate statistic for a sacrifice-cost selection constraint.",
       "cr_refs": [
         "CR 701.21"
@@ -27422,7 +27538,7 @@
       "variants": [
         {
           "name": "TotalPower",
-          "line": 5358,
+          "line": 5399,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27433,7 +27549,7 @@
     },
     "SacrificeRequirement": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5364,
+      "line": 5405,
       "doc": "CR 701.21: How many permanents must be sacrificed, or what aggregate constraint the chosen set must satisfy (Phyrexian Dreadnought).",
       "cr_refs": [
         "CR 701.21"
@@ -27441,7 +27557,7 @@
       "variants": [
         {
           "name": "Count",
-          "line": 5366,
+          "line": 5407,
           "kind": "struct",
           "field_names": [
             "count"
@@ -27451,7 +27567,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 5370,
+          "line": 5411,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -27524,7 +27640,7 @@
     },
     "SeatDirection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4039,
+      "line": 4071,
       "doc": "CR 102.1 + CR 103.1: Seating direction relative to a player. The game's default turn order proceeds clockwise (CR 103.1); the next player in turn order is seated to the active player's left (CR 101.4). Thus walking forward through `seat_order` is `Left`, and walking backward is `Right`.",
       "cr_refs": [
         "CR 101.4",
@@ -27534,7 +27650,7 @@
       "variants": [
         {
           "name": "Left",
-          "line": 4042,
+          "line": 4074,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's left — the next player in turn order (CR 101.4). Forward through `seat_order`.",
@@ -27544,7 +27660,7 @@
         },
         {
           "name": "Right",
-          "line": 4045,
+          "line": 4077,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's right — the previous player in turn order. Backward through `seat_order`.",
@@ -27805,7 +27921,7 @@
     },
     "SideboardPolicy": {
       "file": "crates/engine/src/types/format.rs",
-      "line": 68,
+      "line": 72,
       "doc": "CR 100.4 / CR 100.4a: Per-format sideboard rules.  - `Forbidden`: the format does not have a sideboard at all (Commander, Brawl,   Historic Brawl). Semantically distinct from `Limited(0)` — those formats   don't \"have\" a zero-size sideboard, they have no sideboard concept. - `Limited(n)`: constructed formats cap the sideboard at `n` cards.   CR 100.4a sets this at 15 for standard constructed play. - `Unlimited`: casual multiplayer variants (Free-for-All, Two-Headed Giant)   impose no size constraint.",
       "cr_refs": [
         "CR 100.4",
@@ -27814,7 +27930,7 @@
       "variants": [
         {
           "name": "Forbidden",
-          "line": 69,
+          "line": 73,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27822,7 +27938,7 @@
         },
         {
           "name": "Limited",
-          "line": 70,
+          "line": 74,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27830,7 +27946,7 @@
         },
         {
           "name": "Unlimited",
-          "line": 71,
+          "line": 75,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27841,7 +27957,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4556,
+      "line": 4588,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -27850,7 +27966,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 4558,
+          "line": 4590,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -27862,7 +27978,7 @@
         },
         {
           "name": "Condition",
-          "line": 4568,
+          "line": 4600,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -27874,7 +27990,7 @@
         },
         {
           "name": "Text",
-          "line": 4570,
+          "line": 4602,
           "kind": "struct",
           "field_names": [
             "description"
@@ -27912,7 +28028,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6436,
+      "line": 6477,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -27920,7 +28036,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 6438,
+          "line": 6479,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -27930,7 +28046,7 @@
         },
         {
           "name": "Decrease",
-          "line": 6440,
+          "line": 6481,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -27943,13 +28059,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6116,
+      "line": 6157,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 6117,
+          "line": 6158,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27957,7 +28073,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 6118,
+          "line": 6159,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27965,7 +28081,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 6119,
+          "line": 6160,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27973,7 +28089,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 6121,
+          "line": 6162,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -28085,13 +28201,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4636,
+      "line": 4668,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 4637,
+          "line": 4669,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -28102,7 +28218,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 4641,
+          "line": 4673,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28112,7 +28228,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 4647,
+          "line": 4679,
           "kind": "struct",
           "field_names": [
             "color"
@@ -28122,7 +28238,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 4656,
+          "line": 4688,
           "kind": "struct",
           "field_names": [
             "label"
@@ -28135,7 +28251,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4662,
+          "line": 4694,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -28147,7 +28263,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 4668,
+          "line": 4700,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -28157,7 +28273,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 4670,
+          "line": 4702,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -28170,7 +28286,7 @@
         },
         {
           "name": "And",
-          "line": 4674,
+          "line": 4706,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -28180,7 +28296,7 @@
         },
         {
           "name": "Or",
-          "line": 4678,
+          "line": 4710,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -28190,7 +28306,7 @@
         },
         {
           "name": "Not",
-          "line": 4684,
+          "line": 4716,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -28200,7 +28316,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 4688,
+          "line": 4720,
           "kind": "struct",
           "field_names": [
             "state"
@@ -28212,7 +28328,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 4697,
+          "line": 4729,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -28228,7 +28344,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 4707,
+          "line": 4739,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28241,7 +28357,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 4715,
+          "line": 4747,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -28256,7 +28372,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 4723,
+          "line": 4755,
           "kind": "struct",
           "field_names": [
             "level"
@@ -28268,7 +28384,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 4730,
+          "line": 4762,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28280,7 +28396,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 4734,
+          "line": 4766,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -28290,7 +28406,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 4738,
+          "line": 4770,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -28301,7 +28417,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 4742,
+          "line": 4774,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -28312,7 +28428,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 4746,
+          "line": 4778,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -28322,7 +28438,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 4748,
+          "line": 4780,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -28332,7 +28448,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 4750,
+          "line": 4782,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: True when the controller has the initiative.",
@@ -28342,7 +28458,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 4753,
+          "line": 4785,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -28352,7 +28468,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4755,
+          "line": 4787,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -28362,7 +28478,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 4758,
+          "line": 4790,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -28372,7 +28488,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 4764,
+          "line": 4796,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -28384,7 +28500,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 4772,
+          "line": 4804,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28396,7 +28512,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 4776,
+          "line": 4808,
           "kind": "struct",
           "field_names": [
             "count"
@@ -28408,7 +28524,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 4801,
+          "line": 4833,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -28426,7 +28542,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 4810,
+          "line": 4842,
           "kind": "struct",
           "field_names": [
             "text"
@@ -28436,7 +28552,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 4813,
+          "line": 4845,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28444,7 +28560,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 4816,
+          "line": 4848,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -28453,8 +28569,22 @@
           ]
         },
         {
+          "name": "SourceHasDealtDamage",
+          "line": 4857,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 120.1 + CR 120.3/120.6 + CR 702.11b + CR 613.1f: True once the source permanent has actually dealt damage (combat or noncombat) since it entered the battlefield. Sticky per-object flag (set on the first nonzero amount of damage actually dealt per CR 120.3/120.6, not the would-be amount of CR 120.1a; reset when the object leaves the battlefield). Used as a Layer 6 (CR 613.1f) ability-adding gate for \"has hexproof if it hasn't dealt damage yet\" (Palladia-Mors, the Ruiner; Karakyk Guardian). The \"hasn't\" negation wraps this in `StaticCondition::Not`.",
+          "cr_refs": [
+            "CR 120.1",
+            "CR 120.1a",
+            "CR 120.3",
+            "CR 613.1f",
+            "CR 702.11b"
+          ]
+        },
+        {
           "name": "WasCast",
-          "line": 4821,
+          "line": 4862,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -28467,7 +28597,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 4826,
+          "line": 4867,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -28477,7 +28607,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 4828,
+          "line": 4869,
           "kind": "struct",
           "field_names": [
             "level"
@@ -28489,7 +28619,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 4834,
+          "line": 4875,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -28503,7 +28633,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 4839,
+          "line": 4880,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -28513,7 +28643,7 @@
         },
         {
           "name": "SourceIsSaddled",
-          "line": 4841,
+          "line": 4882,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: True when the source permanent is saddled. Negation via Not { SourceIsSaddled }.",
@@ -28523,7 +28653,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 4848,
+          "line": 4889,
           "kind": "struct",
           "field_names": [
             "player"
@@ -28536,7 +28666,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 4853,
+          "line": 4894,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -28546,7 +28676,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 4857,
+          "line": 4898,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -28556,7 +28686,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 4861,
+          "line": 4902,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -28567,7 +28697,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 4865,
+          "line": 4906,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28579,7 +28709,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 4877,
+          "line": 4918,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28591,7 +28721,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 4881,
+          "line": 4922,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -28601,7 +28731,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 4884,
+          "line": 4925,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -28613,7 +28743,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 4890,
+          "line": 4931,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -28624,7 +28754,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 4895,
+          "line": 4936,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ModifyCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -28635,7 +28765,7 @@
         },
         {
           "name": "None",
-          "line": 4896,
+          "line": 4937,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29113,8 +29243,19 @@
           ]
         },
         {
+          "name": "LinkedCollectionCounterPlayPermission",
+          "line": 990,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 113.6 + CR 601.2a: Marker static identifying a source whose linked \"play a card from exile with a collection counter on it\" permission is live (Evelyn, the Covetous). Per CR 113.6, that play permission is a static ability of the source and functions only while the source is on the battlefield under the player's control; this marker is what `casting.rs::source_has_collection_counter_play_permission` consults so the per-card `CastingPermission::PlayFromExile` (collection-counter + controller provenance) is honored only while a live source remains. CR 601.2a: the permission authorizes moving a matching exiled card to the stack / battlefield (playing it).  Distinct from `ExileCastPermission`: that static is self-contained and grants the cast itself, keyed on a source-identity exile pool. This is a nullary marker; the actual permission lives on each exiled card as a `CastingPermission::PlayFromExile`, linked by the collection counter (not source identity), so the authority winks out if every source leaves but the counter persists.  RUNTIME: handled by direct match in `casting.rs::source_has_collection_counter_play_permission`; coverage support is via `is_data_carrying_static()` (mirrors the cast-permission cluster, which is also runtime-by-direct-match, not registry-keyed).",
+          "cr_refs": [
+            "CR 113.6",
+            "CR 601.2a"
+          ]
+        },
+        {
           "name": "CantBeCountered",
-          "line": 969,
+          "line": 992,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2: This spell/permanent can't be countered.",
@@ -29124,7 +29265,7 @@
         },
         {
           "name": "CantBeCopied",
-          "line": 972,
+          "line": 995,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2 + CR 707.10: This spell can't be copied by spells or abilities. Enforced in `copy_spell::resolve` when selecting the spell to copy.",
@@ -29135,7 +29276,7 @@
         },
         {
           "name": "CantEnterBattlefieldFrom",
-          "line": 974,
+          "line": 997,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 604.3: Cards in specified zones can't enter the battlefield.",
@@ -29145,7 +29286,7 @@
         },
         {
           "name": "CantCastFrom",
-          "line": 994,
+          "line": 1017,
           "kind": "struct",
           "field_names": [
             "who"
@@ -29159,7 +29300,7 @@
         },
         {
           "name": "CantCastDuring",
-          "line": 1000,
+          "line": 1023,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29172,7 +29313,7 @@
         },
         {
           "name": "CantActivateDuring",
-          "line": 1027,
+          "line": 1050,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29190,7 +29331,7 @@
         },
         {
           "name": "PerTurnCastLimit",
-          "line": 1037,
+          "line": 1060,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29205,7 +29346,7 @@
         },
         {
           "name": "PerTurnDrawLimit",
-          "line": 1045,
+          "line": 1068,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29218,7 +29359,7 @@
         },
         {
           "name": "SuppressTriggers",
-          "line": 1072,
+          "line": 1095,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -29233,7 +29374,7 @@
         },
         {
           "name": "CantBeBlocked",
-          "line": 1079,
+          "line": 1102,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: This creature can't be blocked.",
@@ -29243,7 +29384,7 @@
         },
         {
           "name": "CantBeBlockedExceptBy",
-          "line": 1081,
+          "line": 1104,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -29255,7 +29396,7 @@
         },
         {
           "name": "CantBeBlockedBy",
-          "line": 1086,
+          "line": 1109,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29267,7 +29408,7 @@
         },
         {
           "name": "CantBeBlockedByMoreThan",
-          "line": 1094,
+          "line": 1117,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29279,7 +29420,7 @@
         },
         {
           "name": "AttachmentRestriction",
-          "line": 1114,
+          "line": 1137,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29295,7 +29436,7 @@
         },
         {
           "name": "Protection",
-          "line": 1118,
+          "line": 1141,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16: Protection prevents targeting, blocking, damage, and attachment.",
@@ -29305,7 +29446,7 @@
         },
         {
           "name": "Indestructible",
-          "line": 1120,
+          "line": 1143,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.12: Indestructible — prevents destruction by lethal damage and destroy effects.",
@@ -29315,7 +29456,7 @@
         },
         {
           "name": "CantBeDestroyed",
-          "line": 1122,
+          "line": 1145,
           "kind": "unit",
           "field_names": [],
           "doc": "Permanent cannot be destroyed (distinct from Indestructible).",
@@ -29323,7 +29464,7 @@
         },
         {
           "name": "CantBeRegenerated",
-          "line": 1134,
+          "line": 1157,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.19c: \"[Permanent] can't be regenerated [this turn].\" This does not stop regeneration abilities from being activated or shields from being created; rather, it causes regeneration shields to not be applied the next time the affected permanent would be destroyed. The per-target `StaticDefinition::affected` filter carries which permanent is marked; runtime enforcement bypasses the regen shield in `replacement.rs::destroy_applier` (CR 701.19). Distinct from `CantBeDestroyed` (which prevents destruction outright) and the inline `Effect::Destroy { cant_regenerate }` (the \"Destroy X. It can't be regenerated.\" one-shot) — this is the standalone, until-end-of-turn form (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort).",
@@ -29334,7 +29475,7 @@
         },
         {
           "name": "FlashBack",
-          "line": 1136,
+          "line": 1159,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34: Flashback — allows casting from graveyard, exiled after resolution.",
@@ -29344,7 +29485,7 @@
         },
         {
           "name": "Shroud",
-          "line": 1138,
+          "line": 1161,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.18: Shroud — permanent cannot be the target of spells or abilities.",
@@ -29354,7 +29495,7 @@
         },
         {
           "name": "Hexproof",
-          "line": 1143,
+          "line": 1166,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.11: Hexproof — affected player/permanent cannot be the target of spells or abilities an opponent controls. Applied at the player scope (\"You have hexproof.\") mirroring `Shroud`; permanent-scope hexproof grants flow through `ContinuousModification::AddKeyword` instead.",
@@ -29364,7 +29505,7 @@
         },
         {
           "name": "Vigilance",
-          "line": 1145,
+          "line": 1168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.20: Vigilance — attacking doesn't cause this creature to tap.",
@@ -29374,7 +29515,7 @@
         },
         {
           "name": "Menace",
-          "line": 1147,
+          "line": 1170,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.111: Menace — can't be blocked except by two or more creatures.",
@@ -29384,7 +29525,7 @@
         },
         {
           "name": "Reach",
-          "line": 1149,
+          "line": 1172,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.17: Reach — can block creatures with flying.",
@@ -29394,7 +29535,7 @@
         },
         {
           "name": "Flying",
-          "line": 1151,
+          "line": 1174,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.9: Flying — can't be blocked except by creatures with flying or reach.",
@@ -29404,7 +29545,7 @@
         },
         {
           "name": "Trample",
-          "line": 1153,
+          "line": 1176,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.19: Trample — excess combat damage is assigned to the defending player.",
@@ -29414,7 +29555,7 @@
         },
         {
           "name": "Deathtouch",
-          "line": 1155,
+          "line": 1178,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.2: Deathtouch — any amount of damage dealt is lethal.",
@@ -29424,7 +29565,7 @@
         },
         {
           "name": "Lifelink",
-          "line": 1157,
+          "line": 1180,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.15: Lifelink — damage dealt also causes controller to gain that much life.",
@@ -29434,7 +29575,7 @@
         },
         {
           "name": "CantTap",
-          "line": 1160,
+          "line": 1183,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29442,7 +29583,7 @@
         },
         {
           "name": "CantUntap",
-          "line": 1161,
+          "line": 1184,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29450,7 +29591,7 @@
         },
         {
           "name": "MustBeBlocked",
-          "line": 1164,
+          "line": 1187,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: This creature must be blocked if able — the defending player must assign at least one legal blocker to it.",
@@ -29460,7 +29601,7 @@
         },
         {
           "name": "MustBeBlockedByAll",
-          "line": 1170,
+          "line": 1193,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: \"All creatures able to block this creature do so\" (Lure, Prized Unicorn, Breaker of Armies, …). Unlike [`MustBeBlocked`], this places a block requirement on *every* creature able to block it: each such untapped defender must be declared as a blocker of this attacker, not merely one.",
@@ -29470,7 +29611,7 @@
         },
         {
           "name": "Goaded",
-          "line": 1174,
+          "line": 1197,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.15b: This creature is goaded for as long as the static applies. The source controller is the goading player for the \"attack another player if able\" requirement.",
@@ -29480,7 +29621,7 @@
         },
         {
           "name": "CombatAlone",
-          "line": 1182,
+          "line": 1205,
           "kind": "struct",
           "field_names": [
             "action",
@@ -29495,7 +29636,7 @@
         },
         {
           "name": "CantCrew",
-          "line": 1187,
+          "line": 1210,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122c: This creature can't crew Vehicles.",
@@ -29505,7 +29646,7 @@
         },
         {
           "name": "CrewContribution",
-          "line": 1193,
+          "line": 1216,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -29520,7 +29661,7 @@
         },
         {
           "name": "MayLookAtTopOfLibrary",
-          "line": 1197,
+          "line": 1220,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29528,7 +29669,7 @@
         },
         {
           "name": "MayChooseNotToUntap",
-          "line": 1201,
+          "line": 1224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3: You may choose not to untap this permanent during your untap step.",
@@ -29538,7 +29679,7 @@
         },
         {
           "name": "AdditionalLandDrop",
-          "line": 1204,
+          "line": 1227,
           "kind": "struct",
           "field_names": [
             "count"
@@ -29550,7 +29691,7 @@
         },
         {
           "name": "EmblemStatic",
-          "line": 1207,
+          "line": 1230,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29558,7 +29699,7 @@
         },
         {
           "name": "BlockRestriction",
-          "line": 1210,
+          "line": 1233,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29570,7 +29711,7 @@
         },
         {
           "name": "NoMaximumHandSize",
-          "line": 1214,
+          "line": 1237,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 402.2: No maximum hand size.",
@@ -29580,7 +29721,7 @@
         },
         {
           "name": "MaximumHandSize",
-          "line": 1217,
+          "line": 1240,
           "kind": "struct",
           "field_names": [
             "modification"
@@ -29593,7 +29734,7 @@
         },
         {
           "name": "MayPlayAdditionalLand",
-          "line": 1220,
+          "line": 1243,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29601,7 +29742,7 @@
         },
         {
           "name": "CantHaveKeyword",
-          "line": 1224,
+          "line": 1247,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -29613,7 +29754,7 @@
         },
         {
           "name": "CantWinTheGame",
-          "line": 1229,
+          "line": 1252,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: This player can't win the game (Platinum Angel effect).",
@@ -29623,7 +29764,7 @@
         },
         {
           "name": "CantLoseTheGame",
-          "line": 1231,
+          "line": 1254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3b: This player can't lose the game (Platinum Angel effect).",
@@ -29633,7 +29774,7 @@
         },
         {
           "name": "LegendRuleDoesntApply",
-          "line": 1240,
+          "line": 1263,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 704.5j: The \"legend rule\" doesn't apply to the affected permanents, so they are excluded from the same-name legendary grouping in the legend-rule SBA. Scope rides on `StaticDefinition::affected`: `None` = global (Mirror Gallery, \"the legend rule doesn't apply\"); a controller-scoped filter = \"doesn't apply to [permanents/tokens/Slivers/commanders] you control\" (Sakashima of a Thousand Faces, Mirror Box, Cadric, Sliver Gravemother, Try-My-Deck Elemental, ...). Enforced per-permanent in `sba.rs` via `check_static_ability` with the candidate as the target object.",
@@ -29643,7 +29784,7 @@
         },
         {
           "name": "SpeedCanIncreaseBeyondFour",
-          "line": 1242,
+          "line": 1265,
           "kind": "unit",
           "field_names": [],
           "doc": "Speed may increase beyond 4, and 4+ still counts as max speed for that player.",
@@ -29651,7 +29792,7 @@
         },
         {
           "name": "DefilerCostReduction",
-          "line": 1246,
+          "line": 1269,
           "kind": "struct",
           "field_names": [
             "color",
@@ -29665,7 +29806,7 @@
         },
         {
           "name": "SkipStep",
-          "line": 1256,
+          "line": 1279,
           "kind": "struct",
           "field_names": [
             "step"
@@ -29678,7 +29819,7 @@
         },
         {
           "name": "SpendManaAsAnyColor",
-          "line": 1261,
+          "line": 1284,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.4b: \"You may spend mana as though it were mana of any color.\" Allows the controller to pay colored mana costs with mana of any color.",
@@ -29688,7 +29829,7 @@
         },
         {
           "name": "PayLifeAsColoredMana",
-          "line": 1273,
+          "line": 1296,
           "kind": "struct",
           "field_names": [
             "color"
@@ -29700,7 +29841,7 @@
         },
         {
           "name": "StepEndUnspentMana",
-          "line": 1287,
+          "line": 1310,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -29716,7 +29857,7 @@
         },
         {
           "name": "CanAttackWithDefender",
-          "line": 1293,
+          "line": 1316,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.3b: Allows creatures with defender to attack despite having the keyword. \"can attack as though it didn't have defender\" overrides the defender restriction.",
@@ -29726,7 +29867,7 @@
         },
         {
           "name": "IgnoreLandwalkForBlocking",
-          "line": 1310,
+          "line": 1333,
           "kind": "struct",
           "field_names": [
             "qualifier"
@@ -29741,7 +29882,7 @@
         },
         {
           "name": "CanActivateAbilitiesAsThoughHaste",
-          "line": 1318,
+          "line": 1341,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.5a: Bypasses the summoning-sickness gate on a creature's `{T}`/`{Q}` activated abilities — \"You may activate abilities of creatures you control as though those creatures had haste.\" This is NOT `AddKeyword(Haste)`: only the CR 602.5a activation restriction is lifted, combat attacker validation (CR 508.1a) is untouched. Canonical card: Tyvar, Jubilant Brawler.",
@@ -29752,7 +29893,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 1322,
+          "line": 1345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage. Used for creatures like Ornithopter of Paradise and various Walls that can attack/block but deal 0 combat damage.",
@@ -29762,7 +29903,7 @@
         },
         {
           "name": "UntapsDuringEachOtherPlayersUntapStep",
-          "line": 1331,
+          "line": 1354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3 + CR 113.6: Continuous static that grants a second untap pass during each OTHER player's untap step. The source's controller untaps the permanents matching `StaticDefinition.affected` — NOT the active player's permanents. Canonical card: Seedborn Muse (\"Untap all permanents you control during each other player's untap step.\"). Runtime: `turns::execute_untap` runs a second pass after the active player's normal untap, scanning the battlefield for this variant on permanents whose controller != active_player.",
@@ -29773,7 +29914,7 @@
         },
         {
           "name": "EntersWithAdditionalCounters",
-          "line": 1351,
+          "line": 1374,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -29787,7 +29928,7 @@
         },
         {
           "name": "Other",
-          "line": 1356,
+          "line": 1379,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized static mode strings.",
@@ -29829,7 +29970,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6448,
+      "line": 6489,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -29838,7 +29979,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 6449,
+          "line": 6490,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -29846,7 +29987,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 6450,
+          "line": 6491,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29857,7 +29998,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11526,
+      "line": 11615,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -29865,7 +30006,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 11534,
+          "line": 11623,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -29873,7 +30014,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 11539,
+          "line": 11628,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -29886,7 +30027,7 @@
     },
     "SubtypeSet": {
       "file": "crates/engine/src/types/card_type.rs",
-      "line": 183,
+      "line": 191,
       "doc": "CR 205.3: The classification of subtype sets. Each card type has its own correlated subtype pool — creature types, land types, artifact types, etc. Used by `ContinuousModification::RemoveAllSubtypes` to express \"loses all other creature types\" without enumerating individual subtypes.",
       "cr_refs": [
         "CR 205.3"
@@ -29894,7 +30035,7 @@
       "variants": [
         {
           "name": "Creature",
-          "line": 185,
+          "line": 193,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3m: Creature subtypes (creature types).",
@@ -29904,7 +30045,7 @@
         },
         {
           "name": "Land",
-          "line": 187,
+          "line": 195,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i: Land subtypes (land types).",
@@ -29914,7 +30055,7 @@
         },
         {
           "name": "Artifact",
-          "line": 189,
+          "line": 197,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3g: Artifact subtypes.",
@@ -29924,7 +30065,7 @@
         },
         {
           "name": "Enchantment",
-          "line": 191,
+          "line": 199,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3h: Enchantment subtypes.",
@@ -29934,7 +30075,7 @@
         },
         {
           "name": "Planeswalker",
-          "line": 193,
+          "line": 201,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3j: Planeswalker subtypes.",
@@ -29944,7 +30085,7 @@
         },
         {
           "name": "Spell",
-          "line": 195,
+          "line": 203,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3k: Spell subtypes (instant/sorcery).",
@@ -29954,7 +30095,7 @@
         },
         {
           "name": "Battle",
-          "line": 197,
+          "line": 205,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3q: Battle subtypes.",
@@ -30084,7 +30225,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11078,
+      "line": 11167,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -30094,7 +30235,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 11080,
+          "line": 11169,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30102,7 +30243,7 @@
         },
         {
           "name": "Resolution",
-          "line": 11081,
+          "line": 11170,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30560,13 +30701,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14364,
+      "line": 14471,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 14365,
+          "line": 14472,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30574,7 +30715,7 @@
         },
         {
           "name": "Player",
-          "line": 14366,
+          "line": 14473,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30876,13 +31017,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12440,
+      "line": 12529,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 12443,
+          "line": 12532,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -30892,7 +31033,7 @@
         },
         {
           "name": "LostLife",
-          "line": 12445,
+          "line": 12534,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -30900,7 +31041,7 @@
         },
         {
           "name": "Descended",
-          "line": 12447,
+          "line": 12536,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -30908,7 +31049,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 12449,
+          "line": 12538,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30918,7 +31059,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 12451,
+          "line": 12540,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -30928,7 +31069,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 12453,
+          "line": 12542,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -30938,7 +31079,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 12463,
+          "line": 12552,
           "kind": "struct",
           "field_names": [
             "player"
@@ -30951,7 +31092,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 12466,
+          "line": 12555,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -30962,7 +31103,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 12469,
+          "line": 12558,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -30972,7 +31113,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 12482,
+          "line": 12571,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -30986,7 +31127,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 12489,
+          "line": 12578,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -30996,7 +31137,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 12492,
+          "line": 12581,
           "kind": "struct",
           "field_names": [
             "level"
@@ -31008,7 +31149,7 @@
         },
         {
           "name": "AttractionVisitRoll",
-          "line": 12495,
+          "line": 12584,
           "kind": "struct",
           "field_names": [
             "min",
@@ -31022,7 +31163,7 @@
         },
         {
           "name": "WasCast",
-          "line": 12498,
+          "line": 12587,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -31036,7 +31177,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 12507,
+          "line": 12596,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -31047,7 +31188,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 12512,
+          "line": 12601,
           "kind": "struct",
           "field_names": [
             "source",
@@ -31065,7 +31206,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 12532,
+          "line": 12621,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -31075,7 +31216,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 12538,
+          "line": 12627,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -31090,7 +31231,7 @@
         },
         {
           "name": "CastVariantPaidPersistent",
-          "line": 12543,
+          "line": 12632,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -31103,7 +31244,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 12547,
+          "line": 12636,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -31114,7 +31255,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 12551,
+          "line": 12640,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -31125,7 +31266,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 12556,
+          "line": 12645,
           "kind": "struct",
           "field_names": [
             "source"
@@ -31139,7 +31280,7 @@
         },
         {
           "name": "WasType",
-          "line": 12561,
+          "line": 12650,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -31152,7 +31293,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 12564,
+          "line": 12653,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -31164,7 +31305,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 12568,
+          "line": 12657,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -31177,7 +31318,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 12572,
+          "line": 12661,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31189,7 +31330,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 12576,
+          "line": 12665,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -31199,7 +31340,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 12579,
+          "line": 12668,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -31211,7 +31352,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 12583,
+          "line": 12672,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31223,7 +31364,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 12586,
+          "line": 12675,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -31235,7 +31376,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 12592,
+          "line": 12681,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -31245,7 +31386,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 12595,
+          "line": 12684,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -31255,7 +31396,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 12598,
+          "line": 12687,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: \"if you have the initiative\" is true when the controller has the initiative designation.",
@@ -31265,7 +31406,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 12601,
+          "line": 12690,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -31275,7 +31416,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 12608,
+          "line": 12697,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -31287,7 +31428,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 12613,
+          "line": 12702,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -31299,7 +31440,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 12617,
+          "line": 12706,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -31309,7 +31450,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 12622,
+          "line": 12711,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -31321,7 +31462,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 12628,
+          "line": 12717,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -31331,7 +31472,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 12633,
+          "line": 12722,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -31341,7 +31482,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 12636,
+          "line": 12725,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -31351,7 +31492,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 12639,
+          "line": 12728,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -31361,7 +31502,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 12641,
+          "line": 12730,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -31373,7 +31514,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 12644,
+          "line": 12733,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -31383,7 +31524,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 12648,
+          "line": 12737,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -31393,7 +31534,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 12652,
+          "line": 12741,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31406,7 +31547,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 12655,
+          "line": 12744,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -31416,7 +31557,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 12659,
+          "line": 12748,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -31429,7 +31570,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 12662,
+          "line": 12751,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -31442,7 +31583,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 12664,
+          "line": 12753,
           "kind": "struct",
           "field_names": [
             "color",
@@ -31455,7 +31596,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 12666,
+          "line": 12755,
           "kind": "struct",
           "field_names": [
             "text"
@@ -31467,7 +31608,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 12668,
+          "line": 12757,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -31479,7 +31620,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 12672,
+          "line": 12761,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -31493,7 +31634,7 @@
         },
         {
           "name": "IsRenowned",
-          "line": 12679,
+          "line": 12768,
           "kind": "struct",
           "field_names": [
             "subject"
@@ -31507,7 +31648,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 12684,
+          "line": 12773,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -31522,7 +31663,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 12695,
+          "line": 12784,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -31538,7 +31679,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 12710,
+          "line": 12799,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -31550,7 +31691,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 12713,
+          "line": 12802,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31563,7 +31704,7 @@
         },
         {
           "name": "EventDamageSourceMatchesFilter",
-          "line": 12726,
+          "line": 12815,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31576,7 +31717,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 12736,
+          "line": 12825,
           "kind": "struct",
           "field_names": [
             "label"
@@ -31590,7 +31731,7 @@
         },
         {
           "name": "AttackersDeclaredCount",
-          "line": 12750,
+          "line": 12839,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -31607,7 +31748,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 12764,
+          "line": 12853,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -31619,7 +31760,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 12775,
+          "line": 12864,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -31631,7 +31772,7 @@
         },
         {
           "name": "And",
-          "line": 12779,
+          "line": 12868,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -31641,7 +31782,7 @@
         },
         {
           "name": "Or",
-          "line": 12781,
+          "line": 12870,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -31651,7 +31792,7 @@
         },
         {
           "name": "Not",
-          "line": 12791,
+          "line": 12880,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -31667,13 +31808,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12977,
+      "line": 13066,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 12979,
+          "line": 13068,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -31681,7 +31822,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 12981,
+          "line": 13070,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -31689,7 +31830,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 12983,
+          "line": 13072,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -31697,7 +31838,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 12988,
+          "line": 13077,
           "kind": "struct",
           "field_names": [
             "n",
@@ -31708,7 +31849,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 12995,
+          "line": 13084,
           "kind": "struct",
           "field_names": [
             "n"
@@ -31718,7 +31859,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 12997,
+          "line": 13086,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -31726,7 +31867,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 13001,
+          "line": 13090,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -31736,7 +31877,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 13003,
+          "line": 13092,
           "kind": "struct",
           "field_names": [
             "level"
@@ -31748,7 +31889,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 13006,
+          "line": 13095,
           "kind": "struct",
           "field_names": [
             "max"
@@ -31760,11 +31901,24 @@
         },
         {
           "name": "OncePerOpponentPerTurn",
-          "line": 13010,
+          "line": 13099,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: \"for the first time during each of their turns\" — fires once per opponent per turn. Used by Valgavoth, Harrower of Souls: \"Whenever an opponent loses life for the first time during each of their turns, ...\"",
           "cr_refs": [
+            "CR 603.2"
+          ]
+        },
+        {
+          "name": "EventSourceControlledBy",
+          "line": 13106,
+          "kind": "struct",
+          "field_names": [
+            "controller"
+          ],
+          "doc": "CR 109.5 + CR 603.2: Fires only when the triggering event was caused by a spell or ability controlled by `controller` relative to the trigger's controller. Mirrors [`ReplacementCondition::EventSourceControlledBy`] for the trigger side — used by \"when a spell or ability an opponent controls causes you to discard this card, …\" (Guerrilla Tactics, Sand Golem). The event must carry the cause's source id (e.g. `GameEvent::Discarded.source_id`).",
+          "cr_refs": [
+            "CR 109.5",
             "CR 603.2"
           ]
         }
@@ -32351,7 +32505,7 @@
     },
     "TriggerMode": {
       "file": "crates/engine/src/types/triggers.rs",
-      "line": 197,
+      "line": 201,
       "doc": "All trigger modes from Forge's TriggerType enum (CR 603).  Triggered abilities have a trigger condition and an effect, written as \"[When/Whenever/At] [trigger condition], [effect]\" (CR 603.1). When a game event matches a trigger condition, the ability automatically triggers (CR 603.2) and is placed on the stack the next time a player would receive priority (CR 603.3).  Matched case-sensitively against Forge trigger mode strings.",
       "cr_refs": [
         "CR 603",
@@ -32362,7 +32516,7 @@
       "variants": [
         {
           "name": "ChangesZone",
-          "line": 200,
+          "line": 204,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6a: Enters-the-battlefield and other zone-change triggers.",
@@ -32372,7 +32526,7 @@
         },
         {
           "name": "ChangesZoneAll",
-          "line": 202,
+          "line": 206,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6: Zone change affecting all objects matching a filter.",
@@ -32382,7 +32536,7 @@
         },
         {
           "name": "ChangesController",
-          "line": 204,
+          "line": 208,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2e: \"Becomes\" trigger — fires when control changes, not while state persists.",
@@ -32392,7 +32546,7 @@
         },
         {
           "name": "LeavesBattlefield",
-          "line": 206,
+          "line": 210,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6c: Leaves-the-battlefield trigger — fires when a permanent moves from battlefield.",
@@ -32402,7 +32556,7 @@
         },
         {
           "name": "DamageDone",
-          "line": 210,
+          "line": 214,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2: Trigger when a source deals damage.",
@@ -32412,7 +32566,7 @@
         },
         {
           "name": "DamageDoneOnce",
-          "line": 211,
+          "line": 215,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32420,7 +32574,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 212,
+          "line": 216,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32428,7 +32582,7 @@
         },
         {
           "name": "DamageDealtOnce",
-          "line": 213,
+          "line": 217,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32436,7 +32590,7 @@
         },
         {
           "name": "DamageDoneOnceByController",
-          "line": 214,
+          "line": 218,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32444,7 +32598,7 @@
         },
         {
           "name": "DamageReceived",
-          "line": 216,
+          "line": 220,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2: Trigger when an object or player is dealt damage.",
@@ -32454,7 +32608,7 @@
         },
         {
           "name": "DamagePreventedOnce",
-          "line": 217,
+          "line": 221,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32462,7 +32616,7 @@
         },
         {
           "name": "ExcessDamage",
-          "line": 218,
+          "line": 222,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32470,7 +32624,7 @@
         },
         {
           "name": "ExcessDamageAll",
-          "line": 219,
+          "line": 223,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32478,7 +32632,7 @@
         },
         {
           "name": "SpellCast",
-          "line": 223,
+          "line": 227,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2i: Triggers when a spell becomes cast.",
@@ -32488,38 +32642,6 @@
         },
         {
           "name": "SpellCopy",
-          "line": 224,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SpellCastOrCopy",
-          "line": 225,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AbilityCast",
-          "line": 226,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AbilityResolves",
-          "line": 227,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AbilityTriggered",
           "line": 228,
           "kind": "unit",
           "field_names": [],
@@ -32527,7 +32649,7 @@
           "cr_refs": []
         },
         {
-          "name": "SpellAbilityCast",
+          "name": "SpellCastOrCopy",
           "line": 229,
           "kind": "unit",
           "field_names": [],
@@ -32535,7 +32657,7 @@
           "cr_refs": []
         },
         {
-          "name": "SpellAbilityCopy",
+          "name": "AbilityCast",
           "line": 230,
           "kind": "unit",
           "field_names": [],
@@ -32543,8 +32665,40 @@
           "cr_refs": []
         },
         {
-          "name": "Countered",
+          "name": "AbilityResolves",
+          "line": 231,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AbilityTriggered",
           "line": 232,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SpellAbilityCast",
+          "line": 233,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SpellAbilityCopy",
+          "line": 234,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Countered",
+          "line": 236,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2g: Triggers when a spell or ability is countered (event must actually occur).",
@@ -32554,7 +32708,7 @@
         },
         {
           "name": "Attacks",
-          "line": 236,
+          "line": 240,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3a: \"Whenever [a creature] attacks\" — triggers when declared as attacker.",
@@ -32564,7 +32718,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 238,
+          "line": 242,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d: \"Whenever [a player] attacks\" — triggers when one or more creatures attack.",
@@ -32574,7 +32728,7 @@
         },
         {
           "name": "YouAttack",
-          "line": 240,
+          "line": 244,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d: \"Whenever you attack\" — triggers for the attacking player.",
@@ -32584,7 +32738,7 @@
         },
         {
           "name": "YouAttackUnblocked",
-          "line": 244,
+          "line": 248,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d + CR 509.1h: \"Whenever one or more [creatures] attack [you] and aren't blocked\" — fires after blockers are declared when at least one matching attacker was not assigned blockers.",
@@ -32595,7 +32749,7 @@
         },
         {
           "name": "AttackersDeclaredOneTarget",
-          "line": 245,
+          "line": 249,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32603,7 +32757,7 @@
         },
         {
           "name": "AttackerBlocked",
-          "line": 247,
+          "line": 251,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Triggers when an attacking creature becomes blocked.",
@@ -32613,7 +32767,7 @@
         },
         {
           "name": "AttackerBlockedOnce",
-          "line": 248,
+          "line": 252,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32621,7 +32775,7 @@
         },
         {
           "name": "AttackerBlockedByCreature",
-          "line": 250,
+          "line": 254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Triggers when a specific creature blocks the attacker.",
@@ -32631,7 +32785,7 @@
         },
         {
           "name": "AttackerUnblocked",
-          "line": 251,
+          "line": 255,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32639,7 +32793,7 @@
         },
         {
           "name": "AttackerUnblockedOnce",
-          "line": 252,
+          "line": 256,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32647,7 +32801,7 @@
         },
         {
           "name": "Blocks",
-          "line": 256,
+          "line": 260,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: \"Whenever [a creature] blocks\" — triggers when declared as blocker.",
@@ -32657,7 +32811,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 258,
+          "line": 262,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.4: Triggers after all blockers are declared.",
@@ -32667,7 +32821,7 @@
         },
         {
           "name": "BecomesBlocked",
-          "line": 260,
+          "line": 264,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h + CR 603.2e: \"Becomes blocked\" trigger.",
@@ -32678,7 +32832,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 264,
+          "line": 268,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.6: Triggers when one or more counters are placed on a permanent or player.",
@@ -32688,38 +32842,6 @@
         },
         {
           "name": "CounterAddedOnce",
-          "line": 265,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterAddedAll",
-          "line": 266,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterPlayerAddedAll",
-          "line": 267,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterTypeAddedAll",
-          "line": 268,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CounterRemoved",
           "line": 269,
           "kind": "unit",
           "field_names": [],
@@ -32727,7 +32849,7 @@
           "cr_refs": []
         },
         {
-          "name": "CounterRemovedOnce",
+          "name": "CounterAddedAll",
           "line": 270,
           "kind": "unit",
           "field_names": [],
@@ -32735,8 +32857,40 @@
           "cr_refs": []
         },
         {
-          "name": "Sacrificed",
+          "name": "CounterPlayerAddedAll",
+          "line": 271,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CounterTypeAddedAll",
+          "line": 272,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CounterRemoved",
+          "line": 273,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CounterRemovedOnce",
           "line": 274,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Sacrificed",
+          "line": 278,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.21: Triggers when a permanent is sacrificed.",
@@ -32746,7 +32900,7 @@
         },
         {
           "name": "SacrificedOnce",
-          "line": 275,
+          "line": 279,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32754,7 +32908,7 @@
         },
         {
           "name": "Destroyed",
-          "line": 277,
+          "line": 281,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8: Triggers when a permanent is destroyed.",
@@ -32764,7 +32918,7 @@
         },
         {
           "name": "Taps",
-          "line": 279,
+          "line": 283,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26: Triggers when a permanent becomes tapped.",
@@ -32774,7 +32928,7 @@
         },
         {
           "name": "TapsForMana",
-          "line": 281,
+          "line": 285,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.12a: Triggers when a permanent is tapped for mana.",
@@ -32784,7 +32938,7 @@
         },
         {
           "name": "TapAll",
-          "line": 282,
+          "line": 286,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32792,7 +32946,7 @@
         },
         {
           "name": "Untaps",
-          "line": 284,
+          "line": 288,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26: Triggers when a permanent becomes untapped.",
@@ -32802,7 +32956,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 285,
+          "line": 289,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32810,7 +32964,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 289,
+          "line": 293,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2e: \"Becomes the target\" trigger — fires when a spell/ability targets an object.",
@@ -32820,7 +32974,7 @@
         },
         {
           "name": "BecomesTargetOnce",
-          "line": 290,
+          "line": 294,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32828,7 +32982,7 @@
         },
         {
           "name": "Drawn",
-          "line": 294,
+          "line": 298,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1: Triggers when a player draws a card.",
@@ -32838,7 +32992,7 @@
         },
         {
           "name": "Discarded",
-          "line": 296,
+          "line": 300,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9: Triggers when a player discards a card.",
@@ -32848,7 +33002,7 @@
         },
         {
           "name": "DiscardedAll",
-          "line": 297,
+          "line": 301,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32856,7 +33010,7 @@
         },
         {
           "name": "Milled",
-          "line": 299,
+          "line": 303,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.17: Triggers when cards are milled (put from library into graveyard).",
@@ -32866,7 +33020,7 @@
         },
         {
           "name": "MilledOnce",
-          "line": 300,
+          "line": 304,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32874,7 +33028,7 @@
         },
         {
           "name": "MilledAll",
-          "line": 301,
+          "line": 305,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32882,7 +33036,7 @@
         },
         {
           "name": "Exiled",
-          "line": 302,
+          "line": 306,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32890,7 +33044,7 @@
         },
         {
           "name": "Revealed",
-          "line": 303,
+          "line": 307,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32898,7 +33052,7 @@
         },
         {
           "name": "Shuffled",
-          "line": 305,
+          "line": 309,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.24: Triggers when a library is shuffled.",
@@ -32908,7 +33062,7 @@
         },
         {
           "name": "LifeGained",
-          "line": 309,
+          "line": 313,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player gains life.",
@@ -32918,7 +33072,7 @@
         },
         {
           "name": "LifeLost",
-          "line": 311,
+          "line": 315,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player loses life.",
@@ -32928,7 +33082,7 @@
         },
         {
           "name": "LifeLostAll",
-          "line": 312,
+          "line": 316,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32936,7 +33090,7 @@
         },
         {
           "name": "LifeChanged",
-          "line": 314,
+          "line": 318,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player gains or loses life.",
@@ -32946,7 +33100,7 @@
         },
         {
           "name": "PayLife",
-          "line": 315,
+          "line": 319,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32954,7 +33108,7 @@
         },
         {
           "name": "PayCumulativeUpkeep",
-          "line": 317,
+          "line": 321,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.24: Cumulative upkeep trigger.",
@@ -32964,7 +33118,7 @@
         },
         {
           "name": "PayEcho",
-          "line": 319,
+          "line": 323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30: Echo trigger.",
@@ -32974,7 +33128,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 323,
+          "line": 327,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Triggers when a token is created.",
@@ -32984,7 +33138,7 @@
         },
         {
           "name": "TokenCreatedOnce",
-          "line": 324,
+          "line": 328,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32992,7 +33146,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 328,
+          "line": 332,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.37e: Triggers when a face-down permanent is turned face up (morph/manifest/cloak).",
@@ -33002,7 +33156,7 @@
         },
         {
           "name": "Transformed",
-          "line": 330,
+          "line": 334,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27: Triggers when a permanent transforms.",
@@ -33012,7 +33166,7 @@
         },
         {
           "name": "Phase",
-          "line": 334,
+          "line": 338,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2b: \"At the beginning of [phase/step]\" — triggers at phase start.",
@@ -33022,7 +33176,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 336,
+          "line": 340,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26: Triggers when a phased-out permanent phases in.",
@@ -33032,7 +33186,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 338,
+          "line": 342,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26: Triggers when a permanent phases out.",
@@ -33042,7 +33196,7 @@
         },
         {
           "name": "PhaseOutAll",
-          "line": 339,
+          "line": 343,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33050,7 +33204,7 @@
         },
         {
           "name": "TurnBegin",
-          "line": 341,
+          "line": 345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2b: \"At the beginning of [a player's] turn\" trigger.",
@@ -33060,7 +33214,7 @@
         },
         {
           "name": "NewGame",
-          "line": 342,
+          "line": 346,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33068,7 +33222,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 346,
+          "line": 350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725: Triggers when a player becomes the monarch.",
@@ -33078,7 +33232,7 @@
         },
         {
           "name": "TakesInitiative",
-          "line": 348,
+          "line": 352,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.2: Triggers when a player takes the initiative.",
@@ -33088,7 +33242,7 @@
         },
         {
           "name": "LosesGame",
-          "line": 352,
+          "line": 356,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: Triggers when a player loses the game.",
@@ -33098,7 +33252,7 @@
         },
         {
           "name": "Championed",
-          "line": 356,
+          "line": 360,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.72: Champion trigger.",
@@ -33108,7 +33262,7 @@
         },
         {
           "name": "Exerted",
-          "line": 358,
+          "line": 362,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.43: Triggers when a creature is exerted.",
@@ -33118,7 +33272,7 @@
         },
         {
           "name": "Crewed",
-          "line": 360,
+          "line": 364,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122: Triggers when a Vehicle becomes crewed.",
@@ -33128,7 +33282,7 @@
         },
         {
           "name": "Crews",
-          "line": 362,
+          "line": 366,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122: Actor-side crew trigger — fires when this permanent crews a Vehicle.",
@@ -33138,7 +33292,7 @@
         },
         {
           "name": "Saddled",
-          "line": 364,
+          "line": 368,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: Triggers when a creature becomes saddled.",
@@ -33148,7 +33302,7 @@
         },
         {
           "name": "Saddles",
-          "line": 367,
+          "line": 371,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171c: Actor-side saddle trigger — fires when this permanent saddles a Mount. Reserved — no cards today print this without the compound form.",
@@ -33158,7 +33312,7 @@
         },
         {
           "name": "SaddlesOrCrews",
-          "line": 370,
+          "line": 374,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122 + CR 702.171c: Compound actor-side trigger — fires on either saddling a Mount OR crewing a Vehicle.",
@@ -33169,7 +33323,7 @@
         },
         {
           "name": "Cycled",
-          "line": 372,
+          "line": 376,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29: Triggers when a card is cycled.",
@@ -33179,7 +33333,7 @@
         },
         {
           "name": "CycledOrDiscarded",
-          "line": 375,
+          "line": 379,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29d: Triggers when a card is cycled or discarded. Fires on either event but only once per cycling action.",
@@ -33189,7 +33343,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 377,
+          "line": 381,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Triggers when a player activates a ninjutsu-family ability.",
@@ -33199,7 +33353,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 381,
+          "line": 385,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.107a + CR 702.142b + CR 702.177a: Triggers when a player activates a keyword ability tagged by `AbilityTag`. Parameterized to avoid per-keyword sibling proliferation: `AbilityTag::Boast`, `AbilityTag::Exhaust`, `AbilityTag::Outlast` are the current values.",
@@ -33211,7 +33365,7 @@
         },
         {
           "name": "AbilityActivated",
-          "line": 394,
+          "line": 398,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.1 + CR 605.1a: Triggers when any activated ability is activated. Listens to `GameEvent::AbilityActivated`, which is emitted only for stack-using activated abilities — by CR 605.3b, mana abilities resolve without using the stack and do not produce this event. The \"that isn't a mana ability\" qualifier on cards like Burning-Tree Shaman and Flamescroll Celebrant is thus automatically satisfied by listening here, and is additionally preserved in the AST via `TriggerCondition::ActivatedAbilityIsNonMana` for future-proofing should the event family ever widen. Player scope (`a player` / `an opponent` / `you`) lives on `valid_target` (`TargetFilter`); source-object filters (e.g., \"an ability of an artifact source\") live on `valid_card` — both reuse existing infrastructure shared with `KeywordAbilityActivated`.",
@@ -33223,7 +33377,7 @@
         },
         {
           "name": "Evolve",
-          "line": 396,
+          "line": 400,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: Evolve keyword trigger — when a creature enters with greater power/toughness.",
@@ -33233,7 +33387,7 @@
         },
         {
           "name": "Evolved",
-          "line": 398,
+          "line": 402,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100b: Triggers when a creature evolves.",
@@ -33243,7 +33397,7 @@
         },
         {
           "name": "Explored",
-          "line": 400,
+          "line": 404,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.44: Triggers when a creature explores.",
@@ -33253,7 +33407,7 @@
         },
         {
           "name": "Exploited",
-          "line": 402,
+          "line": 406,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.110: Exploit trigger — when a creature exploits another creature.",
@@ -33263,7 +33417,7 @@
         },
         {
           "name": "Enlisted",
-          "line": 404,
+          "line": 408,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.154: Triggers when a creature becomes enlisted.",
@@ -33273,7 +33427,7 @@
         },
         {
           "name": "ManaAdded",
-          "line": 408,
+          "line": 412,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.4: Triggers when mana is added to a player's mana pool.",
@@ -33283,7 +33437,7 @@
         },
         {
           "name": "ManaExpend",
-          "line": 409,
+          "line": 413,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33291,7 +33445,7 @@
         },
         {
           "name": "LandPlayed",
-          "line": 413,
+          "line": 417,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 505.6b: Triggers when a land is played.",
@@ -33302,7 +33456,7 @@
         },
         {
           "name": "PlayCard",
-          "line": 416,
+          "line": 420,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.1a + CR 701.18b: \"Whenever you play a card\" — playing a card means playing it as a land OR casting it as a spell, so this fires on both events.",
@@ -33313,7 +33467,7 @@
         },
         {
           "name": "Attached",
-          "line": 420,
+          "line": 424,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3: Triggers when an Aura, Equipment, or Fortification becomes attached.",
@@ -33323,7 +33477,7 @@
         },
         {
           "name": "Unattach",
-          "line": 422,
+          "line": 426,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3: Triggers when an Equipment or Aura becomes unattached.",
@@ -33333,7 +33487,7 @@
         },
         {
           "name": "Adapt",
-          "line": 426,
+          "line": 430,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.46: Triggers when a creature adapts.",
@@ -33343,7 +33497,7 @@
         },
         {
           "name": "Foretell",
-          "line": 428,
+          "line": 432,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143: Triggers when a card is foretold.",
@@ -33353,7 +33507,7 @@
         },
         {
           "name": "Investigated",
-          "line": 430,
+          "line": 434,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Triggers when a player investigates.",
@@ -33363,22 +33517,6 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 433,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RoomEntered",
-          "line": 434,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlanarDice",
           "line": 437,
           "kind": "unit",
           "field_names": [],
@@ -33386,7 +33524,7 @@
           "cr_refs": []
         },
         {
-          "name": "PlaneswalkedFrom",
+          "name": "RoomEntered",
           "line": 438,
           "kind": "unit",
           "field_names": [],
@@ -33394,23 +33532,23 @@
           "cr_refs": []
         },
         {
+          "name": "PlanarDice",
+          "line": 441,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PlaneswalkedFrom",
+          "line": 442,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "PlaneswalkedTo",
-          "line": 439,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChaosEnsues",
-          "line": 440,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RolledDie",
           "line": 443,
           "kind": "unit",
           "field_names": [],
@@ -33418,7 +33556,7 @@
           "cr_refs": []
         },
         {
-          "name": "RolledDieOnce",
+          "name": "ChaosEnsues",
           "line": 444,
           "kind": "unit",
           "field_names": [],
@@ -33426,8 +33564,24 @@
           "cr_refs": []
         },
         {
+          "name": "RolledDie",
+          "line": 447,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RolledDieOnce",
+          "line": 448,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "FlippedCoin",
-          "line": 445,
+          "line": 449,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33435,7 +33589,7 @@
         },
         {
           "name": "Clashed",
-          "line": 446,
+          "line": 450,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33443,7 +33597,7 @@
         },
         {
           "name": "DayTimeChanges",
-          "line": 450,
+          "line": 454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730: Triggers when it becomes day or night.",
@@ -33453,22 +33607,6 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 453,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Copied",
-          "line": 456,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ConjureAll",
           "line": 457,
           "kind": "unit",
           "field_names": [],
@@ -33476,7 +33614,7 @@
           "cr_refs": []
         },
         {
-          "name": "Vote",
+          "name": "Copied",
           "line": 460,
           "kind": "unit",
           "field_names": [],
@@ -33484,8 +33622,24 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeRenowned",
+          "name": "ConjureAll",
+          "line": 461,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Vote",
           "line": 464,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomeRenowned",
+          "line": 468,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112: Triggers when a creature becomes renowned.",
@@ -33495,7 +33649,7 @@
         },
         {
           "name": "BecomeMonstrous",
-          "line": 466,
+          "line": 470,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99: Triggers when a creature becomes monstrous.",
@@ -33505,7 +33659,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 470,
+          "line": 474,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.34: Triggers when a player proliferates.",
@@ -33515,7 +33669,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 471,
+          "line": 475,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33523,7 +33677,7 @@
         },
         {
           "name": "Surveil",
-          "line": 475,
+          "line": 479,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.25: Triggers when a player surveils.",
@@ -33533,7 +33687,7 @@
         },
         {
           "name": "Scry",
-          "line": 477,
+          "line": 481,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.22: Triggers when a player scries.",
@@ -33543,7 +33697,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 479,
+          "line": 483,
           "kind": "unit",
           "field_names": [],
           "doc": "General typed player-action trigger for joined action lists.",
@@ -33551,7 +33705,7 @@
         },
         {
           "name": "Fight",
-          "line": 483,
+          "line": 487,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.14: Triggers when creatures fight.",
@@ -33561,22 +33715,6 @@
         },
         {
           "name": "FightOnce",
-          "line": 484,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Abandoned",
-          "line": 487,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CaseSolved",
           "line": 488,
           "kind": "unit",
           "field_names": [],
@@ -33584,23 +33722,7 @@
           "cr_refs": []
         },
         {
-          "name": "ClaimPrize",
-          "line": 489,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CollectEvidence",
-          "line": 490,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CommitCrime",
+          "name": "Abandoned",
           "line": 491,
           "kind": "unit",
           "field_names": [],
@@ -33608,7 +33730,7 @@
           "cr_refs": []
         },
         {
-          "name": "CrankContraption",
+          "name": "CaseSolved",
           "line": 492,
           "kind": "unit",
           "field_names": [],
@@ -33616,7 +33738,7 @@
           "cr_refs": []
         },
         {
-          "name": "Devoured",
+          "name": "ClaimPrize",
           "line": 493,
           "kind": "unit",
           "field_names": [],
@@ -33624,7 +33746,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "CollectEvidence",
           "line": 494,
           "kind": "unit",
           "field_names": [],
@@ -33632,7 +33754,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "CommitCrime",
           "line": 495,
           "kind": "unit",
           "field_names": [],
@@ -33640,7 +33762,7 @@
           "cr_refs": []
         },
         {
-          "name": "FullyUnlock",
+          "name": "CrankContraption",
           "line": 496,
           "kind": "unit",
           "field_names": [],
@@ -33648,7 +33770,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveGift",
+          "name": "Devoured",
           "line": 497,
           "kind": "unit",
           "field_names": [],
@@ -33656,7 +33778,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "Discover",
           "line": 498,
           "kind": "unit",
           "field_names": [],
@@ -33664,7 +33786,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mentored",
+          "name": "Forage",
           "line": 499,
           "kind": "unit",
           "field_names": [],
@@ -33672,7 +33794,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mutates",
+          "name": "FullyUnlock",
           "line": 500,
           "kind": "unit",
           "field_names": [],
@@ -33680,7 +33802,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchedLibrary",
+          "name": "GiveGift",
           "line": 501,
           "kind": "unit",
           "field_names": [],
@@ -33688,7 +33810,7 @@
           "cr_refs": []
         },
         {
-          "name": "SeekAll",
+          "name": "ManifestDread",
           "line": 502,
           "kind": "unit",
           "field_names": [],
@@ -33696,7 +33818,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetInMotion",
+          "name": "Mentored",
           "line": 503,
           "kind": "unit",
           "field_names": [],
@@ -33704,7 +33826,7 @@
           "cr_refs": []
         },
         {
-          "name": "Specializes",
+          "name": "Mutates",
           "line": 504,
           "kind": "unit",
           "field_names": [],
@@ -33712,7 +33834,7 @@
           "cr_refs": []
         },
         {
-          "name": "Stationed",
+          "name": "SearchedLibrary",
           "line": 505,
           "kind": "unit",
           "field_names": [],
@@ -33720,7 +33842,7 @@
           "cr_refs": []
         },
         {
-          "name": "Trains",
+          "name": "SeekAll",
           "line": 506,
           "kind": "unit",
           "field_names": [],
@@ -33728,7 +33850,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnlockDoor",
+          "name": "SetInMotion",
           "line": 507,
           "kind": "unit",
           "field_names": [],
@@ -33736,7 +33858,7 @@
           "cr_refs": []
         },
         {
-          "name": "VisitAttraction",
+          "name": "Specializes",
           "line": 508,
           "kind": "unit",
           "field_names": [],
@@ -33744,7 +33866,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesCrewed",
+          "name": "Stationed",
           "line": 509,
           "kind": "unit",
           "field_names": [],
@@ -33752,7 +33874,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesPlotted",
+          "name": "Trains",
           "line": 510,
           "kind": "unit",
           "field_names": [],
@@ -33760,7 +33882,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesSaddled",
+          "name": "UnlockDoor",
           "line": 511,
           "kind": "unit",
           "field_names": [],
@@ -33768,7 +33890,7 @@
           "cr_refs": []
         },
         {
-          "name": "Immediate",
+          "name": "VisitAttraction",
           "line": 512,
           "kind": "unit",
           "field_names": [],
@@ -33776,8 +33898,40 @@
           "cr_refs": []
         },
         {
-          "name": "Always",
+          "name": "BecomesCrewed",
+          "line": 513,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomesPlotted",
           "line": 514,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomesSaddled",
+          "line": 515,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Immediate",
+          "line": 516,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Always",
+          "line": 518,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.1: \"Always\" — a special trigger mode representing a continuous trigger condition.",
@@ -33787,7 +33941,7 @@
         },
         {
           "name": "EntersOrAttacks",
-          "line": 518,
+          "line": 522,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Whenever ~ enters or attacks\" — fires on both ETB (CR 603.6a) and attack (CR 508.3a) events.",
@@ -33798,7 +33952,7 @@
         },
         {
           "name": "AttacksOrBlocks",
-          "line": 520,
+          "line": 524,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Whenever ~ attacks or blocks\" — fires on both attack (CR 508.3a) and block (CR 509.1h) events.",
@@ -33809,7 +33963,7 @@
         },
         {
           "name": "StateCondition",
-          "line": 526,
+          "line": 530,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.8: State trigger — fires when a game-state condition becomes true, rather than in response to an event. Checked whenever a player would receive priority. The engine tracks whether the trigger is already on the stack to prevent re-triggering until the ability has resolved, been countered, or otherwise left the stack.",
@@ -33819,38 +33973,6 @@
         },
         {
           "name": "Airbend",
-          "line": 529,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Earthbend",
-          "line": 530,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Firebend",
-          "line": 531,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Waterbend",
-          "line": 532,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ElementalBend",
           "line": 533,
           "kind": "unit",
           "field_names": [],
@@ -33858,8 +33980,40 @@
           "cr_refs": []
         },
         {
+          "name": "Earthbend",
+          "line": 534,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Firebend",
+          "line": 535,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Waterbend",
+          "line": 536,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ElementalBend",
+          "line": 537,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "HauntedCreatureDies",
-          "line": 541,
+          "line": 545,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.55c: Haunt payoff — \"When the creature this card haunts dies, …\". A dynamic, per-card trigger that fires while the card is in the exile zone (`trigger_zones = [Exile]`): it matches a creature's death only when that creature is the one the source card haunts, resolved through the `ExileLinkKind::Haunt` link. Matched by `game::haunt::match_haunted_creature_dies`.",
@@ -33869,7 +34023,7 @@
         },
         {
           "name": "Unknown",
-          "line": 544,
+          "line": 548,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized trigger mode strings.",
@@ -34133,7 +34287,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4589,
+      "line": 4621,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -34142,7 +34296,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 4591,
+          "line": 4623,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34150,7 +34304,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 4592,
+          "line": 4624,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34158,7 +34312,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 4593,
+          "line": 4625,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34168,7 +34322,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 4596,
+          "line": 4628,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34178,7 +34332,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 4608,
+          "line": 4640,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34194,7 +34348,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4009,
+      "line": 4041,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -34207,7 +34361,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 4013,
+          "line": 4045,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -34220,7 +34374,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 4017,
+          "line": 4049,
           "kind": "struct",
           "field_names": [
             "property",
@@ -34267,7 +34421,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9183,
+      "line": 9263,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -34276,7 +34430,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 9186,
+          "line": 9266,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -34286,7 +34440,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 9190,
+          "line": 9270,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -34296,7 +34450,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 9198,
+          "line": 9278,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",


### PR DESCRIPTION
Adds the Momir Basic format: a 60-basic-land deck, 24 life, and a
game-start-granted command-zone emblem with the activated ability
"{X}, Discard a card: Create a token that's a copy of a creature card
with mana value X chosen at random" (sorcery-speed, once per turn).

Delivery is emblem-based (Vanguard card type deferred); the emblem is
granted programmatically via a new single-authority grant_emblem helper,
leaving Effect::CreateEmblem unchanged so the dormant mtgish-import crate
is untouched.

Core reusable primitive: Effect::CreateTokenCopyFromPool, which creates a
token copy of a card drawn (random/chosen) from the in-game card pool,
filtered by core type and a mana-value comparator. The Arena variants
(Momir's Madness, Oko's Madness) and Alchemy seek-and-conjure cards are
later parameterizations of this effect.

Pool access uses two #[serde(skip)] GameState fields rebuilt per peer in
rehydrate_card_db_metadata (selection index + hydration map), gated on
format==Momir; random selection consumes the seeded ChaCha20 RNG so it
stays deterministic across multiplayer/replay.

Also hardens the shared activation cost pipeline for the {X}+discard cost
shape (CR 601.2f): hoists X-cost resolution before non-mana cost detours
and threads a positive x_residual signal so the residual discard is paid
exactly once.
