### PR TITLE
feat(parser): migrate sacrificed-this-turn quantity to nom combinators

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2861,35 +2861,21 @@ fn parse_number_of_creatures_died_this_turn(input: &str) -> OracleResult<'_, Qua
     Ok((rest, creatures_died_this_turn_ref(controller)))
 }
 
-/// CR 701.21a: Parse "[type] you['ve] sacrificed this turn" → `TargetFilter`.
+/// CR 701.21a: Parse "[type] you['ve] sacrificed this turn" -> `TargetFilter`.
 /// Shared inner combinator for both `parse_number_of_sacrificed_this_turn` and
-/// `parse_for_each_sacrificed_this_turn`. `take_until(" you")` is safe here
-/// because MTG type-phrase tokens are proper nouns that never contain " you"
-/// as a substring (card names are normalized to `~` before parsing).
+/// `parse_for_each_sacrificed_this_turn`.
 fn parse_sacrificed_this_turn_filter(input: &str) -> OracleResult<'_, TargetFilter> {
     // CR 701.21a: sacrifice moves the permanent directly to its owner's graveyard
     // (not destroyed — bypasses indestructible and regeneration).
-    let (suffix_rest, type_text) = take_until(" you").parse(input)?;
-    let (rest, _) =
-        (tag(" you"), opt(tag("'ve")), tag(" sacrificed this turn")).parse(suffix_rest)?;
-    let type_trimmed = type_text.trim();
-    // Fast-path: "permanents" / "permanent" → canonical Permanent supertype filter.
-    if type_trimmed == "permanents" || type_trimmed == "permanent" {
-        return Ok((
-            rest,
-            TargetFilter::Typed(TypedFilter {
-                type_filters: vec![TypeFilter::Permanent],
-                ..Default::default()
-            }),
-        ));
-    }
-    let (filter, leftover) = parse_type_phrase(type_trimmed);
-    if !leftover.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+    let (filter, rest) = parse_type_phrase(input);
+    if !quantity_filter_has_meaningful_content(&filter) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
             nom::error::ErrorKind::Fail,
         )));
     }
+
+    let (rest, _) = (tag(" you"), opt(tag("'ve")), tag(" sacrificed this turn")).parse(rest)?;
     Ok((rest, filter))
 }
 

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -734,13 +734,15 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
         // "<type> you control" arm — the trailing "in your party" is what
         // distinguishes party-size from a controlled-creature count.
         parse_creatures_in_your_party_tail,
-        // CR 400.7 + CR 700.4: entered-this-turn and died-this-turn zone-change
-        // counts share a nested alt to stay within nom's top-level `alt` arity.
-        // The died arm must precede `parse_number_of_controlled_type` so the
-        // leading "creatures" token does not commit to the generic controlled-type arm.
+        // CR 400.7 + CR 700.4 + CR 701.21a: entered-this-turn, died-this-turn,
+        // and sacrificed-this-turn zone-change counts share a nested alt to stay
+        // within nom's top-level `alt` arity (nom 8.0 max: 21 items).
+        // All three arms must precede `parse_number_of_controlled_type` so the
+        // leading type-word token does not commit to the generic controlled-type arm.
         alt((
             parse_entered_this_turn_ref,
             parse_number_of_creatures_died_this_turn,
+            parse_number_of_sacrificed_this_turn,
         )),
         parse_tokens_created_this_turn_tail,
         parse_number_of_distinct_colors_among_permanents_tail,
@@ -2168,6 +2170,10 @@ fn parse_for_each_clause_ref_with_they_controller(
         // would otherwise commit the simple `<type> you control` arm.
         parse_for_each_subtype_died_this_turn,
         parse_for_each_creature_died_this_turn,
+        // CR 701.21a: "[type] you['ve] sacrificed this turn" — event-based count
+        // of sacrifice events. Must precede `parse_for_each_controlled_type` so the
+        // leading type token does not commit to the generic `<type> you control` arm.
+        parse_for_each_sacrificed_this_turn,
         // CR 400.7 + CR 603.10a: "creature that left the battlefield under your
         // control this turn" — destination-agnostic zone-change count, distinct
         // from the graveyard-only "died" arm above.
@@ -2853,6 +2859,74 @@ fn parse_for_each_creature_died_this_turn(input: &str) -> OracleResult<'_, Quant
 fn parse_number_of_creatures_died_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, controller) = parse_creatures_died_this_turn_tail(input)?;
     Ok((rest, creatures_died_this_turn_ref(controller)))
