### PR TITLE
fix(client): preview card hover on touch-primary devices with a mouse

### DIFF
--- a/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
+++ b/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
@@ -154,7 +154,7 @@ describe("BattlefieldZoneOverflow", () => {
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
     Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
     window.matchMedia = ((query: string) => ({
-      matches: query === "(hover: hover)",
+      matches: query === "(hover: hover)" || query === "(any-hover: hover)",
       media: query,
       onchange: null,
       addEventListener: vi.fn(),

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -140,7 +140,7 @@ function renderPermanent(validTargetObjectIds = new Set<number>()) {
 describe("PermanentCard attachments", () => {
   beforeEach(() => {
     window.matchMedia = ((query: string) => ({
-      matches: query === "(hover: hover)",
+      matches: query === "(hover: hover)" || query === "(any-hover: hover)",
       media: query,
       onchange: null,
       addEventListener: vi.fn(),

--- a/client/src/hooks/useCanHover.ts
+++ b/client/src/hooks/useCanHover.ts
@@ -1,15 +1,24 @@
 import { useEffect, useState } from "react";
 
+// `(any-hover: hover)` — true when ANY available input can hover, not just the
+// primary one. `(hover: hover)` reports only the primary pointer, so a tablet
+// whose primary pointer is touch returns false even with a mouse attached; that
+// suppressed mouse-hover card previews on battlefield/zone cards (which gate
+// their onMouseEnter handlers on this) while a mouse was plugged in. `any-hover`
+// keeps pure-touch devices at false (long-press preview only) while enabling
+// real mouse hover on touch-primary devices that also have a pointer.
+const HOVER_QUERY = "(any-hover: hover)";
+
 export function useCanHover(): boolean {
   const [canHover, setCanHover] = useState(() =>
     typeof window !== "undefined" &&
     typeof window.matchMedia === "function" &&
-    window.matchMedia("(hover: hover)").matches,
+    window.matchMedia(HOVER_QUERY).matches,
   );
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
-    const media = window.matchMedia("(hover: hover)");
+    const media = window.matchMedia(HOVER_QUERY);
     const update = () => setCanHover(media.matches);
     update();
     media.addEventListener("change", update);


### PR DESCRIPTION
useCanHover gated mouse-hover card previews on `(hover: hover)`, which
reports only the primary pointer. A tablet whose primary pointer is touch
returns false even with a mouse attached, so battlefield/zone cards (which
gate their onMouseEnter handlers on this) never showed a hover preview —
while hand cards, wired with an ungated onMouseEnter, still did.

Switch to `(any-hover: hover)`: true when ANY available input can hover.
Pure-touch devices stay false (long-press preview only); desktop stays
true; touch-primary devices with a mouse now correctly enable hover.
