### PR TITLE
feat(engine): legend rule integration guardrail test

### DIFF
--- a/crates/engine/tests/integration/issue_3425_legend_rule_exemption_scopes.rs
+++ b/crates/engine/tests/integration/issue_3425_legend_rule_exemption_scopes.rs
@@ -1,0 +1,35 @@
+//! Issue #3425 — legend-rule integration guardrail (control case).
+
+use engine::game::sba::check_state_based_actions;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+#[test]
+fn duplicate_legendaries_without_exemption_prompt_choose_legend() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature(P0, "Thalia", 2, 1)
+        .as_legendary()
+        .id();
+    scenario
+        .add_creature(P0, "Thalia", 2, 1)
+        .as_legendary()
+        .id();
+
+    let mut runner = scenario.build();
+    let mut events = Vec::<GameEvent>::new();
+    check_state_based_actions(runner.state_mut(), &mut events);
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::ChooseLegend { .. }),
+        "duplicate legendaries must trigger the legend-rule SBA choice"
+    );
+}
+
+// Scoped exemption runtime coverage lives in `game/sba.rs` unit tests
+// (`sba_legend_rule_suppressed_for_bare_tokens_scope`,
+// `sba_legend_rule_suppressed_for_commanders_scope`).

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -218,6 +218,7 @@ mod issue_3321_volcanic_spite_optional;
 mod issue_3322_airbend_owner_cast;
 mod issue_3323_nexus_of_fate_extra_turn;
 mod issue_3324_haunted_one;
+mod issue_3425_legend_rule_exemption_scopes;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary

Closes #3425. Adds an integration test ensuring duplicate same-name legendaries trigger `ChooseLegend` through the GameScenario → SBA path.

## Changes

- `issue_3425_legend_rule_exemption_scopes.rs` control-case test
- Scoped exemption SBA coverage remains in unit tests (#3429 / parser in #3428–#3430)

## Implementation method (required)

- [ ] **Not** `/engine-implementer` — integration test only

## CR references

CR 704.5j

## Verification

- [x] `cargo test -p engine --test integration issue_3425`

Made with [Cursor](https://cursor.com)