### PR TITLE
fix(parser): Relative clause 'that didn't attack or enter this turn' is dropped from the PutCounterA

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1857,19 +1857,32 @@ fn target_filter_needs_chosen_x(ability: &ResolvedAbility, filter: &TargetFilter
 
 fn target_filter_contains_chosen_x_ref(filter: &TargetFilter) -> bool {
     match filter {
-        TargetFilter::Typed(typed) => typed.properties.iter().any(|prop| match prop {
-            FilterProp::Cmc { value, .. } | FilterProp::Counters { count: value, .. } => {
-                value.contains_x()
-            }
-            FilterProp::CanEnchant { target } => target_filter_contains_chosen_x_ref(target),
-            _ => false,
-        }),
+        TargetFilter::Typed(typed) => typed
+            .properties
+            .iter()
+            .any(filter_prop_contains_chosen_x_ref),
         TargetFilter::Not { filter } | TargetFilter::TrackedSetFiltered { filter, .. } => {
             target_filter_contains_chosen_x_ref(filter)
         }
         TargetFilter::Or { filters } | TargetFilter::And { filters } => {
             filters.iter().any(target_filter_contains_chosen_x_ref)
         }
+        _ => false,
+    }
+}
+
+/// CR 601.2c: A negated prop (`FilterProp::Not`) can wrap an X-bearing prop
+/// (e.g. `Not(Cmc { value: X })`), so X resolution must descend into it just
+/// like the `CanEnchant` filter-bearing arm — otherwise an unannounced X in a
+/// negated relative clause would be missed when deciding to route through
+/// `ChooseXValue` ahead of target selection.
+fn filter_prop_contains_chosen_x_ref(prop: &FilterProp) -> bool {
+    match prop {
+        FilterProp::Cmc { value, .. } | FilterProp::Counters { count: value, .. } => {
+            value.contains_x()
+        }
+        FilterProp::CanEnchant { target } => target_filter_contains_chosen_x_ref(target),
+        FilterProp::Not { prop } => filter_prop_contains_chosen_x_ref(prop),
         _ => false,
     }
 }
@@ -2344,6 +2357,10 @@ fn filter_prop_references_target_creature_quantity(
         crate::types::ability::FilterProp::AnyOf { props } => props
             .iter()
             .any(filter_prop_references_target_creature_quantity),
+        // CR 608.2c: Negation reads the inner prop's references — recurse (mirrors AnyOf).
+        crate::types::ability::FilterProp::Not { prop } => {
+            filter_prop_references_target_creature_quantity(prop)
+        }
         crate::types::ability::FilterProp::DifferentNameFrom { filter } => {
             filter_references_target_creature_quantity(filter)
         }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -714,6 +714,11 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
                 let inner_tf = TypedFilter::default().properties(props.clone());
                 parts.push(format!("any of ({})", fmt_typed_filter(&inner_tf)));
             }
+            // CR 608.2c: Negation label wraps the inner prop's rendering.
+            FilterProp::Not { prop } => {
+                let inner_tf = TypedFilter::default().properties(vec![(**prop).clone()]);
+                parts.push(format!("not {}", fmt_typed_filter(&inner_tf)));
+            }
             FilterProp::HasXInManaCost => parts.push("with {X} in cost".into()),
             FilterProp::HasManaAbility => parts.push("with a mana ability".into()),
             FilterProp::HasNoAbilities => parts.push("with no abilities".into()),

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -131,6 +131,9 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         }
         // Disjunctive composite: recurse.
         FilterProp::AnyOf { props } => props.iter().any(filter_prop_uses_object_population),
+        // CR 608.2c: Negation does not change WHICH game state the inner prop
+        // reads, so the population dependency is the inner prop's — recurse.
+        FilterProp::Not { prop } => filter_prop_uses_object_population(prop),
         // Intentional leaf-false. These are candidate-local, stack-relative,
         // single-object, or carry no QuantityExpr threshold, so a board entry/exit
         // cannot change whether a pre-existing object satisfies them.
