### PR TITLE
fix(parser): Compound continuous-modification static '+N/+N and can't be blocked unless ...' drops t

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -4604,6 +4604,195 @@ mod tests {
         assert!(can_block_pair(&state, blocker, attacker));
     }
 
+    /// CR 509.1b + CR 506.2 + CR 108.3: An Aura-style `CantBeBlocked` gated on
+    /// `Not(RecipientAttackingOwnerTarget { OwnerOrPlaneswalker })` (Become the
+    /// Pilot) — attached to a creature OWNED by B but CONTROLLED by A. The
+    /// creature is unblockable when attacking anyone except its owner B (or a
+    /// permanent B controls). Exercises the owner-vs-controller distinction.
+    #[test]
+    fn cant_be_blocked_unless_attacking_owner_reads_owner_not_controller() {
+        use crate::types::ability::{
+            FilterProp, StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
+        };
+        use crate::types::triggers::AttackTargetFilter;
+
+        // Player B (1) owns the creature; player A (0) controls it (donated).
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(1), "Donated Beater", 4, 4);
+        {
+            let obj = state.objects.get_mut(&attacker).unwrap();
+            obj.controller = PlayerId(0); // owner B, controller A
+        }
+        // Blocker controlled by the defending player (the creature's owner B).
+        let blocker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+
+        // Aura granting the conditional-evasion static, attached to the attacker.
+        let aura = create_creature(&mut state, PlayerId(0), "Become the Pilot", 0, 0);
+        {
+            let obj = state.objects.get_mut(&aura).unwrap();
+            obj.attached_to = Some(attacker.into());
+            obj.static_definitions.push(
+                StaticDefinition::new(StaticMode::CantBeBlocked)
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                    .condition(StaticCondition::Not {
+                        condition: Box::new(StaticCondition::RecipientAttackingOwnerTarget {
+                            target: AttackTargetFilter::OwnerOrPlaneswalker,
+                        }),
+                    }),
+            );
+        }
+
+        // 1) Attacking a third party (defending player A's own ally seat is N/A
+        //    in 2p, so attack a player who is NOT the owner): unblockable.
+        //    Owner is B(1); attack player A(0) (not the owner) → exception not met
+        //    → Not(false) = true → CantBeBlocked active.
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(0))],
+            ..Default::default()
+        });
+        assert!(
+            !can_block_pair(&state, blocker, attacker),
+            "attacking a non-owner player → unblockable"
+        );
+
+        // 2) Attacking its OWNER (player B = 1): exception met → Not(true) = false
+        //    → static inactive → blockable.
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+        assert!(
+            can_block_pair(&state, blocker, attacker),
+            "attacking its owner → blockable"
+        );
+
+        // 3) Attacking a planeswalker CONTROLLED BY THE OWNER (B): "a permanent
+        //    its owner controls" → exception met → blockable.
+        let owner_pw = create_planeswalker(&mut state, PlayerId(1), "Owner's Walker");
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::new(
+                attacker,
+                AttackTarget::Planeswalker(owner_pw),
+                PlayerId(1),
+            )],
+            ..Default::default()
+        });
+        assert!(
+            can_block_pair(&state, blocker, attacker),
+            "attacking a planeswalker its owner controls → blockable"
+        );
+
+        // 4) Attacking a planeswalker controlled by the CONTROLLER (A, not the
+        //    owner): exception NOT met → still unblockable. Guards the
+        //    owner-vs-controller distinction (CR 108.3).
+        let controller_pw = create_planeswalker(&mut state, PlayerId(0), "Controller's Walker");
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::new(
+                attacker,
+                AttackTarget::Planeswalker(controller_pw),
+                PlayerId(0),
+            )],
+            ..Default::default()
+        });
+        assert!(
+            !can_block_pair(&state, blocker, attacker),
+            "attacking a planeswalker the CONTROLLER (not owner) controls → unblockable"
+        );
+    }
+
+    /// CR 509.1b + CR 506.2: The bare `Owner` parameter only matches a direct
+    /// attack on the owning player, not a permanent the owner controls.
+    #[test]
+    fn cant_be_blocked_unless_attacking_owner_bare_player_only() {
+        use crate::types::ability::{
+            FilterProp, StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
+        };
+        use crate::types::triggers::AttackTargetFilter;
+
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(1), "Donated Beater", 4, 4);
+        state.objects.get_mut(&attacker).unwrap().controller = PlayerId(0);
+        let blocker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+
+        let aura = create_creature(&mut state, PlayerId(0), "Bare Owner Aura", 0, 0);
+        {
+            let obj = state.objects.get_mut(&aura).unwrap();
+            obj.attached_to = Some(attacker.into());
+            obj.static_definitions.push(
+                StaticDefinition::new(StaticMode::CantBeBlocked)
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                    .condition(StaticCondition::Not {
+                        condition: Box::new(StaticCondition::RecipientAttackingOwnerTarget {
+                            target: AttackTargetFilter::Owner,
+                        }),
+                    }),
+            );
+        }
+
+        // Attacking the owner directly → blockable.
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+        assert!(can_block_pair(&state, blocker, attacker));
+
+        // Attacking a planeswalker the owner controls → bare Owner does NOT
+        // match a permanent → exception not met → still unblockable.
+        let owner_pw = create_planeswalker(&mut state, PlayerId(1), "Owner's Walker");
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::new(
+                attacker,
+                AttackTarget::Planeswalker(owner_pw),
+                PlayerId(1),
+            )],
+            ..Default::default()
+        });
+        assert!(
+            !can_block_pair(&state, blocker, attacker),
+            "bare Owner must not match owner-controlled permanents"
+        );
+    }
+
+    /// CR 509.1b: No combat / not-an-attacker → the positive condition is
+    /// `false`, so the `Not` makes the creature unblockable (defensive default).
+    #[test]
+    fn cant_be_blocked_unless_attacking_owner_no_combat_is_unblockable() {
+        use crate::types::ability::{
+            FilterProp, StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
+        };
+        use crate::types::triggers::AttackTargetFilter;
+
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(1), "Donated Beater", 4, 4);
+        state.objects.get_mut(&attacker).unwrap().controller = PlayerId(0);
+        let blocker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+
+        let aura = create_creature(&mut state, PlayerId(0), "Evasion Aura", 0, 0);
+        {
+            let obj = state.objects.get_mut(&aura).unwrap();
+            obj.attached_to = Some(attacker.into());
+            obj.static_definitions.push(
+                StaticDefinition::new(StaticMode::CantBeBlocked)
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                    .condition(StaticCondition::Not {
+                        condition: Box::new(StaticCondition::RecipientAttackingOwnerTarget {
+                            target: AttackTargetFilter::OwnerOrPlaneswalker,
+                        }),
+                    }),
+            );
+        }
+
+        // No combat state at all → not attacking → exception not met → unblockable.
+        assert!(state.combat.is_none());
+        assert!(!can_block_pair(&state, blocker, attacker));
+    }
+
     /// CR 509.1b: Detaching the Equipment must restore blockability — the
     /// global scan's `affected` filter no longer matches the attacker.
     #[test]

