### PR TITLE
fix(parser): recognize "for each card you've discarded this turn" dynamic count

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24684,6 +24684,87 @@ mod tests {
         );
     }
 
+    /// CR 701.9 + CR 603.4: "draw a card for each card you've discarded this
+    /// turn" must produce a dynamic Draw count referencing the controller's
+    /// per-turn discard tally, not a dropped `Fixed(1)`.
+    ///
+    /// Class: Misty Knight, Green Goblin (Revenant), Astonishing Spider-Man,
+    /// and other "for each card you've discarded this turn" draws.
+    #[test]
+    fn for_each_cards_discarded_this_turn_draw_count_replaced() {
+        let e = parse_effect("draw a card for each card you've discarded this turn");
+        match e {
+            Effect::Draw { count, .. } => assert_eq!(
+                count,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::CardsDiscardedThisTurn {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                "draw count must scale with cards discarded this turn, not Fixed(1)"
+            ),
+            other => panic!("expected Draw, got {other:?}"),
+        }
+    }
+
+    /// The "you have discarded" surface variant must resolve identically.
+    #[test]
+    fn for_each_cards_discarded_this_turn_long_form_draw_count_replaced() {
+        let e = parse_effect("draw a card for each card you have discarded this turn");
+        match e {
+            Effect::Draw { count, .. } => assert_eq!(
+                count,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::CardsDiscardedThisTurn {
+                        player: PlayerScope::Controller,
+                    },
+                }
+            ),
+            other => panic!("expected Draw, got {other:?}"),
+        }
+    }
+
+    /// Discriminating runtime test: parse the real clause and resolve its Draw
+    /// count through the live quantity resolver against recorded discard state.
+    /// If the parser fix is reverted, the count is `Fixed(1)` and resolves to 1
+    /// regardless of discards, so the `resolved == 3` assertion flips and fails.
+    #[test]
+    fn for_each_cards_discarded_this_turn_resolves_dynamic_draw_count() {
+        use crate::game::quantity::resolve_quantity;
+        use crate::game::restrictions::record_discard;
+        use crate::game::zones::create_object;
+        use crate::types::game_state::GameState;
+        use crate::types::identifiers::CardId;
+        use crate::types::player::PlayerId;
+        use crate::types::zones::Zone;
+
+        let count = match parse_effect("draw a card for each card you've discarded this turn") {
+            Effect::Draw { count, .. } => count,
+            other => panic!("expected Draw, got {other:?}"),
+        };
+
+        let mut state = GameState::new_two_player(42);
+        let controller = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            controller,
+            "Misty Knight, Hero for Hire".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Controller has discarded three cards this turn.
+        record_discard(&mut state, controller);
+        record_discard(&mut state, controller);
+        record_discard(&mut state, controller);
+
+        let resolved = resolve_quantity(&state, &count, controller, source);
+        assert_eq!(
+            resolved, 3,
+            "draw count must resolve to the controller's discard tally (3), not Fixed(1)"
+        );
+    }
+
     #[test]
     fn for_each_token_count_keeps_counter_history_this_turn_clause() {
         let clause = try_parse_for_each_effect(

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -433,6 +433,34 @@ fn parse_number_of_cards_drawn_this_turn(input: &str) -> OracleResult<'_, Quanti
     Ok((rest, QuantityRef::CardsDrawnThisTurn { player }))
 }
 
+/// CR 701.9 + CR 603.4: "card(s) [you('ve)] discarded this turn". Reuses the
+/// runtime `CardsDiscardedThisTurn` quantity ref already wired for condition
+/// checks; this routes it into the dynamic "for each" count path (Misty Knight,
+/// Green Goblin, Astonishing Spider-Man: "draw a card for each card you've
+/// discarded this turn"). Mirrors `parse_number_of_cards_drawn_this_turn`: the
+/// leading "card" word is optionally plural so both the "the number of *cards* …"
+/// count phrase and the "for each *card* …" clause are served uniformly.
+fn parse_number_of_cards_discarded_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("card").parse(input)?;
+    let (rest, _) = opt(tag("s")).parse(rest)?;
+    let (rest, _) = tag(" ").parse(rest)?;
+    let (rest, player) = alt((
+        // CR 701.9 + CR 102.2/102.3: opponents' discards this turn, summed
+        // across all opponents.
+        value(
+            PlayerScope::Opponent {
+                aggregate: AggregateFunction::Sum,
+            },
+            tag("your opponents have discarded this turn"),
+        ),
+        // CR 701.9: the caster's own discards this turn.
+        value(PlayerScope::Controller, tag("you've discarded this turn")),
+        value(PlayerScope::Controller, tag("you have discarded this turn")),
+    ))
+    .parse(rest)?;
+    Ok((rest, QuantityRef::CardsDiscardedThisTurn { player }))
+}
+
 /// Parse an optional ", rounded up/down" / ", round up/down" suffix.
 ///
 /// CR 107.1a: Oracle text must specify rounding direction for fractional
