### PR TITLE
fix(parser): BecomeCopy duration ForAsLongAs binds the tapped-state condition to ability.source_id v

### DIFF
--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -1258,6 +1258,7 @@ mod tests {
                     ContinuousModification::AddToughness { value: 1 },
                 ],
                 condition: None,
+                duration_subject: None,
                 source_name: String::new(),
             });
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5758,6 +5758,7 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::IsRingBearer => ("IsRingBearer", Handled),
         StaticCondition::RingLevelAtLeast { .. } => ("RingLevelAtLeast", Handled),
         StaticCondition::SourceIsTapped => ("SourceIsTapped", Handled),
+        StaticCondition::IsTapped { .. } => ("IsTapped", Handled),
         StaticCondition::SourceIsSaddled => ("SourceIsSaddled", Handled),
         StaticCondition::SourceControllerEquals { .. } => ("SourceControllerEquals", Handled),
         StaticCondition::Unrecognized { .. } => ("Unrecognized", Handled),

--- a/crates/engine/src/game/effects/become_copy.rs
+++ b/crates/engine/src/game/effects/become_copy.rs
@@ -102,7 +102,14 @@ pub fn resolve(
     }];
     modifications.extend(layered_mods);
 
-    state.add_transient_continuous_effect(
+    // CR 611.2b + CR 110.5d: the copy modification applies to the SOURCE
+    // (`affected = SpecificObject { source_id }`), but a "for as long as that
+    // creature remains tapped" duration (Zygon Infiltrator) tracks the copy
+    // *target*'s tap state — a third object distinct from both source and
+    // affected. The parser cannot know the target's runtime `ObjectId`; capture
+    // it here and bind it as the duration subject so the target-relative
+    // `IsTapped { scope: Target }` condition resolves against the copy target.
+    let tce_id = state.add_transient_continuous_effect(
         ability.source_id,
         ability.controller,
         duration,
@@ -112,6 +119,7 @@ pub fn resolve(
         modifications,
         None,
     );
+    state.set_transient_duration_subject(tce_id, target_id);
 
     // CR 707.9f: "Some exceptions to the copying process apply only if the
     // copy is or has certain characteristics" — flush the layer re-evaluation
@@ -210,7 +218,7 @@ mod tests {
     use crate::game::printed_cards::intrinsic_copiable_values;
     use crate::game::turns::execute_cleanup;
     use crate::game::zones::{create_object, move_to_zone};
-    use crate::types::ability::{Effect, TargetFilter, TargetRef};
+    use crate::types::ability::{Effect, StaticCondition, TargetFilter, TargetRef};
     use crate::types::card_type::{CardType, CoreType};
     use crate::types::identifiers::CardId;
     use crate::types::keywords::Keyword;
@@ -1798,6 +1806,147 @@ mod tests {
         assert!(
             marit_lage.keywords.contains(&Keyword::Indestructible),
             "Marit Lage has indestructible"
+        );
+    }
+
+    // ---- Zygon Infiltrator: target-relative `ForAsLongAs { IsTapped }` ----
+
+    /// CR 611.2b + CR 110.5d: a `BecomeCopy` with a "for as long as that creature
+    /// remains tapped" duration tracks the COPY TARGET's tap state. The copy
+    /// holds while the target is tapped and lapses when the target untaps — even
+    /// though the copy modification applies to the SOURCE and the source's own
+    /// tap state never changes. This is the exact Zygon Infiltrator bug.
+    #[test]
+    fn become_copy_for_as_long_as_target_tapped_tracks_target() {
+        use crate::types::ability::ObjectScope;
+
+        let mut state = GameState::new_two_player(7);
+        // Target: a tapped 3/3 the source will copy.
+        let target_id = create_creature(&mut state, 1, PlayerId(0), "Tapped Bear", 3, 3);
+        state.objects.get_mut(&target_id).unwrap().tapped = true;
+        // Source: a 1/1 that becomes the copy. It is UNTAPPED and stays untapped
+        // (Zygon's activation cost has no {T}).
+        let source_id = create_creature(&mut state, 2, PlayerId(0), "Zygon", 1, 1);
+        state.objects.get_mut(&source_id).unwrap().tapped = false;
+
+        let duration = Some(Duration::ForAsLongAs {
+            condition: StaticCondition::IsTapped {
+                scope: ObjectScope::Target,
+            },
+        });
+        let ability = make_copy_ability(target_id, source_id, PlayerId(0), duration);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        // While the target is tapped, the copy applies even though the source is
+        // untapped — the duration tracks the target, not the source.
+        let source = state.objects.get(&source_id).unwrap();
+        assert_eq!(
+            source.power,
+            Some(3),
+            "copy must apply while the TARGET is tapped (source is untapped)"
+        );
+        assert_eq!(source.name, "Tapped Bear");
+
+        // Untap the target → the `ForAsLongAs { IsTapped { Target } }` duration
+        // ends and the copy lapses.
+        state.objects.get_mut(&target_id).unwrap().tapped = false;
+        evaluate_layers(&mut state);
+        let source = state.objects.get(&source_id).unwrap();
+        assert_eq!(
+            source.power,
+            Some(1),
+            "copy must lapse once the target untaps (CR 611.2b)"
+        );
+        assert_eq!(source.name, "Zygon");
+    }
+
+    /// Divergence guard: with `affected = SpecificObject { source }` but the
+    /// duration subject bound to the TARGET, toggling the SOURCE's tap state must
+    /// have NO effect on the duration — only the target's tap state matters. This
+    /// pins the exact bug (source-binding) so it cannot silently return.
+    #[test]
+    fn become_copy_duration_ignores_source_tap_state() {
+        use crate::types::ability::ObjectScope;
+
+        let mut state = GameState::new_two_player(11);
+        let target_id = create_creature(&mut state, 1, PlayerId(0), "Tapped Bear", 3, 3);
+        state.objects.get_mut(&target_id).unwrap().tapped = true;
+        let source_id = create_creature(&mut state, 2, PlayerId(0), "Zygon", 1, 1);
+        // Source starts UNTAPPED — under the old (buggy) SourceIsTapped binding
+        // the copy would never apply.
+        state.objects.get_mut(&source_id).unwrap().tapped = false;
+
+        let duration = Some(Duration::ForAsLongAs {
+            condition: StaticCondition::IsTapped {
+                scope: ObjectScope::Target,
+            },
+        });
+        let ability = make_copy_ability(target_id, source_id, PlayerId(0), duration);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&source_id).unwrap().power,
+            Some(3),
+            "copy applies with untapped source because the TARGET is tapped"
+        );
+
+        // Tap the source (target still tapped) → still applies.
+        state.objects.get_mut(&source_id).unwrap().tapped = true;
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&source_id).unwrap().power,
+            Some(3),
+            "tapping the source must not change the duration"
+        );
+
+        // Untap the source while the target stays tapped → STILL applies. Source
+        // tap state is irrelevant; only the target's matters.
+        state.objects.get_mut(&source_id).unwrap().tapped = false;
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&source_id).unwrap().power,
+            Some(3),
+            "source tap state must not gate a target-relative duration"
+        );
+    }
+
+    /// `duration_subject` is captured at resolution time and carried on the TCE.
+    #[test]
+    fn become_copy_captures_duration_subject_on_tce() {
+        use crate::types::ability::ObjectScope;
+
+        let mut state = GameState::new_two_player(13);
+        let target_id = create_creature(&mut state, 1, PlayerId(0), "Tapped Bear", 3, 3);
+        state.objects.get_mut(&target_id).unwrap().tapped = true;
+        let source_id = create_creature(&mut state, 2, PlayerId(0), "Zygon", 1, 1);
+
+        let duration = Some(Duration::ForAsLongAs {
+            condition: StaticCondition::IsTapped {
+                scope: ObjectScope::Target,
+            },
+        });
+        let ability = make_copy_ability(target_id, source_id, PlayerId(0), duration);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let tce = state
+            .transient_continuous_effects
+            .iter()
+            .find(|t| t.source_id == source_id)
+            .expect("BecomeCopy must register a TCE");
+        assert_eq!(
+            tce.duration_subject,
+            Some(target_id),
+            "the copy TARGET must be captured as the duration subject"
+        );
+        assert_eq!(
+            tce.affected,
+            TargetFilter::SpecificObject { id: source_id },
+            "the copy modification still applies to the SOURCE"
         );
     }
 }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -547,6 +547,16 @@ fn condition_uses_recipient_context(condition: &StaticCondition) -> bool {
         StaticCondition::Not { condition } => condition_uses_recipient_context(condition),
         StaticCondition::RecipientHasCounters { .. } => true,
         StaticCondition::RecipientMatchesFilter { .. } => true,
+        // CR 110.5b + CR 611.2b: a target/recipient-scoped tap condition must
+        // route through the recipient-eval path so the captured `duration_subject`
+        // (the copy target) binds — relying on the `_ => false` default would
+        // route `Target` to the source binding and reintroduce the bug.
+        // `Source`-scoped (never emitted; spelled `SourceIsTapped`) stays source-bound.
+        StaticCondition::IsTapped { scope } => matches!(
+            scope,
+            crate::types::ability::ObjectScope::Target
+                | crate::types::ability::ObjectScope::Recipient
+        ),
         _ => false,
     }
 }
