### PR TITLE
fix(client): improve Settings modal layout, sidebar navigation, and scroll behavior

### DIFF
--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -252,9 +252,9 @@ export function PreferencesModal({
       subtitle={t("modal.subtitle")}
       onClose={onClose}
       maxWidthClassName="max-w-5xl"
-      bodyClassName="flex flex-col overflow-y-auto p-4 sm:p-6"
+      bodyClassName="flex min-h-0 flex-1 flex-col overflow-hidden pl-4 pt-4 pr-1.5 pb-8 sm:pl-6 sm:pt-6 sm:pr-2 sm:pb-10"
     >
-      <div className="flex flex-1 flex-col gap-4 md:min-h-[28rem] md:flex-row md:items-stretch">
+      <div className="flex min-h-0 flex-1 flex-col gap-4 md:min-h-[28rem] md:flex-row md:overflow-hidden">
             <aside className="flex shrink-0 flex-col md:w-[200px] md:justify-between">
               <nav className="flex snap-x gap-2 overflow-x-auto pb-1 md:flex-col md:overflow-visible md:pb-0">
                 {SETTINGS_TABS.map((tab) => (
@@ -276,7 +276,7 @@ export function PreferencesModal({
               </div>
             </aside>
 
-            <div className="flex min-w-0 flex-1 flex-col gap-4">
+            <div className="thin-scrollbar flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-y-auto pb-4 pr-3 md:pr-4">
               {activeTab === "gameplay" && (
                 <SettingsSection title={t("gameplay.title")}>
                   <SettingGroup label={t("gameplay.language")}>

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -252,26 +252,31 @@ export function PreferencesModal({
       subtitle={t("modal.subtitle")}
       onClose={onClose}
       maxWidthClassName="max-w-5xl"
-      bodyClassName="overflow-y-auto p-4 sm:p-6"
+      bodyClassName="flex flex-col overflow-y-auto p-4 sm:p-6"
     >
-      <div className="grid gap-4 md:grid-cols-[200px_minmax(0,1fr)]">
-            <nav className="flex snap-x gap-2 overflow-x-auto pb-1 md:flex-col md:overflow-visible md:pb-0">
-              {SETTINGS_TABS.map((tab) => (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`min-h-11 shrink-0 snap-start rounded-[16px] border px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.16em] transition-colors md:w-full md:px-4 md:text-xs md:tracking-[0.18em] ${
-                    activeTab === tab.id
-                      ? "border-sky-400/60 bg-sky-500/14 text-sky-100"
-                      : "border-white/8 bg-black/20 text-slate-400 hover:border-white/14 hover:text-slate-100"
-                  }`}
-                >
-                  {t(`tabs.${tab.id}`)}
-                </button>
-              ))}
-            </nav>
+      <div className="flex flex-1 flex-col gap-4 md:min-h-[28rem] md:flex-row md:items-stretch">
+            <aside className="flex shrink-0 flex-col md:w-[200px] md:justify-between">
+              <nav className="flex snap-x gap-2 overflow-x-auto pb-1 md:flex-col md:overflow-visible md:pb-0">
+                {SETTINGS_TABS.map((tab) => (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`min-h-11 shrink-0 snap-start rounded-[16px] border px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-[0.16em] transition-colors md:w-full md:px-4 md:text-xs md:tracking-[0.18em] ${
+                      activeTab === tab.id
+                        ? "border-sky-400/60 bg-sky-500/14 text-sky-100"
+                        : "border-white/8 bg-black/20 text-slate-400 hover:border-white/14 hover:text-slate-100"
+                    }`}
+                  >
+                    {t(`tabs.${tab.id}`)}
+                  </button>
+                ))}
+              </nav>
+              <div className="hidden shrink-0 border-t border-white/5 pt-6 pb-8 md:block">
+                <ResetAllFooter resetAllPreferences={resetAllPreferences} />
+              </div>
+            </aside>
 
-            <div className="min-w-0">
+            <div className="flex min-w-0 flex-1 flex-col gap-4">
               {activeTab === "gameplay" && (
                 <SettingsSection title={t("gameplay.title")}>
                   <SettingGroup label={t("gameplay.language")}>
@@ -652,8 +657,10 @@ export function PreferencesModal({
           <DataSection />
         </>
       )}
+              <div className="border-t border-white/5 py-4 md:hidden">
+                <ResetAllFooter resetAllPreferences={resetAllPreferences} />
+              </div>
             </div>
-            <ResetAllFooter resetAllPreferences={resetAllPreferences} />
           </div>
     </ModalPanelShell>
   );
@@ -676,15 +683,13 @@ function ResetAllFooter({
   }, [resetAllPreferences, t]);
 
   return (
-    <div className="mt-4 flex justify-end border-t border-white/5 pt-3">
-      <button
-        type="button"
-        onClick={onClick}
-        className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500 transition-colors hover:text-rose-300"
-      >
-        {t("resetAll.button")}
-      </button>
-    </div>
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500 transition-colors hover:text-rose-300"
+    >
+      {t("resetAll.button")}
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary

* Rework the Settings modal layout so the left navigation sidebar remains fixed while only the right content panel scrolls
* Move **Reset all preferences** into the sidebar and pin it to the bottom on desktop for improved visibility and consistency
* Improve modal spacing by adding separation between content and the scrollbar and refining right-edge padding
* Preserve a mobile-friendly layout where the tab strip remains at the top and the reset action appears below the content

## Context

The previous Settings modal layout allowed the entire modal body to participate in scrolling, causing the sidebar and reset controls to move out of view when navigating longer settings sections. The reset action was also positioned in a separate grid row, making its placement inconsistent across different content lengths.

This update keeps navigation accessible, improves content readability, and provides a more predictable scrolling experience.

## Changes

* Replace the existing grid layout with a flex-based desktop layout
* Add a fixed-width sidebar for settings navigation
* Restrict scrolling to the right content panel using `overflow-y-auto`
* Apply `thin-scrollbar` styling to the content panel
* Move **Reset all preferences** into the sidebar on desktop layouts
* Simplify `ResetAllFooter`
* Refine modal padding and spacing around the scrollbar

## Screenshots

### Before
<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/f7949972-6290-4032-86d9-c2a932560c86" />

### After
<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/c03a0945-1972-48c6-8168-0004ed0ba2be" />

## Test Plan

* [ ] Open **Settings** on desktop
* [ ] Verify the sidebar remains fixed while scrolling long settings sections
* [ ] Verify only the right content panel scrolls
* [ ] Verify **Reset all preferences** remains pinned to the bottom of the sidebar
* [ ] Verify short sections (e.g. Data) still position the reset action correctly
* [ ] Verify mobile layout displays the tab strip at the top and reset action below the content
* [ ] Verify content has comfortable spacing from the scrollbar
* [ ] Verify no layout regressions across all Settings tabs
