### PR TITLE
fix(parser): Intervening-if 'if it was attacking or blocking alone' on a dies-trigger is dropped (tr

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -2431,6 +2431,27 @@ pub fn unblocked_attackers(state: &GameState) -> Vec<ObjectId> {
         .collect()
 }
 
+/// CR 506.5: A creature is attacking alone if it's attacking but no other
+/// creatures are. This reads live combat (the sole declared attacker); callers
+/// that must survive the attacker leaving combat (CR 506.4) capture the result
+/// into the zone-change snapshot at zone-exit per the look-back rule CR 603.10a.
+pub fn attacking_alone(state: &GameState, object_id: ObjectId) -> bool {
+    state.combat.as_ref().is_some_and(|combat| {
+        combat.attackers.len() == 1 && combat.attackers[0].object_id == object_id
+    })
+}
+
+/// CR 506.5: A creature is blocking alone if it's blocking but no other
+/// creatures are. `blocker_to_attacker` is keyed by blocker id (one entry per
+/// distinct declared blocker), so a single entry that contains `object_id`
+/// means it is the only blocker in combat. Like `attacking_alone`, this reads
+/// live combat; look-back callers snapshot the result (CR 603.10a).
+pub fn blocking_alone(state: &GameState, object_id: ObjectId) -> bool {
+    state.combat.as_ref().is_some_and(|combat| {
+        combat.blocker_to_attacker.len() == 1 && combat.blocker_to_attacker.contains_key(&object_id)
+    })
+}
+
 /// CR 302.6: Returns true iff this creature can't attack or pay `{T}`/`{Q}`
 /// costs due to summoning sickness — i.e., it has NOT been continuously under
 /// its controller's control since that player's most recent turn began.
@@ -4287,6 +4308,52 @@ mod tests {
         let combat = state.combat.as_ref().unwrap();
         assert_eq!(combat.blocker_assignments[&attacker], vec![blocker]);
         assert_eq!(combat.blocker_to_attacker[&blocker], vec![attacker]);
+    }
+
+    /// CR 506.5: the sole declared attacker is "attacking alone"; a co-attacker
+    /// makes neither attacker alone.
+    #[test]
+    fn attacking_alone_authority() {
+        let mut state = setup();
+        let solo = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(solo, PlayerId(1))],
+            ..Default::default()
+        });
+        assert!(attacking_alone(&state, solo));
+
+        let other = create_creature(&mut state, PlayerId(0), "Wolf", 3, 3);
+        state.combat = Some(CombatState {
+            attackers: vec![
+                AttackerInfo::attacking_player(solo, PlayerId(1)),
+                AttackerInfo::attacking_player(other, PlayerId(1)),
+            ],
+            ..Default::default()
+        });
+        assert!(!attacking_alone(&state, solo));
+        assert!(!attacking_alone(&state, other));
+    }
+
+    /// CR 506.5: the sole declared blocker is "blocking alone"; a co-blocker
+    /// makes neither blocker alone.
+    #[test]
+    fn blocking_alone_authority() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let solo = create_creature(&mut state, PlayerId(1), "Wall", 0, 4);
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+        let mut events = Vec::new();
+        declare_blockers(&mut state, &[(solo, attacker)], &mut events).unwrap();
+        assert!(blocking_alone(&state, solo));
+
+        let second = create_creature(&mut state, PlayerId(1), "Guard", 1, 3);
+        let mut events = Vec::new();
+        declare_blockers(&mut state, &[(second, attacker)], &mut events).unwrap();
+        assert!(!blocking_alone(&state, solo));
+        assert!(!blocking_alone(&state, second));
     }
 
     #[test]

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -469,6 +469,8 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             FilterProp::BlockingSource => parts.push("blocking source".into()),
             FilterProp::CombatRelation { .. } => parts.push("combat related".into()),
             FilterProp::Unblocked => parts.push("unblocked".into()),
+            FilterProp::AttackingAlone => parts.push("attacking alone".into()),
+            FilterProp::BlockingAlone => parts.push("blocking alone".into()),
             FilterProp::Tapped => parts.push("tapped".into()),
             FilterProp::IsSaddled => parts.push("saddled".into()),
             FilterProp::Untapped => parts.push("untapped".into()),

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -148,6 +148,8 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::BlockingSource
         | FilterProp::CombatRelation { .. }
         | FilterProp::Unblocked
+        | FilterProp::AttackingAlone
+        | FilterProp::BlockingAlone
         | FilterProp::Tapped
         | FilterProp::IsSaddled
         | FilterProp::Untapped
