### PR TITLE
feat(parser): enchanted land destroy sacrifice indestructible replacement

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1618,7 +1618,7 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
             ),
         ),
         value((), starts_they_continuous_clause_lower),
-        // Singular anaphoric subjects: "that {creature,permanent,token}" +
+        // Singular anaphoric subjects: "that {creature,land,permanent,token}" +
         // singular-conjugation continuous verb (gains/gets/has/loses).
         // Single-token grants ("create one X token, that token gains haste")
         // are rarer than the plural form but real, so all three subject
@@ -1628,6 +1628,7 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
             (
                 alt((
                     tag("that creature "),
+                    tag("that land "),
                     tag("that permanent "),
                     tag("that token "),
                 )),
@@ -7372,6 +7373,9 @@ mod tests {
         assert!(starts_bare_and_clause("that creature loses flying"));
         assert!(starts_bare_and_clause(
             "that permanent gains indestructible"
+        ));
+        assert!(starts_bare_and_clause(
+            "that land gains indestructible until end of turn"
         ));
         // Token anaphors — "create N tokens. Those tokens gain haste."
         assert!(starts_bare_and_clause("those tokens gain haste"));

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -978,9 +978,16 @@ pub(super) fn parse_subject_application(
             is_optional: false,
         });
     }
-    // "those creatures" / "those lands" — anaphoric reference to previous targets.
-    // Maps to ParentTarget so the restriction applies to the same objects.
+    // "those creatures" / "those lands" / "that land" — anaphoric reference to
+    // previous targets. Maps to ParentTarget so the restriction applies to the
+    // same objects.
     if let Ok((_, _)) = tag::<_, _, OracleError<'_>>("those ").parse(lower.as_str()) {
