### PR TITLE
fix(parser): “its owner gains N life” binds the object’s owner, not the controller

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1209,6 +1209,20 @@ pub(super) fn parse_subject_application(
             is_optional: false,
         });
     }
+    // CR 108.3 + CR 109.4: "its owner" / "their owner" — the OWNER of the parent
+    // target, which is distinct from its controller (control can be transferred
+    // separately from ownership). "Its owner gains/loses N life" (Misfortune's
+    // Gain, Path of Peace, Thieving Amalgam, The Matrix of Time) must hit the
+    // referenced object's owner, not the spell's controller.
+    if lower == "its owner" || lower == "their owner" {
+        return Some(SubjectApplication {
+            affected: TargetFilter::ParentTargetOwner,
+            target: None,
+            multi_target: None,
+            inherits_parent: false,
+            is_optional: false,
+        });
+    }
     // CR 608.2c: Definite/anaphoric "[the|that] <noun>'s controller" /
     // "[the|that] <noun>'s owner" — the parent target's controller/owner.
     // Mirrors the generic "the <noun>'s controller" path in `parse_target`
@@ -1226,10 +1240,22 @@ pub(super) fn parse_subject_application(
         // structural check that the remaining tail is `<noun>'s controller` /
         // `<noun>'s owner`, mirroring the existing `parse_target` path that uses
         // `find("'s controller")` for the same purpose.
-        if after_det.ends_with("'s controller may") // allow-noncombinator: post-tokenized subject suffix classification
-            || after_det.ends_with("'s owner may")
+        // CR 108.3 + CR 109.4: "owner" is the OWNER of the parent target (distinct
+        // from its controller); "controller" stays the controller. The owner phrasing
+        // must route to `ParentTargetOwner` (The Matrix of Time: "that card's owner
+        // loses 3 life").
         // allow-noncombinator: post-tokenized subject suffix classification
-        {
+        if after_det.ends_with("'s owner may") {
+            return Some(SubjectApplication {
+                affected: TargetFilter::ParentTargetOwner,
+                target: None,
+                multi_target: None,
+                inherits_parent: false,
+                is_optional: true,
+            });
+        }
+        // allow-noncombinator: post-tokenized subject suffix classification
+        if after_det.ends_with("'s controller may") {
             return Some(SubjectApplication {
                 affected: TargetFilter::ParentTargetController,
                 target: None,
@@ -1238,7 +1264,18 @@ pub(super) fn parse_subject_application(
                 is_optional: true,
             });
         }
-        if after_det.ends_with("'s controller") || after_det.ends_with("'s owner") {
+        // allow-noncombinator: post-tokenized subject suffix classification
+        if after_det.ends_with("'s owner") {
+            return Some(SubjectApplication {
+                affected: TargetFilter::ParentTargetOwner,
+                target: None,
+                multi_target: None,
+                inherits_parent: false,
+                is_optional: false,
+            });
+        }
+        // allow-noncombinator: post-tokenized subject suffix classification
+        if after_det.ends_with("'s controller") {
             return Some(SubjectApplication {
                 affected: TargetFilter::ParentTargetController,
                 target: None,
@@ -4025,6 +4062,136 @@ mod tests {
         let app = result.expect("should recognize 'their controller'");
         assert_eq!(app.affected, TargetFilter::ParentTargetController);
         assert!(!app.is_optional);
+    }
+
+    // CR 108.3 + CR 109.4 (issue #3351): "its owner" / "their owner" is the OWNER
+    // of the parent target — distinct from its controller. Bare "its owner" was
+    // previously unhandled and fell through (Misfortune's Gain / Path of Peace's
+    // "Its owner gains 4 life" clause was DROPPED). It must resolve to
+    // ParentTargetOwner, while "its controller" stays ParentTargetController.
+    #[test]
+    fn parse_subject_its_owner_bare() {
+        let mut ctx = ParseContext::default();
+        let result = parse_subject_application("its owner", &mut ctx);
+        let app = result.expect("should recognize bare 'its owner'");
+        assert_eq!(app.affected, TargetFilter::ParentTargetOwner);
+        assert!(!app.is_optional, "no 'may' modal → not optional");
+    }
+
+    #[test]
+    fn parse_subject_their_owner_bare() {
+        let mut ctx = ParseContext::default();
+        let result = parse_subject_application("their owner", &mut ctx);
+        let app = result.expect("should recognize bare 'their owner'");
+        assert_eq!(app.affected, TargetFilter::ParentTargetOwner);
+        assert!(!app.is_optional);
+    }
+
+    #[test]
+    fn parse_subject_owner_and_controller_are_distinct() {
+        // The discriminating pair: identical phrasing modulo owner/controller must
+        // route to the two distinct context refs.
+        let mut ctx = ParseContext::default();
+        assert_eq!(
+            parse_subject_application("its owner", &mut ctx)
+                .unwrap()
+                .affected,
+            TargetFilter::ParentTargetOwner
+        );
+        assert_eq!(
+            parse_subject_application("its controller", &mut ctx)
+                .unwrap()
+                .affected,
+            TargetFilter::ParentTargetController
+        );
+    }
+
+    // CR 108.3: "that <noun>'s owner" / "the <noun>'s owner" possessive-suffix
+    // form (The Matrix of Time: "that card's owner loses 3 life") routes to
+    // ParentTargetOwner, while the "...'s controller" suffix stays controller.
+    #[test]
+    fn parse_subject_noun_possessive_owner_vs_controller() {
+        let mut ctx = ParseContext::default();
+        assert_eq!(
+            parse_subject_application("that card's owner", &mut ctx)
+                .unwrap()
+                .affected,
+            TargetFilter::ParentTargetOwner
+        );
+        assert_eq!(
+            parse_subject_application("that creature's controller", &mut ctx)
+                .unwrap()
+                .affected,
+            TargetFilter::ParentTargetController
+        );
+    }
+
+    /// Recursively search an ability tree (effect + sub_ability + else_ability)
+    /// for a `GainLife` and return the `player` filter of the first one found.
+    fn find_gain_life_player(ability: &AbilityDefinition) -> Option<TargetFilter> {
+        if let Effect::GainLife { player, .. } = &*ability.effect {
+            return Some(player.clone());
+        }
+        ability
+            .sub_ability
+            .as_deref()
+            .and_then(find_gain_life_player)
+            .or_else(|| {
+                ability
+                    .else_ability
+                    .as_deref()
+                    .and_then(find_gain_life_player)
+            })
+    }
+
+    /// CR 108.3 + CR 109.4 (issue #3351): Misfortune's Gain / Path of Peace —
+    /// "Destroy target creature. Its owner gains 4 life." The "Its owner" subject
+    /// must bind the GainLife to the destroyed object's OWNER (ParentTargetOwner),
+    /// not the spell's controller. Before the fix the bare "its owner" arm was
+    /// unhandled and the GainLife clause was DROPPED entirely.
+    #[test]
+    fn misfortunes_gain_its_owner_gains_life_to_parent_target_owner() {
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Destroy target creature. Its owner gains 4 life.",
+            "Misfortune's Gain",
+            &[],
+            &["Sorcery".to_string()],
+            &[],
+        );
+        let player = parsed
+            .abilities
+            .iter()
+            .find_map(find_gain_life_player)
+            .expect("the 'Its owner gains 4 life' clause must produce a GainLife");
+        assert_eq!(
+            player,
+            TargetFilter::ParentTargetOwner,
+            "life must go to the destroyed creature's OWNER (CR 108.3)"
+        );
+    }
+
+    /// REGRESSION control (issue #3351): the controller phrasing must be UNCHANGED
+    /// — "Its controller gains 4 life." still binds to ParentTargetController. This
+    /// guards the suffix-arm split from accidentally rerouting controller → owner.
+    #[test]
+    fn its_controller_gains_life_stays_parent_target_controller() {
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Destroy target creature. Its controller gains 4 life.",
+            "Control Variant Test",
+            &[],
+            &["Sorcery".to_string()],
+            &[],
+        );
+        let player = parsed
+            .abilities
+            .iter()
+            .find_map(find_gain_life_player)
+            .expect("the 'Its controller gains 4 life' clause must produce a GainLife");
+        assert_eq!(
+            player,
+            TargetFilter::ParentTargetController,
+            "controller phrasing must remain ParentTargetController (no regression)"
+        );
     }
 
     #[test]

--- a/crates/engine/tests/misfortunes_gain_owner_life_3351.rs
+++ b/crates/engine/tests/misfortunes_gain_owner_life_3351.rs
@@ -1,0 +1,52 @@
+//! Regression coverage for issue #3351: "its owner" on a life-change effect must
+//! resolve to the destroyed object's OWNER, not the spell's controller.
+//!
+//! CARD TEXT: Misfortune's Gain and Path of Peace are both
+//! "Destroy target creature. Its owner gains 4 life." (verified identical in the
+//! engine's authoritative MTGJSON `AtomicCards.json`). The "Its owner gains 4
+//! life" rider is the card's intentional drawback — when you destroy an
+//! opponent's creature, the OPPONENT (the creature's owner) gains the 4 life.
+//!
+//! CR 108.3: an object's owner is the player who started the game with it in
+//!   their deck — distinct from its controller (control can change).
+//! CR 109.4: a reference to a player's possession resolves at the moment the
+//!   effect applies (LKI for an object that has left the battlefield).
+//! CR 608.2c: instructions resolve in written order — the destroy fires first,
+//!   then "Its owner gains 4 life" reads the (now-destroyed) creature's owner.
+//!
+//! DISCRIMINATING: P0 casts the spell at a creature OWNED + CONTROLLED by P1.
+//! After resolution P1 (the owner) must have gained 4 life and P0 must have
+//! gained 0. On pre-fix code the bare "its owner" subject was unhandled, so the
+//! GainLife clause was DROPPED and P1 gained 0 — this test fails there.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// "Destroy target creature. Its owner gains 4 life." — shared verbatim text of
+/// Misfortune's Gain and Path of Peace.
+const OWNER_LIFE_ORACLE: &str = "Destroy target creature. Its owner gains 4 life.";
+
+#[test]
+fn misfortunes_gain_destroyed_creatures_owner_gains_life() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The victim is OWNED and CONTROLLED by P1 (the opponent). P0 destroys it.
+    let victim = scenario.add_creature(P1, "Owned Bear", 2, 2).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Misfortune's Gain", false, OWNER_LIFE_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    // CR 608.2c: the destroy resolves first.
+    outcome.assert_zone(&[victim], Zone::Graveyard);
+
+    // CR 108.3 + CR 109.4: the destroyed creature's OWNER (P1) gains 4 life;
+    // the spell's controller (P0) does NOT. Pre-fix the GainLife clause was
+    // dropped, so P1's delta was 0 — the make-or-break correctness gate.
+    outcome.assert_life_delta(P1, 4);
+    outcome.assert_life_delta(P0, 0);
+}


### PR DESCRIPTION
Closes #3351.

## Problem
An **"its owner" / "[that] <noun>'s owner"** subject on a directed life-change effect resolved to the spell's **controller** ("you") instead of the **owner** of the referenced object. `parse_subject_application` had no bare `"its owner"` arm (so the clause defaulted to the `Controller` player ref), and its possessive `"<noun>'s owner"` suffix arm routed owner → `ParentTargetController`.

## Fix (parser-only; no runtime change)
Add a bare `"its owner"` / `"their owner"` arm and split the possessive suffix so the **owner** phrasings emit `TargetFilter::ParentTargetOwner` while `"controller"` phrasings stay `ParentTargetController`. `ParentTargetOwner` is a context-ref already resolved to the object's owner (with last-known-info for objects that have left the battlefield — CR 108.3 / 608.2h), so no runtime/type/variant change is needed.

## Result
**Misfortune's Gain** and **Path of Peace** ("Destroy target creature. Its owner gains 4 life.") — the destroyed creature's owner now gains the 4 life (previously the spell's controller did). The lose-life owner cards (Thieving Amalgam, The Matrix of Time) have a separate trigger-parse gap and are not addressed here.

## Verification
- **Discriminating runtime test** (`tests/misfortunes_gain_owner_life_3351.rs`): P0 casts Misfortune's Gain at a creature owned by P1; asserts P1 (owner) gains 4 life and P0 (controller) gains 0. **Proven fail-if-reverted** (reverting the bare-owner arm → P1 gains 0).
- 6 parser AST tests (bare/possessive owner → `ParentTargetOwner`; controller phrasings unchanged → `ParentTargetController`).
- Engine lib suite (11953) + full integration suite (1038) green; `cargo fmt`, parser-combinator gate, and `clippy --workspace -- -D warnings` clean.
- The bare-owner arm is exact-match, so the blast radius is tight; spot-checked 5 other "its owner …" cards (Funeral Pyre, Aether Gust, Aetherspouts, Power of Persuasion, Oft-Nabbed Goat) — no regression.

CR 108.3 (owner = the player who started the game with the card), CR 109.4 (control is distinct from ownership), CR 608.2c (effects resolve their instructions in written order).