--- a/crates/engine/src/game/conditions.rs
+++ b/crates/engine/src/game/conditions.rs
@@ -4,11 +4,13 @@
 //! `layers.rs` (StaticCondition), `triggers.rs` (TriggerCondition),
 //! `effects/mod.rs` (AbilityCondition), and `replacement.rs` (ReplacementCondition).
 
+use crate::game::combat::AttackTarget;
 use crate::game::game_object::GameObject;
 use crate::types::counter::CounterMatch;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
+use crate::types::triggers::AttackTargetFilter;
 use crate::types::zones::Zone;
 
 /// CR 122.1: True when `obj` has at least `minimum` (and at most `maximum` if specified)
@@ -80,6 +82,59 @@ pub(crate) fn eval_source_is_attacking(state: &GameState, source_id: ObjectId) -
         .combat
         .as_ref()
         .is_some_and(|combat| combat.attackers.iter().any(|a| a.object_id == source_id))
+}
+
+/// CR 509.1b + CR 506.2 + CR 108.3: True when the recipient creature
+/// (`attacker_id`, the per-object subject of the gating continuous effect) is
+/// currently attacking a target permitted by `target`, evaluated relative to the
+/// creature's OWNER (CR 108.3), not its controller. Realizes "attacking its
+/// owner [or a permanent its owner controls]" for the conditional-evasion class
+/// (e.g. Become the Pilot). Not attacking → false; no combat → false.
+pub(crate) fn eval_recipient_attacking_owner_target(
+    state: &GameState,
+    attacker_id: ObjectId,
+    target: &AttackTargetFilter,
+) -> bool {
+    let Some(attacker) = state.objects.get(&attacker_id) else {
+        return false;
+    };
+    // CR 108.3: owner != controller — the donate/evasion class hinges on the
+    // OWNER, who may not control the creature.
+    let owner = attacker.owner;
+    let Some(combat) = state.combat.as_ref() else {
+        return false;
+    };
+    let Some(info) = combat.attackers.iter().find(|a| a.object_id == attacker_id) else {
+        // Not an attacking creature → the exception cannot be met.
+        return false;
+    };
+
+    // CR 506.2: a creature attacks a player, a planeswalker they control, or a
+    // battle they protect. "Owner-controlled permanent" therefore resolves to a
+    // planeswalker/battle whose controller is the owner.
+    let attacks_owner_player =
+        || matches!(info.attack_target, AttackTarget::Player(p) if p == owner);
+    let attacks_owner_permanent = || match info.attack_target {
+        AttackTarget::Planeswalker(pw) | AttackTarget::Battle(pw) => {
+            state.objects.get(&pw).map(|o| o.controller) == Some(owner)
+        }
+        AttackTarget::Player(_) => false,
+    };
+
+    match target {
+        // Bare "attacking its owner" = attacking the owning player directly.
+        AttackTargetFilter::Owner => attacks_owner_player(),
+        // "its owner or a permanent its owner controls".
+        AttackTargetFilter::OwnerOrPlaneswalker => {
+            attacks_owner_player() || attacks_owner_permanent()
+        }
+        // Not produced by the block-evasion parser path. Kept explicit (no
+        // wildcard) so future widening is compiler-flagged.
+        AttackTargetFilter::Player
+        | AttackTargetFilter::Planeswalker
+        | AttackTargetFilter::PlayerOrPlaneswalker
+        | AttackTargetFilter::Battle => false,
+    }
 }
 
 /// CR 725.1: True when no player holds the monarch designation.

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5759,6 +5759,9 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::CastVariantPaid { .. } => ("CastVariantPaid", Handled),
         StaticCondition::RecipientHasCounters { .. } => ("RecipientHasCounters", Handled),
         StaticCondition::RecipientMatchesFilter { .. } => ("RecipientMatchesFilter", Handled),
