### PR TITLE
fix: silently parses an unconditional counter

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19052,15 +19052,42 @@ pub(super) fn counter_unless_pay_modifier(cost: AbilityCost) -> UnlessPayModifie
     }
 }
 
-/// CR 118.12: Parse "unless its controller pays {X}" from counter/trigger text.
+/// CR 118.12 / CR 119.4 / CR 608.2c: Parse "unless its controller pays {X} /
+/// pays N life / sacrifices a [filter] / discards a card [or ...]" from
+/// counter/trigger text.
+///
 /// Returns `AbilityCost::Mana` for static costs ({3}, {1}{U}),
 /// `AbilityCost::ManaDynamic` for "pays {X}, where X is this creature's power",
-/// and `AbilityCost::PayEnergy` for "{E}{E}" patterns.
+/// `AbilityCost::PayEnergy` for "{E}{E}" patterns, and — for the **non-mana**
+/// forms — the corresponding `PayLife` / `Sacrifice` / `Discard` (or `OneOf`
+/// disjunction) cost. The non-mana shapes are delegated to the single
+/// non-mana unless-cost authority (`oracle_trigger::parse_unless_they_alt_cost_chain`)
+/// so counter spells and triggered abilities recognize the same cost grammar.
 pub(super) fn parse_unless_payment(lower: &str) -> Option<AbilityCost> {
-    // Find "unless" followed by a subject and "pays {cost}"
+    // Find "unless" followed by a subject ("its controller", "that player", …).
     let after_unless = strip_after(lower, "unless ")?;
-    // Skip the subject ("its controller", "that player", "he or she", etc.)
-    let cost_str = strip_after(after_unless, "pays ")?;
+    // CR 117.3: the mana / energy / {X} forms require the "pays " verb. Try
+    // them first so existing behavior is preserved exactly for mana costs.
+    if let Some(cost_str) = strip_after(after_unless, "pays ") {
+        if let Some(cost) = parse_unless_mana_or_energy_payment(cost_str) {
+            return Some(cost);
+        }
+    }
+    // CR 118.12 / CR 119.4 / CR 608.2c: non-mana alternative costs — "pays N
+    // life", "sacrifices a [filter]", "discards a card", and `or`-disjunctions
+    // thereof. Normalize the counter subject to the "they" pronoun the shared
+    // authority anchors on, then delegate. The payer is fixed to the targeted
+    // spell's controller by `counter_unless_pay_modifier` at the call site, so
+    // rewriting the recognized subject does not affect resolution.
+    let normalized = normalize_counter_unless_subject(after_unless)?;
+    crate::parser::oracle_trigger::parse_unless_they_alt_cost_chain(&normalized)
+}
+
+/// CR 117.3 + CR 107.14: Parse the mana / energy / dynamic-{X} forms of an
+/// "unless … pays …" alternative cost. Operates on the text immediately after
+/// the "pays " verb. Returns `None` for non-mana shapes (life / sacrifice /
+/// discard), which the caller routes to the shared non-mana authority.
+fn parse_unless_mana_or_energy_payment(cost_str: &str) -> Option<AbilityCost> {
     // CR 107.14 + CR 202.3: dynamic energy unless-cost — checked before the
     // brace-run truncation below, which collapses "an amount of {e} …" to "an".
     if let Some(amount) = parse_dynamic_energy_unless_cost(cost_str) {
@@ -19107,6 +19134,29 @@ pub(super) fn parse_unless_payment(lower: &str) -> Option<AbilityCost> {
         return None;
     }
     Some(AbilityCost::Mana { cost })
+}
+
+/// CR 118.12 / CR 119.4 / CR 608.2c: Normalize the subject of a counter
+/// spell's non-mana "unless" cost to the "they" pronoun recognized by the
+/// shared non-mana cost authority (`parse_unless_they_alt_cost_chain`).
+///
+/// Counter spells phrase the alternative-cost payer as "its controller" (the
+/// targeted spell's controller); the shared chain combinator anchors on
+/// "they" / "that player" / "that opponent". Rewriting the recognized subject
+/// prefix to "they " lets the single authority parse life / sacrifice /
+/// discard (and `or`-disjunctions) without duplicating the verb dispatch here.
+/// Returns `None` when no recognized subject is present.
+fn normalize_counter_unless_subject(after_unless: &str) -> Option<String> {
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("its controller "),
+        tag("their controller "),
+        tag("that player "),
+        tag("that opponent "),
+        tag("they "),
+    ))
+    .parse(after_unless)
+    .ok()?;
+    Some(format!("they {rest}"))
 }
 
 /// CR 118.12a: Tail of "deal N damage to them" unless-cost alternatives.

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -3711,6 +3711,26 @@ mod tests {
                 "Chained Throatseeker",
                 &["Creature"][..],
             ),