+}
+
+/// CR 701.21a: Parse "[type] you['ve] sacrificed this turn" → `TargetFilter`.
+/// Shared inner combinator for both `parse_number_of_sacrificed_this_turn` and
+/// `parse_for_each_sacrificed_this_turn`. `take_until(" you")` is safe here
+/// because MTG type-phrase tokens are proper nouns that never contain " you"
+/// as a substring (card names are normalized to `~` before parsing).
+fn parse_sacrificed_this_turn_filter(input: &str) -> OracleResult<'_, TargetFilter> {
+    // CR 701.21a: sacrifice moves the permanent directly to its owner's graveyard
+    // (not destroyed — bypasses indestructible and regeneration).
+    let (suffix_rest, type_text) = take_until(" you").parse(input)?;
+    let (rest, _) =
+        (tag(" you"), opt(tag("'ve")), tag(" sacrificed this turn")).parse(suffix_rest)?;
+    let type_trimmed = type_text.trim();
+    // Fast-path: "permanents" / "permanent" → canonical Permanent supertype filter.
+    if type_trimmed == "permanents" || type_trimmed == "permanent" {
+        return Ok((
+            rest,
+            TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Permanent],
+                ..Default::default()
+            }),
+        ));
+    }
+    let (filter, leftover) = parse_type_phrase(type_trimmed);
+    if !leftover.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    Ok((rest, filter))
+}
+
+/// CR 701.21a: "the number of [type] you['ve] sacrificed this turn" →
+/// `QuantityRef::SacrificedThisTurn`. Wired into the nested inner alt of
+/// `parse_number_of_inner` alongside `parse_entered_this_turn_ref` and
+/// `parse_number_of_creatures_died_this_turn`.
+///
+/// Structurally identical to `parse_for_each_sacrificed_this_turn` by convention
+/// (mirrors the `parse_number_of_/parse_for_each_creature_died_this_turn` pair).
+/// If opponent/any-player sacrifice forms are ever added, diverge the logic here.
+fn parse_number_of_sacrificed_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, filter) = parse_sacrificed_this_turn_filter(input)?;
+    Ok((
+        rest,
+        QuantityRef::SacrificedThisTurn {
+            player: PlayerScope::Controller,
+            filter,
+        },
+    ))
+}
+
+/// CR 701.21a: "[type] you['ve] sacrificed this turn" in a "for each" context →
+/// `QuantityRef::SacrificedThisTurn`. Separate named fn per the
+/// `parse_number_of_/parse_for_each_creature_died_this_turn` convention.
+///
+/// Structurally identical to `parse_number_of_sacrificed_this_turn` by convention.
+/// If opponent/any-player sacrifice forms are ever added, diverge the logic here.
+fn parse_for_each_sacrificed_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, filter) = parse_sacrificed_this_turn_filter(input)?;
+    Ok((
+        rest,
+        QuantityRef::SacrificedThisTurn {
+            player: PlayerScope::Controller,
+            filter,
+        },
+    ))
 }
 
 /// CR 400.7 + CR 603.10a: Parse "creature that left the battlefield under your

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -102,10 +102,6 @@ pub(crate) fn parse_quantity_ref_with_context(
 
     // Complex patterns requiring type phrase parsing or counter normalization.
 
-    if let Some(qty) = parse_sacrificed_permanents_this_turn_quantity(trimmed) {
-        return Some(qty);
-    }
-
     // CR 608.2c + CR 122.1: "the number of [kind] counter[s] removed this way"
     // is a dynamic amount from the preceding RemoveCounter effect, not an
     // object count over a battlefield type phrase.
@@ -865,50 +861,6 @@ pub(crate) fn parse_cda_quantity_with_context(
     }
 
     None
-}
-
-/// CR 701.21a: "the number of permanents you've sacrificed this turn" and typed
-/// variants ("the number of artifacts you've sacrificed this turn").
-fn parse_sacrificed_permanents_this_turn_quantity(text: &str) -> Option<QuantityRef> {
-    let trimmed = text.trim().trim_end_matches('.');
-    let (rest, _) = tag::<_, _, OracleError<'_>>("the number of ")
-        .parse(trimmed)
-        .ok()?;
-    let (rest, filter) = parse_sacrificed_permanents_this_turn_filter(rest)?;
-    if !rest.is_empty() {
-        return None;
-    }
-    Some(QuantityRef::SacrificedThisTurn {
-        player: PlayerScope::Controller,
-        filter,
-    })
-}
-
-fn parse_sacrificed_permanents_this_turn_filter(input: &str) -> Option<(&str, TargetFilter)> {
-    let (suffix_rest, type_text) = take_until::<_, _, OracleError<'_>>(" you")
-        .parse(input)
-        .ok()?;
-    let (rest, _) = (
-        tag::<_, _, OracleError<'_>>(" you"),
-        opt(tag("'ve")),
-        tag(" sacrificed this turn"),
-    )
-        .parse(suffix_rest)
-        .ok()?;
-    if type_text.trim() == "permanents" {
-        return Some((
-            rest,
-            TargetFilter::Typed(TypedFilter {
-                type_filters: vec![TypeFilter::Permanent],
-                ..Default::default()
-            }),
-        ));
-    }
-    let (filter, leftover) = parse_type_phrase(type_text.trim());
-    if !leftover.trim().is_empty() || filter == TargetFilter::Any {
-        return None;
-    }
-    Some((rest, filter))
 }
 
 // CR 604.3: "the total number of cards you own in exile and in your graveyard
