### PR TITLE
fix(parser): attack-trigger targets honor "defending player controls" controller scope

### DIFF
--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -70,7 +70,8 @@ pub fn parse_enters_origin_zone(input: &str) -> OracleResult<'_, Zone> {
 
 /// Parse a zone owner/controller qualifier following a zone filter.
 ///
-/// Matches "you control", "an opponent controls", "you own", "you don't control".
+/// Matches "you control", "an opponent controls", "your opponents control",
+/// "you don't control", "target player controls", "defending player controls".
 pub fn parse_zone_controller(input: &str) -> OracleResult<'_, ControllerRef> {
     alt((
         value(ControllerRef::You, tag("you control")),
@@ -83,6 +84,16 @@ pub fn parse_zone_controller(input: &str) -> OracleResult<'_, ControllerRef> {
         // (see `collect_target_slots` in `game/ability_utils.rs`) so the player
         // is selected as part of target declaration.
         value(ControllerRef::TargetPlayer, tag("target player controls")),
+        // CR 508.5 / CR 508.5a: "defending player controls" — the controller
+        // scope is the defending player (or that player's planeswalker
+        // controller / battle protector) the attacking creature is attacking.
+        // Resolved per attacker at runtime by
+        // `combat::defending_player_for_attacker`. Shares no prefix with the
+        // arms above, so dispatch order is not load-bearing.
+        value(
+            ControllerRef::DefendingPlayer,
+            tag("defending player controls"),
+        ),
     ))
     .parse(input)
 }
@@ -636,6 +647,22 @@ mod tests {
         let (rest2, c2) = parse_zone_controller("you don't control").unwrap();
         assert_eq!(c2, ControllerRef::Opponent);
         assert_eq!(rest2, "");
+    }
+
+    // CR 508.5 / CR 508.5a: "defending player controls" scopes the filter
+    // controller to the defending player for attack-trigger targets (Kogla,
+    // The Tarrasque, ~42 cards). Class-level combinator behavior, not one card.
+    #[test]
+    fn test_parse_zone_controller_defending_player() {
+        let (rest, c) = parse_zone_controller("defending player controls").unwrap();
+        assert_eq!(c, ControllerRef::DefendingPlayer);
+        assert_eq!(rest, "");
+
+        // Remainder preservation: the new arm consumes only the qualifier and
+        // does not over-consume trailing text.
+        let (rest2, c2) = parse_zone_controller("defending player controls and ").unwrap();
+        assert_eq!(c2, ControllerRef::DefendingPlayer);
+        assert_eq!(rest2, " and ");
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -543,6 +543,28 @@ mod tests {
         assert_eq!(rest2, "");
     }
 
+    // No-regression guard: the "defending player controls" controller scope is
+    // added only to the high-level `oracle_nom::filter::parse_zone_controller`
+    // path (the bug-card path), NOT to this nom combinator consumed by
+    // `parse_type_phrase`. Folding it in here would change the remainder handed
+    // to the five remainder-coupled `parse_type_phrase` callers. This test
+    // documents that deliberate divergence (it also does not match
+    // "you don't control") so a future edit to this combinator is a conscious
+    // choice, not an accident.
+    #[test]
+    fn test_parse_controller_suffix_excludes_defending_player_and_negated() {
+        assert!(
+            parse_controller_suffix("defending player controls").is_err(),
+            "nom parse_controller_suffix must NOT match 'defending player controls' \
+             (handled by parse_zone_controller on the bug-card path)"
+        );
+        assert!(
+            parse_controller_suffix("you don't control").is_err(),
+            "nom parse_controller_suffix must NOT match 'you don't control' \
+             (pre-existing deliberate divergence from parse_zone_controller)"
+        );
+    }
+
     #[test]
     fn test_parse_type_phrase_single() {
         let (rest, filter) = parse_type_phrase("creature you control").unwrap();

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -175,7 +175,9 @@ pub fn parse_event_context_ref(text: &str) -> Option<(TargetFilter, &str)> {
             // a parent target. Placed after longer "that ..." phrases so
             // longest-match-first dispatch is preserved.
             value(TargetFilter::TriggeringSource, tag("that creature")),
-            // CR 506.3d: "defending player" — the player being attacked.
+            // CR 508.5 / CR 508.5a: "defending player" — the player (or the
+            // protector of the battle / controller of the planeswalker) that the
+            // attacking creature is attacking.
             value(TargetFilter::DefendingPlayer, tag("defending player")),
         ))
         .parse(input)
@@ -8902,6 +8904,73 @@ mod tests {
                     ),
                     "leg 2 = modified creatures you control"
                 );