@@ -324,6 +327,11 @@ fn entered_object_perturbs_filter_prop(
         FilterProp::AnyOf { props } => props
             .iter()
             .any(|p| entered_object_perturbs_filter_prop(state, entered_id, ctx, p)),
+        // CR 608.2c: Negation reads the same game state as the inner prop, so an
+        // entry perturbs the negated prop iff it perturbs the inner — recurse.
+        FilterProp::Not { prop } => {
+            entered_object_perturbs_filter_prop(state, entered_id, ctx, prop)
+        }
         // Identical enumeration to the leaf-false arm of
         // `filter_prop_uses_object_population` — candidate-local, stack-relative,
         // single-object, or threshold-free, so a board entry cannot perturb them.
@@ -2514,6 +2522,8 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         FilterProp::AnyOf { props } => props
             .iter()
             .any(|p| spell_record_matches_property(record, p)),
+        // CR 608.2c: Logical negation — recurse under the same snapshot and invert.
+        FilterProp::Not { prop } => !spell_record_matches_property(record, prop),
         // CR 111.1: Spell-cast records only track cast spells. Tokens are
         // permanents, so token identity is false and nontoken identity is true
         // for this snapshot shape.
@@ -3196,6 +3206,8 @@ fn matches_filter_prop(
         FilterProp::AnyOf { props } => props
             .iter()
             .any(|p| matches_filter_prop(p, state, obj, object_id, source)),
+        // CR 608.2c: Logical negation — the object matches iff the inner prop does NOT.
+        FilterProp::Not { prop } => !matches_filter_prop(prop, state, obj, object_id, source),
         // CR 509.1b: Object's power is strictly greater than the source object's power.
         FilterProp::PowerGTSource => {
             let source_power = state
@@ -3722,6 +3734,10 @@ fn zone_change_record_matches_property(
         FilterProp::AnyOf { props } => props
             .iter()
             .any(|p| zone_change_record_matches_property(p, state, record, source)),
+        // CR 608.2c: Logical negation — recurse under the same record and invert.
+        FilterProp::Not { prop } => {
+            !zone_change_record_matches_property(prop, state, record, source)
+        }
 
         // -------- Group 4: not-yet-supported (known conservative gaps) --------
         // These could be snapshotted (e.g. suspected status, damage-dealt-this-turn)
@@ -6485,6 +6501,75 @@ mod tests {
         assert!(matches_target_filter(&state, attacker, &filter, attacker));
         assert!(matches_target_filter(&state, blocker, &filter, attacker));
         assert!(!matches_target_filter(&state, neither, &filter, attacker));
+    }
+
+    /// CR 608.2c: `FilterProp::Not` building block — a single negated prop
+    /// matches exactly the objects for which the inner prop does NOT hold.
+    #[test]
+    fn not_attacked_this_turn_matches_only_non_attackers() {
+        let mut state = setup();
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker");
+        let idle = add_creature(&mut state, PlayerId(0), "Idle");
+        state.creatures_attacked_this_turn.insert(attacker);
+
+        let filter =
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn),
+            }]));
+
+        assert!(!matches_target_filter(&state, attacker, &filter, attacker));
+        assert!(matches_target_filter(&state, idle, &filter, attacker));
+    }
+
+    /// De Morgan: `[Not(Attacked), Not(Entered)]` AND-combines, so it matches
+    /// only the creature that neither attacked nor entered this turn — the
+    /// exact narrowing The Fifth Doctor's relative clause requires.
+    /// NOTE: `add_creature` (via `create_object`) stamps
+    /// `entered_battlefield_turn = Some(turn)`, so the pre-existing "veteran"
+    /// and "attacker" have that field cleared to `None`; only the newcomer
+    /// keeps the current-turn stamp.
+    #[test]
+    fn not_attacked_and_not_entered_matches_only_idle_veteran() {
+        let mut state = setup();
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker");
+        let newcomer = add_creature(&mut state, PlayerId(0), "Newcomer");
+        let veteran = add_creature(&mut state, PlayerId(0), "Veteran");
+        state.creatures_attacked_this_turn.insert(attacker);
+        // Veteran and attacker are pre-existing — they did NOT enter this turn.
+        state
+            .objects
+            .get_mut(&veteran)
+            .unwrap()
+            .entered_battlefield_turn = None;
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .entered_battlefield_turn = None;
+        // Newcomer entered this turn (already stamped by create_object).
+        assert_eq!(
+            state
+                .objects
+                .get(&newcomer)
+                .unwrap()
+                .entered_battlefield_turn,
+            Some(state.turn_number)
+        );
+
+        let filter = TargetFilter::Typed(TypedFilter::creature().properties(vec![
+            FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn),
+            },
+            FilterProp::Not {
+                prop: Box::new(FilterProp::EnteredThisTurn),
+            },
+        ]));
+
+        // Attacker: attacked → excluded. Newcomer: entered → excluded.
+        // Veteran: neither → the only match.
+        assert!(!matches_target_filter(&state, attacker, &filter, attacker));
+        assert!(!matches_target_filter(&state, newcomer, &filter, attacker));
+        assert!(matches_target_filter(&state, veteran, &filter, attacker));
     }
 
     #[test]

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3171,6 +3171,8 @@ fn filter_prop_references_pt_stat(prop: &FilterProp) -> bool {
         | FilterProp::PowerGTSource
         | FilterProp::ToughnessGTPower => true,
         FilterProp::AnyOf { props } => props.iter().any(filter_prop_references_pt_stat),
+        // CR 608.2c: Negation reads the inner prop's stats — recurse (mirrors AnyOf).
+        FilterProp::Not { prop } => filter_prop_references_pt_stat(prop),
         _ => false,
     }
 }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -533,6 +533,8 @@ fn filter_prop_uses_recipient(prop: &FilterProp) -> bool {
     match prop {
         FilterProp::AttachedToRecipient | FilterProp::Another => true,
         FilterProp::AnyOf { props } => props.iter().any(filter_prop_uses_recipient),
+        // CR 608.2c: Negation reads the inner prop's references — recurse (mirrors AnyOf).
+        FilterProp::Not { prop } => filter_prop_uses_recipient(prop),
         FilterProp::SharesQuality {
             reference: Some(reference),
             ..

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5535,6 +5535,11 @@ fn apply_where_x_to_filter_prop(prop: FilterProp, where_x_expression: Option<&st
                 .map(|p| apply_where_x_to_filter_prop(p, where_x_expression))
                 .collect(),
         },
+        // CR 608.2c: Descend into the negated inner prop so X-substitution
+        // reaches it (mirrors the AnyOf transform).
+        FilterProp::Not { prop } => FilterProp::Not {
+            prop: Box::new(apply_where_x_to_filter_prop(*prop, where_x_expression)),
+        },
         other => other,
     }
 }

--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -2075,6 +2075,8 @@ fn filter_prop_is_zone(prop: &FilterProp) -> bool {
     match prop {
         FilterProp::InZone { .. } | FilterProp::InAnyZone { .. } => true,
         FilterProp::AnyOf { props } => props.iter().any(filter_prop_is_zone),
+        // CR 608.2c: Negation wraps the inner prop's zone reference — recurse (mirrors AnyOf).
+        FilterProp::Not { prop } => filter_prop_is_zone(prop),
         _ => false,
     }
 }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -4732,9 +4732,8 @@ pub(crate) fn parse_that_clause_suffix<'a>(
             // a "."/"," terminator) with "this turn" stripped upstream. A trailing
             // SPACE is NOT a boundary — it signals continued, unmatched text
             // ("didn't attack a player"), which must not match.
-            let consumed_at = |remainder: &str| -> Option<usize> {
-                Some(leading_ws + trimmed.len() - remainder.len())
-            };
+            let consumed_at =
+                |remainder: &str| -> usize { leading_ws + trimmed.len() - remainder.len() };
             // (a) explicit " this turn" + word boundary (guards "this turning").
             if let Ok((after_turn, _)) =
                 tag::<_, _, OracleError<'_>>(" this turn").parse(after_disjunction)
@@ -4744,7 +4743,7 @@ pub(crate) fn parse_that_clause_suffix<'a>(
                     .next()
                     .is_none_or(|c| !c.is_alphanumeric() && c != '_');
                 if at_boundary {
-                    return Some((props, consumed_at(after_turn).unwrap()));
+                    return Some((props, consumed_at(after_turn)));
                 }
             }
             // (b) duration stripped upstream: verb at a clause boundary.
