### PR TITLE
feat(parser): legend-rule exemption for base types, tokens, commanders

### DIFF
--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -98,12 +98,14 @@ pub(crate) fn parse_legend_rule_exemption(
 }
 
 /// CR 704.5j: Resolve the `<scope>` noun phrase of a legend-rule exemption
-/// ("permanents you control", "Slivers you control", ...) into a
-/// controller-scoped `affected` filter. Returns `None` for scopes this parser
-/// cannot resolve precisely ("tokens", "commanders", "them"),
-/// so those cards are deferred rather than given a filter that silently matches
-/// nothing. "creature tokens you control" is handled explicitly (The Master,
-/// Multiplied).
+/// ("permanents you control", "creatures you control", "tokens you control",
+/// "commanders you control", "Slivers you control", ...) into a
+/// controller-scoped `affected` filter. The legend rule applies only to
+/// permanents (CR 704.5j: "legendary permanents"), so only permanent card
+/// types are accepted as bare-type scopes. Returns `None` for scopes this
+/// parser cannot resolve precisely (e.g. the bare pronoun "them"), so those
+/// cards are deferred rather than given a filter that silently matches nothing.
+/// "creature tokens you control" is handled explicitly (The Master, Multiplied).
 /// CR 109.5: "you control" resolves to the source's controller.
 pub(crate) fn parse_legend_rule_scope(scope: &TextPair<'_>) -> Option<TargetFilter> {
     // Drop the trailing sentence terminator so the combinator suffix split sees
@@ -132,6 +134,37 @@ pub(crate) fn parse_legend_rule_scope(scope: &TextPair<'_>) -> Option<TargetFilt
         ));
     }
 