@@ -340,6 +342,8 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::BlockingSource
         | FilterProp::CombatRelation { .. }
         | FilterProp::Unblocked
+        | FilterProp::AttackingAlone
+        | FilterProp::BlockingAlone
         | FilterProp::Tapped
         | FilterProp::IsSaddled
         | FilterProp::Untapped
@@ -2537,6 +2541,8 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         | FilterProp::BlockingSource
         | FilterProp::CombatRelation { .. }
         | FilterProp::Unblocked
+        | FilterProp::AttackingAlone
+        | FilterProp::BlockingAlone
         | FilterProp::Tapped
         | FilterProp::IsSaddled
         | FilterProp::Untapped
@@ -2858,6 +2864,10 @@ fn matches_filter_prop(
         // CR 509.1h: Unblocked = attacking creature that was never assigned blockers.
         // unblocked_attackers checks the permanent `blocked` flag, not the current blocker list.
         FilterProp::Unblocked => combat::unblocked_attackers(state).contains(&object_id),
+        // CR 506.5: sole attacker / sole blocker against live combat. Look-back
+        // callers route through the zone-change snapshot arm instead.
+        FilterProp::AttackingAlone => combat::attacking_alone(state, object_id),
+        FilterProp::BlockingAlone => combat::blocking_alone(state, object_id),
         FilterProp::Tapped => obj.tapped,
         // CR 702.171b: Matches permanents with the saddled designation.
         FilterProp::IsSaddled => obj.is_saddled,
@@ -3652,6 +3662,10 @@ fn zone_change_record_matches_property(
         FilterProp::Unblocked => {
             record.combat_status.attacking && !record.combat_status.blocked
         }
+        // CR 506.5 + CR 603.10a: sole-attacker / sole-blocker status as of the
+        // zone change, captured by `capture_combat_status` before combat removal.
+        FilterProp::AttackingAlone => record.combat_status.attacking_alone,
+        FilterProp::BlockingAlone => record.combat_status.blocking_alone,
         FilterProp::HasAttachment {
             kind,
             controller,
@@ -8355,6 +8369,8 @@ mod tests {
                 attacking: true,
                 blocking: false,
                 blocked: false,
+                attacking_alone: true,
+                blocking_alone: false,
                 defending_player: Some(PlayerId(0)),
             },
             ..ZoneChangeRecord::test_minimal(ObjectId(42), Some(Zone::Battlefield), Zone::Graveyard)
@@ -8364,6 +8380,8 @@ mod tests {
                 attacking: false,
                 blocking: true,
                 blocked: false,
+                attacking_alone: false,
+                blocking_alone: true,
                 defending_player: None,
             },
             ..ZoneChangeRecord::test_minimal(ObjectId(43), Some(Zone::Battlefield), Zone::Graveyard)
@@ -8393,6 +8411,54 @@ mod tests {
             &FilterProp::Blocking,
             &state,
             &blocking_record,
+            &source_ctx,
+        ));
+
+        // CR 506.5 + CR 603.10a: sole-attacker / sole-blocker look-back reads
+        // the captured `attacking_alone` / `blocking_alone` snapshot. The
+        // attacking-alone record matches AttackingAlone but not BlockingAlone,
+        // and vice versa for the blocking-alone record.
+        assert!(zone_change_record_matches_property(
+            &FilterProp::AttackingAlone,
+            &state,
+            &attacking_record,
+            &source_ctx,
+        ));
+        assert!(!zone_change_record_matches_property(
+            &FilterProp::BlockingAlone,
+            &state,
+            &attacking_record,
+            &source_ctx,
+        ));
+        assert!(zone_change_record_matches_property(
+            &FilterProp::BlockingAlone,
+            &state,
+            &blocking_record,
+            &source_ctx,
+        ));
+        assert!(!zone_change_record_matches_property(
+            &FilterProp::AttackingAlone,
+            &state,
+            &blocking_record,
+            &source_ctx,
+        ));
+        // CR 506.5 boundary: a record where the creature attacked but NOT alone
+        // (co-attacker present at zone-exit) must fail AttackingAlone.
+        let attacked_with_company = ZoneChangeRecord {
+            combat_status: ZoneChangeCombatStatus {
+                attacking: true,
+                blocking: false,
+                blocked: false,
+                attacking_alone: false,
+                blocking_alone: false,
+                defending_player: Some(PlayerId(0)),
+            },
+            ..ZoneChangeRecord::test_minimal(ObjectId(44), Some(Zone::Battlefield), Zone::Graveyard)
+        };
+        assert!(!zone_change_record_matches_property(
+            &FilterProp::AttackingAlone,
+            &state,
+            &attacked_with_company,
             &source_ctx,
         ));
     }

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -813,6 +813,11 @@ fn capture_combat_status(state: &GameState, object_id: ObjectId) -> ZoneChangeCo
         attacking: attacker.is_some(),
         blocking: combat.blocker_to_attacker.contains_key(&object_id),
         blocked: attacker.is_some_and(|attacker| attacker.blocked),
+        // CR 506.5 + CR 603.10a: snapshot the sole-attacker / sole-blocker
+        // status via the shared combat authority so it cannot diverge from the
+        // live `FilterProp::AttackingAlone` / `BlockingAlone` evaluation.
+        attacking_alone: crate::game::combat::attacking_alone(state, object_id),
+        blocking_alone: crate::game::combat::blocking_alone(state, object_id),
         defending_player: attacker.map(|attacker| attacker.defending_player),
     }
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3407,15 +3407,27 @@ fn parse_zone_change_object_filter_predicate(input: &str) -> OracleResult<'_, Tr
     ))
     .parse(input)?;
 
