### PR TITLE
feat(parser): parse '<player> may have you draw a card'

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1602,6 +1602,16 @@ pub(super) fn strip_optional_effect_prefix(
                 (None, Some(PlayerFilter::Opponent)),
                 tag("target opponent may "),
             ),
+            // CR 506.2 + CR 608.2d + CR 121.3a: "Defending player may have you
+            // draw a card" (Shakedown Heavy) — on an attack trigger, the
+            // defending player is the may-actor who decides whether the
+            // controller performs the granted action. CR 121.3a: the chooser
+            // need not be the player who draws. Parallels the targeted-opponent
+            // arm above; the actor scope is the attack's defending player.
+            value(
+                (None, Some(PlayerFilter::DefendingPlayer)),
+                tag("defending player may "),
+            ),
             // CR 608.2d: "That creature's controller may have this artifact deal …"
             // (Requiem Monolith) — the targeted creature's controller chooses.
             value(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -3144,15 +3144,60 @@ fn try_parse_have_causative(
         return None;
     }
 
-    // Pattern B: "have you [verb]" — controller performs an action directed by opponent
+    // Pattern B: "have you [verb]" — controller performs an action directed by
+    // another player.
+    //
+    // CR 121.3a + CR 608.2d: "<actor> may have you draw a card" (Shakedown
+    // Heavy — "defending player may …"; Palantír of Orthanc / Bane, Lord of
+    // Darkness — "target opponent may …"). The named actor decides, but the
+    // *printed controller* performs the action (CR 121.3a: the player making the
+    // choice need not be the player who draws). The actor is captured upstream
+    // by `strip_optional_effect_prefix` as a may-actor `player_scope`, which the
+    // resolver fans out by rebinding the runtime `controller` to that actor (the
+    // same mechanism as `player_scope: Opponent` discard). A bare
+    // `TargetFilter::Controller` "you" reference would then resolve to the actor
+    // and route the draw to the wrong player. Rebind `Controller` →
+    // `OriginalController` so "you" stays anchored to the printed controller and
+    // survives the scope's controller-rebind (CR 109.5). When no may-actor scope
+    // is present (plain "you may have you …"), the two refer to the same player,
+    // so the rewrite is a no-op in effect.
     if let Some((_, rest_orig)) = nom_on_lower(tp.original, tp.lower, |i| {
         value((), tag("have you ")).parse(i)
     }) {
         let clause = parse_effect_clause(rest_orig, ctx);
-        return Some(clause);
+        return Some(rebind_controller_to_original(clause));
     }
 
     None
+}
+
+/// CR 109.5 + CR 121.3a: Rebind a recursed clause's `TargetFilter::Controller`
+/// "you" references to `TargetFilter::OriginalController`. Used by the causative
+/// "have you [verb]" path so the printed controller's action ("you draw a card")
+/// is unaffected when an outer may-actor `player_scope` rebinds the runtime
+/// controller to the directing player at resolution. Mirrors
+/// `rebind_controller_to_triggering_source`; covers the controller-anchored
+/// effect verbs reachable from a "have you …" grant.
+fn rebind_controller_to_original(mut clause: ParsedEffectClause) -> ParsedEffectClause {
+    let rebind = |target: &mut TargetFilter| {
+        if matches!(target, TargetFilter::Controller) {
+            *target = TargetFilter::OriginalController;
+        }
+    };
+    match &mut clause.effect {
+        Effect::Draw { target, .. } => rebind(target),
+        Effect::Mill { target, .. } => rebind(target),
+        Effect::DiscardCard { target, .. } => rebind(target),
+        Effect::GainLife { player, .. } => rebind(player),
+        // CR 119.3: `LoseLife.target` is `Option<TargetFilter>` — only rebind the
+        // populated `Controller` case; `None` already means the resolving
+        // ability's controller, preserved as-is.
+        Effect::LoseLife {
+            target: Some(t), ..
+        } => rebind(t),
+        _ => {}
+    }
+    clause
 }
 
 fn all_core_type_categories() -> Vec<CoreType> {

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4088,6 +4088,94 @@ mod tests {
         assert!(!has_swallowed_detector(&parsed, "Optional_MayHave"));
     }
 
+    /// CR 121.3a + CR 506.2 + CR 608.2d: "<actor> may have you draw a card" —
+    /// the named actor decides; the printed controller draws. Covers the
+    /// targeted-opponent actor (Palantír of Orthanc, Bane, Lord of Darkness) and
+    /// the defending-player actor (Shakedown Heavy). The build-for-the-class
+    /// invariants checked here:
+    ///   1. the grant is an `Effect::Draw`, not an Unimplemented "have" static;
+    ///   2. the clause is `optional` (the actor's may-choice);
+    ///   3. the actor is captured as the may-actor `player_scope`;
+    ///   4. "you" is bound to `OriginalController`, so the controller-rebind the
+    ///      `player_scope` fan-out applies (CR 109.5) does not redirect the draw
+    ///      to the actor.
+    fn have_you_draw_grant_trigger(text: &str, name: &str) -> AbilityDefinition {
+        let parsed = parse_named(text, name, &["Creature"]);
+        let trigger = parsed
+            .triggers
+            .first()
+            .expect("trigger must parse")
+            .execute
+            .as_deref()
+            .expect("trigger must have an executed ability")
+            .clone();
+        assert!(
+            !def_tree_has_unimplemented(&trigger),
+            "{name}: have-you-draw grant must not be Unimplemented"
+        );
+        trigger
+    }
+
+    #[test]
+    fn defending_player_may_have_you_draw_routes_to_original_controller() {
+        let def = have_you_draw_grant_trigger(
+            "Whenever this creature attacks, defending player may have you draw a card. \
+             If they do, untap this creature and remove it from combat.",
+            "Shakedown Heavy",
+        );
+        assert!(matches!(*def.effect, Effect::Draw { .. }), "must be a Draw");
+        assert!(
+            def.optional,
+            "the defending player's may-choice is optional"
+        );
+        assert_eq!(
+            def.player_scope,
+            Some(crate::types::ability::PlayerFilter::DefendingPlayer),
+            "may-actor must be the defending player",
+        );
+        if let Effect::Draw { ref target, .. } = *def.effect {
+            assert_eq!(
+                *target,
+                TargetFilter::OriginalController,
+                "\"you draw\" must survive the may-actor controller rebind",
+            );
+        }
+    }
+
+    #[test]
+    fn target_opponent_may_have_you_draw_routes_to_original_controller() {
+        let def = have_you_draw_grant_trigger(
+            "At the beginning of your end step, target opponent may have you draw a card. \
+             If they don't, you scry 2.",
+            "Palantir of Orthanc",
+        );
+        assert!(matches!(*def.effect, Effect::Draw { .. }), "must be a Draw");
+        assert!(def.optional, "the opponent's may-choice is optional");
+        assert_eq!(
+            def.player_scope,
+            Some(crate::types::ability::PlayerFilter::Opponent),
+            "may-actor must be the targeted opponent",
+        );
+        if let Effect::Draw { ref target, .. } = *def.effect {
+            assert_eq!(
+                *target,
+                TargetFilter::OriginalController,
+                "\"you draw\" must survive the may-actor controller rebind",
+            );
+        }
+    }
+
+    #[test]
+    fn defending_player_may_have_you_draw_not_swallowed() {
+        let parsed = parse_named(
+            "Whenever this creature attacks, defending player may have you draw a card. \
+             If they do, untap this creature and remove it from combat.",
+            "Shakedown Heavy",
+            &["Creature"],
+        );
+        assert!(!has_swallowed_detector(&parsed, "Optional_MayHave"));
+    }
+
     #[test]
     fn optional_may_have_channel_harm() {
         let parsed = parse_named(


### PR DESCRIPTION
## Problem

`<player> may have you draw a card` — a "may"-grant where one player optionally directs **another** player to draw — was not fully handled by the Oracle parser.

- `defending player may have you draw a card` (Shakedown Heavy) had no actor prefix in `strip_optional_effect_prefix`, so the whole clause fell through to a subject-predicate `have` static and lowered to `Effect::Unimplemented`.
- `target opponent may have you draw a card` (Palantír of Orthanc, Bane, Lord of Darkness) did parse to an optional `Draw`, but the draw target was a bare `TargetFilter::Controller`. The may-actor is captured as a `player_scope`, which the resolver fans out by rebinding the runtime controller to that actor (the same mechanism as `player_scope: Opponent` discard). A `Controller` "you" reference therefore resolved to the **actor**, routing the draw to the wrong player.

## Fix

Parser-only, two surgical changes in `oracle_effect/`:

1. **`strip_optional_effect_prefix`** (`lower.rs`): add a `defending player may ` actor arm mapping to the may-actor `player_scope` `PlayerFilter::DefendingPlayer`, parallel to the existing `target opponent may ` / `that creature's controller may ` arms.
2. **`try_parse_have_causative`** Pattern B (`mod.rs`): rebind the recursed "have you [verb]" clause's `TargetFilter::Controller` → `TargetFilter::OriginalController` so the printed controller's "you draw" survives the may-actor's controller-rebind fan-out. `OriginalController` resolves to `original_controller.unwrap_or(controller)`, so the rewrite is a no-op when no may-actor scope is present (plain "you may have you …"). Covers the controller-anchored verbs reachable from a "have you …" grant (Draw / Mill / DiscardCard / GainLife / LoseLife). Mirrors the existing `rebind_controller_to_triggering_source` helper.

This builds for the class `<player> may have you <verb>`, covering both the targeted-opponent and defending-player actors, and incidentally corrects the latent draw-recipient routing on the already-parsing targeted-opponent cards.

## Cards unlocked / corrected

- Shakedown Heavy — `defending player may have you draw a card` (was `Effect::Unimplemented`)
- Palantír of Orthanc — `target opponent may have you draw a card` (draw recipient corrected)
- Bane, Lord of Darkness — `target opponent may have you draw a card` (draw recipient corrected)

## Tests

`crates/engine/src/parser/swallow_check.rs`:

- `defending_player_may_have_you_draw_routes_to_original_controller` — `Effect::Draw`, `optional`, `player_scope = DefendingPlayer`, target = `OriginalController`.
- `target_opponent_may_have_you_draw_routes_to_original_controller` — `Effect::Draw`, `optional`, `player_scope = Opponent`, target = `OriginalController`.
- `defending_player_may_have_you_draw_not_swallowed` — no `Optional_MayHave` swallow warning.

Discriminating: the tests assert the draw routes to `OriginalController` (not `Controller`), and that the defending-player form is no longer Unimplemented. Existing `optional_may_have_*` regressions (Risk Factor, Channel Harm, Requiem Monolith, …) still pass.

Verification: `cargo fmt --all --check` clean; `cargo test -p engine --lib parser::` 5746 passed / 0 failed; `cargo clippy -p engine --lib -- -D warnings` clean; `./scripts/check-parser-combinators.sh` clean (no new string-dispatch).

## CR

- CR 506.2 — defending player (attack trigger actor).
- CR 121.3a — the player making the draw choice need not be the player who draws.
- CR 608.2d — the optional choice is announced while applying the effect.
- CR 109.5 — "you" stays the printed controller under the scope's controller-rebind.
- CR 119.3 — directed life-loss target (rebind coverage).
