### PR TITLE
fix(engine): crew/saddle legal-action enumerator must use crew-adjusted power

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3972,6 +3972,7 @@ fn crew_vehicle_candidates(
         player,
         eligible_creatures,
         crew_power as i32,
+        crate::types::statics::CrewAction::Crew,
         |creature_ids| GameAction::CrewVehicle {
             vehicle_id,
             creature_ids,
@@ -3994,6 +3995,7 @@ fn saddle_mount_candidates(
         player,
         eligible_creatures,
         saddle_power as i32,
+        crate::types::statics::CrewAction::Saddle,
         |creature_ids| GameAction::SaddleMount {
             mount_id,
             creature_ids,
@@ -4010,6 +4012,7 @@ fn minimal_power_subset_candidates<F>(
     player: PlayerId,
     eligible_creatures: &[crate::types::identifiers::ObjectId],
     threshold: i32,
+    action: crate::types::statics::CrewAction,
     wrap: F,
 ) -> Vec<CandidateAction>
 where
@@ -4017,14 +4020,25 @@ where
 {
     const MAX_CANDIDATES: usize = 20;
 
+    // CR 702.122c / 702.171a: a creature's contribution toward the crew/saddle
+    // threshold may be modified ("as though its power were N greater" / "using
+    // its toughness rather than its power"). The activation gate and the
+    // announcement validator both measure power via `object_crew_power_contribution`,
+    // so the candidate enumerator must use the same authority — measuring raw
+    // `power` here disagrees with those seams and yields zero valid covers for
+    // Pilot-style creatures (e.g. Deathless Pilot, "crews as though its power
+    // were 2 greater"), hanging the controller with an empty legal-action set.
     let mut creatures_with_power: Vec<(crate::types::identifiers::ObjectId, i32)> =
         eligible_creatures
             .iter()
-            .filter_map(|&id| {
-                state
-                    .objects
-                    .get(&id)
-                    .map(|o| (id, o.power.unwrap_or(0).max(0)))
+            .filter(|&&id| state.objects.contains_key(&id))
+            .map(|&id| {
+                (
+                    id,
+                    crate::game::static_abilities::object_crew_power_contribution(
+                        state, id, action,
+                    ),
+                )
             })
             .collect();
     // Ascending-power sort with id tie-break makes enumeration deterministic

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -21297,6 +21297,50 @@ mod crew_tests {
         );
     }
 
+    /// CR 702.122c: regression — the legal-action enumerator must measure crew
+    /// contribution through `object_crew_power_contribution`, exactly like the
+    /// activation gate and announcement validator. A Pilot-style creature whose
+    /// raw power is below the crew cost but whose adjusted power meets it must
+    /// still produce a `CrewVehicle` legal action; otherwise the controller is
+    /// offered an empty action set in the `CrewVehicle` state and hangs.
+    /// (Reproduces the reported Deathless Pilot / Hulldrifter Crew-3 stall.)
+    #[test]
+    fn crew_vehicle_legal_actions_account_for_power_delta_contribution() {
+        let (mut state, vehicle_id, creature_a, creature_b) = setup_crew_scenario();
+        // Tap the 3/3 so the only eligible crewer is the 2/2 Pilot, mirroring
+        // the report where the sole eligible creature is sub-threshold by raw
+        // power but meets Crew 3 via "+2 greater".
+        state.objects.get_mut(&creature_a).unwrap().tapped = true;
+        {
+            let obj = state.objects.get_mut(&creature_b).unwrap();
+            obj.static_definitions.push(
+                StaticDefinition::new(StaticMode::CrewContribution {
+                    kind: CrewContributionKind::PowerDelta { delta: 2 },
+                    actions: vec![CrewAction::Crew],
+                })
+                .affected(TargetFilter::SelfRef),
+            );
+        }
+
+        apply_as_current(
+            &mut state,
+            GameAction::CrewVehicle {
+                vehicle_id,
+                creature_ids: vec![],
+            },
+        )
+        .unwrap();
+
+        let actions = crate::ai_support::legal_actions(&state);
+        assert!(
+            actions.iter().any(|a| matches!(
+                a,
+                GameAction::CrewVehicle { creature_ids, .. } if creature_ids == &vec![creature_b]
+            )),
+            "Crew-3 with only a power-2 Pilot (+2 delta) must offer a crew action, got {actions:?}"
+        );
+    }
+
     /// CR 702.122c: "using its toughness rather than its power" (Giant Ox)
     /// substitutes toughness for power, and the modifier applies only to the
     /// named keyword actions (crew-only here, not saddle).


### PR DESCRIPTION
The activation gate and announcement validator both measure a creature's
crew/saddle contribution via object_crew_power_contribution (applying
CrewContribution statics like "crews as though its power were 2 greater"),
but minimal_power_subset_candidates summed raw o.power. When the only
eligible crewer was a Pilot-style creature below the raw threshold (e.g.
Deathless Pilot, power 2, crewing Hulldrifter's Crew 3), the gate opened a
mandatory CrewVehicle WaitingFor while the enumerator produced zero legal
actions, hanging the AI controller.

Thread CrewAction through the shared subset enumerator and measure power via
the same helper, so all three seams agree. Add a legal-actions-level
regression test (the existing PowerDelta test drove the announcement path
directly and bypassed enumeration).
