### PR TITLE
feat(engine): Momir's Madness format — fixed-deck flow, emblem, token-copy ETB

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -71,6 +71,16 @@ export interface FormatConfig {
    */
   uses_commander: boolean;
   /**
+   * Engine-derived predicate (mirrors `GameFormat::supplies_fixed_deck`): true
+   * when the format's deck is fixed and supplied automatically by the engine,
+   * so the player builds/selects nothing (Momir's Madness). The engine always
+   * emits it in the format registry; it is optional here (like the engine's
+   * `#[serde(default)]`) so hand-built configs need not restate it. Read it via
+   * `formatSuppliesDeck`, which goes through the registry — never re-list
+   * fixed-deck formats client-side.
+   */
+  supplies_fixed_deck?: boolean;
+  /**
    * Sandbox capability flag: when true the server permits `GameAction.Debug(_)`
    * from any player in the `debug_permitted` set. Off by default. Orthogonal
    * to format — applies on top of any `GameFormat`. Immutable for the life

--- a/client/src/components/menu/AiOpponentConfig.tsx
+++ b/client/src/components/menu/AiOpponentConfig.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GameFormat, MatchType } from "../../adapter/types";
+import { formatSuppliesDeck } from "../../data/formatRegistry";
 import { AI_DIFFICULTIES, type AIDifficulty } from "../../constants/ai";
 import type { AiDeckCandidate } from "../../services/aiDeckCatalog";
 import { filterByBracket, useAiDeckCatalog } from "../../services/aiDeckCatalog";
@@ -79,6 +80,11 @@ export function AiOpponentConfig({
   const setBracketFilter = usePreferencesStore((s) => s.setAiBracketFilter);
   const isCedhFormat = isCommanderFamilyFormat(selectedFormat);
   const effectiveCedhMode = cedhMode && isCedhFormat;
+  // Fixed-deck formats (Momir's Madness) have the engine supply every AI seat's
+  // deck, so there is no AI deck catalog, no deck picker, and no "no legal
+  // decks" condition — only the per-seat difficulty matters. Drives off the
+  // engine-derived registry flag, never a format literal.
+  const suppliesDeck = selectedFormat ? formatSuppliesDeck(selectedFormat) : false;
 
   // Keep the persisted seat list in sync with the setup page's player count.
   useEffect(() => {
@@ -192,6 +198,7 @@ export function AiOpponentConfig({
             cedhMode={effectiveCedhMode}
             candidates={candidates}
             filteredDecks={filteredDecks}
+            hideDeckPicker={suppliesDeck}
             expanded={!isMulti || expandedIndex === i}
             collapsible={isMulti}
             onToggle={() => setExpandedIndex((cur) => (cur === i ? null : i))}
@@ -201,7 +208,7 @@ export function AiOpponentConfig({
         ))}
       </div>
 
-      {!loading && candidates.length === 0 && (
+      {!loading && candidates.length === 0 && !suppliesDeck && (
         <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
           {t("aiOpponent.noLegalDecks")}
         </div>
@@ -213,7 +220,10 @@ export function AiOpponentConfig({
         </div>
       )}
 
-      {/* Global pool filters — apply to every seat set to Random. */}
+      {/* Global pool filters — apply to every seat set to Random. Hidden for
+          fixed-deck formats, where the engine supplies every AI deck and there
+          is no Random pool to filter. */}
+      {!suppliesDeck && (
       <div className="mt-1 flex flex-col gap-3 rounded-lg border border-white/5 bg-black/20 px-3 py-2.5">
         <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500">
           {t("aiOpponent.randomPoolFilters")}
@@ -264,6 +274,7 @@ export function AiOpponentConfig({
           </div>
         )}
       </div>
+      )}
     </div>
   );
 }