@@ -636,6 +646,9 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
         | StaticCondition::SourceIsTapped
+        // Tap status is per-object state, never board-population-dependent —
+        // non-population exactly like `SourceIsTapped`.
+        | StaticCondition::IsTapped { .. }
         | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceControllerEquals { .. }
         | StaticCondition::SourceIsEquipped
@@ -754,6 +767,9 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::IsRingBearer
         | StaticCondition::RingLevelAtLeast { .. }
         | StaticCondition::SourceIsTapped
+        // An entering object cannot perturb a per-object tap gate — `false`
+        // exactly like `SourceIsTapped`.
+        | StaticCondition::IsTapped { .. }
         | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceControllerEquals { .. }
         | StaticCondition::SourceIsEquipped
@@ -953,6 +969,29 @@ fn evaluate_condition_with_context(
         // Callous Oppressor dying while tapped) fails this predicate and any
         // `ForAsLongAs { SourceIsTapped }` continuous effect (gain-control, etc.) ends.
         StaticCondition::SourceIsTapped => eval_source_is_tapped_on_battlefield(state, source_id),
+        // CR 110.5b + CR 110.5d: scope-parameterized tap check (the non-source
+        // sibling of `SourceIsTapped`). Resolve the scope to a concrete object,
+        // then reuse the same zone-guarded battlefield tap predicate. The parser
+        // only ever emits `scope: Target` (the demonstrative "that creature
+        // remains tapped" case — Zygon Infiltrator), bound at resolution time to
+        // the copy target via `duration_subject` and surfaced here as the
+        // `recipient_id`. `Recipient` resolves identically. `Source` is spelled
+        // `SourceIsTapped` and never reaches this arm; the remaining scopes are
+        // never produced for a duration tap condition, so they fail safely.
+        StaticCondition::IsTapped { scope } => match scope {
+            crate::types::ability::ObjectScope::Source => {
+                eval_source_is_tapped_on_battlefield(state, source_id)
+            }
+            crate::types::ability::ObjectScope::Target
+            | crate::types::ability::ObjectScope::Recipient => {
+                recipient_id.is_some_and(|id| eval_source_is_tapped_on_battlefield(state, id))
+            }
+            crate::types::ability::ObjectScope::EventSource
+            | crate::types::ability::ObjectScope::EventTarget
+            | crate::types::ability::ObjectScope::CostPaidObject
+            | crate::types::ability::ObjectScope::Anaphoric
+            | crate::types::ability::ObjectScope::Demonstrative => false,
+        },
         // CR 702.171b + CR 110.5d: off-battlefield permanents have no saddled designation.
         StaticCondition::SourceIsSaddled => state.objects.get(&source_id).is_some_and(|obj| {
             obj.zone == crate::types::zones::Zone::Battlefield && obj.is_saddled
@@ -2654,7 +2693,19 @@ fn transient_duration_holds(state: &GameState, tce: &TransientContinuousEffect) 
     // tracks the controlled/granted creature's counters rather than the source.
     match (&tce.affected, condition_uses_recipient_context(condition)) {
         (TargetFilter::SpecificObject { id }, true) => {
-            evaluate_condition_with_recipient(state, condition, tce.controller, tce.source_id, *id)
+            // CR 611.2b: a target-relative duration tracks the captured
+            // `duration_subject` (the copy target for BecomeCopy — Zygon
+            // Infiltrator) when it diverges from `affected`; otherwise the
+            // affected object (Shield Broker's recipient-relative control
+            // duration, where the recipient IS the tracked object).
+            let recipient = tce.duration_subject.unwrap_or(*id);
+            evaluate_condition_with_recipient(
+                state,
+                condition,
+                tce.controller,
+                tce.source_id,
+                recipient,
+            )
         }
         _ => evaluate_condition(state, condition, tce.controller, tce.source_id),
     }
@@ -8583,6 +8634,7 @@ mod tests {
                     keyword: Keyword::Flying,
                 }],
                 condition: None,
+                duration_subject: None,
                 source_name: String::new(),
             });
         let mut effects = vec![];
