### PR TITLE
feat(engine): first kicked spell per-turn cost reduction static

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -27795,6 +27795,62 @@ mod tests {
     }
 
     #[test]
+    fn second_kicked_spell_not_reduced_after_first_kicked_this_turn() {
+        // CR 702.33d: a "first kicked spell you cast each turn costs {1} less"
+        // reducer is gated on `SpellsCastThisTurn{WasKicked} == 0`. With one kicked
+        // spell already recorded this turn, the gate count is 1, so a second kicked
+        // spell must NOT be reduced even after its kicker is declared. This pins the
+        // once-per-turn semantics that the recompute-after-kicker path rides on.
+        let mut state = setup_game_at_main_phase();
+        let obj_id = create_kicker_modal_charm(&mut state, PlayerId(0));
+        state.objects.get_mut(&obj_id).unwrap().mana_cost = ManaCost::generic(1);
+        install_first_kicked_spell_reducer(&mut state, PlayerId(0));
+
+        // Seed one kicked spell already cast this turn so the per-turn gate is closed.
+        state
+            .spells_cast_this_turn_by_player
+            .entry(PlayerId(0))
+            .or_default()
+            .push_back(crate::types::game_state::SpellCastRecord {
+                was_kicked: true,
+                ..Default::default()
+            });
+
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        add_mana(&mut state, PlayerId(0), ManaType::Green, 1);
+
+        let mut events = Vec::new();
+        state.waiting_for =
+            handle_cast_spell(&mut state, PlayerId(0), obj_id, CardId(50), &mut events).unwrap();
+        let (pending, cost) = match &state.waiting_for {
+            WaitingFor::OptionalCostChoice {
+                pending_cast, cost, ..
+            } => (*pending_cast.clone(), cost.clone()),
+            other => panic!("expected OptionalCostChoice, got {other:?}"),
+        };
+        assert_eq!(pending.cost, ManaCost::generic(1));
+
+        state.waiting_for = crate::game::engine_casting::handle_optional_cost_choice(
+            &mut state,
+            PlayerId(0),
+            pending,
+            &cost,
+            true,
+            &mut events,
+        )
+        .unwrap();
+
+        let WaitingFor::ModeChoice { pending_cast, .. } = &state.waiting_for else {
+            panic!("expected ModeChoice, got {:?}", state.waiting_for);
+        };
+        assert_eq!(
+            pending_cast.cost,
+            ManaCost::generic(1),
+            "CR 702.33d: a kicked spell cast after the first kicked spell this turn keeps full cost"
+        );
+    }
+
+    #[test]
     fn modal_escalate_pays_tap_creature_cost_for_extra_mode() {
         let mut state = setup_game_at_main_phase();
         let obj_id = create_modal_charm(&mut state, PlayerId(0));

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -27594,6 +27594,48 @@ mod tests {
         obj_id
     }
 
+    fn first_kicked_spell_filter() -> TargetFilter {
+        TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::WasKicked]))
+    }
+
+    fn install_first_kicked_spell_reducer(state: &mut GameState, player: PlayerId) -> ObjectId {
+        let source = create_object(
+            state,
+            CardId(4_231),
+            player,
+            "Vine Gecko".to_string(),
+            Zone::Battlefield,
+        );
+        let kicked_filter = first_kicked_spell_filter();
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::ModifyCost {
+                    mode: CostModifyMode::Reduce,
+                    amount: ManaCost::generic(1),
+                    spell_filter: Some(kicked_filter.clone()),
+                    dynamic_count: None,
+                })
+                .affected(TargetFilter::Typed(
+                    TypedFilter::card().controller(ControllerRef::You),
+                ))
+                .condition(StaticCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::SpellsCastThisTurn {
+                            scope: CountScope::Controller,
+                            filter: Some(kicked_filter),
+                        },
+                    },
+                    comparator: Comparator::EQ,
+                    rhs: QuantityExpr::Fixed { value: 0 },
+                }),
+            );
+        source
+    }
+
     #[test]
     fn modal_kicker_declined_caps_modes_before_mode_choice() {
         let mut state = setup_game_at_main_phase();
@@ -27706,6 +27748,50 @@ mod tests {
         assert!(ability.context.additional_cost_paid);
         assert_eq!(ability.context.kickers_paid, vec![KickerVariant::First]);
         assert_eq!(state.players[0].mana_pool.count_color(ManaType::Green), 0);
+    }
+
+    #[test]
+    fn first_kicked_spell_reducer_recomputes_after_kicker_declared() {
+        let mut state = setup_game_at_main_phase();
+        let obj_id = create_kicker_modal_charm(&mut state, PlayerId(0));
+        state.objects.get_mut(&obj_id).unwrap().mana_cost = ManaCost::generic(1);
+        install_first_kicked_spell_reducer(&mut state, PlayerId(0));
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        add_mana(&mut state, PlayerId(0), ManaType::Green, 1);
+
+        let mut events = Vec::new();
+        state.waiting_for =
+            handle_cast_spell(&mut state, PlayerId(0), obj_id, CardId(50), &mut events).unwrap();
+        let (pending, cost) = match &state.waiting_for {
+            WaitingFor::OptionalCostChoice {
+                pending_cast, cost, ..
+            } => (*pending_cast.clone(), cost.clone()),
+            other => panic!("expected OptionalCostChoice, got {other:?}"),
+        };
+        assert_eq!(
+            pending.cost,
+            ManaCost::generic(1),
+            "the spell is not kicked yet, so the reducer must not apply"
+        );
+
+        state.waiting_for = crate::game::engine_casting::handle_optional_cost_choice(
+            &mut state,
+            PlayerId(0),
+            pending,
+            &cost,
+            true,
+            &mut events,
+        )
+        .unwrap();
+
+        let WaitingFor::ModeChoice { pending_cast, .. } = &state.waiting_for else {
+            panic!("expected ModeChoice, got {:?}", state.waiting_for);
+        };
+        assert_eq!(
+            pending_cast.cost,
+            ManaCost::generic(0),
+            "CR 601.2f + CR 702.33d: once kicker is declared, the first kicked spell reducer applies before mana payment"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -365,6 +365,7 @@ fn spell_record_for_restrictions(spell_obj: &super::game_object::GameObject) -> 
         has_x_in_cost: super::casting_costs::cost_has_x(&spell_obj.mana_cost),
         from_zone: spell_obj.zone,
         cast_variant: crate::types::game_state::CastingVariant::Normal,
+        was_kicked: !spell_obj.kickers_paid.is_empty(),
     }
 }
 
@@ -12722,6 +12723,7 @@ fn cant_cast_filter_matches(
                 has_x_in_cost: super::casting_costs::cost_has_x(&spell_obj.mana_cost),
                 from_zone: spell_obj.zone,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: !spell_obj.kickers_paid.is_empty(),
             };
             super::filter::spell_record_matches_filter(
                 &record,
@@ -12774,6 +12776,7 @@ fn is_blocked_by_per_turn_cast_limit(
                     has_x_in_cost: super::casting_costs::cost_has_x(&spell_obj.mana_cost),
                     from_zone: spell_obj.zone,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: !spell_obj.kickers_paid.is_empty(),
                 };
                 if !super::filter::spell_record_matches_filter(
                     &current_record,
@@ -13709,6 +13712,7 @@ mod tests {
                 has_x_in_cost: false,
                 from_zone: Zone::Hand,
                 cast_variant: CastingVariant::Normal,
+                was_kicked: false,
             }]),
         );
     }
