### PR TITLE
test(engine): pin Unearth activation-zone gate via Scrapwork Mutt (issue #3295)

### DIFF
--- a/crates/engine/tests/integration/issue_3295_scrapwork_mutt_unearth_zone.rs
+++ b/crates/engine/tests/integration/issue_3295_scrapwork_mutt_unearth_zone.rs
@@ -1,0 +1,86 @@
+//! GitHub issue #3295 — Scrapwork Mutt's Unearth ability can be activated
+//! while the card is on the battlefield.
+//!
+//! Oracle text:
+//!   Scrapwork Mutt
+//!   When this creature enters, you may discard a card. If you do, draw a card.
+//!   Unearth {1}{R} ({1}{R}: Return this card from your graveyard to the
+//!     battlefield. It gains haste. Exile it at the beginning of the next end
+//!     step or if it would leave the battlefield. Unearth only as a sorcery.)
+//!
+//! CR 702.84a: "Unearth [cost]" means "[cost]: Return this card from your
+//! graveyard to the battlefield. It gains haste. Exile it at the beginning of
+//! the next end step or if it would leave the battlefield. **Activate this
+//! ability only as a sorcery.**" The activation site is the **graveyard** —
+//! the ability "functions only while the card is in a graveyard." Surfacing
+//! Unearth as a castable/activatable action on a permanent already on the
+//! battlefield is a CR 602.1a / CR 702.84a violation: a player can't pay
+//! {1}{R} to "return this card from your graveyard to the battlefield" when
+//! the card is not in any graveyard.
+//!
+//! The `unearth_ability` builder in `crates/engine/src/database/unearth.rs:88`
+//! sets `activation_zone = Some(Zone::Graveyard)` for exactly this reason, and
+//! the activation gate at `crates/engine/src/game/casting.rs:11290-11293`
+//! filters out activations whose source zone disagrees with `activation_zone`.
+//! This test is the discriminating runtime guard: with a Scrapwork-Mutt-shape
+//! card on the battlefield (zone = Battlefield), no `GameAction::ActivateAbility`
+//! targeting its Unearth ability should appear in `legal_actions`.
+
+use engine::ai_support::legal_actions;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::mana::ManaColor;
+use engine::types::zones::Zone;
+
+const SCRAPWORK_MUTT_ORACLE: &str = "When this creature enters, you may \
+    discard a card. If you do, draw a card.\nUnearth {1}{R}";
+
+#[test]
+fn scrapwork_mutt_unearth_is_not_activatable_from_battlefield() {
+    let mut scenario = GameScenario::new();
+
+    // Place a Scrapwork-Mutt-shape card on P0's battlefield. The card text
+    // is the fully parsed Oracle text including the Unearth keyword line;
+    // the synthesizer attaches the Unearth ability with
+    // `activation_zone = Some(Zone::Graveyard)` automatically.
+    let mutt = scenario
+        .add_creature_from_oracle(P0, "Scrapwork Mutt", 3, 1, SCRAPWORK_MUTT_ORACLE)
+        .id();
+
+    // Give P0 a mountain so any cost shortage cannot be the reason an
+    // Unearth offer is *not* surfaced — without this guard, a buggy
+    // implementation that silently failed on the cost check would look
+    // like a passing test.
+    scenario.add_basic_land(P0, ManaColor::Red);
+
+    let runner = scenario.build();
+    let state = runner.state();
+
+    // Sanity: the Mutt is on the battlefield, not the graveyard.
+    assert_eq!(
+        state.objects.get(&mutt).map(|o| o.zone),
+        Some(Zone::Battlefield),
+        "precondition: Scrapwork Mutt must be on the battlefield"
+    );
+
+    // CR 702.84a + CR 602.1a: enumerate every legal action the active
+    // player could take. The discriminator: no `ActivateAbility` whose
+    // `source_id == mutt` should appear, because Unearth's activation zone
+    // is the graveyard, not the battlefield.
+    let actions = legal_actions(state);
+    let unearth_from_battlefield: Vec<&GameAction> = actions
+        .iter()
+        .filter(|a| match a {
+            GameAction::ActivateAbility { source_id, .. } => *source_id == mutt,
+            _ => false,
+        })
+        .collect();
+
+    assert!(
+        unearth_from_battlefield.is_empty(),
+        "issue #3295: Scrapwork Mutt's Unearth ability must NOT be activatable \
+         while the card is on the battlefield (CR 702.84a: 'functions only \
+         while the card is in a graveyard'). Offered actions: {:#?}",
+        unearth_from_battlefield
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -213,6 +213,7 @@ mod issue_2943_kayas_wrath;
 mod issue_3127_reveal_otherwise_graveyard;
 mod issue_3245_abhorrent_oculus_manifest_dread;
 mod issue_3285_face_down_public_zone;
+mod issue_3295_scrapwork_mutt_unearth_zone;
 mod issue_3311_manifest_dread_land;
 mod issue_3320_peregrine_drake_untap_prompt;
 mod issue_3321_volcanic_spite_optional;


### PR DESCRIPTION
## Summary
- End-to-end regression test that pins the **Unearth activation-zone gate** through the public `legal_actions` enumeration, using Scrapwork Mutt as the discriminating fixture. Closes #3295.

## Background
The reporter (#3295) observed Scrapwork Mutt's Unearth ability being activatable while the card was on the battlefield. Per **CR 702.84a**, Unearth "functions only while the card is in a graveyard."

The protection is already in the codebase:
- `crates/engine/src/database/unearth.rs:88` sets `activation_zone = Some(Zone::Graveyard)` on the synthesized Unearth ability.
- `crates/engine/src/game/casting.rs:11290-11293` checks `if obj.zone != required_zone { return false }` for every activatable-ability candidate.

What was missing: an integration regression test that drives the full `GameScenario` + `legal_actions(state)` path and asserts that a Scrapwork Mutt on the battlefield offers no `GameAction::ActivateAbility` for its Unearth. This PR fills that gap so a future change (dropping the `activation_zone` field, the gate, or the threading into `legal_actions`) can't silently regress the case the reporter hit.

## Test
`issue_3295_scrapwork_mutt_unearth_zone::scrapwork_mutt_unearth_is_not_activatable_from_battlefield`

1. `GameScenario` with Scrapwork Mutt (full Oracle text with `Unearth {1}{R}`) on P0's battlefield.
2. Give P0 a Mountain so any cost shortage cannot mask a missing offer.
3. Sanity check the Mutt's zone is `Battlefield`.
4. Enumerate `legal_actions(state)` and filter for `ActivateAbility { source_id == mutt }`.
5. **Assert** the filtered list is empty.

If a future change drops the activation_zone gate, the assertion fails with the listed offered actions as evidence.

### CR annotations (verified against `docs/MagicCompRules.txt`)
- CR 602.1a — activated-ability activation gates.
- CR 702.84a — Unearth's function zone is the graveyard, "activate only as a sorcery."

## Test Plan
- [x] `cargo fmt --all` clean.
- [x] `cargo test -p engine --test integration issue_3295` → **1 passed; 0 failed**.

```
test issue_3295_scrapwork_mutt_unearth_zone::scrapwork_mutt_unearth_is_not_activatable_from_battlefield ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1067 filtered out
```

Closes #3295