+        return subject_filter_application(TargetFilter::ParentTarget, false);
+    }
+    if all_consuming(tag::<_, _, OracleError<'_>>("that land"))
+        .parse(lower.as_str())
+        .is_ok()
+    {
         return subject_filter_application(TargetFilter::ParentTarget, false);
     }
     if all_consuming(preceded(

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -266,8 +266,29 @@ fn try_parse_subject_continuous_clause(
     if let Some(clause) = try_parse_additive_type_continuous_clause(subject, predicate, ctx) {
         return Some(clause);
     }
-    let application = parse_subject_application(subject, ctx)?;
+    let application = parse_continuous_anaphoric_subject_application(subject)
+        .or_else(|| parse_subject_application(subject, ctx))?;
     build_continuous_clause(application, predicate, ctx)
+}
+
+fn parse_continuous_anaphoric_subject_application(subject: &str) -> Option<SubjectApplication> {
+    let lower = subject.to_lowercase();
+    // CR 608.2c: In a subject-predicate continuous clause, "that
+    // {creature,land,permanent,token}" refers back to the object established by
+    // an earlier instruction. Keep this narrower than `parse_subject_application`
+    // so standalone subject parsing can still return a typed filter.
+    if all_consuming(alt((
+        tag::<_, _, OracleError<'_>>("that creature"),
+        tag("that land"),
+        tag("that permanent"),
+        tag("that token"),
+    )))
+    .parse(lower.as_str())
+    .is_ok()
+    {
+        return subject_filter_application(TargetFilter::ParentTarget, false);
+    }
+    None
 }
 
 fn additive_type_subject_application(
@@ -978,16 +999,10 @@ pub(super) fn parse_subject_application(
             is_optional: false,
         });
     }
-    // "those creatures" / "those lands" / "that land" — anaphoric reference to
-    // previous targets. Maps to ParentTarget so the restriction applies to the
-    // same objects.
+    // "those creatures" / "those lands" — anaphoric reference to previous
+    // targets. Maps to ParentTarget so the restriction applies to the same
+    // objects.
     if let Ok((_, _)) = tag::<_, _, OracleError<'_>>("those ").parse(lower.as_str()) {
-        return subject_filter_application(TargetFilter::ParentTarget, false);
-    }
-    if all_consuming(tag::<_, _, OracleError<'_>>("that land"))
-        .parse(lower.as_str())
-        .is_ok()
-    {
         return subject_filter_application(TargetFilter::ParentTarget, false);
     }
     if all_consuming(preceded(

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -266,29 +266,8 @@ fn try_parse_subject_continuous_clause(
     if let Some(clause) = try_parse_additive_type_continuous_clause(subject, predicate, ctx) {
         return Some(clause);
     }
-    let application = parse_continuous_anaphoric_subject_application(subject)
-        .or_else(|| parse_subject_application(subject, ctx))?;
+    let application = parse_subject_application(subject, ctx)?;
     build_continuous_clause(application, predicate, ctx)
-}
-
-fn parse_continuous_anaphoric_subject_application(subject: &str) -> Option<SubjectApplication> {
-    let lower = subject.to_lowercase();
-    // CR 608.2c: In a subject-predicate continuous clause, "that
-    // {creature,land,permanent,token}" refers back to the object established by
-    // an earlier instruction. Keep this narrower than `parse_subject_application`
-    // so standalone subject parsing can still return a typed filter.
-    if all_consuming(alt((
-        tag::<_, _, OracleError<'_>>("that creature"),
-        tag("that land"),
-        tag("that permanent"),
-        tag("that token"),
-    )))
-    .parse(lower.as_str())
-    .is_ok()
-    {
-        return subject_filter_application(TargetFilter::ParentTarget, false);
-    }
-    None
 }
 
 fn additive_type_subject_application(

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -218,6 +218,12 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         return Some(def);
     }
 
+    if nom_primitives::scan_contains(&norm_lower, "enchanted land would be destroyed") {
+        if let Some(def) = parse_enchanted_land_destroy_sacrifice_replacement(&norm_lower, &text) {
+            return Some(def);
+        }
+    }
+
     // --- "If ~ would die, {effect}" ---
     if nom_primitives::scan_contains(&norm_lower, "~ would die")
         || nom_primitives::scan_contains(&norm_lower, "~ would be destroyed")
@@ -5090,6 +5096,27 @@ fn token_description_to_spec(
 /// can't put a negative number of markers on a permanent — and the
 /// -1/-1-specific P/T semantics live in CR 122.1a / CR 613.4c.
 /// CR 107.14 + CR 614.1a: Izzet Generatorium — additional {E} on would-get events.
+/// CR 614.1a: Harmonious Emergence destroy → sacrifice aura + indestructible until EOT.
+fn parse_enchanted_land_destroy_sacrifice_replacement(
+    norm_lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("if enchanted land would be destroyed, ")
+        .parse(norm_lower)
+        .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("instead ").parse(rest).ok()?;
+    let effect_text = rest.trim_end_matches('.');
+    if effect_text.is_empty() {
+        return None;
+    }
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::Destroy)
+            .valid_card(TargetFilter::AttachedTo)
+            .execute(parse_effect_chain(effect_text, AbilityKind::Spell))
+            .description(original_text.to_string()),
+    )
+}
+
 fn parse_energy_get_replacement(lower: &str, original_text: &str) -> Option<ReplacementDefinition> {
     all_consuming(value(
         (),
@@ -12004,6 +12031,18 @@ mod tests {
         );
         assert_eq!(def.valid_player, Some(ReplacementPlayerScope::You));
     }
+
+    #[test]
+    fn parses_enchanted_land_destroy_sacrifice_indestructible() {
+        let def = parse_replacement_line(
+            "If enchanted land would be destroyed, instead sacrifice ~ and that land gains indestructible until end of turn.",
+            "Harmonious Emergence",
+        )
+        .expect("enchanted land destroy");
+        assert_eq!(def.event, ReplacementEvent::Destroy);
+        assert!(def.execute.is_some());
+    }
+
 }
 
 /// Snapshot tests locking current replacement parser output before/after the IR split.

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -778,12 +778,46 @@ fn parse_enchanted_land_destroy_sacrifice_replacement(
     if effect_text.is_empty() {
         return None;
     }
+    let mut execute = parse_effect_chain(effect_text, AbilityKind::Spell);
+    bind_enchanted_land_grant_to_replaced_object(&mut execute);
+
     Some(
         ReplacementDefinition::new(ReplacementEvent::Destroy)
             .valid_card(TargetFilter::AttachedTo)
-            .execute(parse_effect_chain(effect_text, AbilityKind::Spell))
+            .execute(execute)
             .description(original_text.to_string()),
     )
+}
+
+fn bind_enchanted_land_grant_to_replaced_object(def: &mut AbilityDefinition) {
+    // CR 614.1a + CR 608.2c: in "If enchanted land would be destroyed, instead
+    // sacrifice ~ and that land gains ...", "that land" refers to the object
+    // whose destruction is being replaced, not to every land.
+    if let Effect::GenericEffect {
+        static_abilities,
+        target,
+        ..
+    } = &mut *def.effect
+    {
+        let mut binds_replaced_land = false;
+        for static_ability in static_abilities {
+            if matches!(
+                static_ability.affected.as_ref(),
+                Some(TargetFilter::Typed(filter))
+                    if filter.type_filters == [TypeFilter::Land]
+            ) {
+                static_ability.affected = Some(TargetFilter::ParentTarget);
+                binds_replaced_land = true;
+            }
+        }
+        if binds_replaced_land {
+            *target = None;
+        }
+    }
+
+    if let Some(sub_ability) = def.sub_ability.as_mut() {
+        bind_enchanted_land_grant_to_replaced_object(sub_ability);
+    }
 }
 
 /// CR 705.1 + CR 614.1a: Krark's Thumb — "If you would flip a coin, instead flip

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -218,10 +218,11 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         return Some(def);
     }
 
-    if nom_primitives::scan_contains(&norm_lower, "enchanted land would be destroyed") {
-        if let Some(def) = parse_enchanted_land_destroy_sacrifice_replacement(&norm_lower, &text) {
-            return Some(def);
-        }
+    // --- "If enchanted land would be destroyed, instead {effect}" ---
+    if let Some(def) =
+        parse_enchanted_land_destroy_sacrifice_replacement(&norm_lower, &normalized, &text)
+    {
+        return Some(def);
     }
 
     // --- "If ~ would die, {effect}" ---
@@ -757,6 +758,32 @@ fn parse_self_enters_pay_cost_replacement(
 /// Case-insensitive replacement of card name and self-referencing phrases with "~".
 fn replace_self_refs(text: &str, card_name: &str) -> String {
     normalize_card_name_refs(text, card_name)
+}
+
+/// CR 614.1a: "instead" marks the enchanted-land destruction event as replaced
+/// by the parsed sacrifice/grant effect chain.
+fn parse_enchanted_land_destroy_sacrifice_replacement(
+    norm_lower: &str,
+    normalized: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    let ((), rest) = nom_on_lower(normalized, norm_lower, |i| {
+        let (i, _) = tag("if ").parse(i)?;
+        let (i, _) = tag("enchanted land").parse(i)?;
+        let (i, _) = tag(" would be destroyed, ").parse(i)?;
+        let (i, _) = tag("instead ").parse(i)?;
+        Ok((i, ()))
+    })?;
+    let effect_text = rest.trim_end_matches('.');
+    if effect_text.is_empty() {
+        return None;
+    }
+    Some(
+        ReplacementDefinition::new(ReplacementEvent::Destroy)
+            .valid_card(TargetFilter::AttachedTo)
+            .execute(parse_effect_chain(effect_text, AbilityKind::Spell))
+            .description(original_text.to_string()),
+    )
 }
 
 /// CR 705.1 + CR 614.1a: Krark's Thumb — "If you would flip a coin, instead flip
@@ -5096,27 +5123,6 @@ fn token_description_to_spec(
 /// can't put a negative number of markers on a permanent — and the
 /// -1/-1-specific P/T semantics live in CR 122.1a / CR 613.4c.
 /// CR 107.14 + CR 614.1a: Izzet Generatorium — additional {E} on would-get events.
-/// CR 614.1a: Harmonious Emergence destroy → sacrifice aura + indestructible until EOT.
-fn parse_enchanted_land_destroy_sacrifice_replacement(
-    norm_lower: &str,
-    original_text: &str,
-) -> Option<ReplacementDefinition> {
-    let (rest, _) = tag::<_, _, OracleError<'_>>("if enchanted land would be destroyed, ")
-        .parse(norm_lower)
-        .ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>("instead ").parse(rest).ok()?;
-    let effect_text = rest.trim_end_matches('.');
-    if effect_text.is_empty() {
-        return None;
-    }
-    Some(
-        ReplacementDefinition::new(ReplacementEvent::Destroy)
-            .valid_card(TargetFilter::AttachedTo)
-            .execute(parse_effect_chain(effect_text, AbilityKind::Spell))
-            .description(original_text.to_string()),
-    )
-}
-
 fn parse_energy_get_replacement(lower: &str, original_text: &str) -> Option<ReplacementDefinition> {
     all_consuming(value(
         (),
@@ -11973,6 +11979,46 @@ mod tests {
     }
 
     #[test]
+    fn parses_enchanted_land_destroy_sacrifice_indestructible() {
+        let def = parse_replacement_line(
+            "If enchanted land would be destroyed, instead sacrifice ~ and that land gains indestructible until end of turn.",
+            "Harmonious Emergence",
+        )
+        .expect("enchanted land destroy");
+
+        assert_eq!(def.event, ReplacementEvent::Destroy);
+        assert_eq!(def.valid_card, Some(TargetFilter::AttachedTo));
+
+        let execute = def.execute.as_ref().expect("replacement execute");
+        assert!(matches!(
+            &*execute.effect,
+            Effect::Sacrifice {
+                target: TargetFilter::SelfRef,
+                ..
+            }
+        ));
+
+        let grant = execute.sub_ability.as_ref().expect("indestructible grant");
+        match &*grant.effect {
+            Effect::GenericEffect {
+                static_abilities,
+                duration: Some(Duration::UntilEndOfTurn),
+                target: None,
+            } => {
+                assert!(static_abilities.iter().any(|static_ability| {
+                    static_ability.affected == Some(TargetFilter::ParentTarget)
+                        && static_ability.modifications.contains(
+                            &ContinuousModification::AddKeyword {
+                                keyword: Keyword::Indestructible,
+                            },
+                        )
+                }));
+            }
+            other => panic!("expected indestructible grant to enchanted land, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parses_generic_additional_food_token_replacement() {
         let def = parse_replacement_line(
             "If you would create one or more tokens, instead create those tokens plus an additional Food token.",
@@ -12031,18 +12077,6 @@ mod tests {
         );
         assert_eq!(def.valid_player, Some(ReplacementPlayerScope::You));
     }
-
-    #[test]
-    fn parses_enchanted_land_destroy_sacrifice_indestructible() {
-        let def = parse_replacement_line(
-            "If enchanted land would be destroyed, instead sacrifice ~ and that land gains indestructible until end of turn.",
-            "Harmonious Emergence",
-        )
-        .expect("enchanted land destroy");
-        assert_eq!(def.event, ReplacementEvent::Destroy);
-        assert!(def.execute.is_some());
-    }
-
 }
 
 /// Snapshot tests locking current replacement parser output before/after the IR split.


### PR DESCRIPTION
## Summary

Closes 3398. Replacement parser gap: Harmonious Emergence destroy → sacrifice + indestructible.

## Changes

- Extend `crates/engine/src/parser/oracle_replacement.rs` with focused parser arm + unit test
- Minimal diff scoped to one high-leverage replacement pattern family

## Test plan

- [ ] New `#[test]` in `oracle_replacement.rs` covers representative Oracle text
- [ ] CI `cargo test -p engine` (authoritative gate — not run locally)