@@ -277,6 +288,9 @@ interface AiSeatPanelProps {
   cedhMode: boolean;
   candidates: AiDeckCandidate[];
   filteredDecks: AiDeckCandidate[];
+  /** When true (fixed-deck formats), the engine supplies this seat's deck — the
+   *  deck picker is hidden and only the difficulty selector is shown. */
+  hideDeckPicker: boolean;
   expanded: boolean;
   collapsible: boolean;
   onToggle: () => void;
@@ -290,6 +304,7 @@ function AiSeatPanel({
   cedhMode,
   candidates,
   filteredDecks,
+  hideDeckPicker,
   expanded,
   collapsible,
   onToggle,
@@ -358,6 +373,7 @@ function AiSeatPanel({
 
   const body = (
     <div className="flex flex-col gap-2.5 px-3 pb-3 pt-1">
+      {!hideDeckPicker && (
       <label className="flex flex-col gap-1">
         <span className="text-xs text-slate-400">{t("aiOpponent.deck")}</span>
         <MenuSelect
@@ -372,6 +388,7 @@ function AiSeatPanel({
           className={`${AI_MENU_CLASS} text-white`}
         />
       </label>
+      )}
 
       <label className="flex flex-col gap-1">
         <span className="text-xs text-slate-400">{t("aiOpponent.difficulty")}</span>

--- a/client/src/components/zone/CommandZone.tsx
+++ b/client/src/components/zone/CommandZone.tsx
@@ -1,10 +1,17 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GameObject, PlayerId } from "../../adapter/types.ts";
+import { dispatchAction } from "../../game/dispatch.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { useUiStore } from "../../stores/uiStore.ts";
+import {
+  collectObjectActions,
+  resolveSingleActionDispatch,
+} from "../../viewmodel/cardActionChoice.ts";
+import { RichLabel } from "../mana/RichLabel.tsx";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
 
 /** Emblem chips are deliberately rendered well below card size (Arena-style):
@@ -25,9 +32,10 @@ interface GroupedEmblem {
 
 /** The emblem's granted rules text ("what it does"). The engine attaches it to
  *  the produced ability definition's `description` — a static for static
- *  emblems, the first trigger for triggered emblems (CR 114.4) — so pull from
- *  both definition lists. Falls back to the generic "Emblem" label only when no
- *  text is available. */
+ *  emblems, the first trigger for triggered emblems, and the activated ability
+ *  for activatable emblems (the Momir Basic `{X}, Discard a card: …` emblem,
+ *  CR 114.4) — so pull from all three definition lists. Falls back to the
+ *  generic "Emblem" label only when no text is available. */
 function descriptionOf(emblem: GameObject, fallback: string): string {
   const descriptionsOf = (defs: unknown[] | undefined): string[] =>
     ((defs as Array<{ description?: string }> | undefined) ?? [])
@@ -37,6 +45,7 @@ function descriptionOf(emblem: GameObject, fallback: string): string {
   const parts = [
     ...descriptionsOf(emblem.static_definitions),
     ...descriptionsOf(emblem.trigger_definitions),
+    ...descriptionsOf(emblem.abilities),
   ];
   return parts.join("; ") || fallback;
 }
@@ -103,23 +112,71 @@ export function CommandZone({ playerId }: CommandZoneProps) {
  */
 function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
   const isCompactHeight = useIsCompactHeight();
-  const printedRef = group.representative.emblem_source?.printed_ref ?? null;
+  const emblem = group.representative;
+  const printedRef = emblem.emblem_source?.printed_ref ?? null;
   const { src: artSrc } = useCardImage(group.sourceName ?? "", {
     size: "art_crop",
     oracleId: printedRef?.oracle_id,
     faceName: printedRef?.face_name,
   });
 
+  // CR 114.4 + CR 602.1: an emblem can carry an activated ability (the Momir
+  // Basic `{X}, Discard a card: …` emblem). The engine maps each legal
+  // `ActivateAbility` to its source via `GameAction::source_object()` and
+  // surfaces it in `legalActionsByObject` only when activation is legal now
+  // (sorcery speed, the controller's priority, once each turn). The chip is
+  // therefore clickable exactly when the engine reports a live action for it —
+  // no client-side legality inference. Static/triggered emblems never report
+  // actions here, so they stay display-only as before.
+  const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
+  const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
+  const emblemActions = useMemo(
+    () => collectObjectActions(legalActionsByObject, emblem.id),
+    [legalActionsByObject, emblem.id],
+  );
+  const isActivatable = emblemActions.length > 0;
+
+  const handleActivate = useCallback(() => {
+    if (emblemActions.length === 0) return;
+    // Reuse the shared single-authority dispatch helper (issue #506): a
+    // card-consuming ability surfaces the confirmation modal; otherwise the
+    // lone action auto-fires, kicking off the engine's X / discard prompts.
+    const auto = resolveSingleActionDispatch(emblemActions, emblem);
+    if (auto) {
+      dispatchAction(auto);
+    } else {
+      setPendingAbilityChoice({ objectId: emblem.id, actions: emblemActions });
+    }
+  }, [emblemActions, emblem, setPendingAbilityChoice]);
+
   return (
     <div
       // `hover:z-50` lifts the chip above later DOM siblings (the commander
       // column) within the support column so its tooltip paints on top.
-      className="group relative select-none drop-shadow-[0_3px_5px_rgba(0,0,0,0.6)] hover:z-50"
+      className={`group relative select-none drop-shadow-[0_3px_5px_rgba(0,0,0,0.6)] hover:z-50 ${
+        isActivatable
+          ? "cursor-pointer rounded-[6px] ring-1 ring-amber-300/70 hover:ring-2 hover:ring-amber-200"
+          : ""
+      }`}
       style={{
         width: `calc(var(--art-crop-w) * ${EMBLEM_CHIP_SCALE})`,
         height: `calc(var(--art-crop-h) * ${EMBLEM_CHIP_SCALE})`,
       }}
       data-testid="emblem-card"
+      data-activatable={isActivatable || undefined}
+      role={isActivatable ? "button" : undefined}
+      tabIndex={isActivatable ? 0 : undefined}
+      onClick={isActivatable ? handleActivate : undefined}
+      onKeyDown={
+        isActivatable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleActivate();
+              }
+            }
+          : undefined
+      }
     >
       {/* No-delay custom hover tooltip — the chip is too small to show "where
           it came from" and "what it does" inline. */}
@@ -128,7 +185,14 @@ function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
           {label}
           {group.sourceName ? ` — ${group.sourceName}` : ""}
         </span>
-        <span className="mt-0.5 block text-slate-200">{group.description}</span>
+        {/* Interpolate `{X}`/`{1}`/`{R}`/`{T}` etc. into Scryfall SVG symbols
+            (RichLabel → ManaSymbol) so the emblem's `{X}, Discard a card: …`
+            rules text reads like printed card text instead of raw braces. */}
+        <RichLabel
+          text={group.description}
+          size="xs"
+          className="mt-0.5 block text-slate-200"
+        />
       </GameplayTooltip>
       {/* Outer black border + gold inlay so the chip reads as an emblem even
           over arbitrary source art. */}

--- a/client/src/data/formatRegistry.ts
+++ b/client/src/data/formatRegistry.ts
@@ -24,6 +24,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -45,6 +46,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -66,6 +68,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -87,6 +90,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -108,6 +112,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -129,6 +134,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -150,6 +156,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -171,6 +178,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -192,6 +200,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -213,6 +222,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: true,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -234,6 +244,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: true,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -255,6 +266,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: true,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -276,6 +288,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -297,6 +310,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -318,6 +332,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: true,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -339,6 +354,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: true,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -360,6 +376,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -381,6 +398,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: false,
       allow_debug_actions: false,
     },
   },
@@ -402,6 +420,7 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
       range_of_influence: null,
       team_based: false,
       uses_commander: false,
+      supplies_fixed_deck: true,
       allow_debug_actions: false,
     },
   },
@@ -409,4 +428,17 @@ export const FORMAT_REGISTRY: readonly FormatMetadata[] = [
 
 export function formatMetadata(format: GameFormat): FormatMetadata | undefined {
   return FORMAT_REGISTRY.find((m) => m.format === format);
+}
+
+/**
+ * Whether the format's deck is fixed by the format rules and supplied
+ * automatically by the engine — the player never builds or selects one. This
+ * reads the engine-derived `supplies_fixed_deck` flag from the mirrored format
+ * registry (single source of truth: `GameFormat::supplies_fixed_deck` in the
+ * engine); it must never hardcode format strings. For these formats the
+ * deck-selection gates are bypassed and an empty decklist is submitted, which
+ * `load_and_hydrate_decks` fills with the fixed deck for every seat.
+ */
+export function formatSuppliesDeck(format: GameFormat): boolean {
+  return formatMetadata(format)?.default_config.supplies_fixed_deck ?? false;
 }

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import type { FormatConfig, FormatGroup, GameFormat, MatchType } from "../adapter/types";
-import { formatMetadata } from "../data/formatRegistry";
+import { formatMetadata, formatSuppliesDeck } from "../data/formatRegistry";
 import { useAudioContext } from "../audio/useAudioContext";
 import { ScreenChrome } from "../components/chrome/ScreenChrome";
 import { AiOpponentConfig } from "../components/menu/AiOpponentConfig";
@@ -148,8 +148,12 @@ export function GameSetupPage() {
   );
 
   const handleStartAI = () => {
-    if (!activeDeckName || !formatConfig) return;
-    touchDeckPlayed(activeDeckName);
+    if (!formatConfig) return;
+    // Fixed-deck formats (Momir's Madness) supply the deck automatically, so an
+    // active deck is not required to start.
+    const suppliesDeck = formatSuppliesDeck(formatConfig.format);
+    if (!activeDeckName && !suppliesDeck) return;
+    if (activeDeckName) touchDeckPlayed(activeDeckName);
     const gameId = crypto.randomUUID();
     // Snapshot the per-seat AI config from preferences into the active-game
     // record. `AiOpponentConfig`'s `ensureAiSeatCount` effect normally syncs
@@ -180,9 +184,14 @@ export function GameSetupPage() {
 
   // Sidebar deck preview. `selectedCompat` is now state pushed up from MyDecks
   // (active-deck-only) rather than derived from a full compatibilities map.
-  const noDeckSelected = !activeDeckName;
-  const deckBlockedForSelectedFormat = selectedCompat?.selected_format_compatible === false;
-  const noLegalAiDecks = legalAiDeckCount === 0;
+  // Fixed-deck formats (Momir's Madness) supply both the player's deck and the
+  // AI seats automatically (the engine synthesizes them), so the deck-selection
+  // and AI-deck-availability gates do not apply.
+  const suppliesDeck = selectedFormat ? formatSuppliesDeck(selectedFormat) : false;
+  const noDeckSelected = !suppliesDeck && !activeDeckName;
+  const deckBlockedForSelectedFormat =
+    !suppliesDeck && selectedCompat?.selected_format_compatible === false;
+  const noLegalAiDecks = !suppliesDeck && legalAiDeckCount === 0;
   // Block start only while the card DB is actively loading — not on `error`/`idle`,
   // since initializeGame awaits ensureCardDb itself and an errored warm must not
   // trap the user on this screen.

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -25,6 +25,7 @@ import { hostRoom, joinRoom } from "../network/connection";
 import type { BrokerClient } from "../services/brokerClient";
 import { loadP2PSession } from "../services/p2pSession";
 import { expandParsedDeck, type ParsedDeck } from "../services/deckParser";
+import { formatSuppliesDeck } from "../data/formatRegistry";
 import { consumeRecentAutoUpdateMarker } from "../pwa/updateMarker";
 import { ensureCardDatabase } from "../services/cardData";
 import { loadDraftRun } from "../services/quickDraftPersistence";
@@ -252,6 +253,11 @@ function pickOpponentDeck(
   return randomPickDistinct(filtered.length > 0 ? filtered : catalog, excludeIds);
 }
 
+// Placeholder decklist for fixed-deck formats (Momir's Madness): the player
+// builds nothing, and the engine synthesizes the real deck for every seat. The
+// builders below ignore its contents for such formats.
+const EMPTY_PARSED_DECK: ParsedDeck = { main: [], sideboard: [] };
+
 function buildPlayerOnlyDeckList(deck: ParsedDeck, playerBracket?: CommanderBracket | null): DeckListPayload {
   const expanded = expandParsedDeck(deck);
   const player: ExpandedDeckWithTier = { ...expanded, bracket_tier: bracketToEngineTier(playerBracket) };
@@ -271,6 +277,29 @@ async function buildLocalAiDeckList(
   selectedMatchType?: MatchType,
   playerBracket?: CommanderBracket | null,
 ): Promise<DeckListPayload> {
+  // Fixed-deck formats (Momir's Madness) supply the deck for every seat from the
+  // engine, so there is no AI deck catalog to draw from — submit empty seats and
+  // let `load_and_hydrate_decks` synthesize the identical fixed deck per player.
+  if (formatConfig && formatSuppliesDeck(formatConfig.format)) {
+    const { aiSeats, cedhMode } = usePreferencesStore.getState();
+    const opponentCount = Math.max(1, playerCount - 1);
+    const emptySeat = (): ExpandedDeckWithTier => ({
+      main_deck: [],
+      sideboard: [],
+      commander: [],
+      bracket_tier: "core",
+    });
+    const aiDifficulties = Array.from({ length: opponentCount }, (_, i) =>
+      effectiveAiDifficulty(aiSeats[i]?.difficulty ?? "Medium", cedhMode),
+    );
+    return {
+      player: emptySeat(),
+      opponent: emptySeat(),
+      ai_decks: Array.from({ length: opponentCount - 1 }, emptySeat),
+      ai_difficulties: aiDifficulties,
+    };
+  }
+
   const { aiSeats, cedhMode, aiArchetypeFilter, aiCoverageFloor } = usePreferencesStore.getState();
   const catalog = await buildLegalAiDeckCatalog({
     selectedFormat: formatConfig?.format,
@@ -566,7 +595,10 @@ export function GameProvider({
 
     if (isP2P) {
       const parsedDeck = loadActiveDeck();
-      if (!parsedDeck) {
+      // Fixed-deck formats (Momir's Madness) supply the deck from the engine for
+      // host and guests alike, so no active deck is required to host/join.
+      const suppliesDeck = formatConfig ? formatSuppliesDeck(formatConfig.format) : false;
+      if (!parsedDeck && !suppliesDeck) {
         onNoDeckRef.current?.();
         return;
       }
@@ -603,7 +635,10 @@ export function GameProvider({
 
       const setupP2P = async () => {
         const effectivePlayerCount = playerCount ?? 2;
-        const deckList = buildPlayerOnlyDeckList(parsedDeck, loadActiveDeckBracket());
+        const deckList = buildPlayerOnlyDeckList(
+          parsedDeck ?? EMPTY_PARSED_DECK,
+          loadActiveDeckBracket(),
+        );
         signal.throwIfAborted();
 
         // Resources that may need undoing on abort/error. `broker` is
@@ -1092,7 +1127,8 @@ export function GameProvider({
           onResumeResetRef.current?.(reason);
           clearGame(gameId);
           const parsedDeck = loadActiveDeck();
-          if (!parsedDeck) {
+          const suppliesDeck = formatConfig ? formatSuppliesDeck(formatConfig.format) : false;
+          if (!parsedDeck && !suppliesDeck) {
             onNoDeckRef.current?.();
             return;
           }
@@ -1100,7 +1136,7 @@ export function GameProvider({
           try {
             deckList = await buildLocalAiDeckList(
               tRef.current,
-              parsedDeck,
+              parsedDeck ?? EMPTY_PARSED_DECK,
               playerCount ?? 2,
               formatConfig,
               matchConfig?.match_type,
@@ -1198,7 +1234,8 @@ export function GameProvider({
       }
 
       const parsedDeck = loadActiveDeck();
-      if (!parsedDeck) {
+      const suppliesDeck = formatConfig ? formatSuppliesDeck(formatConfig.format) : false;
+      if (!parsedDeck && !suppliesDeck) {
         onNoDeckRef.current?.();
         return;
       }
@@ -1207,7 +1244,7 @@ export function GameProvider({
       try {
         deckList = await buildLocalAiDeckList(
           tRef.current,
-          parsedDeck,
+          parsedDeck ?? EMPTY_PARSED_DECK,
           playerCount ?? 2,
           formatConfig,
           matchConfig?.match_type,

--- a/client/src/services/__tests__/cardImageLookup.test.ts
+++ b/client/src/services/__tests__/cardImageLookup.test.ts
@@ -89,6 +89,46 @@ describe("cardImageLookup", () => {
     });
   });
 
+  it("resolves an emblem's art from emblem_source name when it has no printed_ref", () => {
+    // CR 114.5: the Momir emblem carries no printed_ref of its own; its art is
+    // resolved from the display-only emblem_source (the card it represents) so
+    // its activated ability on the stack shows Momir Vig instead of a blank.
+    expect(
+      cardImageLookup({
+        name: "Emblem",
+        transformed: false,
+        back_face: null,
+        is_emblem: true,
+        emblem_source: { name: "Momir Vig, Simic Visionary" },
+      }),
+    ).toEqual({
+      name: "Momir Vig, Simic Visionary",
+      oracleId: undefined,
+      faceName: undefined,
+      faceIndex: 0,
+    });
+  });
+
+  it("prefers emblem_source.printed_ref oracle_id when present", () => {
+    expect(
+      cardImageLookup({
+        name: "Emblem",
+        transformed: false,
+        back_face: null,
+        is_emblem: true,
+        emblem_source: {
+          name: "Jace, the Mind Sculptor",
+          printed_ref: { oracle_id: "jace-oracle", face_name: "Jace, the Mind Sculptor" },
+        },
+      }),
+    ).toEqual({
+      name: "Jace, the Mind Sculptor",
+      oracleId: "jace-oracle",
+      faceName: "Jace, the Mind Sculptor",
+      faceIndex: 0,
+    });
+  });
+
   it("uses obj.printed_ref directly when transformed (engine tracks current face)", () => {
     // After transform, the engine overwrites obj.printed_ref to point at the
     // back face (printed_cards.rs:190). The Scryfall service resolves the

--- a/client/src/services/cardImageLookup.ts
+++ b/client/src/services/cardImageLookup.ts
@@ -51,7 +51,10 @@ export interface CardImageLookup {
  *      issue #90 (The Legend of Kuruk) for context.
  */
 export function cardImageLookup(
-  obj: Pick<GameObject, "name" | "transformed" | "back_face" | "printed_ref">,
+  obj: Pick<
+    GameObject,
+    "name" | "transformed" | "back_face" | "printed_ref" | "is_emblem" | "emblem_source"
+  >,
 ): CardImageLookup {
   if (obj.printed_ref) {
     return {
@@ -59,6 +62,21 @@ export function cardImageLookup(
       faceName: obj.printed_ref.face_name,
       name: obj.name,
       faceIndex: obj.transformed ? 1 : 0,
+    };
+  }
+
+  // CR 114.5: an emblem is neither a card nor a permanent and has no
+  // `printed_ref` of its own (setting one would leak the source card's
+  // types/P-T into the layer system). Resolve its art from the display-only
+  // `emblem_source` provenance — the card the emblem represents (e.g. Momir Vig
+  // for the Momir emblem) — so an emblem's activated ability on the stack shows
+  // the same art as its command-zone chip instead of a blank placeholder.
+  if (obj.is_emblem && obj.emblem_source) {
+    return {
+      name: obj.emblem_source.name,
+      oracleId: obj.emblem_source.printed_ref?.oracle_id,
+      faceName: obj.emblem_source.printed_ref?.face_name,
+      faceIndex: 0,
     };
   }
 

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -593,42 +593,49 @@ pub fn initialize_game(
             let borrow = cell.borrow();
             let db = borrow.as_ref().expect("CARD_DB presence checked above");
 
-            for (seat, deck) in [
-                ("Player".to_string(), &deck_list.player),
-                ("AI opponent".to_string(), &deck_list.opponent),
-            ] {
-                if let Err(reasons) = validate_name_deck_for_format(
-                    db,
-                    &deck.main_deck,
-                    &deck.sideboard,
-                    &deck.commander,
-                    game_format,
-                    Some(state.match_config.match_type),
-                ) {
-                    return Some(
-                        reasons
-                            .into_iter()
-                            .map(|reason| format!("{seat} deck: {reason}"))
-                            .collect(),
-                    );
+            // Fixed-deck formats (Momir's Madness) supply the deck from the
+            // engine for every seat, so the client submits empty decks — there
+            // is nothing client-side to validate. `load_and_hydrate_decks` below
+            // fills each seat's library with the engine-owned fixed deck. Gate on
+            // the engine predicate, never a format literal.
+            if !game_format.supplies_fixed_deck() {
+                for (seat, deck) in [
+                    ("Player".to_string(), &deck_list.player),
+                    ("AI opponent".to_string(), &deck_list.opponent),
+                ] {
+                    if let Err(reasons) = validate_name_deck_for_format(
+                        db,
+                        &deck.main_deck,
+                        &deck.sideboard,
+                        &deck.commander,
+                        game_format,
+                        Some(state.match_config.match_type),
+                    ) {
+                        return Some(
+                            reasons
+                                .into_iter()
+                                .map(|reason| format!("{seat} deck: {reason}"))
+                                .collect(),
+                        );
+                    }
                 }
-            }
-            for (idx, deck) in deck_list.ai_decks.iter().enumerate() {
-                let seat = format!("AI player {}", idx + 2);
-                if let Err(reasons) = validate_name_deck_for_format(
-                    db,
-                    &deck.main_deck,
-                    &deck.sideboard,
-                    &deck.commander,
-                    game_format,
-                    Some(state.match_config.match_type),
-                ) {
-                    return Some(
-                        reasons
-                            .into_iter()
-                            .map(|reason| format!("{seat} deck: {reason}"))
-                            .collect(),
-                    );
+                for (idx, deck) in deck_list.ai_decks.iter().enumerate() {
+                    let seat = format!("AI player {}", idx + 2);
+                    if let Err(reasons) = validate_name_deck_for_format(
+                        db,
+                        &deck.main_deck,
+                        &deck.sideboard,
+                        &deck.commander,
+                        game_format,
+                        Some(state.match_config.match_type),
+                    ) {
+                        return Some(
+                            reasons
+                                .into_iter()
+                                .map(|reason| format!("{seat} deck: {reason}"))
+                                .collect(),
+                        );
+                    }
                 }
             }
 

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -186,6 +186,66 @@ pub fn create_object_from_card_face(
     obj_id
 }
 
+/// The five snow basic land card names that make up every Momir's Madness deck.
+/// CR 305.6: Snow-Covered Wastes is intentionally excluded — "Wastes" is the
+/// basic colorless land, not a basic land type. These printed names are the
+/// single source the format auto-supplies; `deck_validation::evaluate_momir`
+/// validates the same structure via typed snow-basic detection, kept in lockstep
+/// by the `momir_fixed_deck_*` cross-check tests.
+pub const MOMIR_SNOW_BASICS: [&str; 5] = [
+    "Snow-Covered Plains",
+    "Snow-Covered Island",
+    "Snow-Covered Swamp",
+    "Snow-Covered Mountain",
+    "Snow-Covered Forest",
+];
+
+/// Momir's Madness fixed-deck ratio: exactly 12 copies of each snow basic, 60
+/// total. Players never build this deck — the engine supplies it for every seat.
+const MOMIR_COPIES_PER_BASIC: usize = 12;
+
+/// Display-only art source for the Momir emblem (CR 114.5: an emblem has no art
+/// of its own). The emblem is named for Momir Vig, so the client renders the
+/// chip with his card art via the standard name-based image lookup — the same
+/// `emblem_source` provenance path planeswalker emblems use for their source's
+/// art crop.
+const MOMIR_EMBLEM_SOURCE_NAME: &str = "Momir Vig, Simic Visionary";
+
+/// The canonical Momir's Madness decklist as a flat name list (12× each of the
+/// five snow basics, 60 cards). Single source of truth for the auto-supplied
+/// deck across every transport (wasm/server/tauri) and every seat.
+pub fn momir_fixed_deck_names() -> Vec<String> {
+    let mut names = Vec::with_capacity(MOMIR_SNOW_BASICS.len() * MOMIR_COPIES_PER_BASIC);
+    for basic in MOMIR_SNOW_BASICS {
+        for _ in 0..MOMIR_COPIES_PER_BASIC {
+            names.push(basic.to_string());
+        }
+    }
+    names
+}
+
+/// Build the auto-supplied Momir's Madness `DeckPayload`: every seat (player,
+/// opponent, and each AI seat) receives the identical fixed 60-card snow-basic
+/// deck. Momir admits exactly one legal deck, so the submitted payload's deck
+/// *contents* are ignored; only its seat structure (AI seat count and per-seat
+/// difficulties) is preserved so the correct number of players is created.
+fn momir_fixed_deck_payload(db: &CardDatabase, submitted: &DeckPayload) -> DeckPayload {
+    let fixed_seat = || PlayerDeckPayload {
+        main_deck: resolve_names(db, &momir_fixed_deck_names()),
+        sideboard: Vec::new(),
+        commander: Vec::new(),
+        attraction_deck: Vec::new(),
+        signature_spell: Vec::new(),
+        bracket_tier: CommanderBracketTier::default(),
+    };
+    DeckPayload {
+        player: fixed_seat(),
+        opponent: fixed_seat(),
+        ai_decks: submitted.ai_decks.iter().map(|_| fixed_seat()).collect(),
+        ai_difficulties: submitted.ai_difficulties.clone(),
+    }
+}
+
 /// Build the Momir Basic emblem's activated ability programmatically (no Oracle
 /// text — emblems have no card to parse). CR 113.1b + CR 114.4:
 /// "{X}, Discard a card: Create a token that's a copy of a creature card with
@@ -484,13 +544,24 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
     if state.format_config.format == crate::types::format::GameFormat::Momir {
         for i in 0..state.players.len() {
             let player = PlayerId(i as u8);
-            crate::game::effects::create_emblem::grant_emblem(
+            let emblem_id = crate::game::effects::create_emblem::grant_emblem(
                 state,
                 player,
                 Vec::new(),
                 Vec::new(),
                 vec![momir_emblem_ability()],
             );
+            // CR 114.5: give the emblem chip a face. `grant_emblem` leaves
+            // `emblem_source` unset (it has no ability source of its own), so
+            // attach Momir Vig as the display-only art provenance the client
+            // already renders for emblems. Name-only is sufficient — the
+            // name-based image path resolves the art crop from the card pool.
+            if let Some(obj) = state.objects.get_mut(&emblem_id) {
+                obj.emblem_source = Some(crate::game::game_object::EmblemSource {
+                    name: MOMIR_EMBLEM_SOURCE_NAME.to_string(),
+                    printed_ref: None,
+                });
+            }
         }
     }
 
@@ -564,6 +635,23 @@ pub fn load_and_hydrate_decks(
     payload: &DeckPayload,
     db: Option<&CardDatabase>,
 ) {
+    // Momir's Madness supplies a fixed deck (CR-defined: 12× each snow basic) for
+    // every seat — players never build it. Synthesize it here, in the canonical
+    // init path shared by all transports, so web/server/tauri and every AI seat
+    // receive the identical deck. Hydration needs the CardDatabase to resolve the
+    // snow-basic names; with no db we fall back to whatever was submitted.
+    let momir_payload;
+    let payload = if state.format_config.format == crate::types::format::GameFormat::Momir {
+        match db {
+            Some(card_db) => {
+                momir_payload = momir_fixed_deck_payload(card_db, payload);
+                &momir_payload
+            }
+            None => payload,
+        }
+    } else {
+        payload
+    };
     load_deck_into_state(state, payload);
     match db {
         Some(db) => {
@@ -816,6 +904,99 @@ mod tests {
         assert_eq!(state.players[0].library.len(), 6); // 4 + 2
         assert_eq!(state.players[1].library.len(), 3);
         assert_eq!(state.objects.len(), 9); // 6 + 3
+    }
+
+    /// A minimal card database containing only the five snow basic lands, so a
+    /// unit test can exercise the Momir auto-deck synthesis without the full
+    /// 92MB corpus.
+    fn snow_basics_db() -> CardDatabase {
+        let mut map = serde_json::Map::new();
+        for (key, name, subtype) in [
+            ("snow-covered plains", "Snow-Covered Plains", "Plains"),
+            ("snow-covered island", "Snow-Covered Island", "Island"),
+            ("snow-covered swamp", "Snow-Covered Swamp", "Swamp"),
+            ("snow-covered mountain", "Snow-Covered Mountain", "Mountain"),
+            ("snow-covered forest", "Snow-Covered Forest", "Forest"),
+        ] {
+            map.insert(
+                key.to_string(),
+                serde_json::json!({
+                    "name": name,
+                    "mana_cost": { "type": "NoCost" },
+                    "card_type": {
+                        "supertypes": ["Basic", "Snow"],
+                        "core_types": ["Land"],
+                        "subtypes": [subtype]
+                    },
+                    "power": null, "toughness": null, "loyalty": null, "defense": null,
+                    "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                    "keywords": [], "abilities": [], "triggers": [],
+                    "static_abilities": [], "replacements": [],
+                    "color_override": null, "scryfall_oracle_id": null
+                }),
+            );
+        }
+        let json = serde_json::Value::Object(map).to_string();
+        CardDatabase::from_json_str(&json).expect("snow-basics fixture parses")
+    }
+
+    #[test]
+    fn momir_fixed_deck_names_is_sixty_snow_basics() {
+        let names = momir_fixed_deck_names();
+        assert_eq!(names.len(), 60, "Momir's Madness deck is exactly 60 cards");
+        for basic in MOMIR_SNOW_BASICS {
+            assert_eq!(
+                names.iter().filter(|n| n.as_str() == basic).count(),
+                12,
+                "exactly 12 copies of {basic}"
+            );
+        }
+    }
+
+    #[test]
+    fn momir_auto_supplies_fixed_deck_for_every_seat() {
+        // The bug: starting a Momir's Madness game failed deck validation because
+        // no Momir-legal deck was selected. The engine now supplies the fixed
+        // 60-card snow-basic deck for every seat regardless of what was submitted.
+        // This test drives the real `load_and_hydrate_decks` path with an EMPTY
+        // payload (one AI seat) and would fail if the synthesis were reverted.
+        let mut state = GameState::new(crate::types::format::FormatConfig::momir(), 3, 42);
+        let db = snow_basics_db();
+
+        // Submit nothing — just a seat for one AI deck (3 players total).
+        let submitted = DeckPayload {
+            ai_decks: vec![PlayerDeckPayload::default()],
+            ..Default::default()
+        };
+
+        load_and_hydrate_decks(&mut state, &submitted, Some(&db));
+
+        for player in 0..3 {
+            let library = &state.players[player].library;
+            assert_eq!(
+                library.len(),
+                60,
+                "seat {player} library is the fixed 60-card Momir deck"
+            );
+            let snow_count = library
+                .iter()
+                .filter(|id| MOMIR_SNOW_BASICS.contains(&state.objects[id].name.as_str()))
+                .count();
+            assert_eq!(snow_count, 60, "seat {player} holds only snow basics");
+
+            // Every seat is fully initialized: it also owns exactly one Momir
+            // emblem in the command zone (CR 114.1) — the source of the
+            // random-creature activated ability that makes the deck playable.
+            let emblems = state
+                .command_zone
+                .iter()
+                .filter(|id| {
+                    let obj = &state.objects[id];
+                    obj.is_emblem && obj.owner == PlayerId(player as u8)
+                })
+                .count();
+            assert_eq!(emblems, 1, "seat {player} owns exactly one Momir emblem");
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -5006,19 +5006,12 @@ mod tests {
     }
 
     /// The fixed Momir's Madness deck: 12 copies of each of the five snow basic
-    /// lands (no Snow-Covered Wastes), totaling 60.
+    /// lands (no Snow-Covered Wastes), totaling 60. Delegates to the engine's
+    /// canonical `momir_fixed_deck_names()` so the auto-supplied deck and this
+    /// validator are exercised against the same single source of truth — if they
+    /// ever drift, `momir_madness_snow_basics_pass` below catches it.
     fn momir_madness_deck() -> Vec<String> {
-        let mut deck = Vec::with_capacity(60);
-        for name in [
-            "Snow-Covered Plains",
-            "Snow-Covered Island",
-            "Snow-Covered Swamp",
-            "Snow-Covered Mountain",
-            "Snow-Covered Forest",
-        ] {
-            deck.extend(expand(name, 12));
-        }
-        deck
+        crate::game::deck_loading::momir_fixed_deck_names()
     }
 
     #[test]

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -434,9 +434,18 @@ pub(crate) fn apply_copy_token_after_replacement(
     // (CR 614.1a). Without this a copied planeswalker enters with 0 loyalty
     // counters and dies immediately to CR 704.5i. Copies don't track battle
     // defense (`CopiableValues` has no defense field), so only loyalty is seeded.
+    // CR 306.5b loyalty + CR 614.1c "~ enters with N counters" self-replacement
+    // (Atraxa's Skitterfang's three oil counters, Hangarback/Walking Ballista
+    // +1/+1, etc.) + any explicit counters the creating effect added. The copy
+    // path bypasses the ZoneChange replacement pass, so the copied card's
+    // intrinsic "enters with counters" replacement is seeded here from its
+    // copiable replacement set rather than firing during entry.
     let etb_counters: Vec<(crate::types::counter::CounterType, u32)> =
         crate::game::printed_cards::intrinsic_face_counters(values.loyalty, None)
             .into_iter()
+            .chain(crate::game::printed_cards::self_etb_counter_replacements(
+                &values.replacement_definitions,
+            ))
             .chain(enter_with_counters.iter().cloned())
             .collect();
 

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1,8 +1,8 @@
 use crate::database::CardDatabase;
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, ConjureSource, ContinuousModification, CopiableValues,
-    CounterSourceRider, Effect, PtValue, ReplacementDefinition, ReplacementMode, StaticDefinition,
-    TriggerDefinition,
+    CounterSourceRider, Effect, PtValue, QuantityExpr, ReplacementDefinition, ReplacementMode,
+    StaticDefinition, TargetFilter, TriggerDefinition,
 };
 use crate::types::card::{CardFace, CardLayout, LayoutKind, PrintedCardRef};
 use crate::types::card_type::{CardType, CoreType};
@@ -11,6 +11,7 @@ use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use crate::types::replacements::ReplacementEvent;
 use crate::types::zones::Zone;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -385,6 +386,50 @@ pub fn intrinsic_etb_counters(obj: &GameObject) -> Vec<(CounterType, u32)> {
         }
     }
     counters
+}
+
+/// CR 614.1c: The counters a permanent enters with from a "~ enters with N
+/// <type> counters on it" ability (Atraxa's Skitterfang → three oil counters;
+/// Hangarback Walker / Walking Ballista copies → +1/+1). The parser models this
+/// as a `Moved`→Battlefield replacement whose `execute` puts counters on the
+/// entering object itself.
+///
+/// Cast/play/effect entries apply these by running the replacement during the
+/// ZoneChange pass. The token-copy path, however, builds the object directly on
+/// the battlefield (CR 707.2) and never runs that pass, so it must seed these
+/// counters the same way it seeds intrinsic loyalty (`intrinsic_face_counters`).
+/// This extracts them from the copiable replacement set so a token copy of an
+/// "enters with counters" creature enters with them.
+///
+/// Only the unconditional, mandatory, fixed-count self form is recognized:
+/// variable or conditional counts ("a +1/+1 counter for each artifact you
+/// control") need resolution context this static extraction lacks, and on
+/// non-copy entries the normal replacement pass still handles every form.
+pub fn self_etb_counter_replacements(
+    replacements: &[ReplacementDefinition],
+) -> Vec<(CounterType, u32)> {
+    replacements
+        .iter()
+        .filter_map(|repl| {
+            if repl.event != ReplacementEvent::Moved
+                || repl.destination_zone != Some(Zone::Battlefield)
+                || !matches!(repl.mode, ReplacementMode::Mandatory)
+                || repl.condition.is_some()
+                || !matches!(repl.valid_card, Some(TargetFilter::SelfRef))
+            {
+                return None;
+            }
+            let Effect::PutCounter {
+                counter_type,
+                count: QuantityExpr::Fixed { value },
+                target: TargetFilter::SelfRef,
+            } = &*repl.execute.as_ref()?.effect
+            else {
+                return None;
+            };
+            (*value > 0).then(|| (counter_type.clone(), *value as u32))
+        })
+        .collect()
 }
 
 pub fn intrinsic_copiable_values(obj: &GameObject) -> CopiableValues {
@@ -1172,13 +1217,22 @@ fn rehydrate_card_db_metadata(state: &mut GameState, db: &CardDatabase) {
     // CR 707.2 + CR 202.3: Build the Momir Basic random-token pool. Gated on the
     // format AND emptiness: `rehydrate_card_db_metadata` also runs on the
     // mid-game debug-spawn path (engine-wasm), so without the emptiness guard we
-    // would rescan the full creature corpus on every spawn. The deserialize case
-    // is covered — `format_config` is serialized, so a peer deserializing a Momir
-    // game sees `format == Momir && momir_pool.is_empty()` and rebuilds the same
-    // pool from its own copy of the card DB (the keys are sorted, so the index is
-    // deterministic across peers).
+    // would rescan the full creature corpus on every spawn.
+    //
+    // The emptiness check must watch `momir_pool_faces`, NOT just `momir_pool`:
+    // `momir_pool` is serialized but `momir_pool_faces` is `#[serde(skip)]`
+    // (it holds full `CardFace` values, too heavy to ship). After ANY
+    // deserialize — `restore_game_state` on worker restart/PWA update, or a peer
+    // syncing — `momir_pool` comes back populated while `momir_pool_faces` is
+    // empty. Gating on `momir_pool.is_empty()` alone would then refuse to rebuild
+    // the faces map, leaving `CreateTokenCopyFromPool` with zero hydratable
+    // candidates (every name in the pool misses the empty faces map) and the
+    // emblem silently makes no token. Rebuilding when EITHER is empty restores
+    // the faces map; the rebuild overwrites `momir_pool` wholesale, so a
+    // non-empty pool is regenerated identically (keys are sorted → deterministic
+    // across peers), never duplicated.
     if state.format_config.format == crate::types::format::GameFormat::Momir
-        && state.momir_pool.is_empty()
+        && (state.momir_pool.is_empty() || state.momir_pool_faces.is_empty())
     {
         let mut pool: std::collections::BTreeMap<i32, Vec<String>> =
             std::collections::BTreeMap::new();
@@ -1663,6 +1717,108 @@ mod tests {
             ),
             "non-legendary token copies must not trigger the legend rule on load"
         );
+    }
+
+    /// CR 707.2 + CR 202.3: The Momir random-token pool's hydration map
+    /// (`momir_pool_faces`) is `#[serde(skip)]`, while `momir_pool` is
+    /// serialized. After a deserialize-then-rehydrate cycle (`restore_game_state`
+    /// on worker restart / PWA update, or a peer sync), `momir_pool` is populated
+    /// but `momir_pool_faces` is empty. Rehydration MUST rebuild the faces map in
+    /// that state — otherwise `CreateTokenCopyFromPool` finds zero hydratable
+    /// candidates and the Momir emblem silently makes no creature token. This is
+    /// the discriminating guard: it fails if the rebuild is gated on
+    /// `momir_pool.is_empty()` alone (the pre-fix behavior).
+    #[test]
+    fn momir_pool_faces_rebuilt_after_restore_drops_serde_skip_map() {
+        // A mana-value-4 creature ({3}{G} = MV 4) is the only card in the pool.
+        let creature = test_face(
+            "Test Pool Beast",
+            "test-pool-beast-oracle-id",
+            vec![CoreType::Creature],
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Green],
+                generic: 3,
+            },
+        );
+        let export = serde_json::json!({
+            "test pool beast": serde_json::to_value(&creature).unwrap(),
+        })
+        .to_string();
+        let db = CardDatabase::from_json_str(&export).expect("export db should parse");
+
+        let mut state = GameState::new_two_player(42);
+        state.format_config = crate::types::format::FormatConfig::momir();
+
+        // First hydration builds both the pool and the faces map.
+        rehydrate_game_from_card_db(&mut state, &db);
+        assert_eq!(
+            state.momir_pool.get(&4).map(Vec::as_slice),
+            Some(["Test Pool Beast".to_string()].as_slice()),
+            "MV-4 creature must land in the pool keyed by mana value"
+        );
+        assert!(
+            state.momir_pool_faces.contains_key("test pool beast"),
+            "faces map must hydrate the MV-4 creature on first build"
+        );
+
+        // Simulate the serde round-trip: `momir_pool` survives, the
+        // `#[serde(skip)]` faces map comes back empty.
+        state.momir_pool_faces = std::sync::Arc::new(HashMap::new());
+        assert!(!state.momir_pool.is_empty(), "pool persists across serde");
+
+        // Rehydrating a restored game must repopulate the faces map even though
+        // `momir_pool` is non-empty.
+        rehydrate_game_from_card_db(&mut state, &db);
+        assert!(
+            state.momir_pool_faces.contains_key("test pool beast"),
+            "faces map must be rebuilt after a restore that dropped the skip map"
+        );
+    }
+
+    fn self_etb_plus_one_replacement(count: i32) -> ReplacementDefinition {
+        crate::types::ability::ReplacementDefinition::new(ReplacementEvent::Moved)
+            .destination_zone(Zone::Battlefield)
+            .valid_card(TargetFilter::SelfRef)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: count },
+                    target: TargetFilter::SelfRef,
+                },
+            ))
+    }
+
+    /// CR 614.1c: "~ enters with N +1/+1 counters on it" (Hangarback Walker /
+    /// Walking Ballista class, like Atraxa's Skitterfang's oil counters) is
+    /// modeled as a Moved→Battlefield self-replacement. The extractor must
+    /// surface `(counter, N)` so a token copy — which bypasses the ZoneChange
+    /// replacement pass — can seed those counters on entry.
+    #[test]
+    fn self_etb_counter_replacement_extracts_fixed_self_counters() {
+        assert_eq!(
+            self_etb_counter_replacements(&[self_etb_plus_one_replacement(3)]),
+            vec![(CounterType::Plus1Plus1, 3)],
+        );
+    }
+
+    /// A conditional "enters with" replacement is NOT a plain fixed-count self
+    /// seed — it must be left to the normal replacement pass, not statically
+    /// extracted (where the condition would be silently ignored). A replacement
+    /// whose destination is not the battlefield must also be ignored.
+    #[test]
+    fn self_etb_counter_replacement_skips_conditional_and_non_self() {
+        let conditional = ReplacementDefinition {
+            condition: Some(
+                crate::types::ability::ReplacementCondition::UnlessPlayerLifeAtMost { amount: 5 },
+            ),
+            ..self_etb_plus_one_replacement(1)
+        };
+        let wrong_zone = ReplacementDefinition {
+            destination_zone: Some(Zone::Graveyard),
+            ..self_etb_plus_one_replacement(1)
+        };
+        assert!(self_etb_counter_replacements(&[conditional, wrong_zone]).is_empty());
     }
 
     /// CR 111.1 + CR 707.2: The same token-copy rehydration rule applies to a

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -116,6 +116,13 @@ pub struct FormatConfig {
     /// Historic Brawl. The frontend consumes this directly — it must never
     /// re-list commander-style formats client-side.
     pub uses_commander: bool,
+    /// Engine-derived predicate (mirrors `GameFormat::supplies_fixed_deck`):
+    /// true when the format's deck is fixed and supplied automatically by the
+    /// engine, so the player builds/selects nothing. True only for Momir's
+    /// Madness. The frontend consumes this directly to bypass deck-selection
+    /// gates — it must never re-list fixed-deck formats client-side.
+    #[serde(default)]
+    pub supplies_fixed_deck: bool,
     /// Capability flag: when true, the server (and other transport gates)
     /// permit `GameAction::Debug(_)` from any player in this session. Off by
     /// default. Orthogonal to format — a sandbox Commander game plays
@@ -220,6 +227,17 @@ impl GameFormat {
                 | GameFormat::Brawl
                 | GameFormat::HistoricBrawl,
         )
+    }
+
+    /// Whether this format's deck is fixed by the format rules and supplied
+    /// automatically by the engine — the player never builds or selects one.
+    /// True only for Momir's Madness, whose deck is the fixed 60-card snow-basic
+    /// list (`deck_loading::momir_fixed_deck_names`); `load_and_hydrate_decks`
+    /// synthesizes it for every seat. The frontend consumes the derived
+    /// `FormatConfig::supplies_fixed_deck` field to bypass deck-selection gates,
+    /// and must never re-list fixed-deck formats client-side.
+    pub fn supplies_fixed_deck(self) -> bool {
+        matches!(self, GameFormat::Momir)
     }
 
     /// Display label for validation error messages (e.g., "Not Pioneer legal").
@@ -425,6 +443,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: false,
             uses_commander: false,
+            supplies_fixed_deck: false,
             allow_debug_actions: false,
         }
     }
@@ -442,6 +461,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: false,
             uses_commander: true,
+            supplies_fixed_deck: false,
             allow_debug_actions: false,
         }
     }
@@ -531,6 +551,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: false,
             uses_commander: false,
+            supplies_fixed_deck: false,
             allow_debug_actions: false,
         }
     }
@@ -552,6 +573,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: false,
             uses_commander: false,
+            supplies_fixed_deck: false,
             allow_debug_actions: false,
         }
     }
@@ -586,6 +608,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: false,
             uses_commander: true,
+            supplies_fixed_deck: false,
             allow_debug_actions: false,
         }
     }
@@ -611,6 +634,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: false,
             uses_commander: false,
+            supplies_fixed_deck: false,
             allow_debug_actions: false,
         }
     }
@@ -630,6 +654,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: false,
             uses_commander: false,
+            supplies_fixed_deck: false,
             allow_debug_actions: false,
         }
     }
@@ -652,6 +677,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: false,
             uses_commander: false,
+            supplies_fixed_deck: true,
             allow_debug_actions: false,
         }
     }
@@ -669,6 +695,7 @@ impl FormatConfig {
             range_of_influence: None,
             team_based: true,
             uses_commander: false,
+            supplies_fixed_deck: false,
             allow_debug_actions: false,
         }
     }
@@ -1000,11 +1027,21 @@ mod tests {
                 "{:?}: commander_damage_threshold presence must match uses_commander",
                 meta.format
             );
+            // The derived `supplies_fixed_deck` field must agree with the
+            // predicate for every variant (engine is the single authority for
+            // which formats auto-supply their deck).
+            assert_eq!(
+                meta.default_config.supplies_fixed_deck,
+                meta.format.supplies_fixed_deck(),
+                "{:?}: registry default disagrees with supplies_fixed_deck predicate",
+                meta.format
+            );
         }
         // Variants not in the user-facing registry still respect the invariant.
         for format in [GameFormat::TwoHeadedGiant, GameFormat::Limited] {
             let config = FormatConfig::for_format(format);
             assert_eq!(config.uses_commander, format.uses_commander());
+            assert_eq!(config.supplies_fixed_deck, format.supplies_fixed_deck());
         }
     }
 

--- a/crates/phase-ai/src/policies/mulligan/fixed_deck_keepables.rs
+++ b/crates/phase-ai/src/policies/mulligan/fixed_deck_keepables.rs
@@ -1,0 +1,103 @@
+//! `FixedDeckKeepMulligan` — force-keep for engine-supplied fixed decks.
+//!
+//! CR 103.5 (`docs/MagicCompRules.txt:295`): a player mulligans to find a
+//! workable opening hand. That premise assumes a varied deck where some hands
+//! are better than others. The Momir family of formats inverts it: the engine
+//! supplies a fixed 60-card all-basic-land deck (`FormatConfig::
+//! supplies_fixed_deck`) and the entire game plan is the command-zone emblem
+//! (`{X}, Discard a card: create a random creature token`). Every legal hand is
+//! seven lands, and one seven-land hand is as good as any other — there is
+//! nothing to mulligan *toward*.
+//!
+//! Without this force-keep, the deck-agnostic `KeepablesByLandCount` policy
+//! reads an all-land / no-spell hand as unkeepable, force-mulligans every
+//! redraw to the maximum (CR 103.5 final sentence), and bottoms the AI down to
+//! a zero-card opening hand. This policy emits `ForceKeep`, which outranks every
+//! `ForceMulligan` in the registry's three-way precedence, whenever the format
+//! supplies a fixed deck. Non-fixed-deck formats abstain with a neutral
+//! additive score, exactly as the archetype keepables do when not applicable.
+
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+
+use crate::features::DeckFeatures;
+use crate::plan::PlanSnapshot;
+use crate::policies::registry::{PolicyId, PolicyReason};
+
+use super::{MulliganPolicy, MulliganScore, TurnOrder};
+
+pub struct FixedDeckKeepMulligan;
+
+impl MulliganPolicy for FixedDeckKeepMulligan {
+    fn id(&self) -> PolicyId {
+        PolicyId::FixedDeckKeepMulligan
+    }
+
+    fn evaluate(
+        &self,
+        _hand: &[ObjectId],
+        state: &GameState,
+        _features: &DeckFeatures,
+        _plan: &PlanSnapshot, // input-unused: the keep decision depends only on the format
+        _turn_order: TurnOrder, // input-unused: every fixed-deck hand is equivalent
+        _mulligans_taken: u8, // input-unused: a fixed all-land deck is always kept
+    ) -> MulliganScore {
+        if state.format_config.supplies_fixed_deck {
+            MulliganScore::ForceKeep {
+                reason: PolicyReason::new("fixed_deck_force_keep")
+                    .with_fact("supplies_fixed_deck", 1),
+            }
+        } else {
+            MulliganScore::Score {
+                delta: 0.0,
+                reason: PolicyReason::new("fixed_deck_not_applicable")
+                    .with_fact("supplies_fixed_deck", 0),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::types::format::FormatConfig;
+    use engine::types::game_state::GameState;
+
+    /// A fixed-deck format (Momir) must force-keep regardless of hand contents.
+    #[test]
+    fn fixed_deck_format_force_keeps() {
+        let mut state = GameState::new_two_player(0);
+        state.format_config = FormatConfig::momir();
+        let score = FixedDeckKeepMulligan.evaluate(
+            &[],
+            &state,
+            &DeckFeatures::default(),
+            &PlanSnapshot::default(),
+            TurnOrder::OnPlay,
+            0,
+        );
+        assert!(
+            matches!(score, MulliganScore::ForceKeep { .. }),
+            "Momir (supplies_fixed_deck) must ForceKeep, got {score:?}"
+        );
+    }
+
+    /// A normal constructed format must abstain (neutral score), leaving the
+    /// keep/mulligan decision to the archetype policies.
+    #[test]
+    fn non_fixed_deck_format_abstains() {
+        let state = GameState::new_two_player(0);
+        let score = FixedDeckKeepMulligan.evaluate(
+            &[],
+            &state,
+            &DeckFeatures::default(),
+            &PlanSnapshot::default(),
+            TurnOrder::OnPlay,
+            0,
+        );
+        match score {
+            MulliganScore::Score { delta, .. } => assert_eq!(delta, 0.0),
+            other => panic!("expected neutral Score for non-fixed-deck format, got {other:?}"),
+        }
+    }
+}

--- a/crates/phase-ai/src/policies/mulligan/mod.rs
+++ b/crates/phase-ai/src/policies/mulligan/mod.rs
@@ -32,6 +32,7 @@ use crate::policies::registry::{PolicyId, PolicyReason};
 pub mod aggro_keepables;
 pub mod aristocrats_keepables;
 pub mod cedh_keepables;
+pub mod fixed_deck_keepables;
 pub mod keepables_by_land_count;
 pub mod landfall_keepables;
 pub mod plus_one_counters_keepables;
@@ -43,6 +44,7 @@ pub mod tribal_density;
 pub use aggro_keepables::AggroKeepablesMulligan;
 pub use aristocrats_keepables::AristocratsKeepablesMulligan;
 pub use cedh_keepables::CedhKeepablesMulligan;
+pub use fixed_deck_keepables::FixedDeckKeepMulligan;
 pub use keepables_by_land_count::KeepablesByLandCount;
 pub use landfall_keepables::LandfallKeepablesMulligan;
 pub use plus_one_counters_keepables::PlusOneCountersMulligan;
@@ -120,6 +122,7 @@ impl Default for MulliganRegistry {
                 Box::new(PlusOneCountersMulligan),
                 Box::new(SpellslingerKeepablesMulligan),
                 Box::new(CedhKeepablesMulligan::new()),
+                Box::new(FixedDeckKeepMulligan),
             ],
         }
     }
@@ -205,6 +208,20 @@ mod cedh_registration_tests {
         assert!(
             has,
             "MulliganRegistry::default() must register CedhKeepablesMulligan"
+        );
+    }
+
+    #[test]
+    fn default_registry_contains_fixed_deck_keepables() {
+        let reg = MulliganRegistry::default();
+        let has = reg
+            .policies
+            .iter()
+            .any(|p| p.id() == PolicyId::FixedDeckKeepMulligan);
+        assert!(
+            has,
+            "MulliganRegistry::default() must register FixedDeckKeepMulligan \
+             so Momir-family all-land hands are kept, not mulliganed to zero"
         );
     }
 

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -94,6 +94,7 @@ pub enum PolicyId {
     ReactiveSelfProtection,
     ComboLineProgress,
     CedhKeepablesMulligan,
+    FixedDeckKeepMulligan,
     PlaneswalkerLoyalty,
     EquipmentPriority,
     SpellskitePriority,


### PR DESCRIPTION
Adds GameFormat::Momir end-to-end: an engine-supplied fixed 60-card
snow-basic deck, the command-zone emblem granting "{X}, Discard a card:
create a token that's a copy of a random creature with mana value X", plus
the supporting display and AI layers.

Engine
- format.rs: GameFormat::supplies_fixed_deck() predicate and the derived
  FormatConfig::supplies_fixed_deck field (engine-owned; the frontend
  consumes it directly and never re-lists fixed-deck formats client-side).
- deck_loading.rs / deck_validation.rs: canonical momir_fixed_deck_names() as
  the single source for the auto-supplied deck; load_and_hydrate_decks
  synthesizes the identical deck for every seat.
- printed_cards.rs: fix the momir_pool_faces serde-skip vs serialized desync
  on restore (rebuild gate now checks both maps); add
  self_etb_counter_replacements() to extract "enters with N counters"
  self-replacements statically.
- token_copy.rs: seed those extracted ETB counters alongside loyalty so copy
  tokens (e.g. Atraxa's Skitterfang) enter with their counters. CR 707.
- engine-wasm/lib.rs: gate per-seat deck fill on supplies_fixed_deck().

AI
- FixedDeckKeepMulligan: ForceKeep for fixed-deck formats so the AI keeps its
  all-land Momir hand; neutral Score{0.0} for every other format, so it is a
  provable no-op outside fixed-deck play. ai-gate clean (0 FAIL).

Frontend (display-only)
- formatRegistry / GameProvider / GameSetupPage / AiOpponentConfig: bypass
  deck-selection gates via the engine-derived formatSuppliesDeck.
- cardImageLookup: resolve emblem art from emblem_source (CR 114.5).
- CommandZone: emblem activated-ability tooltip, activation, and mana-symbol
  interpolation.