-    let (rest, prop) = alt((
-        value(FilterProp::Blocking, tag("blocking")),
-        map_attachment_kind_filter_prop,
+    // CR 506.5: combat-alone predicates are tried first, with the disjunctive
+    // "attacking or blocking alone" form ordered ahead of the single-phrase
+    // forms so longest-match wins (the same ordering discipline as the other
+    // disjunctive look-back conditions in this module). They map to the
+    // sole-attacker / sole-blocker `FilterProp`s, which evaluate via the
+    // zone-change snapshot per CR 603.10a.
+    let (rest, props) = alt((
+        parse_combat_alone_props,
+        map(
+            alt((
+                value(FilterProp::Blocking, tag("blocking")),
+                map_attachment_kind_filter_prop,
+            )),
+            |prop| vec![prop],
+        ),
     ))
     .parse(rest)?;
     let condition = TriggerCondition::ZoneChangeObjectMatchesFilter {
         origin: Some(Zone::Battlefield),
         destination: Zone::Graveyard,
-        filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![prop])),
+        filter: TargetFilter::Typed(TypedFilter::creature().properties(props)),
     };
 
     if negated {
@@ -3428,6 +3440,27 @@ fn parse_zone_change_object_filter_predicate(input: &str) -> OracleResult<'_, Tr
     } else {
         Ok((rest, condition))
     }
