### PR TITLE
feat(engine): static permission to block shadow creatures

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -622,13 +622,23 @@ fn blocker_has_cant_block_static(state: &GameState, blocker_id: ObjectId) -> boo
 /// CR 509.1b + CR 609.4 + CR 702.28b: A creature without shadow normally can't
 /// block a creature with shadow. This returns `true` when the blocker has a
 /// functioning `CanBlockShadow` static — "~ can block creatures with shadow as
-/// though they didn't have shadow" / "as though it had shadow" — which lifts the
-/// shadow blocker-side restriction for that creature only (Heartwood Dryad, Wall
-/// of Diffusion). Mirrors the `CanAttackWithDefender` lookup: the static is
-/// `affected: SelfRef`, so it is read off the blocker's own active statics.
+/// though they didn't have shadow" / "as though it had shadow" — which lifts
+/// the shadow blocker-side restriction for that affected creature.
+///
+/// Mirrors the `CanAttackWithDefender` lookup: intrinsic self statics are read
+/// from the blocker, and remote affected filters are resolved through the shared
+/// static-ability checker.
 fn blocker_can_block_shadow(state: &GameState, blocker: &GameObject) -> bool {
     super::functioning_abilities::active_static_definitions(state, blocker)
         .any(|sd| sd.mode == StaticMode::CanBlockShadow)
+        || crate::game::static_abilities::check_static_ability(
+            state,
+            StaticMode::CanBlockShadow,
+            &crate::game::static_abilities::StaticCheckContext {
+                target_id: Some(blocker.id),
+                ..Default::default()
+            },
+        )
 }
 
 /// CR 509.1b: Static abilities on the blocker (or on another source whose
@@ -4373,9 +4383,6 @@ mod tests {
     /// Discriminating: an identical non-shadow creature WITHOUT the static cannot.
     #[test]
     fn can_block_shadow_static_lets_non_shadow_block_shadow() {
-        use crate::types::ability::{StaticDefinition, TargetFilter};
-        use crate::types::statics::StaticMode;
-
         let mut state = setup();
         let attacker = create_creature(&mut state, PlayerId(0), "Shadow A", 2, 2);
         state
@@ -4402,6 +4409,24 @@ mod tests {
             );
         assert!(validate_blockers(&state, &[(dryad, attacker)]).is_ok());
         assert!(can_block_pair(&state, dryad, attacker));
+
+        // A source whose affected filter matches another creature also grants
+        // that creature the permission; the parser accepts subject-scoped
+        // variants, so runtime must honor `affected` rather than only checking
+        // the blocker's own statics.
+        let standard_bearer = create_creature(&mut state, PlayerId(1), "Shadow Standard", 1, 1);
+        state
+            .objects
+            .get_mut(&standard_bearer)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::CanBlockShadow).affected(TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::You),
+                )),
+            );
+        assert!(validate_blockers(&state, &[(plain_blocker, attacker)]).is_ok());
+        assert!(can_block_pair(&state, plain_blocker, attacker));
 
         // The permission does NOT make the Dryad itself blockable-by-anything or
         // change the non-shadow attacker symmetry: a shadow blocker still can't

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -619,6 +619,18 @@ fn blocker_has_cant_block_static(state: &GameState, blocker_id: ObjectId) -> boo
         .is_some()
 }
 
+/// CR 509.1b + CR 609.4 + CR 702.28b: A creature without shadow normally can't
+/// block a creature with shadow. This returns `true` when the blocker has a
+/// functioning `CanBlockShadow` static — "~ can block creatures with shadow as
+/// though they didn't have shadow" / "as though it had shadow" — which lifts the
+/// shadow blocker-side restriction for that creature only (Heartwood Dryad, Wall
+/// of Diffusion). Mirrors the `CanAttackWithDefender` lookup: the static is
+/// `affected: SelfRef`, so it is read off the blocker's own active statics.
+fn blocker_can_block_shadow(state: &GameState, blocker: &GameObject) -> bool {
+    super::functioning_abilities::active_static_definitions(state, blocker)
+        .any(|sd| sd.mode == StaticMode::CanBlockShadow)
+}
+
 /// CR 509.1b: Static abilities on the blocker (or on another source whose
 /// `affected` filter matches the blocker) that restrict which attackers it
 /// may block — e.g. "This creature can block only creatures with flying."