+            }
+            other => panic!("Expected Or filter, got {other:?}"),
+        }
+        assert_eq!(rest.trim(), "");
+    }
+
+    // CR 508.5 / CR 508.5a: the "defending player controls" controller suffix
+    // scopes attack-trigger targets to the defending player (Kogla, The
+    // Tarrasque, ~42 cards). These tests pin the class-level combinator
+    // behavior across the bug-card path: the high-level controller-suffix
+    // delegate, the end-to-end target verb path, and Or-target propagation.
+
+    // High-level `parse_controller_suffix` (the runtime function the bug-card
+    // path relies on). The direct assertion guarantees the `parse_zone_controller`
+    // delegate is actually reached and not shadowed by an earlier past-tense or
+    // "that player controls" arm.
+    #[test]
+    fn parse_controller_suffix_defending_player() {
+        let ctx = ParseContext::default();
+        let (ctrl, len) = parse_controller_suffix("defending player controls", &ctx)
+            .expect("defending player controls should resolve a controller scope");
+        assert_eq!(ctrl, ControllerRef::DefendingPlayer);
+        assert_eq!(len, "defending player controls".len());
+
+        // Leading whitespace is included in the consumed length (the type-phrase
+        // suffix step passes the post-type-word remainder, which begins with a
+        // space).
+        let (ctrl_ws, len_ws) = parse_controller_suffix(" defending player controls", &ctx)
+            .expect("leading-space variant should resolve");
+        assert_eq!(ctrl_ws, ControllerRef::DefendingPlayer);
+        assert_eq!(len_ws, " defending player controls".len());
+    }
+
+    // End-to-end target verb path: a representative effect phrase parses to a
+    // Typed filter scoped to the defending player. Generic type phrase, not a
+    // card name (The Tarrasque class: "fights target creature defending player
+    // controls").
+    #[test]
+    fn parse_target_defending_player_controls_single_type() {
+        let (f, rest) = parse_target("target creature defending player controls");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::DefendingPlayer))
+        );
+        assert_eq!(rest.trim(), "");
+    }
+
+    // Or-target propagation: an Or-target phrase ending in "defending player
+    // controls" fans the DefendingPlayer scope onto each disjunct via
+    // `distribute_controller_to_or` (Kogla class: "destroy target artifact or
+    // enchantment defending player controls").
+    #[test]
+    fn parse_target_defending_player_controls_or_target() {
+        let (f, rest) = parse_target("target artifact or enchantment defending player controls");
+        match f {
+            TargetFilter::Or { ref filters } => {
+                assert_eq!(filters.len(), 2, "expected 2-way OR, got {filters:#?}");
+                for (i, leg) in filters.iter().enumerate() {
+                    match leg {
+                        TargetFilter::Typed(tf) => assert_eq!(
+                            tf.controller,
+                            Some(ControllerRef::DefendingPlayer),
+                            "leg {i} must inherit the defending-player scope"
+                        ),
+                        other => panic!("leg {i} expected Typed, got {other:?}"),
+                    }
+                }
             }
             other => panic!("Expected Or filter, got {other:?}"),
         }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -27824,6 +27824,71 @@ mod tests {
         }
     }
 