+}
+
+/// CR 506.5: Parse the combat-alone predicate phrase of a zone-change
+/// look-back intervening-if ("attacking or blocking alone", "attacking alone",
+/// "blocking alone"). The disjunctive form is ordered first so it is not
+/// shadowed by the single-phrase forms (longest-match precedence). Returns the
+/// `FilterProp` list to drop into the creature filter — the disjunction is
+/// expressed via the existing typed `FilterProp::AnyOf` rather than bespoke
+/// parsing, so it composes with the surrounding negation axis for free.
+fn parse_combat_alone_props(input: &str) -> OracleResult<'_, Vec<FilterProp>> {
+    alt((
+        value(
+            vec![FilterProp::AnyOf {
+                props: vec![FilterProp::AttackingAlone, FilterProp::BlockingAlone],
+            }],
+            tag("attacking or blocking alone"),
+        ),
+        value(vec![FilterProp::AttackingAlone], tag("attacking alone")),
+        value(vec![FilterProp::BlockingAlone], tag("blocking alone")),
+    ))
+    .parse(input)
 }
 
 fn zone_change_object_token_condition(negated: bool) -> TriggerCondition {
@@ -26235,6 +26268,84 @@ mod tests {
                     destination: Zone::Graveyard,
                     filter: TargetFilter::Typed(
                         TypedFilter::creature().properties(vec![FilterProp::Blocking])
+                    ),
+                }),
+            }
+        );
+    }
+
+    /// CR 506.5: the disjunctive "attacking or blocking alone" intervening-if
+    /// (Thijarian Witness "Bear Witness") becomes a zone-change look-back over
+    /// an `AnyOf([AttackingAlone, BlockingAlone])` creature filter, and the
+    /// clause is stripped from the residual effect text.
+    #[test]
+    fn extract_if_it_was_attacking_or_blocking_alone_as_zone_change_lookback() {
+        let (cleaned, cond) =
+            extract_if_condition("if it was attacking or blocking alone, exile it and investigate");
+        assert_eq!(cleaned, "exile it and investigate");
+        assert_eq!(
+            cond.unwrap(),
+            TriggerCondition::ZoneChangeObjectMatchesFilter {
+                origin: Some(Zone::Battlefield),
+                destination: Zone::Graveyard,
+                filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                    FilterProp::AnyOf {
+                        props: vec![FilterProp::AttackingAlone, FilterProp::BlockingAlone],
+                    },
+                ])),
+            }
+        );
+    }
+
+    /// CR 506.5: the single-phrase "attacking alone" form (building-block
+    /// coverage — the class, not just the disjunctive card text).
+    #[test]
+    fn extract_if_it_was_attacking_alone_as_zone_change_lookback() {
+        let (cleaned, cond) = extract_if_condition("if it was attacking alone, draw a card");
+        assert_eq!(cleaned, "draw a card");
+        assert_eq!(
+            cond.unwrap(),
+            TriggerCondition::ZoneChangeObjectMatchesFilter {
+                origin: Some(Zone::Battlefield),
+                destination: Zone::Graveyard,
+                filter: TargetFilter::Typed(
+                    TypedFilter::creature().properties(vec![FilterProp::AttackingAlone])
+                ),
+            }
+        );
+    }
+
+    /// CR 506.5: the single-phrase "blocking alone" form.
+    #[test]
+    fn extract_if_it_was_blocking_alone_as_zone_change_lookback() {
+        let (cleaned, cond) = extract_if_condition("if it was blocking alone, draw a card");
+        assert_eq!(cleaned, "draw a card");
+        assert_eq!(
+            cond.unwrap(),
+            TriggerCondition::ZoneChangeObjectMatchesFilter {
+                origin: Some(Zone::Battlefield),
+                destination: Zone::Graveyard,
+                filter: TargetFilter::Typed(
+                    TypedFilter::creature().properties(vec![FilterProp::BlockingAlone])
+                ),
+            }
+        );
+    }
+
+    /// CR 506.5 + CR 603.4: the negated polarity composes through the existing
+    /// negation axis ("if it wasn't attacking alone" → `Not(...)`).
+    #[test]
+    fn extract_if_it_wasnt_attacking_alone_negates_zone_change_lookback() {
+        let (cleaned, cond) = extract_if_condition("if it wasn't attacking alone, draw a card");
+        assert_eq!(cleaned, "draw a card");
+        assert_eq!(
+            cond.unwrap(),
+            TriggerCondition::Not {
+                condition: Box::new(TriggerCondition::ZoneChangeObjectMatchesFilter {
+                    origin: Some(Zone::Battlefield),
+                    destination: Zone::Graveyard,
+                    filter: TargetFilter::Typed(
+                        TypedFilter::creature().properties(vec![FilterProp::AttackingAlone])
                     ),
                 }),
             }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2224,6 +2224,15 @@ pub enum FilterProp {
     },
     /// CR 509.1h: Matches attacking creatures with no blockers assigned.
     Unblocked,
+    /// CR 506.5: Matches a creature that is (or, via the zone-change look-back
+    /// snapshot, was) the sole attacker — "attacking alone". Live evaluation
+    /// reads combat; look-back evaluation reads
+    /// `ZoneChangeCombatStatus::attacking_alone`.
+    AttackingAlone,
+    /// CR 506.5: Matches a creature that is (or was) the sole blocker —
+    /// "blocking alone". Look-back evaluation reads
+    /// `ZoneChangeCombatStatus::blocking_alone`.
+    BlockingAlone,
     Tapped,
     /// CR 302.6 / CR 110.5: Untapped status as targeting qualifier.
     Untapped,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -446,6 +446,17 @@ pub struct ZoneChangeCombatStatus {
     pub blocking: bool,
     #[serde(default)]
     pub blocked: bool,
+    /// CR 506.5 + CR 603.10a: Whether the object was the sole attacker when it
+    /// left combat. Captured at zone-exit because combat membership is cleared
+    /// by CR 506.4 before look-back ("leaves the battlefield") trigger
+    /// conditions are evaluated, so live combat can no longer answer it.
+    #[serde(default)]
+    pub attacking_alone: bool,
+    /// CR 506.5 + CR 603.10a: Whether the object was the sole blocker when it
+    /// left combat. Captured at zone-exit for the same look-back reason as
+    /// `attacking_alone`.
+    #[serde(default)]
+    pub blocking_alone: bool,
     #[serde(default)]
     pub defending_player: Option<PlayerId>,
 }


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** Intervening-if 'if it was attacking or blocking alone' on a dies-trigger is dropped (trigger condition null); there is no event-object-relative TriggerCondition for the dying object's combat-alone state.

## Cards corrected
- Thijarian Witness

## Fix
Implemented the cluster-16 fix for Thijarian Witness's "Bear Witness" dies-trigger, whose intervening-if "if it was attacking or blocking alone" was dropped (condition: null, live SwallowedClause/Condition_If warning) on current main. Built it as a class-level combat-look-back primitive, not a one-off, exactly per the approved plan and confirming the plan's correction to the cluster spec: TriggerCondition::ZoneChangeObjectMatchesFilter already exists and is the right slot, so NO new TriggerCondition variant was added. The genuinely missing piece was the CR 506.5 "alone" combat dimension. Changes: (1) game/combat.rs — two authority helpers attacking_alone/blocking_alone (single source for CR 506.5 live evaluation, mirroring the unblocked_attackers pattern); (2) types/game_state.rs — added attacking_alone/blocking_alone #[serde(default)] bool fields to ZoneChangeCombatStatus (the look-back capture per CR 603.10a, since CR 506.4 clears live combat before the dies-trigger evaluates); (3) game/zones.rs — capture_combat_status populates them via the combat authority so live + snapshot cannot diverge; (4) types/ability.rs — added first-class FilterProp::AttackingAlone/BlockingAlone leaf variants (mirroring Unblocked, no bool parameterization), via the /add-engine-variant gate (DOES_NOT_EXIST, EXTEND_OK, WITHIN_SECTION CR 506); (5) game/filter.rs — live arms (matches_filter_prop), look-back arms (zone_change_record_matches_property), fail-closed arm in spell_record_matches_property, and registered both in the two combat-prop classification |-chains; (6) game/coverage.rs — registered both as Handled; (7) parser/oracle_trigger.rs — new parse_combat_alone_props nom combinator (alt/tag/value, disjunctive form ordered first for longest-match) wired into parse_zone_change_object_filter_predicate, emitting ZoneChangeObjectMatchesFilter over AnyOf([AttackingAlone, BlockingAlone]) composing with the existing was/wasn't negation axis. Added building-block tests: 4 parser tests (disjunctive, both single phrases, negated), filter look-back snapshot tests incl. the CR 506.5 not-alone boundary, and 2 combat authority tests (sole vs co-attacker/co-blocker). All CR numbers grep-verified against docs/MagicCompRules.txt. VERIFICATION: cargo fmt clean; cargo clippy -p engine --all-targets -D warnings exit 0, zero warnings; full cargo test -p engine green (0 failed across all binaries); my own parser diff has zero string-dispatch lines (parser combinator gate PASS for my diff; the repo-wide gate exits 1 only on pre-existing structural uses in files I never touched, diffing an old base commit). After ./scripts/gen-card-data.sh, Thijarian Witness now shows the correct ZoneChangeObjectMatchesFilter/AnyOf([AttackingAlone,BlockingAlone]) condition with empty parse_warnings, its effect body (exile TriggeringSource + Investigate) still parses, semantic-audit shows zero Thijarian findings, and 3 transient *_db_load_path/synthesis test failures (stale card-data.json carrying an obsolete FilterProp::Not shape, unrelated to my change) cleared after the regen. Did NOT commit; changes left in the working tree.

## Files changed
- crates/engine/src/game/combat.rs
- crates/engine/src/types/game_state.rs
- crates/engine/src/game/zones.rs
- crates/engine/src/types/ability.rs
- crates/engine/src/game/filter.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/parser/oracle_trigger.rs

## CR references
- CR 506.5 (attacking alone / blocking alone definition; verified line 2230)
- CR 603.10a (leaves-the-battlefield look-back; verified line 2634)
- CR 603.4 (intervening-if checked at fire-time and resolution-time; verified line 2588)
- CR 506.4 (permanent removed from combat stops being attacking/blocking; verified line 2218)
- CR 508.1a (declare attackers; verified line 2260)
- CR 509.1a (declare blockers; verified line 2341)

## Verification
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo fmt --all` — pass
- `cd /Users/ntindle/code/random/magic/phase-main-base && ./scripts/check-parser-combinators.sh "$(git merge-base upstream/main HEAD)"` — pass
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo clippy -p engine --all-targets -- -D warnings` — pass
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo test -p engine` — pass
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo run --profile tool --features cli --bin oracle-gen -- data --filter "thijarian witness"` — pass
Cards confirmed re-parsed correctly: thijarian witness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