@@ -19233,6 +19237,7 @@ mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 crate::types::SpellCastRecord {
                     name: "Opt".to_string(),
@@ -19245,6 +19250,7 @@ mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: CastingVariant::Normal,
+                    was_kicked: false,
                 },
             ]),
         );
@@ -31383,6 +31389,7 @@ mod tests {
                 has_x_in_cost: false,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }]),
         );
 
@@ -31499,6 +31506,7 @@ mod tests {
                 has_x_in_cost: true,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }]),
         );
 
@@ -31570,6 +31578,7 @@ mod tests {
                 has_x_in_cost: false,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }]),
         );
 
@@ -43520,6 +43529,7 @@ mod tests {
                 has_x_in_cost: false,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }]
             .into(),
         );

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -105,6 +105,21 @@ fn collect_controller_controlled_as_cast_filters_from_condition(
     }
 }
 
+fn recompute_pending_cast_cost_after_additional_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    pending: &mut PendingCast,
+) {
+    let object_id = pending.object_id;
+    let prior_pending = state.pending_cast.take();
+    state.pending_cast = Some(Box::new(pending.clone()));
+    let recomputed = super::casting::recompute_pending_cast_cost(state, player, object_id);
+    state.pending_cast = prior_pending;
+    if let Some(cost) = recomputed {
+        pending.cost = cost;
+    }
+}
+
 /// Handle the player's decision on an additional cost (kicker, blight, "or pay").
 ///
 /// For `Optional`: `pay=true` pays the cost and sets `additional_cost_paid`, `pay=false` skips.
