### PR TITLE
fix(parser): route bare "you don't own" ownership suffix (Agent of Treachery)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -5952,6 +5952,50 @@ mod tests {
         }
     }
 
+    /// CR 108.3 + CR 109.4 + CR 603.4: "you control N or more permanents you
+    /// don't own" — the bare negated-ownership suffix must be consumed by the
+    /// type-phrase parser so the whole count condition is recognized (Agent of
+    /// Treachery #3304). Before the fix "you don't own" was left unconsumed,
+    /// leaving a non-empty remainder that aborted intervening-if hoisting.
+    #[test]
+    fn parse_control_count_ge_permanents_you_dont_own() {
+        for text in [
+            "you control three or more permanents you don't own",
+            "you control three or more permanents you do not own",
+        ] {
+            let (rest, cond) = parse_control_count_ge(text)
+                .unwrap_or_else(|e| panic!("failed to parse {text:?}: {e:?}"));
+            assert_eq!(rest, "", "unconsumed remainder for {text:?}");
+            let StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            } = cond
+            else {
+                panic!("expected ObjectCount >= 3 comparison for {text:?}, got {cond:?}");
+            };
+            let TargetFilter::Typed(tf) = filter else {
+                panic!("expected Typed filter for {text:?}, got {filter:?}");
+            };
+            assert_eq!(
+                tf.controller,
+                Some(ControllerRef::You),
+                "controller pinned to You via inject_controller_you for {text:?}"
+            );
+            assert!(
+                tf.properties.contains(&FilterProp::Owned {
+                    controller: ControllerRef::Opponent,
+                }),
+                "filter must carry Owned{{Opponent}} (\"you don't own it\") for {text:?}, \
+                 got {:?}",
+                tf.properties
+            );
+        }
+    }
+
     #[test]
     fn parse_quantity_quantity_comparison_x_ge_library() {
         // CR 107.3 + CR 608.2c: Thassa's Oracle trailing intervening-if.

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -4175,6 +4175,27 @@ fn parse_ownership_or_controller_suffix(
         });
         return own_ctrl_offset + "you own".len();
     }
+    // CR 108.3 + CR 109.4: bare "you don't own"/"you do not own" — negated
+    // ownership with no "but" lead (distinct from the "but don't own" block in
+    // `parse_type_phrase`, which requires a controller already set). Placed after
+    // the affirmative "you own"/"you own and control" arms ("you own" is not a
+    // prefix of "you don't own", so no shadowing) and before the anaphoric
+    // subject×action block. `Owned { Opponent }` is runtime-evaluated as
+    // owner != controller (filter.rs), i.e. "you don't own it". Does NOT set
+    // *controller — ownership is independent of control; for "you control N
+    // permanents you don't own" the controller is supplied upstream by
+    // `inject_controller_you`. (Agent of Treachery #3304.)
+    if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>("you don't own"),
+        tag::<_, _, OracleError<'_>>("you do not own"),
+    ))
+    .parse(own_ctrl)
+    {
+        properties.push(FilterProp::Owned {
+            controller: ControllerRef::Opponent,
+        });
+        return own_ctrl_offset + (own_ctrl.len() - rest.len());
+    }
     // CR 108.3: "an opponent owns" — the card belongs to an opponent, used by Eldrazi Processors.
     for phrase in ["an opponent owns", "opponents own"] {
         if tag::<_, _, OracleError<'_>>(phrase).parse(own_ctrl).is_ok() {
@@ -11927,6 +11948,65 @@ mod tests {
             }
             other => panic!("expected And filter, got {other:?}"),
         }
