### PR TITLE
Fix Haunted One buffing ineligible creatures (#3324)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -10065,6 +10065,36 @@ fn parse_controlled_creature_each_second_subject(rest: &str) -> Option<(usize, T
     Some((rest.len() - remaining.len(), filter))
 }
 
+/// Second-subject axis: "other creatures you control that share a creature type
+/// with it each " (Haunted One: "~ and other creatures you control that share
+/// a creature type with it each get +2/+0 and gain undying until end of turn").
+fn parse_other_creatures_share_type_each_second_subject(
+    rest: &str,
+) -> Option<(usize, TargetFilter)> {
+    use crate::types::ability::{
+        ControllerRef, FilterProp, SharedQuality, SharedQualityRelation, TypedFilter,
+    };
+    const PREFIX: &str = "other creatures you control that share a creature type with it each ";
+    if !rest.starts_with(PREFIX) {
+        return None;
+    }
+    Some((
+        PREFIX.len(),
+        TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .properties(vec![
+                    FilterProp::Another,
+                    FilterProp::SharesQuality {
+                        quality: SharedQuality::CreatureType,
+                        reference: Some(Box::new(TargetFilter::TriggeringSource)),
+                        relation: SharedQualityRelation::Shares,
+                    },
+                ]),
+        ),
+    ))
+}
+
 fn type_phrase_has_compound_conjunction(type_phrase: &str) -> bool {
     take_until::<_, _, OracleError<'_>>(" and ")
         .parse(type_phrase)
@@ -10106,11 +10136,12 @@ fn parse_dynamic_compound_subject_prefix(
             tag::<_, _, OracleError<'_>>("you and "),
         ),
         value(TargetFilter::SelfRef, tag("~ and ")),
+        value(TargetFilter::SelfRef, tag("it and ")),
     ))
     .parse(lower)
     .ok()?;