@@ -906,7 +918,9 @@ pub fn validate_blockers_for_player(
         // and cannot block creatures without shadow.
         let attacker_has_shadow = attacker.has_keyword(&Keyword::Shadow);
         let blocker_has_shadow = blocker.has_keyword(&Keyword::Shadow);
-        if attacker_has_shadow && !blocker_has_shadow {
+        // CR 509.1b + CR 609.4 + CR 702.28b: a `CanBlockShadow` static lifts the
+        // shadow restriction for this blocker (Heartwood Dryad, Wall of Diffusion).
+        if attacker_has_shadow && !blocker_has_shadow && !blocker_can_block_shadow(state, blocker) {
             return Err(format!(
                 "{:?} cannot block {:?} (shadow can only be blocked by shadow)",
                 blocker_id, attacker_id
@@ -2704,7 +2718,9 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
     }
     let attacker_has_shadow = attacker.has_keyword(&Keyword::Shadow);
     let blocker_has_shadow = blocker.has_keyword(&Keyword::Shadow);
-    if attacker_has_shadow && !blocker_has_shadow {
+    // CR 509.1b + CR 609.4 + CR 702.28b: a `CanBlockShadow` static lifts the
+    // shadow restriction for this blocker (Heartwood Dryad, Wall of Diffusion).
+    if attacker_has_shadow && !blocker_has_shadow && !blocker_can_block_shadow(state, blocker) {
         return false;
     }
     if !attacker_has_shadow && blocker_has_shadow {
@@ -4350,6 +4366,55 @@ mod tests {
 
         // Shadow creature can't block non-shadow attacker
         assert!(validate_blockers(&state, &[(shadow_blocker, attacker)]).is_err());
+    }
+
+    /// CR 509.1b + CR 609.4 + CR 702.28b: Heartwood Dryad / Wall of Diffusion —
+    /// a non-shadow creature with `CanBlockShadow` may block a shadow attacker.
+    /// Discriminating: an identical non-shadow creature WITHOUT the static cannot.
+    #[test]
+    fn can_block_shadow_static_lets_non_shadow_block_shadow() {
+        use crate::types::ability::{StaticDefinition, TargetFilter};
+        use crate::types::statics::StaticMode;
+
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Shadow A", 2, 2);
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Shadow);
+
+        // Plain non-shadow blocker: cannot block the shadow attacker.
+        let plain_blocker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+        assert!(validate_blockers(&state, &[(plain_blocker, attacker)]).is_err());
+        assert!(!can_block_pair(&state, plain_blocker, attacker));
+
+        // Non-shadow blocker with CanBlockShadow: now allowed by both seams.
+        let dryad = create_creature(&mut state, PlayerId(1), "Heartwood Dryad", 2, 2);
+        state
+            .objects
+            .get_mut(&dryad)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::CanBlockShadow).affected(TargetFilter::SelfRef),
+            );
+        assert!(validate_blockers(&state, &[(dryad, attacker)]).is_ok());
+        assert!(can_block_pair(&state, dryad, attacker));
+
+        // The permission does NOT make the Dryad itself blockable-by-anything or
+        // change the non-shadow attacker symmetry: a shadow blocker still can't
+        // block a non-shadow attacker (the other CR 702.28b half is untouched).
+        let normal_attacker = create_creature(&mut state, PlayerId(0), "Grizzly", 2, 2);
+        let shadow_blocker = create_creature(&mut state, PlayerId(1), "Shadow B", 2, 2);
+        state
+            .objects
+            .get_mut(&shadow_blocker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Shadow);
+        assert!(validate_blockers(&state, &[(shadow_blocker, normal_attacker)]).is_err());
     }
 
     #[test]

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -7087,6 +7087,14 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                 effective_lower.contains("as though those creatures had haste")
                     || effective_lower.contains("as though that creature had haste")
             }
+            // CR 509.1b + CR 609.4 + CR 702.28b: both printed phrasings of the
+            // shadow block permission ("as though they didn't have shadow" /
+            // "as though it had shadow"). Anchor on the "block creatures with
+            // shadow" subject so it doesn't false-match other shadow lines.
+            StaticMode::CanBlockShadow => {
+                effective_lower.contains("can block creatures with shadow")
+                    && effective_lower.contains("as though")
+            }
             // CR 614.1b + CR 614.10: "Skip your [step] step" is a
             // step-specific replacement effect, so coverage must match the
             // parsed `Phase` rather than any syntactically similar skip line.
@@ -7121,6 +7129,12 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
                             && effective_lower.contains(&kw)
                     }
                     StaticMode::IgnoreLandwalkForBlocking { qualifier: None } => false,
+                    // CR 509.1b + CR 609.4 + CR 702.28b: mirror predicate for the
+                    // shadow block permission nested under a GenericEffect.
+                    StaticMode::CanBlockShadow => {
+                        effective_lower.contains("can block creatures with shadow")
+                            && effective_lower.contains("as though")
+                    }
                     _ => false,
                 })
             } else {

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -245,6 +245,11 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
         StaticMode::CanActivateAbilitiesAsThoughHaste,
         handle_rule_mod,
     );
