### PR TITLE
feat(parser): parse per-kind counter add-or-remove

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3448,8 +3448,16 @@ fn rebind_iterated_counter_kind(
             if branch.iteration_kind_binding
                 == Some(crate::types::ability::IterationKindBinding::RebindToIteratedKind)
             {
-                if let Effect::PutCounter { counter_type, .. } = branch.effect.as_mut() {
-                    *counter_type = kind.clone();
+                // CR 122.1: rebind both the add (`PutCounter`) and remove
+                // (`RemoveCounter`) leaves to the iterated kind. Dramatist's
+                // Puppet / Quarry Hauler offer a per-kind add-OR-remove choice,
+                // so the remove branch must also track the current kind.
+                match branch.effect.as_mut() {
+                    Effect::PutCounter { counter_type, .. } => *counter_type = kind.clone(),
+                    Effect::RemoveCounter { counter_type, .. } => {
+                        *counter_type = Some(kind.clone())
+                    }
+                    _ => {}
                 }
             }
         }
@@ -16910,6 +16918,153 @@ mod tests {
         assert_eq!(
             state.waiting_for, initial_waiting,
             "empty counter set must not prompt"
+        );
+    }
+
+    /// CR 122.1 + CR 608.2d: Dramatist's Puppet / Quarry Hauler end-to-end — a
+    /// `TargetOnly` parent plus a per-kind add-OR-remove `ChooseOneOf` driven by
+    /// `repeat_for: DistinctCounterKindsAmong { ParentTarget }` over the chosen
+    /// permanent. Discriminating: the kind set must resolve against the chosen
+    /// TARGET (not the battlefield), and the remove branch must rebind to the
+    /// iterated kind. Two kinds on the target; the deterministic sort by
+    /// `as_str` is ["P1P1", "lore"], so iteration 0 (Plus1Plus1) ADDS and
+    /// iteration 1 (Lore) REMOVES.
+    #[test]
+    fn targeted_counter_adjust_add_and_remove_per_kind() {
+        use crate::game::engine::apply;
+        use crate::types::ability::{IterationKindBinding, PlayerFilter};
+        use crate::types::actions::GameAction;
+        use crate::types::counter::CounterType;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Quarry Hauler".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        // The chosen target permanent carries TWO distinct counter kinds.
+        let target = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Target".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&target).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.counters.insert(CounterType::Plus1Plus1, 2);
+            obj.counters.insert(CounterType::Lore, 1);
+        }
+
+        let add_branch = AbilityDefinition {
+            iteration_kind_binding: Some(IterationKindBinding::RebindToIteratedKind),
+            ..AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::ParentTarget,
+                },
+            )
+        };
+        let remove_branch = AbilityDefinition {
+            iteration_kind_binding: Some(IterationKindBinding::RebindToIteratedKind),
+            ..AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::RemoveCounter {
+                    counter_type: Some(CounterType::Plus1Plus1),
+                    count: 1,
+                    target: TargetFilter::ParentTarget,
+                },
+            )
+        };
+
+        let mut choice_sub = ResolvedAbility::new(
+            Effect::ChooseOneOf {
+                chooser: PlayerFilter::Controller,
+                branches: vec![add_branch, remove_branch],
+            },
+            vec![TargetRef::Object(target)],
+            source,
+            PlayerId(0),
+        );
+        choice_sub.repeat_for = Some(QuantityExpr::Ref {
+            qty: QuantityRef::DistinctCounterKindsAmong {
+                filter: TargetFilter::ParentTarget,
+            },
+        });
+
+        let mut ability = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::Typed(crate::types::ability::TypedFilter {
+                    type_filters: vec![crate::types::ability::TypeFilter::Permanent],
+                    controller: None,
+                    properties: vec![],
+                }),
+            },
+            vec![TargetRef::Object(target)],
+            source,
+            PlayerId(0),
+        );
+        ability.sub_ability = Some(Box::new(choice_sub));
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        // Iteration 0 (Plus1Plus1 — sorts first): surface the branch choice, ADD.
+        assert!(
+            matches!(state.waiting_for, WaitingFor::ChooseOneOfBranch { .. }),
+            "iteration 0 must surface the per-kind add/remove choice, got {:?}",
+            state.waiting_for
+        );
+        let r = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::ChooseBranch { index: 0 }, // add
+        )
+        .unwrap();
+        events.extend(r.events);
+
+        // Iteration 1 (Lore): surface again, then REMOVE.
+        assert!(
+            matches!(state.waiting_for, WaitingFor::ChooseOneOfBranch { .. }),
+            "iteration 1 must surface its own per-kind choice, got {:?}",
+            state.waiting_for
+        );
+        let r = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::ChooseBranch { index: 1 }, // remove
+        )
+        .unwrap();
+        events.extend(r.events);
+
+        let obj = state.objects.get(&target).unwrap();
+        // Plus1Plus1: started at 2, ADD one of THAT kind → 3 (rebind binds P1P1).
+        assert_eq!(
+            obj.counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            3,
+            "adding the P1P1 iteration must add a P1P1 counter (rebind)"
+        );
+        // Lore: started at 1, REMOVE one of THAT kind → 0 (rebind binds Lore).
+        assert_eq!(
+            obj.counters.get(&CounterType::Lore).copied().unwrap_or(0),
+            0,
+            "removing the Lore iteration must remove a LORE counter (rebind)"
         );
     }
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2788,10 +2788,31 @@ pub(crate) fn distinct_counter_kinds_among(
     filter: &TargetFilter,
     filter_ctx: &FilterContext<'_>,
 ) -> Vec<CounterType> {
+    let mut seen: HashSet<CounterType> = HashSet::new();
+    // CR 608.2c + CR 122.1: a `ParentTarget` iteration source ("for each kind of
+    // counter on target permanent" — Dramatist's Puppet, Quarry Hauler) resolves
+    // to the chosen target(s) carried on the resolving ability, not via
+    // battlefield object matching (`matches_target_filter` returns false for
+    // `ParentTarget` by design — it is resolution-time context, not a predicate).
+    if matches!(filter, TargetFilter::ParentTarget) {
+        if let Some(ability) = filter_ctx.ability {
+            for target in &ability.targets {
+                if let TargetRef::Object(id) = target {
+                    if let Some(obj) = state.objects.get(id) {
+                        for counter_type in positive_counter_types(&obj.counters) {
+                            seen.insert(counter_type);
+                        }
+                    }
+                }
+            }
+        }
+        let mut kinds: Vec<CounterType> = seen.into_iter().collect();
+        kinds.sort_by(|a, b| a.as_str().cmp(&b.as_str()));
+        return kinds;
+    }
     let zone = filter
         .extract_in_zone()
         .unwrap_or(crate::types::zones::Zone::Battlefield);
-    let mut seen: HashSet<CounterType> = HashSet::new();
     for &id in crate::game::targeting::zone_object_ids(state, zone).iter() {
         if !matches_target_filter(state, id, filter, filter_ctx) {
             continue;

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4463,6 +4463,15 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
 
+    // CR 122.1 + CR 608.2d: targeted per-kind add-OR-remove choice — "for each
+    // kind of counter on target permanent, put another counter of that kind on
+    // it or remove one from it" (Dramatist's Puppet, Quarry Hauler). Must precede
+    // the generic `for each` splitter, which would drop the "target permanent"
+    // and the per-kind choice.
+    if let Some(clause) = try_parse_for_each_counter_kind_adjust_target(text) {
+        return clause;
+    }
+
     // "for each" patterns: "draw a card for each [filter]", etc.
     if let Some(clause) = try_parse_for_each_effect(text, ctx) {
         return clause;
@@ -7943,6 +7952,153 @@ fn try_parse_proliferate_target(text: &str) -> Option<Effect> {
     }
 
     Some(Effect::ProliferateTarget { target })
+}
+
+/// CR 122.1 + CR 608.2d: "For each kind of counter on target permanent, put
+/// another counter of that kind on it or remove one from it." — a per-counter-
+/// kind add-OR-remove choice forced on a single chosen target (Dramatist's
+/// Puppet, Quarry Hauler). Unlike `try_parse_proliferate_target` (which always
+/// adds) the controller chooses, kind by kind, whether to add another counter of
+/// that kind or remove one of that kind.
+///
+/// Lowers to the proven Bribe-Taker counter-kind loop machinery, but targeted:
+/// the clause designates "target permanent" via an `Effect::TargetOnly` parent
+/// (which surfaces the target slot), and a sub-ability carries the iteration and
+/// the choice:
+///   - `repeat_for: DistinctCounterKindsAmong { filter: ParentTarget }` — one
+///     iteration per distinct counter kind already on the chosen permanent. The
+///     `repeat_for` loop resolves the kind set against the inherited target and
+///     rebinds each tagged branch to the iterated kind (CR 609.3 + CR 608.2c).
+///   - `Effect::ChooseOneOf { chooser: Controller, branches: [PutCounter,
+///     RemoveCounter] }` — both branches act on `ParentTarget` (the same chosen
+///     permanent) and are tagged `RebindToIteratedKind`, so each iteration's
+///     prompt offers "add one of THIS kind" vs "remove one of THIS kind"
+///     (CR 608.2d resolution choice).
+///
+/// Both "put … or remove …" and "remove … or put …" word orders are accepted so
+/// the class is not pinned to one card's phrasing. The placeholder counter type
+/// on each branch is a don't-care — the loop overwrites it every iteration.
+fn try_parse_for_each_counter_kind_adjust_target(text: &str) -> Option<ParsedEffectClause> {
+    type E<'a> = OracleError<'a>;
+    let lower = text.to_lowercase();
+
+    // Consume the leading "for each kind of counter on " phrase, then read the
+    // designated target with the shared target parser ("target permanent").
+    let (_, after_on) = nom_on_lower(text, &lower, |i| {
+        value((), tag::<_, _, E>("for each kind of counter on ")).parse(i)
+    })?;
+    let (target, remainder) = parse_target(after_on);
+    // A concrete target filter is required so a target slot is requested; bare
+    // `Any` would silently skip targeting.
+    if matches!(target, TargetFilter::Any) {
+        return None;
+    }
+
+    // The tail enumerates the two per-kind options joined by " or ". "it"
+    // anaphors the chosen target on both sides; the counter kind ("of that
+    // kind" / "one") is the per-iteration kind, bound by the loop.
+    let rem_lower = remainder
+        .trim_start_matches([',', ' '])
+        .to_lowercase()
+        .trim_end_matches(['.', ' '])
+        .to_string();
+
+    // CR 608.2d: each option is an independent leaf. Parse them as two
+    // alternatives in either printed order — the choice itself (which to apply)
+    // is the resolution-time decision.
+    fn parse_add_option(input: &str) -> OracleResult<'_, ()> {
+        value(
+            (),
+            alt((
+                tag("put another counter of that kind on it"),
+                tag("put one more counter of that kind on it"),
+            )),
+        )
+        .parse(input)
+    }
+    fn parse_remove_option(input: &str) -> OracleResult<'_, ()> {
+        value(
+            (),
+            alt((
+                tag("remove one from it"),
+                tag("remove a counter of that kind from it"),
+                tag("remove one of those counters from it"),
+            )),
+        )
+        .parse(input)
+    }
+
+    let rem = rem_lower.as_str();
+    let rem = if let Ok((rest, _)) = parse_add_option(rem) {
+        let (rest, _) = tag::<_, _, E>(" or ").parse(rest).ok()?;
+        let (rest, _) = parse_remove_option(rest).ok()?;
+        rest
+    } else {
+        let (rest, _) = parse_remove_option(rem).ok()?;
+        let (rest, _) = tag::<_, _, E>(" or ").parse(rest).ok()?;
+        let (rest, _) = parse_add_option(rest).ok()?;
+        rest
+    };
+    if !rem.trim().is_empty() {
+        return None;
+    }
+
+    // CR 608.2d: the two per-kind branches both act on the chosen permanent
+    // (`ParentTarget`, inherited from the `TargetOnly` parent) and are rebound to
+    // the current iterated kind by the `repeat_for` loop. The placeholder counter
+    // type is a don't-care.
+    let add_branch = AbilityDefinition {
+        description: Some("put another counter of that kind".to_string()),
+        iteration_kind_binding: Some(IterationKindBinding::RebindToIteratedKind),
+        ..AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::ParentTarget,
+            },
+        )
+    };
+    let remove_branch = AbilityDefinition {
+        description: Some("remove a counter of that kind".to_string()),
+        iteration_kind_binding: Some(IterationKindBinding::RebindToIteratedKind),
+        ..AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::RemoveCounter {
+                counter_type: Some(CounterType::Plus1Plus1),
+                count: 1,
+                target: TargetFilter::ParentTarget,
+            },
+        )
+    };
+
+    // Sub-ability: the per-kind choice, driven once per distinct kind on the
+    // chosen permanent.
+    let mut choice_sub = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChooseOneOf {
+            chooser: PlayerFilter::Controller,
+            branches: vec![add_branch, remove_branch],
+        },
+    );
+    choice_sub.repeat_for = Some(QuantityExpr::Ref {
+        qty: QuantityRef::DistinctCounterKindsAmong {
+            filter: TargetFilter::ParentTarget,
+        },
+    });
+
+    Some(ParsedEffectClause {
+        // CR 115.1: `TargetOnly` surfaces the "target permanent" slot; the chosen
+        // permanent is inherited by the sub-ability's `ParentTarget` references.
+        effect: Effect::TargetOnly { target },
+        duration: None,
+        sub_ability: Some(Box::new(choice_sub)),
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
 }
 
 fn lower_imperative_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause {
@@ -16642,15 +16798,22 @@ pub(crate) fn parse_effect_chain_ir(
         // `parse_effect_clause` claims it. The generic `for each` strip would
         // otherwise lift the counter-kind iteration into `repeat_for` and drop
         // the target, leaving an Unimplemented "give … counter" body.
-        let (repeat_for, text, for_each_reference_target) =
-            if try_parse_proliferate_target(&text).is_some() {
-                (None, text, None)
-            } else {
-                let reference_target = for_each_clause_target_controller_filter(&text);
-                let (repeat_for, text) = strip_for_each_prefix(&text);
-                let reference_target = repeat_for.as_ref().and(reference_target);
-                (repeat_for, text, reference_target)
-            };
+        // CR 122.1 + CR 608.2d: the same intact-clause requirement applies to the
+        // targeted per-kind add-OR-remove choice ("for each kind of counter on
+        // target permanent, put another counter of that kind on it or remove one
+        // from it" — Dramatist's Puppet, Quarry Hauler), whose target and choice
+        // would likewise be dropped by the generic strip.
+        let (repeat_for, text, for_each_reference_target) = if try_parse_proliferate_target(&text)
+            .is_some()
+            || try_parse_for_each_counter_kind_adjust_target(&text).is_some()
+        {
+            (None, text, None)
+        } else {
+            let reference_target = for_each_clause_target_controller_filter(&text);
+            let (repeat_for, text) = strip_for_each_prefix(&text);
+            let reference_target = repeat_for.as_ref().and(reference_target);
+            (repeat_for, text, reference_target)
+        };
         let (text_without_where_x, local_where_x_expression) = {
             let text_where_x_lower = text.to_lowercase();
             let (without_where_x, where_x_expression) =
@@ -19592,6 +19755,148 @@ mod tests {
             }
             other => panic!("expected ChooseOneOf, got {other:?}"),
         }
+    }
+
+    /// CR 122.1 + CR 608.2d: targeted per-kind add-OR-remove choice — the
+    /// Dramatist's Puppet / Quarry Hauler class. "for each kind of counter on
+    /// target permanent, put another counter of that kind on it or remove one
+    /// from it" must lower to a `TargetOnly` parent (surfacing the "target
+    /// permanent" slot) plus a sub-ability carrying a `ChooseOneOf` add/remove
+    /// choice driven once per distinct kind on the chosen permanent — NOT
+    /// `Unimplemented`.
+    #[test]
+    fn for_each_counter_kind_adjust_target_choice() {
+        let mut ctx = ParseContext::default();
+        let def = parse_effect_chain_with_context(
+            "for each kind of counter on target permanent, put another counter of that kind on it or remove one from it.",
+            AbilityKind::Spell,
+            &mut ctx,
+        );
+
+        // Parent: TargetOnly with a concrete (non-Any) target so a target slot
+        // is requested.
+        let target = match &*def.effect {
+            Effect::TargetOnly { target } => {
+                assert_ne!(
+                    *target,
+                    TargetFilter::Any,
+                    "TargetOnly must carry a concrete permanent filter so a target slot is built"
+                );
+                target.clone()
+            }
+            other => panic!("expected TargetOnly parent, got {other:?}"),
+        };
+        assert!(
+            def.effect.target_filter().is_some(),
+            "the clause must surface a target filter"
+        );
+        assert_eq!(target, def.effect.target_filter().cloned().unwrap());
+
+        // Sub-ability: the per-kind choice driven by the DistinctCounterKindsAmong
+        // loop over the chosen target (ParentTarget).
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("adjust-target clause must carry a choice sub-ability");
+        match &sub.repeat_for {
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::DistinctCounterKindsAmong { filter },
+            }) => assert_eq!(
+                *filter,
+                TargetFilter::ParentTarget,
+                "iteration source must resolve against the chosen target"
+            ),
+            other => panic!("expected DistinctCounterKindsAmong repeat_for, got {other:?}"),
+        }
+        match &*sub.effect {
+            Effect::ChooseOneOf { chooser, branches } => {
+                assert_eq!(*chooser, PlayerFilter::Controller);
+                assert_eq!(branches.len(), 2, "add and remove branches");
+                // Both branches are dynamic (rebind to the iterated kind) and act
+                // on the chosen permanent.
+                let mut saw_add = false;
+                let mut saw_remove = false;
+                for branch in branches {
+                    assert_eq!(
+                        branch.iteration_kind_binding,
+                        Some(IterationKindBinding::RebindToIteratedKind),
+                        "every branch must rebind to the iterated kind"
+                    );
+                    match &*branch.effect {
+                        Effect::PutCounter { target, .. } => {
+                            assert_eq!(*target, TargetFilter::ParentTarget);
+                            saw_add = true;
+                        }
+                        Effect::RemoveCounter { target, count, .. } => {
+                            assert_eq!(*target, TargetFilter::ParentTarget);
+                            assert_eq!(*count, 1, "remove exactly one counter of that kind");
+                            saw_remove = true;
+                        }
+                        other => panic!("expected Put/RemoveCounter branch, got {other:?}"),
+                    }
+                }
+                assert!(saw_add && saw_remove, "both add and remove options present");
+            }
+            other => panic!("expected ChooseOneOf sub-effect, got {other:?}"),
+        }
+    }
+
+    /// Word-order independence (build for the class): "remove one from it or put
+    /// another counter of that kind on it" parses to the same structure.
+    #[test]
+    fn for_each_counter_kind_adjust_target_remove_first_order() {
+        let mut ctx = ParseContext::default();
+        let def = parse_effect_chain_with_context(
+            "for each kind of counter on target creature, remove one from it or put another counter of that kind on it.",
+            AbilityKind::Spell,
+            &mut ctx,
+        );
+        assert!(
+            matches!(&*def.effect, Effect::TargetOnly { .. }),
+            "reverse word order must still produce a TargetOnly clause, got {:?}",
+            def.effect
+        );
+        let sub = def.sub_ability.as_ref().expect("choice sub-ability");
+        assert!(matches!(
+            &sub.repeat_for,
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::DistinctCounterKindsAmong { .. }
+            })
+        ));
+        assert!(matches!(&*sub.effect, Effect::ChooseOneOf { .. }));
+    }
+
+    /// CR 603.2: the full Dramatist's Puppet / Quarry Hauler card — an
+    /// enters-the-battlefield trigger whose body is the targeted per-kind
+    /// add/remove choice. Confirms the trigger surfaces the body (not
+    /// Unimplemented) and the target rides on the trigger's execute body.
+    #[test]
+    fn dramatists_puppet_etb_targeted_counter_adjust() {
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "When this creature enters, for each kind of counter on target permanent, put another counter of that kind on it or remove one from it.",
+            "Dramatist's Puppet",
+            &[],
+            &["Creature".to_string()],
+            &[],
+        );
+        let trigger = parsed
+            .triggers
+            .first()
+            .expect("should produce the enters trigger");
+        let execute = trigger
+            .execute
+            .as_ref()
+            .expect("trigger has an execute body");
+        assert!(
+            matches!(&*execute.effect, Effect::TargetOnly { .. }),
+            "ETB trigger body must be the targeted counter-adjust TargetOnly clause, got {:?}",
+            execute.effect
+        );
+        let sub = execute
+            .sub_ability
+            .as_ref()
+            .expect("trigger body must carry the choice sub-ability");
+        assert!(matches!(&*sub.effect, Effect::ChooseOneOf { .. }));
     }
 
     /// CR 608.2c (issue #503): "exile ~, then return him to the battlefield


