### PR TITLE
fix(deck-builder): use anchored dropdowns for mobile filter selects

### DIFF
--- a/client/src/components/deck-builder/CardSearch.tsx
+++ b/client/src/components/deck-builder/CardSearch.tsx
@@ -6,7 +6,7 @@ import type { GameFormat } from "../../adapter/types";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import { useSetList } from "../../hooks/useSetList";
 import { hasSearchCriteria } from "./searchFilters";
-import { SelectField } from "../ui/SelectField";
+import { MenuSelect } from "../ui/MenuSelect";
 
 const DEBOUNCE_MS = 300;
 const MANA_COLORS = ["W", "U", "B", "R", "G"] as const;
@@ -33,9 +33,8 @@ const CARD_TYPES = [
   "Land",
   "Planeswalker",
 ];
-const FILTER_SELECT_CLASS =
-  "w-full cursor-pointer rounded-[16px] border border-white/10 bg-black/18 px-3 py-1.5 text-sm text-white focus:border-white/20 focus:outline-none";
-const FILTER_OPTION_CLASS = "bg-[#0a0f1b] text-slate-100";
+const FILTER_MENU_CLASS =
+  "min-h-[44px] rounded-[16px] text-base sm:min-h-0 sm:text-sm";
 
 export type BrowserLegalityFilter = "all" | GameFormat;
 
@@ -74,6 +73,18 @@ export function CardSearch({
     ],
     [t],
   );