@@ -282,14 +297,7 @@ pub(crate) fn handle_decide_additional_cost(
     // flag via `state.pending_cast`, so publish `updated_pending` there for the
     // duration of the recompute, then restore the prior value.
     if optional_cost_paid {
-        let object_id = updated_pending.object_id;
-        let prior_pending = state.pending_cast.take();
-        state.pending_cast = Some(Box::new(updated_pending.clone()));
-        let recomputed = super::casting::recompute_pending_cast_cost(state, player, object_id);
-        state.pending_cast = prior_pending;
-        if let Some(cost) = recomputed {
-            updated_pending.cost = cost;
-        }
+        recompute_pending_cast_cost_after_additional_cost(state, player, &mut updated_pending);
     }
 
     if let Some(cost) = cost_to_pay {
@@ -467,6 +475,10 @@ fn handle_decide_kicker_cost(
 
     pending.ability.context.additional_cost_paid = true;
     pending.ability.context.kickers_paid.push(variant);
+    // CR 601.2b + CR 601.2f + CR 702.33d: Kicker is declared before total cost is
+    // locked in. Recompute now so "kicked spell" cost reducers see the paid kicker
+    // through `state.pending_cast` before mana payment.
+    recompute_pending_cast_cost_after_additional_cost(state, player, &mut pending);
     if pending.deferred_modal_choice.is_some() || pending.deferred_target_selection {
         pending.declared_kickers_to_pay.push(variant);
         return finish_pending_cost_or_cast(state, player, pending, events);

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -729,6 +729,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
                 parts.push(format!("not {}", fmt_typed_filter(&inner_tf)));
             }
             FilterProp::HasXInManaCost => parts.push("with {X} in cost".into()),
+            FilterProp::WasKicked => parts.push("kicked".into()),
             FilterProp::HasXInActivationCost => parts.push("with {X} in activation cost".into()),
             FilterProp::HasManaAbility => parts.push("with a mana ability".into()),
             FilterProp::HasNoAbilities => parts.push("with no abilities".into()),

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -197,6 +197,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::AttackedOrBlockedThisTurn
         | FilterProp::FaceDown
         | FilterProp::HasXInManaCost
+        | FilterProp::WasKicked
         | FilterProp::HasXInActivationCost
         | FilterProp::HasManaAbility
         | FilterProp::HasNoAbilities
@@ -397,6 +398,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::AttackedOrBlockedThisTurn
         | FilterProp::FaceDown
         | FilterProp::HasXInManaCost
+        | FilterProp::WasKicked
         | FilterProp::HasXInActivationCost
         | FilterProp::HasManaAbility
         | FilterProp::HasNoAbilities
@@ -2194,6 +2196,8 @@ fn spell_cast_record_from_object(spell_obj: &GameObject) -> SpellCastRecord {
             .mana_value_with_x(spell_obj.zone, spell_obj.cost_x_paid),
         has_x_in_cost: crate::game::casting_costs::cost_has_x(&spell_obj.mana_cost),
         from_zone: spell_obj.zone,
+        // CR 702.33d: Kicker-paid state for "first kicked spell" cost reducers.
+        was_kicked: !spell_obj.kickers_paid.is_empty(),
         cast_variant: crate::types::game_state::CastingVariant::Normal,
     }
 }
@@ -2431,6 +2435,21 @@ fn spell_object_matches_property(
                 &source,
             )
         }
+        // CR 702.33d: Kicker-paid during live cost-modifier evaluation.
+        FilterProp::WasKicked => context.is_some_and(|ctx| {
+            let Some(spell_id) = ctx.spell_object_id else {
+                return false;
+            };
+            if let Some(pending) = ctx.state.pending_cast.as_ref() {
+                if pending.object_id == spell_id {
+                    return !pending.ability.context.kickers_paid.is_empty();
+                }
+            }
+            ctx.state
+                .objects
+                .get(&spell_id)
+                .is_some_and(|obj| !obj.kickers_paid.is_empty())
+        }),
         _ => spell_record_matches_property(record, prop),
     }
 }