### PR DESCRIPTION
## Problem

"For each kind of counter on target permanent, put another counter of that kind on it or remove one from it" parsed to `Effect::Unimplemented`. This is a targeted, per-counter-kind add-OR-remove player choice — distinct from proliferate (which only adds) and from Bribe Taker's untargeted per-kind add (which acts on `~`).

Affected cards (identical Oracle text, both enters-the-battlefield triggers):
- Dramatist's Puppet
- Quarry Hauler

## Fix

Parser only (`oracle_effect`) plus the minimal runtime plumbing the per-kind choice needs. Reuses the proven Bribe Taker counter-kind loop machinery (`repeat_for: DistinctCounterKindsAmong` + `ChooseOneOf` + `IterationKindBinding::RebindToIteratedKind`), now targeted:

- New combinator `try_parse_for_each_counter_kind_adjust_target` (nom combinators only) lowers the clause to:
  - `Effect::TargetOnly { target }` parent — surfaces the "target permanent" slot (CR 115.1), mirroring how `ProliferateTarget` rides on a trigger.
  - a sub-ability carrying `repeat_for: DistinctCounterKindsAmong { filter: ParentTarget }` and `Effect::ChooseOneOf { chooser: Controller, branches: [PutCounter, RemoveCounter] }`, both branches on `ParentTarget` and tagged `RebindToIteratedKind`.
  - Both "put … or remove …" and "remove … or put …" word orders are accepted, so the class is not pinned to one card's phrasing.