+            // Issue #3466: counter spells with a NON-mana "unless" cost. The
+            // counter path previously recognized only the mana form ("pays
+            // {N}") and silently dropped life / sacrifice / discard costs,
+            // shipping an unconditional counter. CR 118.12 / CR 119.4 / CR
+            // 608.2c.
+            (
+                "Counter target spell unless its controller pays 5 life.",
+                "Dash Hopes",
+                &["Instant"][..],
+            ),
+            (
+                "Counter target spell unless its controller sacrifices a creature.",
+                "Counter-Sacrifice",
+                &["Instant"][..],
+            ),
+            (
+                "Counter target spell unless its controller discards a card.",
+                "Counter-Discard",
+                &["Instant"][..],
+            ),
         ] {
             let parsed = parse_named(oracle, name, types);
             assert!(


### PR DESCRIPTION
## Summary
Counter spells whose "unless" alternative cost is **non-mana** — `pays N life`, `sacrifices a creature`, `discards a card` (and `or`-disjunctions of these) —were silently parsed as an **unconditional** `Counter`, making the card strictly stronger than printed (the opponent never got the chance to pay). The counter path used a mana-only extractor; this PR routes its non-mana forms through the existing single non-mana unless-cost authority. 

## Related Issue
Closes: 3466
## Change Type (select all that apply)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Parser change (Oracle text → AST)
- [ ] New feature / new engine capability
- [ ] New effect / mechanic / keyword
- [ ] Engine resolver / targeting / rules behavior change
- [ ] Refactor (no behavior change) — *internal: mana logic extracted to a helper, behavior preserved*
- [x] Tests added/updated

## Root cause
`parse_unless_payment` (the counter path, `crates/engine/src/parser/oracle_effect/mod.rs`) required the literal `"pays "` verb followed by a brace-delimited `{...}` mana cost, returning `None` for any non-mana shape. Its 5 callers then built `Counter { unless_pay: None }` — a clean AST with no "missing part", so `card_face_gaps()` reported the card as fully supported even though the parser raised a `SwallowedClause{detector:"Condition_Unless"}` diagnostic (only visible in the offline coverage tool, never in the deck-validation path that gates play).
The non-mana cost grammar was already implemented for triggered abilities (`parse_unless_they_alt_cost_chain`); the counter path simply didn't reuse it.

## Real behavior proof
Parsed AST through the production entry point `parse_oracle_text` (control:
Mana Leak / Power Sink unchanged):

| Card / text | Before | After |
|---|---|---|
| **Dash Hopes** — `...unless its controller pays 5 life.` | `Counter` (no `unless_pay`) + `SwallowedClause` | `unless_pay { cost: PayLife{5}, payer: ParentTargetController }` |
| `...unless its controller sacrifices a creature.` | `Counter` (no `unless_pay`) | `unless_pay { cost: Sacrifice{Creature you control, 1} }` |
| `...unless its controller discards a card.` | `Counter` (no `unless_pay`) | `unless_pay { cost: Discard{1} }` |
| **Mana Leak** — `...pays {3}.` | `unless_pay { Mana{3} }` | `unless_pay { Mana{3} }` (unchanged) |
| **Power Sink** — `...pays {X}.` | `unless_pay { ManaDynamic{X} }` | `unless_pay { ManaDynamic{X} }` (unchanged) |


Exact serialized result for Dash Hopes after the fix:
```json
{"effect":{"type":"Counter","target":{"type":"StackSpell"}},
 "unless_pay":{"cost":{"type":"PayLife","amount":{"type":"Fixed","value":5}},
               "payer":{"type":"ParentTargetController"}}}
