### PR TITLE
feat(engine): Halving Season HalfRoundedUp counter replacement

### DIFF
--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -385,6 +385,7 @@ pub(crate) fn copy_count_with_replacements(
         }
         count = match def.quantity_modification {
             Some(QuantityModification::Double) => count.saturating_mul(2),
+            Some(QuantityModification::HalfRoundedUp) => count.div_ceil(2),
             Some(QuantityModification::Plus { value }) => count.saturating_add(value as usize),
             Some(QuantityModification::Minus { value }) => count.saturating_sub(value as usize),
             // `Prevent` / unspecified is not a copy-count increase — leave as-is.

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1711,6 +1711,7 @@ fn gain_life_applier(
         {
             let new_amount = match modification {
                 QuantityModification::Double => amount.saturating_mul(2),
+                QuantityModification::HalfRoundedUp => amount.div_ceil(2),
                 QuantityModification::Plus { value } => amount.saturating_add(value),
                 QuantityModification::Minus { value } => amount.saturating_sub(value),
                 // CR 614.6 + CR 614.7: No life-gain replacement uses Prevent
@@ -1918,6 +1919,7 @@ fn add_counter_applier(
     }
     let new_count = |count: u32| match modification {
         QuantityModification::Double => count.saturating_mul(2),
+        QuantityModification::HalfRoundedUp => count.div_ceil(2),
         QuantityModification::Plus { value } => count.saturating_add(value),
         QuantityModification::Minus { value } => count.saturating_sub(value),
         QuantityModification::Prevent => unreachable!(),
@@ -2053,6 +2055,7 @@ fn create_token_applier(
         // CR 614.1a: Modify token count per replacement effect.
         let new_count = match modification {
             Some(QuantityModification::Double) => count.saturating_mul(2),
+            Some(QuantityModification::HalfRoundedUp) => count.div_ceil(2),
             Some(QuantityModification::Plus { value }) => count.saturating_add(value),
             Some(QuantityModification::Minus { value }) => count.saturating_sub(value),
             // CR 614.6 + CR 614.7 + CR 111.1: No printed token-creation
@@ -4726,6 +4729,7 @@ impl CommuteClass {
 fn quantity_commute_class(modification: &QuantityModification) -> CommuteClass {
     match modification {
         QuantityModification::Double => CommuteClass::Multiplicative,
+        QuantityModification::HalfRoundedUp => CommuteClass::NonCommuting,
         QuantityModification::Plus { .. } => CommuteClass::Additive,
         QuantityModification::Minus { .. } => CommuteClass::Subtractive,
         QuantityModification::Prevent => CommuteClass::NonCommuting,

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5287,6 +5287,8 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
 
     let modification = if nom_primitives::scan_contains(lower, "twice that many") {
         QuantityModification::Double
+    } else if nom_primitives::scan_contains(lower, "half that many") {
+        QuantityModification::HalfRoundedUp
     } else if let Some(rest) = strip_after(lower, "that many plus ") {
         // "that many plus one ... counters are put on it instead"
         // Delegate to nom_primitives::parse_number (input already lowercase)
@@ -5316,6 +5318,11 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
         def = def.valid_card(TargetFilter::Typed(
             TypedFilter::creature().controller(ControllerRef::You),
         ));
+    }
+    if nom_primitives::scan_contains(lower, "if an opponent would")
+        || nom_primitives::scan_contains(lower, "an opponent would put")
+    {
+        def.valid_player = Some(ReplacementPlayerScope::Opponent);
     }
 
     // CR 122.1a + CR 614.1a: When the Oracle text names a specific counter type
@@ -10972,6 +10979,21 @@ mod tests {
             Some(QuantityModification::Double)
         );
         assert_eq!(def.token_owner_scope, Some(ControllerRef::You));
+    }
+
+    #[test]
+    fn counter_halving_replacement_opponent_scope() {
+        let def = parse_replacement_line(
+            "If an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded up.",
+            "Halving Season",
+        )
+        .unwrap();
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::HalfRoundedUp)
+        );
+        assert_eq!(def.valid_player, Some(ReplacementPlayerScope::Opponent));
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -13863,6 +13863,9 @@ pub enum QuantityModification {
     /// SelfRef` for permanent-scoped protection and with player-scope filters
     /// for the future Solemnity-class global variant.
     Prevent,
+    /// CR 107.1a + CR 614.1a: Halving Season class — half the counter count,
+    /// rounded up.
+    HalfRoundedUp,
 }
 
 /// CR 106.3 + CR 614.1a: Mana-production replacement payload.


### PR DESCRIPTION
## Summary
- Add `QuantityModification::HalfRoundedUp` and wire through counter/token/life-gain replacement appliers
- Parse Halving Season opponent counter-halving Oracle text (`half that many ... rounded up`)
- Add parser unit test

## Token score
Shared quantity-modification primitive — high `cards_unlocked` leverage per `gap_analysis.rs` for the opponent counter-halving replacement family.

## Test plan
- [x] `cargo test -p engine --lib counter_halving_replacement_opponent_scope`
- [ ] CI

Closes #3470. Also closes #3396.

Made with [Cursor](https://cursor.com)