@@ -4753,7 +4752,7 @@ pub(crate) fn parse_that_clause_suffix<'a>(
                 .next()
                 .is_none_or(|c| c == '.' || c == ',');
             if at_clause_boundary {
-                return Some((props, consumed_at(after_disjunction).unwrap()));
+                return Some((props, consumed_at(after_disjunction)));
             }
         }
     }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2121,6 +2121,20 @@ pub fn parse_type_phrase_with_ctx<'a>(
             if let Some((ctrl, consumed)) = parse_controller_suffix(after_that, ctx) {
                 controller = Some(ctrl);
                 pos += that_ctrl_offset + "that ".len() + consumed;
+
+                // A predicate relative clause can follow the controller clause —
+                // e.g. "untapped creatures that player controls that didn't attack
+                // this turn" (Angel's Trumpet). The controller clause was consumed
+                // above, so re-run the generic relative-clause extractor on the
+                // remainder to pick up the trailing verb/quality/attachment "that …"
+                // restriction that the first call (which saw "that player controls")
+                // could not match.
+                if let Some((trailing_props, consumed)) =
+                    parse_that_clause_suffix(&lower[pos..], Some(ctx))
+                {
+                    properties.extend(trailing_props);
+                    pos += consumed;
+                }
             }
         }
     }
