### PR TITLE
refactor(parser): centralize optional, repeat-for, and player-scope peeling in clause_shell

### DIFF
--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -16,12 +16,17 @@
 //! ## Migrated slots
 //!
 //! - **Optional** (`you may [verb]` → `optional: true`)
+//! - **Opponent-may** (`each opponent may` / `any opponent may` / … →
+//!   `opponent_may_scope` + optional + implicit `player_scope`)
 //! - **Duration** (`... this turn` / `... until end of turn` /
 //!   `... until your next turn` / `... for as long as ~ remains tapped` etc.
 //!   → `Duration` variant)
+//! - **Leading condition** (`if [cond], [effect]` → `AbilityCondition`)
+//! - **Repeat-for** (`for each [qty], ` prefix and trailing `twice` / `N times`)
+//! - **Player-scope** (`each opponent` / `each player` subject prefixes)
 //!
-//! Every other slot continues to flow through its existing per-callsite
-//! handling until a follow-up commit migrates it here.
+//! Remaining slots (unless-pay, activation limits, `where X`) continue through
+//! the chunk loop until migrated here.
 //!
 //! As slots migrate, each becomes:
 //! 1. A new field on `ClauseContext`.
@@ -73,7 +78,9 @@ use super::oracle_effect::conditions::{
 use super::oracle_effect::strip_trailing_duration;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_nom::bridge::nom_on_lower;
-use crate::types::ability::{AbilityCondition, Duration};
+use crate::types::ability::{
+    AbilityCondition, Duration, OpponentMayScope, PlayerFilter, QuantityExpr,
+};
 
 /// Synthesized attributes accumulated by `peel_clause` as it strips
 /// structural slots off the head of a clause.
@@ -101,6 +108,16 @@ pub(crate) struct ClauseContext {
     /// pipeline (via the existing `strip_leading_general_conditional`
     /// building block).
     pub(crate) condition: Option<AbilityCondition>,
+    /// CR 608.2d: `any opponent may` / `any player may` first-accept-wins
+    /// scope. Set when `peel_clause` strips an opponent-may prefix.
+    pub(crate) opponent_may_scope: Option<OpponentMayScope>,
+    /// CR 608.2d: Implicit per-player iteration from an opponent-may prefix
+    /// (`each opponent may`, `target opponent may`, `defending player may`, …).
+    pub(crate) may_implicit_player_scope: Option<PlayerFilter>,
+    /// CR 609.3: `for each [qty], ` prefix or trailing `twice` / `N times`.
+    pub(crate) repeat_for: Option<QuantityExpr>,
+    /// CR 109.5: `each opponent` / `each player` subject-prefix iteration scope.
+    pub(crate) player_scope: Option<PlayerFilter>,
 }
 
 impl ClauseContext {
@@ -130,10 +147,33 @@ impl ClauseContext {
         self.condition.as_ref()
     }
 
+    pub(crate) fn opponent_may_scope(&self) -> Option<&OpponentMayScope> {
+        self.opponent_may_scope.as_ref()
+    }
+
+    pub(crate) fn may_implicit_player_scope(&self) -> Option<&PlayerFilter> {
+        self.may_implicit_player_scope.as_ref()
+    }
+
+    pub(crate) fn repeat_for(&self) -> Option<&QuantityExpr> {
+        self.repeat_for.as_ref()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn player_scope(&self) -> Option<&PlayerFilter> {
+        self.player_scope.as_ref()
+    }
+
     /// True when no slot has been populated. Callers can short-circuit
     /// `apply_*` when nothing was peeled.
     pub(crate) fn is_empty(&self) -> bool {
-        !self.optional && self.duration.is_none() && self.condition.is_none()
+        !self.optional
+            && self.duration.is_none()
+            && self.condition.is_none()
+            && self.opponent_may_scope.is_none()
+            && self.may_implicit_player_scope.is_none()
+            && self.repeat_for.is_none()
+            && self.player_scope.is_none()
     }
 }
 
@@ -150,9 +190,16 @@ pub(crate) fn peel_clause(text: &str) -> (String, ClauseContext) {
 }
 
 fn peel_inner(text: String, mut ctx: ClauseContext) -> (String, ClauseContext) {
-    // Optional: "you may [bare imperative verb]" — leading prefix.
-    if !ctx.optional {
-        if let Some(rest) = strip_optional_prefix(&text) {
+    // Optional / opponent-may prefixes — leading slot family (CR 608.2d).
+    if !ctx.optional && ctx.opponent_may_scope.is_none() && ctx.may_implicit_player_scope.is_none()
+    {
+        if let Some((scope, player_scope, rest)) = try_peel_opponent_may_prefix(&text) {
+            ctx.optional = true;
+            ctx.opponent_may_scope = scope;
+            ctx.may_implicit_player_scope = player_scope;
+            return peel_inner(rest, ctx);
+        }
+        if let Some(rest) = peel_you_may_prefix(&text, YouMayBlocklist::PeelClause) {
             ctx.optional = true;
             return peel_inner(rest, ctx);
         }
@@ -185,6 +232,24 @@ fn peel_inner(text: String, mut ctx: ClauseContext) -> (String, ClauseContext) {
         }
     }
 
+    // Repeat-for: "for each [qty], " leading prefix (CR 107.1 / CR 609.3).
+    if ctx.repeat_for.is_none() {
+        let (qty, rest) = peel_for_each_prefix(&text);
+        if qty.is_some() {
+            ctx.repeat_for = qty;
+            return peel_inner(rest, ctx);
+        }
+    }
+
+    // Player-scope subject: "each opponent/player …" (CR 109.5).
+    if ctx.player_scope.is_none() {
+        let (scope, rest) = peel_player_scope_subject(&text);
+        if let Some(scope) = scope {
+            ctx.player_scope = Some(scope);
+            return peel_inner(rest, ctx);
+        }
+    }
+
     // CR 608.2c + CR 608.2d: Unrepresentable `If <X>, ` head fallback — strips
     // ONLY when the body begins with `"you may "` so the recursive call's
     // step-1 optional-prefix peel captures the may-choice. Runs after the
@@ -202,17 +267,105 @@ fn peel_inner(text: String, mut ctx: ClauseContext) -> (String, ClauseContext) {
     (text, ctx)
 }
 
-/// CR 608.2d: Strip a leading bare "you may " when it precedes a fresh
-/// imperative. Returns the remainder text on a match, `None` when the
-/// "you may " phrase is part of a specialized construction handled by a
-/// dedicated body parser (see `is_specialized_you_may_phrase`).
-fn strip_optional_prefix(text: &str) -> Option<String> {
+/// Which specialized-phrase blocklist applies when peeling a leading `you may `.
+enum YouMayBlocklist {
+    /// `peel_clause` / `parse_effect_clause`: broad blocklist — specialized
+    /// cast/play/pay/reveal handlers keep the full surface form.
+    PeelClause,
+    /// Chunk-loop cascade: narrow blocklist — only retarget phrases block peel;
+    /// Beseech-style `you may cast the exiled card …` still peels optional.
+    ChunkLoop,
+}
+
+/// CR 107.1 + CR 609.3: Peel a leading `for each [qty], ` repeat prefix.
+/// Delegates to the existing `strip_for_each_prefix` building block.
+pub(crate) fn peel_for_each_prefix(text: &str) -> (Option<QuantityExpr>, String) {
+    super::oracle_effect::lower::strip_for_each_prefix(text)
+}
+
+/// CR 608.2c: Peel a trailing `twice` / `N times` repeat suffix.
+pub(crate) fn peel_repeat_count_suffix(text: &str) -> (Option<QuantityExpr>, String) {
+    super::oracle_effect::lower::strip_repeat_count_suffix(text)
+}
+
+/// CR 109.5: Peel an `each player` / `each opponent` subject prefix.
+pub(crate) fn peel_player_scope_subject(text: &str) -> (Option<PlayerFilter>, String) {
+    super::oracle_effect::lower::strip_player_scope_subject(text)
+}
+
+/// CR 608.2d: Single authority for optional / opponent-may prefix peeling in
+/// the chunk-loop cascade. Delegates opponent-may arms and the narrow `you may`
+/// blocklist to `clause_shell` so the strip logic is not duplicated in
+/// `oracle_effect/lower.rs`.
+pub(crate) fn peel_optional_slots(
+    text: &str,
+) -> (bool, Option<OpponentMayScope>, Option<PlayerFilter>, String) {
+    if let Some((scope, player_scope, rest)) = try_peel_opponent_may_prefix(text) {
+        return (true, scope, player_scope, rest);
+    }
+    if let Some(rest) = peel_you_may_prefix(text, YouMayBlocklist::ChunkLoop) {
+        return (true, None, None, rest);
+    }
+    (false, None, None, text.to_string())
+}
+
+/// CR 608.2d: Opponent-may and group-bargain prefixes (`each opponent may`,
+/// `any opponent may`, `defending player may`, …). Shared by `peel_clause`
+/// and `peel_optional_slots`.
+fn try_peel_opponent_may_prefix(
+    text: &str,
+) -> Option<(Option<OpponentMayScope>, Option<PlayerFilter>, String)> {
+    let lower = text.to_lowercase();
+    nom_on_lower(text, &lower, |input| {
+        alt((
+            value(
+                (None, Some(PlayerFilter::Opponent)),
+                tag("each opponent may "),
+            ),
+            value(
+                (Some(OpponentMayScope::AnyOpponent), None),
+                tag("any opponent may "),
+            ),
+            value(
+                (Some(OpponentMayScope::AnyPlayer), None),
+                tag("any player may "),
+            ),
+            value(
+                (None, Some(PlayerFilter::TriggeringPlayer)),
+                tag("the first player may "),
+            ),
+            value(
+                (None, Some(PlayerFilter::Opponent)),
+                tag("target opponent may "),
+            ),
+            value(
+                (None, Some(PlayerFilter::DefendingPlayer)),
+                tag("defending player may "),
+            ),
+            value(
+                (None, Some(PlayerFilter::ParentObjectTargetController)),
+                tag("that creature's controller may "),
+            ),
+        ))
+        .parse(input)
+    })
+    .map(|(slots, rest)| (slots.0, slots.1, rest.to_string()))
+}
+
+/// CR 608.2d: Strip a leading bare `you may ` when it precedes a fresh
+/// imperative. Returns the remainder on a match, `None` when the phrase is
+/// part of a specialized construction handled by a dedicated body parser.
+fn peel_you_may_prefix(text: &str, blocklist: YouMayBlocklist) -> Option<String> {
     let lower = text.to_lowercase();
     let (_, rest) = nom_on_lower(text, &lower, |i| {
         value((), tag::<_, _, OracleError<'_>>("you may ")).parse(i)
     })?;
     let rest_lower = rest.to_lowercase();
-    if is_specialized_you_may_phrase(&rest_lower) {
+    let blocked = match blocklist {
+        YouMayBlocklist::PeelClause => is_specialized_you_may_phrase(&rest_lower),
+        YouMayBlocklist::ChunkLoop => is_specialized_you_may_retarget_phrase(&rest_lower),
+    };
+    if blocked {
         return None;
     }
     Some(rest.to_string())
@@ -624,5 +777,59 @@ mod tests {
         assert_eq!(peeled, "target creature gets +2/+2");
         assert!(ctx.condition().is_some());
         assert_eq!(ctx.duration(), Some(&Duration::UntilEndOfTurn));
+    }
+
+    #[test]
+    fn peel_each_opponent_may_strips_and_captures_scope() {
+        let (peeled, ctx) = peel_clause("each opponent may sacrifice a creature");
+        assert_eq!(peeled, "sacrifice a creature");
+        assert!(ctx.optional);
+        assert_eq!(
+            ctx.may_implicit_player_scope(),
+            Some(&PlayerFilter::Opponent)
+        );
+        assert!(ctx.opponent_may_scope().is_none());
+    }
+
+    #[test]
+    fn peel_any_opponent_may_strips_and_captures_first_accept_scope() {
+        let (peeled, ctx) = peel_clause("any opponent may pay {3}");
+        assert_eq!(peeled, "pay {3}");
+        assert!(ctx.optional);
+        assert_eq!(
+            ctx.opponent_may_scope(),
+            Some(&OpponentMayScope::AnyOpponent)
+        );
+    }
+
+    #[test]
+    fn peel_optional_slots_chunk_loop_beseech_cast_still_strips() {
+        let (is_optional, _, _, rest) =
+            peel_optional_slots("you may cast the exiled card without paying its mana cost");
+        assert!(is_optional);
+        assert_eq!(rest, "cast the exiled card without paying its mana cost");
+    }
+
+    #[test]
+    #[test]
+    fn peel_player_scope_each_opponent() {
+        let (scope, rest) = peel_player_scope_subject("each opponent discards a card");
+        assert_eq!(scope, Some(PlayerFilter::Opponent));
+        assert_eq!(rest, "discard a card");
+    }
+
+    #[test]
+    fn peel_for_each_prefix_strips_repeat_quantity() {
+        let (qty, rest) = peel_for_each_prefix("for each creature you control, draw a card");
+        assert!(qty.is_some());
+        assert_eq!(rest, "draw a card");
+    }
+
+    #[test]
+    fn peel_clause_combines_for_each_and_player_scope() {
+        let (peeled, ctx) = peel_clause("for each opponent, each opponent loses 1 life");
+        assert!(ctx.repeat_for().is_some());
+        assert_eq!(ctx.player_scope(), Some(&PlayerFilter::Opponent));
+        assert_eq!(peeled, "lose 1 life");
     }
 }

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -147,23 +147,6 @@ impl ClauseContext {
         self.condition.as_ref()
     }
 
-    pub(crate) fn opponent_may_scope(&self) -> Option<&OpponentMayScope> {
-        self.opponent_may_scope.as_ref()
-    }
-
-    pub(crate) fn may_implicit_player_scope(&self) -> Option<&PlayerFilter> {
-        self.may_implicit_player_scope.as_ref()
-    }
-
-    pub(crate) fn repeat_for(&self) -> Option<&QuantityExpr> {
-        self.repeat_for.as_ref()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn player_scope(&self) -> Option<&PlayerFilter> {
-        self.player_scope.as_ref()
-    }
-
     /// True when no slot has been populated. Callers can short-circuit
     /// `apply_*` when nothing was peeled.
     pub(crate) fn is_empty(&self) -> bool {
@@ -784,11 +767,8 @@ mod tests {
         let (peeled, ctx) = peel_clause("each opponent may sacrifice a creature");
         assert_eq!(peeled, "sacrifice a creature");
         assert!(ctx.optional);
-        assert_eq!(
-            ctx.may_implicit_player_scope(),
-            Some(&PlayerFilter::Opponent)
-        );
-        assert!(ctx.opponent_may_scope().is_none());
+        assert_eq!(ctx.may_implicit_player_scope, Some(PlayerFilter::Opponent));
+        assert!(ctx.opponent_may_scope.is_none());
     }
 
     #[test]
@@ -796,10 +776,7 @@ mod tests {
         let (peeled, ctx) = peel_clause("any opponent may pay {3}");
         assert_eq!(peeled, "pay {3}");
         assert!(ctx.optional);
-        assert_eq!(
-            ctx.opponent_may_scope(),
-            Some(&OpponentMayScope::AnyOpponent)
-        );
+        assert_eq!(ctx.opponent_may_scope, Some(OpponentMayScope::AnyOpponent));
     }
 
     #[test]
@@ -810,7 +787,6 @@ mod tests {
         assert_eq!(rest, "cast the exiled card without paying its mana cost");
     }
 
-    #[test]
     #[test]
     fn peel_player_scope_each_opponent() {
         let (scope, rest) = peel_player_scope_subject("each opponent discards a card");
@@ -828,8 +804,8 @@ mod tests {
     #[test]
     fn peel_clause_combines_for_each_and_player_scope() {
         let (peeled, ctx) = peel_clause("for each opponent, each opponent loses 1 life");
-        assert!(ctx.repeat_for().is_some());
-        assert_eq!(ctx.player_scope(), Some(&PlayerFilter::Opponent));
+        assert!(ctx.repeat_for.is_some());
+        assert_eq!(ctx.player_scope, Some(PlayerFilter::Opponent));
         assert_eq!(peeled, "lose 1 life");
     }
 }

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -795,6 +795,17 @@ mod tests {
     }
 
     #[test]
+    fn peel_player_scope_skips_per_grantee_play_permission() {
+        let text = "each player may play the card they exiled this way";
+        let (scope, rest) = peel_player_scope_subject(text);
+        assert_eq!(scope, None);
+        assert_eq!(rest, text);
+        let (peeled, ctx) = peel_clause(text);
+        assert!(ctx.player_scope.is_none());
+        assert_eq!(peeled, text);
+    }
+
+    #[test]
     fn peel_for_each_prefix_strips_repeat_quantity() {
         let (qty, rest) = peel_for_each_prefix("for each creature you control, draw a card");
         assert!(qty.is_some());

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1850,6 +1850,18 @@ pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, St
         return (None, text.to_string());
     };
 
+    // CR 611.2a + CR 400.7i: "each player may play/cast …" is a per-grantee
+    // casting permission (`try_parse_per_grantee_play_grant`), not a player-scoped
+    // imperative subject. Stripping "each player " leaves "may play …", which
+    // misroutes to `Effect::CastFromZone` instead of `GrantCastingPermission`.
+    let rest_lower = rest.trim_start().to_lowercase();
+    if alt((tag::<_, _, OracleError<'_>>("may play "), tag("may cast ")))
+        .parse(rest_lower.as_str())
+        .is_ok()
+    {
+        return (None, text.to_string());
+    }
+
     // CR 109.4 + CR 109.5: A "who controls [comparator] [count] [type-phrase]"
     // relative clause restricts the player set to those whose controlled-permanent
     // count satisfies the comparison (Thornbow Archer: "each opponent who doesn't

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1548,83 +1548,7 @@ pub(super) fn strip_optional_effect_prefix(
     Option<PlayerFilter>,
     String,
 ) {
-    let lower = text.to_lowercase();
-    // CR 608.2d + CR 115.7: "you may choose new targets for …" is a retarget
-    // effect, not a generic optional wrapper. Only that narrow class keeps the
-    // full surface form; other specialized `you may cast/play/…` clauses still
-    // peel here so `optional: true` is stamped (Beseech the Mirror, etc.).
-    if let Some((_, rest)) = nom_on_lower(text, &lower, |input| {
-        value((), tag::<_, _, OracleError<'_>>("you may ")).parse(input)
-    }) {
-        let rest_lower = rest.to_lowercase();
-        if crate::parser::clause_shell::is_specialized_you_may_retarget_phrase(&rest_lower) {
-            return (false, None, None, text.to_string());
-        }
-        return (true, None, None, rest.to_string());
-    }
-    // CR 608.2d: "each opponent may" — per-opponent optional effect.
-    // "any opponent may" — first-accept-wins opponent-choice optional effect.
-    if let Some(((scope, player_scope), rest)) = nom_on_lower(text, &lower, |input| {
-        alt((
-            value(
-                (None, Some(PlayerFilter::Opponent)),
-                tag("each opponent may "),
-            ),
-            value(
-                (
-                    Some(crate::types::ability::OpponentMayScope::AnyOpponent),
-                    None,
-                ),
-                tag("any opponent may "),
-            ),
-            // CR 608.2d + CR 101.4: "any player may" — every player INCLUDING the
-            // controller is offered in APNAP order; first accept wins (group
-            // bargain / punisher cards: Browbeat, Argothian Wurm, …). Diverges
-            // from "any opponent may " at byte 5 — no ordering hazard.
-            value(
-                (
-                    Some(crate::types::ability::OpponentMayScope::AnyPlayer),
-                    None,
-                ),
-                tag("any player may "),
-            ),
-            // CR 608.2c: "the first player may" — Oath of Mages and analogous
-            // cross-clause patterns where the chooser of a prior sentence
-            // (= TriggeringPlayer for upkeep/event triggers) is invited to
-            // take an optional action in a later sentence. Marks the chunk
-            // optional and scopes the actor to the triggering player.
-            value(
-                (None, Some(PlayerFilter::TriggeringPlayer)),
-                tag("the first player may "),
-            ),
-            // CR 608.2d: "Target opponent may have ~ deal … to them" (Risk Factor).
-            value(
-                (None, Some(PlayerFilter::Opponent)),
-                tag("target opponent may "),
-            ),
-            // CR 506.2 + CR 608.2d + CR 121.3a: "Defending player may have you
-            // draw a card" (Shakedown Heavy) — on an attack trigger, the
-            // defending player is the may-actor who decides whether the
-            // controller performs the granted action. CR 121.3a: the chooser
-            // need not be the player who draws. Parallels the targeted-opponent
-            // arm above; the actor scope is the attack's defending player.
-            value(
-                (None, Some(PlayerFilter::DefendingPlayer)),
-                tag("defending player may "),
-            ),
-            // CR 608.2d: "That creature's controller may have this artifact deal …"
-            // (Requiem Monolith) — the targeted creature's controller chooses.
-            value(
-                (None, Some(PlayerFilter::ParentObjectTargetController)),
-                tag("that creature's controller may "),
-            ),
-        ))
-        .parse(input)
-    }) {
-        (true, scope, player_scope, rest.to_string())
-    } else {
-        (false, None, None, text.to_string())
-    }
+    crate::parser::clause_shell::peel_optional_slots(text)
 }
 
 /// CR 107.1: Detect and strip a trailing "a number of times equal to the
@@ -1663,7 +1587,7 @@ fn is_chain_veil_for_each_grant(lower: &str) -> bool {
     )
 }
 
-pub(super) fn strip_for_each_prefix(text: &str) -> (Option<QuantityExpr>, String) {
+pub(crate) fn strip_for_each_prefix(text: &str) -> (Option<QuantityExpr>, String) {
     let lower = text.to_lowercase();
     if let Some(((), rest)) = nom_on_lower(text, &lower, |i| value((), tag("for each ")).parse(i)) {
         let rest_lower = &lower[text.len() - rest.len()..];
@@ -1856,7 +1780,7 @@ pub(super) fn strip_for_each_repeat_suffix(text: &str) -> (Option<QuantityExpr>,
 /// CR 609.3 "do as much as possible" rule. Unified with `strip_for_each_prefix`
 /// at the chain level so the base action is parsed normally and the resolver
 /// loops it N times.
-pub(super) fn strip_repeat_count_suffix(text: &str) -> (Option<QuantityExpr>, String) {
+pub(crate) fn strip_repeat_count_suffix(text: &str) -> (Option<QuantityExpr>, String) {
     let lower = text.to_lowercase();
     let suffixes: &[(&str, i32)] = &[
         (" twice", 2),
@@ -1900,7 +1824,7 @@ pub(super) fn strip_repeat_count_suffix(text: &str) -> (Option<QuantityExpr>, St
 /// "Each opponent discards a card" → (Some(Opponent), "discard a card")
 /// "Each other player sacrifices a creature" → (Some(Opponent), "sacrifice a creature")
 /// "Each player draws a card" → (Some(All), "draw a card")
-pub(super) fn strip_player_scope_subject(text: &str) -> (Option<PlayerFilter>, String) {
+pub(crate) fn strip_player_scope_subject(text: &str) -> (Option<PlayerFilter>, String) {
     let (scope, stripped) = strip_linked_exile_owner_subject(text);
     if scope.is_some() {
         return (scope, stripped);

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -3433,12 +3433,11 @@ fn try_parse_distinct_card_types_from_revealed(tp: TextPair<'_>) -> Option<Parse
 
 #[tracing::instrument(level = "debug")]
 fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause {
-    // Phase 2 PoC: peel structural slots off the head of the clause before
-    // body parsing. The recursive shell strips slot-bearing prefixes
-    // (currently just "you may " for the Optional slot) and accumulates them
+    // Phase 2: peel structural slots off the head of the clause before
+    // body parsing. The recursive shell strips slot-bearing prefixes/suffixes
+    // (optional, opponent-may, condition, duration, for-each, player-scope)
     // into a `ClauseContext`. The bare imperative remainder is parsed by the
-    // existing pipeline; the context is applied onto the result before
-    // return so no slot is silently dropped.
+    // existing pipeline; the context is applied onto the result before return.
     //
     // See `data/parser-swallow-progress.md` for the full architecture and
     // `crates/engine/src/parser/clause_shell.rs` for the slot machinery.
@@ -17209,7 +17208,7 @@ pub(crate) fn parse_effect_chain_ir(
             (None, text, None)
         } else {
             let reference_target = for_each_clause_target_controller_filter(&text);
-            let (repeat_for, text) = strip_for_each_prefix(&text);
+            let (repeat_for, text) = super::clause_shell::peel_for_each_prefix(&text);
             let reference_target = repeat_for.as_ref().and(reference_target);
             (repeat_for, text, reference_target)
         };
@@ -17221,7 +17220,8 @@ pub(crate) fn parse_effect_chain_ir(
         };
         // CR 608.2c: "twice" / "N times" suffix — same mechanism as "for each" prefix.
         let (repeat_count, text) = if repeat_for.is_none() {
-            let (repeat_count, stripped_text) = strip_repeat_count_suffix(&text_without_where_x);
+            let (repeat_count, stripped_text) =
+                super::clause_shell::peel_repeat_count_suffix(&text_without_where_x);
             if repeat_count.is_some() {
                 (repeat_count, stripped_text)
             } else {
@@ -17236,7 +17236,7 @@ pub(crate) fn parse_effect_chain_ir(
             // conditional strip ("a number of times equal to the difference").
             .or(difference_repeat)
             .or_else(|| pending_repeat_for.take());
-        let (player_scope, text) = strip_player_scope_subject(&text);
+        let (player_scope, text) = super::clause_shell::peel_player_scope_subject(&text);
         let pending_player_scope_for_clause = pending_player_scope.take();
         let carried_player_scope = if player_scope.is_none()
             && !sequence::starts_clause_text(&text)


### PR DESCRIPTION
## Summary

- Extends the no-text-swallowing clause shell (clause_shell.rs) with opponent-may, for each prefix, trailing twice/N times, and each player/each opponent subject peeling.
- Makes clause_shell the single entry point for structural slot stripping; oracle_effect/lower.rs sheds ~80 lines of duplicated optional-peel logic.
- Routes the chunk-loop cascade through peel_for_each_prefix, peel_repeat_count_suffix, and peel_player_scope_subject instead of calling lower.rs directly.
- Preserves two you may blocklist policies: broad (peel_clause / specialized cast-play parsers) vs narrow (chunk loop / Beseech-style cast peeling).
- Promotes strip_for_each_prefix, strip_repeat_count_suffix, and strip_player_scope_subject to pub(crate) so the shell can delegate without duplicating implementations.

## Test plan

- [x]  cargo test -p engine --lib peel_ (31 tests)
- [x]  cargo test -p engine --lib strip_optional_effect_prefix (3 tests)
- [x]  cargo check -p engine
- [ ]  Spot-check a card with each opponent may … and for each … in coverage overlay after card-data regen (optional)
