### PR TITLE
fix(client): improve AI opponent dropdown behavior on mobile

### DIFF
--- a/client/src/components/menu/AiOpponentConfig.tsx
+++ b/client/src/components/menu/AiOpponentConfig.tsx
@@ -13,9 +13,14 @@ import {
   type AiArchetypeFilter,
   type AiDeckSelection,
 } from "../../stores/preferencesStore";
-import { SelectField } from "../ui/SelectField";
+import { MenuSelect } from "../ui/MenuSelect";
 import type { DeckArchetype } from "../../services/engineRuntime";
 import { BracketFilter } from "./BracketFilter";
+
+const AI_MENU_CLASS =
+  "min-h-[44px] rounded-lg border border-gray-700 bg-gray-800/60 px-2 py-1.5 text-sm sm:min-h-0";
+const AI_MENU_LAYOUT = "dropdown" as const;
+const AI_MENU_WRAPPER = "w-full min-w-0";
 
 interface Props {
   selectedFormat?: GameFormat | null;
@@ -215,20 +220,19 @@ export function AiOpponentConfig({
         </div>
         <label className="flex flex-col gap-1">
           <span className="text-xs text-slate-400">{t("aiOpponent.archetype")}</span>
-          <SelectField
-            wrapperClassName="w-full"
-            value={archetypeFilter}
-            onChange={(e) => setArchetypeFilter(e.target.value as AiArchetypeFilter)}
-            className={`w-full rounded-lg border border-gray-700 bg-gray-800/60 px-2 py-1.5 text-sm font-medium ${archetypeAccent(
+          <MenuSelect
+            ariaLabel={t("aiOpponent.archetype")}
+            label={archetypeFilter}
+            selectedValue={archetypeFilter}
+            items={ARCHETYPE_OPTIONS.map((opt) => ({ value: opt, label: opt }))}
+            onSelect={(value) => setArchetypeFilter(value as AiArchetypeFilter)}
+            menuLayout={AI_MENU_LAYOUT}
+            fitContainer
+            wrapperClassName={AI_MENU_WRAPPER}
+            className={`${AI_MENU_CLASS} font-medium ${archetypeAccent(
               archetypeFilter === "Any" ? null : (archetypeFilter as DeckArchetype),
             )}`}
-          >
-            {ARCHETYPE_OPTIONS.map((opt) => (
-              <option key={opt} value={opt} className="text-white">
-                {opt}
-              </option>
-            ))}
-          </SelectField>
+          />
         </label>
 
         <label className="flex flex-col gap-1">
@@ -320,50 +324,70 @@ function AiSeatPanel({
     ? t("aiOpponent.cedhToggle.badge")
     : t(`aiDifficulty.levels.${seat.difficulty}`);
 
+  const formatDeckLabel = (candidate: AiDeckCandidate): string => {
+    const suffix = [sourceLabel(candidate), candidate.archetype, candidate.coveragePct != null ? `${candidate.coveragePct}%` : null]
+      .filter(Boolean)
+      .join(" · ");
+    return suffix ? `${candidate.name} — ${suffix}` : candidate.name;
+  };
+
+  const randomDeckLabel = t("aiOpponent.deckRandomCount", { count: filteredDecks.length });
+  const deckMenuItems = useMemo(
+    () => [
+      { value: AI_DECK_RANDOM, label: randomDeckLabel },
+      ...deckOptions.map((d) => ({ value: d.id, label: formatDeckLabel(d) })),
+    ],
+    [deckOptions, randomDeckLabel],
+  );
+  const selectedDeckLabel =
+    effectiveSelection === AI_DECK_RANDOM
+      ? randomDeckLabel
+      : (deckMenuItems.find((item) => item.value === effectiveSelection)?.label ?? randomDeckLabel);
+
+  const difficultyItems = useMemo(
+    () =>
+      AI_DIFFICULTIES.map((item) => ({
+        value: item.id,
+        label: t(`aiDifficulty.levels.${item.id}`),
+      })),
+    [t],
+  );
+  const selectedDifficultyLabel =
+    difficultyItems.find((item) => item.value === seat.difficulty)?.label ??
+    t(`aiDifficulty.levels.${seat.difficulty}`);
+
   const body = (
     <div className="flex flex-col gap-2.5 px-3 pb-3 pt-1">
       <label className="flex flex-col gap-1">
         <span className="text-xs text-slate-400">{t("aiOpponent.deck")}</span>
-        <SelectField
-          wrapperClassName="w-full"
-          value={effectiveSelection}
-          onChange={(e) => onDeckChange(e.target.value as AiDeckSelection)}
-          className="w-full rounded-lg border border-gray-700 bg-gray-800/60 px-2 py-1.5 text-sm text-white"
-        >
-          <option value={AI_DECK_RANDOM}>{t("aiOpponent.deckRandomCount", { count: filteredDecks.length })}</option>
-          {deckOptions.map((d) => {
-            const suffix = [sourceLabel(d), d.archetype, d.coveragePct != null ? `${d.coveragePct}%` : null]
-              .filter(Boolean)
-              .join(" · ");
-            return (
-              <option key={d.id} value={d.id}>
-                {d.name}
-                {suffix ? ` — ${suffix}` : ""}
-              </option>
-            );
-          })}
-        </SelectField>
+        <MenuSelect
+          ariaLabel={t("aiOpponent.deck")}
+          label={selectedDeckLabel}
+          selectedValue={effectiveSelection}
+          items={deckMenuItems}
+          onSelect={(value) => onDeckChange(value as AiDeckSelection)}
+          menuLayout={AI_MENU_LAYOUT}
+          fitContainer
+          wrapperClassName={AI_MENU_WRAPPER}
+          className={`${AI_MENU_CLASS} text-white`}
+        />
       </label>
 
       <label className="flex flex-col gap-1">
         <span className="text-xs text-slate-400">{t("aiOpponent.difficulty")}</span>
         <div className="relative">
-          <SelectField
-            wrapperClassName="w-full"
-            value={seat.difficulty}
-            onChange={(e) => onDifficultyChange(e.target.value as AIDifficulty)}
+          <MenuSelect
+            ariaLabel={t("aiOpponent.difficulty")}
+            label={selectedDifficultyLabel}
+            selectedValue={seat.difficulty}
+            items={difficultyItems}
+            onSelect={(value) => onDifficultyChange(value as AIDifficulty)}
             disabled={cedhMode}
-            aria-disabled={cedhMode}
-            className={`w-full rounded-lg border border-gray-700 bg-gray-800/60 px-2 py-1.5 text-sm text-white ${
-              cedhMode ? "cursor-not-allowed opacity-50" : ""
-            }`}
-          >
-            {AI_DIFFICULTIES.map((item) => (
-              <option key={item.id} value={item.id}>
-                {t(`aiDifficulty.levels.${item.id}`)}
-              </option>
-            ))}
-          </SelectField>
+            menuLayout={AI_MENU_LAYOUT}
+            fitContainer
+            wrapperClassName={AI_MENU_WRAPPER}
+            className={`${AI_MENU_CLASS} text-white ${cedhMode ? "cursor-not-allowed opacity-50" : ""}`}
+          />
           {cedhMode && (
             <span
               aria-label="cEDH"

--- a/client/src/components/menu/__tests__/AiOpponentConfig.test.tsx
+++ b/client/src/components/menu/__tests__/AiOpponentConfig.test.tsx
@@ -92,8 +92,9 @@ describe("AiOpponentConfig — cEDH toggle", () => {
 
     // Expand the first seat panel and change only seat 0.
     await user.click(screen.getByRole("button", { name: /Opponent 1/i }));
-    const difficultySelects = screen.getAllByRole("combobox", { name: /Difficulty/i });
-    await user.selectOptions(difficultySelects[0], "Medium");
+    const difficultyTriggers = screen.getAllByRole("button", { name: /^Difficulty$/i });
+    await user.click(difficultyTriggers[0]);
+    await user.click(screen.getByRole("option", { name: /Medium/i }));
 
     // Seat 1 must still be Hard — changing one seat never affects another.
     await waitFor(() => {
@@ -150,13 +151,13 @@ describe("AiOpponentConfig — cEDH badge + disabled difficulty", () => {
 
     // Before enabling: no badge, dropdown enabled.
     expect(screen.queryByLabelText("cEDH")).not.toBeInTheDocument();
-    expect(screen.getByRole("combobox", { name: /Difficulty/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /^Difficulty$/i })).toBeEnabled();
 
     await user.click(screen.getByRole("switch", { name: /cEDH mode/i }));
 
     await waitFor(() => {
       expect(screen.getByLabelText("cEDH")).toBeInTheDocument();
-      expect(screen.getByRole("combobox", { name: /Difficulty/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /^Difficulty$/i })).toBeDisabled();
     });
   });
 
@@ -210,7 +211,7 @@ describe("AiOpponentConfig — bracket filter", () => {
 
   it("filter off (empty selection) keeps untagged candidates in the random pool", () => {
     render(<AiOpponentConfig selectedFormat="Commander" opponentCount={1} />);
-    expect(screen.getByRole("option", { name: /Random \(4\)/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Deck$/i })).toHaveTextContent(/Random \(4\)/);
   });
 
   it("selecting brackets {2, 4} narrows the pool to those candidates and excludes untagged", async () => {
@@ -221,7 +222,7 @@ describe("AiOpponentConfig — bracket filter", () => {
     await user.click(screen.getByRole("button", { name: "4 Optimized" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("option", { name: /Random \(2\)/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^Deck$/i })).toHaveTextContent(/Random \(2\)/);
     });
   });
 });

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -78,6 +78,12 @@ export interface MenuSelectProps {
    * select — use inside scrollable panels (e.g. deck-builder filters).
    */
   menuLayout?: "auto" | "dropdown";
+  /**
+   * When true, the trigger fills its wrapper and truncates long labels instead
+   * of growing the wrapper to fit the widest option. Use on full-width form
+   * fields; omit in compact toolbars where the trigger should size to content.
+   */
+  fitContainer?: boolean;
   /** Class on the outer relative wrapper (e.g. `max-w-[8rem] shrink-0`). */
   wrapperClassName?: string;
   /** Class on the trigger button. */
@@ -127,6 +133,7 @@ export function MenuSelect({
   ariaLabel,
   selectedValue,
   menuLayout = "auto",
+  fitContainer = false,
   wrapperClassName = "",
   className = "",
 }: MenuSelectProps) {
@@ -154,6 +161,11 @@ export function MenuSelect({
   });
 
   useLayoutEffect(() => {
+    if (fitContainer) {
+      setMinWidthPx(undefined);
+      return;
+    }
+
     const measure = measureRef.current;
     if (!measure) return;
 
@@ -165,7 +177,7 @@ export function MenuSelect({
 
     // px-3 padding + chevron + gap between label and icon.
     setMinWidthPx(Math.min(contentWidth + 48, TRIGGER_MAX_WIDTH_PX));
-  }, [label, allItems]);
+  }, [fitContainer, label, allItems]);
 
   const updatePosition = useCallback(() => {
     if (useBottomSheet) return;
@@ -321,7 +333,9 @@ export function MenuSelect({
         }}
         className={triggerClassName}
       >
-        <span className="truncate">{label}</span>
+        <span className="min-w-0 truncate" title={label}>
+          {label}
+        </span>
         <ChevronDownIcon className="h-4 w-4 shrink-0 text-white/70" />
       </button>
 

--- a/client/src/components/ui/__tests__/MenuSelect.test.tsx
+++ b/client/src/components/ui/__tests__/MenuSelect.test.tsx
@@ -98,4 +98,29 @@ describe("MenuSelect", () => {
 
     vi.unstubAllGlobals();
   });
+
+  it("does not apply content-based minWidth when fitContainer is set", () => {
+    const longLabel = "Option ".repeat(12).trimEnd();
+    const items = [{ value: "option-a", label: longLabel }];
+
+    const { container: fitContainerRoot } = render(
+      <MenuSelect
+        label={longLabel}
+        items={items}
+        onSelect={vi.fn()}
+        fitContainer
+        wrapperClassName="w-full min-w-0"
+      />,
+    );
+
+    const { container: contentSizedRoot } = render(
+      <MenuSelect label={longLabel} items={items} onSelect={vi.fn()} />,
+    );
+
+    const fitWrapper = fitContainerRoot.firstElementChild as HTMLElement;
+    const contentWrapper = contentSizedRoot.firstElementChild as HTMLElement;
+
+    expect(fitWrapper.style.minWidth).toBe("");
+    expect(contentWrapper.style.minWidth).not.toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

Improves the AI Opponent configuration experience by replacing native select controls with `MenuSelect` components and ensuring dropdowns behave consistently on mobile devices.

Previously, AI Opponent fields could open using native mobile select behavior, resulting in platform-specific pickers or bottom-sheet style menus. Long deck names could also cause the deck selector to expand beyond the width of adjacent fields, creating an inconsistent layout.

This change standardizes all AI Opponent dropdowns using anchored `MenuSelect` menus and introduces sizing behavior that keeps controls aligned while truncating long deck names when necessary.

## Changes

* Replace native select controls with `MenuSelect` for:

  * Deck
  * Difficulty
  * Archetype
* Use anchored dropdown menus on mobile instead of native pickers or bottom sheets
* Add `fitContainer` support to keep dropdown triggers aligned within their container
* Truncate long deck names with ellipsis instead of expanding the control width
* Ensure AI Opponent fields maintain consistent sizing across viewports

## Verification

* `pnpm exec vitest run src/components/ui/__tests__/MenuSelect.test.tsx`
* `pnpm exec vitest run src/components/menu/__tests__/AiOpponentConfig.test.tsx`

## Screenshots

### Before
<img width="411" height="740" alt="image" src="https://github.com/user-attachments/assets/6a7d1de9-b034-4752-a270-ead8bf9208d9" />
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/6b6ee83d-a949-4360-ab2d-0280547f7bc7" />


### After
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/39a294e7-586e-482c-9566-ed6de1e6de59" />
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/4aeda828-dc91-4f68-b74d-c094443b4bd3" />

## Test Plan

* [ ] Open **Play → Match Setup → AI Opponent**
* [ ] Verify Deck, Difficulty, and Archetype controls have consistent widths
* [ ] Verify long deck names are truncated with ellipsis
* [ ] Verify each dropdown opens as an anchored menu below the trigger
* [ ] Verify dropdowns do not open as native mobile pickers or bottom sheets
* [ ] Verify selections update correctly
* [ ] Verify behavior on mobile (<820px)
* [ ] Verify behavior on desktop remains unchanged