@@ -2518,6 +2537,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         // CR 107.3 + CR 202.1: The snapshot captured whether the printed mana
         // cost contained an `{X}` shard at cast time.
         FilterProp::HasXInManaCost => record.has_x_in_cost,
+        FilterProp::WasKicked => record.was_kicked,
         FilterProp::HasXInActivationCost => false,
         // CR 605.1: Spell-cast records snapshot the spell object, not the
         // object's ability list. Fail closed for history predicates.
@@ -2956,6 +2976,14 @@ fn matches_filter_prop(
         // typed type/controller filters via `TargetFilter::And`/`Or`.
         FilterProp::HasXInActivationCost => {
             crate::game::casting_costs::pending_activation_cost_has_x(state, object_id)
+        }
+        FilterProp::WasKicked => {
+            if let Some(pending) = state.pending_cast.as_ref() {
+                if pending.object_id == object_id {
+                    return !pending.ability.context.kickers_paid.is_empty();
+                }
+            }
+            !obj.kickers_paid.is_empty()
         }
         // CR 605.1: Delegate to the single mana-ability classifier instead of
         // duplicating the definition at the filter layer.
@@ -3787,6 +3815,7 @@ fn zone_change_record_matches_property(
         // meaning for a zone-change record (the object has already left the stack
         // or never was a spell). Fail closed — the snapshot carries no such info.
         | FilterProp::HasXInManaCost
+        | FilterProp::WasKicked
         | FilterProp::HasXInActivationCost
         // CR 605.1: Zone-change records do not snapshot ability lists.
         | FilterProp::HasManaAbility
@@ -4903,6 +4932,7 @@ mod tests {
             has_x_in_cost: false,
             from_zone: Zone::Hand,
             cast_variant: crate::types::game_state::CastingVariant::Normal,
+            was_kicked: false,
         };
         let filter = TargetFilter::Typed(
             TypedFilter::creature()
@@ -4944,6 +4974,7 @@ mod tests {
             has_x_in_cost: true,
             from_zone: Zone::Hand,
             cast_variant: crate::types::game_state::CastingVariant::Normal,
+            was_kicked: false,
         };
         let non_x_record = SpellCastRecord {
             has_x_in_cost: false,
@@ -5024,6 +5055,7 @@ mod tests {
             has_x_in_cost: false,
             from_zone: Zone::Hand,
             cast_variant: crate::types::game_state::CastingVariant::Normal,
+            was_kicked: false,
         };
         let exile_record = SpellCastRecord {
             from_zone: Zone::Exile,
@@ -8368,6 +8400,7 @@ mod tests {
                 has_x_in_cost: false,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }
         };
 
@@ -8822,6 +8855,7 @@ mod tests {
             has_x_in_cost: false,
             from_zone: Zone::Hand,
             cast_variant: crate::types::game_state::CastingVariant::Normal,
+            was_kicked: false,
         };
         let dragon_filter = make_subtype_filter("Dragon");
         let plains_filter = make_subtype_filter("Plains");

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -7999,6 +7999,7 @@ mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 SpellCastRecord {
                     name: String::new(),
@@ -8011,6 +8012,7 @@ mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
             ]),
         );

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -207,6 +207,8 @@ pub fn record_spell_cast_from_zone(
         // spell-history conditions ("a spell was warped this turn") can
         // resolve after the spell has left the stack.
         cast_variant,
+        // CR 702.33d: Kicker-paid state captured at cast time.
+        was_kicked: !obj.kickers_paid.is_empty(),
     };
     state
         .spells_cast_this_turn_by_player
@@ -2552,6 +2554,7 @@ mod tests {
                 has_x_in_cost: false,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }]),
         );
 
