### PR TITLE
fix(parser): route sorcery cycling lines to keyword extraction

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -10271,6 +10271,74 @@ mod cycling_synthesis_tests {
         let shuffle = put_in_hand.sub_ability.as_ref().expect("shuffle");
         assert!(matches!(&*shuffle.effect, Effect::Shuffle { .. }));
     }
+
+    /// Issue #629: Production `build_oracle_face` must synthesize cycling and
+    /// retain the when-you-cycle trigger for sorceries whose Oracle text prints
+    /// a spell effect before the cycling keyword line.
+    #[test]
+    fn build_oracle_face_fractured_sanity_synthesizes_cycling_and_trigger() {
+        use crate::database::mtgjson::AtomicIdentifiers;
+        use crate::types::ability::AbilityTag;
+
+        let oracle = "Each opponent mills fourteen cards.\n\
+                      Cycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\n\
+                      When you cycle this card, each opponent mills four cards.";
+        let mtgjson = AtomicCard {
+            name: "Fractured Sanity".to_string(),
+            mana_cost: Some("{3}{U}".to_string()),
+            colors: vec!["U".to_string()],
+            color_identity: vec!["U".to_string()],
+            text: Some(oracle.to_string()),
+            power: None,
+            toughness: None,
+            loyalty: None,
+            defense: None,
+            layout: "normal".to_string(),
+            type_line: Some("Sorcery".to_string()),
+            types: vec!["Sorcery".to_string()],
+            subtypes: vec![],
+            supertypes: vec![],
+            keywords: Some(vec!["Cycling".to_string()]),
+            side: None,
+            face_name: None,
+            mana_value: 4.0,
+            legalities: Default::default(),
+            leadership_skills: None,
+            printings: Vec::new(),
+            rulings: Vec::new(),
+            is_game_changer: false,
+            identifiers: AtomicIdentifiers {
+                scryfall_oracle_id: Some("fractured-sanity-test".to_string()),
+                scryfall_id: Some("fractured-sanity-test-face".to_string()),
+            },
+            foreign_data: Vec::new(),
+        };
+
+        let face = build_oracle_face(&mtgjson, None);
+
+        let cycling = face
+            .abilities
+            .iter()
+            .find(|a| a.ability_tag == Some(AbilityTag::Cycling))
+            .expect("synthesized cycling ability with AbilityTag::Cycling");
+        assert_eq!(cycling.activation_zone, Some(Zone::Hand));
+        assert!(
+            face.triggers
+                .iter()
+                .any(|t| t.mode == TriggerMode::Cycled && t.execute.is_some()),
+            "when-you-cycle trigger must survive synthesis"
+        );
+        assert!(matches!(&*face.abilities[0].effect, Effect::Mill { .. }));
+        assert!(
+            !face.abilities.iter().any(|a| {
+                matches!(
+                    &*a.effect,
+                    Effect::Unimplemented { name, .. } if name.contains("Cycling")
+                )
+            }),
+            "cycling line must not become an Unimplemented spell ability"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3258,9 +3258,9 @@ pub(crate) fn parse_oracle_ir(
             if is_keyword_cost_line(&lower) {
                 if let Some(kw) = parse_keyword_from_oracle(&lower) {
                     result.extracted_keywords.push(kw);
+                    i += 1;
+                    continue;
                 }
-                i += 1;
-                continue;
             }
 
             // B7: Strip ability-word prefix and attach condition for spell effects.

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3246,6 +3246,23 @@ pub(crate) fn parse_oracle_ir(
 
         // Priority 9: Imperative verb for instants/sorceries
         if is_spell {
+            // CR 702.29a/e + CR 702.27a: Keyword-cost lines (cycling, flashback,
+            // suspend, …) are not spell resolution instructions. Without this
+            // guard, a sorcery whose Oracle text prints a spell effect followed
+            // by a cycling line (Fractured Sanity, Decree of Justice) routes
+            // "Cycling {cost}" through the spell catch-all and produces an
+            // `Unimplemented` spell ability instead of extracting the keyword
+            // for `synthesize_cycling`. Continuation-line protection already
+            // lives in `is_spell_resolution_instruction_line`; this covers the
+            // case where the keyword-cost line is its own main-loop iteration.
+            if is_keyword_cost_line(&lower) {
+                if let Some(kw) = parse_keyword_from_oracle(&lower) {
+                    result.extracted_keywords.push(kw);
+                }
+                i += 1;
+                continue;
+            }
+
             // B7: Strip ability-word prefix and attach condition for spell effects.
             let mut spell_body_lines = Vec::new();
             let mut spell_description_lines = Vec::new();
@@ -9976,6 +9993,44 @@ mod tests {
             !has_unimplemented,
             "Typecycling keyword line should not produce Unimplemented effects"
         );
+    }
+
+    /// Issue #629: Sorcery whose Oracle text prints a spell effect then a cycling
+    /// line must extract `Keyword::Cycling` and a `TriggerMode::Cycled` trigger,
+    /// not mis-route the cycling line through the spell catch-all.
+    #[test]
+    fn fractured_sanity_sorcery_cycling_line_not_spell_effect() {
+        use crate::types::triggers::TriggerMode;
+
+        let oracle = "Each opponent mills fourteen cards.\n\
+                      Cycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\n\
+                      When you cycle this card, each opponent mills four cards.";
+        let r = parse_with_keyword_names(oracle, "Fractured Sanity", &[], &["Sorcery"], &[]);
+        assert!(
+            r.extracted_keywords
+                .iter()
+                .any(|kw| matches!(kw, Keyword::Cycling(_))),
+            "cycling line must extract Keyword::Cycling"
+        );
+        assert!(
+            !r.abilities.iter().any(|a| {
+                matches!(
+                    *a.effect,
+                    crate::types::ability::Effect::Unimplemented { .. }
+                )
+            }),
+            "cycling line must not become an Unimplemented spell ability"
+        );
+        let cycle_trigger = r
+            .triggers
+            .iter()
+            .find(|t| t.mode == TriggerMode::Cycled)
+            .expect("must parse when-you-cycle-this-card trigger");
+        assert!(cycle_trigger.execute.is_some());
+        assert!(matches!(
+            &*r.abilities[0].effect,
+            crate::types::ability::Effect::Mill { .. }
+        ));
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_629_fractured_sanity_cycling.rs
+++ b/crates/engine/tests/integration/issue_629_fractured_sanity_cycling.rs
@@ -1,0 +1,102 @@
+//! Issue #629 — Fractured Sanity cycling must mill each opponent four cards.
+//!
+//! CR 702.29a: Cycling is an activated ability from hand (discard, draw).
+//! CR 702.29c: "When you cycle this card" triggers fire from the graveyard.
+//! CR 701.13: Mill moves cards from library to graveyard.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::AbilityTag;
+use engine::types::actions::GameAction;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const FRACTURED_SANITY_ORACLE: &str = "\
+Each opponent mills fourteen cards.\n\
+Cycling {1}{U} ({1}{U}, Discard this card: Draw a card.)\n\
+When you cycle this card, each opponent mills four cards.";
+
+fn cycling_index(state: &engine::types::game_state::GameState, card: ObjectId) -> usize {
+    state.objects[&card]
+        .abilities
+        .iter()
+        .position(|ability| ability.ability_tag == Some(AbilityTag::Cycling))
+        .expect("synthesized cycling ability")
+}
+
+#[test]
+fn fractured_sanity_parses_cycle_trigger_with_mill() {
+    let mut scenario = GameScenario::new();
+    let card = scenario
+        .add_spell_to_hand_from_oracle(P0, "Fractured Sanity", false, FRACTURED_SANITY_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let obj = &runner.state().objects[&card];
+
+    let cycle_trigger = obj
+        .trigger_definitions
+        .iter_unchecked()
+        .find(|t| t.mode == TriggerMode::Cycled)
+        .expect("must parse a Cycled self-trigger");
+    assert_eq!(
+        cycle_trigger.valid_card,
+        Some(engine::types::ability::TargetFilter::SelfRef)
+    );
+    assert!(cycle_trigger.trigger_zones.contains(&Zone::Graveyard));
+    assert!(
+        cycle_trigger.execute.is_some(),
+        "cycle trigger must carry the mill effect"
+    );
+    assert!(
+        cycling_index(runner.state(), card) < obj.abilities.len(),
+        "cycling activated ability must be synthesized"
+    );
+}
+
+#[test]
+fn fractured_sanity_cycling_mills_each_opponent_four() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Cycled Draw"]);
+    for i in 0..10 {
+        scenario.with_library_top(P1, &[&format!("Opp Card {i}")]);
+    }
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Blue, ObjectId(9_998), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(9_999), false, vec![]),
+        ],
+    );
+
+    let card = scenario
+        .add_spell_to_hand_from_oracle(P0, "Fractured Sanity", false, FRACTURED_SANITY_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let opp_library_before = runner.state().players[1].library.len();
+    let cycling_index = cycling_index(runner.state(), card);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: card,
+            ability_index: cycling_index,
+        })
+        .expect("activate cycling");
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(runner.state().objects[&card].zone, Zone::Graveyard);
+    assert_eq!(
+        runner.state().players[1].graveyard.len(),
+        4,
+        "cycling trigger must mill opponent four cards"
+    );
+    assert_eq!(
+        runner.state().players[1].library.len(),
+        opp_library_before - 4,
+        "opponent library must shrink by four"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -222,6 +222,7 @@ mod issue_566_ragavan_dash_cast;
 mod issue_580_solitude_evoke_prompt;
 mod issue_581_mystic_remora_cumulative_upkeep;
 mod issue_583_vivi_ornitier_mana_source;
+mod issue_629_fractured_sanity_cycling;
 mod issue_688_mind_into_matter;
 mod issue_689_resonating_lute_hand_size;
 mod issue_691_sheoldred_saga_lore;


### PR DESCRIPTION
## Summary

- Fixes [#629](https://github.com/phase-rs/phase/issues/629): cycling Fractured Sanity only discarded and drew; the "When you cycle this card, each opponent mills four cards" trigger never fired.
- Root cause: on instants/sorceries, a standalone `Cycling {cost}` line after a spell effect was parsed by Priority 9 (spell catch-all) as `Unimplemented` instead of `Keyword::Cycling`, so `synthesize_cycling` never installed the cycling ability with `AbilityTag::Cycling`.
- Adds a Priority 9 guard via `is_keyword_cost_line` so cycling/flashback/suspend-style lines extract as keywords — covers the whole class of spell + keyword-cost oracle layouts, not just Fractured Sanity.

## Test plan

- [x] `cargo test -p engine --lib fractured_sanity`
- [x] `cargo test -p engine --test integration issue_629`
- [x] `cargo test -p engine --lib issue_1579_cycling`
- [ ] Regenerate `card-data.json` (Tilt `card-data` resource) so production picks up corrected parses for Fractured Sanity and similar cards