+    // CR 704.5j: bare permanent card-type scopes ("creatures you control",
+    // "artifacts you control", ...). Generalizes the "creatures" case (Council
+    // of Reeds) to the whole "<permanent type>s you control" class. Only
+    // permanent types map — the legend rule applies solely to permanents.
+    if let Some(card_type) = legend_rule_permanent_type(base.lower) {
+        return Some(TargetFilter::Typed(
+            TypedFilter::new(card_type).controller(ControllerRef::You),
+        ));
+    }
+
+    // CR 111.1 + CR 704.5j: "tokens you control" — any token permanent (Cadric,
+    // Soul Kindler). Token-ness is a property, not a card type.
+    if base.lower == "tokens" {
+        return Some(TargetFilter::Typed(
+            TypedFilter::permanent()
+                .properties(vec![FilterProp::Token])
+                .controller(ControllerRef::You),
+        ));
+    }
+
+    // CR 903.3 + CR 704.5j: "commanders you control" — permanents that are
+    // commanders. Commander designation is a card attribute, modeled as a
+    // permanent property.
+    if base.lower == "commanders" {
+        return Some(TargetFilter::Typed(
+            TypedFilter::permanent()
+                .properties(vec![FilterProp::IsCommander])
+                .controller(ControllerRef::You),
+        ));
+    }
+
     if let Some((canonical, consumed)) = parse_subtype(base.original) {
         if consumed == base.original.len() {
             return Some(TargetFilter::Typed(
@@ -143,6 +176,31 @@ pub(crate) fn parse_legend_rule_scope(scope: &TextPair<'_>) -> Option<TargetFilt
     }
 
     None
+}
+
+/// CR 704.5j: Map a plural permanent card-type word ("creatures", "artifacts",
+/// …) to its `TypeFilter`. Only permanent types are returned — the legend rule
+/// applies solely to permanents — so instant/sorcery words (and anything else)
+/// yield `None` and the card stays deferred rather than mis-scoped.
+fn legend_rule_permanent_type(word: &str) -> Option<crate::types::ability::TypeFilter> {
+    use crate::types::ability::TypeFilter;
+    // Composed via nom `alt`/`value` per the combinator mandate; a new permanent
+    // type is one extra `value(..., tag(...))` branch. Instant/sorcery words (and
+    // anything else) fail every branch, so the card stays deferred.
+    let (rest, tf) = alt((
+        value(
+            TypeFilter::Creature,
+            tag::<_, _, OracleError<'_>>("creatures"),
+        ),
+        value(TypeFilter::Artifact, tag("artifacts")),
+        value(TypeFilter::Enchantment, tag("enchantments")),
+        value(TypeFilter::Planeswalker, tag("planeswalkers")),
+        value(TypeFilter::Land, tag("lands")),
+        value(TypeFilter::Battle, tag("battles")),
+    ))
+    .parse(word)
+    .ok()?;
+    rest.is_empty().then_some(tf)
 }
 
 /// Parse the subject of "X can't be countered" lines.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6060,6 +6060,56 @@ fn static_legend_rule_creature_tokens_scope() {
 }
 
 #[test]
+fn static_legend_rule_creatures_you_control() {
+    // CR 704.5j: Council of Reeds — bare permanent type "creatures you control".
+    let def =
+        parse_static_line("The \"legend rule\" doesn't apply to creatures you control.").unwrap();
+    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+    match def.affected {
+        Some(TargetFilter::Typed(ref typed)) => {
+            assert_eq!(typed.controller, Some(ControllerRef::You));
+            assert!(typed
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, crate::types::ability::TypeFilter::Creature)));
+        }
+        other => panic!("expected typed creature filter, got {other:?}"),
+    }
+}
+
+#[test]
+fn static_legend_rule_tokens_you_control() {
+    // CR 111.1 + CR 704.5j: Cadric, Soul Kindler — "tokens you control".
+    let def =
+        parse_static_line("The \"legend rule\" doesn't apply to tokens you control.").unwrap();
+    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+    assert!(matches!(
+        def.affected,
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::You),
+            properties,
+            ..
+        })) if properties.contains(&FilterProp::Token)
+    ));
+}
+
+#[test]
+fn static_legend_rule_commanders_you_control() {
+    // CR 903.3 + CR 704.5j: "commanders you control".
+    let def =
+        parse_static_line("The \"legend rule\" doesn't apply to commanders you control.").unwrap();
+    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+    assert!(matches!(
+        def.affected,
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::You),
+            properties,
+            ..
+        })) if properties.contains(&FilterProp::IsCommander)
+    ));
+}
+
+#[test]
 fn static_cant_cause_sacrifice_or_exile_creature_tokens() {
     // CR 603.2 + CR 609.3: The Master, Multiplied.
     let def = parse_static_line(
@@ -6088,8 +6138,10 @@ fn static_legend_rule_defers_unparseable_scopes() {
     // forms, must NOT be emitted as a LegendRuleDoesntApply static — they are
     // deferred (left Unimplemented), never misparsed into a no-op exemption.
     for text in [
-            "The \"legend rule\" doesn't apply to tokens you control.", // Cadric
-            "The \"legend rule\" doesn't apply to commanders you control.", // Try-My-Deck Elemental
+            // Bare pronoun scope with no concrete filter — must defer, not be
+            // emitted as a no-op exemption.
+            "The \"legend rule\" doesn't apply to them.",
+            // Conditional form that doesn't begin with the exemption clause.
             "If there are exactly two permanents named Brothers Yamazaki on the battlefield, the \"legend rule\" doesn't apply to them.",
         ] {
             assert!(


### PR DESCRIPTION
## Summary

Extends the legend-rule-exemption scope parser (`parse_legend_rule_scope`) to handle three scope classes it previously left `Unimplemented`:

- **Bare permanent card types** — "The legend rule doesn't apply to **creatures** you control." (Council of Reeds). Generalized to the whole `<permanent type>s you control` class (creatures, artifacts, enchantments, planeswalkers, lands, battles) via a nom `alt`/`value` combinator. Only permanent types map — the legend rule applies solely to permanents (CR 704.5j: "legendary permanents") — so instant/sorcery words fail every branch and the card stays deferred.
- **"tokens you control"** — Cadric, Soul Kindler. Token-ness is a property (`FilterProp::Token`), not a card type (CR 111.1).
- **"commanders you control"** — modeled with `FilterProp::IsCommander` (CR 903.3).

All three emit the existing `StaticMode::LegendRuleDoesntApply` with an existing `TargetFilter::Typed(...)` controller-scoped filter — no new types or variants.

## Why

`parse_legend_rule_scope` only recognized `permanents you control`, `creature tokens you control`, and bare `<subtype>s you control`, returning `None` for base card types, `tokens`, and `commanders`. Those cards fell to `Unimplemented`.

## Honesty / scope

- Truly-unparseable scopes still defer: the bare pronoun ("...doesn't apply to **them**") and conditional forms that don't begin with the exemption clause (Brothers Yamazaki) remain `None` rather than being misparsed into a no-op exemption. The existing defer test is updated to assert exactly those remaining cases.
- Verified the full lines parse to the correct filter (no swallowed clause) for the three new positive tests.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings), `cargo test -p engine` (all green, incl. 3 new tests + the updated defer test), and `./scripts/check-parser-combinators.sh` all pass.
