### PR TITLE
feat(parser): grant the chosen keyword (choose <kw> ... gain that ability)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2855,6 +2855,9 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
         // CR 608.2d + CR 613.1f: Urborg / Walking Sponge — strip the
         // keyword chosen at resolution time.
         ContinuousModification::RemoveChosenKeyword => "remove chosen keyword".into(),
+        // CR 608.2d + CR 613.1f: Angelic Skirmisher / Linvala, Shield of Sea
+        // Gate — grant the keyword chosen at resolution time.
+        ContinuousModification::AddChosenKeyword => "add chosen keyword".into(),
         ContinuousModification::SetColor { colors } => {
             let c: Vec<_> = colors
                 .iter()

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3324,6 +3324,7 @@ fn modification_dynamic_quantity(m: &ContinuousModification) -> Option<&Quantity
         | ContinuousModification::AddChosenSubtype { .. }
         | ContinuousModification::AddChosenColor
         | ContinuousModification::RemoveChosenKeyword
+        | ContinuousModification::AddChosenKeyword
         | ContinuousModification::SetColor { .. }
         | ContinuousModification::AddColor { .. }
         | ContinuousModification::AddStaticMode { .. }
@@ -3466,7 +3467,7 @@ fn apply_continuous_effect_filtered(
     // chosen-attribute scoping refactor.
     let chosen_keyword = if matches!(
         effect.modification,
-        ContinuousModification::RemoveChosenKeyword
+        ContinuousModification::RemoveChosenKeyword | ContinuousModification::AddChosenKeyword
     ) {
         state
             .objects
@@ -3733,6 +3734,27 @@ fn apply_continuous_effect_filtered(
                     obj.trigger_definitions.retain(|trigger| {
                         !KeywordTriggerInstaller::trigger_matches_keyword_kind(trigger, kw)
                     });
+                }
+            }
+            // CR 608.2d + CR 613.1f: Grant the *exact* keyword chosen at
+            // resolution time (read off the source's `chosen_attributes`
+            // above). The additive mirror of `RemoveChosenKeyword` — installs
+            // the keyword and its keyword-derived triggers (e.g. lifelink's
+            // lifegain hook) onto each recipient, matching the plain
+            // `AddKeyword` arm. Used by "choose [keyword]; creatures you
+            // control gain that ability until end of turn" (Angelic
+            // Skirmisher, Linvala, Shield of Sea Gate). If the source has no
+            // stored chosen keyword (e.g. the static is gathered before the
+            // choose effect has resolved), this is a no-op rather than a panic,
+            // mirroring `AddChosenColor` / `RemoveChosenKeyword`.
+            ContinuousModification::AddChosenKeyword => {
+                if let Some(kw) = chosen_keyword.as_ref() {
+                    if !obj.keywords.contains(kw) {
+                        obj.keywords.push(kw.clone());
+                    }
+                    for trigger in KeywordTriggerInstaller::triggers_for(kw) {
+                        obj.trigger_definitions.push(trigger);
+                    }
                 }
             }
             ContinuousModification::RemoveAllAbilities => {

--- a/crates/engine/src/game/off_zone_characteristics.rs
+++ b/crates/engine/src/game/off_zone_characteristics.rs
@@ -103,6 +103,10 @@ fn supports_off_zone_keyword_query(modification: &ContinuousModification) -> boo
             // applicability as `RemoveKeyword` — the granted/printed keyword
             // it targets may live on an object outside the battlefield.
             | ContinuousModification::RemoveChosenKeyword
+            // CR 608.2d + CR 613.1f: `AddChosenKeyword` grants the keyword
+            // stored in the source's `chosen_attributes`. Same off-zone
+            // applicability as `AddKeyword`.
+            | ContinuousModification::AddChosenKeyword
     )
 }
 
@@ -140,6 +144,19 @@ fn apply_keyword_modification(
                 .and_then(|src| src.chosen_keyword())
             {
                 keywords.retain(|existing| existing != kw);
+            }
+        }
+        // CR 608.2d + CR 613.1f: Grant the *exact* keyword chosen at
+        // resolution time — the additive mirror of `RemoveChosenKeyword`,
+        // matching the `AddKeyword` upsert semantics above. No-op when the
+        // source has no stored chosen keyword.
+        ContinuousModification::AddChosenKeyword => {
+            if let Some(kw) = state
+                .objects
+                .get(&effect.source_id)
+                .and_then(|src| src.chosen_keyword())
+            {
+                upsert_keyword(keywords, kw.clone());
             }
         }
         _ => {}

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -618,6 +618,7 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         | ContinuousModification::AddChosenSubtype { .. }
         | ContinuousModification::AddChosenColor
         | ContinuousModification::RemoveChosenKeyword
+        | ContinuousModification::AddChosenKeyword
         | ContinuousModification::SetColor { .. }
         | ContinuousModification::AddColor { .. }
         | ContinuousModification::AddStaticMode { .. }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5045,6 +5045,67 @@ mod tests {
         parse_oracle_text(text, name, &keyword_names, &types, &subtypes)
     }
 
+    /// CR 608.2d + CR 113.3 + CR 611.2: Linvala, Shield of Sea Gate's
+    /// activated ability — "{W/U}, Sacrifice ~: Choose hexproof or
+    /// indestructible. Creatures you control gain that ability until end of
+    /// turn." The activated ability's effect chain must prompt a typed
+    /// `Effect::Choose { ChoiceType::Keyword }` and then grant
+    /// `AddChosenKeyword` — never `Effect::Unimplemented`. Confirms the
+    /// chosen-keyword anaphor works in the activated-ability frame as well as
+    /// the trigger frame (Angelic Skirmisher).
+    #[test]
+    fn parse_linvala_shield_activated_choose_then_grant_chosen_keyword() {
+        use crate::types::ability::ChoiceType;
+        let text = "Flying\n{W/U}, Sacrifice Linvala, Shield of Sea Gate: Choose \
+                    hexproof or indestructible. Creatures you control gain that \
+                    ability until end of turn.";
+        let result = parse(
+            text,
+            "Linvala, Shield of Sea Gate",
+            &[Keyword::Flying],
+            &["Creature"],
+            &["Angel", "Wizard"],
+        );
+
+        // Collect every effect across all parsed abilities and their sub_ability chains.
+        let mut effects: Vec<&Effect> = Vec::new();
+        for ability in &result.abilities {
+            let mut node = Some(ability);
+            while let Some(d) = node {
+                effects.push(&d.effect);
+                node = d.sub_ability.as_deref();
+            }
+        }
+
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                Effect::Choose {
+                    choice_type: ChoiceType::Keyword { options },
+                    persist: true,
+                } if options.as_slice()
+                    == [Keyword::Hexproof, Keyword::Indestructible]
+            )),
+            "expected a persisting keyword Choose(hexproof|indestructible), got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                Effect::GenericEffect { static_abilities, .. }
+                    if static_abilities.iter().any(|s| s
+                        .modifications
+                        .contains(&ContinuousModification::AddChosenKeyword))
+            )),
+            "expected an AddChosenKeyword grant, got {effects:?}"
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::Unimplemented { .. })),
+            "no clause may be Unimplemented, got {effects:?}"
+        );
+    }
+
     /// Issue #2385 — the free-cast window class must parse its resolution text to a real
     /// interactive `Effect::FreeCastFromZones` (the free-cast window), NOT get
     /// swallowed into a `GraveyardCastPermission` static with an empty `abilities`

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3172,12 +3172,18 @@ pub(super) fn lower_choose_ast(ast: ChooseImperativeAst) -> Effect {
             // chosen card type via `FilterProp::IsChosenCardType`. Persisting a
             // Labeled choice is also what `ChosenLabelIs` companion conditions
             // rely on (CR 614.12c), so it is uniformly safe.
+            // CR 608.2d + CR 113.3: A `Keyword` choice ("choose first strike,
+            // vigilance, or lifelink") persists so a later "creatures you
+            // control gain that ability" clause can read the typed
+            // `ChosenAttribute::Keyword` via
+            // `ContinuousModification::AddChosenKeyword` at layer evaluation.
             persist: matches!(
                 choice_type,
                 ChoiceType::CardName
                     | ChoiceType::CreatureType
                     | ChoiceType::CardType
                     | ChoiceType::Labeled { .. }
+                    | ChoiceType::Keyword { .. }
             ),
             choice_type,
         },

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5231,6 +5231,7 @@ fn apply_where_x_continuous_modification(
         | ContinuousModification::AddChosenSubtype { .. }
         | ContinuousModification::AddChosenColor
         | ContinuousModification::RemoveChosenKeyword
+        | ContinuousModification::AddChosenKeyword
         | ContinuousModification::SetColor { .. }
         | ContinuousModification::AddColor { .. }
         | ContinuousModification::AddStaticMode { .. }
@@ -5323,6 +5324,7 @@ fn rebind_target_anaphor_continuous_modification(modification: &mut ContinuousMo
         | ContinuousModification::AddChosenSubtype { .. }
         | ContinuousModification::AddChosenColor
         | ContinuousModification::RemoveChosenKeyword
+        | ContinuousModification::AddChosenKeyword
         | ContinuousModification::SetColor { .. }
         | ContinuousModification::AddColor { .. }
         | ContinuousModification::AddStaticMode { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13419,11 +13419,42 @@ pub(crate) fn try_parse_named_choice(lower: &str) -> Option<ChoiceType> {
         Some(ChoiceType::Word)
     } else if tag::<_, _, E>("an artist").parse(rest).is_ok() {
         Some(ChoiceType::Artist)
+    } else if let Some(options) = try_parse_keyword_choice(rest) {
+        // CR 608.2d: "choose [keyword], [keyword], or [keyword]" — a typed
+        // keyword enumeration (Angelic Skirmisher's "first strike, vigilance,
+        // or lifelink"; Linvala, Shield of Sea Gate's "hexproof or
+        // indestructible"). Recognized BEFORE the generic labeled fallback so
+        // the chosen value persists as a typed `ChosenAttribute::Keyword` that
+        // `ContinuousModification::AddChosenKeyword` ("creatures you control
+        // gain that ability") can read at layer evaluation.
+        Some(ChoiceType::Keyword { options })
     } else {
         // Generic "X or Y" / "X, Y, or Z" / "W, X, Y, or Z" labeled choice —
         // must come AFTER all specific patterns above.
         try_parse_labeled_choice(rest).map(|options| ChoiceType::Labeled { options })
     }
+}
+
+/// CR 608.2d + CR 113.3: Parse a typed keyword enumeration following "choose "
+/// ("first strike, vigilance, or lifelink", "hexproof or indestructible") into
+/// its `Keyword` option list.
+///
+/// Reuses `try_parse_labeled_choice`'s structural Oxford-comma / "or" splitting
+/// (the canonical N-ary disjunction grammar) and then maps every label through
+/// the shared single-keyword parser `parse_keyword_from_oracle`. Returns `None`
+/// unless **every** label maps to a real keyword — partial matches fall through
+/// to the generic labeled-choice handler so non-keyword disjunctions are
+/// unaffected. Building for the class: any "choose <kw>, <kw>, or <kw>" line,
+/// not the two cards that motivate it.
+fn try_parse_keyword_choice(rest: &str) -> Option<Vec<Keyword>> {
+    let labels = try_parse_labeled_choice(rest)?;
+    let keywords: Vec<Keyword> = labels
+        .iter()
+        .map(|label| {
+            crate::parser::oracle_keyword::parse_keyword_from_oracle(&label.to_lowercase())
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some(keywords)
 }
 
 /// Try to parse a labeled choice ("X or Y", "X, Y, or Z", "W, X, Y, or Z", ...) into
@@ -42993,6 +43024,47 @@ mod tests {
                     "Land".to_string(),
                     "Non-aura enchantment".to_string(),
                 ]
+            })
+        );
+    }
+
+    /// CR 608.2d + CR 113.3: A "choose <kw>, <kw>, or <kw>" line whose labels
+    /// are all real keywords must parse to a typed `ChoiceType::Keyword` option
+    /// list (Angelic Skirmisher), NOT the opaque-string `Labeled` form — the
+    /// typed list is what persists as `ChosenAttribute::Keyword` for a later
+    /// `AddChosenKeyword` grant to read.
+    #[test]
+    fn keyword_choice_ternary_first_strike_vigilance_lifelink() {
+        assert_eq!(
+            super::try_parse_named_choice("choose first strike, vigilance, or lifelink"),
+            Some(ChoiceType::Keyword {
+                options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+            })
+        );
+    }
+
+    /// CR 608.2d: Binary keyword choice (Linvala, Shield of Sea Gate —
+    /// "hexproof or indestructible").
+    #[test]
+    fn keyword_choice_binary_hexproof_indestructible() {
+        assert_eq!(
+            super::try_parse_named_choice("choose hexproof or indestructible"),
+            Some(ChoiceType::Keyword {
+                options: vec![Keyword::Hexproof, Keyword::Indestructible],
+            })
+        );
+    }
+
+    /// Discriminating: a disjunction whose labels are NOT all keywords must
+    /// fall through to the generic `Labeled` handler — the keyword recognizer
+    /// only fires when every option maps to a real keyword. "Creature" / "land"
+    /// are card types, not keywords.
+    #[test]
+    fn keyword_choice_falls_through_for_non_keyword_labels() {
+        assert_eq!(
+            super::try_parse_named_choice("choose left or right"),
+            Some(ChoiceType::Labeled {
+                options: vec!["Left".to_string(), "Right".to_string()],
             })
         );
     }

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -914,6 +914,29 @@ pub(crate) fn push_grant_clause_modifications(
         }
     }
 