@@ -2586,6 +2589,7 @@ mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 crate::types::game_state::SpellCastRecord {
                     name: String::new(),
@@ -2598,6 +2602,7 @@ mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 crate::types::game_state::SpellCastRecord {
                     name: String::new(),
@@ -2610,6 +2615,7 @@ mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
             ]),
         );

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7431,6 +7431,7 @@ pub mod tests {
             has_x_in_cost: false,
             from_zone: Zone::Hand,
             cast_variant: crate::types::game_state::CastingVariant::Normal,
+            was_kicked: false,
         };
         let current_record = SpellCastRecord {
             name: String::new(),
@@ -7443,6 +7444,7 @@ pub mod tests {
             has_x_in_cost: false,
             from_zone: Zone::Hand,
             cast_variant: crate::types::game_state::CastingVariant::Normal,
+            was_kicked: false,
         };
         state.spells_cast_this_turn_by_player.insert(
             player,
@@ -9969,6 +9971,7 @@ pub mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 SpellCastRecord {
                     name: String::new(),
@@ -9981,6 +9984,7 @@ pub mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
             ]),
         );
@@ -13409,6 +13413,7 @@ pub mod tests {
                 has_x_in_cost: true,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }]),
         );
         assert!(
@@ -13430,6 +13435,7 @@ pub mod tests {
                 has_x_in_cost: false,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }]),
         );
         assert!(
@@ -13452,6 +13458,7 @@ pub mod tests {
                     has_x_in_cost: true,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 SpellCastRecord {
                     name: String::new(),
@@ -13464,6 +13471,7 @@ pub mod tests {
                     has_x_in_cost: true,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
             ]),
         );
@@ -13489,6 +13497,7 @@ pub mod tests {
                     has_x_in_cost: true,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 SpellCastRecord {
                     name: String::new(),
@@ -13501,6 +13510,7 @@ pub mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
             ]),
         );
@@ -13524,6 +13534,7 @@ pub mod tests {
                     has_x_in_cost: true,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 SpellCastRecord {
                     name: String::new(),
@@ -13536,6 +13547,7 @@ pub mod tests {
                     has_x_in_cost: false,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
                 SpellCastRecord {
                     name: String::new(),
@@ -13548,6 +13560,7 @@ pub mod tests {
                     has_x_in_cost: true,
                     from_zone: Zone::Hand,
                     cast_variant: crate::types::game_state::CastingVariant::Normal,
+                    was_kicked: false,
                 },
             ]),
         );
@@ -13571,6 +13584,7 @@ pub mod tests {
                 has_x_in_cost: false,
                 from_zone: Zone::Hand,
                 cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
             }
         }
 

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1655,13 +1655,22 @@ pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedS
         Some(TargetFilter::Typed(
             TypedFilter::card().properties(vec![FilterProp::Historic]),
         ))
