### PR TITLE
feat(parser): parse 'pay any amount of life' and 'pay half your life'

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5656,6 +5656,35 @@ fn parse_pay_life_amount(rest: &str) -> Option<QuantityExpr> {
         });
     }
 
+    // CR 119.4 + CR 107.3: "pay any amount of life" — the player chooses the
+    // amount as the cost is paid (Necrodominance, Phyrexian Processor, Lurking
+    // Evil). Modeled as the same player-chosen `X` variable as "pay X life".
+    if terminated(
+        tag::<_, _, OracleError<'_>>("any amount of life"),
+        word_boundary,
+    )
+    .parse(rest)
+    .is_ok()
+    {
+        return Some(QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        });
+    }
+
+    // CR 118.8: "pay half your life[, rounded up]" — delegate the life-fraction
+    // phrase to the shared quantity expression parser (`DivideRounded` over the
+    // controller's `LifeTotal`), so the rounding mode and life-total wording
+    // recognized everywhere else compose here too. Gated on a "half " prefix so
+    // only fraction phrases reach the (non-dispatch) all-consuming delegation.
+    if tag::<_, _, OracleError<'_>>("half ").parse(rest).is_ok() {
+        let qty_text = rest.trim_end().trim_end_matches('.').trim_end();
+        if let Ok(("", expr)) = crate::parser::oracle_nom::quantity::parse_quantity(qty_text) {
+            return Some(expr);
+        }
+    }
+
     // CR 118.8: "pay N life" — literal amount via `parse_number` (digit words
     // or numerals, never "X" — handled above). Same word-boundary guard so
     // hypothetical phrases like "3 lifelink" cannot false-match.
@@ -10634,6 +10663,72 @@ mod tests {
             shards.as_slice(),
             [crate::types::mana::ManaCostShard::X]
         ));
+    }
+
+    #[test]
+    fn parse_pay_any_amount_of_life_as_variable() {
+        // CR 119.4: Necrodominance / Phyrexian Processor / Lurking Evil —
+        // player-chosen life payment, modeled as the X variable.
+        let text = "pay any amount of life";
+        let lower = text.to_lowercase();
+        let Some(CostResourceImperativeAst::Pay {
+            cost: AbilityCost::PayLife { amount },
+        }) = parse_cost_resource_ast(text, &lower, &mut ParseContext::default())
+        else {
+            panic!("expected PayLife cost for {text:?}");
+        };
+        assert!(
+            matches!(
+                amount,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { ref name },
+                } if name == "X"
+            ),
+            "expected variable X life payment, got {amount:?}"
+        );
+    }
+
+    #[test]
+    fn parse_pay_half_your_life_rounded_up() {
+        // CR 118.8: delegate the life-fraction phrase to the shared quantity
+        // parser (DivideRounded over the controller's life total).
+        let text = "pay half your life, rounded up";
+        let lower = text.to_lowercase();
+        let Some(CostResourceImperativeAst::Pay {
+            cost: AbilityCost::PayLife { amount },
+        }) = parse_cost_resource_ast(text, &lower, &mut ParseContext::default())
+        else {
+            panic!("expected PayLife cost for {text:?}");
+        };
+        assert!(
+            matches!(
+                amount,
+                QuantityExpr::DivideRounded {
+                    divisor: 2,
+                    rounding: crate::types::ability::RoundingMode::Up,
+                    ..
+                }
+            ),
+            "expected half-life DivideRounded, got {amount:?}"
+        );
+    }
+
+    #[test]
+    fn parse_pay_does_not_false_match_lifelink_or_lifeless() {
+        // Word-boundary guard: "any amount of life" must be a complete token.
+        for text in ["pay any amount of lifelink", "pay any amount of lifeforce"] {
+            let lower = text.to_lowercase();
+            let res = parse_cost_resource_ast(text, &lower, &mut ParseContext::default());
+            assert!(
+                !matches!(
+                    res,
+                    Some(CostResourceImperativeAst::Pay {
+                        cost: AbilityCost::PayLife { .. }
+                    })
+                ),
+                "{text:?} must not parse as a life payment"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5656,23 +5656,6 @@ fn parse_pay_life_amount(rest: &str) -> Option<QuantityExpr> {
         });
     }
 
-    // CR 119.4 + CR 107.3: "pay any amount of life" — the player chooses the
-    // amount as the cost is paid (Necrodominance, Phyrexian Processor, Lurking
-    // Evil). Modeled as the same player-chosen `X` variable as "pay X life".
-    if terminated(
-        tag::<_, _, OracleError<'_>>("any amount of life"),
-        word_boundary,
-    )
-    .parse(rest)
-    .is_ok()
-    {
-        return Some(QuantityExpr::Ref {
-            qty: QuantityRef::Variable {
-                name: "X".to_string(),
-            },
-        });
-    }
-
     // CR 118.8: "pay half your life[, rounded up]" — delegate the life-fraction
     // phrase to the shared quantity expression parser (`DivideRounded` over the
     // controller's `LifeTotal`), so the rounding mode and life-total wording
@@ -10663,29 +10646,6 @@ mod tests {
             shards.as_slice(),
             [crate::types::mana::ManaCostShard::X]
         ));
-    }
-
-    #[test]
-    fn parse_pay_any_amount_of_life_as_variable() {
-        // CR 119.4: Necrodominance / Phyrexian Processor / Lurking Evil —
-        // player-chosen life payment, modeled as the X variable.
-        let text = "pay any amount of life";
-        let lower = text.to_lowercase();
-        let Some(CostResourceImperativeAst::Pay {
-            cost: AbilityCost::PayLife { amount },
-        }) = parse_cost_resource_ast(text, &lower, &mut ParseContext::default())
-        else {
-            panic!("expected PayLife cost for {text:?}");
-        };
-        assert!(
-            matches!(
-                amount,
-                QuantityExpr::Ref {
-                    qty: QuantityRef::Variable { ref name },
-                } if name == "X"
-            ),
-            "expected variable X life payment, got {amount:?}"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Teaches the imperative "pay" cost parser two life-payment forms it previously left `Unimplemented`, by extending the single-authority `parse_pay_life_amount` helper:

- **"pay any amount of life"** — Necrodominance, Phyrexian Processor, Lurking Evil, … (~8 cards). The player chooses the amount as the cost is paid, so it's modeled as the same player-chosen `X` variable that "pay X life" already uses (`QuantityExpr::Ref { Variable("X") }`). Emits the existing `AbilityCost::PayLife { amount }` (CR 119.4 / CR 107.3).
- **"pay half your life[, rounded up]"** — delegates the life-fraction phrase to the shared quantity-expression parser (`DivideRounded` over the controller's `LifeTotal`), reusing the rounding/life-total wording recognized everywhere else (CR 118.8).

No new types or variants — both flow through the existing `AbilityCost::PayLife` / `QuantityExpr` shapes.

## Why

`parse_pay_life_amount` handled "N life", "X life", and "life equal to <ref>", but not "any amount of life" or "half your life", so those cost clauses fell to `Unimplemented`.

## Safety

- Word-boundary guard (shared `word_boundary` peek) so "any amount of life" is a complete token — added a negative test proving "…lifelink"/"…lifeforce" do not false-match as a life payment.
- The "half " gate keeps the (non-dispatch) all-consuming `parse_quantity` delegation scoped to fraction phrases only.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings), `cargo test -p engine` (all green incl. 3 new tests), and `./scripts/check-parser-combinators.sh` (clean vs upstream/main) all pass.
