### PR TITLE
fix(parser): route “dealt damage this way can’t be regenerated” riders

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2843,6 +2843,24 @@ fn affected_objects_from_events(
                 _ => None,
             })
             .collect(),
+        // CR 608.2c + CR 701.19c: damage publishes the damaged objects so a
+        // downstream "<noun> dealt damage this way can't be regenerated"
+        // sub-ability binds to exactly those creatures (Incinerate/Flamebreak/
+        // Jaya Ballard, Task Mage). Object targets only — a player carries no
+        // regen shield and the static is inert on players. CR 120.3/120.6: only
+        // creatures actually dealt a nonzero amount were "dealt damage this way"
+        // (fully-prevented damage doesn't count), so require `amount > 0`.
+        Effect::DealDamage { .. } | Effect::DamageAll { .. } => events
+            .iter()
+            .filter_map(|event| match event {
+                GameEvent::DamageDealt {
+                    target: TargetRef::Object(id),
+                    amount,
+                    ..
+                } if *amount > 0 => Some(*id),
+                _ => None,
+            })
+            .collect(),
         Effect::Sacrifice { .. } => events
             .iter()
             .filter_map(|event| match event {

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -3946,4 +3946,85 @@ mod tests {
         assert!(obj.abilities.is_empty());
         assert!(obj.keywords.is_empty());
     }
+
+    /// Build a scenario with a 2/2 victim (P1) that carries a regeneration
+    /// shield and an Incinerate-class spell (P0) carrying `oracle_text`. Casts
+    /// the spell at the victim through the full pipeline and returns the
+    /// `(CastOutcome, victim_id)`.
+    fn cast_damage_at_shielded_victim(oracle_text: &str) -> (CastOutcome, ObjectId) {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        // CR 701.19a: a 2/2 creature carrying a one-shot regeneration shield.
+        let victim = scenario
+            .add_creature(P1, "Shielded Bear", 2, 2)
+            .with_replacement_definition(
+                ReplacementDefinition::new(crate::types::replacements::ReplacementEvent::Destroy)
+                    .valid_card(TargetFilter::SelfRef)
+                    .description("Regenerate".to_string())
+                    .regeneration_shield(),
+            )
+            .id();
+        let spell = scenario
+            .add_spell_to_hand_from_oracle(P0, "Incinerate Test", true, oracle_text)
+            .id();
+        let mut runner = scenario.build();
+        let outcome = runner.cast(spell).target_object(victim).resolve();
+        (outcome, victim)
+    }
+
+    /// CR 701.19c + CR 608.2c + CR 614.8 (issue #3333) — DISCRIMINATING runtime
+    /// gate. Incinerate deals LETHAL damage to a creature that HAS a regeneration
+    /// shield. The "A creature dealt damage this way can't be regenerated this
+    /// turn." rider must publish the damaged creature (non-empty tracked set) and
+    /// grant it `CantBeRegenerated`, so the SBA destruction BYPASSES the shield
+    /// and the creature DIES. This fails if the Part 1 collector arm OR the Part 3
+    /// TrackedSet binding is reverted (the set is empty → no static → shield
+    /// saves the creature).
+    #[test]
+    fn incinerate_rider_bypasses_regeneration_shield() {
+        let (outcome, victim) = cast_damage_at_shielded_victim(
+            "Incinerate deals 3 damage to any target. A creature dealt damage \
+             this way can't be regenerated this turn.",
+        );
+
+        // CR 701.19c: the shield is not applied — the creature is destroyed.
+        outcome.assert_zone(&[victim], Zone::Graveyard);
+
+        // DIRECTLY catches the empty-bind regression: the damage clause must have
+        // published a NON-EMPTY tracked set containing the damaged creature's id.
+        let published_any = outcome
+            .state()
+            .tracked_object_sets
+            .values()
+            .any(|set| set.contains(&victim));
+        assert!(
+            published_any,
+            "the damage clause must publish a non-empty tracked set containing \
+             the damaged creature (got {:?})",
+            outcome.state().tracked_object_sets
+        );
+    }
+
+    /// CR 701.19a/b — CONTROL for the discriminating gate. The same lethal damage
+    /// to the same shielded creature WITHOUT the regen rider: the regeneration
+    /// shield SAVES the creature (it stays on the battlefield, tapped, with damage
+    /// removed). Confirms the bypass above is caused specifically by the rider,
+    /// not by the damage alone.
+    #[test]
+    fn damage_without_rider_lets_regeneration_shield_save() {
+        let (outcome, victim) =
+            cast_damage_at_shielded_victim("Incinerate Test deals 3 damage to any target.");
+
+        // CR 701.19a/b: the shield regenerates the creature — it survives.
+        outcome.assert_zone(&[victim], Zone::Battlefield);
+        assert!(
+            outcome.state().objects[&victim].tapped,
+            "CR 701.19b: a regenerated creature is tapped"
+        );
+        assert_eq!(
+            outcome.state().objects[&victim].damage_marked,
+            0,
+            "CR 701.19a: regeneration removes all marked damage"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -149,6 +149,19 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
                         }
                         true
                     }
+                    SpecialClause::CantBeRegeneratedRider(rider_def) => {
+                        // CR 608.2c + CR 701.19c: Attach the "<noun> dealt damage
+                        // this way can't be regenerated" rider as the tail of the
+                        // preceding damage clause's sub_ability chain. The rider's
+                        // `GenericEffect{target: TrackedSet}` then trips
+                        // `next_sub_needs_tracked_set` on that damage clause, so it
+                        // publishes the damaged object ids the rider's
+                        // CantBeRegenerated static binds to.
+                        if let Some(last_def) = defs.last_mut() {
+                            append_to_deepest_sub_ability(last_def, Some(rider_def.clone()));
+                        }
+                        true
+                    }
                     SpecialClause::DigInsteadAlt(alt_def) => {
                         if let Some(last_def) = defs.pop() {
                             let mut new_def = *alt_def.clone();

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16108,6 +16108,61 @@ pub(crate) fn parse_effect_chain_ir(
             }
         }
 
+        // CR 608.2c + CR 701.19c: "[noun] dealt damage this way can't be
+        // regenerated this turn." — a separate-sentence regen rider on the
+        // preceding damage clause (Incinerate, Flamebreak, Jaya Ballard, Task
+        // Mage). Attaches as that clause's sub_ability so the damage clause
+        // publishes its struck-object set, which the rider's CantBeRegenerated
+        // static binds to via `TrackedSet`. Guarded on a preceding damage clause
+        // so the targeted/anaphor regen forms (Hurr Jackal, Lim-Dûl's Cohort)
+        // keep their standalone in-chain dispatch.
+        if clauses
+            .iter()
+            .rev()
+            .find(|clause| !clause.absorbed_by_followup)
+            .is_some_and(|clause| {
+                matches!(
+                    &clause.parsed.effect,
+                    Effect::DealDamage { .. } | Effect::DamageAll { .. }
+                )
+            })
+        {
+            if let Some(rider_def) = subject::try_parse_cant_be_regenerated_damage_rider(
+                normalized_text.trim_end_matches('.').trim(),
+                kind,
+            ) {
+                clauses.push(ClauseIr {
+                    // Structural sentinel: replaced during lowering by the
+                    // SpecialClause attach (mirrors the DieExileRider placeholder).
+                    parsed: parsed_clause(Effect::unimplemented(
+                        "cant_be_regenerated_rider_placeholder",
+                        "",
+                    )),
+                    boundary: chunk.boundary_after,
+                    condition: None,
+                    is_optional: false,
+                    opponent_may_scope: None,
+                    repeat_for: None,
+                    player_scope: None,
+                    starting_with: None,
+                    delayed_condition: None,
+                    prefix_delayed_condition: None,
+                    intrinsic_continuation: None,
+                    followup_continuation: None,
+                    absorbed_by_followup: false,
+                    multi_target: None,
+                    where_x_expression: None,
+                    is_otherwise: false,
+                    unless_pay: None,
+                    special: Some(SpecialClause::CantBeRegeneratedRider(Box::new(rider_def))),
+                    source_text: normalized_text.to_string(),
+                    target_selection_mode: TargetSelectionMode::Chosen,
+                    target_chooser: None,
+                });
+                continue;
+            }
+        }
+
         if is_free_cast_exile_instead_rider(rider_lower.trim_end_matches('.').trim()) {
             if let Some(previous) = clauses.iter_mut().rev().find(|clause| {
                 !clause.absorbed_by_followup
@@ -31353,6 +31408,157 @@ mod tests {
             sd.affected,
             Some(TargetFilter::ParentTarget),
             "the 'that creature' anaphor must resolve to ParentTarget"
+        );
+    }
+
+    /// CR 608.2c + CR 701.19c: Incinerate — "Incinerate deals 3 damage to any
+    /// target. A creature dealt damage this way can't be regenerated this turn."
+    /// The regen sentence is a damage-anaphor rider: it attaches as a sub-ability
+    /// of the parent DealDamage clause and binds to the published `TrackedSet`,
+    /// NOT a fresh target.
+    #[test]
+    fn cant_be_regenerated_damage_rider_incinerate() {
+        use crate::types::statics::StaticMode;
+        let def = parse_effect_chain(
+            "Incinerate deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(&*def.effect, Effect::DealDamage { .. }),
+            "parent must be DealDamage, got {:?}",
+            def.effect
+        );
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("regen rider must attach as a sub-ability of the damage clause");
+        let Effect::GenericEffect {
+            static_abilities,
+            duration,
+            target,
+        } = &*sub.effect
+        else {
+            panic!("expected GenericEffect rider, got {:?}", sub.effect);
+        };
+        assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+        assert_eq!(
+            *target,
+            Some(TargetFilter::TrackedSet {
+                id: TrackedSetId(0)
+            }),
+            "rider must bind to the damage clause's published tracked set"
+        );
+        let sd = static_abilities
+            .first()
+            .expect("expected CantBeRegenerated static");
+        assert!(
+            matches!(&sd.mode, StaticMode::CantBeRegenerated),
+            "expected CantBeRegenerated, got {:?}",
+            sd.mode
+        );
+        assert_eq!(
+            sd.affected,
+            Some(TargetFilter::ParentTarget),
+            "static affected resolves the TrackedSet via ParentTarget at runtime"
+        );
+    }
+
+    /// CR 608.2c + CR 701.19c: Flamebreak — "Flamebreak deals 3 damage to each
+    /// creature without flying and each player. Creatures dealt damage this way
+    /// can't be regenerated this turn." Parent is DamageAll; the PLURAL anaphor
+    /// ("creatures dealt damage this way") routes to the same TrackedSet rider.
+    #[test]
+    fn cant_be_regenerated_damage_rider_flamebreak_plural() {
+        use crate::types::statics::StaticMode;
+        let def = parse_effect_chain(
+            "Flamebreak deals 3 damage to each creature without flying and each player. Creatures dealt damage this way can't be regenerated this turn.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(&*def.effect, Effect::DamageAll { .. }),
+            "parent must be DamageAll, got {:?}",
+            def.effect
+        );
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("plural regen rider must attach as a sub-ability of DamageAll");
+        let Effect::GenericEffect {
+            static_abilities,
+            target,
+            ..
+        } = &*sub.effect
+        else {
+            panic!("expected GenericEffect rider, got {:?}", sub.effect);
+        };
+        assert_eq!(
+            *target,
+            Some(TargetFilter::TrackedSet {
+                id: TrackedSetId(0)
+            }),
+        );
+        assert!(matches!(
+            static_abilities.first().map(|sd| &sd.mode),
+            Some(StaticMode::CantBeRegenerated)
+        ));
+    }
+
+    /// CR 608.2c + CR 701.19c: Jaya Ballard, Task Mage mode 2 — "{1}{R}, {T},
+    /// Discard a card: Jaya Ballard deals 3 damage to any target. A creature
+    /// dealt damage this way can't be regenerated this turn." The activated
+    /// ability's effect body has the same damage-anaphor rider shape.
+    #[test]
+    fn cant_be_regenerated_damage_rider_jaya_ballard() {
+        use crate::types::statics::StaticMode;
+        let def = parse_effect_chain(
+            "Jaya Ballard deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
+            AbilityKind::Activated,
+        );
+        assert!(
+            matches!(&*def.effect, Effect::DealDamage { .. }),
+            "parent must be DealDamage, got {:?}",
+            def.effect
+        );
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("regen rider must attach as a sub-ability");
+        let Effect::GenericEffect {
+            static_abilities,
+            target,
+            ..
+        } = &*sub.effect
+        else {
+            panic!("expected GenericEffect rider, got {:?}", sub.effect);
+        };
+        assert_eq!(
+            *target,
+            Some(TargetFilter::TrackedSet {
+                id: TrackedSetId(0)
+            }),
+        );
+        assert!(matches!(
+            static_abilities.first().map(|sd| &sd.mode),
+            Some(StaticMode::CantBeRegenerated)
+        ));
+    }
+
+    /// CR 701.19c: Full-card flip — Incinerate's regen clause must NOT fall to
+    /// an Unimplemented effect anywhere in its resolved chain.
+    #[test]
+    fn incinerate_full_card_has_no_unimplemented_regen_clause() {
+        let def = parse_effect_chain(
+            "Incinerate deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
+            AbilityKind::Spell,
+        );
+        fn has_unimplemented(def: &crate::types::ability::AbilityDefinition) -> bool {
+            matches!(&*def.effect, Effect::Unimplemented { .. })
+                || def.sub_ability.as_deref().is_some_and(has_unimplemented)
+                || def.else_ability.as_deref().is_some_and(has_unimplemented)
+        }
+        assert!(
+            !has_unimplemented(&def),
+            "Incinerate must parse with no Unimplemented clause: {def:?}"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -454,7 +454,14 @@ fn try_parse_subject_restriction_clause(
         nom_primitives::scan_preceded(&lower, parse_cant_be_regenerated_predicate)
     {
         let subject = text[..before_lower.len()].trim();
-        let application = subject_application_for_cant_be_activated(subject, ctx)?;
+        // CR 608.2c + CR 701.19c: the DAMAGE-form anaphor ("a creature/creatures/
+        // a permanent dealt damage this way") binds to the preceding damage
+        // clause's published set (`TrackedSet`) rather than a fresh target.
+        // Tried first so it pre-empts the generic subject resolution; non-damage
+        // subjects (Hurr Jackal, Lim-Dûl's Cohort) return None here and fall
+        // through to `subject_application_for_cant_be_activated`.
+        let application = subject_application_for_cant_be_regenerated(subject)
+            .or_else(|| subject_application_for_cant_be_activated(subject, ctx))?;
         let affected = static_affected_for_application(&application);
         let mode = StaticMode::CantBeRegenerated;
         return Some(ParsedEffectClause {
@@ -1380,6 +1387,85 @@ pub(super) fn parse_leading_subject_application(
 ) -> Option<SubjectApplication> {
     let subject_text = extract_subject_text(text)?;
     parse_subject_application(&subject_text, ctx)
+}
+
+/// CR 608.2c + CR 701.19c: Resolve the subject of a DAMAGE-form
+/// "[noun] dealt damage this way can't be regenerated [this turn]" clause.
+///
+/// The three clean cards (Incinerate, Flamebreak, Jaya Ballard, Task Mage)
+/// print this regen prohibition as a separate sentence following a damage
+/// clause. The subject is the anaphor "a creature/creatures/a permanent dealt
+/// damage this way" — a back-reference (CR 608.2c "this way") to the set of
+/// objects the preceding damage effect struck, NOT a fresh target. It resolves
+/// to the most recently published tracked set (`TrackedSetId(0)` sentinel),
+/// which the parent damage clause publishes once this rider is attached as its
+/// sub-ability (the `target: Some(TrackedSet)` trips
+/// `next_sub_needs_tracked_set`, and `affected_objects_from_events`' DealDamage
+/// arm collects the damaged object ids). The anaphor tag set mirrors the
+/// die-exile rider's (`oracle_effect/mod.rs::try_parse_die_exile_rider`) plus
+/// the plural "creatures dealt damage this way" for the DamageAll form
+/// (Flamebreak). Returns `None` for every non-damage subject so the other
+/// "can't be regenerated" clauses (Hurr Jackal, Lim-Dûl's Cohort) fall through
+/// to `subject_application_for_cant_be_activated` unchanged.
+fn subject_application_for_cant_be_regenerated(subject: &str) -> Option<SubjectApplication> {
+    let lower = subject.to_lowercase();
+    let matched = all_consuming(alt((
+        tag::<_, _, OracleError<'_>>("a creature dealt damage this way"),
+        tag("creatures dealt damage this way"),
+        tag("a permanent dealt damage this way"),
+    )))
+    .parse(lower.as_str())
+    .is_ok();
+    if !matched {
+        return None;
+    }
+    let tracked = TargetFilter::TrackedSet {
+        id: crate::types::identifiers::TrackedSetId(0),
+    };
+    Some(SubjectApplication {
+        affected: tracked.clone(),
+        // The static binds to the damaged-object tracked set via `target`/`affected`
+        // above; the rider does not inherit the parent's chosen targets.
+        target: Some(tracked),
+        multi_target: None,
+        inherits_parent: false,
+        is_optional: false,
+    })
+}
+
+/// CR 608.2c + CR 701.19c: Build the separate-sentence regen rider attached to a
+/// preceding damage clause. Recognizes the full "[noun] dealt damage this way
+/// can't be regenerated [this turn]" sentence (the three clean cards print it as
+/// its own sentence) and returns an `AbilityDefinition` carrying the
+/// `GenericEffect{CantBeRegenerated}` whose `target: TrackedSet(0)` binds to the
+/// damage clause's published set. Mirrors `static_affected_for_application`'s
+/// `target.is_some() → ParentTarget` convention so the static's `affected` is the
+/// runtime-bound `ParentTarget` (which the GenericEffect resolver reads against
+/// `chain_tracked_set_id`). Returns `None` for any other "can't be regenerated"
+/// subject (the targeted/anaphor forms keep their existing in-chain dispatch).
+pub(super) fn try_parse_cant_be_regenerated_damage_rider(
+    text: &str,
+    kind: AbilityKind,
+) -> Option<AbilityDefinition> {
+    let lower = text.to_lowercase();
+    let (before_lower, (), _) =
+        nom_primitives::scan_preceded(&lower, parse_cant_be_regenerated_predicate)?;
+    let subject = text[..before_lower.len()].trim();
+    let application = subject_application_for_cant_be_regenerated(subject)?;
+    let affected = static_affected_for_application(&application);
+    let mode = StaticMode::CantBeRegenerated;
+    let def = AbilityDefinition::new(
+        kind,
+        Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::new(mode.clone())
+                .affected(affected)
+                .modifications(vec![ContinuousModification::AddStaticMode { mode }])],
+            duration: Some(Duration::UntilEndOfTurn),
+            target: application.target,
+        },
+    )
+    .duration(Duration::UntilEndOfTurn);
+    Some(def)
 }
 
 /// CR 602.5 + CR 603.2a + CR 608.2c: Resolve the subject of an EFFECT-form

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -57,6 +57,12 @@ pub(crate) enum SpecialClause {
     OtherwiseFallback(Box<AbilityDefinition>),
     /// CR 614.1a + CR 514.2: Die-exile-rider — attach as sub_ability on previous def.
     DieExileRider(Box<AbilityDefinition>),
+    /// CR 608.2c + CR 701.19c: "[noun] dealt damage this way can't be
+    /// regenerated this turn." — a separate-sentence regen rider that attaches
+    /// as a sub_ability on the previous damage clause (Incinerate, Flamebreak,
+    /// Jaya Ballard, Task Mage). Carries a `GenericEffect{CantBeRegenerated}`
+    /// whose `target: TrackedSet` binds to the damage clause's published set.
+    CantBeRegeneratedRider(Box<AbilityDefinition>),
     /// CR 608.2c: Dig-instead alternative — replace previous Dig with conditional alternative.
     DigInsteadAlt(Box<AbilityDefinition>),
     /// CR 608.2e: Generic instead clause — attach to previous def as sub_ability.


### PR DESCRIPTION
Closes #3333.

## Problem
The post-damage regeneration-prohibition rider with an anaphoric subject — **"A creature dealt damage this way can’t be regenerated this turn"** / **"Creatures dealt damage this way …"** — was dropped. It requires binding the existing `StaticMode::CantBeRegenerated` to the set of creatures the source damaged, but `affected_objects_from_events` had no `DealDamage`/`DamageAll` arm, so that tracked set was always empty and the rider did nothing.

## Fix (parser + one engine collector arm)
- Add the missing `DealDamage`/`DamageAll` arm to `affected_objects_from_events`, collecting `GameEvent::DamageDealt` object targets dealt a **nonzero** amount (CR 120.3/120.6 — fully-prevented damage doesn’t count).
- A dedicated `subject_application_for_cant_be_regenerated` combinator recognizes the singular/plural/permanent “dealt damage this way” anaphors and binds the static to `TrackedSet`.
- A `CantBeRegeneratedRider` sub-ability attaches to the preceding damage clause (mirrors the existing die-exile rider), so the static binds to exactly those creatures and the regen-shield bypass (`object_has_active_cant_be_regenerated`) fires at destroy time.

## Result
Flips **Incinerate, Flamebreak** (mass damage), and **Jaya Ballard, Task Mage**. Conditional forms (Disintegrate/Carbonize “if it’s a creature”), kicker-gated Scorching Lava, and destroy-form riders (Breaking Point, Kirtar’s Wrath, War Barge) are intentionally left as separate gaps.

## Verification
- **Discriminating runtime tests** drive the real damage → SBA-destroy → regen-shield pipeline: a creature with a regeneration shield dealt lethal damage **dies** with the rider (shield bypassed) and the published tracked set is **non-empty**; **without** the rider the shield **saves** it. Proven fail-if-reverted (disabling the collector arm yields an empty set and the shield saves).
- The collector arm only changes behavior when a sub-ability references the tracked set; no existing card co-occurs damage + a tracked-set sub-ability (full integration suite green).
- Engine lib suite (11921) + full integration suite (1035) green; `cargo fmt`, parser-combinator gate, and `clippy --workspace -- -D warnings` clean.
- Coverage regen vs same-commit baseline: **supported +3, swallowed-clause delta 0, 0 regressions.**

CR 701.19a (regeneration shield), CR 701.19c (effects that say a permanent can’t be regenerated cause regeneration shields to not be applied), CR 614.8 (regeneration is a destruction-replacement effect), CR 608.2c.