+        StaticCondition::RecipientAttackingOwnerTarget { .. } => {
+            ("RecipientAttackingOwnerTarget", Handled)
+        }
         StaticCondition::ClassLevelGE { .. } => ("ClassLevelGE", Handled),
         StaticCondition::DuringYourTurn => ("DuringYourTurn", Handled),
         StaticCondition::DayNightIs { .. } => ("DayNightIs", Handled),

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -5,9 +5,9 @@ use crate::database::synthesis::KeywordTriggerInstaller;
 use crate::game::arithmetic::saturating_pt_add;
 use crate::game::conditions::{
     counter_condition_matches, eval_chosen_label_is, eval_class_level_ge, eval_has_city_blessing,
-    eval_is_initiative, eval_is_monarch, eval_no_monarch, eval_source_entered_this_turn,
-    eval_source_has_dealt_damage, eval_source_in_zone, eval_source_is_attacking,
-    eval_source_is_tapped_on_battlefield,
+    eval_is_initiative, eval_is_monarch, eval_no_monarch, eval_recipient_attacking_owner_target,
+    eval_source_entered_this_turn, eval_source_has_dealt_damage, eval_source_in_zone,
+    eval_source_is_attacking, eval_source_is_tapped_on_battlefield,
 };
 use crate::game::devotion::count_devotion;
 use crate::game::filter::{matches_target_filter, FilterContext};
