### PR TITLE
feat(parser): complete distribute/divide parser gaps

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7697,6 +7697,23 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             clause.multi_target = multi_target;
             clause
         }
+        // CR 601.2d + CR 615.7: "prevent N damage divided/distributed among [targets]"
+        // — intercepted here so `distribute` and `multi_target` propagate to
+        // `ParsedEffectClause`. The bare Effect returned by `lower_utility_imperative_ast`
+        // cannot carry these fields. Mirrors the ZoneCounter { unless_pay } intercept above.
+        ImperativeFamilyAst::Structured(ImperativeAst::Utility(
+            UtilityImperativeAst::Prevent { ref text },
+        )) => {
+            if let Some(clause) = super::lower::try_parse_prevent_distribute(text) {
+                return clause;
+            }
+            // Fallback: standard prevent with no distribution.
+            // lower_utility_imperative_ast is defined in THIS file (imperative.rs),
+            // called unqualified — NOT super::lower::lower_utility_imperative_ast.
+            parsed_clause(lower_utility_imperative_ast(
+                UtilityImperativeAst::Prevent { text: text.clone() },
+            ))
+        }
         // All other arms produce a bare Effect with no sub_ability chain.
         other => parsed_clause(lower_imperative_family_effect(other)),
     }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -25,9 +25,10 @@ use crate::parser::oracle_ir::effect_chain::{ClauseIr, EffectChainIr, SpecialCla
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AttackScope, AttackSubject,
     Comparator, ContinuousModification, ControllerRef, DamageSource, DelayedTriggerCondition,
-    Duration, Effect, EffectScope, FilterProp, MultiTargetSpec, ObjectScope, PlayerFilter, PtValue,
-    QuantityExpr, QuantityRef, RoundingMode, StaticCondition, StaticDefinition, SubAbilityLink,
-    TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
+    Duration, Effect, EffectScope, FilterProp, MultiTargetSpec, ObjectScope, PlayerFilter,
+    PreventionAmount, PreventionScope, PtValue, QuantityExpr, QuantityRef, RoundingMode,
+    StaticCondition, StaticDefinition, SubAbilityLink, TargetChoiceTiming, TargetFilter,
+    TypeFilter, TypedFilter,
 };
 use crate::types::counter::CounterType;
 use crate::types::game_state::{DistributionUnit, TargetSelectionConstraint};
@@ -3745,6 +3746,7 @@ pub(super) fn try_parse_distribute_damage(lower: &str, text: &str) -> Option<Par
     let (_, after_tp) = tp.split_at(pos + verb_len);
 
     let (amount, rest_tp) = if let Some((qty, rem)) = parse_count_expr(after_tp.lower) {
+        // Pattern A: "[qty] damage divided/distributed among …"
         if tag::<_, _, OracleError<'_>>("damage").parse(rem).is_ok() {
             let skip = after_tp.lower.len() - rem.len() + "damage".len();
             let (_, rest) = after_tp.split_at(skip);
@@ -3752,6 +3754,33 @@ pub(super) fn try_parse_distribute_damage(lower: &str, text: &str) -> Option<Par
         } else {
             return None;
         }
+    } else if let Ok((after_prefix, _)) =
+        tag::<_, _, OracleError<'_>>("damage equal to ").parse(after_tp.lower)
+    {
+        // Pattern B: "damage equal to [qty] divided/distributed among …"
+        // CR 601.2d: the quantity follows the "equal to" phrase and is a dynamic
+        // reference (e.g., "its power" — Emberwilde Captain), so it routes through
+        // the CDA quantity layer rather than the fixed/X-only `parse_count_expr`.
+        // The quantity slice is the text between "equal to " and the distribution
+        // keyword; the distribution phrase is then located in `rest` below exactly
+        // as in Pattern A.
+        let after_prefix_offset = after_tp.lower.len() - after_prefix.len();
+        let (_, rest) = after_tp.split_at(after_prefix_offset);
+        let qty_end = [
+            "divided as you choose among",
+            "distributed among",
+            "divided evenly",
+        ]
+        .iter()
+        // allow-noncombinator: structural slice bound, not parsing dispatch — locate
+        // the earliest distribution keyword so `parse_cda_quantity` receives only the
+        // quantity phrase. The dispatch on *which* distribution kind applies is done
+        // by the `distribute_kind` combinator block below; this only bounds the slice.
+        .filter_map(|kw| rest.lower.find(kw))
+        .min()?;
+        let qty_text = rest.lower[..qty_end].trim();
+        let qty = parse_cda_quantity(qty_text)?;
+        (qty, rest)
     } else {
         return None;
     };