+    } else if all_consuming(tag::<_, _, OracleError<'_>>("kicked"))
+        .parse(pre_type)
+        .is_ok()
+    {
+        // CR 702.33d: bare "kicked spell" — kicker-paid qualifier for Vine Gecko
+        // class cost reducers.
+        Some(TargetFilter::Typed(
+            TypedFilter::card().properties(vec![FilterProp::WasKicked]),
+        ))
     } else {
         let (filter, remainder) = parse_type_phrase(pre_type);
         if remainder.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
             Some(filter)
         } else {
-            // Unrecognized pre-spell qualifier (e.g. "kicked") — decline rather
-            // than emit a cost reduction that ignores the printed restriction.
+            // Unrecognized pre-spell qualifier — decline rather than emit a cost
+            // reduction that ignores the printed restriction.
             return FirstQualifiedSpell::UnsupportedQualifier;
         }
     };

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3466,21 +3466,50 @@ fn static_first_unqualified_spell_costs_less_keeps_first_spell_gate() {
 }
 
 /// CR 601.2f + CR 702.33d: "The first kicked spell you cast each turn costs {1}
-/// less to cast." (Vine Gecko). The "kicked" qualifier — whether the spell's
-/// kicker additional cost was paid — is not a representable spell-cost filter,
-/// so the parser must DECLINE the cost static rather than emit a filterless,
-/// conditionless reducer. A broad reducer would silently drop both the printed
-/// "first … each turn" once-per-turn gate and the "kicked" qualifier, reducing
-/// every spell the controller casts (the bug this guards against).
+/// less to cast." (Vine Gecko).
 #[test]
-fn static_first_kicked_spell_does_not_emit_broad_reducer() {
-    let parsed =
-        parse_static_line("The first kicked spell you cast each turn costs {1} less to cast.");
+fn static_first_kicked_spell_costs_less() {
+    let def =
+        parse_static_line("The first kicked spell you cast each turn costs {1} less to cast.")
+            .expect("Vine Gecko static should parse");
 
-    assert!(
-        parsed.is_none(),
-        "kicked-spell cost reducer must be declined until paid-kicker state is representable; got {parsed:?}"
-    );
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        amount,
+        ref spell_filter,
+        ..
+    } = def.mode
+    else {
+        panic!("expected ReduceCost, got {:?}", def.mode);
+    };
+
+    assert_eq!(amount, ManaCost::generic(1));
+    let filter = spell_filter
+        .as_ref()
+        .expect("expected WasKicked spell filter");
+    assert!(matches!(
+        filter,
+        TargetFilter::Typed(TypedFilter { properties, .. })
+            if properties.contains(&FilterProp::WasKicked)
+    ));
+
+    let condition = def.condition.expect("expected first-kicked-spell gate");
+    assert!(matches!(
+        &condition,
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::SpellsCastThisTurn {
+                    scope: CountScope::Controller,
+                    filter: Some(inner),
+                },
+            },
+            comparator: Comparator::EQ,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        } if matches!(
+            inner,
+            TargetFilter::Typed(tf) if tf.properties.contains(&FilterProp::WasKicked)
+        )
+    ));
 }
 
 #[test]
@@ -6083,13 +6112,41 @@ fn static_cant_cause_sacrifice_or_exile_creature_tokens() {
 }
 
 #[test]