+    /// CR 508.5 / CR 508.5a: an attack-trigger effect whose target carries the
+    /// explicit "defending player controls" qualifier must scope to the
+    /// defending player. This is the bug class (Kogla, The Tarrasque, ~42
+    /// cards) — distinct from the "attack a player ... that player controls"
+    /// anaphor path covered above. Drives the full trigger→effect→target
+    /// pipeline on the real Oracle text; the assertion flips to `None` if the
+    /// `parse_zone_controller` arm is reverted.
+    #[test]
+    fn attack_trigger_destroy_or_target_defending_player_controls() {
+        use crate::types::ability::Effect;
+
+        // Kogla, the Titan Ape: Or-target destroy, scope must fan onto each leg.
+        let def = parse_trigger_line(
+            "Whenever Kogla, the Titan Ape attacks, destroy target artifact or enchantment defending player controls.",
+            "Kogla, the Titan Ape",
+        );
+        assert_eq!(def.mode, TriggerMode::Attacks);
+        let execute = def.execute.as_deref().expect("execute ability");
+        match execute.effect.as_ref() {
+            Effect::Destroy { target, .. } => match target {
+                TargetFilter::Or { filters } => {
+                    assert_eq!(filters.len(), 2, "expected 2-way OR, got {filters:#?}");
+                    for (i, leg) in filters.iter().enumerate() {
+                        match leg {
+                            TargetFilter::Typed(t) => assert_eq!(
+                                t.controller,
+                                Some(ControllerRef::DefendingPlayer),
+                                "leg {i} must scope to the defending player, not null",
+                            ),
+                            other => panic!("leg {i} expected Typed, got {other:?}"),
+                        }
+                    }
+                }
+                other => panic!("expected Or target, got {other:?}"),
+            },
+            other => panic!("expected Destroy effect, got {other:?}"),
+        }
+    }
+
+    /// CR 508.5 / CR 508.5a + CR 701.14a: The Tarrasque — "it fights target
+    /// creature defending player controls". The fight target must scope to the
+    /// defending player. Covers the Fight verb of the bug class.
+    #[test]
+    fn attack_trigger_fight_defending_player_controls() {
+        use crate::types::ability::Effect;
+
+        let def = parse_trigger_line(
+            "Whenever The Tarrasque attacks, it fights target creature defending player controls.",
+            "The Tarrasque",
+        );
+        assert_eq!(def.mode, TriggerMode::Attacks);
+        let execute = def.execute.as_deref().expect("execute ability");
+        match execute.effect.as_ref() {
+            Effect::Fight { target, .. } => match target {
+                TargetFilter::Typed(t) => assert_eq!(
+                    t.controller,
+                    Some(ControllerRef::DefendingPlayer),
+                    "fight target should scope to the defending player, not null",
+                ),
+                other => panic!("expected Typed target, got {other:?}"),
+            },
+            other => panic!("expected Fight effect, got {other:?}"),
+        }
+    }
+
     /// CR 120.3: Damage-to-player triggers (e.g., "Whenever ~ deals combat
     /// damage to a player, destroy target creature that player controls") must
     /// continue using `ControllerRef::TargetPlayer`, not `DefendingPlayer`,


### PR DESCRIPTION
## Summary
Fixes a verified misparse: attack-triggered ability targets qualified by "defending player controls". Found by triaging Moxfield deck DzoufuCTTkuCrWQt3_Q5yg against the Phase engine.

## Cards fixed
- A-Radha's Firebrand
- Avalanche Tusker
- Captain America's Shield
- Colossal Whale
- Coveted Peacock
- Cyclops Gladiator
- Distracting Geist
- Elite Scaleguard
- Fear of Falling
- Fiend Binder
- Frenzied Trapbreaker
- Genestealer Patriarch
- Goblin Racketeer
- Gouged Zealot
- Grimgrin, Corpse-Born
- Heart-Piercer Bow
- Hellkite Whelp
- Jangling Automaton
- Kogla, the Titan Ape
- Lord of Shatterskull Pass
- Lothlórien Blade
- Mage-Ring Responder
- Master of Diversion
- Mjölnir, Storm Hammer
- Moradin's Disciples
- Nazahn, Revered Bladesmith
- Purifying Dragon
- Radha's Firebrand
- Ronin Cliffrider
- Scalding Salamander
- Sensational Spider-Man
- Sidar Jabari
- Skymark Roc
- Spring Splasher
- Star-Crowned Stag
- Swathcutter Giant
- The Flood of Mars
- The Tarrasque
- The Wasp, Winsome Avenger
- Thunder Lasso
- Torrent Elemental
- Warkite Marauder