+    // CR 509.1b + CR 609.4 + CR 702.28b: CanBlockShadow — per-source permission to
+    // block shadow attackers despite not having shadow (Heartwood Dryad, Wall of
+    // Diffusion). Runtime enforcement is in combat.rs via `can_block_shadow_attacker`,
+    // consulted by both validate_blockers_for_player and can_block_pair.
+    registry.insert(StaticMode::CanBlockShadow, handle_rule_mod);
     // CR 510.1a: AssignNoCombatDamage — creature assigns no combat damage.
     // Runtime enforcement is in combat_damage.rs::combat_damage_amount().
     registry.insert(StaticMode::AssignNoCombatDamage, handle_rule_mod);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -16502,6 +16502,35 @@ mod tests {
     }
 
     /// CR 702.94a + CR 400.3: End-to-end reproduction of Sliver Weftwinder's
+    /// CR 509.1b + CR 702.28b: both shadow-block cards reach a `CanBlockShadow`
+    /// static through the full pipeline (card-name → `~` normalization included),
+    /// instead of falling to `Effect::Unimplemented`.
+    #[test]
+    fn block_shadow_cards_reach_can_block_shadow_static() {
+        for (oracle, name) in [
+            (
+                "Heartwood Dryad can block creatures with shadow as though they didn't have shadow.",
+                "Heartwood Dryad",
+            ),
+            (
+                "Wall of Diffusion can block creatures with shadow as though it had shadow.",
+                "Wall of Diffusion",
+            ),
+        ] {
+            let parsed = parse(oracle, name, &[], &["Creature"], &[]);
+            assert!(
+                parsed
+                    .statics
+                    .iter()
+                    .any(|s| s.mode == StaticMode::CanBlockShadow
+                        && s.affected == Some(TargetFilter::SelfRef)),
+                "{name}: expected a SelfRef CanBlockShadow static, got statics={:?}, abilities={:?}",
+                parsed.statics,
+                parsed.abilities,
+            );
+        }
+    }
+
     /// hand-grant line through the full `parse_oracle_text` pipeline.
     #[test]
     fn hand_grant_reaches_statics_through_full_pipeline() {

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -327,6 +327,11 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     "as though they had flash",
     "as though those creatures had haste",
     "as though that creature had haste",
+    // CR 509.1b + CR 702.28b: shadow block permission (Heartwood Dryad, Wall of
+    // Diffusion) — "can block creatures with shadow as though [they didn't|it] had
+    // shadow". Anchored on the full subject so it never false-matches a plain
+    // shadow grant or attacker-side restriction.
+    "block creatures with shadow as though",
     // CR 205.3 + CR 700.8: "<source> is also a[n] <subtype>(, <subtype>)*" —
     // self continuous type-grant (Burakos, Veteran Adventurer, and any future
     // printing whose first subtype opens with a vowel: "is also an Elf, …").

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -266,6 +266,13 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // CR 509.1b + CR 609.4 + CR 702.28b: "<subject> can block creatures with shadow
+    // as though they didn't have shadow" / "... as though it had shadow" — per-source
+    // permission to block shadow attackers (Heartwood Dryad, Wall of Diffusion).
+    if let Some(def) = parse_block_shadow_as_though(&tp, &text) {
+        return Some(def);
+    }
+
     // CR 611.3a: An inverted static of the form "As long as <condition>, <effect>"
     // is semantically equivalent to the canonical "<effect> as long as <condition>".
     // Rewrite to canonical form and re-dispatch so the existing conditional-continuous

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -2236,6 +2236,55 @@ pub(crate) fn parse_activate_abilities_as_though_haste(
     )
 }
 