@@ -547,6 +547,14 @@ fn condition_uses_recipient_context(condition: &StaticCondition) -> bool {
         StaticCondition::Not { condition } => condition_uses_recipient_context(condition),
         StaticCondition::RecipientHasCounters { .. } => true,
         StaticCondition::RecipientMatchesFilter { .. } => true,
+        // CR 509.1b + CR 506.2: the attacking creature (recipient) is the subject
+        // of the owner-attack check, so this MUST route through the recipient-eval
+        // path. The `Not` wrapper above already recurses, so the positive inner
+        // condition is what must report `true`. This match carries a `_ => false`
+        // wildcard, so the compiler will NOT flag an omission here — it is
+        // functionally required: without it `recipient_id` arrives `None`, the
+        // evaluator returns `false`, and the `Not` inverts it to "always blockable".
+        StaticCondition::RecipientAttackingOwnerTarget { .. } => true,
         // CR 110.5b + CR 611.2b: a target/recipient-scoped tap condition must
         // route through the recipient-eval path so the captured `duration_subject`
         // (the copy target) binds — relying on the `_ => false` default would
@@ -628,6 +636,9 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::ClassLevelGE { .. }
         | StaticCondition::SourceAttackingAlone
         | StaticCondition::SourceIsAttacking
+        // CR 509.1b: combat-status gate on the recipient's attack target — per-object
+        // combat state, never board-population-dependent (like `SourceIsAttacking`).
+        | StaticCondition::RecipientAttackingOwnerTarget { .. }
         | StaticCondition::SourceIsBlocking
         | StaticCondition::SourceIsBlocked
         | StaticCondition::IsMonarch
@@ -749,6 +760,9 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::ClassLevelGE { .. }
         | StaticCondition::SourceAttackingAlone
         | StaticCondition::SourceIsAttacking
+        // CR 509.1b: an entering object cannot perturb a per-object combat-status
+        // gate on the recipient's attack target — `false` like `SourceIsAttacking`.
+        | StaticCondition::RecipientAttackingOwnerTarget { .. }
         | StaticCondition::SourceIsBlocking
         | StaticCondition::SourceIsBlocked
         | StaticCondition::IsMonarch
@@ -929,6 +943,13 @@ fn evaluate_condition_with_context(
                     &FilterContext::from_source_with_recipient(state, source_id, id),
                 )
             })
+            .unwrap_or(false),
+        // CR 509.1b + CR 506.2 + CR 108.3: the recipient (the attacking creature
+        // this static gates) is attacking its owner / a permanent its owner
+        // controls. Owner-relative (CR 108.3); no recipient → false (mirrors the
+        // RecipientMatchesFilter defensive default).
+        StaticCondition::RecipientAttackingOwnerTarget { target } => recipient_id
+            .map(|id| eval_recipient_attacking_owner_target(state, id, target))
             .unwrap_or(false),
         // CR 716.2a + CR 716.3: Level abilities are active at or above the specified
         // level. No battlefield zone guard here — the functioning-abilities machinery