+    }
+
+    /// CR 108.3 + CR 109.4: bare "permanents you don't own" — the new
+    /// negated-ownership suffix in `parse_ownership_or_controller_suffix`. With
+    /// no controller and no "but" lead it pushes `Owned { Opponent }` directly
+    /// onto a single `Typed` filter (runtime: owner != controller, i.e. "you
+    /// don't own it"). Distinct from the "but don't own" `And[Typed, Not(..)]`
+    /// shape below, which is left UNCHANGED — proving the bare arm is additive.
+    /// (Agent of Treachery #3304.)
+    #[test]
+    fn parse_type_phrase_permanents_you_dont_own_pushes_owned_opponent() {
+        for text in ["permanents you don't own", "permanents you do not own"] {
+            let (filter, rest) = parse_type_phrase(text);
+            assert_eq!(rest, "", "fully consumed for {text:?}");
+            let TargetFilter::Typed(tf) = filter else {
+                panic!("expected single Typed filter for {text:?}, got {filter:?}");
+            };
+            assert!(
+                tf.properties.contains(&FilterProp::Owned {
+                    controller: ControllerRef::Opponent
+                }),
+                "{text:?} must push Owned{{Opponent}}, got {:?}",
+                tf.properties
+            );
+            // Ownership is independent of control: the bare suffix must NOT pin
+            // a controller (CR 109.4).
+            assert_eq!(
+                tf.controller, None,
+                "bare ownership suffix must not set controller for {text:?}"
+            );
+        }
+    }
+
+    /// No-regression guard: the "but don't own" path (controller already set)
+    /// still yields the `And[Typed(You), Not(Owned{You})]` shape, UNCHANGED by
+    /// the additive bare "you don't own" arm. (CR 108.3 + CR 109.4.)
+    #[test]
+    fn parse_type_phrase_but_dont_own_shape_unchanged_by_bare_arm() {
+        let (filter, rest) = parse_type_phrase("creature you control but don't own");
+        assert_eq!(rest, "");
+        let TargetFilter::And { filters } = filter else {
+            panic!("expected And filter, got {filter:?}");
+        };
+        assert!(matches!(
+            filters.first(),
+            Some(TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: Some(ControllerRef::You),
+                ..
+            })) if type_filters == &vec![TypeFilter::Creature]
+        ));
+        assert!(matches!(
+            filters.get(1),
+            Some(TargetFilter::Not { filter }) if matches!(
+                filter.as_ref(),
+                TargetFilter::Typed(TypedFilter { properties, .. })
+                    if properties == &vec![FilterProp::Owned { controller: ControllerRef::You }]
+            )
+        ));
     }
 
     /// CR 205.3 + CR 205.4b: "target attacking Vampire that isn't a Demon" — the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -29283,6 +29283,80 @@ mod tests {
             "the boost lasts until end of turn"
         );
     }
+
+    /// CR 108.3 + CR 109.4 + CR 603.4: Agent of Treachery's end-step draw is
+    /// gated by an intervening-if — "if you control three or more permanents you
+    /// don't own". The bare "you don't own" negated-ownership suffix must be
+    /// consumed by the type-phrase parser so the count condition reaches a word
+    /// boundary and the intervening-if is hoisted onto the trigger. Before the
+    /// fix the suffix was unconsumed, the condition was discarded
+    /// (`condition: None`), and Agent drew three cards unconditionally every end
+    /// step (#3304).
+    #[test]
+    fn agent_of_treachery_end_step_draw_is_gated_by_not_owned_count() {
+        let parsed = parse_oracle_text(
+            "When this creature enters, gain control of target permanent.\n\
+             At the beginning of your end step, if you control three or more \
+             permanents you don't own, draw three cards.",
+            "Agent of Treachery",
+            &[],
+            &["Creature".to_string()],
+            &["Human".to_string(), "Rogue".to_string()],
+        );
+
+        assert!(
+            parsed.parse_warnings.is_empty(),
+            "no parse warnings expected, got {:?}",
+            parsed.parse_warnings
+        );
+
+        let end_step = parsed
+            .triggers
+            .iter()
+            .find(|t| t.phase == Some(Phase::End))
+            .expect("an end-step (Phase::End) trigger must be parsed");
+
+        // The intervening-if must survive as a QuantityComparison, NOT be dropped.
+        let Some(TriggerCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 3 },
+        }) = end_step.condition.clone()
+        else {
+            panic!(
+                "end-step trigger must carry ObjectCount >= 3 intervening-if, got {:?}",
+                end_step.condition
+            );
+        };
+
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("count filter must be Typed, got {filter:?}");
+        };
+        assert_eq!(
+            tf.controller,
+            Some(ControllerRef::You),
+            "the counted permanents are ones YOU control (CR 109.4)"
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::Owned {
+                controller: ControllerRef::Opponent,
+            }),
+            "the counted permanents are ones you DON'T own — Owned{{Opponent}} \
+             (runtime: owner != controller); got {:?}",
+            tf.properties
+        );
+
+        // The execute body still draws three cards.
+        let exec = end_step.execute.as_deref().expect("end-step execute body");
+        assert!(
+            matches!(exec.effect.as_ref(), Effect::Draw { .. }),
+            "end-step trigger draws cards, got {:?}",
+            exec.effect
+        );
+    }
 }
 
 /// Snapshot tests locking current trigger parser output before the IR split.