+  const typeOptions = useMemo(
+    () => [
+      { value: "", label: t("search.allTypes") },
+      ...CARD_TYPES.map((cardType) => ({ value: cardType, label: cardType })),
+    ],
+    [t],
+  );
+  const selectedTypeLabel =
+    typeOptions.find((opt) => opt.value === filters.type)?.label ?? t("search.allTypes");
+  const selectedBrowseFormatLabel =
+    browserFormats.find((opt) => opt.value === filters.browseFormat)?.label
+    ?? t("search.browseFormat.all");
   const setList = useSetList();
   const availableSets = useMemo(() => {
     if (!setList) return [];
@@ -305,21 +316,16 @@ export function CardSearch({
         ))}
       </div>
 
-      <SelectField
+      <MenuSelect
+        ariaLabel={t("search.cardType")}
+        label={selectedTypeLabel}
+        selectedValue={filters.type}
+        items={typeOptions}
+        onSelect={handleTypeChange}
+        menuLayout="dropdown"
         wrapperClassName="w-full"
-        value={filters.type}
-        onChange={(e) => handleTypeChange(e.target.value)}
-        className={FILTER_SELECT_CLASS}
-      >
-        <option value="" className={FILTER_OPTION_CLASS}>
-          {t("search.allTypes")}
-        </option>
-        {CARD_TYPES.map((cardType) => (
-          <option key={cardType} value={cardType} className={FILTER_OPTION_CLASS}>
-            {cardType}
-          </option>
-        ))}
-      </SelectField>
+        className={FILTER_MENU_CLASS}
+      />
 
       <div className="flex items-center gap-2">
         <label className="text-xs text-gray-400">{t("search.cmcMax")}</label>
@@ -333,18 +339,16 @@ export function CardSearch({
         />
       </div>
 
-      <SelectField
+      <MenuSelect
+        ariaLabel={t("search.browseFormatFilter")}
+        label={selectedBrowseFormatLabel}
+        selectedValue={filters.browseFormat}
+        items={browserFormats}
+        onSelect={(value) => handleBrowseFormatChange(value as BrowserLegalityFilter)}
+        menuLayout="dropdown"
         wrapperClassName="w-full"
-        value={filters.browseFormat}
-        onChange={(e) => handleBrowseFormatChange(e.target.value as BrowserLegalityFilter)}
-        className={FILTER_SELECT_CLASS}
-      >
-        {browserFormats.map(({ value, label }) => (
-          <option key={value} value={value} className={FILTER_OPTION_CLASS}>
-            {label}
-          </option>
-        ))}
-      </SelectField>
+        className={FILTER_MENU_CLASS}
+      />
 
       <div className="space-y-2">
         <label className="text-xs text-gray-400">{t("search.sets")}</label>

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -72,6 +72,12 @@ export interface MenuSelectProps {
   ariaLabel?: string;
   /** Highlights the matching option in the open menu. */
   selectedValue?: string;
+  /**
+   * `auto` (default): bottom sheet below 820px, anchored dropdown at wider
+   * widths. `dropdown`: always anchor below/above the trigger like a native
+   * select — use inside scrollable panels (e.g. deck-builder filters).
+   */
+  menuLayout?: "auto" | "dropdown";
   /** Class on the outer relative wrapper (e.g. `max-w-[8rem] shrink-0`). */
   wrapperClassName?: string;
   /** Class on the trigger button. */
@@ -120,11 +126,13 @@ export function MenuSelect({
   disabled = false,
   ariaLabel,
   selectedValue,
+  menuLayout = "auto",
   wrapperClassName = "",
   className = "",
 }: MenuSelectProps) {
   const listboxId = useId();
   const mobileSheet = useMobileSheetLayout();
+  const useBottomSheet = menuLayout === "auto" && mobileSheet;
   const [open, setOpen] = useState(false);
   const [minWidthPx, setMinWidthPx] = useState<number | undefined>(undefined);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -160,7 +168,7 @@ export function MenuSelect({
   }, [label, allItems]);
 
   const updatePosition = useCallback(() => {
-    if (mobileSheet) return;
+    if (useBottomSheet) return;
     const trigger = triggerRef.current;
     if (!trigger) return;
 
@@ -188,7 +196,7 @@ export function MenuSelect({
       top: openUp ? "auto" : rect.bottom + MENU_GAP_PX,
       bottom: openUp ? window.innerHeight - rect.top + MENU_GAP_PX : "auto",
     });
-  }, [mobileSheet]);
+  }, [useBottomSheet]);
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -202,7 +210,7 @@ export function MenuSelect({
         : null;
     (selectedOption ?? menu?.querySelector<HTMLButtonElement>('[role="option"]'))?.focus();
     selectedOption?.scrollIntoView({ block: "nearest" });
-  }, [open, selectedValue, updatePosition, mobileSheet]);
+  }, [open, selectedValue, updatePosition, useBottomSheet]);
 
   useEffect(() => {
     if (!open) return;
@@ -258,7 +266,7 @@ export function MenuSelect({
         parent.removeEventListener("scroll", handleScroll);
       });
     };
-  }, [open, updatePosition, mobileSheet]);
+  }, [open, updatePosition, useBottomSheet]);
 
   const renderOption = (item: MenuSelectItem) => (
     <button
@@ -320,7 +328,7 @@ export function MenuSelect({
       {open &&
         createPortal(
           <>
-            {mobileSheet && (
+            {useBottomSheet && (
               <button
                 type="button"
                 aria-label={ariaLabel ?? label}
@@ -335,13 +343,13 @@ export function MenuSelect({
               aria-label={ariaLabel ?? label}
               className={[
                 "fixed z-[120] flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain border border-white/10 bg-[#0a0f1b]/98 py-1 shadow-xl backdrop-blur-md thin-scrollbar",
-                mobileSheet
+                useBottomSheet
                   ? "inset-x-0 bottom-[calc(76px+env(safe-area-inset-bottom))] max-h-[min(70dvh,calc(100dvh-76px-env(safe-area-inset-bottom)-1rem))] rounded-t-2xl rounded-b-none border-b-0"
                   : "rounded-xl",
               ].join(" ")}
               onWheel={(event) => event.stopPropagation()}
               style={
-                mobileSheet
+                useBottomSheet
                   ? undefined
                   : {
                       top: menuStyle.top,

--- a/client/src/components/ui/__tests__/MenuSelect.test.tsx
+++ b/client/src/components/ui/__tests__/MenuSelect.test.tsx
@@ -70,4 +70,32 @@ describe("MenuSelect", () => {
     fireEvent.click(screen.getByRole("button", { name: "Load deck..." }));
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
+
+  it("uses an anchored dropdown when menuLayout is dropdown, even on mobile", () => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(max-width: 819px)",
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    render(
+      <MenuSelect
+        label="All types"
+        items={items}
+        onSelect={vi.fn()}
+        menuLayout="dropdown"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "All types" }));
+
+    const listbox = screen.getByRole("listbox");
+    expect(listbox).toBeInTheDocument();
+    expect(listbox.className).toContain("rounded-xl");
+    expect(listbox.className).not.toContain("rounded-t-2xl");
+    expect(screen.queryByRole("button", { name: "All types" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "All types" })).toHaveLength(1);
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/client/src/i18n/locales/de/deck-builder.json
+++ b/client/src/i18n/locales/de/deck-builder.json
@@ -5,6 +5,8 @@
     "reset": "Zurücksetzen",
     "textPlaceholder": "Karten suchen...",
     "allTypes": "Alle Typen",
+    "cardType": "Kartentyp",
+    "browseFormatFilter": "Legal im Format",
     "cmcMax": "CMC max:",
     "sets": "Sets",
     "addSetPlaceholder": "Set-Code hinzufügen...",

--- a/client/src/i18n/locales/en/deck-builder.json
+++ b/client/src/i18n/locales/en/deck-builder.json
@@ -5,6 +5,8 @@
     "reset": "Reset",
     "textPlaceholder": "Search cards...",
     "allTypes": "All types",
+    "cardType": "Card type",
+    "browseFormatFilter": "Legal in format",
     "cmcMax": "CMC max:",
     "sets": "Sets",
     "addSetPlaceholder": "Add set code...",

--- a/client/src/i18n/locales/es/deck-builder.json
+++ b/client/src/i18n/locales/es/deck-builder.json
@@ -5,6 +5,8 @@
     "reset": "Restablecer",
     "textPlaceholder": "Buscar cartas...",
     "allTypes": "Todos los tipos",
+    "cardType": "Tipo de carta",
+    "browseFormatFilter": "Legal en formato",
     "cmcMax": "CMC máx.:",
     "sets": "Colecciones",
     "addSetPlaceholder": "Añadir código de colección...",

--- a/client/src/i18n/locales/fr/deck-builder.json
+++ b/client/src/i18n/locales/fr/deck-builder.json
@@ -5,6 +5,8 @@
     "reset": "Réinitialiser",
     "textPlaceholder": "Rechercher des cartes...",
     "allTypes": "Tous les types",
+    "cardType": "Type de carte",
+    "browseFormatFilter": "Légal en format",
     "cmcMax": "CMC max :",
     "sets": "Extensions",
     "addSetPlaceholder": "Ajouter un code d'extension...",

--- a/client/src/i18n/locales/it/deck-builder.json
+++ b/client/src/i18n/locales/it/deck-builder.json
@@ -5,6 +5,8 @@
     "reset": "Reimposta",
     "textPlaceholder": "Cerca carte...",
     "allTypes": "Tutti i tipi",
+    "cardType": "Tipo di carta",
+    "browseFormatFilter": "Legale nel formato",
     "cmcMax": "CMC max:",
     "sets": "Set",
     "addSetPlaceholder": "Aggiungi codice set...",

--- a/client/src/i18n/locales/pl/deck-builder.json
+++ b/client/src/i18n/locales/pl/deck-builder.json
@@ -5,6 +5,8 @@
     "reset": "Resetuj",
     "textPlaceholder": "Szukaj kart...",
     "allTypes": "Wszystkie typy",
+    "cardType": "Typ karty",
+    "browseFormatFilter": "Legalny w formacie",
     "cmcMax": "Maks. CMC:",
     "sets": "Dodatki",
     "addSetPlaceholder": "Dodaj kod dodatku...",

--- a/client/src/i18n/locales/pt/deck-builder.json
+++ b/client/src/i18n/locales/pt/deck-builder.json
@@ -5,6 +5,8 @@
     "reset": "Redefinir",
     "textPlaceholder": "Buscar cartas...",
     "allTypes": "Todos os tipos",
+    "cardType": "Tipo de carta",
+    "browseFormatFilter": "Legal no formato",
     "cmcMax": "CMC máx.:",
     "sets": "Coleções",
     "addSetPlaceholder": "Adicionar código da coleção...",


### PR DESCRIPTION
## Summary

Improves the mobile Deck Builder filter experience by replacing native `<select>` controls with `MenuSelect` components configured to use anchored dropdown menus.

Previously, the card type and browse format filters could open using native mobile select behavior, resulting in full-screen pickers, bottom sheets, or UI that extended beyond the filter panel. This made filter interactions feel inconsistent with the rest of the application and reduced usable space within the mobile filter drawer.

This change introduces an anchored dropdown layout for filter selects, ensuring options appear directly beneath the trigger as a compact, scrollable menu on both desktop and mobile devices.

## Context

The Deck Builder filter sheet is designed as a contained mobile workflow. Native mobile select controls can bypass that experience by rendering platform-specific pickers outside the intended UI flow.

Using the existing `MenuSelect` component provides a more consistent interaction model and aligns filter controls with other dropdowns used throughout the application.

## Changes

* Add `menuLayout="dropdown"` support to `MenuSelect`
* Use anchored dropdown menus for Deck Builder filter selects
* Replace native select behavior for:

  * Card Type filter
  * Browse Format filter
* Ensure filter options render as compact, scrollable dropdown menus
* Preserve existing filter functionality and selection behavior
* Add test coverage for mobile dropdown rendering

## Screenshots

### Before
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/26a696b4-4530-4882-abe4-51f114f8a08a" />

### After
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/4314ed80-ae8e-49da-863f-94a31f28db6f" />

## Test Plan

* [ ] Open **Deck Builder → Filters** on a mobile viewport
* [ ] Open the **All types** filter and verify options appear in an anchored dropdown below the trigger
* [ ] Open the **All cards** filter and verify options appear in an anchored dropdown below the trigger
* [ ] Verify dropdown menus remain fully visible within the filter workflow
* [ ] Verify options are scrollable when the list exceeds available space
* [ ] Verify filters continue to update search results correctly
* [ ] Verify desktop behavior remains unchanged
* [ ] Run the MenuSelect and DeckBuilder test suites successfully