@@ -8564,6 +8585,161 @@ mod tests {
             &StaticCondition::SourceIsAttacking,
             PlayerId(0),
             bystander,
+        ));
+    }
+
+    // -- RecipientAttackingOwnerTarget evaluator tests (CR 509.1b / CR 506.2 / CR 108.3) --
+
+    #[test]
+    fn recipient_attacking_owner_target_owner_player_matches_owner() {
+        use crate::game::combat::{AttackerInfo, CombatState};
+        use crate::types::triggers::AttackTargetFilter;
+        let mut state = setup();
+        // Owned by B(1), controlled by A(0).
+        let attacker = make_creature(&mut state, "Donated", 4, 4, PlayerId(1));
+        state.objects.get_mut(&attacker).unwrap().controller = PlayerId(0);
+        let condition = StaticCondition::RecipientAttackingOwnerTarget {
+            target: AttackTargetFilter::Owner,
+        };
+
+        // Attacking its owner (B) → positive condition true.
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+        assert!(evaluate_condition_with_recipient(
+            &state,
+            &condition,
+            PlayerId(0),
+            attacker,
+            attacker,
+        ));
+
+        // Attacking a non-owner player (A) → false.
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(0))],
+            ..Default::default()
+        });
+        assert!(!evaluate_condition_with_recipient(
+            &state,
+            &condition,
+            PlayerId(0),
+            attacker,
+            attacker,
+        ));
+    }
+
+    #[test]
+    fn recipient_attacking_owner_target_or_planeswalker_matches_owner_controlled_pw() {
+        use crate::game::combat::{AttackTarget, AttackerInfo, CombatState};
+        use crate::types::triggers::AttackTargetFilter;
+        let mut state = setup();
+        let attacker = make_creature(&mut state, "Donated", 4, 4, PlayerId(1));
+        state.objects.get_mut(&attacker).unwrap().controller = PlayerId(0);
+        let owner_pw = make_creature(&mut state, "Owner Walker", 0, 4, PlayerId(1));
+        let controller_pw = make_creature(&mut state, "Controller Walker", 0, 4, PlayerId(0));
+        let condition = StaticCondition::RecipientAttackingOwnerTarget {
+            target: AttackTargetFilter::OwnerOrPlaneswalker,
+        };
+
+        // Planeswalker the OWNER (B) controls → true.
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::new(
+                attacker,
+                AttackTarget::Planeswalker(owner_pw),
+                PlayerId(1),
+            )],
+            ..Default::default()
+        });
+        assert!(evaluate_condition_with_recipient(
+            &state,
+            &condition,
+            PlayerId(0),
+            attacker,
+            attacker,
+        ));
+
+        // Planeswalker the CONTROLLER (A, not owner) controls → false (CR 108.3).
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::new(
+                attacker,
+                AttackTarget::Planeswalker(controller_pw),
+                PlayerId(0),
+            )],
+            ..Default::default()
+        });
+        assert!(!evaluate_condition_with_recipient(
+            &state,
+            &condition,
+            PlayerId(0),
+            attacker,
+            attacker,
+        ));
+    }
+
+    #[test]
+    fn recipient_attacking_owner_target_false_when_not_attacking() {
+        use crate::game::combat::CombatState;
+        use crate::types::triggers::AttackTargetFilter;
+        let mut state = setup();
+        let attacker = make_creature(&mut state, "Idle", 4, 4, PlayerId(1));
+        state.objects.get_mut(&attacker).unwrap().controller = PlayerId(0);
+        let condition = StaticCondition::RecipientAttackingOwnerTarget {
+            target: AttackTargetFilter::OwnerOrPlaneswalker,
+        };
+
+        // Combat exists but the creature is not an attacker → false.
+        state.combat = Some(CombatState::default());
+        assert!(!evaluate_condition_with_recipient(
+            &state,
+            &condition,
+            PlayerId(0),
+            attacker,
+            attacker,
+        ));
+    }
+
+    #[test]
+    fn recipient_attacking_owner_target_false_when_no_combat() {
+        use crate::types::triggers::AttackTargetFilter;
+        let mut state = setup();
+        let attacker = make_creature(&mut state, "Idle", 4, 4, PlayerId(1));
+        state.objects.get_mut(&attacker).unwrap().controller = PlayerId(0);
+        let condition = StaticCondition::RecipientAttackingOwnerTarget {
+            target: AttackTargetFilter::Owner,
+        };
+        assert!(state.combat.is_none());
+        assert!(!evaluate_condition_with_recipient(
+            &state,
+            &condition,
+            PlayerId(0),
+            attacker,
+            attacker,
+        ));
+    }
+
+    #[test]
+    fn recipient_attacking_owner_target_false_when_no_recipient() {
+        // CR 509.1b: routing through the source-binding path (recipient_id == None)
+        // must yield false — guards the `condition_uses_recipient_context` arm.
+        use crate::game::combat::{AttackerInfo, CombatState};
+        use crate::types::triggers::AttackTargetFilter;
+        let mut state = setup();
+        let attacker = make_creature(&mut state, "Donated", 4, 4, PlayerId(1));
+        state.objects.get_mut(&attacker).unwrap().controller = PlayerId(0);
+        let condition = StaticCondition::RecipientAttackingOwnerTarget {
+            target: AttackTargetFilter::Owner,
+        };
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+        // No recipient supplied → defensive false, even though attacking owner.
+        assert!(!evaluate_condition_for_test(
+            &state,
+            &condition,
+            PlayerId(0),
+            attacker,
         ));
     }
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2498,6 +2498,9 @@ pub(crate) fn static_condition_to_ability_condition(
         | StaticCondition::ClassLevelGE { .. }
         | StaticCondition::RecipientHasCounters { .. }
         | StaticCondition::RecipientMatchesFilter { .. }
+        // CR 509.1b: recipient-scoped block-evasion gate; no effect-resolution
+        // (`AbilityCondition`) equivalent — lowering returns `None`.
+        | StaticCondition::RecipientAttackingOwnerTarget { .. }
         | StaticCondition::IsRingBearer
         | StaticCondition::SourceInZone { .. }
         | StaticCondition::DefendingPlayerControls { .. }

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -1217,6 +1217,23 @@ fn cant_be_blocked_mode(clause: &str) -> Option<(StaticMode, Option<StaticCondit
         }
         return None;
     }