+    // CR 608.2d + CR 613.1f: chosen-keyword anaphor — "that ability" / "the
+    // chosen ability" / "the chosen keyword" refers back to a preceding
+    // `Effect::Choose { ChoiceType::Keyword, persist }` clause (Angelic
+    // Skirmisher: "choose first strike, vigilance, or lifelink. Creatures you
+    // control gain that ability ..."; Linvala, Shield of Sea Gate: "choose
+    // hexproof or indestructible. Creatures you control gain that ability
+    // ..."). Emits `AddChosenKeyword`, which reads the granting source's
+    // `ChosenAttribute::Keyword` at layer evaluation — the additive mirror of
+    // `RemoveChosenKeyword` (Urborg / Walking Sponge). Checked before
+    // `map_keyword` so the anaphor is never mis-classified as an unknown
+    // keyword. Builds for the whole "gain the chosen keyword" class.
+    if alt((
+        tag::<_, _, OracleError<'_>>("that ability"),
+        tag("the chosen ability"),
+        tag("the chosen keyword"),
+    ))
+    .parse(part_lower.as_str())
+    .is_ok()
+    {
+        modifications.push(ContinuousModification::AddChosenKeyword);
+        return;
+    }
+
     if let Some(kw) = map_keyword(part_trimmed) {
         modifications.push(ContinuousModification::AddKeyword { keyword: kw });
         return;

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1118,6 +1118,28 @@ fn continuous_mods_decompose_becomes_compound_type_phrase() {
     );
 }
 
