### PR TITLE
fix(deck-builder): ensure mobile filter sheet overlays app shell chrome

### DIFF
--- a/client/src/components/deck-builder/DeckBuilder.tsx
+++ b/client/src/components/deck-builder/DeckBuilder.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { useIsMobile } from "../../hooks/useIsMobile";
@@ -220,6 +221,40 @@ export function DeckBuilder({
   const mainVisible = activeSurface === "deck" ? "flex" : "hidden md:flex";
   const infoVisible = activeSurface === "info" ? "flex" : "hidden md:flex";
 
+  const filterPanel = filtersOpen ? (
+    <div
+      ref={filterPanelRef}
+      role={filtersAsDialog ? "dialog" : undefined}
+      aria-modal={filtersAsDialog ? true : undefined}
+      aria-label={filtersAsDialog ? t("filters.title") : undefined}
+      className={
+        filtersAsDialog
+          ? "fixed inset-y-0 left-0 z-[56] flex w-[min(20rem,85vw)] flex-col border-r border-white/10 bg-[#0b1020]/96 pt-[env(safe-area-inset-top)] backdrop-blur-md"
+          : "flex w-64 flex-col border-r border-white/10 bg-black/12"
+      }
+    >
+      <div className="flex shrink-0 items-center justify-between border-b border-white/8 px-4 py-3">
+        <span className="text-sm font-semibold text-white">{t("filters.title")}</span>
+        <button
+          type="button"
+          onClick={() => setFiltersOpen(false)}
+          className="rounded-lg px-2 py-1 text-xs text-slate-300 hover:bg-white/10"
+        >
+          {t("filters.done")}
+        </button>
+      </div>
+      <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto pb-16">
+        <CardSearch
+          onResults={handleSearchResults}
+          onSearchTrigger={handleSearchTrigger}
+          filters={searchFilters}
+          onFiltersChange={onSearchFiltersChange}
+          onReset={onResetSearch}
+        />
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
       <DeckBuilderToolbar
@@ -244,56 +279,24 @@ export function DeckBuilder({
       />
 
       <div className="flex min-h-0 flex-1">
-        {/* Filter rail backdrop (mobile overlay). */}
-        {filtersOpen && (
-          <button
-            type="button"
-            aria-label={t("filters.close")}
-            onClick={() => setFiltersOpen(false)}
-            className="fixed inset-0 z-30 bg-black/60 min-[820px]:hidden"
-          />
-        )}
-
-        {/* Collapsible filter rail: inline sidebar at lg+ when open, overlay
-            sheet below lg, hidden when closed. A single CardSearch instance
-            (kept mounted so filter-driven searches keep running). */}
-        <div
-          ref={filterPanelRef}
-          role={filtersAsDialog ? "dialog" : undefined}
-          aria-modal={filtersAsDialog ? true : undefined}
-          aria-label={filtersAsDialog ? t("filters.title") : undefined}
-          className={
-            filtersOpen
-              ? // Overlay sheet below 820px (where the shell rail is hidden, so a
-                // fixed left-0 sheet is unobstructed). At ≥820px — exactly where the
-                // rail appears — the sheet becomes an inline `static` sidebar that
-                // flows inside the rail-offset content column, so it can never be
-                // painted over by the rail. Breakpoint matches the rail's so there
-                // is no in-between band.
-                "fixed inset-y-0 left-0 z-40 flex w-[min(20rem,85vw)] flex-col border-r border-white/10 bg-[#0b1020]/96 backdrop-blur-md min-[820px]:static min-[820px]:left-auto min-[820px]:z-auto min-[820px]:w-64 min-[820px]:bg-black/12"
-              : "hidden"
-          }
-        >
-          <div className="flex shrink-0 items-center justify-between border-b border-white/8 px-4 py-3">
-            <span className="text-sm font-semibold text-white">{t("filters.title")}</span>
-            <button
-              type="button"
-              onClick={() => setFiltersOpen(false)}
-              className="rounded-lg px-2 py-1 text-xs text-slate-300 hover:bg-white/10"
-            >
-              {t("filters.done")}
-            </button>
-          </div>
-          <div className="thin-scrollbar min-h-0 flex-1 overflow-y-auto pb-16">
-            <CardSearch
-              onResults={handleSearchResults}
-              onSearchTrigger={handleSearchTrigger}
-              filters={searchFilters}
-              onFiltersChange={onSearchFiltersChange}
-              onReset={onResetSearch}
-            />
-          </div>
-        </div>
+        {/* Mobile filter sheet: portaled to `document.body` so it paints above
+            AppShell ChromeControls (z-40) and TabBar (z-50), which live outside
+            the shell content column's `relative z-10` stacking context. */}
+        {filtersAsDialog &&
+          createPortal(
+            <>
+              <button
+                type="button"
+                aria-label={t("filters.close")}
+                onClick={() => setFiltersOpen(false)}
+                className="fixed inset-0 z-[55] bg-black/60"
+              />
+              {filterPanel}
+            </>,
+            document.body,
+          )}
+        {/* Desktop inline filter rail (≥820px). */}
+        {filtersOpen && !isNarrow && filterPanel}
 
         {/* Main canvas: the deck (idle) or search results (searching). Tab panel
             for the phone tab bar; on md+ it's simply a visible column (the

--- a/client/src/components/deck-builder/__tests__/DeckBuilder.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckBuilder.test.tsx
@@ -337,6 +337,7 @@ describe("DeckBuilder", () => {
   });
 
   it("opens and closes the mobile filter sheet", async () => {
+    vi.mocked(useIsMobile).mockReturnValue(true);
     const user = userEvent.setup();
     render(
       <DeckBuilder


### PR DESCRIPTION
## Summary

Fixes a mobile layering issue where AppShell chrome controls (mute, language selector, settings, and navigation elements) could appear above the Deck Builder Filters sheet.

The filter panel was previously rendered inside the page content stacking context, which prevented it from visually overlaying fixed shell elements rendered at higher z-index levels. As a result, parts of the application chrome remained visible while the filter drawer was open.

This change portals the mobile filter sheet to `document.body`, allowing it to render above all shell chrome and behave consistently with other overlay-based UI components.

## Context

On mobile viewports, opening the Filters panel should create a full-screen modal experience. However, because the sheet was rendered within the Deck Builder content hierarchy, it remained constrained by the page's stacking context and could not visually cover fixed AppShell controls.

Using a portal aligns the Filters sheet implementation with existing overlay patterns used elsewhere in the application.

## Changes

* Portal the mobile Filters sheet to `document.body`
* Add a full-screen backdrop that overlays AppShell chrome
* Render the mobile filter sheet above the backdrop using dedicated overlay z-index levels
* Add safe-area top spacing for mobile devices
* Extract filter panel markup for reuse between desktop and mobile layouts
* Update Deck Builder tests to mock `useIsMobile` when validating filter sheet behavior

## Screenshots

### Before
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/1e240303-610c-4ee6-a4e1-dc64b2393f06" />

### After
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/f7614cc7-f732-4a10-a5d9-91be53d713bc" />

## Test Plan

* [ ] On mobile (<820px), open **Deck Builder → Filters**
* [ ] Verify mute, language, settings, and other shell controls are fully covered by the overlay
* [ ] Verify the backdrop covers the entire viewport
* [ ] Tap the backdrop and confirm the sheet closes
* [ ] Tap **Done** and confirm the sheet closes
* [ ] Verify focus returns to the Filters trigger after closing
* [ ] On desktop (≥820px), verify the filter rail still renders inline as a sidebar
* [ ] Run `pnpm exec vitest run src/components/deck-builder/__tests__/DeckBuilder.test.tsx`