+/// CR 509.1b + CR 609.4 + CR 702.28b: parse "<subject> can block creatures with
+/// shadow as though <they didn't have shadow | it had shadow>" into a
+/// `StaticMode::CanBlockShadow` on `affected`.
+///
+/// Captures both printed phrasings of the same block-legality outcome — Heartwood
+/// Dryad ("... as though they didn't have shadow") and Wall of Diffusion ("... as
+/// though it had shadow"). Mirrors `parse_can_attack_despite_defender`: locate the
+/// `"can block creatures with shadow as though"` phrase at a word boundary with
+/// `scan_split_at_phrase`, verify the tail with an `alt()` of the two forms, then
+/// resolve the subject via `parse_continuous_subject_filter`. Returns `None`
+/// (graceful fall-through) when the phrase is absent, the tail doesn't match, or
+/// the subject can't be resolved — so unrelated shadow lines never match here.
+pub(crate) fn parse_block_shadow_as_though(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    type VE<'a> = OracleError<'a>;
+
+    let (subject_prefix, _) = nom_primitives::scan_split_at_phrase(tp.lower, |i| {
+        tag::<_, _, VE>("can block creatures with shadow as though").parse(i)
+    })?;
+
+    // Verify the trailing clause: " they didn't have shadow" (Heartwood Dryad)
+    // or " it had shadow" (Wall of Diffusion). Both lift the same CR 702.28b
+    // blocker-side restriction; the `alt()` keeps the two phrasings on one axis.
+    let after_phrase =
+        &tp.lower[subject_prefix.len() + "can block creatures with shadow as though".len()..];
+    let (rest, _) = alt((
+        tag::<_, _, VE>(" they didn't have shadow"),
+        tag::<_, _, VE>(" it had shadow"),
+    ))
+    .parse(after_phrase)
+    .ok()?;
+    let (rest, _) = opt(tag::<_, _, VE>(".")).parse(rest).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    // Subject text = original slice for correct case preservation.
+    let subject_original = tp.original[..subject_prefix.len()].trim();
+    let affected = parse_continuous_subject_filter(subject_original)?;
+
+    Some(
+        StaticDefinition::new(StaticMode::CanBlockShadow)
+            .affected(affected)
+            .description(description.to_string()),
+    )
+}
+
 /// CR 508.1d / CR 509.1c: Parse subject-scoped "attack/block each combat if able" patterns.
 ///
 /// Handles "All creatures attack each combat if able", "Creatures you control attack each

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3759,6 +3759,41 @@ fn static_can_attack_despite_defender_self_unconditional() {
 }
 
 #[test]