+/// CR 608.2d + CR 613.1f: "gain that ability" / "the chosen ability" / "the
+/// chosen keyword" is a chosen-keyword anaphor referring back to a preceding
+/// `Effect::Choose { ChoiceType::Keyword }` clause (Angelic Skirmisher,
+/// Linvala, Shield of Sea Gate). It must lower to `AddChosenKeyword`, NOT a
+/// bare `AddKeyword` (the chosen value is unknown at parse time) and NOT a
+/// silent drop. Builds for the whole "gain the chosen keyword" class.
+#[test]
+fn continuous_mods_grant_chosen_keyword_anaphor() {
+    for phrase in [
+        "gain that ability",
+        "gain the chosen ability",
+        "gain the chosen keyword",
+    ] {
+        let mods = parse_continuous_modifications(phrase);
+        assert_eq!(
+            mods,
+            vec![ContinuousModification::AddChosenKeyword],
+            "expected AddChosenKeyword for {phrase:?}, got {mods:?}"
+        );
+    }
+}
+
 #[test]
 fn continuous_mods_replace_creature_subtypes_for_bare_becomes_clause() {
     let mods = parse_continuous_modifications("gets +3/+3 and becomes a Bear Berserker");

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -28590,6 +28590,76 @@ mod tests {
         }
     }
 
