### PR TITLE
fix(engine): defer manifest dread graveyard on manifest entry pause (#3245)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2360,7 +2360,7 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             )]
         }
         // CR 701.62a: AI selects one card to manifest — one action per card option
-        WaitingFor::ManifestDreadChoice { player, cards } => {
+        WaitingFor::ManifestDreadChoice { player, cards, .. } => {
             if cards.is_empty() {
                 vec![candidate(
                     GameAction::SelectCards { cards: vec![] },

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -514,7 +514,9 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
             GameAction::SelectCards { cards: chosen },
         ) => selection_mismatch(chosen, cards, Some(1)),
         (
-            WaitingFor::ManifestDreadChoice { player: _, cards },
+            WaitingFor::ManifestDreadChoice {
+                player: _, cards, ..
+            },
             GameAction::SelectCards { cards: chosen },
         ) => selection_mismatch(chosen, cards, Some(1)),
         (

--- a/crates/engine/src/game/effects/manifest_dread.rs
+++ b/crates/engine/src/game/effects/manifest_dread.rs
@@ -45,6 +45,7 @@ pub fn resolve(
             state,
             player,
             card_id,
+            ability.source_id,
             crate::types::ability::FaceDownProfile::vanilla_2_2(),
             events,
         )
@@ -56,7 +57,11 @@ pub fn resolve(
             state.revealed_cards.insert(card_id);
         }
 
-        state.waiting_for = WaitingFor::ManifestDreadChoice { player, cards };
+        state.waiting_for = WaitingFor::ManifestDreadChoice {
+            player,
+            cards,
+            source_id: ability.source_id,
+        };
     }
 
     events.push(GameEvent::EffectResolved {
@@ -105,7 +110,9 @@ mod tests {
         resolve(&mut state, &ability, &mut events).unwrap();
 
         match &state.waiting_for {
-            WaitingFor::ManifestDreadChoice { player: p, cards } => {
+            WaitingFor::ManifestDreadChoice {
+                player: p, cards, ..
+            } => {
                 assert_eq!(*p, player);
                 assert_eq!(cards.len(), 2);
                 assert_eq!(*cards, top_2);

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -408,14 +408,41 @@ pub(super) fn handle_resolution_choice(
                 .copied()
                 .collect();
 
-            crate::game::morph::manifest_card(
+            let face_down = crate::types::ability::FaceDownProfile::vanilla_2_2();
+            match crate::game::zone_pipeline::move_object(
                 state,
-                player,
-                manifest_id,
-                crate::types::ability::FaceDownProfile::vanilla_2_2(),
+                crate::game::zone_pipeline::ZoneMoveRequest::effect(
+                    manifest_id,
+                    Zone::Battlefield,
+                    manifest_id,
+                )
+                .face_down(face_down),
                 events,
-            )
-            .map_err(|error| EngineError::InvalidAction(format!("{error}")))?;
+            ) {
+                crate::game::zone_pipeline::ZoneMoveResult::Done => {}
+                // CR 616.1: the chosen card's manifest entry paused (aura host pick
+                // or a replacement-ordering prompt). Defer the non-manifested card's
+                // graveyard move + reveal-marker cleanup until the manifest finishes
+                // entering — otherwise the other card is graved while the chosen card
+                // is still in the library (issue #3245).
+                crate::game::zone_pipeline::ZoneMoveResult::NeedsChoice(_)
+                | crate::game::zone_pipeline::ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                    crate::game::zone_pipeline::defer_completion_on_pause(
+                        state,
+                        crate::types::game_state::BatchCompletion::RevealRestPile {
+                            player,
+                            rest_cards: graveyard_cards,
+                            rest_destination: Zone::Graveyard,
+                            clear_markers: cards.clone(),
+                            publish_tracked_set: None,
+                            emit_reveal_until_resolved: None,
+                        },
+                    );
+                    return Ok(ResolutionChoiceOutcome::WaitingFor(
+                        state.waiting_for.clone(),
+                    ));
+                }
+            }
 
             // CR 614.6 + CR 701.17a class: route the non-manifested cards to the
             // graveyard through the simultaneous-move batch so each card's own

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -390,7 +390,11 @@ pub(super) fn handle_resolution_choice(
             ResolutionChoiceOutcome::WaitingFor(wf)
         }
         (
-            WaitingFor::ManifestDreadChoice { player, cards },
+            WaitingFor::ManifestDreadChoice {
+                player,
+                cards,
+                source_id,
+            },
             GameAction::SelectCards {
                 cards: selected_cards,
             },
@@ -414,17 +418,18 @@ pub(super) fn handle_resolution_choice(
                 crate::game::zone_pipeline::ZoneMoveRequest::effect(
                     manifest_id,
                     Zone::Battlefield,
-                    manifest_id,
+                    source_id,
                 )
                 .face_down(face_down),
                 events,
             ) {
                 crate::game::zone_pipeline::ZoneMoveResult::Done => {}
-                // CR 616.1: the chosen card's manifest entry paused (aura host pick
-                // or a replacement-ordering prompt). Defer the non-manifested card's
-                // graveyard move + reveal-marker cleanup until the manifest finishes
-                // entering — otherwise the other card is graved while the chosen card
-                // is still in the library (issue #3245).
+                // CR 303.4f / CR 616.1 + CR 701.62a: the chosen card's manifest
+                // entry paused (aura host pick or a replacement-ordering prompt).
+                // Defer the non-manifested card's graveyard move + reveal-marker
+                // cleanup until the manifest finishes entering — otherwise the
+                // other card is graved while the chosen card is still in the
+                // library (issue #3245).
                 crate::game::zone_pipeline::ZoneMoveResult::NeedsChoice(_)
                 | crate::game::zone_pipeline::ZoneMoveResult::NeedsAuraAttachmentChoice => {
                     crate::game::zone_pipeline::defer_completion_on_pause(
@@ -444,7 +449,7 @@ pub(super) fn handle_resolution_choice(
                 }
             }
 
-            // CR 614.6 + CR 701.17a class: route the non-manifested cards to the
+            // CR 614.6 + CR 701.62a class: route the non-manifested cards to the
             // graveyard through the simultaneous-move batch so each card's own
             // `Moved` redirects (Rest in Peace / Leyline of the Void: "would be
             // put into a graveyard from anywhere → exile instead") fire — a raw

--- a/crates/engine/src/game/morph.rs
+++ b/crates/engine/src/game/morph.rs
@@ -259,10 +259,13 @@ pub fn turn_face_up(
 /// 2. Moves it to the battlefield
 /// 3. Applies face-down 2/2 creature overrides
 /// 4. Stores originals in `back_face` for later turn-face-up
+///
+/// `source_id` is the spell or ability source responsible for the manifest entry.
 pub fn manifest_card(
     state: &mut GameState,
     _player: PlayerId,
     object_id: ObjectId,
+    source_id: ObjectId,
     profile: crate::types::ability::FaceDownProfile,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
@@ -288,7 +291,7 @@ pub fn manifest_card(
     // resumes face down with nothing left for this helper to do.
     match super::zone_pipeline::move_object(
         state,
-        super::zone_pipeline::ZoneMoveRequest::effect(object_id, Zone::Battlefield, object_id)
+        super::zone_pipeline::ZoneMoveRequest::effect(object_id, Zone::Battlefield, source_id)
             .face_down(profile),
         events,
     ) {
@@ -343,6 +346,7 @@ pub fn manifest(
         state,
         player,
         object_id,
+        object_id,
         crate::types::ability::FaceDownProfile::vanilla_2_2(),
         events,
     )
@@ -360,6 +364,7 @@ pub fn cloak(
     manifest_card(
         state,
         player,
+        object_id,
         object_id,
         crate::types::ability::FaceDownProfile::cloaked_2_2(),
         events,

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -36,7 +36,10 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
     }
 
     let (manifest_dread_visible, manifest_dread_cards): (HashSet<ObjectId>, HashSet<ObjectId>) =
-        if let WaitingFor::ManifestDreadChoice { player, ref cards } = filtered.waiting_for {
+        if let WaitingFor::ManifestDreadChoice {
+            player, ref cards, ..
+        } = filtered.waiting_for
+        {
             let all_cards: HashSet<ObjectId> = cards.iter().copied().collect();
             if can_view_private_for_player(player) {
                 (all_cards.clone(), all_cards)
@@ -249,11 +252,17 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         }
     }
 
-    if let WaitingFor::ManifestDreadChoice { player, ref cards } = state.waiting_for {
+    if let WaitingFor::ManifestDreadChoice {
+        player,
+        ref cards,
+        source_id,
+    } = state.waiting_for
+    {
         if !can_view_private_for_player(player) {
             filtered.waiting_for = WaitingFor::ManifestDreadChoice {
                 player,
                 cards: cards.iter().map(|_| ObjectId(0)).collect(),
+                source_id,
             };
         }
     }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3044,6 +3044,7 @@ pub enum WaitingFor {
     ManifestDreadChoice {
         player: PlayerId,
         cards: Vec<ObjectId>,
+        source_id: ObjectId,
     },
     TriggerTargetSelection {
         player: PlayerId,
@@ -7602,6 +7603,7 @@ mod tests {
         assert!(!WaitingFor::ManifestDreadChoice {
             player: PlayerId(0),
             cards: vec![],
+            source_id: ObjectId(1),
         }
         .accepts_freeform_card_selection());
     }

--- a/crates/engine/tests/integration/issue_1018_manifest_dread_choice.rs
+++ b/crates/engine/tests/integration/issue_1018_manifest_dread_choice.rs
@@ -52,7 +52,7 @@ fn manifest_dread_prompts_for_top_two_library_cards() {
         runner.state().waiting_for
     );
 
-    let WaitingFor::ManifestDreadChoice { player, cards } = runner.state().waiting_for.clone()
+    let WaitingFor::ManifestDreadChoice { player, cards, .. } = runner.state().waiting_for.clone()
     else {
         unreachable!();
     };

--- a/crates/engine/tests/integration/issue_3245_abhorrent_oculus_manifest_dread.rs
+++ b/crates/engine/tests/integration/issue_3245_abhorrent_oculus_manifest_dread.rs
@@ -1,0 +1,184 @@
+//! Issue #3245 — Abhorrent Oculus manifest dread must manifest the chosen card
+//! to the battlefield and grave the other looked-at card.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, ReplacementDefinition, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::{ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::Zone;
+
+const ABHORRENT_OCULUS_ORACLE: &str =
+    "Flying\nAt the beginning of each opponent's upkeep, manifest dread.";
+
+const MANIFEST_DREAD_ORACLE: &str = "Manifest dread.";
+
+fn enter_tapped_battlefield_replacement(description: &str) -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(Zone::Battlefield)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::SetTapState {
+                target: TargetFilter::SelfRef,
+                scope: engine::types::ability::EffectScope::Single,
+                state: engine::types::ability::TapStateChange::Tap,
+            },
+        ))
+        .description(description.to_string())
+}
+
+fn advance_to_manifest_dread_choice(runner: &mut GameRunner) {
+    for _ in 0..240 {
+        match &runner.state().waiting_for {
+            WaitingFor::ManifestDreadChoice { .. } => return,
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declare no attackers");
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("declare no blockers");
+            }
+            _ => return,
+        }
+    }
+}
+
+#[test]
+fn abhorrent_oculus_manifest_dread_manifests_choice_and_graves_other() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    for &pid in &[P0, P1] {
+        scenario.with_library_top(pid, &["Lib A", "Lib B", "Lib C", "Lib D", "Lib E"]);
+    }
+    scenario
+        .add_creature_from_oracle(P0, "Abhorrent Oculus", 5, 5, ABHORRENT_OCULUS_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 2,
+            shards: vec![ManaCostShard::Blue],
+        });
+    scenario.add_card_to_library_top(P0, "Library Top");
+    scenario.add_card_to_library_top(P0, "Second Top");
+
+    let mut runner = scenario.build();
+    let lib = runner.state().players[0].library.clone();
+    let [top, second] = [lib[0], lib[1]];
+
+    advance_to_manifest_dread_choice(&mut runner);
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::ManifestDreadChoice { .. }
+        ),
+        "opponent-upkeep manifest dread must pause for choice, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![top] })
+        .expect("choose card to manifest");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&top].zone,
+        Zone::Battlefield,
+        "chosen card must manifest onto the battlefield"
+    );
+    assert!(
+        runner.state().objects[&top].face_down,
+        "manifested card must be face down on the battlefield"
+    );
+    assert_eq!(
+        runner.state().objects[&second].zone,
+        Zone::Graveyard,
+        "other looked-at card must go to the graveyard"
+    );
+    assert!(
+        !runner.state().objects[&second].face_down,
+        "graveyard card must be face up in the public zone"
+    );
+}
+
+#[test]
+fn manifest_dread_defers_graveyard_until_paused_manifest_entry_resolves() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let other = scenario.add_card_to_library_top(P0, "Other Card");
+    let manifest = scenario.add_card_to_library_top(P0, "Manifest Me");
+    scenario
+        .add_creature(P1, "Kismet", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(enter_tapped_battlefield_replacement(
+            "Creatures enter the battlefield tapped.",
+        ));
+    scenario
+        .add_creature(P1, "Frozen Aether", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(enter_tapped_battlefield_replacement(
+            "Permanents enter the battlefield tapped.",
+        ));
+    let spell = scenario
+        .add_spell_to_hand(P0, "Dread Test", false)
+        .from_oracle_text(MANIFEST_DREAD_ORACLE)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    scenario.with_mana_pool(P0, vec![]);
+
+    let mut runner = scenario.build();
+    runner.cast(spell).resolve();
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![manifest],
+        })
+        .expect("choose card to manifest");
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ),
+        "manifest entry must pause on enter-tapped collision, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        runner.state().objects[&other].zone,
+        Zone::Library,
+        "the non-manifested card must not be graved while manifest entry is paused"
+    );
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("answer enter-tapped ordering");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&manifest].zone,
+        Zone::Battlefield,
+        "chosen card must finish manifesting onto the battlefield"
+    );
+    assert!(
+        runner.state().objects[&manifest].face_down,
+        "manifested card must be face down on the battlefield"
+    );
+    assert_eq!(
+        runner.state().objects[&other].zone,
+        Zone::Graveyard,
+        "other looked-at card must go to the graveyard after manifest completes"
+    );
+}

--- a/crates/engine/tests/integration/issue_3245_abhorrent_oculus_manifest_dread.rs
+++ b/crates/engine/tests/integration/issue_3245_abhorrent_oculus_manifest_dread.rs
@@ -66,12 +66,13 @@ fn abhorrent_oculus_manifest_dread_manifests_choice_and_graves_other() {
     for &pid in &[P0, P1] {
         scenario.with_library_top(pid, &["Lib A", "Lib B", "Lib C", "Lib D", "Lib E"]);
     }
-    scenario
+    let oculus = scenario
         .add_creature_from_oracle(P0, "Abhorrent Oculus", 5, 5, ABHORRENT_OCULUS_ORACLE)
         .with_mana_cost(ManaCost::Cost {
             generic: 2,
             shards: vec![ManaCostShard::Blue],
-        });
+        })
+        .id();
     scenario.add_card_to_library_top(P0, "Library Top");
     scenario.add_card_to_library_top(P0, "Second Top");
 
@@ -112,6 +113,11 @@ fn abhorrent_oculus_manifest_dread_manifests_choice_and_graves_other() {
     assert!(
         !runner.state().objects[&second].face_down,
         "graveyard card must be face up in the public zone"
+    );
+    assert_eq!(
+        runner.state().objects[&top].entered_via_ability_source,
+        Some(oculus),
+        "manifest dread entry must be attributed to the resolving ability source"
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -210,6 +210,7 @@ mod issue_2940_krark_thumbless;
 mod issue_2941_vivien_reid;
 mod issue_2943_kayas_wrath;
 mod issue_3127_reveal_otherwise_graveyard;
+mod issue_3245_abhorrent_oculus_manifest_dread;
 mod issue_3320_peregrine_drake_untap_prompt;
 mod issue_3321_volcanic_spite_optional;
 mod issue_3322_airbend_owner_cast;

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -1267,7 +1267,7 @@ fn choosable_objects(waiting_for: &WaitingFor, viewer: PlayerId) -> HashSet<Obje
         | WaitingFor::ChooseFromZoneChoice { player, cards, .. }
         | WaitingFor::EffectZoneChoice { player, cards, .. }
         | WaitingFor::DrawnThisTurnTopdeckChoice { player, cards, .. }
-        | WaitingFor::ManifestDreadChoice { player, cards }
+        | WaitingFor::ManifestDreadChoice { player, cards, .. }
         | WaitingFor::WardDiscardChoice { player, cards, .. }
         | WaitingFor::ConniveDiscard { player, cards, .. }
         | WaitingFor::PairChoice {

--- a/crates/server-core/src/filter.rs
+++ b/crates/server-core/src/filter.rs
@@ -272,6 +272,7 @@ mod tests {
         state.waiting_for = WaitingFor::ManifestDreadChoice {
             player: p0,
             cards: vec![card_a, card_b],
+            source_id: ObjectId(99),
         };
         state.revealed_cards.insert(card_a);
         state.revealed_cards.insert(card_b);


### PR DESCRIPTION
## Summary
- When manifest dread's chosen card pauses on a CR 616.1 battlefield-entry prompt (enter-tapped replacement collision, aura host pick), defer sending the other looked-at card to the graveyard until manifest entry completes.
- Add integration coverage for Abhorrent Oculus upkeep manifest dread and for the paused-entry deferral path.

Fixes #3245

## Test plan
- [x] `cargo test -p engine --test integration issue_3245`
- [x] `cargo clippy -p engine -- -D warnings`
- [x] `./scripts/check-parser-combinators.sh upstream/main`

Made with [Cursor](https://cursor.com)