+    // CR 509.1b: "can't be blocked unless it's attacking its owner [or a
+    // permanent its owner controls]" — conditional evasion gated on the
+    // recipient's attack target relative to its OWNER (CR 108.3). Express as
+    // CantBeBlocked + Not(RecipientAttackingOwnerTarget): unblockable EXCEPT when
+    // attacking owner / owner-controlled permanent. Must precede the generic
+    // "as long as …" condition fallthrough so the "unless" form is classified
+    // explicitly rather than mis-handled by the generic condition parser.
+    if let Some(after) = nom_tag_lower(rest, rest, " unless ") {
+        if let Some(target) = parse_block_unless_attacking_owner_nom(after) {
+            return Some((
+                StaticMode::CantBeBlocked,
+                Some(StaticCondition::Not {
+                    condition: Box::new(StaticCondition::RecipientAttackingOwnerTarget { target }),
+                }),
+            ));
+        }
+    }
     // Bare "can't be blocked".
     if rest.is_empty() {
         return Some((StaticMode::CantBeBlocked, None));
@@ -1225,6 +1242,36 @@ fn cant_be_blocked_mode(clause: &str) -> Option<(StaticMode, Option<StaticCondit
         return Some((StaticMode::CantBeBlocked, Some(condition)));
     }
     None
+}
+
+/// CR 509.1b + CR 506.2 + CR 108.3: classify the "unless it's attacking its
+/// owner [or a permanent its owner controls]" exception following
+/// "can't be blocked". Mirrors the attack-side owner-relative axis
+/// (`parse_cant_attack_rule_static_predicate_nom`). The longer
+/// `OwnerOrPlaneswalker` phrase is ordered before `Owner` (nom `alt` is
+/// leftmost-match). `tag_no_case` handles casing; the split path reconstructs
+/// the clause with an ASCII apostrophe (`try_split_and_cant_be_blocked`), so a
+/// single ASCII-apostrophe arm suffices. Returns `Some` only when the combinator
+/// consumes the whole tail — the parser IS the detector.
+fn parse_block_unless_attacking_owner_nom(
+    input: &str,
+) -> Option<crate::types::triggers::AttackTargetFilter> {
+    use crate::types::triggers::AttackTargetFilter;
+    let (rest, target) = alt((
+        value(
+            AttackTargetFilter::OwnerOrPlaneswalker,
+            tag_no_case::<_, _, OracleError<'_>>(
+                "it's attacking its owner or a permanent its owner controls",
+            ),
+        ),
+        value(
+            AttackTargetFilter::Owner,
+            tag_no_case::<_, _, OracleError<'_>>("it's attacking its owner"),
+        ),
+    ))
+    .parse(input)
+    .ok()?;
+    rest.trim().is_empty().then_some(target)
 }
 
 /// CR 509.1b: Attach a trailing "as long as …" condition to the evasion

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -832,6 +832,134 @@ fn cant_be_blocked_static_split_keeps_trailing_condition() {
     );
 }
 