+    /// CR 608.2d + CR 113.3 + CR 611.2: Angelic Skirmisher — "At the beginning
+    /// of each combat, choose first strike, vigilance, or lifelink. Creatures
+    /// you control gain that ability until end of turn." The trigger execute
+    /// chain must (a) prompt a typed `Effect::Choose { ChoiceType::Keyword }`
+    /// with `persist: true`, then (b) grant `AddChosenKeyword` to creatures you
+    /// control — never `Effect::Unimplemented`.
+    #[test]
+    fn parse_angelic_skirmisher_choose_then_grant_chosen_keyword() {
+        use crate::types::ability::ChoiceType;
+        use crate::types::keywords::Keyword;
+
+        let def = parse_trigger_line(
+            "At the beginning of each combat, choose first strike, vigilance, or \
+             lifelink. Creatures you control gain that ability until end of turn.",
+            "Angelic Skirmisher",
+        );
+        let execute = def
+            .execute
+            .expect("Angelic Skirmisher trigger must have an execute");
+        let chain = ability_chain(&execute);
+
+        // (a) The choose clause is a persisting typed keyword choice.
+        let choose = chain
+            .iter()
+            .find_map(|node| match &*node.effect {
+                Effect::Choose {
+                    choice_type,
+                    persist,
+                } => Some((choice_type.clone(), *persist)),
+                _ => None,
+            })
+            .expect("expected an Effect::Choose in the chain");
+        assert_eq!(
+            choose.0,
+            ChoiceType::Keyword {
+                options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+            },
+            "choose clause must be a typed keyword choice"
+        );
+        assert!(
+            choose.1,
+            "keyword choice must persist for the grant to read"
+        );
+
+        // (b) The grant clause adds the chosen keyword to creatures you control.
+        let granted_chosen = chain.iter().any(|node| match &*node.effect {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => static_abilities.iter().any(|sdef| {
+                sdef.modifications
+                    .contains(&ContinuousModification::AddChosenKeyword)
+            }),
+            _ => false,
+        });
+        assert!(
+            granted_chosen,
+            "expected an AddChosenKeyword grant, chain: {:?}",
+            chain.iter().map(|n| &n.effect).collect::<Vec<_>>()
+        );
+
+        // Nothing in the chain may be Unimplemented.
+        for node in &chain {
+            assert!(
+                !matches!(&*node.effect, Effect::Unimplemented { .. }),
+                "no clause may be Unimplemented, got {:?}",
+                node.effect
+            );
+        }
+    }
+
     /// Walk an ability chain (effect + every `sub_ability`) collecting a
     /// reference to each `AbilityDefinition` node so tests can inspect both the
     /// effect and the per-node `condition`.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -14347,6 +14347,16 @@ pub enum ContinuousModification {
     /// same discriminant. Used by Urborg / Walking Sponge: "target creature
     /// loses [chosen ability] until end of turn".
     RemoveChosenKeyword,
