### PR TITLE
fix(engine): Seasoned Pyromancer creates correct token count for each nonland card discarded

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7172,6 +7172,30 @@ mod tests {
     }
 
     #[test]
+    fn repeat_for_tracked_set_marks_ability_as_referencing_tracked_set() {
+        // Issue #740 (Seasoned Pyromancer): "for each nonland card discarded this
+        // way, create a token" carries its loop count as `repeat_for: TrackedSetSize`
+        // on the ResolvedAbility, NOT inside Effect. The publish predicate must
+        // detect it so the forced-discard path (no WaitingFor pause) still publishes
+        // the tracked set; without this check the token loop sees size 0.
+        let mut ability = optional_gain_life(ObjectId(1), PlayerId(0), 1);
+        ability.optional = false;
+        // Control: a plain GainLife with no `repeat_for` references no tracked set.
+        assert!(
+            !ability_or_branch_references_tracked_set(&ability),
+            "baseline ability must not reference a tracked set"
+        );
+        // With a tracked-set loop count, the predicate must return true.
+        ability.repeat_for = Some(QuantityExpr::Ref {
+            qty: QuantityRef::TrackedSetSize,
+        });
+        assert!(
+            ability_or_branch_references_tracked_set(&ability),
+            "repeat_for: TrackedSetSize must mark the ability as referencing the tracked set"
+        );
+    }
+
+    #[test]
     fn optional_trigger_prompt_includes_may_trigger_key() {
         let mut state = GameState::new_two_player(42);
         let source_id = ObjectId(100);

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2565,7 +2565,17 @@ fn ability_or_branch_references_tracked_set(ability: &ResolvedAbility) -> bool {
             uses_tracked_set: true,
             ..
         } | Effect::ChooseFromZone { .. }
-    ) || effect_references_tracked_set(&ability.effect);
+    ) || effect_references_tracked_set(&ability.effect)
+        // CR 608.2c + CR 609.3: `repeat_for` is a loop-count quantity on the
+        // ResolvedAbility, not inside Effect — e.g. "for each nonland card
+        // discarded this way, create a token" uses `repeat_for: TrackedSetSize`.
+        // Without this check, the forced-discard path (no WaitingFor pause)
+        // never publishes the tracked set, so the downstream token loop sees
+        // size 0 and creates no tokens (Seasoned Pyromancer bug #740).
+        || ability
+            .repeat_for
+            .as_ref()
+            .is_some_and(quantity_expr_references_tracked_set);
 
     consumes
         || ability

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -1778,8 +1778,25 @@ fn parse_destroyed_or_sacrificed_this_way_filter(
         let result: OracleResult<'_, &str> =
             terminated(take_until(suffix), tag(suffix)).parse(lower);
         if let Ok(("", filter_phrase)) = result {
-            let (filter, remainder) =
-                crate::parser::oracle_target::parse_type_phrase(filter_phrase.trim());
+            // "card"/"cards" is zone-agnostic Oracle phrasing for any permanent
+            // card (e.g. "nonland card discarded this way"). Normalize to
+            // "permanent"/"permanents" so parse_type_phrase can extract the full
+            // filter (e.g. NonLand + Permanent) rather than leaving "card" as an
+            // unrecognised remainder and falling back to the unfiltered TrackedSetSize.
+            let normalized;
+            let phrase = {
+                let t = filter_phrase.trim();
+                if let Some(prefix) = t.strip_suffix(" cards") {
+                    normalized = format!("{prefix} permanents");
+                    &normalized
+                } else if let Some(prefix) = t.strip_suffix(" card") {
+                    normalized = format!("{prefix} permanent");
+                    &normalized
+                } else {
+                    t
+                }
+            };
+            let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase(phrase);
             if remainder.trim().is_empty() {
                 return Some((Some(filter), cause));
             }
@@ -5868,6 +5885,38 @@ mod tests {
                 ),
                 other => panic!("expected Typed filter, got {other:?}"),
             },
+            other => panic!("expected FilteredTrackedSetSize, got {other:?}"),
+        }
+    }
+
+    /// CR 608.2c + CR 701.9a: "nonland card discarded this way" (Seasoned
+    /// Pyromancer) must emit `FilteredTrackedSetSize` with a NonLand filter,
+    /// not the plain `TrackedSetSize` fallback. Without the "card" → "permanent"
+    /// normalisation in `parse_destroyed_or_sacrificed_this_way_filter`, the
+    /// "card" tail is left as an unrecognised remainder and the filter is dropped,
+    /// so discarding 1 land + 1 nonland would create 2 tokens instead of 1.
+    /// (Primary engine fix for issue #740 is in `ability_or_branch_references_tracked_set`.)
+    #[test]
+    fn nonland_card_discarded_this_way_uses_filtered_tracked_set_nonland() {
+        let qty = parse_for_each_clause("nonland card discarded this way").expect("must parse");
+        match qty {
+            QuantityRef::FilteredTrackedSetSize { filter, caused_by } => {
+                assert_eq!(
+                    caused_by,
+                    Some(crate::types::ability::ThisWayCause::Discarded),
+                    "cause must be Discarded"
+                );
+                match *filter {
+                    TargetFilter::Typed(ref tf) => {
+                        assert!(
+                            tf.type_filters
+                                .contains(&TypeFilter::Non(Box::new(TypeFilter::Land))),
+                            "filter must include NonLand; got {tf:?}"
+                        );
+                    }
+                    other => panic!("expected Typed filter, got {other:?}"),
+                }
+            }
             other => panic!("expected FilteredTrackedSetSize, got {other:?}"),
         }
     }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -1778,30 +1778,14 @@ fn parse_destroyed_or_sacrificed_this_way_filter(
         let result: OracleResult<'_, &str> =
             terminated(take_until(suffix), tag(suffix)).parse(lower);
         if let Ok(("", filter_phrase)) = result {
-            // "card"/"cards" is zone-agnostic Oracle phrasing for any permanent
-            // card (e.g. "nonland card discarded this way"). Normalize to
-            // "permanent"/"permanents" so parse_type_phrase can extract the full
-            // filter (e.g. NonLand + Permanent) rather than leaving "card" as an
-            // unrecognised remainder and falling back to the unfiltered TrackedSetSize.
-            // Pattern 2a: terminated(take_until(suffix), tag(suffix)) consumes
-            // "cards"/"card" tail, yielding a prefix we can re-join with the
-            // permanent synonym.
-            let t = filter_phrase.trim();
-            let normalized;
-            let phrase = if let Ok(("", prefix)) =
-                terminated(take_until(" cards"), tag(" cards")).parse(t) as OracleResult<'_, &str>
-            {
-                normalized = format!("{prefix} permanents");
-                &normalized as &str
-            } else if let Ok(("", prefix)) =
-                terminated(take_until(" card"), tag(" card")).parse(t) as OracleResult<'_, &str>
-            {
-                normalized = format!("{prefix} permanent");
-                &normalized as &str
-            } else {
-                t
-            };
-            let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase(phrase);
+            // CR 700.1: "card" is the zone-agnostic head noun for the discarded
+            // members ("nonland card discarded this way"). parse_type_phrase maps
+            // it to TypeFilter::Card (matches every card type), so "nonland card"
+            // yields [Card, Non(Land)] — counting nonland instants/sorceries too.
+            // It must NOT be narrowed to TypeFilter::Permanent: a nonland instant
+            // discarded by Seasoned Pyromancer is still counted (CR 701.9a).
+            let (filter, remainder) =
+                crate::parser::oracle_target::parse_type_phrase(filter_phrase.trim());
             if remainder.trim().is_empty() {
                 return Some((Some(filter), cause));
             }
@@ -5895,11 +5879,12 @@ mod tests {
     }
 
     /// CR 608.2c + CR 701.9a: "nonland card discarded this way" (Seasoned
-    /// Pyromancer) must emit `FilteredTrackedSetSize` with a NonLand filter,
-    /// not the plain `TrackedSetSize` fallback. Without the "card" → "permanent"
-    /// normalisation in `parse_destroyed_or_sacrificed_this_way_filter`, the
-    /// "card" tail is left as an unrecognised remainder and the filter is dropped,
-    /// so discarding 1 land + 1 nonland would create 2 tokens instead of 1.
+    /// Pyromancer) must emit `FilteredTrackedSetSize` with a `[Card, NonLand]`
+    /// filter, not the plain `TrackedSetSize` fallback. The filter must include
+    /// `TypeFilter::Card` (every card type) and `Non(Land)`, and must NOT be
+    /// narrowed to `TypeFilter::Permanent` — a discarded nonland INSTANT or
+    /// SORCERY is still a nonland card and must be counted, so the token count
+    /// equals every nonland card discarded (CR 701.9a).
     /// (Primary engine fix for issue #740 is in `ability_or_branch_references_tracked_set`.)
     #[test]
     fn nonland_card_discarded_this_way_uses_filtered_tracked_set_nonland() {
@@ -5917,6 +5902,12 @@ mod tests {
                             tf.type_filters
                                 .contains(&TypeFilter::Non(Box::new(TypeFilter::Land))),
                             "filter must include NonLand; got {tf:?}"
+                        );
+                        // CR 701.9a: must NOT narrow to Permanent — a nonland
+                        // instant/sorcery discarded by Seasoned Pyromancer counts.
+                        assert!(
+                            !tf.type_filters.contains(&TypeFilter::Permanent),
+                            "filter must not exclude nonland instants/sorceries; got {tf:?}"
                         );
                     }
                     other => panic!("expected Typed filter, got {other:?}"),

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -1783,18 +1783,23 @@ fn parse_destroyed_or_sacrificed_this_way_filter(
             // "permanent"/"permanents" so parse_type_phrase can extract the full
             // filter (e.g. NonLand + Permanent) rather than leaving "card" as an
             // unrecognised remainder and falling back to the unfiltered TrackedSetSize.
+            // Pattern 2a: terminated(take_until(suffix), tag(suffix)) consumes
+            // "cards"/"card" tail, yielding a prefix we can re-join with the
+            // permanent synonym.
+            let t = filter_phrase.trim();
             let normalized;
-            let phrase = {
-                let t = filter_phrase.trim();
-                if let Some(prefix) = t.strip_suffix(" cards") {
-                    normalized = format!("{prefix} permanents");
-                    &normalized
-                } else if let Some(prefix) = t.strip_suffix(" card") {
-                    normalized = format!("{prefix} permanent");
-                    &normalized
-                } else {
-                    t
-                }
+            let phrase = if let Ok(("", prefix)) =
+                terminated(take_until(" cards"), tag(" cards")).parse(t) as OracleResult<'_, &str>
+            {
+                normalized = format!("{prefix} permanents");
+                &normalized as &str
+            } else if let Ok(("", prefix)) =
+                terminated(take_until(" card"), tag(" card")).parse(t) as OracleResult<'_, &str>
+            {
+                normalized = format!("{prefix} permanent");
+                &normalized as &str
+            } else {
+                t
             };
             let (filter, remainder) = crate::parser::oracle_target::parse_type_phrase(phrase);
             if remainder.trim().is_empty() {


### PR DESCRIPTION
## Summary

- **Engine**: `ability_or_branch_references_tracked_set` now checks `ability.repeat_for`
  for tracked set references (e.g. `repeat_for: TrackedSetSize`). Previously the
  forced-discard path (hand size ≤ discard count) skipped publishing the tracked set
  entirely, causing `TrackedSetSize` to resolve to 0 and no tokens to be created.
- **Parser**: `parse_destroyed_or_sacrificed_this_way_filter` now normalises `"nonland
  card[s]"` → `"nonland permanent[s]"` before calling `parse_type_phrase`, so
  `"nonland card discarded this way"` emits `FilteredTrackedSetSize { filter: NonLand,
  caused_by: Discarded }` instead of the plain `TrackedSetSize` fallback. Fixes the
  secondary correctness bug where discarding 1 land + 1 nonland would create 2 tokens.
- **Test**: `nonland_card_discarded_this_way_uses_filtered_tracked_set_nonland` asserts
  the parser emits the correct `FilteredTrackedSetSize` with `NonLand` filter and
  `Discarded` cause.

Fixes #740.

## Test plan

- [ ] `cargo test -p engine --lib -- nonland_card_discarded_this_way` passes
- [ ] Play Seasoned Pyromancer with exactly 2 cards in hand — discarding both nonlands
  creates **2** Elemental tokens
- [ ] Play Seasoned Pyromancer discarding 1 land + 1 nonland — creates **1** token
- [ ] Play Seasoned Pyromancer with 3+ cards (interactive choice path) — still creates
  the correct number of tokens
- [ ] `cargo clippy --all-targets -- -D warnings` clean