@@ -4584,8 +4598,8 @@ pub(crate) fn attachment_kinds_filter_prop(
 /// - CR 301.5 + CR 303.4: "that are enchanted or equipped" → attachment predicate
 ///
 /// Returns `(properties, bytes_consumed)` or `None` if the text doesn't match.
-pub(crate) fn parse_that_clause_suffix(
-    text: &str,
+pub(crate) fn parse_that_clause_suffix<'a>(
+    text: &'a str,
     ctx: Option<&ParseContext>,
 ) -> Option<(Vec<FilterProp>, usize)> {
     let default_ctx = ParseContext::default();
@@ -4660,6 +4674,87 @@ pub(crate) fn parse_that_clause_suffix(
         if let Some((props, consumed)) = parse_targets_constraint(rest, that_len + targets_verb_len)
         {
             return Some((props, consumed));
+        }
+    }
+
+    // --- CR 608.2c (De Morgan): "that didn't <verb> [or <verb>] this turn" ---
+    // Negated verb-phrase relative clause. The verbs after "didn't" are
+    // present-tense/infinitive ("attack"/"block"/"enter"), distinct from the
+    // past-tense positive VERB_PHRASES below ("attacked"/"entered"). Each verb
+    // maps to its existing positive FilterProp wrapped in `Not`; a disjunction
+    // ("attack or enter") lowers to AND-of-negations because the parsed props
+    // are AND-combined in the enclosing TypedFilter ("apply the rules of
+    // English", CR 608.2c). Must run BEFORE the positive VERB_PHRASES loop, but
+    // there is no collision risk since past-tense and present-tense are disjoint.
+    if let Ok((after_neg, _)) = tag::<_, _, OracleError<'_>>("didn't ").parse(after_that) {
+        // verb token -> positive FilterProp; longest-match-first
+        // ("enter the battlefield" before "enter"), mirroring VERB_PHRASES.
+        // CR 508.1a (attack declaration) / CR 509.1a (block declaration) /
+        // CR 400.7 (entering the battlefield is a new object).
+        static NEG_VERBS: &[(&str, FilterProp)] = &[
+            ("attack", FilterProp::AttackedThisTurn),
+            ("block", FilterProp::BlockedThisTurn),
+            ("enter the battlefield", FilterProp::EnteredThisTurn),
+            ("enter", FilterProp::EnteredThisTurn),
+        ];
+        let parse_neg_verb = |i: &'a str| -> Option<(&'a str, FilterProp)> {
+            NEG_VERBS.iter().find_map(|(token, prop)| {
+                tag::<_, _, OracleError<'_>>(*token)
+                    .parse(i)
+                    .ok()
+                    .map(|(rest, _)| (rest, prop.clone()))
+            })
+        };
+        if let Some((rest1, prop1)) = parse_neg_verb(after_neg) {
+            let mut props = vec![FilterProp::Not {
+                prop: Box::new(prop1),
+            }];
+            // Optional " or <verb>" disjunction (CR 608.2c De Morgan split).
+            let after_disjunction = match tag::<_, _, OracleError<'_>>(" or ").parse(rest1) {
+                Ok((rest2, _)) => match parse_neg_verb(rest2) {
+                    Some((rest3, prop2)) => {
+                        props.push(FilterProp::Not {
+                            prop: Box::new(prop2),
+                        });
+                        rest3
+                    }
+                    None => rest1,
+                },
+                Err(_) => rest1,
+            };
+            // Terminator: the canonical form carries the shared " this turn"
+            // suffix ("...didn't attack or enter this turn", The Fifth Doctor).
+            // Some upstream producers (e.g. the "tap all" target extractor for
+            // Angel's Trumpet) strip a trailing duration before the target text
+            // reaches here, leaving "...didn't attack" with the duration already
+            // removed. Accept either: (a) an explicit " this turn" + boundary, or
+            // (b) the verb already sitting at a clause boundary (end-of-string or
+            // a "."/"," terminator) with "this turn" stripped upstream. A trailing
+            // SPACE is NOT a boundary — it signals continued, unmatched text
+            // ("didn't attack a player"), which must not match.
+            let consumed_at = |remainder: &str| -> Option<usize> {
+                Some(leading_ws + trimmed.len() - remainder.len())
+            };
+            // (a) explicit " this turn" + word boundary (guards "this turning").
+            if let Ok((after_turn, _)) =
+                tag::<_, _, OracleError<'_>>(" this turn").parse(after_disjunction)
+            {
+                let at_boundary = after_turn
+                    .chars()
+                    .next()
+                    .is_none_or(|c| !c.is_alphanumeric() && c != '_');
+                if at_boundary {
+                    return Some((props, consumed_at(after_turn).unwrap()));
+                }
+            }
+            // (b) duration stripped upstream: verb at a clause boundary.
+            let at_clause_boundary = after_disjunction
+                .chars()
+                .next()
+                .is_none_or(|c| c == '.' || c == ',');
+            if at_clause_boundary {
+                return Some((props, consumed_at(after_disjunction).unwrap()));
+            }
         }
     }
 