+    /// CR 608.2d + CR 613.1f: Grant the chosen keyword (read from the granting
+    /// source's `chosen_attributes`) to the affected object. The additive
+    /// counterpart of `RemoveChosenKeyword`, mirroring the `AddChosenColor` /
+    /// `AddChosenSubtype` chosen-attribute family. Used by the "choose
+    /// [keyword], …; creatures you control gain that ability until end of
+    /// turn" class (Angelic Skirmisher, Linvala, Shield of Sea Gate): a
+    /// preceding `Effect::Choose { ChoiceType::Keyword, persist }` stores the
+    /// selection as `ChosenAttribute::Keyword`, which this modification reads at
+    /// Layer 6 evaluation to install on every recipient.
+    AddChosenKeyword,
     SetColor {
         colors: Vec<ManaColor>,
     },

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -94,6 +94,7 @@ impl ContinuousModification {
             ContinuousModification::AddKeyword { .. }
             | ContinuousModification::RemoveKeyword { .. }
             | ContinuousModification::RemoveChosenKeyword
+            | ContinuousModification::AddChosenKeyword
             | ContinuousModification::AddDynamicKeyword { .. }
             | ContinuousModification::GrantAbility { .. }
             | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }


### PR DESCRIPTION
## Problem

"Choose a keyword, then grant the just-chosen keyword to a scope" was unparsed,
leaving the affected cards at `Effect::Unimplemented`:

