### PR TITLE
fix(engine): block auto-pass when sacrifice-for-mana is available

### DIFF
--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -611,23 +611,55 @@ fn matches_waiting_target_choice(
     }
 }
 
+/// True when an `ActivateAbility` action is a meaningful priority decision.
+///
+/// Non-mana abilities are always meaningful. Mana abilities are meaningful only
+/// when their penalty axis says so (today: sacrifice-for-mana per CR 605.3a +
+/// CR 603.6, issue #544).
+fn activate_ability_is_meaningful_priority(
+    state: &GameState,
+    source_id: ObjectId,
+    ability_index: usize,
+) -> bool {
+    state.objects.get(&source_id).is_some_and(|obj| {
+        obj.abilities.get(ability_index).is_some_and(|ability| {
+            !mana_abilities::is_mana_ability(ability)
+                || mana_sources::mana_ability_penalty(ability).is_meaningful_priority_activation()
+        })
+    })
+}
+
 /// True when `actions` contains a priority action that materially changes the
 /// game beyond passing or producing standalone mana.
+///
+/// Sacrifice-for-mana activations are omitted from the flat `legal_actions`
+/// list (they live in `legal_actions_by_object` only) but remain meaningful
+/// priority decisions, so during `WaitingFor::Priority` this also scans
+/// `activatable_object_mana_actions`.
 pub fn has_meaningful_priority_action(state: &GameState, actions: &[GameAction]) -> bool {
-    actions.iter().any(|action| match action {
+    if actions.iter().any(|action| match action {
         GameAction::PassPriority => false,
         GameAction::ActivateAbility {
             source_id,
             ability_index,
-        } => state.objects.get(source_id).is_some_and(|obj| {
-            obj.abilities.get(*ability_index).is_some_and(|ability| {
-                !mana_abilities::is_mana_ability(ability)
-                    || mana_sources::mana_ability_penalty(ability)
-                        .is_meaningful_priority_activation()
-            })
-        }),
+        } => activate_ability_is_meaningful_priority(state, *source_id, *ability_index),
         _ => true,
-    })
+    }) {
+        return true;
+    }
+
+    // Issue #544: sacrifice-for-mana abilities (KCI, Phyrexian Altar, etc.) are
+    // excluded from the flat legal-actions list but must still block auto-pass.
+    matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && activatable_object_mana_actions(state).iter().any(|action| {
+            matches!(
+                action,
+                GameAction::ActivateAbility {
+                    source_id,
+                    ability_index,
+                } if activate_ability_is_meaningful_priority(state, *source_id, *ability_index)
+            )
+        })
 }
 
 fn auto_passes_initial_priority_by_default(state: &GameState) -> bool {
@@ -2250,6 +2282,34 @@ mod tests {
         assert!(
             !super::auto_pass_recommended(&state, &actions),
             "Auto-pass must not fire when only a sacrifice-for-mana ability is available (#544)"
+        );
+
+        // Production path: flat `legal_actions` omits mana abilities, so the
+        // auto-pass gate must consult `activatable_object_mana_actions` instead
+        // of relying on the caller to inject the activation.
+        let (flat, _, grouped) = legal_actions_full(&state);
+        assert!(
+            !flat.iter().any(|a| matches!(
+                a,
+                GameAction::ActivateAbility { source_id, .. } if *source_id == kci
+            )),
+            "precondition: KCI activation is grouped-only during priority"
+        );
+        assert!(
+            bucket_has(
+                &grouped,
+                kci,
+                &GameAction::ActivateAbility {
+                    source_id: kci,
+                    ability_index: 0,
+                },
+            ),
+            "KCI activation must appear in legal_actions_by_object"
+        );
+        assert!(
+            !super::auto_pass_recommended(&state, &flat),
+            "Issue #544: auto-pass must not fire from flat legal_actions alone \
+             when grouped sacrifice-for-mana is available"
         );
     }
 

--- a/crates/engine/tests/integration/issue_544_krark_clan_ironworks_auto_pass.rs
+++ b/crates/engine/tests/integration/issue_544_krark_clan_ironworks_auto_pass.rs
@@ -1,0 +1,166 @@
+//! Issue #544 — Krark-Clan Ironworks auto-pass during priority.
+//!
+//! Oracle: `Sacrifice an artifact: Add {C}{C}.`
+//!
+//! Sacrifice-for-mana abilities are exposed via `legal_actions_by_object` but
+//! omitted from the flat `legal_actions` list. `auto_pass_recommended` must
+//! still consult activatable sacrifice mana sources so the client does not
+//! auto-pass when the player may want to sac for triggers or mana.
+
+use engine::ai_support::{auto_pass_recommended, legal_actions_full};
+use engine::game::apply_as_current;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaProduction, QuantityExpr,
+    SacrificeCost, TargetFilter, TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+use std::sync::Arc;
+
+const P0: PlayerId = PlayerId(0);
+
+fn priority_main_phase(state: &mut GameState, player: PlayerId) {
+    state.phase = Phase::PreCombatMain;
+    state.active_player = player;
+    state.priority_player = player;
+    state.waiting_for = WaitingFor::Priority { player };
+    state.turn_number = 2;
+}
+
+fn add_kci(state: &mut GameState, player: PlayerId) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(1001),
+        player,
+        "Krark-Clan Ironworks".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Artifact);
+    obj.summoning_sick = false;
+    Arc::make_mut(&mut obj.abilities).push(
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::Colorless {
+                    count: QuantityExpr::Fixed { value: 2 },
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+            TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+            1,
+        ))),
+    );
+    id
+}
+
+fn add_artifact_creature(
+    state: &mut GameState,
+    player: PlayerId,
+    card_id: u64,
+    name: &str,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(card_id),
+        player,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Artifact);
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.power = Some(1);
+    obj.toughness = Some(1);
+    obj.summoning_sick = false;
+    id
+}
+
+// CR 605.3a + CR 603.6: Sacrificing a permanent for mana is a meaningful
+// priority decision — the player may want ETB/dies triggers or graveyard value.
+#[test]
+fn auto_pass_blocked_when_kci_sacrifice_mana_is_only_action() {
+    let mut state = GameState::new_two_player(42);
+    priority_main_phase(&mut state, P0);
+
+    let kci = add_kci(&mut state, P0);
+    let _fodder = add_artifact_creature(&mut state, P0, 2001, "Myr Retriever");
+
+    let (flat, _, grouped) = legal_actions_full(&state);
+
+    let kci_activation = GameAction::ActivateAbility {
+        source_id: kci,
+        ability_index: 0,
+    };
+    assert!(
+        grouped
+            .get(&kci)
+            .is_some_and(|actions| actions.contains(&kci_activation)),
+        "KCI sacrifice mana must be in legal_actions_by_object during priority"
+    );
+    assert!(
+        !flat.contains(&kci_activation),
+        "precondition: sacrifice mana stays out of flat legal_actions during priority"
+    );
+    assert!(
+        !auto_pass_recommended(&state, &flat),
+        "Issue #544: must not auto-pass when KCI sacrifice-for-mana is available"
+    );
+}
+
+// CR 605.3b: Activating KCI during priority resolves inline and adds mana.
+#[test]
+fn kci_activation_during_priority_adds_mana_to_pool() {
+    let mut state = GameState::new_two_player(42);
+    priority_main_phase(&mut state, P0);
+
+    let kci = add_kci(&mut state, P0);
+    let retriever = add_artifact_creature(&mut state, P0, 2001, "Myr Retriever");
+
+    apply_as_current(
+        &mut state,
+        GameAction::ActivateAbility {
+            source_id: kci,
+            ability_index: 0,
+        },
+    )
+    .expect("KCI activation during priority must be legal");
+
+    match &state.waiting_for {
+        engine::types::game_state::WaitingFor::PayCost {
+            kind: engine::types::game_state::PayCostKind::Sacrifice,
+            ..
+        } => {}
+        other => panic!("Expected sacrifice choice prompt, got {other:?}"),
+    }
+
+    apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: vec![retriever],
+        },
+    )
+    .expect("Sacrifice retriever for KCI");
+
+    assert_eq!(
+        state.players[P0.0 as usize].mana_pool.total(),
+        2,
+        "KCI must add {{C}}{{C}} to the mana pool"
+    );
+    assert!(
+        state.players[P0.0 as usize].graveyard.contains(&retriever),
+        "Sacrificed artifact must be in graveyard"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -215,6 +215,7 @@ mod issue_3323_nexus_of_fate_extra_turn;
 mod issue_3324_haunted_one;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
+mod issue_544_krark_clan_ironworks_auto_pass;
 mod issue_564_wishclaw_talisman_control;
 mod issue_565_birthing_ritual_end_step_trigger;
 mod issue_566_ragavan_dash_cast;


### PR DESCRIPTION
## Summary

- Fixes [#544](https://github.com/phase-rs/phase/issues/544): the game auto-passed during priority when Krark-Clan Ironworks (`Sacrifice an artifact: Add {C}{C}`) was the only meaningful action.
- `has_meaningful_priority_action` now scans `activatable_object_mana_actions` during `WaitingFor::Priority`, since sacrifice-for-mana activations live in `legal_actions_by_object` only and are excluded from flat `legal_actions`.
- Tap-for-mana (lands, mana dorks) still auto-pass; only `ManaSourcePenalty::Sacrifices` blocks auto-pass (KCI, Phyrexian Altar, Ashnod's Altar, Treasure tokens, etc.).

## Root cause

The sacrifice classifier (`ManaSourcePenalty::Sacrifices` → `is_meaningful_priority_activation`) was already correct, but `auto_pass_recommended` received only the flat `legal_actions` list from WASM/server. With KCI as the sole option, that list was `[PassPriority]` → auto-pass fired incorrectly.

## Test plan

- [x] `cargo test -p engine auto_pass_does_not_skip_sacrifice`
- [x] `cargo test -p engine issue_544`
- [x] `cargo test -p engine auto_pass --lib`
- [ ] Manual: board with KCI + sacrificable artifacts, priority in main phase — game should **not** auto-pass; clicking KCI should offer sacrifice choice and add `{C}{C}`