### PR TITLE
feat(parser): parse 'discard it'/'discard them' pronoun back-reference

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1213,14 +1213,28 @@ pub(super) fn parse_targeted_action_ast(
         nom_on_lower(text, lower, |input| value((), tag("discard ")).parse(input))
     {
         let after_discard = &lower[lower.len() - after_discard_orig.len()..];
-        // CR 701.9a: Back-reference discard — "discard that card" / "discard
-        // those cards" target a specific card identified by the parent effect
-        // (Seek/Conjure/Reveal-Choose populate ParentTarget at runtime). Must
-        // be checked before the player-choice count-based discard path, since
-        // "that card" is not a count phrase.
+        // CR 701.9a: Back-reference discard — the noun forms "discard that
+        // card" / "discard those cards" and the pronoun (anaphoric) forms
+        // "discard it" / "discard them" all target a specific card the parent
+        // effect already identified (Seek/Conjure/Reveal-Choose/"look at the
+        // top card ... discard it" populate ParentTarget at runtime). Must be
+        // checked before the player-choice count-based discard path, since a
+        // back-reference is not a count phrase.
+        //
+        // The pronoun arms need a word boundary so a bare "it"/"them" does not
+        // swallow longer words ("itself", "themselves", "theme") or a trailing
+        // continuation ("discard them all", "discard it into exile"): the
+        // back-reference word must be a complete word, i.e. immediately
+        // followed by end-of-input or clause punctuation. The noun arms are
+        // unambiguous and keep their existing (boundary-free) behavior.
+        fn discard_backref_word_boundary(i: &str) -> OracleResult<'_, ()> {
+            peek(alt((value((), eof), value((), one_of(".,"))))).parse(i)
+        }
         if alt((
-            tag::<_, _, OracleError<'_>>("that card"),
-            tag("those cards"),
+            value((), tag::<_, _, OracleError<'_>>("that card")),
+            value((), tag("those cards")),
+            value((), terminated(tag("it"), discard_backref_word_boundary)),
+            value((), terminated(tag("them"), discard_backref_word_boundary)),
         ))
         .parse(after_discard)
         .is_ok()
@@ -10878,6 +10892,68 @@ mod tests {
                 );
             }
             other => panic!("Expected Discard with unless_filter, got {other:?}"),
+        }
+    }
+
+    /// CR 701.9a: Pronoun back-reference discard — "discard it" / "discard
+    /// them" anaphorically refer to a card the parent effect already
+    /// identified (e.g. "look at the top card of your library ... discard
+    /// it."). These must lower to `DiscardCard { ParentTarget }`, exactly
+    /// like the noun forms "discard that card" / "discard those cards", not
+    /// to a player-choice `Discard` count and not to `Unimplemented`.
+    #[test]
+    fn parse_discard_it_backref() {
+        for text in ["discard it", "discard it.", "discard it,"] {
+            let lower = text.to_lowercase();
+            let result = parse_targeted_action_ast(text, &lower, &mut ParseContext::default());
+            assert!(
+                matches!(
+                    result,
+                    Some(TargetedImperativeAst::DiscardCard {
+                        target: TargetFilter::ParentTarget
+                    })
+                ),
+                "Expected DiscardCard {{ ParentTarget }} for {text:?}, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_discard_them_backref() {
+        for text in ["discard them", "discard them.", "discard them,"] {
+            let lower = text.to_lowercase();
+            let result = parse_targeted_action_ast(text, &lower, &mut ParseContext::default());
+            assert!(
+                matches!(
+                    result,
+                    Some(TargetedImperativeAst::DiscardCard {
+                        target: TargetFilter::ParentTarget
+                    })
+                ),
+                "Expected DiscardCard {{ ParentTarget }} for {text:?}, got {result:?}"
+            );
+        }
+    }
+
+    /// Word-boundary guard regression: a bare "it"/"them" back-reference must
+    /// NOT swallow longer words that merely start with those letters. "discard
+    /// itself" / "discard themselves" / "discard them all" / "discard it into
+    /// exile" must NOT lower to the `ParentTarget` back-reference — the pronoun
+    /// is not a complete word there.
+    #[test]
+    fn parse_discard_pronoun_word_boundary_guard() {
+        for text in [
+            "discard itself",
+            "discard themselves",
+            "discard them all",
+            "discard it into exile",
+        ] {
+            let lower = text.to_lowercase();
+            let result = parse_targeted_action_ast(text, &lower, &mut ParseContext::default());
+            assert!(
+                !matches!(result, Some(TargetedImperativeAst::DiscardCard { .. })),
+                "Did not expect a back-reference DiscardCard for {text:?}, got {result:?}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

The imperative discard parser already recognized the **noun** back-reference forms `discard that card` / `discard those cards` and lowered them to `DiscardCard { target: ParentTarget }` (CR 701.9a) — the card to discard is the one the parent effect already identified (a dig/reveal/seek/conjure that put an object into `ParentTarget`). But the equivalent **pronoun** (anaphoric) forms `discard it` / `discard them` fell through the entire discard branch and produced `Unimplemented`, because `it`/`them` are not count phrases and never reached a handler.

This extends the existing back-reference `alt(...)` block to also accept the pronoun forms, emitting the **same** existing AST. No new enum variant or type.

## Class of cards covered

Anaphoric "look at / reveal / draw ... then discard it" lines, e.g.:

- Fa'adiyah Seer / Sindbad — `{T}: Draw a card and reveal it. If it isn't a land card, discard it.`
- Binding Negotiation — `... You may choose a nonland card from it. If you do, they discard it.`
- Library of Leng — `If an effect causes you to discard a card, discard it, ...`

By the time these clauses reach the imperative parser they are already split on sentence/`then`/`,` boundaries and the leading conditional is peeled by the clause shell, so the discard clause is exactly `discard it` / `discard them`. The fix generalizes to the whole anaphoric-discard class (the same `ParentTarget` shape future dig/seek/reveal-then-discard cards will use), not a single card.

## Implementation

The discard back-reference matcher gains two pronoun arms alongside the existing noun arms, all producing the existing `TargetedImperativeAst::DiscardCard { target: TargetFilter::ParentTarget }`:

```rust
if alt((
    value((), tag::<_, _, OracleError<'_>>("that card")),
    value((), tag("those cards")),
    value((), terminated(tag("it"), discard_backref_word_boundary)),
    value((), terminated(tag("them"), discard_backref_word_boundary)),
))
.parse(after_discard)
.is_ok()
```

### Word-boundary guard

A bare `tag("it")` would also match the `it` in `itself`, and `tag("them")` the `them` in `themselves` / `theme`; a space-led continuation such as `discard them all` or `discard it into exile` must not be swallowed either. The pronoun arms are therefore wrapped in `terminated(tag(...), discard_backref_word_boundary)`, where the boundary is a nom `peek` that requires the next position to be end-of-input or clause punctuation (`.` / `,`):

```rust
fn discard_backref_word_boundary(i: &str) -> OracleResult<'_, ()> {
    peek(alt((value((), eof), value((), one_of(".,"))))).parse(i)
}
```

This mirrors the existing word-boundary idiom already used elsewhere in this file (`parse_pay_life_amount`'s `word_boundary`). The noun arms are unambiguous and keep their existing boundary-free behavior, so `discard that card` / `discard those cards` are unaffected.

## Tests

- `parse_discard_it_backref` — `discard it`, `discard it.`, `discard it,` all lower to `DiscardCard { ParentTarget }`.
- `parse_discard_them_backref` — `discard them`, `discard them.`, `discard them,` likewise.
- `parse_discard_pronoun_word_boundary_guard` — negative case: `discard itself`, `discard themselves`, `discard them all`, `discard it into exile` must **not** produce a back-reference `DiscardCard`.

The two positive tests were verified to fail on a clean tree (`it`/`them` → `None`) before the change and pass after; the guard test passes both before and after.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- `cargo test -p engine` — 0 failed (includes the three new tests; existing discard regressions `discard your hand` / `discard their hand` / `discard a card` / `discard two cards` / unless-filter still green)
- `./scripts/check-parser-combinators.sh` — clean (nom combinators only; no string-method dispatch in the added lines)