- `distinct_counter_kinds_among` now resolves a `ParentTarget` iteration source against the resolving ability's chosen target(s) (it previously only handled static filters; `matches_target_filter` returns `false` for `ParentTarget` by design).
- `rebind_iterated_counter_kind` now rebinds `RemoveCounter` (not just `PutCounter`) to the iterated kind, so the remove branch tracks the current kind.

The targeted clause is held intact past the generic `for each` strip (same guard that protects targeted proliferate), so the target and the per-kind choice are not dropped.

## Tests

- `for_each_counter_kind_adjust_target_choice` — discriminating: the body lowers to `TargetOnly` + sub-ability `ChooseOneOf` with `DistinctCounterKindsAmong { ParentTarget }`, an add branch (`PutCounter`, ParentTarget, rebind) and a remove branch (`RemoveCounter`, count 1, ParentTarget, rebind) — not `Unimplemented`.
- `for_each_counter_kind_adjust_target_remove_first_order` — reverse word order parses to the same structure.
- `dramatists_puppet_etb_targeted_counter_adjust` — the full card: the ETB trigger surfaces the targeted counter-adjust body (not Unimplemented).
- `targeted_counter_adjust_add_and_remove_per_kind` — end-to-end engine resolution: target with two kinds (P1P1, lore); per-kind prompts fire; ADD on the P1P1 iteration adds a P1P1 counter, REMOVE on the lore iteration removes a lore counter (rebind proven on both add and remove sides).

`cargo fmt --all --check`, `cargo clippy -p engine --lib -- -D warnings`, the counter parser/resolver test modules, `./scripts/check-parser-combinators.sh`, and the parser string-dispatch diff gate all pass.

## CR

All annotations grep-verified against `docs/MagicCompRules.txt`:
- CR 122.1 — counters
- CR 608.2c — resolution order / per-iteration kind rebinding
- CR 608.2d — choices made while applying the effect (the per-kind add/remove decision)
- CR 609.3 — do as much as possible (the repeat loop)
- CR 115.1 — targeting (the `TargetOnly` slot)
