### PR TITLE
test(engine): SBA commander legend-rule exemption

### DIFF
--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -3066,6 +3066,36 @@ mod tests {
     }
 
     #[test]
+    fn sba_legend_rule_suppressed_for_commanders_scope() {
+        // CR 704.5j + CR 903.3: commander-scoped exemption.
+        use crate::types::ability::FilterProp;
+        let mut state = setup();
+        let id1 = add_legendary(&mut state, CardId(10), PlayerId(0), "Kenrith", 1);
+        let id2 = add_legendary(&mut state, CardId(11), PlayerId(0), "Kenrith", 2);
+        state.objects.get_mut(&id1).unwrap().is_commander = true;
+        state.objects.get_mut(&id2).unwrap().is_commander = true;
+        add_legend_exemption(
+            &mut state,
+            PlayerId(0),
+            Some(TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .properties(vec![FilterProp::IsCommander])
+                    .controller(ControllerRef::You),
+            )),
+        );
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::ChooseLegend { .. }),
+            "commander-scoped legend-rule exemption must suppress the choice"
+        );
+        assert!(state.battlefield.contains(&id1));
+        assert!(state.battlefield.contains(&id2));
+    }
+
+    #[test]
     fn sba_legend_rule_suppressed_by_global_exemption() {
         // CR 704.5j: Mirror Gallery — "The legend rule doesn't apply." (global).
         let mut state = setup();


### PR DESCRIPTION
## Summary
- Add `sba_legend_rule_suppressed_for_commanders_scope` for commander-scoped legend exemptions

## Token score
High Commander-format leverage — closes SBA guardrail gap for `FilterProp::IsCommander` exemptions.

## Test plan
- [x] `cargo test -p engine --lib sba_legend_rule_suppressed_for_commanders_scope`
- [ ] CI

Closes #3474.

Made with [Cursor](https://cursor.com)