@@ -3819,10 +3848,19 @@ pub(super) fn try_parse_distribute_damage(lower: &str, text: &str) -> Option<Par
 /// CR 601.2d: Parse "distribute N [type] counters among [targets]"
 /// → Effect::PutCounter with distribute flag set.
 pub(super) fn try_parse_distribute_counters(lower: &str, text: &str) -> Option<ParsedEffectClause> {
-    // "distribute " is 11 bytes; Oracle text is ASCII so byte == char offsets.
-    let (after_lower, _) = tag::<_, _, OracleError<'_>>("distribute ")
-        .parse(lower)
-        .ok()?;
+    // "distribute " = 11 bytes; "distributes " = 12 bytes. Capture matched length for
+    // the expected_min sanity check. Both infinitive and 3rd-person forms appear in Oracle text.
+    let (after_lower, verb_len): (&str, usize) = {
+        let mut verb_alt = alt((
+            tag::<_, _, OracleError<'_>>("distributes "),
+            tag::<_, _, OracleError<'_>>("distribute "),
+        ));
+        if let Ok((rest, matched)) = verb_alt.parse(lower) {
+            (rest, matched.len())
+        } else {
+            return None;
+        }
+    };
     let (count_expr, rest_lower) =
         if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("up to ").parse(after_lower) {
             let (inner, rest) = parse_count_expr(rest)?;
@@ -3878,7 +3916,7 @@ pub(super) fn try_parse_distribute_counters(lower: &str, text: &str) -> Option<P
 
     // Verify the "among" comes after the counter word (sanity guard against false matches).
     let expected_min =
-        "distribute ".len() + (after_lower.len() - rest_lower.len()) + type_end + counter_word_len;
+        verb_len + (after_lower.len() - rest_lower.len()) + type_end + counter_word_len;
     if among_pos < expected_min {
         return None;
     }
@@ -3894,6 +3932,90 @@ pub(super) fn try_parse_distribute_counters(lower: &str, text: &str) -> Option<P
         duration: None,
         sub_ability: None,
         distribute: Some(DistributionUnit::Counters(counter_name)),
+        multi_target,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
+/// CR 601.2d + CR 615.7: Parse "prevent [qty] damage divided/distributed among [targets]"
+/// → Effect::PreventDamage with distribute flag. Called from the Prevent intercept arm
+/// in `lower_imperative_family_ast` before the standard prevent resolver.
+pub(super) fn try_parse_prevent_distribute(text: &str) -> Option<ParsedEffectClause> {
+    let lower = text.to_lowercase();
+    // Quick-reject: require a distribution marker before spending effort on parsing.
+    if !scan_contains_phrase(&lower, "distributed among")
+        && !scan_contains_phrase(&lower, "divided as you choose among")
+    {
+        return None;
+    }
+    // Parse "prevent " prefix via nom combinator.
+    let (after_prevent, _) = tag::<_, _, OracleError<'_>>("prevent ")
+        .parse(lower.as_str())
+        .ok()?;
+    // CR 615.7: prevention shields are printed as "prevent the next N damage …".
+    // Strip the optional "the next "/"next " quantifier before the count so the
+    // shared `parse_count_expr` sees a bare quantity. `opt` makes both the
+    // "the next" and the determiner-less "next" forms parse, and leaves the input
+    // untouched for "prevent N damage" (no quantifier).
+    let (after_quantifier, _) = opt(alt((
+        tag::<_, _, OracleError<'_>>("the next "),
+        tag::<_, _, OracleError<'_>>("next "),
+    )))
+    .parse(after_prevent)
+    .unwrap_or((after_prevent, None));
+    // Parse the prevention amount.
+    let (qty, rem) = parse_count_expr(after_quantifier)?;
+    // CR 615.7: Require "damage" immediately after the quantity.
+    let (after_damage, _) = tag::<_, _, OracleError<'_>>("damage").parse(rem).ok()?;
+
+    // Locate the distribution keyword using TextPair-style strip_after.
+    let tp = TextPair::new(text, &lower);
+    // Reconstruct byte offset into after_damage in the lower string.
+    let after_damage_offset = lower.len() - after_damage.len();
+    let (_, after_damage_tp) = tp.split_at(after_damage_offset);
+
+    let target_tp = after_damage_tp
+        .strip_after("divided as you choose among ")
+        .or_else(|| after_damage_tp.strip_after("distributed among "))?;
+    let target_text = target_tp.original.trim();
+
+    // CR 601.2d: each divide target must receive at least one unit — "any number of"
+    // corresponds to multi_target with min:0 (player may assign zero to any target).
+    let target_lower = target_text.to_lowercase();
+    let (stripped_target, multi_target) = if let Ok((rest, _)) =
+        tag::<_, _, OracleError<'_>>("any number of ").parse(target_lower.as_str())
+    {
+        let skip = target_lower.len() - rest.len();
+        (
+            &target_text[skip..],
+            Some(multi_target_for_distribute_among(&qty)),
+        )
+    } else {
+        strip_optional_target_prefix(target_text)
+    };
+    let (target, _) = parse_target(stripped_target);
+
+    // Convert the parsed QuantityExpr to PreventionAmount.
+    // CR 615.7: Fixed amounts use Next(n); dynamic amounts use amount_dynamic.
+    let (amount, amount_dynamic) = match &qty {
+        QuantityExpr::Fixed { value } => (PreventionAmount::Next(*value as u32), None),
+        _ => (PreventionAmount::All, Some(qty)),
+    };
+
+    Some(ParsedEffectClause {
+        effect: Effect::PreventDamage {
+            amount,
+            amount_dynamic,
+            target,
+            scope: PreventionScope::AllDamage,
+            damage_source_filter: None,
+            prevention_duration: None,
+        },
+        duration: None,
+        sub_ability: None,
+        distribute: Some(DistributionUnit::Damage),
         multi_target,
         condition: None,
         optional: false,
@@ -5838,6 +5960,56 @@ mod tests {
     use crate::types::phase::Phase;
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
+
+    #[test]
+    fn distribute_damage_power_equal_pattern() {
+        // Gap 1: "damage equal to its power" — Pattern B where qty follows "damage equal to"
+        use crate::types::game_state::DistributionUnit;
+        let text = "deal damage equal to its power divided as you choose among any number of target creatures and/or players";
+        let lower = text.to_lowercase();
+        let clause = super::try_parse_distribute_damage(&lower, text).expect("Gap 1 should parse");
+        assert!(matches!(clause.distribute, Some(DistributionUnit::Damage)));
+        assert!(
+            clause.multi_target.is_some(),
+            "must have multi_target for distribute"
+        );
+        assert!(matches!(clause.effect, Effect::DealDamage { .. }));
+    }
+
+    #[test]
+    fn distribute_counters_third_person_predicate() {
+        // Gap 2: "distributes" (3rd-person) verb after subject stripping
+        use crate::types::game_state::DistributionUnit;
+        let text = "distributes 3 +1/+1 counters among any number of target creatures you control";
+        let lower = text.to_lowercase();
+        let clause =
+            super::try_parse_distribute_counters(&lower, text).expect("Gap 2 should parse");
+        // Counter distribution uses DistributionUnit::Counters, NOT Damage
+        assert!(matches!(
+            clause.distribute,
+            Some(DistributionUnit::Counters(_))
+        ));
+        assert!(clause.multi_target.is_some());
+    }
+
+    #[test]
+    fn distribute_prevent_damage_fixed() {
+        // Gap 3: fixed-N prevent-divide
+        use crate::types::ability::PreventionAmount;
+        use crate::types::game_state::DistributionUnit;
+        let text =
+            "prevent the next 5 damage divided as you choose among any number of target creatures";
+        let clause = super::try_parse_prevent_distribute(text).expect("Gap 3 should parse");
+        assert!(matches!(clause.distribute, Some(DistributionUnit::Damage)));
+        assert!(clause.multi_target.is_some());
+        assert!(matches!(
+            clause.effect,
+            Effect::PreventDamage {
+                amount: PreventionAmount::Next(5),
+                ..
+            }
+        ));
+    }
 
     /// CR 400.7 + CR 700.4: A per-turn VALUE quantity's " this turn" suffix must
     /// not be claimed as an outer effect duration. Both the value-ownership

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4561,9 +4561,7 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
 
     // CR 601.2d: "distribute N [type] counters among [targets]" →
     // PutCounter with distribute: Some(Counters(type)).
-    if tag::<_, _, OracleError<'_>>("distribute ")
-        .parse(lower.as_str())
-        .is_ok()
+    if (scan_contains_phrase(&lower, "distribute ") || scan_contains_phrase(&lower, "distributes "))
         && scan_contains_phrase(&lower, "counter")
         && scan_contains_phrase(&lower, "among")
     {

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -814,11 +814,17 @@ pub enum Keyword {
     /// on target creature, which gains this creature's other abilities until EOT.
     Backup(u32),
 
-    /// RUNTIME: TODO — converter accepts this keyword but engine has no
-    /// behavioral handler (variable additional cost + ETB token-per-payment
-    /// not wired).
-    /// CR 702.157: Squad {cost} — as an additional cost to cast, you may pay {cost}
-    /// any number of times; ETB creates that many tokens.
+    /// CR 702.157a: Squad {cost} — "As an additional cost to cast this spell,
+    /// you may pay {cost} any number of times." "When this creature enters, if
+    /// its squad cost was paid, create a token that's a copy of it for each time
+    /// its squad cost was paid." (CR 702.157b: each instance triggers separately.)
+    ///
+    /// Runtime: `database::synthesis::synthesize_squad` builds a
+    /// `AdditionalCost::Optional { repeatability: Repeatable }` additional-cost
+    /// instance (origin: `AdditionalCostOrigin::Squad`) and an ETB copy trigger
+    /// keyed on `QuantityRef::AdditionalCostPaymentCountFor { origin: Squad }`.
+    /// `casting_costs::effective_squad_additional_cost_instances` surfaces the
+    /// per-instance additional costs during casting. Fully wired.
     Squad(ManaCost),
 
     /// CR 702.29: Typecycling — "{subtype}cycling {cost}": discard this card and pay {cost}
@@ -923,11 +929,17 @@ pub enum Keyword {
     /// mana cost.
     Replicate(ManaCost),
 
-    /// RUNTIME: TODO — converter accepts this keyword but engine has no
-    /// behavioral handler (alt-cast hook + awaken-paid branch not wired).
-    /// CR 702.113a: Awaken N—{cost} — alternative cost that also puts
-    /// N +1/+1 counters on target land, animating it as a 0/0 Elemental
-    /// creature with haste.
+    /// CR 702.113a: Awaken N—{cost} — alternative cost that also puts N +1/+1
+    /// counters on target land you control, animating it as a 0/0 Elemental
+    /// creature with haste (it's still a land). Casting with awaken follows
+    /// CR 601.2b and CR 601.2f–h. CR 702.113b: the land target exists only
+    /// when the awaken cost was paid.
+    ///
+    /// Runtime: `CastingVariant::Awaken` + `casting::handle_awaken_cost_choice`
+    /// substitutes the awaken mana cost for the printed cost and calls
+    /// `effects::awaken::append_awaken_rider` to append the resolution rider
+    /// (`PutCounter{N, land you control}` → `Animate{0/0 Elemental, Haste,
+    /// Permanent}`) at the tail of the spell's ability tree. Fully wired.
     Awaken {
         count: u32,
         cost: ManaCost,
@@ -939,40 +951,57 @@ pub enum Keyword {
     /// trigger semantics are synthesized in `database::synthesis`.
     ForMirrodin,
 
-    /// RUNTIME: TODO — converter accepts this keyword but engine has no
-    /// behavioral handler (alt-cost cast hook not wired).
     /// CR 702.162a: More Than Meets the Eye {cost} — alternative cost
-    /// (Transformers crossover). "You may cast this card converted by
-    /// paying [cost] rather than its mana cost." Stores the alt mana
-    /// cost; the runtime alt-cost cast hook is not yet wired.
+    /// (Transformers crossover). "You may cast this card converted by paying
+    /// [cost] rather than its mana cost." Follows CR 701.28 (Convert) —
+    /// the permanent enters the battlefield transformed (back face up).
+    /// Alternative cost rules: CR 601.2b, CR 601.2f–h, CR 118.9.
+    ///
+    /// Runtime: `CastingVariant::MoreThanMeetsTheEye` + `casting::handle_mtmte_cost_choice`
+    /// substitutes the MTMTE mana cost for the printed cost and routes through
+    /// `continue_cast_with_alternative_spell_face`, which sets the stack spell
+    /// to use back-face characteristics. On resolution, `enter_transformed`
+    /// ZoneChange seed ensures the permanent enters back face up.
+    /// `CastingVariant::restores_front_face_after_stack_exit` handles cleanup
+    /// if the spell leaves the stack without resolving. Fully wired.
     MoreThanMeetsTheEye(ManaCost),
 
-    /// RUNTIME: TODO — converter accepts this keyword but engine has no
-    /// behavioral handler (alt-cast hook + combat-damage-this-turn predicate
-    /// not wired).
-    /// CR 702.173a: Freerunning {cost} — alternative cost. "You may pay
-    /// [cost] rather than pay this spell's mana cost if a player was
-    /// dealt combat damage this turn by a creature that, at the time it
-    /// dealt that damage, was an Assassin creature or a commander under
-    /// your control." Stores the alt mana cost; runtime alt-cast hook
-    /// (combat-damage-this-turn predicate) is not yet wired.
+    /// CR 702.173a: Freerunning {cost} — alternative cost. "You may pay [cost]
+    /// rather than pay this spell's mana cost if a player was dealt combat damage
+    /// this turn by a creature that, at the time it dealt that damage, was an
+    /// Assassin creature or a commander under your control." Follows CR 601.2b
+    /// and CR 601.2f–h. A pure cost substitution — no resolution rider.
+    ///
+    /// Runtime: The eligibility predicate is tracked in
+    /// `GameState::assassin_or_commander_dealt_combat_damage_this_turn`
+    /// (a `HashSet<PlayerId>` seeded by `triggers::collect_pending_triggers`
+    /// when an Assassin or commander deals combat damage, per CR 702.173a).
+    /// The ledger is cleared at cleanup (CR 514) by `turns::run_cleanup`.
+    /// `casting::casting_variant_candidates` checks the ledger to surface
+    /// `CastingVariant::Freerunning`; `casting_costs` substitutes the
+    /// Freerunning cost for the printed cost. Fully wired.
     Freerunning(ManaCost),
 
     /// CR 702.191a: Increment — spell-cast trigger synthesized in
     /// `database::synthesis::synthesize_increment`.
     Increment,
 
-    /// RUNTIME: TODO — converter accepts this keyword but engine has no
-    /// behavioral handler (choose-color + transform hooks not wired).
-    /// CR ???: Specialize {cost} — not in CR text (needs manual
-    /// verification). Strixhaven student-into-mage transformation:
-    /// activated alt-cast that turns the source into a colour-specific
-    /// version. Stores the activation mana cost; the choose-color and
-    /// transform hooks are not yet wired. mtgish encodes activation
-    /// timing modifiers and from-graveyard variants separately; this
-    /// keyword carries only the cost (the engine drops the activation
-    /// modifier and the from-graveyard hint, mirroring how `LevelUp`
-    /// drops its `Vec<Level>` payload).
+    /// Digital-only Specialize (Alchemy Horizons: Baldur's Gate) — not in the
+    /// Comprehensive Rules; behavior follows MTG Arena. "{cost}, Discard a
+    /// colored card or a card with a basic land subtype: This permanent becomes
+    /// the matching color-specialized face permanently." Activated ability,
+    /// sorcery speed. The keyword carries only the activation mana cost; the
+    /// discard filter and color selection are built at synthesis time.
+    ///
+    /// Runtime: `database::synthesis::synthesize_specialize` builds a sorcery-
+    /// speed `AbilityKind::Activated` with `Effect::Specialize` and
+    /// `AbilityCost::Composite { Mana + Discard { filter: specialize_discard_filter } }`.
+    /// `effects::specialize::resolve` reads the discarded card's LKI snapshot to
+    /// determine eligible colors via `game::specialize::eligible_specialize_colors`,
+    /// then either calls `specialize_permanent` directly (one option) or sets
+    /// `WaitingFor::SpecializeColor` for the player to choose.
+    /// `engine_resolution_choices` dispatches `GameAction::ChooseSpecializeColor`
+    /// to complete the transformation. Fully wired.
     Specialize(ManaCost),
 
     /// CR 702.48a: "[Quality] offering" — as an additional cost to cast this


### PR DESCRIPTION

## Summary
- Adds Pattern B to `try_parse_distribute_damage` for "damage equal to [qty] divided among" (CR 601.2d)
- Extends `try_parse_distribute_counters` to match 3rd-person "distributes" verb form
- Adds `try_parse_prevent_distribute` + intercept arm for "prevent N damage divided among" (CR 615.7)

## Test plan
- [ ] 3 new discriminating parser tests pass (`distribute_damage_power_equal_pattern`, `distribute_counters_third_person_predicate`, `distribute_prevent_damage_fixed`)
- [ ] All existing distribute tests (~21) still pass
- [ ] Clippy clean