@@ -8614,6 +8666,7 @@ mod tests {
                     keyword: Keyword::Flying,
                 }],
                 condition: None,
+                duration_subject: None,
                 source_name: String::new(),
             });
         let mut effects = vec![];

--- a/crates/engine/src/game/meld_tests.rs
+++ b/crates/engine/src/game/meld_tests.rs
@@ -475,6 +475,7 @@ fn meld_renamed_non_meld_partner_is_noop() {
                 name: "Bruna, the Fading Light".to_string(),
             }],
             condition: None,
+            duration_subject: None,
             source_name: String::new(),
         });
     crate::game::layers::flush_layers(&mut state);

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -17238,6 +17238,7 @@ pub mod tests {
                         },
                     }],
                     condition: None,
+                    duration_subject: None,
                     source_name: "Jhoira of the Ghitu".to_string(),
                 },
             );

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2531,6 +2531,10 @@ pub(crate) fn static_condition_to_ability_condition(
         // (`AbilityCondition`) equivalent. `Not(SourceHasDealtDamage)` is handled by
         // the inner Not sub-match's `_ => None` arm above.
         | StaticCondition::SourceHasDealtDamage
+        // CR 110.5b + CR 611.2b: `IsTapped { scope }` is a duration-only
+        // target-relative tap condition (Zygon Infiltrator's copy duration), not
+        // an effect-resolution gate — no `AbilityCondition` equivalent.
+        | StaticCondition::IsTapped { .. }
         | StaticCondition::None => None,
     }
 }