@@ -3331,6 +3283,66 @@ mod tests {
                     }),
                 }
             }
+        );
+    }
+
+    #[test]
+    fn parse_for_each_sacrificed_this_turn_permanents() {
+        let qty = parse_for_each_clause("permanent you've sacrificed this turn")
+            .expect("should parse for-each sacrificed-this-turn permanents");
+        assert_eq!(
+            qty,
+            QuantityRef::SacrificedThisTurn {
+                player: PlayerScope::Controller,
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Permanent],
+                    ..Default::default()
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_cda_quantity_sacrificed_this_turn_creatures() {
+        let expr = parse_cda_quantity("the number of creatures you sacrificed this turn")
+            .expect("should parse cda quantity sacrificed-this-turn creatures");
+        assert_eq!(
+            expr,
+            QuantityExpr::Ref {
+                qty: QuantityRef::SacrificedThisTurn {
+                    player: PlayerScope::Controller,
+                    filter: TargetFilter::Typed(TypedFilter {
+                        type_filters: vec![TypeFilter::Creature],
+                        ..Default::default()
+                    }),
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn parse_for_each_sacrificed_this_turn_no_contraction() {
+        // "you sacrificed" without "'ve" contraction
+        let qty = parse_for_each_clause("artifact you sacrificed this turn")
+            .expect("should parse for-each sacrificed-this-turn without contraction");
+        assert_eq!(
+            qty,
+            QuantityRef::SacrificedThisTurn {
+                player: PlayerScope::Controller,
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Artifact],
+                    ..Default::default()
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_sacrificed_this_turn_rejects_last_turn() {
+        // "last turn" is not "this turn" — must not parse
+        assert!(
+            parse_cda_quantity("the number of creatures you sacrificed last turn").is_none(),
+            "should not parse 'sacrificed last turn'"
         );
     }
 


### PR DESCRIPTION
## Summary

- Migrates `QuantityRef::SacrificedThisTurn` grammar recognition from the frozen legacy `oracle_quantity.rs` into `oracle_nom/quantity.rs`
- Covers both Oracle surface forms:
  - `"the number of [type] you['ve] sacrificed this turn"` — where-X bindings (Obsessive Pursuit, Pyre-Sledge Arsonist, ~30+ cards)
  - `"for each [type] you['ve] sacrificed this turn"` — cost-reduction (Gingerbehemoth, Korvold, Yahenni, ~15-25 cards)
- Removes the two legacy helper functions and call site from `oracle_quantity.rs`
- Adds `parse_sacrificed_this_turn_filter` (shared inner combinator), wired into both `parse_number_of_inner` and `parse_for_each_clause_ref_with_they_controller`

Fixes #598

## Notes

The nested inner alt in `parse_number_of_inner` was expanded from 2 → 3 items (rather than adding to the outer 21-item alt which is at nom 8.0's arity limit). Both event-based "this turn" arms (`died`, `sacrificed`) must precede `parse_number_of_controlled_type` to avoid the leading type-word committing to the generic controlled-type arm.

## Test plan

- [ ] `cargo test -p engine --lib sacrificed_this_turn` — 6 tests pass (4 new + 2 pre-existing)
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Existing `parse_cda_quantity_permanents_sacrificed_this_turn` test still routes through the nom path after legacy removal