- **Angelic Skirmisher** — *At the beginning of each combat, choose first
  strike, vigilance, or lifelink. Creatures you control gain that ability until
  end of turn.*
- **Linvala, Shield of Sea Gate** — *{W/U}, Sacrifice Linvala, Shield of Sea
  Gate: Choose hexproof or indestructible. Creatures you control gain that
  ability until end of turn.*

The "choose `<kw1>`, `<kw2>`, or `<kw3>`" clause fell through to the generic
`Labeled` choice (opaque strings, no typed keyword), and the follow-up
"creatures you control gain **that ability**" anaphor mapped to no keyword, so
the grant clause produced no modifications and the line was dropped.

## Fix

Builds for the whole *choose-a-keyword → grant-the-chosen-keyword* class, not
the two motivating cards:

1. **Typed keyword choice.** `try_parse_named_choice` now recognizes a keyword
   enumeration after `choose ` and emits `ChoiceType::Keyword { options }`
   (reusing the existing Oxford-comma/`or` splitter and the shared
   `parse_keyword_from_oracle` mapper). It only fires when *every* option maps
   to a real keyword, so non-keyword disjunctions still route to `Labeled`. The
   choice is marked `persist: true` so the selection is stored as
   `ChosenAttribute::Keyword`.
2. **Chosen-keyword anaphor grant.** `push_grant_clause_modifications` (the
   single authority every "gain `<kw>`" part runs through) now recognizes the
   `that ability` / `the chosen ability` / `the chosen keyword` anaphor and
   emits the new `ContinuousModification::AddChosenKeyword` — the additive
   mirror of the existing `RemoveChosenKeyword` (Urborg / Walking Sponge),
   alongside `AddChosenColor` / `AddChosenSubtype` in the chosen-attribute
   family.
3. **Runtime.** `AddChosenKeyword` reads the granting source's stored chosen
   keyword at Layer 6 and installs it (plus its keyword-derived triggers) on
   each recipient, on the battlefield (`layers.rs`) and off-zone
   (`off_zone_characteristics.rs`). No-op when the choice has not yet resolved,
   mirroring `AddChosenColor` / `RemoveChosenKeyword`.

No new interactive/anaphor infrastructure was needed — the choice prompt,
`ChoiceType::Keyword`, `ChosenAttribute::Keyword`, and the persist→store→read
path already existed for `RemoveChosenKeyword`. nom combinators only; no new
string dispatch.

## Cards unblocked

- Angelic Skirmisher
- Linvala, Shield of Sea Gate

## Tests

- `keyword_choice_ternary_first_strike_vigilance_lifelink`,
  `keyword_choice_binary_hexproof_indestructible`,
  `keyword_choice_falls_through_for_non_keyword_labels` (typed-choice vs.
  labeled-choice boundary).
- `continuous_mods_grant_chosen_keyword_anaphor` (`that ability` / `the chosen
  ability` / `the chosen keyword` → `AddChosenKeyword`).
- `parse_angelic_skirmisher_choose_then_grant_chosen_keyword` (full trigger
  chain) and `parse_linvala_shield_activated_choose_then_grant_chosen_keyword`
  (full activated-ability chain): both assert `Choose{Keyword, persist}` +
  `AddChosenKeyword` and no `Unimplemented`.
- Full `engine` lib suite green (11944 passed), `clippy -D warnings` clean,
  `cargo fmt --check` clean, parser-combinator gate clean, existing
  labeled-choice tests unchanged.

## CR

- **CR 608.2d** — choices announced while applying an effect (the keyword
  choice).
- **CR 113.3** — keyword abilities (what is granted).
- **CR 611.2 / 611.2a** — continuous effect from a resolving ability lasting
  "until end of turn".
- **CR 613.1f** — Layer 6 ability-adding effects (where the grant applies).

All CR numbers verified against `docs/MagicCompRules.txt`.
