### PR TITLE
fix: Phyrexian Mana autotap prioritization

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6172,27 +6172,48 @@ fn auto_tap_mana_sources_inner(
 
     // Build the typed shard-requirements list first — used by both the
     // combination pre-pass and the main MCV/LCV loop.
+    //
+    // CR 107.4f: Phyrexian shards can be paid with 2 life, so they should
+    // not block using flexible mana sources (dual lands) for strict colored
+    // requirements. We track Phyrexian shards separately and prioritize
+    // them after strict colored shards (MCV will sort them as least constrained).
     let mut deferred_generic: usize = 0;
-    let mut needs: Vec<(Vec<ManaType>, bool, bool)> = Vec::new();
+    let mut needs: Vec<(Vec<ManaType>, bool, bool, bool)> = Vec::new();
     for shard in shards {
         use crate::game::mana_payment::{shard_to_mana_type, ShardRequirement};
         match shard_to_mana_type(*shard) {
-            ShardRequirement::Single(color) | ShardRequirement::Phyrexian(color) => {
+            ShardRequirement::Single(color) => {
                 let acceptable = if any_color { Vec::new() } else { vec![color] };
-                needs.push((acceptable, false, false));
+                needs.push((acceptable, false, false, false));
             }
-            ShardRequirement::Hybrid(a, b) | ShardRequirement::HybridPhyrexian(a, b) => {
+            ShardRequirement::Phyrexian(color) => {
+                // CR 107.4f: Mark as phyrexian (4th field = true) so MCV deprioritizes it
+                // compared to strict Single color requirements. Phyrexian can be paid with
+                // life, so we should consume other mana sources for strict requirements first.
+                let acceptable = if any_color { Vec::new() } else { vec![color] };
+                needs.push((acceptable, false, false, true));
+            }
+            ShardRequirement::Hybrid(a, b) => {
                 let acceptable = if any_color { Vec::new() } else { vec![a, b] };
-                needs.push((acceptable, false, false));
+                needs.push((acceptable, false, false, false));
             }
-            ShardRequirement::TwoGenericHybrid(color)
+            ShardRequirement::HybridPhyrexian(a, b) => {
+                // CR 107.4f: Hybrid Phyrexian also allows life payment, so deprioritize.
+                let acceptable = if any_color { Vec::new() } else { vec![a, b] };
+                needs.push((acceptable, false, false, true));
+            }
+            ShardRequirement::TwoGenericHybrid(color) => {
+                let acceptable = if any_color { Vec::new() } else { vec![color] };
+                needs.push((acceptable, true, false, false));
+            }
             // CR 107.4f: K'rrik promotion never reaches the auto-tap
             // planner (`shard_to_mana_type` never emits this variant),
             // but the arm is required for exhaustiveness. Same
-            // tap-planning shape as the unpromoted `TwoGenericHybrid`.
-            | ShardRequirement::TwoGenericHybridPhyrexian(color) => {
+            // tap-planning shape as the unpromoted `TwoGenericHybrid` but
+            // with potential life payment, so deprioritize.
+            ShardRequirement::TwoGenericHybridPhyrexian(color) => {
                 let acceptable = if any_color { Vec::new() } else { vec![color] };
-                needs.push((acceptable, true, false));
+                needs.push((acceptable, true, false, true));
             }
             ShardRequirement::ColorlessHybrid(color) => {
                 let acceptable = if any_color {
@@ -6200,10 +6221,10 @@ fn auto_tap_mana_sources_inner(
                 } else {
                     vec![ManaType::Colorless, color]
                 };
-                needs.push((acceptable, false, false));
+                needs.push((acceptable, false, false, false));
             }
             ShardRequirement::TwoOrMoreColorSource => {
-                needs.push((Vec::new(), false, true));
+                needs.push((Vec::new(), false, true, false));
             }
             ShardRequirement::Snow | ShardRequirement::X => {
                 deferred_generic += 1;
@@ -6234,11 +6255,15 @@ fn auto_tap_mana_sources_inner(
     // a color only the flexible source can produce.
     //
     // MCV: process the most constrained shard first (fewest available sources).
+    // Phyrexian shards are deprioritized since they can be paid with life.
     // LCV: for each shard, prefer the least flexible source (fewest color options).
     for _ in 0..needs.len() {
         let mut best_idx = None;
         let mut min_sources = usize::MAX;
-        for (i, (acceptable, _, requires_two_or_more_color_source)) in needs.iter().enumerate() {
+        let mut best_priority = 1u8; // 0 = strict color (prioritized), 1 = phyrexian (deprioritized)
+        for (i, (acceptable, _, requires_two_or_more_color_source, is_phyrexian)) in
+            needs.iter().enumerate()
+        {
             if assigned[i] {
                 continue;
             }
@@ -6249,23 +6274,28 @@ fn auto_tap_mana_sources_inner(
                 *requires_two_or_more_color_source,
                 effective_ctx,
             );
-            if count < min_sources {
+            let priority = if *is_phyrexian { 1u8 } else { 0u8 };
+            // CR 107.4f: Prioritize strict colored shards (priority 0) over Phyrexian
+            // shards (priority 1). Within the same priority tier, use MCV (fewest sources).
+            if priority < best_priority || (priority == best_priority && count < min_sources) {
                 min_sources = count;
+                best_priority = priority;
                 best_idx = Some(i);
             }
         }
         let Some(idx) = best_idx else { break };
-        let (ref acceptable, two_generic_fallback, requires_two_or_more_color_source) = needs[idx];
+        let (ref acceptable, two_generic_fallback, requires_two_or_more_color_source, _) =
+            &needs[idx];
         if let Some(option) = find_least_flexible_source(
             &available,
             &used_sources,
             acceptable,
-            requires_two_or_more_color_source,
+            *requires_two_or_more_color_source,
             effective_ctx,
         ) {
             used_sources.insert(option.object_id);
             to_tap.push(option);
-        } else if two_generic_fallback {
+        } else if *two_generic_fallback {
             deferred_generic += 2;
         }
         assigned[idx] = true;
@@ -6469,7 +6499,7 @@ fn mana_sub_cost_of(cost: &Option<AbilityCost>) -> Option<&ManaCost> {
 /// `used_sources`, blocking further rows of every combination variant.
 fn assign_combination_sources(
     available: &[ManaSourceOption],
-    needs: &[(Vec<ManaType>, bool, bool)],
+    needs: &[(Vec<ManaType>, bool, bool, bool)],
     assigned: &mut [bool],
     used_sources: &mut HashSet<ObjectId>,
     to_tap: &mut Vec<ManaSourceOption>,
@@ -6544,13 +6574,13 @@ fn assign_combination_sources(
 /// first-fit is sufficient for the filter-land class).
 fn score_combination(
     combo: &[ManaType],
-    needs: &[(Vec<ManaType>, bool, bool)],
+    needs: &[(Vec<ManaType>, bool, bool, bool)],
     assigned: &[bool],
 ) -> (usize, Vec<usize>) {
     let mut locally_consumed: Vec<bool> = assigned.to_vec();
     let mut covered = Vec::new();
     for mana in combo {
-        for (i, (acceptable, _, requires_two_or_more_color_source)) in needs.iter().enumerate() {
+        for (i, (acceptable, _, requires_two_or_more_color_source, _)) in needs.iter().enumerate() {
             if locally_consumed[i] {
                 continue;
             }

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -363,6 +363,43 @@ pub fn classify_payment(cost: &ManaCost) -> PaymentClassification {
     PaymentClassification::Unambiguous
 }
 
+/// CR 107.4f + CR 118.3: True for shard requirements that carry the Phyrexian
+/// mana-vs-life choice — `{C/P}`, hybrid `{C/C/P}`, and the K'rrik-promoted
+/// `{2/C/P}`. The payment seams defer these until after strict requirements so
+/// each life-vs-mana decision sees the pool that actually remains.
+fn is_phyrexian_requirement(req: &ShardRequirement) -> bool {
+    matches!(
+        req,
+        ShardRequirement::Phyrexian(..)
+            | ShardRequirement::HybridPhyrexian(..)
+            | ShardRequirement::TwoGenericHybridPhyrexian(..)
+    )
+}
+
+/// CR 107.4f + CR 118.3: Order shard indices so every non-Phyrexian shard is
+/// resolved before any Phyrexian-shape shard, mirroring `can_pay_for_spell`'s
+/// deferral. Deciding a Phyrexian shard against the pool *after* strict
+/// requirements are met stops a contested colored source from being spent on
+/// the Phyrexian option and starving a strict shard — e.g. `{B/P}{B}` with one
+/// Swamp must spend the black on the strict `{B}` and pay life for `{B/P}`.
+/// Phyrexian indices keep their relative order so per-shard `ShardChoice`
+/// cursors and `PhyrexianShard` results stay aligned with the printed cost.
+fn phyrexian_deferred_order(
+    shards: &[ManaCostShard],
+    life_colors: crate::types::mana::LifePaymentColors,
+) -> Vec<usize> {
+    let is_phyrexian = |i: usize| {
+        is_phyrexian_requirement(&effective_shard_requirement(
+            shard_to_mana_type(shards[i]),
+            life_colors,
+        ))
+    };
+    (0..shards.len())
+        .filter(|&i| !is_phyrexian(i))
+        .chain((0..shards.len()).filter(|&i| is_phyrexian(i)))
+        .collect()
+}
+
 /// Check if the pool can pay the cost, respecting mana restrictions when `spell` is provided.
 ///
 /// CR 106.6: Some abilities that produce mana restrict how that mana can be spent.
@@ -784,12 +821,13 @@ pub fn pay_cost_with_demand_and_choices(
             let mut choice_cursor = 0usize;
             let mut preferred_hybrid_colors: Vec<(ManaType, ManaType, ManaType)> = Vec::new();
 
-            // CR 107.4a: Pay colored shards first (exact color match required).
-            for (idx, shard) in shards.iter().enumerate() {
-                // CR 107.4f: K'rrik promotion — dispatch the post-promotion
-                // shape so life-as-payment arms (Phyrexian/HybridPhyrexian/
-                // TwoGenericHybridPhyrexian) handle the ShardChoice uniformly.
-                match effective_shard_requirement(shard_to_mana_type(*shard), life_colors) {
+            // CR 107.4a + CR 107.4f + CR 118.3: Pay non-Phyrexian shards before
+            // Phyrexian-shape shards (see `phyrexian_deferred_order`) so each
+            // mana-vs-life decision sees the pool remaining after every strict
+            // requirement is met. K'rrik promotion is applied per shard so the
+            // life-as-payment arms handle the ShardChoice uniformly.
+            for idx in phyrexian_deferred_order(shards, life_colors) {
+                match effective_shard_requirement(shard_to_mana_type(shards[idx]), life_colors) {
                     ShardRequirement::Single(mt) => {
                         // CR 609.4b: When any_color, any mana can pay colored costs.
                         if any_color && mt != ManaType::Colorless {
@@ -1102,11 +1140,12 @@ pub fn compute_phyrexian_shards(
     // (or `LifeOnly`/unpayable would have failed `can_pay_for_spell` upstream).
     let mut life_budget = max_life_payments;
 
-    for (idx, shard) in shards.iter().enumerate() {
-        // CR 107.4f: K'rrik promotion — `{B}` becomes `{B/P}`, `{2/B}` becomes
-        // `{2/B/P}` for grant-bearing players. Dispatched arms below cover both
-        // intrinsic Phyrexian and the synthetic K'rrik fusion uniformly.
-        match effective_shard_requirement(shard_to_mana_type(*shard), life_colors) {
+    // CR 107.4f + CR 118.3: Resolve non-Phyrexian shards first (consuming their
+    // mana from `sim`), then the deferred Phyrexian shards — so each shard's
+    // `ShardOptions` reflects the pool after every strict requirement is met
+    // (see `phyrexian_deferred_order`). K'rrik promotion is applied per shard.
+    for idx in phyrexian_deferred_order(shards, life_colors) {
+        match effective_shard_requirement(shard_to_mana_type(shards[idx]), life_colors) {
             ShardRequirement::Single(mt) => {
                 if any_color && mt != ManaType::Colorless {
                     let _ = spend_any_for_required_colors(&mut sim, &[mt], spell);
@@ -2470,6 +2509,56 @@ mod tests {
         assert!(spent.is_empty());
         assert_eq!(life.len(), 1);
         assert_eq!(life[0].amount, 2);
+    }
+
+    #[test]
+    fn pay_cost_phyrexian_defers_to_same_color_strict_shard() {
+        // CR 107.4f + CR 118.3: {B/P}{B} with a single black source. The strict
+        // {B} must claim the lone black; the {B/P} is then paid with 2 life.
+        // Printed-order evaluation would spend the only black on {B/P} and then
+        // fail the strict {B} with InsufficientMana (regression for #3306 review).
+        let mut pool = pool_with(&[(ManaType::Black, 1)]);
+        let cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::PhyrexianBlack, ManaCostShard::Black],
+            generic: 0,
+        };
+        let (spent, life) = pay_from_pool(&mut pool, &cost).unwrap();
+        assert_eq!(spent.len(), 1, "the lone black pays the strict {{B}}");
+        assert_eq!(spent[0].color, ManaType::Black);
+        assert_eq!(life.len(), 1, "the {{B/P}} is paid with 2 life");
+        assert_eq!(life[0].amount, 2);
+    }
+
+    #[test]
+    fn compute_phyrexian_shards_defers_to_strict_reports_life_only() {
+        // CR 107.4f + CR 601.2f: {B/P}{B} with one black source. Because the
+        // strict {B} consumes the lone black, the {B/P} shard's only legal option
+        // is life — the UI must not surface ManaOrLife (regression for #3306).
+        let pool = pool_with(&[(ManaType::Black, 1)]);
+        let cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::PhyrexianBlack, ManaCostShard::Black],
+            generic: 0,
+        };
+        let shards = compute_phyrexian_shards(
+            &pool,
+            &cost,
+            None,
+            crate::types::mana::CostPermissionContext {
+                any_color: false,
+                max_life: 1,
+                life_colors: crate::types::mana::LifePaymentColors::EMPTY,
+            },
+        );
+        assert_eq!(shards.len(), 1, "one Phyrexian shard ({{B/P}})");
+        assert_eq!(
+            shards[0].shard_index, 0,
+            "shard_index stays the printed position"
+        );
+        assert_eq!(
+            shards[0].options,
+            crate::types::game_state::ShardOptions::LifeOnly,
+            "the lone black is reserved for the strict {{B}}, so {{B/P}} is life-only"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3306: Autotap now correctly deprioritizes Phyrexian mana shards in favor of flexible mana sources for strict color requirements.