--- a/crates/engine/src/parser/oracle_nom/duration.rs
+++ b/crates/engine/src/parser/oracle_nom/duration.rs
@@ -21,9 +21,9 @@ use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
 use super::condition::{parse_inner_condition, parse_recipient_has_counters};
-use super::error::OracleResult;
+use super::error::{oracle_err, OracleError, OracleResult};
 use super::primitives::scan_contains;
-use crate::types::ability::{Duration, PlayerScope, StaticCondition};
+use crate::types::ability::{Duration, ObjectScope, PlayerScope, StaticCondition};
 use crate::types::phase::Phase;
 
 /// Parse a duration phrase from Oracle text.
@@ -146,7 +146,9 @@ fn parse_until_next_turn(input: &str) -> OracleResult<'_, Duration> {
 ///
 /// Mapping (ported verbatim from the legacy `strip_trailing_duration` table):
 /// - compound "[a] and [b]" → `ForAsLongAs(And[..])`
-/// - "[subject] remains tapped" → `ForAsLongAs(SourceIsTapped)`
+/// - "[subject] remains tapped" → `ForAsLongAs(SourceIsTapped)` for source
+///   subjects, `ForAsLongAs(IsTapped { scope: Target })` for demonstrative
+///   subjects (see `parse_remains_tapped`)
 /// - "you control [subject]" → `UntilHostLeavesPlay`
 /// - "[subject] remains on the battlefield" → `UntilHostLeavesPlay`
 /// - "[subject] has [N] [type] counter(s) on it" → `ForAsLongAs(HasCounters)`
@@ -160,14 +162,12 @@ fn parse_until_next_turn(input: &str) -> OracleResult<'_, Duration> {
 pub fn parse_for_as_long_as_condition(input: &str) -> OracleResult<'_, Duration> {
     alt((
         parse_compound_for_as_long_as,
-        // "[subject] remains tapped" — subject varies ("~", "it", "this
-        // creature"), so the phrase is matched at any word boundary.
-        value(
-            Duration::ForAsLongAs {
-                condition: StaticCondition::SourceIsTapped,
-            },
-            verify(rest, |tail: &str| scan_contains(tail, "remains tapped")),
-        ),
+        // "[subject] remains tapped" — the grammatical subject selects the
+        // tracked object's scope. Demonstrative subjects ("that creature") bind
+        // the duration to the copy/control TARGET; source subjects ("~", "this
+        // creature", bare card names) bind to the source. See
+        // `parse_remains_tapped`.
+        parse_remains_tapped,
         // "you control [subject]" → host-control lifetime, modeled with the
         // existing UntilHostLeavesPlay variant.
         value(
@@ -204,6 +204,99 @@ pub fn parse_for_as_long_as_condition(input: &str) -> OracleResult<'_, Duration>
         }),
     ))
     .parse(input)