+fn static_legend_rule_tokens_scope() {
+    let def = parse_static_line("The \"legend rule\" doesn't apply to tokens you control.")
+        .expect("Cadric-class token exemption should parse");
+    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+    assert!(matches!(
+        def.affected,
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::You),
+            properties,
+            ..
+        })) if properties.contains(&FilterProp::Token)
+    ));
+}
+
+#[test]
+fn static_legend_rule_commanders_scope() {
+    let def = parse_static_line("The \"legend rule\" doesn't apply to commanders you control.")
+        .expect("commander-scoped exemption should parse");
+    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
+    assert!(matches!(
+        def.affected,
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::You),
+            properties,
+            ..
+        })) if properties.contains(&FilterProp::IsCommander)
+    ));
+}
+
+#[test]
 fn static_legend_rule_defers_unparseable_scopes() {
     // CR 704.5j: scopes this parser cannot resolve precisely, and conditional
     // forms, must NOT be emitted as a LegendRuleDoesntApply static — they are
     // deferred (left Unimplemented), never misparsed into a no-op exemption.
     for text in [
-            "The \"legend rule\" doesn't apply to tokens you control.", // Cadric
-            "The \"legend rule\" doesn't apply to commanders you control.", // Try-My-Deck Elemental
             "If there are exactly two permanents named Brothers Yamazaki on the battlefield, the \"legend rule\" doesn't apply to them.",
         ] {
             assert!(
@@ -14657,10 +14714,25 @@ fn cant_search_library_each_player_may_not_variant() {
 }
 
 #[test]
-fn cant_search_library_opponents_form_deferred() {
-    // Opponent-scoped direct-search phrasing remains deferred until the runtime
-    // cause-vs-searcher axis is split.
-    assert!(parse_static_line("Your opponents can't search libraries.").is_none());
+fn cant_search_library_opponents_form() {
+    // CR 701.23 + CR 609.3: opponent-scoped direct search prohibition.
+    let def = parse_static_line("Your opponents can't search libraries.")
+        .expect("opponent-scoped direct search prohibition should parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::CantSearchLibrary {
+            cause: ProhibitionScope::Opponents,
+        }
+    );
+
+    let each = parse_static_line("Each opponent can't search libraries.")
+        .expect("each-opponent variant should parse");
+    assert_eq!(
+        each.mode,
+        StaticMode::CantSearchLibrary {
+            cause: ProhibitionScope::Opponents,
+        }
+    );
 }
 
 // --- CR 603.2g + CR 603.6a + CR 700.4: SuppressTriggers (Torpor Orb / Hushbringer) ---

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6112,41 +6112,13 @@ fn static_cant_cause_sacrifice_or_exile_creature_tokens() {
 }
 
 #[test]
-fn static_legend_rule_tokens_scope() {
-    let def = parse_static_line("The \"legend rule\" doesn't apply to tokens you control.")
-        .expect("Cadric-class token exemption should parse");
-    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
-    assert!(matches!(
-        def.affected,
-        Some(TargetFilter::Typed(TypedFilter {
-            controller: Some(ControllerRef::You),
-            properties,
-            ..
-        })) if properties.contains(&FilterProp::Token)
-    ));
-}
-
-#[test]
-fn static_legend_rule_commanders_scope() {
-    let def = parse_static_line("The \"legend rule\" doesn't apply to commanders you control.")
-        .expect("commander-scoped exemption should parse");
-    assert_eq!(def.mode, StaticMode::LegendRuleDoesntApply);
-    assert!(matches!(
-        def.affected,
-        Some(TargetFilter::Typed(TypedFilter {
-            controller: Some(ControllerRef::You),
-            properties,
-            ..
-        })) if properties.contains(&FilterProp::IsCommander)
-    ));
-}
-
-#[test]
 fn static_legend_rule_defers_unparseable_scopes() {
     // CR 704.5j: scopes this parser cannot resolve precisely, and conditional
     // forms, must NOT be emitted as a LegendRuleDoesntApply static — they are
     // deferred (left Unimplemented), never misparsed into a no-op exemption.
     for text in [
+            "The \"legend rule\" doesn't apply to tokens you control.", // Cadric
+            "The \"legend rule\" doesn't apply to commanders you control.", // Try-My-Deck Elemental
             "If there are exactly two permanents named Brothers Yamazaki on the battlefield, the \"legend rule\" doesn't apply to them.",
         ] {
             assert!(
@@ -14714,25 +14686,10 @@ fn cant_search_library_each_player_may_not_variant() {
 }
 
 #[test]
-fn cant_search_library_opponents_form() {
-    // CR 701.23 + CR 609.3: opponent-scoped direct search prohibition.
-    let def = parse_static_line("Your opponents can't search libraries.")
-        .expect("opponent-scoped direct search prohibition should parse");
-    assert_eq!(
-        def.mode,
-        StaticMode::CantSearchLibrary {
-            cause: ProhibitionScope::Opponents,
-        }
-    );
-
-    let each = parse_static_line("Each opponent can't search libraries.")
-        .expect("each-opponent variant should parse");
-    assert_eq!(
-        each.mode,
-        StaticMode::CantSearchLibrary {
-            cause: ProhibitionScope::Opponents,
-        }
-    );
+fn cant_search_library_opponents_form_deferred() {
+    // Opponent-scoped direct-search phrasing remains deferred until the runtime
+    // cause-vs-searcher axis is split.
+    assert!(parse_static_line("Your opponents can't search libraries.").is_none());
 }
 
 // --- CR 603.2g + CR 603.6a + CR 700.4: SuppressTriggers (Torpor Orb / Hushbringer) ---

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2598,6 +2598,11 @@ pub enum FilterProp {
     /// contains an `{X}` shard. Used for "activate an ability with {X} in its
     /// activation cost" on `AbilityActivated` delayed triggers (Magus Lucea Kane).
     HasXInActivationCost,
+    /// CR 702.33d: Matches spells whose kicker additional cost was paid for this
+    /// cast. Used for "the first kicked spell you cast each turn" cost reducers
+    /// (Vine Gecko). Live evaluation reads `pending_cast` / `GameObject.kickers_paid`;
+    /// turn-history evaluation reads `SpellCastRecord.was_kicked`.
+    WasKicked,
     /// CR 605.1: Matches objects that have at least one ability classified as a
     /// mana ability by the engine's authoritative mana-ability classifier.
     /// Used for library filters such as "artifact card with a mana ability".

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -258,6 +258,10 @@ pub struct SpellCastRecord {
     /// for serialized snapshots predating this field.
     #[serde(default)]
     pub cast_variant: CastingVariant,
+    /// CR 702.33d: Whether kicker was paid when this spell was cast. Captured at
+    /// cast-time for per-turn spell-history filters ("first kicked spell each turn").
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub was_kicked: bool,
 }
 
 /// Snapshot of a land play's cast-capable origin for per-turn history queries.
@@ -289,6 +293,7 @@ impl Default for SpellCastRecord {
             has_x_in_cost: false,
             from_zone: Zone::Hand,
             cast_variant: CastingVariant::Normal,
+            was_kicked: false,
         }
     }
 }
@@ -8765,6 +8770,7 @@ mod tests {
             has_x_in_cost: false,
             from_zone: Zone::Graveyard,
             cast_variant: CastingVariant::Normal,
+            was_kicked: false,
         };
         let json = serde_json::to_string(&original).unwrap();
         let round_tripped: SpellCastRecord = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary

Closes #3424. Parses and represents `"The first kicked spell you cast each turn costs {N} less to cast."` (Vine Gecko) using `FilterProp::WasKicked` and existing first-spell turn gates.

## Changes

- `FilterProp::WasKicked` + `SpellCastRecord.was_kicked`
- Parser: `"kicked"` qualifier in `parse_first_qualified_spell_filter`
- Runtime: live and history kicker-paid filter matching in `filter.rs`

## Implementation method (required)

- [ ] **Not** `/engine-implementer` — focused parser + filter extension with existing ModifyCost infrastructure

## CR references

CR 601.2f, CR 702.33d

## Verification

- [x] `cargo test -p engine static_first_kicked --lib`
- [x] `cargo clippy -p engine -- -D warnings`

Made with [Cursor](https://cursor.com)