@@ -10614,6 +10709,186 @@ mod tests {
                 value: Supertype::Legendary,
             }),
             "must exclude legendary permanents, got {:?}",
+            tf.properties
+        );
+    }
+
+    /// Cluster 15 (The Fifth Doctor / Angel's Trumpet): the negated verb-phrase
+    /// relative clause "that didn't <verb> this turn" was dropped, so the
+    /// mass effect applied to every creature. CR 608.2c De Morgan: each verb
+    /// becomes its positive FilterProp wrapped in `Not`.
+    #[test]
+    fn that_didnt_attack_emits_not_attacked() {
+        let (props, consumed) = parse_that_clause_suffix(" that didn't attack this turn", None)
+            .expect("should parse negated attack clause");
+        assert_eq!(consumed, " that didn't attack this turn".len());
+        assert_eq!(
+            props,
+            vec![FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn),
+            }]
+        );
+    }
+
+    #[test]
+    fn that_didnt_attack_or_enter_emits_de_morgan_pair() {
+        let (props, consumed) =
+            parse_that_clause_suffix(" that didn't attack or enter this turn", None)
+                .expect("should parse negated attack-or-enter clause");
+        assert_eq!(consumed, " that didn't attack or enter this turn".len());
+        assert_eq!(
+            props,
+            vec![
+                FilterProp::Not {
+                    prop: Box::new(FilterProp::AttackedThisTurn),
+                },
+                FilterProp::Not {
+                    prop: Box::new(FilterProp::EnteredThisTurn),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn that_didnt_enter_the_battlefield_emits_not_entered() {
+        let (props, consumed) =
+            parse_that_clause_suffix(" that didn't enter the battlefield this turn", None)
+                .expect("should parse negated enter-the-battlefield clause");
+        assert_eq!(
+            consumed,
+            " that didn't enter the battlefield this turn".len()
+        );
+        assert_eq!(
+            props,
+            vec![FilterProp::Not {
+                prop: Box::new(FilterProp::EnteredThisTurn),
+            }]
+        );
+    }
+
+    #[test]
+    fn that_didnt_block_emits_not_blocked() {
+        let (props, consumed) = parse_that_clause_suffix(" that didn't block this turn", None)
+            .expect("should parse negated block clause");
+        assert_eq!(consumed, " that didn't block this turn".len());
+        assert_eq!(
+            props,
+            vec![FilterProp::Not {
+                prop: Box::new(FilterProp::BlockedThisTurn),
+            }]
+        );
+    }
+
+    /// Word-boundary guard: " this turning" must NOT match (the negated arm
+    /// requires a boundary after "this turn", unlike the positive VERB_PHRASES).
+    #[test]
+    fn that_didnt_attack_this_turning_does_not_match() {
+        assert!(parse_that_clause_suffix(" that didn't attack this turning", None).is_none());
+    }
+
+    /// Regression: the negated arm must not shadow the positive past-tense path.
+    #[test]
+    fn that_attacked_still_emits_positive_attacked() {
+        let (props, _) = parse_that_clause_suffix(" that attacked this turn", None)
+            .expect("positive past-tense clause must still parse");
+        assert_eq!(props, vec![FilterProp::AttackedThisTurn]);
+    }
+
+    /// Upstream-truncated form: some producers (the "tap all" target extractor)
+    /// strip the trailing " this turn" duration before the target text reaches
+    /// the type-phrase parser, leaving "that didn't attack" at end-of-string.
+    /// The negated arm must still match when the verb sits at a clause boundary.
+    #[test]
+    fn that_didnt_attack_without_this_turn_at_boundary_matches() {
+        let (props, _) = parse_that_clause_suffix(" that didn't attack", None)
+            .expect("duration-stripped form must still parse at end-of-string");
+        assert_eq!(
+            props,
+            vec![FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn),
+            }]
+        );
+
+        // Also accepts a "."/"," clause terminator.
+        let (props, _) = parse_that_clause_suffix(" that didn't attack.", None)
+            .expect("duration-stripped form must parse before a period");
+        assert_eq!(
+            props,
+            vec![FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn),
+            }]
+        );
+    }
+
+    /// Guard: a verb followed by a SPACE + more words (no "this turn", no clause
+    /// boundary) must NOT match — that is unmatched continued text, not a
+    /// complete negated relative clause.
+    #[test]
+    fn that_didnt_attack_with_trailing_words_does_not_match() {
+        assert!(parse_that_clause_suffix(" that didn't attack a player", None).is_none());
+    }
+
+    /// The Fifth Doctor end-to-end: the mass-target type phrase (the "each"
+    /// quantifier is stripped upstream before `parse_type_phrase` is reached)
+    /// must carry both negated props alongside the controller scope, so the
+    /// counter (and the chained TrackedSet untap) follow only the qualifying
+    /// subset.
+    #[test]
+    fn creature_you_control_that_didnt_attack_or_enter_full_phrase() {
+        let (filter, rest) =
+            parse_type_phrase("creature you control that didn't attack or enter this turn");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(
+            tf.properties.contains(&FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn),
+            }),
+            "must exclude attackers, got {:?}",
+            tf.properties
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::Not {
+                prop: Box::new(FilterProp::EnteredThisTurn),
+            }),
+            "must exclude this-turn entrants, got {:?}",
+            tf.properties
+        );
+    }
+
+    /// Angel's Trumpet end-to-end: a negated verb clause that FOLLOWS a
+    /// controller clause ("untapped creatures that player controls that didn't
+    /// attack this turn") must still attach. The controller clause is consumed
+    /// first, then the trailing relative clause is re-parsed — so `Untapped`
+    /// (from "untapped creatures"), the `ScopedPlayer` controller, AND
+    /// `Not(AttackedThisTurn)` all land together.
+    #[test]
+    fn untapped_creatures_that_player_controls_that_didnt_attack_full_phrase() {
+        let mut ctx = ParseContext {
+            relative_player_scope: Some(ControllerRef::ScopedPlayer),
+            ..ParseContext::default()
+        };
+        let (filter, rest) = parse_type_phrase_with_ctx(
+            "untapped creatures that player controls that didn't attack this turn",
+            &mut ctx,
+        );
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::ScopedPlayer));
+        assert!(
+            tf.properties.contains(&FilterProp::Untapped),
+            "must keep the untapped restriction, got {:?}",
+            tf.properties
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::Not {
+                prop: Box::new(FilterProp::AttackedThisTurn),
+            }),
+            "trailing negated clause must attach after the controller clause, got {:?}",
             tf.properties
         );
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2474,6 +2474,17 @@ pub enum FilterProp {
     AnyOf {
         props: Vec<FilterProp>,
     },
+    /// CR 608.2c: Logical negation of a filter property — matches objects for
+    /// which the inner property does NOT hold ("apply the rules of English").
+    /// General recursive combinator mirroring `TargetFilter::Not`,
+    /// `StaticCondition::Not`, `AbilityCondition::Not`, and `TriggerCondition::Not`.
+    /// Composes with the AND-combined `properties` vector, so a negated-verb
+    /// relative clause like "that didn't attack or enter this turn" decomposes
+    /// (De Morgan) into `Not(AttackedThisTurn)` AND `Not(EnteredThisTurn)` rather
+    /// than a bespoke `NotAttacked`/`NotEntered` sibling cluster. Boxed for recursion.
+    Not {
+        prop: Box<FilterProp>,
+    },
     /// CR 700.9: A permanent is modified if it has one or more counters on it
     /// (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura
     /// that is controlled by that permanent's controller (CR 303.4).
@@ -9354,6 +9365,9 @@ fn normalized_filter_prop(prop: FilterProp) -> FilterProp {
         },
         FilterProp::Targets { filter } => FilterProp::Targets {
             filter: Box::new(filter.normalized()),
+        },
+        FilterProp::Not { prop } => FilterProp::Not {
+            prop: Box::new(normalized_filter_prop(*prop)),
         },
         prop => prop,
     }


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** Relative clause 'that didn't attack or enter this turn' is dropped from the PutCounterAll/untap target, so the effect applies to all your creatures instead of the qualifying subset.

