### PR TITLE
fix(parser): count distinct card types among discarded cards (Occult Epiphany)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -2427,7 +2427,9 @@ fn quantity_ref_references_target_creature(qty: &QuantityRef) -> bool {
             CardTypeSetSource::Objects { filter } => {
                 filter_references_target_creature_quantity(filter)
             }
-            CardTypeSetSource::Zone { .. } | CardTypeSetSource::ExiledBySource => false,
+            CardTypeSetSource::Zone { .. }
+            | CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::TrackedSet { .. } => false,
         },
         QuantityRef::ManaSpentToCast { metric, .. } => match metric {
             CastManaSpentMetric::FromSource { source_filter } => {

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1139,6 +1139,22 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             CardTypeSetSource::Objects { filter } => {
                 format!("card types among {}", fmt_target(filter))
             }
+            CardTypeSetSource::TrackedSet { caused_by } => match caused_by {
+                Some(cause) => {
+                    use crate::types::ability::ThisWayCause;
+                    let verb = match cause {
+                        ThisWayCause::Discarded => "discarded",
+                        ThisWayCause::Exiled => "exiled",
+                        ThisWayCause::Milled => "milled",
+                        ThisWayCause::Destroyed => "destroyed",
+                        ThisWayCause::Sacrificed => "sacrificed",
+                        ThisWayCause::Returned => "returned",
+                        ThisWayCause::Bounced => "bounced",
+                    };
+                    format!("card types among cards {verb} this way")
+                }
+                None => "card types among tracked cards".into(),
+            },
         },
         QuantityRef::CardsExiledBySource => "cards exiled with source".into(),
         QuantityRef::ZoneCardCount {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -8,11 +8,12 @@ use crate::game::conditions::{
 use crate::game::filter;
 use crate::game::speed::has_max_speed;
 use crate::types::ability::{
-    AbilityCondition, AbilityCost, AbilityKind, ControllerRef, CopyRetargetPermission,
-    CostPaidObjectSnapshot, Effect, EffectError, EffectKind, EffectOutcomeSignal, EffectScope,
-    FilterProp, OpponentMayScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef,
-    RepeatContinuation, ResolvedAbility, SacrificeCost, SacrificeRequirement, SharedQuality,
-    SharedQualityRelation, SubAbilityLink, TapStateChange, TargetFilter, TargetRef, ThisWayCause,
+    AbilityCondition, AbilityCost, AbilityKind, CardTypeSetSource, ControllerRef,
+    CopyRetargetPermission, CostPaidObjectSnapshot, Effect, EffectError, EffectKind,
+    EffectOutcomeSignal, EffectScope, FilterProp, OpponentMayScope, PlayerFilter, PlayerScope,
+    QuantityExpr, QuantityRef, RepeatContinuation, ResolvedAbility, SacrificeCost,
+    SacrificeRequirement, SharedQuality, SharedQualityRelation, SubAbilityLink, TapStateChange,
+    TargetFilter, TargetRef, ThisWayCause,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -2684,7 +2685,11 @@ fn quantity_expr_references_tracked_set(qty: &QuantityExpr) -> bool {
         QuantityExpr::Ref { qty } => {
             matches!(
                 qty,
-                QuantityRef::TrackedSetSize | QuantityRef::FilteredTrackedSetSize { .. }
+                QuantityRef::TrackedSetSize
+                    | QuantityRef::FilteredTrackedSetSize { .. }
+                    | QuantityRef::DistinctCardTypes {
+                        source: CardTypeSetSource::TrackedSet { .. }
+                    }
             )
         }
         QuantityExpr::Offset { inner, .. }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -260,7 +260,9 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         // is the object-filter variant; zone / linked-exile sources do not.
         QuantityRef::DistinctCardTypes { source } => match source {
             CardTypeSetSource::Objects { .. } => true,
-            CardTypeSetSource::Zone { .. } | CardTypeSetSource::ExiledBySource => false,
+            CardTypeSetSource::Zone { .. }
+            | CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::TrackedSet { .. } => false,
         },
         // Player-level, single-object, history-record, payment, and choice
         // references: unaffected by another object's battlefield entry/exit.
@@ -406,9 +408,12 @@ fn entered_object_perturbs_quantity_ref(
             CardTypeSetSource::Objects { filter } => {
                 matches_target_filter(state, entered.id, filter, ctx)
             }
-            // Zone / linked-exile sources are not battlefield population — the
-            // classifier returns false for them, so they cannot be perturbed.
-            CardTypeSetSource::Zone { .. } | CardTypeSetSource::ExiledBySource => false,
+            // Zone / linked-exile / tracked-set sources are not battlefield
+            // population — the classifier returns false for them, so they cannot
+            // be perturbed.
+            CardTypeSetSource::Zone { .. }
+            | CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::TrackedSet { .. } => false,
         },
         // CR 700.5: devotion is perturbed iff the entered object's mana cost
         // contributes a symbol for one of the fixed colors. `ChosenColor`'s
@@ -1607,6 +1612,36 @@ fn resolve_ref(
                         if let Some(obj) = state.objects.get(&obj_id) {
                             for ct in &obj.card_types.core_types {
                                 seen.insert(*ct);
+                            }
+                        }
+                    }
+                }
+                // CR 608.2c + CR 205.2a/205.2b: distinct card types among the most
+                // recent chain tracked set. A merged Draw->Discard set is
+                // disambiguated by CAUSE: `Some(cause)` (e.g. Discarded) tallies
+                // only members whose recorded producer action equals the bound
+                // cause; drawn members are unstamped and excluded. `None` counts
+                // every member. Mirrors `FilteredTrackedSetSize`'s set selection
+                // (highest set id) and cause filter (`tracked_set_member_causes`).
+                CardTypeSetSource::TrackedSet { caused_by } => {
+                    if let Some((set_id, ids)) =
+                        state.tracked_object_sets.iter().max_by_key(|(id, _)| id.0)
+                    {
+                        for &oid in ids {
+                            let cause_ok = match caused_by {
+                                None => true,
+                                Some(cause) => state
+                                    .tracked_set_member_causes
+                                    .get(set_id)
+                                    .and_then(|causes| causes.get(&oid))
+                                    .is_some_and(|member_cause| member_cause == cause),
+                            };
+                            if cause_ok {
+                                if let Some(obj) = state.objects.get(&oid) {
+                                    for ct in &obj.card_types.core_types {
+                                        seen.insert(*ct);
+                                    }
+                                }
                             }
                         }
                     }
@@ -10472,6 +10507,167 @@ mod tests {
             count_for(None),
             4,
             "None must count every member of the set (legacy parity)"
+        );
+    }
+
+    /// Occult Epiphany #3307: "Draw X, then discard X. Create a 1/1 Spirit for
+    /// each card type among cards discarded this way." Draw and Discard MERGE
+    /// into one chain tracked set; the token count must be DISTINCT CARD TYPES
+    /// among the DISCARDED members only (drawn members are unstamped and must be
+    /// excluded). CR 608.2c + CR 205.2a/205.2b.
+    #[test]
+    fn distinct_card_types_tracked_set_counts_discarded_members_by_cause() {
+        let mut state = GameState::new_two_player(42);
+        // Two drawn INSTANTS (unstamped) and two discarded CREATURES (stamped
+        // Discarded) merged into a single Draw->Discard chain tracked set.
+        let drawn_a = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Drawn-A".into(),
+            Zone::Hand,
+        );
+        let drawn_b = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Drawn-B".into(),
+            Zone::Hand,
+        );
+        let disc_creature_a = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Disc-Creature-A".into(),
+            Zone::Graveyard,
+        );
+        let disc_creature_b = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Disc-Creature-B".into(),
+            Zone::Graveyard,
+        );
+        let disc_instant = create_object(
+            &mut state,
+            CardId(5),
+            PlayerId(0),
+            "Disc-Instant".into(),
+            Zone::Graveyard,
+        );
+        for id in [drawn_a, drawn_b, disc_instant] {
+            state.objects.get_mut(&id).unwrap().card_types.core_types = vec![CoreType::Instant];
+        }
+        for id in [disc_creature_a, disc_creature_b] {
+            state.objects.get_mut(&id).unwrap().card_types.core_types = vec![CoreType::Creature];
+        }
+
+        let set_id = TrackedSetId(state.next_tracked_set_id);
+        state.next_tracked_set_id += 1;
+        // A higher-id (later) set: the resolver must pick THIS merged set, the
+        // highest id, exactly like FilteredTrackedSetSize.
+        state.tracked_object_sets.insert(
+            set_id,
+            vec![
+                drawn_a,
+                drawn_b,
+                disc_creature_a,
+                disc_creature_b,
+                disc_instant,
+            ],
+        );
+        state.chain_tracked_set_id = Some(set_id);
+        // Only the DISCARDED members carry a cause; drawn members are unstamped.
+        let mut causes = HashMap::new();
+        causes.insert(disc_creature_a, ThisWayCause::Discarded);
+        causes.insert(disc_creature_b, ThisWayCause::Discarded);
+        causes.insert(disc_instant, ThisWayCause::Discarded);
+        state.tracked_set_member_causes.insert(set_id, causes);
+
+        let count_for = |caused_by| {
+            let expr = QuantityExpr::Ref {
+                qty: QuantityRef::DistinctCardTypes {
+                    source: CardTypeSetSource::TrackedSet { caused_by },
+                },
+            };
+            resolve_quantity(&state, &expr, PlayerId(0), ObjectId(999))
+        };
+
+        // The canonical Occult Epiphany reading: distinct card types among the
+        // DISCARDED members = {Creature, Instant} = 2. The two drawn Instants are
+        // unstamped and excluded; the discarded Instant DOES contribute Instant.
+        assert_eq!(
+            count_for(Some(ThisWayCause::Discarded)),
+            2,
+            "distinct card types among discarded members = Creature + Instant (drawn unstamped)"
+        );
+
+        // Discriminating bug check: the OLD behavior (TrackedSetSize) would have
+        // returned 5 (all members); a naive distinct-types-of-WHOLE-set would be
+        // 2 as well but for the wrong reason, so also assert the all-creature
+        // variant differs from the merged-instant variant via the next test.
+        assert_eq!(
+            count_for(None),
+            2,
+            "None counts distinct types of every member: Instant + Creature = 2"
+        );
+    }
+
+    /// Companion to the above: discarding exactly one creature + one instant
+    /// (2 distinct types) yields 2; discarding two creatures (1 distinct type)
+    /// yields 1 — proving the count is DISTINCT TYPES, not member count.
+    #[test]
+    fn distinct_card_types_tracked_set_is_distinct_types_not_member_count() {
+        let mut state = GameState::new_two_player(7);
+        let drawn = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Drawn".into(),
+            Zone::Hand,
+        );
+        let cr_a = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Cr-A".into(),
+            Zone::Graveyard,
+        );
+        let cr_b = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Cr-B".into(),
+            Zone::Graveyard,
+        );
+        state.objects.get_mut(&drawn).unwrap().card_types.core_types = vec![CoreType::Sorcery];
+        for id in [cr_a, cr_b] {
+            state.objects.get_mut(&id).unwrap().card_types.core_types = vec![CoreType::Creature];
+        }
+
+        let set_id = TrackedSetId(state.next_tracked_set_id);
+        state.next_tracked_set_id += 1;
+        state
+            .tracked_object_sets
+            .insert(set_id, vec![drawn, cr_a, cr_b]);
+        state.chain_tracked_set_id = Some(set_id);
+        let mut causes = HashMap::new();
+        causes.insert(cr_a, ThisWayCause::Discarded);
+        causes.insert(cr_b, ThisWayCause::Discarded);
+        state.tracked_set_member_causes.insert(set_id, causes);
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::DistinctCardTypes {
+                source: CardTypeSetSource::TrackedSet {
+                    caused_by: Some(ThisWayCause::Discarded),
+                },
+            },
+        };
+        // Two discarded CREATURES -> 1 distinct card type (NOT 2 members).
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(0), ObjectId(999)),
+            1,
+            "two discarded creatures share one card type -> 1 token, not 2"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -496,9 +496,29 @@ fn parse_token_description_with_context(
     {
         let suffix_lower = suffix.to_lowercase();
         if suffix_lower.contains("for each") && suffix_lower.contains("this way") {
-            count = QuantityExpr::Ref {
-                qty: QuantityRef::TrackedSetSize,
-            };
+            // CR 608.2c + CR 205.2a: route ONLY "card type among cards <verb> this
+            // way" to the cause-filtered distinct-card-types count (Occult
+            // Epiphany #3307); every other "... this way" token keeps
+            // `TrackedSetSize`. The dispatch decision is the nom combinator's
+            // Ok/Err — the post-"for each " clause is extracted with nom
+            // (`take_until` + `tag`), not string-method splitting.
+            let after_for_each = take_until::<_, _, OracleError<'_>>("for each ")
+                .parse(suffix_lower.as_str())
+                .and_then(|(rest, _)| tag("for each ").parse(rest))
+                .map(|(clause, _)| clause.trim_end_matches('.').trim());
+            count = after_for_each
+                .ok()
+                .and_then(|clause| {
+                    crate::parser::oracle_nom::quantity::parse_distinct_card_types_among_tracked_set(
+                        clause,
+                    )
+                    .ok()
+                    .filter(|(rest, _)| rest.is_empty())
+                    .map(|(_, qty)| QuantityExpr::Ref { qty })
+                })
+                .unwrap_or(QuantityExpr::Ref {
+                    qty: QuantityRef::TrackedSetSize,
+                });
         }
     }
 
@@ -1179,6 +1199,48 @@ mod tests {
     use super::*;
     use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef, RoundingMode, TypeFilter};
     use crate::types::card_type::CoreType;
+
+    #[test]
+    fn occult_epiphany_token_counts_distinct_types_of_discarded() {
+        // Occult Epiphany #3307: the token count must be DISTINCT CARD TYPES
+        // among the DISCARDED chain members (cause-filtered), NOT TrackedSetSize.
+        let txt = "Create a 1/1 white Spirit creature token with flying for each card type among cards discarded this way.";
+        let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
+            .expect("expected Token effect");
+        let Effect::Token { count, .. } = effect else {
+            panic!("expected Effect::Token, got {effect:?}");
+        };
+        assert_eq!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::DistinctCardTypes {
+                    source: crate::types::ability::CardTypeSetSource::TrackedSet {
+                        caused_by: Some(crate::types::ability::ThisWayCause::Discarded),
+                    },
+                },
+            },
+            "Occult Epiphany must count distinct discarded card types, not TrackedSetSize"
+        );
+    }
+
+    #[test]
+    fn bare_for_each_card_discarded_this_way_keeps_tracked_set_size() {
+        // No-regression: a plain "for each card discarded this way" token (member
+        // count, NOT distinct types) must still resolve to TrackedSetSize.
+        let txt = "Create a 1/1 white Spirit creature token with flying for each card discarded this way.";
+        let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
+            .expect("expected Token effect");
+        let Effect::Token { count, .. } = effect else {
+            panic!("expected Effect::Token, got {effect:?}");
+        };
+        assert_eq!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::TrackedSetSize,
+            },
+            "bare 'card discarded this way' must keep TrackedSetSize"
+        );
+    }
 
     #[test]
     fn copy_x_tokens_of_target_parses_variable_count() {

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -25,8 +25,8 @@ use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
     AggregateFunction, CardTypeSetSource, CastManaObjectScope, CastManaSpentMetric, ControllerRef,
     CountScope, DamageKindFilter, DevotionColors, FilterProp, ObjectProperty, ObjectScope,
-    PlayerScope, QuantityExpr, QuantityRef, RoundingMode, SharedQuality, TargetFilter, TypeFilter,
-    TypedFilter, ZoneRef,
+    PlayerScope, QuantityExpr, QuantityRef, RoundingMode, SharedQuality, TargetFilter,
+    ThisWayCause, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::CounterMatch;
 use crate::types::keywords::Keyword;
@@ -490,7 +490,15 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         parse_distinct_card_types_exiled_with_source,
         parse_linked_exile_mana_value_ref,
         parse_distinct_card_types_in_zone,
-        parse_distinct_card_types_among_objects,
+        // CR 608.2c + CR 205.2a: "card type[s] among cards <verb> this way" must
+        // precede the generic `among <objects>` arm so the chain-tracked-set,
+        // cause-filtered count wins on the "card type among cards" prefix. Nested
+        // with `parse_distinct_card_types_among_objects` to keep the outer `alt`
+        // within nom's tuple arity (nom 8.0 max: 21 items).
+        alt((
+            parse_distinct_card_types_among_tracked_set,
+            parse_distinct_card_types_among_objects,
+        )),
         // CR 406.6: "cards exiled with ~" — must precede `parse_cards_in_zone_ref`
         // so "cards exiled with …" wins over the generic "cards in …" zone phrase.
         parse_cards_exiled_with_source,
@@ -714,7 +722,14 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
     alt((
         parse_distinct_card_types_exiled_with_source,
         parse_distinct_card_types_in_zone,
-        parse_distinct_card_types_among_objects,
+        // CR 608.2c + CR 205.2a: "card type[s] among cards <verb> this way" must
+        // precede the generic `among <objects>` arm (same ordering as
+        // `parse_quantity_ref`). Nested with `parse_distinct_card_types_among_objects`
+        // to stay within nom's top-level `alt` arity (nom 8.0 max: 21 items).
+        alt((
+            parse_distinct_card_types_among_tracked_set,
+            parse_distinct_card_types_among_objects,
+        )),
         // CR 201.2 + CR 603.4: "differently named <type-phrase>" — distinct-by-
         // name population count. Must precede `parse_number_of_controlled_type`
         // so the adjective prefix is consumed before the generic typed-filter
@@ -1222,6 +1237,33 @@ fn parse_distinct_card_types_among_objects(input: &str) -> OracleResult<'_, Quan
         &input[consumed..],
         QuantityRef::DistinctCardTypes {
             source: CardTypeSetSource::Objects { filter },
+        },
+    ))
+}
+
+/// CR 608.2c + CR 205.2a: "card type[s] among cards <verb> this way" -> distinct
+/// card types among the chain tracked set, cause-filtered to <verb> (Occult Epiphany #3307).
+pub(crate) fn parse_distinct_card_types_among_tracked_set(
+    input: &str,
+) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("card type").parse(input)?;
+    let (rest, _) = opt(tag("s")).parse(rest)?;
+    let (rest, _) = tag(" among cards ").parse(rest)?;
+    let (rest, cause) = alt((
+        value(ThisWayCause::Discarded, tag("discarded")),
+        value(ThisWayCause::Exiled, tag("exiled")),
+        value(ThisWayCause::Milled, tag("milled")),
+        value(ThisWayCause::Destroyed, tag("destroyed")),
+        value(ThisWayCause::Sacrificed, tag("sacrificed")),
+    ))
+    .parse(rest)?;
+    let (rest, _) = tag(" this way").parse(rest)?;
+    Ok((
+        rest,
+        QuantityRef::DistinctCardTypes {
+            source: CardTypeSetSource::TrackedSet {
+                caused_by: Some(cause),
+            },
         },
     ))
 }