@@ -518,6 +546,7 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         // exact complete phrase (no greedy prefix consumption).
         alt((
             parse_number_of_cards_drawn_this_turn,
+            parse_number_of_cards_discarded_this_turn,
             parse_cards_in_zone_ref,
         )),
         parse_self_power_ref,
@@ -775,9 +804,14 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
         // `parse_number_of_controlled_type`, whose " you control" suffix does
         // not match the battlefield-wide form.
         parse_number_of_type_on_battlefield_with_keyword,
-        // CR 121.1: "cards you've drawn this turn" — must precede generic
-        // controlled-type arms whose type words could overlap.
-        parse_number_of_cards_drawn_this_turn,
+        // CR 121.1 + CR 701.9 + CR 603.4: "cards you've drawn this turn" and
+        // "cards you've discarded this turn" — must precede generic
+        // controlled-type arms whose type words could overlap. Nested together
+        // to stay within nom's top-level `alt` arity (nom 8.0 max: 21 items).
+        alt((
+            parse_number_of_cards_drawn_this_turn,
+            parse_number_of_cards_discarded_this_turn,
+        )),
         parse_number_of_controlled_type,
         parse_cards_exiled_with_source,
         // CR 109.4 + CR 115.7: "cards in their <zone>" / "cards in that player's <zone>"


### PR DESCRIPTION
## Summary
Fixes a verified misparse subclass: effects with "… **for each card you've discarded this turn**" emitted `Fixed(1)`. The for-each effect wiring was already correct; the gap was a missing quantity combinator, so `parse_for_each_clause` returned `None` and the count fell back to 1. Adds `parse_number_of_cards_discarded_this_turn` (mirroring the existing drawn-this-turn combinator), wired into both quantity-dispatch paths, emitting the existing `QuantityRef::CardsDiscardedThisTurn`. No new engine surface.

## Cards fixed (10)
Misty Knight, Astonishing Spider-Man, Green Goblin (Revenant), Change of Fortune, Dihada's Ploy, Living Laser, and the 4 Ambergris variants — all "for each card you've discarded this turn".

## Files changed
- `crates/engine/src/parser/oracle_nom/quantity.rs` — `parse_number_of_cards_discarded_this_turn` combinator + wiring into both dispatch `alt` chains (nested under the drawn-this-turn arm to respect nom's `alt` arity)
- `crates/engine/src/parser/oracle_effect/mod.rs` — 2 parser-shape tests + 1 discriminating runtime test

## CR references
- CR 701.9 — discard
- CR 603.4 — turn-based ("this turn") condition tracking

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

Tier: Frontier

## Verification
- `cargo fmt --all`, `./scripts/check-parser-combinators.sh` (Gate A) — clean
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `cargo test -p engine` — full suite passes (incl. discriminating `for_each_cards_discarded_this_turn_resolves_dynamic_draw_count`: records 3 discards, resolves the parsed Draw count through the live resolver, asserts 3; reverting the combinator drops it to `Fixed(1)`→1 and the test fails)
- AST diff vs `origin/main` baseline: exactly 10 cards changed, zero regression suspects

## Scope Expansion
None. (The broader "for each" audit cluster contains several *distinct* root causes — missing subtype, power<0 filter, copy-token count — addressed separately.)

## Validation Failures
None.

## CI Failures
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