-    let (second_consumed, second_filter) =
-        parse_controlled_creature_each_second_subject(remaining)?;
+    let (second_consumed, second_filter) = parse_controlled_creature_each_second_subject(remaining)
+        .or_else(|| parse_other_creatures_share_type_each_second_subject(remaining))?;
     Some((
         lower.len() - remaining.len() + second_consumed,
         first_filter,
@@ -47891,6 +47922,48 @@ mod tests {
             );
             cursor = node.sub_ability.as_deref();
         }
+    }
+
+    /// Haunted One granted trigger: compound-subject distribution with
+    /// SharesQuality relative to the tapped commander.
+    #[test]
+    fn compound_subject_each_other_creatures_share_commander_type() {
+        use crate::types::ability::{FilterProp, SharedQuality, TypedFilter};
+
+        let mut ctx = ParseContext::default();
+        let text = "it and other creatures you control that share a creature type with it each get +2/+0 and gain undying until end of turn";
+        let clause = try_parse_compound_subject_each(text, &mut ctx)
+            .expect("Haunted One body should parse as compound-subject each");
+        assert_eq!(chain_len(&clause), 2, "expected 2 links");
+        assert_no_unimplemented(&clause);
+        match &clause.effect {
+            Effect::GenericEffect {
+                target: Some(t), ..
+            } => assert_eq!(*t, TargetFilter::SelfRef),
+            Effect::Pump { target, .. } => assert_eq!(*target, TargetFilter::SelfRef),
+            other => panic!("expected head with SelfRef recipient, got {other:?}"),
+        }
+        let tail = clause.sub_ability.as_ref().expect("tail link");
+        let tail_target = match &*tail.effect {
+            Effect::GenericEffect {
+                target: Some(t),
+                ..
+            }
+            | Effect::Pump { target: t, .. } => t.clone(),
+            other => panic!("expected tail GenericEffect/Pump, got {other:?}"),
+        };
+        let TargetFilter::Typed(tf) = tail_target else {
+            panic!("expected typed tail filter, got {tail_target:?}");
+        };
+        assert!(tf.properties.contains(&FilterProp::Another));
+        assert!(tf.properties.iter().any(|p| matches!(
+            p,
+            FilterProp::SharesQuality {
+                quality: SharedQuality::CreatureType,
+                reference: Some(reference),
+                ..
+            } if matches!(reference.as_ref(), TargetFilter::TriggeringSource)
+        )));
     }
 
     /// "~ and that creature each get +2/+0" → 2-link Pump chain:

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -97,9 +97,10 @@ use crate::types::ability::{
     ManaSpendPermission, MultiTargetSpec, ObjectProperty, ObjectScope, PlayerFilter,
     PlayerRelation, PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue,
     QuantityExpr, QuantityRef, ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope,
-    RoundingMode, StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink,
-    TapStateChange, TargetFilter, TargetSelectionMode, ThisWayCause, TriggerCondition,
-    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
+    RoundingMode, SharedQuality, SharedQualityRelation, StaticCondition, StaticDefinition,
+    StepSkipTarget, SubAbilityLink, TapStateChange, TargetFilter, TargetSelectionMode,
+    ThisWayCause, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
+    UntilCondition, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -10071,15 +10072,13 @@ fn parse_controlled_creature_each_second_subject(rest: &str) -> Option<(usize, T
 fn parse_other_creatures_share_type_each_second_subject(
     rest: &str,
 ) -> Option<(usize, TargetFilter)> {
-    use crate::types::ability::{
-        ControllerRef, FilterProp, SharedQuality, SharedQualityRelation, TypedFilter,
-    };
-    const PREFIX: &str = "other creatures you control that share a creature type with it each ";
-    if !rest.starts_with(PREFIX) {
-        return None;
-    }
+    let (remaining, _) = tag::<_, _, OracleError<'_>>(
+        "other creatures you control that share a creature type with it each ",
+    )
+    .parse(rest)
+    .ok()?;
     Some((
-        PREFIX.len(),
+        rest.len() - remaining.len(),
         TargetFilter::Typed(
             TypedFilter::creature()
                 .controller(ControllerRef::You)
@@ -47928,7 +47927,7 @@ mod tests {
     /// SharesQuality relative to the tapped commander.
     #[test]
     fn compound_subject_each_other_creatures_share_commander_type() {
-        use crate::types::ability::{FilterProp, SharedQuality, TypedFilter};
+        use crate::types::ability::{FilterProp, SharedQuality};
 
         let mut ctx = ParseContext::default();
         let text = "it and other creatures you control that share a creature type with it each get +2/+0 and gain undying until end of turn";
@@ -47946,8 +47945,7 @@ mod tests {
         let tail = clause.sub_ability.as_ref().expect("tail link");
         let tail_target = match &*tail.effect {
             Effect::GenericEffect {
-                target: Some(t),
-                ..
+                target: Some(t), ..
             }
             | Effect::Pump { target: t, .. } => t.clone(),
             other => panic!("expected tail GenericEffect/Pump, got {other:?}"),

--- a/crates/engine/tests/integration/issue_3324_haunted_one.rs
+++ b/crates/engine/tests/integration/issue_3324_haunted_one.rs
@@ -1,0 +1,85 @@
+//! Issue #3324 — Haunted One must buff only the tapped commander and other
+//! creatures you control that share a creature type with it.
+
+use engine::parser::oracle_static::parse_static_line;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityKind, ContinuousModification, Effect, FilterProp, SharedQuality, TargetFilter,
+};
+
+const HAUNTED_ONE_ORACLE: &str = "Commander creatures you own have \"Whenever this creature becomes tapped, it and other creatures you control that share a creature type with it each get +2/+0 and gain undying until end of turn.\" (When a creature with undying dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)";
+
+const GRANTED_BODY: &str =
+    "it and other creatures you control that share a creature type with it each get +2/+0 and gain undying until end of turn";
+
+#[test]
+fn haunted_one_granted_trigger_body_is_not_unfiltered_any() {
+    let def = parse_effect_chain(GRANTED_BODY, AbilityKind::Spell);
+    assert!(
+        !matches!(
+            def.effect.as_ref(),
+            Effect::GenericEffect {
+                target: Some(TargetFilter::Any),
+                ..
+            }
+        ),
+        "Haunted One body must not broadcast to Any, got {:?}",
+        def.effect
+    );
+}
+
+#[test]
+fn haunted_one_static_grants_compound_subject_trigger() {
+    let def = parse_static_line(HAUNTED_ONE_ORACLE).expect("Haunted One static must parse");
+    let grant = def
+        .modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::GrantTrigger { trigger } => Some(trigger),
+            _ => None,
+        })
+        .expect("Haunted One must parse as GrantTrigger");
+
+    let execute = grant.execute.as_ref().expect("grant must have execute");
+    assert!(
+        !matches!(
+            execute.effect.as_ref(),
+            Effect::GenericEffect {
+                target: Some(TargetFilter::Any),
+                ..
+            }
+        ),
+        "granted execute must not use unfiltered Any, got {:?}",
+        execute.effect
+    );
+
+    let tail = execute.sub_ability.as_ref().expect("compound-subject tail");
+    let tail_target = match &*tail.effect {
+        Effect::GenericEffect {
+            target: Some(t),
+            ..
+        }
+        | Effect::Pump { target: t, .. } => t,
+        other => panic!("expected tail with recipient filter, got {other:?}"),
+    };
+    let TargetFilter::Typed(tf) = tail_target else {
+        panic!("expected typed tail filter, got {tail_target:?}");
+    };
+    assert!(tf.properties.contains(&FilterProp::Another));
+    assert!(tf.properties.iter().any(|p| matches!(
+        p,
+        FilterProp::SharesQuality {
+            quality: SharedQuality::CreatureType,
+            reference: Some(reference),
+            ..
+        } if matches!(reference.as_ref(), TargetFilter::TriggeringSource)
+    )));
+    assert_eq!(
+        tf.controller,
+        Some(engine::types::ability::ControllerRef::You)
+    );
+    assert!(
+        tf.type_filters
+            .contains(&engine::types::ability::TypeFilter::Creature)
+    );
+}

--- a/crates/engine/tests/integration/issue_3324_haunted_one.rs
+++ b/crates/engine/tests/integration/issue_3324_haunted_one.rs
@@ -1,8 +1,8 @@
 //! Issue #3324 — Haunted One must buff only the tapped commander and other
 //! creatures you control that share a creature type with it.
 
-use engine::parser::oracle_static::parse_static_line;
 use engine::parser::oracle_effect::parse_effect_chain;
+use engine::parser::oracle_static::parse_static_line;
 use engine::types::ability::{
     AbilityKind, ContinuousModification, Effect, FilterProp, SharedQuality, TargetFilter,
 };
@@ -56,8 +56,7 @@ fn haunted_one_static_grants_compound_subject_trigger() {
     let tail = execute.sub_ability.as_ref().expect("compound-subject tail");
     let tail_target = match &*tail.effect {
         Effect::GenericEffect {
-            target: Some(t),
-            ..
+            target: Some(t), ..
         }
         | Effect::Pump { target: t, .. } => t,
         other => panic!("expected tail with recipient filter, got {other:?}"),
@@ -78,8 +77,7 @@ fn haunted_one_static_grants_compound_subject_trigger() {
         tf.controller,
         Some(engine::types::ability::ControllerRef::You)
     );
-    assert!(
-        tf.type_filters
-            .contains(&engine::types::ability::TypeFilter::Creature)
-    );
+    assert!(tf
+        .type_filters
+        .contains(&engine::types::ability::TypeFilter::Creature));
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -208,6 +208,7 @@ mod issue_2940_krark_thumbless;
 mod issue_2941_vivien_reid;
 mod issue_2943_kayas_wrath;
 mod issue_3127_reveal_otherwise_graveyard;
+mod issue_3324_haunted_one;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_564_wishclaw_talisman_control;


### PR DESCRIPTION
## Summary
- Parse Haunted One's granted `"it and other creatures you control that share a creature type with it each"` compound subject instead of falling back to unfiltered `Any`
- Recognize `"it and "` as a self-reference prefix alongside `"~ and "`
- Add parser unit test and integration coverage for the static grant trigger

Fixes #3324

## Test plan
- [x] `cargo test -p engine --test integration issue_3324`
- [x] Parser unit test `compound_subject_each_other_creatures_share_commander_type`

Made with [Cursor](https://cursor.com)