+}
+
+/// CR 110.5b + CR 611.2b: subject-aware "[subject] remains tapped" duration.
+///
+/// The grammatical subject of "remains tapped" selects which object's tap state
+/// the `ForAsLongAs` duration tracks:
+///
+/// - **Demonstrative subjects** ("that creature/permanent/artifact") → the
+///   copy/control TARGET. Emits `IsTapped { scope: Target }` so the resolver
+///   (`become_copy.rs`) binds the duration to the resolved target object (Zygon
+///   Infiltrator: "as long as THAT creature remains tapped" tracks the copied
+///   creature, not Zygon). This tier is tried FIRST.
+///
+/// The anaphoric pronoun "it" is deliberately NOT in the demonstrative set: its
+/// referent is clause-context-dependent ("you control ~ and it remains tapped"
+/// → "it" is the source; "tap another target permanent. Its abilities can't be
+/// activated for as long as it remains tapped" → "it" is the target). The
+/// duration combinator has no clause subject to disambiguate, so "it" falls to
+/// the source fallback (the pre-existing behavior), preserving every "it
+/// remains tapped" card's current parse. The only cluster card needing the
+/// target binding (Zygon) uses the unambiguous "that creature".
+/// - **Source subjects** ("~", "this creature", a `SELF_REF_TYPE_PHRASES`
+///   self-reference, or a bare card name like "The Blackstaff of Waterdeep") →
+///   the source. Emits `SourceIsTapped`. The explicit self-reference `alt()`
+///   plus the retained `scan_contains` word-boundary fallback covers every
+///   source phrasing, including proper names beginning with "The".
+///
+/// Demonstrative dispatch MUST precede the source fallback so a proper-name card
+/// is never misread as a target subject and "that creature" is never swallowed
+/// by the source `scan_contains` scan. The closed demonstrative `alt()`
+/// deliberately excludes any "the " arm — a leading "The" belongs to a card name
+/// (source), not a demonstrative. Compound cards (Hivis, Rubinia) are split by
+/// `parse_compound_for_as_long_as` before this combinator runs, so each side
+/// re-enters here and lands on the source fallback.
+fn parse_remains_tapped(input: &str) -> OracleResult<'_, Duration> {
+    // Each tier is clause-final: a trailing `rest` consumes any remainder after
+    // "[subject] remains tapped" so the arm behaves like the legacy `verify(rest,
+    // ..)` arm (the phrase sits at the trailing edge of the effect clause).
+    //
+    // Tier 1: demonstrative subject → target-relative tap state.
+    let demonstrative = value(
+        Duration::ForAsLongAs {
+            condition: StaticCondition::IsTapped {
+                scope: ObjectScope::Target,
+            },
+        },
+        (
+            alt((
+                tag("that creature"),
+                tag("that permanent"),
+                tag("that artifact"),
+            )),
+            tag(" remains tapped"),
+            rest,
+        ),
+    );
+
+    // Tier 2a: explicit source self-reference → source-relative tap state.
+    let source_self_ref = value(
+        Duration::ForAsLongAs {
+            condition: StaticCondition::SourceIsTapped,
+        },
+        (parse_self_reference_subject, tag(" remains tapped"), rest),
+    );
+
+    // Tier 2b: any other source phrasing (proper card names like "The Blackstaff
+    // of Waterdeep", compound-clause remnants) → source. Word-boundary scan, not
+    // a dispatch primitive, and only reached after demonstrative dispatch fails.
+    let source_fallback = value(
+        Duration::ForAsLongAs {
+            condition: StaticCondition::SourceIsTapped,
+        },
+        verify(rest, |tail: &str| scan_contains(tail, "remains tapped")),
+    );
+
+    alt((demonstrative, source_self_ref, source_fallback)).parse(input)
+}
+
+/// Source self-reference subject combinator: "~" or any `SELF_REF_TYPE_PHRASES`
+/// phrase ("this creature", "this permanent", …). Iterates the shared
+/// self-reference constant — the single authority for source self-references —
+/// so no card-specific phrasing leaks in. (`SELF_REF_TYPE_PHRASES` is a runtime
+/// slice, so the closed set is folded by iteration rather than a fixed `alt()`
+/// tuple; each candidate is still matched with the nom `tag()` combinator.)
+fn parse_self_reference_subject(input: &str) -> OracleResult<'_, ()> {
+    for phrase in std::iter::once(&"~").chain(crate::parser::oracle_util::SELF_REF_TYPE_PHRASES) {
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(*phrase).parse(input) {
+            return Ok((rest, ()));
+        }
+    }
+    // No self-reference subject matched — surface a recoverable nom error so the
+    // outer `alt()` falls through to the `scan_contains` source fallback.
+    Err(oracle_err(input))
 }
 
 /// Compound "for as long as [a] and [b]" → `ForAsLongAs(And[..])`.
