### PR TITLE
feat(parser): each-opponent direct library search prohibition

### DIFF
--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -407,6 +407,8 @@ pub(crate) fn parse_filter_scoped_cant_be_activated(
 ///   library." (Ashiok class)
 /// - "Players can't search libraries." / "Each player can't search libraries."
 ///   (Mindlock Orb class)
+/// - "Your opponents can't search libraries." / "Each opponent can't search
+///   libraries." (Stranglehold class — direct opponent search prohibition)
 pub(crate) fn parse_cant_search_library(tp: &TextPair<'_>, text: &str) -> Option<StaticDefinition> {
     fn parse_search_negation_prefix(input: &str) -> OracleResult<'_, ()> {
         let (input, _) = alt((
@@ -452,10 +454,14 @@ pub(crate) fn parse_cant_search_library(tp: &TextPair<'_>, text: &str) -> Option
         );
     }
 
-    // Mindlock Orb class: "Players can't search libraries." / "Each player can't
-    // search libraries." Keep this branch all-players only.
+    // Mindlock Orb / Stranglehold class: "Players can't search libraries.",
+    // "Each player can't search libraries.", "Your opponents can't search
+    // libraries.", "Each opponent can't search libraries."
     let (cause, predicate) = strip_casting_prohibition_subject(tp.lower)?;
-    if cause != ProhibitionScope::AllPlayers {
+    if !matches!(
+        cause,
+        ProhibitionScope::AllPlayers | ProhibitionScope::Opponents
+    ) {
         return None;
     }
     let predicate_lower = predicate.to_lowercase();

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14762,10 +14762,16 @@ fn cant_search_library_each_player_may_not_variant() {
 }
 
 #[test]
-fn cant_search_library_opponents_form_deferred() {
-    // Opponent-scoped direct-search phrasing remains deferred until the runtime
-    // cause-vs-searcher axis is split.
-    assert!(parse_static_line("Your opponents can't search libraries.").is_none());
+fn cant_search_library_each_opponent_direct() {
+    // CR 701.23: building-block — "Each opponent" subject maps to Opponents scope.
+    let def = parse_static_line("Each opponent can't search libraries.")
+        .expect("each-opponent direct search prohibition should parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::CantSearchLibrary {
+            cause: ProhibitionScope::Opponents,
+        }
+    );
 }
 
 // --- CR 603.2g + CR 603.6a + CR 700.4: SuppressTriggers (Torpor Orb / Hushbringer) ---


### PR DESCRIPTION
## Summary
- Same `parse_cant_search_library` Opponents-scope gate
- Add `cant_search_library_each_opponent_direct` for `"Each opponent can't search libraries."`

## Token score
Category B subject-stripping variant on the shared library-search prohibition primitive.

## Test plan
- [x] `cargo test -p engine --lib cant_search_library_each_opponent_direct`
- [ ] CI

Closes #3472. Related #3457.

Made with [Cursor](https://cursor.com)