## Cards corrected
- The Fifth Doctor

## Fix
Implemented cluster 15 (negated verb-phrase relative clauses "that didn't <verb> this turn") surgically against /Users/ntindle/code/random/magic/phase-main-base (branch fix/who-misparse-15... tracking upstream/main, tip ee914c48e). Both target cards were genuinely misparsed before the fix and parse correctly after.

WHAT CHANGED (per the approved plan):
1. Added a general recursive combinator `FilterProp::Not { prop: Box<FilterProp> }` to types/ability.rs (mirrors TargetFilter::Not / StaticCondition::Not / AbilityCondition::Not / TriggerCondition::Not), NOT a DidNotAttack/DidNotEnter sibling cluster. CR 608.2c (verified).
2. Added the 11 recursion/transform parity arms: 6 compiler-forced exhaustive matches (filter.rs matches_filter_prop, spell_record_matches_property, zone_change_record_matches_property — all invert; filter_prop_uses_object_population, entered_object_perturbs_filter_prop — recurse; coverage.rs label) + 5 wildcard/transform sites (quantity.rs filter_prop_uses_recipient, layers.rs filter_prop_references_pt_stat, ability_utils.rs filter_prop_references_target_creature_quantity, search.rs filter_prop_is_zone, lower.rs apply_where_x_to_filter_prop). All match the adjacent AnyOf arm's call shape.
3. Added a nom-combinator negated-verb branch inside parse_that_clause_suffix (oracle_target.rs) after the "that " prefix and before the positive VERB_PHRASES loop. Present-tense verbs (attack/block/enter the battlefield/enter, longest-match-first) map to their positive FilterProp wrapped in Not; "attack or enter" lowers via De Morgan to AND-of-negations. No string dispatch (tag/alt/Parser only).