### PR DESCRIPTION
## Summary

Fixes #3304

**Agent of Treachery** — "At the beginning of your end step, **if you control three or more permanents you don't own**, draw three cards." — drew three cards **every** end step, because the intervening-if condition was silently dropped (the trigger parsed with `condition: null`).

## Root cause

`parse_ownership_or_controller_suffix` only recognized the **"but** don't own" family (which additionally requires a controller already set). The bare **"you don't own"** suffix had no arm, so `parse_type_phrase("permanents you don't own")` left "you don't own" unconsumed → `parse_control_count_ge` returned a non-empty remainder → `try_extract_intervening`'s boundary check failed → the entire condition was discarded.

## Fix (parser-only; no new engine variant)

Add a bare `"you don't own"` / `"you do not own"` arm to `parse_ownership_or_controller_suffix` that pushes the existing `FilterProp::Owned { controller: Opponent }` — runtime-evaluated as `owner != controller`, i.e. "you don't own it". The arm deliberately does **not** set the controller (ownership is independent of control, CR 109.4); for "you control N permanents you don't own" the controller is supplied upstream by `inject_controller_you`, composing to `Typed(Permanent, controller: You, [Owned{Opponent}, InZone Battlefield])` = "permanents you control but don't own".

The end-step trigger now carries `QuantityComparison(ObjectCount{…} >= 3)` and is gated at detection and resolution per CR 603.4 — so it draws only when the controller controls ≥3 permanents they don't own. The `"but don't own"` path (Thieving Amalgam family) is a separate code path and is untouched.

## Runtime

- Control ≥3 not-owned (e.g. stolen) permanents at your end step → trigger fires, draw 3.
- Control <3 → condition false → no draw.

The fix consumes only previously-orphaned text; it also lets `Sentinel of Lost Lore` / similar "card you don't own …" object phrases consume the suffix (strictly additive — the parallel `"you own"` arm already exists).

## Tests

- `agent_of_treachery_end_step_draw_is_gated_by_not_owned_count` — the end-step trigger's `condition` is `Some(QuantityComparison{ GE, Fixed 3, ObjectCount{ filter } })` (not `None`), with the filter `Typed(Permanent, controller: You)` carrying `FilterProp::Owned{ Opponent }`; the execute body still draws; no parse warnings.
- `parse_control_count_ge_permanents_you_dont_own` — combinator unit (both "don't"/"do not"), empty remainder, `Owned{Opponent}` + `controller: You`.
- `parse_type_phrase_but_dont_own_shape_unchanged_by_bare_arm` — no-regression: "creature you control but don't own" still yields the unchanged `And[Typed(You), Not(Owned{You})]` shape (proves the bare arm is additive).

(Reverting the new arm makes the first two tests fail with the exact dropped-condition signature; the no-regression test still passes.)

## Verification

- `cargo +nightly test -p engine --lib "own"`: 297 passed; `"dont_own"`: 8 passed; `--test integration`: 1065 passed (no fixture diff).
- `cargo +nightly clippy -p engine --lib -- -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean (the new arm uses only `tag`/`alt`).

CR references grep-verified against `docs/MagicCompRules.txt`: **108.3** (owner), **109.4** (control ≠ ownership), **603.4** (intervening-if).
