### PR TITLE
feat(parser): opponent-scoped direct library search prohibition

### DIFF
--- a/crates/engine/src/game/effects/search_library.rs
+++ b/crates/engine/src/game/effects/search_library.rs
@@ -2004,6 +2004,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn opponent_direct_search_muzzled() {
+        // CR 701.23: "Your opponents can't search libraries." — cause=Opponents
+        // muzzles an opponent's own library search (Mindlock Orb opponent variant).
+        let mut state = GameState::new_two_player(42);
+        add_cant_search_library_permanent(&mut state, PlayerId(0), ProhibitionScope::Opponents);
+
+        let _bear = add_library_creature(&mut state, 1, PlayerId(1), "Bear");
+
+        let ability = ResolvedAbility::new(
+            Effect::SearchLibrary {
+                filter: TargetFilter::Typed(TypedFilter::creature()),
+                count: QuantityExpr::Fixed { value: 1 },
+                reveal: false,
+                target_player: None,
+                selection_constraint: SearchSelectionConstraint::None,
+                split: None,
+                source_zones: vec![crate::types::zones::Zone::Library],
+            },
+            vec![],
+            ObjectId(9996),
+            PlayerId(1),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            !state
+                .players_who_searched_library_this_turn
+                .contains(&PlayerId(1)),
+            "Opponent direct search must be muzzled"
+        );
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::SearchChoice { .. }),
+            "Muzzled search must NOT transition to SearchChoice"
+        );
+    }
+
     /// CR 608.2c + CR 701.23a: Assassin's Trophy-shape search with
     /// `target_player = Some(ParentTargetController)` + parent target = an
     /// opponent's permanent. The opponent (destroyed permanent's controller)

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -132,25 +132,6 @@ pub(crate) fn parse_legend_rule_scope(scope: &TextPair<'_>) -> Option<TargetFilt
         ));
     }
 