+/// CR 509.1b + CR 506.2 + CR 108.3: The compound "+N/+N and can't be blocked
+/// unless it's attacking its owner or a permanent its owner controls" must
+/// decompose into BOTH the P/T grant AND a `CantBeBlocked` static whose
+/// condition is `Not(RecipientAttackingOwnerTarget { OwnerOrPlaneswalker })`,
+/// both sharing the enchanted-creature filter. (Become the Pilot.)
+#[test]
+fn cant_be_blocked_static_split_unless_attacking_owner_or_permanent() {
+    use crate::types::triggers::AttackTargetFilter;
+
+    let defs = parse_static_line_multi(
+        "Enchanted creature gets +2/+2 and can't be blocked unless it's attacking its owner or a permanent its owner controls.",
+    );
+
+    // Evasion companion: CantBeBlocked gated on Not(RecipientAttackingOwnerTarget).
+    let evasion = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantBeBlocked)
+        .expect("expected split CantBeBlocked static");
+    assert!(
+        matches!(
+            evasion.condition.as_ref(),
+            Some(StaticCondition::Not { condition })
+                if matches!(
+                    condition.as_ref(),
+                    StaticCondition::RecipientAttackingOwnerTarget {
+                        target: AttackTargetFilter::OwnerOrPlaneswalker
+                    }
+                )
+        ),
+        "expected Not(RecipientAttackingOwnerTarget {{ OwnerOrPlaneswalker }}), got {:?}",
+        evasion.condition
+    );
+
+    // The +2/+2 grant is preserved as a continuous P/T modification.
+    let pt = defs
+        .iter()
+        .find(|d| matches!(d.mode, StaticMode::Continuous))
+        .expect("P/T grant must be preserved");
+    assert!(
+        pt.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddPower { value: 2 }
+                | ContinuousModification::AddToughness { value: 2 }
+        )),
+        "expected AddPower(2)/AddToughness(2), got {:?}",
+        pt.modifications
+    );
+
+    // Both statics share the same EnchantedBy-creature affected filter.
+    let enchanted_by = |d: &StaticDefinition| {
+        matches!(
+            &d.affected,
+            Some(TargetFilter::Typed(TypedFilter { properties, .. }))
+                if properties.contains(&FilterProp::EnchantedBy)
+        )
+    };
+    assert!(
+        enchanted_by(evasion) && enchanted_by(pt),
+        "both statics must share the EnchantedBy filter"
+    );
+
+    // No condition was dropped into an Unrecognized/None bucket.
+    assert!(
+        !defs
+            .iter()
+            .any(|d| matches!(d.condition, Some(StaticCondition::Unrecognized { .. }))),
+        "no Unrecognized condition should be emitted, got {:?}",
+        defs.iter().map(|d| &d.condition).collect::<Vec<_>>()
+    );
+}
+
+/// CR 509.1b + CR 506.2: The bare "unless it's attacking its owner" form (no
+/// "or a permanent its owner controls" tail) yields the `Owner` parameter.
+#[test]
+fn cant_be_blocked_static_split_unless_attacking_owner_bare() {
+    use crate::types::triggers::AttackTargetFilter;
+
+    let defs = parse_static_line_multi(
+        "Enchanted creature gets +2/+2 and can't be blocked unless it's attacking its owner.",
+    );
+    let evasion = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantBeBlocked)
+        .expect("expected split CantBeBlocked static");
+    assert!(
+        matches!(
+            evasion.condition.as_ref(),
+            Some(StaticCondition::Not { condition })
+                if matches!(
+                    condition.as_ref(),
+                    StaticCondition::RecipientAttackingOwnerTarget {
+                        target: AttackTargetFilter::Owner
+                    }
+                )
+        ),
+        "expected Not(RecipientAttackingOwnerTarget {{ Owner }}), got {:?}",
+        evasion.condition
+    );
+}
+
+/// CR 509.1b: Negative guard — an unrelated "unless" tail must NOT be stolen by
+/// the new owner-attack arm; the "as long as" condition path still wins for the
+/// Gate condition card, so the new arm returns `None` for non-owner tails.
+#[test]
+fn cant_be_blocked_unless_owner_arm_does_not_steal_other_conditions() {
+    // The "as long as you control a Gate" condition still classifies via its own
+    // arm — proving the owner-attack arm is scoped to its exact phrase.
+    let defs = parse_static_line_multi(
+        "Enchanted creature gets +2/+2 and can't be blocked as long as you control a Gate.",
+    );
+    let evasion = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantBeBlocked)
+        .expect("expected split CantBeBlocked static");
+    assert!(
+        !matches!(
+            evasion.condition.as_ref(),
+            Some(StaticCondition::Not { condition })
+                if matches!(
+                    condition.as_ref(),
+                    StaticCondition::RecipientAttackingOwnerTarget { .. }
+                )
+        ),
+        "owner-attack arm must not steal the Gate condition, got {:?}",
+        evasion.condition
+    );
+}
+
 /// CR 118.9: Rooftop Storm grants {0} as an alternative MANA cost for Zombie
 /// creature spells the controller casts.
 #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2751,6 +2751,9 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
         | StaticCondition::SpeedGE { .. }
         | StaticCondition::RecipientHasCounters { .. }
         | StaticCondition::RecipientMatchesFilter { .. }