## Files changed
- /home/ntindle/code/phase-card-runs/crates/engine/src/parser/oracle_nom/filter.rs
- /home/ntindle/code/phase-card-runs/crates/engine/src/parser/oracle_target.rs
- /home/ntindle/code/phase-card-runs/crates/engine/src/parser/oracle_nom/target.rs
- /home/ntindle/code/phase-card-runs/crates/engine/src/parser/oracle_trigger.rs

## CR references
- CR 508.5
- CR 508.5a

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

Tier: Frontier

## Verification
  - `cargo fmt --all` — pass (exit 0, no diff)
  - `./scripts/check-parser-combinators.sh (Gate A)` — pass (exit 0)
  - `cargo clippy-strict` — pass for all buildable crates (engine + 17 others clean under -D warnings, exit 0). The literal --all-targets workspace alias cannot fully run in this sandbox because two unrelated peripheral crates need system C libs that are absent: feed-scraper -> openssl-sys (missing pkg-config/libssl-dev), phase-server -> libsqlite3-sys (cc target-query 'UnknownOperatingSystem'). Neither crate is touched by this parser-only change; the changed crate (engine) and its consumers (phase-ai, engine-wasm) are clippy-clean.
  - `cargo test -p engine` — pass (0 failures across all suites; 7 new defending-player tests green incl. attack_trigger_destroy_or_target_defending_player_controls, attack_trigger_fight_defending_player_controls, test_parse_zone_controller_defending_player, parse_controller_suffix_defending_player, parse_target_defending_player_controls_single_type, parse_target_defending_player_controls_or_target, test_parse_controller_suffix_excludes_defending_player_and_negated)
  - `./scripts/gen-card-data.sh` — pass (exit 0; card-data.json regenerated, 35403 faces validated)
  - `cargo semantic-audit` — pass (exit 0; 294/31464 cards flagged DB-wide, NONE of the listed/confirmed cards flagged)

## Scope Expansion
Generated `crates/engine/data/known-tokens.toml` was modified as a side effect of running `gen-card-data.sh` (newer MTGJSON than baseline); it is unrelated to this parser fix and a `git checkout` to restore it was denied by the multi-agent-safety classifier — the orchestrator should NOT stage it with this change. Gitignored regenerated artifacts under client/public/ (card-data.json, coverage, semantic-audit) are also touched but untracked.

## Validation Failures
None.

## CI Failures
- cargo clippy-strict (the --all-targets workspace alias) could not run to completion verbatim due to a sandbox environment limitation, NOT a code defect: feed-scraper depends on openssl-sys which needs pkg-config + libssl-dev (not installed, no root to apt-get), and phase-server depends on libsqlite3-sys whose cc build script fails with 'unable to parse target query x86_64-unknown-linux-gnu: UnknownOperatingSystem'. Both crates are unrelated to this parser-only change. Equivalent clippy coverage was obtained by running cargo clippy across the whole workspace excluding only those two unbuildable crates (engine + phase-ai + engine-wasm + 14 others, exit 0, clean under -D warnings).
- Decimator Beetle is NOT one of the named cards and is correctly out of this fix's scope, but noting for completeness: its Attacks-trigger second chained clause ('and put a -1/-1 counter on up to one target creature defending player controls') is dropped entirely by a separate pre-existing chained-effect parser gap, so no defending-player target is produced for it. This is not a regression of the controller-scope fix (the target was never emitted) and the card is clean in semantic-audit.