TWO PLAN DEVIATIONS, both forced by tracing the REAL card path (PTP trace instrumentation, since removed):
A) The plan's terminator required " this turn" + boundary. But the upstream "tap all" target extractor strips the trailing " this turn" duration BEFORE the target reaches parse_that_clause_suffix (Angel's Trumpet arrived as "...that didn't attack"). I extended the terminator to ALSO accept a clause boundary (end-of-string / "." / ",") when "this turn" was stripped upstream; a trailing SPACE is rejected ("didn't attack a player" must not match). Guard tests added.
B) The plan assumed parse_that_clause_suffix's single existing call site sufficed. It did NOT for Angel's Trumpet: its relative clause FOLLOWS a controller clause ("untapped creatures that player controls that didn't attack this turn"). The first call sees "that player controls" and cannot match; the controller clause is then consumed; the negated clause needs a SECOND parse_that_clause_suffix call. I added that re-parse immediately after the controller-clause block in parse_type_phrase_with_ctx — a general improvement for any "[type] that <player> controls that <predicate>" composition.

RESULTS (regenerated via oracle-gen): The Fifth Doctor PutCounterAll target -> Typed{Creature, You, [Not(AttackedThisTurn), Not(EnteredThisTurn)]}; its chained SetTapState{Untap, Single, TrackedSet{0}} rider intact (narrowed CounterAdded events -> smaller TrackedSet -> correctly-narrowed untap, zero effect-layer change). Angel's Trumpet SetTapState{Tap, All, ScopedPlayer} target -> [Untapped, Not(AttackedThisTurn)]. Both cards absent from semantic-audit SilentDrop/DroppedCondition findings. Angel's Trumpet retains one PRE-EXISTING, out-of-scope Unimplemented on its SECOND sentence ("deal damage equal to creatures tapped"), unrelated to this cluster.