@@ -495,6 +588,112 @@ mod tests {
         assert_eq!(
             parse_cast_snapshot_suffix(" as you cast this spell."),
             Ok((".", ()))
+        );
+    }
+
+    // ---- "remains tapped" subject-aware duration (CR 110.5b + CR 611.2b) ----
+
+    /// Demonstrative subject ("that creature") → target-relative tap state. This
+    /// is the Zygon Infiltrator copy-duration class: the duration must track the
+    /// copied creature (the target), not the source.
+    #[test]
+    fn test_remains_tapped_demonstrative_binds_target() {
+        for subject in ["that creature", "that permanent", "that artifact"] {
+            let text = format!("for as long as {subject} remains tapped");
+            let (rest, d) = parse_duration(&text).unwrap();
+            assert_eq!(rest, "", "failed for {subject:?}");
+            assert_eq!(
+                d,
+                Duration::ForAsLongAs {
+                    condition: StaticCondition::IsTapped {
+                        scope: ObjectScope::Target,
+                    },
+                },
+                "demonstrative subject {subject:?} must bind the target",
+            );
+        }
+    }
+
+    /// Source self-reference ("this creature"/"~") → source-relative tap state
+    /// (`SourceIsTapped`) — the 41-card source-subject majority of the class.
+    #[test]
+    fn test_remains_tapped_self_reference_binds_source() {
+        for subject in ["~", "this creature", "this artifact", "this permanent"] {
+            let text = format!("for as long as {subject} remains tapped");
+            let (rest, d) = parse_duration(&text).unwrap();
+            assert_eq!(rest, "", "failed for {subject:?}");
+            assert_eq!(
+                d,
+                Duration::ForAsLongAs {
+                    condition: StaticCondition::SourceIsTapped,
+                },
+                "self-reference subject {subject:?} must bind the source",
+            );
+        }
+    }
+
+    /// Proper-name regression: a card name beginning with "The" is a SOURCE
+    /// subject and must NOT be misread as a demonstrative target despite the
+    /// leading "The" (Animate Walking Statue → The Blackstaff of Waterdeep; The
+    /// Pandorica). Guards the closed demonstrative `alt()` from a "the " leak.
+    #[test]
+    fn test_remains_tapped_proper_name_binds_source() {
+        for subject in ["The Blackstaff of Waterdeep", "The Pandorica"] {
+            let text = format!("for as long as {subject} remains tapped");
+            let (rest, d) = parse_duration(&text).unwrap();
+            assert_eq!(rest, "", "failed for {subject:?}");
+            assert_eq!(
+                d,
+                Duration::ForAsLongAs {
+                    condition: StaticCondition::SourceIsTapped,
+                },
+                "proper-name subject {subject:?} must stay source-bound",
+            );
+        }
+    }
+
+    /// Compound regression (Hivis / Rubinia): "you control X and X remains
+    /// tapped" splits on " and " and each side re-enters the combinator; the
+    /// "X remains tapped" side hits the source fallback → `SourceIsTapped`. The
+    /// new demonstrative tier must not perturb the compound path.
+    #[test]
+    fn test_remains_tapped_compound_card_name_binds_source() {
+        for name in ["rubinia soulsinger", "hivis"] {
+            let text = format!("for as long as you control {name} and {name} remains tapped");
+            let (rest, d) = parse_duration(&text).unwrap();
+            assert_eq!(rest, "", "failed for {name:?}");
+            match d {
+                Duration::ForAsLongAs {
+                    condition: StaticCondition::And { conditions },
+                } => {
+                    assert_eq!(conditions.len(), 2, "failed for {name:?}");
+                    assert!(
+                        matches!(conditions[0], StaticCondition::IsPresent { filter: None }),
+                        "control side for {name:?}",
+                    );
+                    assert!(
+                        matches!(conditions[1], StaticCondition::SourceIsTapped),
+                        "tapped side for {name:?} must be source-bound",
+                    );
+                }
+                other => panic!("expected ForAsLongAs(And[..]) for {name:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// Anaphoric "it" stays source-bound (the pre-existing behavior): "it" is
+    /// excluded from the demonstrative set because its referent is clause-context
+    /// dependent. This pins the decision so a future edit cannot silently move
+    /// "it" into the target-binding tier and regress the compound-control class.
+    #[test]
+    fn test_remains_tapped_it_stays_source() {
+        let (rest, d) = parse_duration("for as long as it remains tapped").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            d,
+            Duration::ForAsLongAs {
+                condition: StaticCondition::SourceIsTapped,
+            },
         );
     }
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2759,6 +2759,11 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
         | StaticCondition::SourceIsEquipped
         | StaticCondition::SourceIsPaired
         | StaticCondition::SourceIsMonstrous
+        // CR 110.5b + CR 611.2b: `IsTapped { scope }` is a duration-only
+        // target-relative tap condition (Zygon Infiltrator's copy duration). It
+        // is never produced as an intervening-if, so there is no
+        // `TriggerCondition` equivalent — lowering returns `None`.
+        | StaticCondition::IsTapped { .. }
         // CR 702.171b: the saddled designation has no intervening-if
         // (`TriggerCondition`) equivalent.
         | StaticCondition::SourceIsSaddled

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4880,6 +4880,25 @@ pub enum StaticCondition {
     /// CR 110.5b: True when the source object is tapped.
     /// Used for "for as long as ~ remains tapped" duration conditions.
     SourceIsTapped,
+    /// CR 110.5b + CR 110.5d: True when a scope-resolved object is on the
+    /// battlefield AND tapped. Scope-parameterized sibling of `SourceIsTapped`.
+    ///
+    /// `SourceIsTapped` is intentionally retained as the canonical `scope: Source`
+    /// spelling: it lives on three enums (`StaticCondition`, `AbilityCondition`,
+    /// `TriggerCondition`) plus `TriggerCondition::ZoneChangeObjectIsTapped`, so a
+    /// full collapse into `IsTapped { scope: Source }` would be a cross-enum
+    /// rename. This asymmetry (source = `SourceIsTapped`, non-source =
+    /// `IsTapped { scope }`) mirrors the `QuantityRef::Power { scope }` precedent:
+    /// tap status is a single CR 110.5 status category, so the scope axis lies
+    /// wholly within one rule section (no categorical-boundary violation).
+    ///
+    /// The parser emits this only for demonstrative subjects ("for as long as
+    /// THAT creature remains tapped" — Zygon Infiltrator's copy duration, where
+    /// the tracked object is the copy *target*, not the source). Negation is
+    /// `Not { Box::new(IsTapped { scope }) }`.
+    IsTapped {
+        scope: ObjectScope,
+    },
     /// CR 702.171b: True when the source permanent is saddled. Negation via Not { SourceIsSaddled }.
     SourceIsSaddled,
     /// CR 702.62a + CR 611.2b: True when the source object's current controller

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6470,6 +6470,18 @@ pub struct TransientContinuousEffect {
     pub modifications: Vec<ContinuousModification>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub condition: Option<StaticCondition>,
+    /// CR 611.2b + CR 110.5d: the concrete object a target-relative
+    /// `ForAsLongAs` duration tracks, captured at resolution time. Distinct
+    /// from `affected` when the modification's recipient and the duration's
+    /// subject diverge — Zygon Infiltrator: the copy modification applies to
+    /// the source, but the duration tracks the copy *target*'s tap state.
+    /// `None` for the common case where the duration tracks `affected` or the
+    /// source. Set only via [`GameState::set_transient_duration_subject`] on the
+    /// TCE that `add_transient_continuous_effect` just created, so all TCE
+    /// construction stays in one authority. Backward-compatible across the
+    /// WASM/multiplayer serialization boundary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_subject: Option<ObjectId>,
     /// Snapshot of the originating object's name, captured at construction.
     /// The originating spell/ability typically moves to a new zone (graveyard,
     /// stack→exile, etc.) with a new ObjectId per CR 400.7 after resolution,
@@ -7070,10 +7082,31 @@ impl GameState {
                 affected,
                 modifications,
                 condition,
+                duration_subject: None,
                 source_name,
             });
         self.layers_dirty.mark_full();
         id
+    }
+
+    /// CR 611.2b + CR 110.5d: bind a target-relative `ForAsLongAs` duration to a
+    /// concrete object resolved at effect-resolution time, on the TCE that
+    /// [`Self::add_transient_continuous_effect`] just created (addressed by its
+    /// returned `id`). Used when the duration's tracked subject diverges from the
+    /// effect's `affected` recipient — Zygon Infiltrator: the copy modification
+    /// applies to the source, but the duration tracks the copy *target*'s tap
+    /// state. Keeps construction in one authority (no second constructor); the
+    /// only divergent caller is `effects/become_copy.rs`. Marks layers dirty so
+    /// the duration re-evaluation picks up the binding.
+    pub fn set_transient_duration_subject(&mut self, id: u64, subject: ObjectId) {
+        if let Some(tce) = self
+            .transient_continuous_effects
+            .iter_mut()
+            .find(|tce| tce.id == id)
+        {
+            tce.duration_subject = Some(subject);
+            self.layers_dirty.mark_full();
+        }
     }
 
     /// CR 614.12a + CR 615.5: Migrate the pre-2026-05-09 audit M4 split-slot


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** BecomeCopy duration ForAsLongAs binds the tapped-state condition to ability.source_id via StaticCondition::SourceIsTapped, but the text scopes the duration to the copy TARGET's tap state ('as long as that creature remains tapped').

## Cards corrected
- Zygon Infiltrator

## Fix
Implemented cluster 12 (Zygon Infiltrator BecomeCopy ForAsLongAs subject-binding bug) surgically and verified. The duration "for as long as that creature remains tapped" now binds to the copy TARGET's tap state instead of the source's.

WHAT CHANGED (two coordinated primitives):
1. Type: added scope-parameterized StaticCondition::IsTapped { scope: ObjectScope } (sibling of SourceIsTapped, mirroring the QuantityRef::Power { scope } precedent). SourceIsTapped is intentionally retained as the canonical scope:Source spelling to avoid a cross-enum rename (it lives on StaticCondition/AbilityCondition/TriggerCondition); the parser only ever emits IsTapped { scope: Target }. CR 110.5 single-section, no categorical-boundary violation.
2. Parser (oracle_nom/duration.rs): rewrote the "[subject] remains tapped" arm into a subject-dispatching nom combinator parse_remains_tapped — Tier 1 demonstrative alt(("that creature","that permanent","that artifact")) -> IsTapped { scope: Target }; Tier 2 source self-references (~, SELF_REF_TYPE_PHRASES) + retained scan_contains word-boundary fallback -> SourceIsTapped. Demonstrative tier runs first; the closed alt() deliberately excludes "the " (proper-name cards) and "it" (see judgement call).
3. Runtime (Primitive B): added TransientContinuousEffect.duration_subject: Option<ObjectId> (serde default/skip) carrying the resolution-time target id; transient_duration_holds prefers it over the affected id for recipient-context conditions; become_copy.rs captures target_id and binds it via a new GameState::set_transient_duration_subject. Eval reuses eval_source_is_tapped_on_battlefield parameterized on the resolved id, routed through the existing recipient-context plumbing.

VERIFICATION (worktree not under Tilt; ran cargo directly):
- cargo fmt --all: clean.
- cargo clippy -p engine --all-targets -- -D warnings: exit 0, zero warnings.
- cargo test -p engine: all green, 0 failures (1038 main-lib + every integration suite), including 8 new building-block tests.
- ./scripts/gen-card-data.sh: exit 0. Zygon now parses BecomeCopy duration = ForAsLongAs { IsTapped { scope: Target } } (verified in card-data.json). Parity confirmed: ONLY Zygon got IsTapped; Hivis, Rubinia (compound), The Blackstaff of Waterdeep, The Pandorica (proper-name) all retained SourceIsTapped with zero leakage.
- cargo engine-inventory: refreshed data/engine-inventory.json, IsTapped registered.

PARSER DIFF GATE: check-parser-combinators.sh exits 1, but ENTIRELY from pre-existing string-dispatch/Effect::Unimplemented lines in files I did NOT touch (oracle.rs, oracle_effect/lower.rs, oracle_static/cda.rs, keyword_grant.rs, restriction.rs) — the script diffs against an old baseline commit ff799f8 and surfaces accumulated debt. My main parser file duration.rs is NOT flagged. Filtering my own added lines across all three parser files I edited (duration.rs, oracle_trigger.rs, oracle_effect/conditions.rs) for .contains/.starts_with/.find/.split_once/etc yields ZERO matches. Per multi-agent safety I did not touch the unrelated pre-existing debt.

CR ANNOTATIONS ADDED (all verified against docs/MagicCompRules.txt before writing):
- CR 110.5b (permanent tapped status) — grep -n '^110.5b' -> FOUND.
- CR 110.5d (cards not on battlefield are neither tapped nor untapped; zone guard) — grep -n '^110.5d' -> FOUND.
- CR 611.2b (ForAsLongAs: if duration ends before the effect first applies, the effect does nothing — the exact Zygon failure mode) — grep -n '^611.2b' -> FOUND.
- CR 611.3a (referenced in existing nearby annotations) — grep -n '^611.3a' -> FOUND.
- CR 707.2c (existing become_copy annotation, referenced not modified) — grep -n '^707.2c' -> FOUND.

JUDGEMENT CALLS:
1. EXCLUDED "it" from the demonstrative set (the plan listed it). Corpus inspection of all 42 "remains tapped" cards showed "it" is anaphoric and clause-context-dependent: in "you control ~ and it remains tapped" (and the existing test_for_as_long_as_compound_control_and_tapped) "it" = source; in "tap another target permanent. Its abilities can't be activated for as long as it remains tapped" "it" = target. The duration combinator has no clause subject to disambiguate, and including "it" would BREAK the existing compound test and regress many source-"it" cards. Zygon uses the unambiguous "that creature", so excluding "it" fully fixes the cluster with zero regression. Added test_remains_tapped_it_stays_source to pin this decision. Anaphoric "it = target" is a separate, larger class out of scope here.
2. Used a GameState::set_transient_duration_subject SETTER on the just-created TCE instead of the plan's 8th trailing parameter on add_transient_continuous_effect (which would have churned ~80 call sites across ~33 files). The setter keeps ALL construction in one authority (the field defaults to None in the constructor; the only divergent caller is become_copy.rs), changes zero behavior for the other ~79 callers, and is far more surgical / multi-agent-safe — the same surgical-safety rationale the plan itself invoked to avoid the SourceIsTapped cross-enum collapse. 5 direct struct-literal constructions of TransientContinuousEffect (in combat_damage.rs, layers.rs x2, meld_tests.rs, triggers.rs) still required adding duration_subject: None (compiler-forced, one token each).

DEVIATIONS FROM PLAN: (a) "it" excluded from demonstrative set (judgement call 1). (b) setter mechanism instead of trailing constructor param (judgement call 2) — net effect identical, far fewer touched files. (c) One additional exhaustive-match site the plan did not enumerate: parser/oracle_effect/conditions.rs static_condition_to_ability_condition — added IsTapped to the None cluster (duration-only, no AbilityCondition equivalent); compiler-surfaced.

STOP-AND-RETURN ITEMS: none — every ambiguity (the "it" anaphora) was resolvable within scope by following the parse_counter_condition_subject closed-alt precedent and corpus evidence.

RISKS for /review-impl: (1) The "it = target" anaphora class (gain-control / restriction cards where the tapped subject is the target, e.g. "Its abilities can't be activated for as long as it remains tapped") remains source-bound — pre-existing behavior, NOT regressed, but genuinely a separate latent defect a reviewer may want tracked. (2) gen-card-data.sh regenerated crates/engine/data/known-tokens.toml with large reordering churn (~12k lines, balanced ins/del) — incidental generated-artifact non-determinism from the mandated regen, not a logic change; orchestrator should decide whether to stage it. (3) The serde-optional duration_subject field is backward-compatible across WASM/multiplayer; no migration needed.

## Files changed
- crates/engine/src/types/ability.rs
- crates/engine/src/types/game_state.rs
- crates/engine/src/game/layers.rs
- crates/engine/src/game/effects/become_copy.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/combat_damage.rs
- crates/engine/src/game/meld_tests.rs
- crates/engine/src/game/triggers.rs
- crates/engine/src/parser/oracle_nom/duration.rs
- crates/engine/src/parser/oracle_trigger.rs
- crates/engine/src/parser/oracle_effect/conditions.rs
- data/engine-inventory.json
- client/public/card-data.json
- crates/engine/data/known-tokens.toml

## CR references
- CR 110.5b
- CR 110.5d
- CR 611.2b
- CR 611.3a
- CR 707.2c

## Verification
- `cargo fmt --all` — clean (no files changed, no commit needed)
- `check-parser-combinators.sh (scoped to upstream merge-base 992c9706d)` — clean (exit 0)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean (exit 0, zero errors/warnings)
- `cargo test -p engine` — clean (exit 0, all tests pass, zero failures)
- `cargo run --profile tool --features cli --bin oracle-gen -- data --filter "zygon infiltrator"` — card parses correctly, AST matches Oracle text
Cards confirmed re-parsed correctly: zygon infiltrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