+        // CR 509.1b: recipient-scoped block-evasion gate; no intervening-if
+        // (`TriggerCondition`) equivalent — lowering returns `None`.
+        | StaticCondition::RecipientAttackingOwnerTarget { .. }
         | StaticCondition::DefendingPlayerControls { .. }
         | StaticCondition::SourceAttackingAlone
         | StaticCondition::SourceIsAttacking

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5064,6 +5064,22 @@ pub enum StaticCondition {
     RecipientMatchesFilter {
         filter: TargetFilter,
     },
+    /// CR 509.1b + CR 506.2 + CR 108.3: True when the recipient creature (the
+    /// per-object subject of the continuous effect — i.e. the attacking creature
+    /// this static is gating) is currently attacking a target permitted by
+    /// `target`, evaluated relative to the recipient's OWNER (CR 108.3), not its
+    /// controller. Used to express "can't be blocked unless it's attacking its
+    /// owner or a permanent its owner controls" by wrapping this in
+    /// `StaticCondition::Not` (the "unless"): the creature is unblockable except
+    /// when attacking its owner or a permanent its owner controls. Recipient-scoped
+    /// (mirrors `RecipientMatchesFilter`/`RecipientHasCounters`); the affected
+    /// (attacking) creature is supplied as the recipient by the block-restriction
+    /// gate in `combat.rs`. `target` reuses `AttackTargetFilter` — the same
+    /// owner-relative axis as the attack-side "can't attack its owner …"
+    /// restriction (CR 506.2 / CR 508.1).
+    RecipientAttackingOwnerTarget {
+        target: crate::types::triggers::AttackTargetFilter,
+    },
     /// CR 702.95b: True while the source object is paired with another creature.
     SourceIsPaired,
     /// CR 113.6b: True when the source card is in the specified zone.


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** Compound continuous-modification static '+N/+N and can't be blocked unless ...' drops the second conjunct, losing the conditional-evasion (CantBeBlocked with owner-attacking exception) modification.

## Cards corrected
- Become the Pilot

## Fix
Implemented cluster-18 fix: the compound static "Enchanted creature gets +2/+2 and can't be blocked unless it's attacking its owner or a permanent its owner controls" (Become the Pilot) no longer drops the conditional-evasion conjunct. Added one typed StaticCondition::RecipientAttackingOwnerTarget { target: AttackTargetFilter } variant (parameterized by Owner vs OwnerOrPlaneswalker — no sibling proliferation), wired it into every exhaustive consumer match (layers evaluator + 3 classifier matches, coverage, oracle_trigger, oracle_effect/conditions) plus the functionally-required (non-compiler-forced) condition_uses_recipient_context arm, extended the cant_be_blocked_mode tail classifier with a nom-only combinator (tag_no_case/alt/value, OwnerOrPlaneswalker ordered before Owner), and added the owner-relative runtime evaluator helper in game/conditions.rs reusing the existing block_restriction_statics_against condition gate (zero combat.rs production change). Added 11 building-block-level tests (3 parser, 3 layers evaluator including the no-recipient defensive guard, 5 combat runtime including the owner-vs-controller CR 108.3 distinction). Verification all green: cargo fmt clean, clippy -D warnings clean, 12060 engine tests pass, oracle-gen + full card-data export confirm the third CantBeBlocked static with Not(RecipientAttackingOwnerTarget{OwnerOrPlaneswalker}) and no parse_warnings, semantic-audit/coverage clean with the card removed from findings. Parser combinator gate exits 1 only on a pre-existing baseline flag unrelated to this change; my production parser additions contain no string dispatch. Two mechanical deviations from the plan: helper placed in conditions.rs (idiomatic shared-predicate home, mirrors eval_source_is_attacking) and the parser fn uses a fully-qualified return type. No commit made; changes left in the working tree.

## Files changed
- crates/engine/src/types/ability.rs
- crates/engine/src/game/conditions.rs
- crates/engine/src/game/layers.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/combat.rs
- crates/engine/src/parser/oracle_static/evasion.rs
- crates/engine/src/parser/oracle_static/tests.rs
- crates/engine/src/parser/oracle_trigger.rs
- crates/engine/src/parser/oracle_effect/conditions.rs
- data/engine-inventory.json
- client/public/card-data.json

## CR references
- CR 509.1b (docs/MagicCompRules.txt line 2343) — a creature can't block unless some condition is met; the authorizing rule for the conditional block-evasion static and the new condition + parser arm
- CR 506.2 (line 2196) — defines legal attack targets (defending player, planeswalkers they control, battles they protect); the owner-relative attack-target axis
- CR 508.1k (line 2282) — attacking-creature persistence; basis for reading AttackerInfo from state.combat
- CR 108.3 (line 564) — owner is the player who started the game with the card; the load-bearing owner != controller distinction for the donate/evasion class
- CR 109.5 (line 610) — you/your resolves to controller/owner; supports the owner-relative reading

## Verification
- `cargo fmt --all` — pass
- `check-parser-combinators.sh <upstream/main merge-base 2f9d6a6dbf90>` — pass
- `cargo clippy -p engine --all-targets -- -D warnings` — pass
- `cargo test -p engine` — pass
- `oracle-gen data --filter "become the pilot"` — pass
Cards confirmed re-parsed correctly: Become the Pilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