TESTS ADDED (building-block level): 9 parser tests (single-verb Not, De Morgan pair, enter-the-battlefield, block, "this turning" boundary guard, positive past-tense still works, duration-stripped form at boundary, trailing-words rejection, controller+verb compound full phrase, Fifth Doctor full phrase) + 2 runtime filter.rs tests (Not(Attacked) matches only non-attackers; De Morgan pair matches only the idle veteran).

VERIFICATION (worktree NOT under Tilt -> cargo direct): cargo fmt --all clean (--check exit 0); cargo clippy --all-targets -- -D warnings clean (fixed one clippy field_reassign_with_default in a new test via struct-update syntax); cargo test -p engine = 12015 lib tests pass, 0 failed; ./scripts/gen-card-data.sh succeeded; cargo coverage and cargo semantic-audit both run clean with no regression for these cards.

PARSER DIFF GATE: PASS. The only string-method matches in added parser lines are tf.properties.contains(&FilterProp::...) typed Vec membership checks inside #[test] functions (allowed test exception) — zero production string dispatch. ./scripts/check-parser-combinators.sh exits 1, but every flagged line (oracle.rs:310 split, search.rs:2664 altanak test) is PRE-EXISTING in committed HEAD — the gate's base ref ff799f899 is a months-old ancestor merge, so it flags accumulated branch history, NOT my uncommitted diff. My added parser lines contain no A/E/F patterns.

MULTI-AGENT SAFETY: gen-card-data.sh incidentally regenerated the tracked crates/engine/data/known-tokens.toml (network token-set drift, unrelated to cluster 15) — I restored it to HEAD since it was my own pipeline side effect, leaving only the 9 intended source files. client/public/card-data.json is gitignored. Did NOT commit.

## Files changed
- crates/engine/src/types/ability.rs
- crates/engine/src/game/filter.rs
- crates/engine/src/game/quantity.rs
- crates/engine/src/game/layers.rs
- crates/engine/src/game/ability_utils.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/parser/oracle_effect/search.rs
- crates/engine/src/parser/oracle_effect/lower.rs
- crates/engine/src/parser/oracle_target.rs

## CR references
- CR 608.2c (docs/MagicCompRules.txt:2789 — read whole text / apply rules of English; the De Morgan basis for FilterProp::Not and the negated-verb split)
- CR 508.1a (docs/MagicCompRules.txt:2260 — attack declaration; 'attack' -> AttackedThisTurn)
- CR 509.1a (docs/MagicCompRules.txt:2341 — block declaration; 'block' -> BlockedThisTurn)
- CR 400.7 (docs/MagicCompRules.txt:1948 — moving zones becomes a new object; 'enter' -> EnteredThisTurn)
- CR 120.6 (docs/MagicCompRules.txt:1128 — damage marked persists this turn; future-facing WasDealtDamageThisTurn negation)

## Verification
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo fmt --all` — passed (no file changes, exit 0)
- `cd /Users/ntindle/code/random/magic/phase-main-base && ./scripts/check-parser-combinators.sh <upstream/main merge-base 088a2969d>` — passed (exit 0, no flagged lines in fix's changed files)
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo clippy -p engine --all-targets -- -D warnings` — passed (exit 0, zero errors/warnings)
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo test -p engine` — passed (exit 0, all tests passed, zero failures)
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo run --profile tool --features cli --bin oracle-gen -- data --filter "the fifth doctor"` — passed (card parses correctly, relative clause captured as Not{AttackedThisTurn} + Not{EnteredThisTurn})
Cards confirmed re-parsed correctly: The Fifth Doctor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
