### PR TITLE
Fix airbend cast permission granted to wrong player (#3322)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1791,15 +1791,15 @@ pub(super) fn lower_targeted_action_ast(ast: TargetedImperativeAst) -> Effect {
                 cost,
                 cast_transformed: false,
                 constraint: None,
-                // CR 611.2a: bound to the ability controller by
-                // `grant_permission::resolve`.
+                // CR 611.2a: airbend grants cast permission to each exiled
+                // object's owner, not the airbender's controller.
                 granted_to: None,
                 resolution_cleanup: None,
                 duration: None,
                 exile_instead_of_graveyard_on_resolve: false,
             },
             target,
-            grantee: Default::default(),
+            grantee: crate::types::ability::PermissionGrantee::ObjectOwner,
         },
         TargetedImperativeAst::ZoneCounterProxy(ast) => lower_zone_counter_ast(*ast),
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1948,8 +1948,8 @@ fn try_parse_airbend_clause(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
                         cost,
                         cast_transformed: false,
                         constraint: None,
-                        // CR 611.2a: `grant_permission::resolve` binds this to
-                        // the ability controller at grant time.
+                        // CR 611.2a: airbend grants cast permission to each
+                        // exiled object's owner, not the airbender's controller.
                         granted_to: None,
                         resolution_cleanup: None,
                         duration: None,
@@ -1958,7 +1958,7 @@ fn try_parse_airbend_clause(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
                     target: TargetFilter::TrackedSet {
                         id: TrackedSetId(0),
                     },
-                    grantee: Default::default(),
+                    grantee: crate::types::ability::PermissionGrantee::ObjectOwner,
                 },
             )
             .sub_ability(register_bending),

--- a/crates/engine/tests/integration/issue_3322_airbend_owner_cast.rs
+++ b/crates/engine/tests/integration/issue_3322_airbend_owner_cast.rs
@@ -1,0 +1,84 @@
+//! Issue #3322 — Airbend must grant the exiled object's owner permission to
+//! cast it for the alt cost, even when an opponent controls the airbender.
+
+use engine::game::casting::spell_objects_available_to_cast;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, PermissionGrantee};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const AANG_ORACLE: &str = "Flash\nFlying\nWhen Aang enters, airbend up to one other target creature or spell. (Exile it. While it's exiled, its owner may cast it for {2} rather than its mana cost.)\nWaterbend {8}: Transform Aang.";
+
+const AIRBEND_CLAUSE: &str = "airbend up to one other target creature or spell";
+
+fn floating_mana(n: usize, ty: ManaType) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ty, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn grant_priority(runner: &mut engine::game::scenario::GameRunner, player: PlayerId) {
+    let state = runner.state_mut();
+    state.priority_player = player;
+    state.waiting_for = WaitingFor::Priority { player };
+}
+
+#[test]
+fn airbend_parser_grants_cast_permission_to_object_owner() {
+    let def = parse_effect_chain(AIRBEND_CLAUSE, AbilityKind::Spell);
+    let grant = def
+        .sub_ability
+        .as_ref()
+        .expect("airbend must chain a cast permission grant");
+    match &*grant.effect {
+        Effect::GrantCastingPermission { grantee, .. } => {
+            assert_eq!(
+                *grantee,
+                PermissionGrantee::ObjectOwner,
+                "airbend must grant cast permission to each exiled object's owner"
+            );
+        }
+        other => panic!("expected GrantCastingPermission, got {other:?}"),
+    }
+}
+
+#[test]
+fn opponent_airbend_lets_owner_cast_exiled_card_for_two() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P1, ManaColor::White);
+    scenario.add_basic_land(P1, ManaColor::Blue);
+
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let aang = scenario
+        .add_creature_to_hand_from_oracle(P1, "Aang, Swift Savior", 2, 3, AANG_ORACLE)
+        .id();
+    scenario.with_mana_pool(P1, floating_mana(3, ManaType::Blue));
+
+    let mut runner = scenario.build();
+    grant_priority(&mut runner, P1);
+
+    runner
+        .cast(aang)
+        .target_object(bear)
+        .resolve();
+
+    assert_eq!(
+        runner.state().objects[&bear].zone,
+        Zone::Exile,
+        "airbended creature must be exiled"
+    );
+    assert!(
+        spell_objects_available_to_cast(runner.state(), P0).contains(&bear),
+        "exiled card owner must be able to cast the airbended card for {{2}}"
+    );
+    assert!(
+        !spell_objects_available_to_cast(runner.state(), P1).contains(&bear),
+        "airbender's controller must not receive the owner's cast permission"
+    );
+}

--- a/crates/engine/tests/integration/issue_3322_airbend_owner_cast.rs
+++ b/crates/engine/tests/integration/issue_3322_airbend_owner_cast.rs
@@ -63,10 +63,7 @@ fn opponent_airbend_lets_owner_cast_exiled_card_for_two() {
     let mut runner = scenario.build();
     grant_priority(&mut runner, P1);
 
-    runner
-        .cast(aang)
-        .target_object(bear)
-        .resolve();
+    runner.cast(aang).target_object(bear).resolve();
 
     assert_eq!(
         runner.state().objects[&bear].zone,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -208,6 +208,7 @@ mod issue_2940_krark_thumbless;
 mod issue_2941_vivien_reid;
 mod issue_2943_kayas_wrath;
 mod issue_3127_reveal_otherwise_graveyard;
+mod issue_3322_airbend_owner_cast;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_564_wishclaw_talisman_control;


### PR DESCRIPTION
## Summary
- Bind airbend's `ExileWithAltCost` grant to `PermissionGrantee::ObjectOwner` instead of the ability controller
- Add parser and integration coverage for Aang airbending an opponent's creature

Fixes #3322

## Test plan
- [x] `cargo test -p engine --test integration issue_3322`

Made with [Cursor](https://cursor.com)