+fn static_block_shadow_as_though_they_didnt_have_shadow() {
+    // CR 509.1b + CR 702.28b: Heartwood Dryad phrasing. After card-name
+    // normalization the subject is `~`.
+    let def =
+        parse_static_line("~ can block creatures with shadow as though they didn't have shadow.")
+            .unwrap();
+    assert_eq!(def.mode, StaticMode::CanBlockShadow);
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert!(def.condition.is_none());
+}
+
+#[test]
+fn static_block_shadow_as_though_it_had_shadow() {
+    // CR 509.1b + CR 702.28b: Wall of Diffusion phrasing — same block-legality
+    // outcome, different "as though" clause; both map to CanBlockShadow.
+    let def =
+        parse_static_line("~ can block creatures with shadow as though it had shadow.").unwrap();
+    assert_eq!(def.mode, StaticMode::CanBlockShadow);
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+}
+
+#[test]
+fn static_block_shadow_does_not_match_plain_shadow_grant() {
+    // Discriminating: a plain shadow keyword grant must NOT parse to CanBlockShadow.
+    let parsed = parse_static_line("~ has shadow.");
+    assert!(
+        !matches!(
+            parsed.as_ref().map(|d| &d.mode),
+            Some(StaticMode::CanBlockShadow)
+        ),
+        "plain shadow grant must not become CanBlockShadow: {parsed:?}"
+    );
+}
+
+#[test]
 fn static_can_attack_despite_defender_self_conditional() {
     // CR 702.3b + CR 611.3a: ~ subject + "as long as" condition
     // (Bristlepack Sentry pattern).

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3781,6 +3781,24 @@ fn static_block_shadow_as_though_it_had_shadow() {
 }
 
 #[test]
+fn static_block_shadow_as_though_keeps_subject_scope() {
+    // CR 509.1b + CR 609.4 + CR 702.28b: subject-scoped as-though permissions
+    // must keep their affected filter; runtime resolves this through
+    // `check_static_ability` against the blocker.
+    let def = parse_static_line(
+        "Creatures you control can block creatures with shadow as though they didn't have shadow.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::CanBlockShadow);
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You)
+        ))
+    );
+}
+
+#[test]
 fn static_block_shadow_does_not_match_plain_shadow_grant() {
     // Discriminating: a plain shadow keyword grant must NOT parse to CanBlockShadow.
     let parsed = parse_static_line("~ has shadow.");

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1339,6 +1339,21 @@ pub enum StaticMode {
     /// CR 602.5a activation restriction is lifted, combat attacker validation
     /// (CR 508.1a) is untouched. Canonical card: Tyvar, Jubilant Brawler.
     CanActivateAbilitiesAsThoughHaste,
+    /// CR 509.1b + CR 609.4 + CR 702.28b: Per-source block permission that lifts
+    /// the shadow blocker-side restriction for the affected creature only — it may
+    /// block creatures with shadow despite not having shadow itself. Shadow is the
+    /// unique evasion keyword (CR 702.28b) with a symmetric "without-shadow can't
+    /// block with-shadow" pairing, so this is keyword-specific (mirrors
+    /// `CanAttackWithDefender`) rather than a generic keyword-parameterized form,
+    /// which would cross keyword CR sections with distinct runtime resolvers.
+    ///
+    /// Captures both printed phrasings of the same CR 509.1b outcome: "can block
+    /// creatures with shadow as though they didn't have shadow" (Heartwood Dryad)
+    /// and "can block creatures with shadow as though it had shadow" (Wall of
+    /// Diffusion). `affected: SelfRef` (per-source, not the global rule
+    /// modification `IgnoreLandwalkForBlocking` uses). Enforced inside the shadow
+    /// block-legality seam in `combat.rs`, not as a layer-6 keyword grant.
+    CanBlockShadow,
     /// CR 510.1a: This creature assigns no combat damage.
     /// Used for creatures like Ornithopter of Paradise and various Walls that can
     /// attack/block but deal 0 combat damage.
@@ -1598,6 +1613,7 @@ impl StaticMode {
             | StaticMode::CanAttackWithDefender
             | StaticMode::IgnoreLandwalkForBlocking { .. }
             | StaticMode::CanActivateAbilitiesAsThoughHaste
+            | StaticMode::CanBlockShadow
             | StaticMode::AssignNoCombatDamage
             | StaticMode::UntapsDuringEachOtherPlayersUntapStep
             | StaticMode::EntersWithAdditionalCounters { .. }
@@ -1882,6 +1898,7 @@ impl fmt::Display for StaticMode {
             StaticMode::CanActivateAbilitiesAsThoughHaste => {
                 write!(f, "CanActivateAbilitiesAsThoughHaste")
             }
+            StaticMode::CanBlockShadow => write!(f, "CanBlockShadow"),
             StaticMode::AssignNoCombatDamage => write!(f, "AssignNoCombatDamage"),
             StaticMode::UntapsDuringEachOtherPlayersUntapStep => {
                 write!(f, "UntapsDuringEachOtherPlayersUntapStep")
@@ -2215,6 +2232,7 @@ impl FromStr for StaticMode {
                 StaticMode::IgnoreLandwalkForBlocking { qualifier: None }
             }
             "CanActivateAbilitiesAsThoughHaste" => StaticMode::CanActivateAbilitiesAsThoughHaste,
+            "CanBlockShadow" => StaticMode::CanBlockShadow,
             s if s.starts_with("StepEndUnspentMana(") => StaticMode::Other(s.to_string()),
             "UntapsDuringEachOtherPlayersUntapStep" => {
                 StaticMode::UntapsDuringEachOtherPlayersUntapStep


### PR DESCRIPTION
## Problem

Two single-line cards parse to `Effect::Unimplemented` because the engine has no
representation for the shadow block-permission static:

- **Heartwood Dryad** — "can block creatures with shadow as though they didn't have shadow."
- **Wall of Diffusion** — "can block creatures with shadow as though it had shadow."

Shadow (CR 702.28b) is a symmetric evasion ability: a creature without shadow
can't block a creature with shadow. These cards grant the source creature
permission to block shadow attackers anyway. There was no `StaticMode` for it and
no runtime hook in the block-legality seam.

## Fix

- **New variant** `StaticMode::CanBlockShadow` (per-source, `affected: SelfRef`),
  mirroring the keyword-specific `CanAttackWithDefender`. Both printed phrasings
  ("as though they didn't have shadow" / "as though it had shadow") map to this
  single variant — same CR 509.1b outcome, one axis.
- **Parser** `parse_block_shadow_as_though` in `oracle_static/evasion.rs`, modeled
  on `parse_can_attack_despite_defender`: `scan_split_at_phrase` locates the
  subject, an `alt()` verifies the two tail forms, `parse_continuous_subject_filter`
  resolves the subject. Routed via `is_static_pattern()` + a dispatch branch next
  to the analogous `IgnoreLandwalkForBlocking` parser. Nom combinators only; no
  string dispatch.
- **Runtime** `blocker_can_block_shadow` consulted at both shadow block-legality
  seams (`validate_blockers_for_player` and `can_block_pair`) before the shadow
  restriction fails — mirrors the `CanAttackWithDefender` lookup via
  `active_static_definitions`. Registered in the static-ability registry. The
  other half of CR 702.28b (shadow creature can't block non-shadow) is untouched.
- Coverage attribution arms added so the static is recognized as covering the
  Oracle line.

## Cards unlocked

- Heartwood Dryad
- Wall of Diffusion

## Tests

- Parser (unit): both phrasings → `CanBlockShadow` with `SelfRef`; discriminating
  test that a plain "has shadow" grant does NOT become `CanBlockShadow`.
- Full pipeline: both cards (by real name → `~` normalization) reach a `SelfRef`
  `CanBlockShadow` static instead of `Unimplemented`.
- Runtime (combat): a non-shadow creature with `CanBlockShadow` may block a shadow
  attacker via both legality seams; an identical creature without it cannot; the
  reverse-direction shadow restriction still holds.

`cargo fmt --all --check`, `cargo clippy -p engine --lib -- -D warnings`, the
touched engine lib tests, the parser combinator gate, and the skill-doc gate all
pass.

## CR

- CR 702.28b — shadow blocker-side restriction (verified).
- CR 509.1b — declare-blockers restriction legality (verified).
- CR 609.4 — "as though" effects are scoped to the stated effect only (verified).