@@ -4801,6 +4843,56 @@ mod tests {
             .properties
             .iter()
             .any(|property| matches!(property, FilterProp::Another)));
+    }
+
+    #[test]
+    fn test_parse_distinct_card_types_among_cards_discarded_this_way() {
+        // Occult Epiphany #3307: singular "card type" + Discarded cause.
+        let (rest, q) =
+            parse_distinct_card_types_among_tracked_set("card type among cards discarded this way")
+                .unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::DistinctCardTypes {
+                source: CardTypeSetSource::TrackedSet {
+                    caused_by: Some(ThisWayCause::Discarded),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_distinct_card_types_among_cards_exiled_this_way() {
+        // Plural "card types" + Exiled cause.
+        let (rest, q) =
+            parse_distinct_card_types_among_tracked_set("card types among cards exiled this way")
+                .unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::DistinctCardTypes {
+                source: CardTypeSetSource::TrackedSet {
+                    caused_by: Some(ThisWayCause::Exiled),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_distinct_card_types_among_tracked_set_via_parse_quantity_ref() {
+        // The combinator must win over `parse_distinct_card_types_among_objects`
+        // when reached through the top-level `parse_quantity_ref` alt chain.
+        let (rest, q) = parse_quantity_ref("card types among cards discarded this way").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::DistinctCardTypes {
+                source: CardTypeSetSource::TrackedSet {
+                    caused_by: Some(ThisWayCause::Discarded),
+                },
+            }
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2316,6 +2316,14 @@ fn parse_for_each_clause_with_they_controller(
         if let Some(qty) = parse_filtered_destroyed_this_way(&lower) {
             return Some(qty);
         }
+        // CR 608.2c + CR 205.2a: "card type[s] among cards <verb> this way" —
+        // distinct card types among the cause-filtered chain tracked set (Occult
+        // Epiphany #3307). Must precede the bare `TrackedSetSize` fallback.
+        if let Ok(("", qty)) =
+            crate::parser::oracle_nom::quantity::parse_distinct_card_types_among_tracked_set(&lower)
+        {
+            return Some(qty);
+        }
         return Some(QuantityRef::TrackedSetSize);
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3415,6 +3415,15 @@ pub enum CardTypeSetSource {
     ExiledBySource,
     /// CR 109.2: Objects matching a battlefield-style filter.
     Objects { filter: TargetFilter },
+    /// CR 608.2c + CR 205.2a: distinct card types among the current chain
+    /// tracked set, optionally restricted to members produced by `caused_by`.
+    /// Mirrors `QuantityRef::FilteredTrackedSetSize { caused_by }`: a merged
+    /// Draw->Discard set is disambiguated by CAUSE (drawn members are unstamped),
+    /// so Some(Discarded) counts only discarded members. None counts all.
+    TrackedSet {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        caused_by: Option<ThisWayCause>,
+    },
 }
 
 /// CR 601.2h: Which cast object a mana-spent quantity reads.


### PR DESCRIPTION
## Summary

Fixes #3307 

**Occult Epiphany** — "Draw X cards, then discard X cards. Create a 1/1 white Spirit creature token with flying **for each card type among cards discarded this way**." — created one token per discarded **card** (`QuantityRef::TrackedSetSize`) instead of per distinct card **type** among the discarded cards. Discarding two creatures made two tokens instead of one.

## Fix

Add `CardTypeSetSource::TrackedSet { caused_by: Option<ThisWayCause> }` (parallel to the existing `ExiledBySource` dynamic-set source) so `QuantityRef::DistinctCardTypes` can count distinct card types among the chain tracked set, cause-filtered.

The subtlety: "Draw X, then discard X" **merges** the drawn and discarded cards into a single chain tracked set (the chain id extends; there's no "If you do" boundary to reset it). So the resolver filters members by `caused_by = Some(Discarded)` — drawn cards are unstamped and excluded — exactly mirroring how `FilteredTrackedSetSize` disambiguates the same merged set. The publish gate (`quantity_expr_references_tracked_set`) is widened so the discard set is actually published for the `Token` effect (otherwise the resolver reads an empty set → 0 tokens).

Parser: a new combinator recognizes `"card type[s] among cards <verb> this way"` (mapping the verb to `ThisWayCause`), registered ahead of `parse_distinct_card_types_among_objects` and routed from both the token `"for each"` suffix and `parse_for_each_clause`. The change is **narrow** — only the `"card type among … this way"` form reroutes to the distinct-types count; every other `"for each … this way"` token still counts members (`TrackedSetSize`), so the ~75 other such cards are unaffected.

No new AST reshape (additive variant, `#[serde(default, skip_serializing_if)]`); no runtime change beyond the new resolver + publish arms.

## Runtime

- Discard 2 creatures (after drawing 2 instants) → the merged set's discarded members are 2 creatures → distinct types `{Creature}` → **1 token**.
- Discard 1 creature + 1 instant → `{Creature, Instant}` → **2 tokens**.

The drawn cards are excluded by **cause** (unstamped), not by set recency.

## Tests

- `occult_epiphany_token_counts_distinct_types_of_discarded` — the Token count parses to `DistinctCardTypes{ TrackedSet{ Some(Discarded) } }`, not `TrackedSetSize`.
- `distinct_card_types_tracked_set_is_distinct_types_not_member_count` — a merged set (drawn Sorcery + 2 discarded Creatures) resolves to 1 under `Some(Discarded)` (dropping the cause filter would wrongly include the Sorcery → 2).
- `distinct_card_types_tracked_set_counts_discarded_members_by_cause` — cause-filtered count.
- Parser combinator tests for "discarded"/"exiled this way" + routing via `parse_quantity_ref`.
- `bare_for_each_card_discarded_this_way_keeps_tracked_set_size` — no-regression: the bare "for each card discarded this way" form still counts members.

## Verification

- `cargo +nightly check --workspace`: clean (the new variant + all exhaustive match arms compile across every crate).
- `cargo +nightly test -p engine --lib distinct`: 62 passed; `--test integration`: 1063 passed (no fixture diff).
- `cargo +nightly clippy -p engine --lib -- -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean.

CR references grep-verified against `docs/MagicCompRules.txt`: **205.2a / 205.2b** (card types / multi-type objects), **608.2c** (tracked "this way" set / instruction order).