-    // "tokens you control" — all tokens (Cadric, Soul's Messenger). Distinct from
-    // the creature-token intersection above.
-    if base.lower == "tokens" {
-        return Some(TargetFilter::Typed(
-            TypedFilter::permanent()
-                .properties(vec![FilterProp::Token])
-                .controller(ControllerRef::You),
-        ));
-    }
-
-    // "commanders you control" — Try-My-Deck Elemental class.
-    if base.lower == "commanders" {
-        return Some(TargetFilter::Typed(
-            TypedFilter::permanent()
-                .properties(vec![FilterProp::IsCommander])
-                .controller(ControllerRef::You),
-        ));
-    }
-
     if let Some((canonical, consumed)) = parse_subtype(base.original) {
         if consumed == base.original.len() {
             return Some(TargetFilter::Typed(

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -132,6 +132,25 @@ pub(crate) fn parse_legend_rule_scope(scope: &TextPair<'_>) -> Option<TargetFilt
         ));
     }
 
+    // "tokens you control" — all tokens (Cadric, Soul's Messenger). Distinct from
+    // the creature-token intersection above.
+    if base.lower == "tokens" {
+        return Some(TargetFilter::Typed(
+            TypedFilter::permanent()
+                .properties(vec![FilterProp::Token])
+                .controller(ControllerRef::You),
+        ));
+    }
+
+    // "commanders you control" — Try-My-Deck Elemental class.
+    if base.lower == "commanders" {
+        return Some(TargetFilter::Typed(
+            TypedFilter::permanent()
+                .properties(vec![FilterProp::IsCommander])
+                .controller(ControllerRef::You),
+        ));
+    }
+
     if let Some((canonical, consumed)) = parse_subtype(base.original) {
         if consumed == base.original.len() {
             return Some(TargetFilter::Typed(
@@ -395,9 +414,13 @@ pub(crate) fn parse_cant_search_library(tp: &TextPair<'_>, text: &str) -> Option
     }
 
     // Mindlock Orb class: "Players can't search libraries." / "Each player can't
-    // search libraries." Keep this branch all-players only.
+    // search libraries." (all players), and opponent-scoped direct search
+    // prohibitions ("Your opponents can't search libraries.").
     let (cause, predicate) = strip_casting_prohibition_subject(tp.lower)?;
-    if cause != ProhibitionScope::AllPlayers {
+    if !matches!(
+        cause,
+        ProhibitionScope::AllPlayers | ProhibitionScope::Opponents
+    ) {
         return None;
     }
     let predicate_lower = predicate.to_lowercase();

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3466,21 +3466,50 @@ fn static_first_unqualified_spell_costs_less_keeps_first_spell_gate() {
 }
 
 /// CR 601.2f + CR 702.33d: "The first kicked spell you cast each turn costs {1}
-/// less to cast." (Vine Gecko). The "kicked" qualifier — whether the spell's
-/// kicker additional cost was paid — is not a representable spell-cost filter,
-/// so the parser must DECLINE the cost static rather than emit a filterless,
-/// conditionless reducer. A broad reducer would silently drop both the printed
-/// "first … each turn" once-per-turn gate and the "kicked" qualifier, reducing
-/// every spell the controller casts (the bug this guards against).
+/// less to cast." (Vine Gecko).
 #[test]
-fn static_first_kicked_spell_does_not_emit_broad_reducer() {
-    let parsed =
-        parse_static_line("The first kicked spell you cast each turn costs {1} less to cast.");
+fn static_first_kicked_spell_costs_less() {
+    let def =
+        parse_static_line("The first kicked spell you cast each turn costs {1} less to cast.")
+            .expect("Vine Gecko static should parse");
 
-    assert!(
-        parsed.is_none(),
-        "kicked-spell cost reducer must be declined until paid-kicker state is representable; got {parsed:?}"
-    );
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        amount,
+        ref spell_filter,
+        ..
+    } = def.mode
+    else {
+        panic!("expected ReduceCost, got {:?}", def.mode);
+    };
+
+    assert_eq!(amount, ManaCost::generic(1));
+    let filter = spell_filter
+        .as_ref()
+        .expect("expected WasKicked spell filter");
+    assert!(matches!(
+        filter,
+        TargetFilter::Typed(TypedFilter { properties, .. })
+            if properties.contains(&FilterProp::WasKicked)
+    ));
+
+    let condition = def.condition.expect("expected first-kicked-spell gate");
+    assert!(matches!(
+        &condition,
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::SpellsCastThisTurn {
+                    scope: CountScope::Controller,
+                    filter: Some(inner),
+                },
+            },
+            comparator: Comparator::EQ,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        } if matches!(
+            inner,
+            TargetFilter::Typed(tf) if tf.properties.contains(&FilterProp::WasKicked)
+        )
+    ));
 }
 
 #[test]
@@ -6083,13 +6112,41 @@ fn static_cant_cause_sacrifice_or_exile_creature_tokens() {
 }
 
 #[test]
+fn static_legend_rule_tokens_scope() {
+    let def = parse_static_line("The \"legend rule\" doesn't apply to tokens you control.")
+        .expect("Cadric-class token exemption should parse");
+    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+    assert!(matches!(
+        def.affected,
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::You),
+            properties,
+            ..
+        })) if properties.contains(&FilterProp::Token)
+    ));
+}
+
+#[test]
+fn static_legend_rule_commanders_scope() {
+    let def = parse_static_line("The \"legend rule\" doesn't apply to commanders you control.")
+        .expect("commander-scoped exemption should parse");
+    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+    assert!(matches!(
+        def.affected,
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::You),
+            properties,
+            ..
+        })) if properties.contains(&FilterProp::IsCommander)
+    ));
+}
+
+#[test]
 fn static_legend_rule_defers_unparseable_scopes() {
     // CR 704.5j: scopes this parser cannot resolve precisely, and conditional
     // forms, must NOT be emitted as a LegendRuleDoesntApply static — they are
     // deferred (left Unimplemented), never misparsed into a no-op exemption.
     for text in [
-            "The \"legend rule\" doesn't apply to tokens you control.", // Cadric
-            "The \"legend rule\" doesn't apply to commanders you control.", // Try-My-Deck Elemental
             "If there are exactly two permanents named Brothers Yamazaki on the battlefield, the \"legend rule\" doesn't apply to them.",
         ] {
             assert!(
@@ -14657,10 +14714,25 @@ fn cant_search_library_each_player_may_not_variant() {
 }
 
 #[test]
-fn cant_search_library_opponents_form_deferred() {
-    // Opponent-scoped direct-search phrasing remains deferred until the runtime
-    // cause-vs-searcher axis is split.
-    assert!(parse_static_line("Your opponents can't search libraries.").is_none());
+fn cant_search_library_opponents_form() {
+    // CR 701.23 + CR 609.3: opponent-scoped direct search prohibition.
+    let def = parse_static_line("Your opponents can't search libraries.")
+        .expect("opponent-scoped direct search prohibition should parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::CantSearchLibrary {
+            cause: ProhibitionScope::Opponents,
+        }
+    );
+
+    let each = parse_static_line("Each opponent can't search libraries.")
+        .expect("each-opponent variant should parse");
+    assert_eq!(
+        each.mode,
+        StaticMode::CantSearchLibrary {
+            cause: ProhibitionScope::Opponents,
+        }
+    );
 }
 
 // --- CR 603.2g + CR 603.6a + CR 700.4: SuppressTriggers (Torpor Orb / Hushbringer) ---

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3466,50 +3466,21 @@ fn static_first_unqualified_spell_costs_less_keeps_first_spell_gate() {
 }
 
 /// CR 601.2f + CR 702.33d: "The first kicked spell you cast each turn costs {1}
-/// less to cast." (Vine Gecko).
+/// less to cast." (Vine Gecko). The "kicked" qualifier — whether the spell's
+/// kicker additional cost was paid — is not a representable spell-cost filter,
+/// so the parser must DECLINE the cost static rather than emit a filterless,
+/// conditionless reducer. A broad reducer would silently drop both the printed
+/// "first … each turn" once-per-turn gate and the "kicked" qualifier, reducing
+/// every spell the controller casts (the bug this guards against).
 #[test]
-fn static_first_kicked_spell_costs_less() {
-    let def =
-        parse_static_line("The first kicked spell you cast each turn costs {1} less to cast.")
-            .expect("Vine Gecko static should parse");
+fn static_first_kicked_spell_does_not_emit_broad_reducer() {
+    let parsed =
+        parse_static_line("The first kicked spell you cast each turn costs {1} less to cast.");
 
-    let StaticMode::ModifyCost {
-        mode: CostModifyMode::Reduce,
-        amount,
-        ref spell_filter,
-        ..
-    } = def.mode
-    else {
-        panic!("expected ReduceCost, got {:?}", def.mode);
-    };
-
-    assert_eq!(amount, ManaCost::generic(1));
-    let filter = spell_filter
-        .as_ref()
-        .expect("expected WasKicked spell filter");
-    assert!(matches!(
-        filter,
-        TargetFilter::Typed(TypedFilter { properties, .. })
-            if properties.contains(&FilterProp::WasKicked)
-    ));
-
-    let condition = def.condition.expect("expected first-kicked-spell gate");
-    assert!(matches!(
-        &condition,
-        StaticCondition::QuantityComparison {
-            lhs: QuantityExpr::Ref {
-                qty: QuantityRef::SpellsCastThisTurn {
-                    scope: CountScope::Controller,
-                    filter: Some(inner),
-                },
-            },
-            comparator: Comparator::EQ,
-            rhs: QuantityExpr::Fixed { value: 0 },
-        } if matches!(
-            inner,
-            TargetFilter::Typed(tf) if tf.properties.contains(&FilterProp::WasKicked)
-        )
-    ));
+    assert!(
+        parsed.is_none(),
+        "kicked-spell cost reducer must be declined until paid-kicker state is representable; got {parsed:?}"
+    );
 }
 
 #[test]
@@ -6112,41 +6083,13 @@ fn static_cant_cause_sacrifice_or_exile_creature_tokens() {
 }
 
 #[test]
-fn static_legend_rule_tokens_scope() {
-    let def = parse_static_line("The \"legend rule\" doesn't apply to tokens you control.")
-        .expect("Cadric-class token exemption should parse");
-    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
-    assert!(matches!(
-        def.affected,
-        Some(TargetFilter::Typed(TypedFilter {
-            controller: Some(ControllerRef::You),
-            properties,
-            ..
-        })) if properties.contains(&FilterProp::Token)
-    ));
-}
-
-#[test]
-fn static_legend_rule_commanders_scope() {
-    let def = parse_static_line("The \"legend rule\" doesn't apply to commanders you control.")
-        .expect("commander-scoped exemption should parse");
-    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
-    assert!(matches!(
-        def.affected,
-        Some(TargetFilter::Typed(TypedFilter {
-            controller: Some(ControllerRef::You),
-            properties,
-            ..
-        })) if properties.contains(&FilterProp::IsCommander)
-    ));
-}
-
-#[test]
 fn static_legend_rule_defers_unparseable_scopes() {
     // CR 704.5j: scopes this parser cannot resolve precisely, and conditional
     // forms, must NOT be emitted as a LegendRuleDoesntApply static — they are
     // deferred (left Unimplemented), never misparsed into a no-op exemption.
     for text in [
+            "The \"legend rule\" doesn't apply to tokens you control.", // Cadric
+            "The \"legend rule\" doesn't apply to commanders you control.", // Try-My-Deck Elemental
             "If there are exactly two permanents named Brothers Yamazaki on the battlefield, the \"legend rule\" doesn't apply to them.",
         ] {
             assert!(


### PR DESCRIPTION
## Summary

Closes #3421. Parses opponent-scoped direct library search prohibitions and adds a runtime enforcement test.

## Changes

- Extend `parse_cant_search_library` to accept `ProhibitionScope::Opponents` (Mindlock Orb opponent variant)
- Unit tests for `"Your opponents can't search libraries."` and `"Each opponent can't search libraries."`
- Runtime test confirming an opponent's direct search is muzzled

## Implementation method (required)

- [ ] **Not** `/engine-implementer` — explain why below

> Targeted parser extension with existing runtime support; no new effect/resolver behavior beyond a test.

## CR references

CR 701.23, CR 609.3

## Verification

- [x] `cargo test -p engine cant_search_library_opponents --lib`
- [x] `cargo test -p engine opponent_direct_search --lib`
- [x] `cargo clippy -p engine -- -D warnings`

Made with [Cursor](https://cursor.com)