### PR TITLE
fix: Killian, Decisive Mentor trigger

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -3477,10 +3477,11 @@ pub(super) fn matching_you_attack_pairs(
     // CR 603.2c: the player-scope gate (valid_target). No filter ⇒ legacy
     // "attackers controlled by the trigger's source controller" semantics.
     let player_ok = match trigger.valid_target.as_ref() {
-        // Parser legacy for "one or more creatures attack a player": the
-        // attacked-player type is represented as `TargetFilter::Player`, not
-        // as attacking-player scope. The per-attack target filter below handles
-        // it, so keep the attacking-player gate permissive here.
+        // CR 506.2 + CR 303.4e: `valid_target == Player` is purely the permissive
+        // attacking-player pass-through (any attacking player) and carries NO
+        // attack-target narrowing — that lives solely in `attack_target_filter`.
+        // Used by attachment-relation triggers ("enchanted by an Aura you control
+        // attack") whose enchanted/equipped attacker may be opponent-controlled.
         Some(TargetFilter::Player) => true,
         Some(_) => valid_player_matches(trigger, state, attacking_player, source_id),
         None => {
@@ -3506,15 +3507,14 @@ pub(super) fn matching_you_attack_pairs(
                 .iter()
                 .find_map(|(attacker_id, target)| (*attacker_id == *id).then_some(*target))
                 .unwrap_or(crate::game::combat::AttackTarget::Player(*defending_player));
+            // CR 508.3a: attacked-target narrowing ("attacks a player/planeswalker/
+            // battle") lives solely in `attack_target_filter`; `valid_target` carries
+            // only attacking-player scope (CR 506.2), mirroring
+            // `matching_you_attack_unblocked_pairs`.
             if trigger
                 .attack_target_filter
                 .as_ref()
                 .is_some_and(|filter| !attack_target_type_matches(target, filter))
-            {
-                return None;
-            }
-            if matches!(trigger.valid_target, Some(TargetFilter::Player))
-                && !matches!(target, crate::game::combat::AttackTarget::Player(_))
             {
                 return None;
             }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8684,11 +8684,25 @@ fn try_parse_n_or_more_attacks(lower: &str) -> Option<(TriggerMode, TriggerDefin
             continue;
         }
 
+        let has_attachment_clause = attachment_prop.is_some();
         let filter = apply_attachment_prop(filter, attachment_prop);
 
         let mut def = make_base();
         def.mode = TriggerMode::YouAttack;
+        // CR 508.3a: a lexical "attack a player" restriction narrows the attacked
+        // target through the purpose-built attack_target_filter channel, not the
+        // valid_target overload.
         if attacks_player {
+            def.attack_target_filter = Some(AttackTargetFilter::Player);
+        }
+        // CR 303.4e + CR 506.2: an attachment-relation subject ("enchanted by an
+        // Aura / equipped by an Equipment you control") binds "you control" to the
+        // attachment, not the attacker — the enchanted/equipped creature may be
+        // controlled by an opponent. Set the attacking-player gate to pass-through
+        // (any attacking player) WITHOUT an attack-target restriction, so the trigger
+        // fires regardless of whether the attack targets a player, planeswalker, or
+        // battle (Killian, Decisive Mentor; #3314).
+        if has_attachment_clause {
             def.valid_target = Some(TargetFilter::Player);
         }
         if min_count > 1 {
@@ -18242,6 +18256,21 @@ mod tests {
             "Killian, Decisive Mentor",
         );
         assert_eq!(def.mode, TriggerMode::YouAttack);
+        // CR 303.4e + CR 506.2: the attachment-relation clause ("enchanted by an
+        // Aura you control") makes the attacking-player gate pass-through
+        // (`valid_target == Player`) — the enchanted attacker may be
+        // opponent-controlled — WITHOUT any attacked-target narrowing
+        // (`attack_target_filter == None`), since this text has no "attack a
+        // player" restriction. (#3314)
+        assert_eq!(
+            def.valid_target,
+            Some(TargetFilter::Player),
+            "attachment-relation subject ⇒ permissive attacking-player pass-through"
+        );
+        assert_eq!(
+            def.attack_target_filter, None,
+            "no \"attack a player\" clause ⇒ no attacked-target narrowing"
+        );
         let filter = def.valid_card.as_ref().expect("valid_card set");
         match filter {
             TargetFilter::Typed(tf) => {
@@ -24545,7 +24574,20 @@ mod tests {
                 count: 2,
             })
         );
-        assert_eq!(def.valid_target, Some(TargetFilter::Player));
+        // CR 508.3a: the lexical "attack a player" restriction is an
+        // attacked-target narrowing carried by `attack_target_filter`, NOT the
+        // `valid_target` overload. With no attachment-relation clause, the
+        // attacking-player gate stays at the controller-scoped default
+        // (`valid_target == None`).
+        assert_eq!(
+            def.attack_target_filter,
+            Some(AttackTargetFilter::Player),
+            "\"attack a player\" sets the purpose-built attack_target_filter"
+        );
+        assert_eq!(
+            def.valid_target, None,
+            "no attachment clause ⇒ controller-scoped default, not the Player overload"
+        );
         assert!(def.execute.is_some());
     }
 

--- a/crates/engine/tests/integration/issue_3314_killian.rs
+++ b/crates/engine/tests/integration/issue_3314_killian.rs
@@ -16,6 +16,7 @@
 //!     attacking player qualifies (CR 303.4e).
 //!   - attacked-target narrowing ("attack a player", CR 508.3a) → moves to the
 //!     purpose-built `attack_target_filter`.
+//!
 //! Decoupling them is what lets Killian fire when its enchanted creature attacks
 //! a planeswalker or battle, not only a player.
 //!

--- a/crates/engine/tests/integration/issue_3314_killian.rs
+++ b/crates/engine/tests/integration/issue_3314_killian.rs
@@ -1,0 +1,245 @@
+//! Regression for issue #3314: Killian, Decisive Mentor.
+//!
+//! Killian reads "Whenever one or more creatures that are enchanted by an Aura
+//! you control attack, draw a card." Per CR 303.4e an Aura's controller is
+//! separate from the enchanted object's controller — so the trigger must fire
+//! even when an *opponent's* creature, enchanted by an Aura *you* control,
+//! attacks. The live parser already produced the attachment-relation filter,
+//! but the runtime matcher left the trigger controller-scoped (it only fired
+//! when the trigger's controller was the attacking player), so an opponent's
+//! enchanted creature attacking did not draw the card.
+//!
+//! The fix decouples two channels that the matcher previously conflated through
+//! `valid_target = Some(TargetFilter::Player)`:
+//!   - attacking-player scope (CR 506.2) → stays in `valid_target`; for the
+//!     attachment-relation class it is set to the permissive pass-through so any
+//!     attacking player qualifies (CR 303.4e).
+//!   - attacked-target narrowing ("attack a player", CR 508.3a) → moves to the
+//!     purpose-built `attack_target_filter`.
+//! Decoupling them is what lets Killian fire when its enchanted creature attacks
+//! a planeswalker or battle, not only a player.
+//!
+//! https://github.com/phase-rs/phase/issues/3314
+
+use engine::game::game_object::AttachTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+const KILLIAN_TRIGGER: &str =
+    "Whenever one or more creatures that are enchanted by an Aura you control attack, draw a card.";
+const CONTROL_SCOPED_TRIGGER: &str =
+    "Whenever one or more creatures you control attack, draw a card.";
+
+/// Number of cards in `player`'s hand right now.
+fn hand_size(runner: &GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.hand.len())
+        .unwrap_or(0)
+}
+
+/// Attach a P0-controlled Aura to `host` (which may be controlled by anyone).
+/// CR 303.4e: the Aura's controller (P0) is independent of the host's
+/// controller. Returns the Aura's id.
+fn attach_p0_aura(runner: &mut GameRunner, host: ObjectId) -> ObjectId {
+    let state = runner.state_mut();
+    let aura = engine::game::zones::create_object(
+        state,
+        engine::types::identifiers::CardId(9000 + host.0),
+        P0,
+        "Cartouche".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let aura_obj = state.objects.get_mut(&aura).unwrap();
+        aura_obj.card_types.core_types.push(CoreType::Enchantment);
+        aura_obj.card_types.subtypes.push("Aura".to_string());
+        aura_obj.attached_to = Some(AttachTarget::Object(host));
+    }
+    {
+        let host_obj = state.objects.get_mut(&host).unwrap();
+        host_obj.attachments.push(aura);
+    }
+    aura
+}
+
+/// Turn an existing battlefield object into a planeswalker with loyalty so it is
+/// a legal attack target (CR 306, CR 508.1b).
+fn make_planeswalker(runner: &mut GameRunner, id: ObjectId, loyalty: u32) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    // Replace the builder's Creature type with Planeswalker (a 0/0 creature would
+    // be destroyed by SBAs, CR 704.5f); a planeswalker has no power/toughness.
+    obj.card_types.core_types = vec![CoreType::Planeswalker];
+    obj.power = None;
+    obj.toughness = None;
+    obj.base_power = None;
+    obj.base_toughness = None;
+    // Mirror onto base_card_types so layer re-evaluation (which rebuilds
+    // card_types from base_card_types) preserves the Planeswalker type.
+    obj.base_card_types = obj.card_types.clone();
+    // CR 306.5b: loyalty field and counter map mirror each other.
+    obj.loyalty = Some(loyalty);
+    obj.counters.insert(CounterType::Loyalty, loyalty);
+}
+
+/// Drive the (already-declared) combat trigger to resolution by passing
+/// priority until the stack and any triggered abilities settle. Declares empty
+/// blocks if asked.
+fn settle(runner: &mut GameRunner) {
+    runner.advance_until_stack_empty();
+}
+
+/// (1) CR 303.4e: P1 (active) attacks a player with a creature enchanted by P0's
+/// Aura; P0 controls Killian → P0 draws a card.
+///
+/// Discriminator for EDIT A: if `try_parse_n_or_more_attacks` does not set the
+/// attachment-relation gate to the permissive pass-through, the matcher stays
+/// controller-scoped, the attacking player (P1) ≠ Killian's controller (P0),
+/// and P0's hand does not grow.
+#[test]
+fn killian_fires_on_opponent_attack_with_enchanted_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Mountain"]);
+
+    let _killian = scenario
+        .add_creature_from_oracle(P0, "Killian, Decisive Mentor", 2, 4, KILLIAN_TRIGGER)
+        .id();
+    // Opponent's attacker, enchanted by P0's Aura.
+    let opp_attacker = scenario.add_creature(P1, "Hostile Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    attach_p0_aura(&mut runner, opp_attacker);
+
+    runner.state_mut().active_player = P1;
+    let before = hand_size(&runner, P0);
+
+    runner.pass_both_players();
+    runner
+        .declare_attackers(&[(opp_attacker, AttackTarget::Player(P0))])
+        .expect("P1 declares its enchanted creature as an attacker");
+    settle(&mut runner);
+
+    assert_eq!(
+        hand_size(&runner, P0),
+        before + 1,
+        "Killian must draw when an opponent's creature enchanted by P0's Aura attacks (CR 303.4e)"
+    );
+}
+
+/// (2) CR 508.3a decoupling discriminator: P1's creature enchanted by P0's Aura
+/// attacks a PLANESWALKER (controlled by P0). Killian must still draw — the
+/// trigger has no "attack a player" restriction.
+///
+/// If the old conflation block in `matching_you_attack_pairs` is still present,
+/// `valid_target == Player` would suppress every non-player attack target, so
+/// this attack at a planeswalker would NOT draw. The fix removes that block; the
+/// attacked-target narrowing lives solely in `attack_target_filter`, which
+/// Killian leaves unset.
+#[test]
+fn killian_fires_when_enchanted_creature_attacks_planeswalker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Mountain"]);
+
+    let _killian = scenario
+        .add_creature_from_oracle(P0, "Killian, Decisive Mentor", 2, 4, KILLIAN_TRIGGER)
+        .id();
+    // P0 controls the planeswalker (it is the defending, non-active player).
+    let pw = scenario.add_creature(P0, "Test Planeswalker", 0, 0).id();
+    let opp_attacker = scenario.add_creature(P1, "Hostile Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    make_planeswalker(&mut runner, pw, 5);
+    attach_p0_aura(&mut runner, opp_attacker);
+
+    runner.state_mut().active_player = P1;
+    let before = hand_size(&runner, P0);
+
+    runner.pass_both_players();
+    runner
+        .declare_attackers(&[(opp_attacker, AttackTarget::Planeswalker(pw))])
+        .expect("P1 declares its enchanted creature attacking P0's planeswalker");
+    settle(&mut runner);
+
+    assert_eq!(
+        hand_size(&runner, P0),
+        before + 1,
+        "Killian must draw even when the enchanted attacker targets a planeswalker (CR 508.3a)"
+    );
+}
+
+/// (3) The trigger must stay silent when the attacker is NOT enchanted by a
+/// P0-controlled Aura.
+#[test]
+fn killian_silent_on_unenchanted_attacker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Mountain"]);
+
+    let _killian = scenario
+        .add_creature_from_oracle(P0, "Killian, Decisive Mentor", 2, 4, KILLIAN_TRIGGER)
+        .id();
+    let opp_attacker = scenario.add_creature(P1, "Hostile Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    // No Aura attached.
+    runner.state_mut().active_player = P1;
+    let before = hand_size(&runner, P0);
+
+    runner.pass_both_players();
+    runner
+        .declare_attackers(&[(opp_attacker, AttackTarget::Player(P0))])
+        .expect("P1 declares an unenchanted attacker");
+    settle(&mut runner);
+
+    assert_eq!(
+        hand_size(&runner, P0),
+        before,
+        "Killian must NOT draw when the attacker is not enchanted by a P0 Aura"
+    );
+}
+
+/// (4) Regression guard for the control-scoped class (the maintainer's explicit
+/// concern): a plain "Whenever one or more creatures you control attack" trigger
+/// must remain controller-scoped — only its controller's attacks fire it, not an
+/// opponent's. Proves the decoupling did not loosen the default path.
+#[test]
+fn control_scoped_attack_trigger_silent_on_opponent_attack() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Mountain"]);
+
+    // P0-controlled source with the control-scoped trigger.
+    let _source = scenario
+        .add_creature_from_oracle(P0, "Control Scoped Source", 2, 2, CONTROL_SCOPED_TRIGGER)
+        .id();
+    let opp_attacker = scenario.add_creature(P1, "Hostile Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    let before = hand_size(&runner, P0);
+
+    runner.pass_both_players();
+    runner
+        .declare_attackers(&[(opp_attacker, AttackTarget::Player(P0))])
+        .expect("only P1 attacks");
+    settle(&mut runner);
+
+    assert_eq!(
+        hand_size(&runner, P0),
+        before,
+        "a control-scoped 'creatures you control attack' trigger must not fire on an \
+         opponent-only attack (CR 506.2)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -220,6 +220,7 @@ mod issue_3285_face_down_public_zone;
 mod issue_3295_scrapwork_mutt_unearth_zone;
 mod issue_3302_breach_multiverse;
 mod issue_3311_manifest_dread_land;
+mod issue_3314_killian;
 mod issue_3320_peregrine_drake_untap_prompt;
 mod issue_3321_volcanic_spite_optional;
 mod issue_3322_airbend_owner_cast;


### PR DESCRIPTION
Fixes #3314: Killian's second trigger now fires when any creature matching the filter attacks, regardless of controller — previously it only fired for the controller's own attacking creatures.