### PR TITLE
fix(parser): Path of Ancestry (Commander-staple land) is UNSUPPORTED — implement full support, not a

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -10642,11 +10642,37 @@ fn apply_mana_spell_grants(
             else {
                 continue;
             };
-            if restriction.as_ref().is_some_and(|restriction| {
-                !spell_meta
+            // CR 106.6: Gate the reflexive trigger on the spend filter. Most
+            // restrictions are evaluated purely from `SpellMeta` via
+            // `allows_spell`; the commander-relational filter
+            // (`SharesCreatureTypeWithCommander`) needs game state and is
+            // evaluated here, the single authoritative spend-check site.
+            let passes = match restriction.as_ref() {
+                None => true,
+                Some(crate::types::mana::ManaRestriction::SharesCreatureTypeWithCommander) => {
+                    spell_meta.as_ref().is_some_and(|meta| {
+                        // CR 205.3m + CR 903.3: the spell must be a creature AND
+                        // share at least one creature type with the controller's
+                        // commander(s).
+                        let is_creature = meta
+                            .types
+                            .iter()
+                            .any(|t| t.eq_ignore_ascii_case("Creature"));
+                        if !is_creature {
+                            return false;
+                        }
+                        let commander_types =
+                            super::commander::commander_creature_types(state, caster);
+                        meta.subtypes
+                            .iter()
+                            .any(|s| commander_types.iter().any(|c| c.eq_ignore_ascii_case(s)))
+                    })
+                }
+                Some(restriction) => spell_meta
                     .as_ref()
-                    .is_some_and(|meta| restriction.allows_spell(meta))
-            }) {
+                    .is_some_and(|meta| restriction.allows_spell(meta)),
+            };
+            if !passes {
                 continue;
             }
             let timestamp = state.next_timestamp() as u32;
@@ -14272,6 +14298,127 @@ mod tests {
             state.deferred_triggers.len(),
             deferred_before + 1,
             "spending on a non-matching spell must not queue another trigger"
+        );
+    }
+
+    /// CR 106.6 + CR 205.3m + CR 903.3: Path of Ancestry's
+    /// `SharesCreatureTypeWithCommander` spend filter fires the reflexive scry
+    /// only when the spell is a creature sharing a creature type with the
+    /// controller's commander. Evaluated at the spend-check site (game-state
+    /// aware), not via `allows_spell`.
+    #[test]
+    fn mana_spend_trigger_shares_creature_type_with_commander() {
+        let mut state = setup_game_at_main_phase();
+        // Elf commander in the command zone for PlayerId(0).
+        let commander = create_object(
+            &mut state,
+            CardId(400),
+            PlayerId(0),
+            "Elvish Commander".to_string(),
+            Zone::Command,
+        );
+        {
+            let c = state.objects.get_mut(&commander).unwrap();
+            c.is_commander = true;
+            c.card_types.core_types.push(CoreType::Creature);
+            c.card_types.subtypes.push("Elf".to_string());
+        }
+
+        let path = create_object(
+            &mut state,
+            CardId(401),
+            PlayerId(0),
+            "Path of Ancestry".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&path)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+
+        // An Elf creature spell (shares a type), a Goblin creature spell (no
+        // shared type), and an Elf-typed noncreature (Tribal instant) spell.
+        let elf_id = create_object(
+            &mut state,
+            CardId(402),
+            PlayerId(0),
+            "Elvish Mystic".to_string(),
+            Zone::Stack,
+        );
+        {
+            let e = state.objects.get_mut(&elf_id).unwrap();
+            e.card_types.core_types.push(CoreType::Creature);
+            e.card_types.subtypes.push("Elf".to_string());
+        }
+        let goblin_id = create_object(
+            &mut state,
+            CardId(403),
+            PlayerId(0),
+            "Goblin Piker".to_string(),
+            Zone::Stack,
+        );
+        {
+            let g = state.objects.get_mut(&goblin_id).unwrap();
+            g.card_types.core_types.push(CoreType::Creature);
+            g.card_types.subtypes.push("Goblin".to_string());
+        }
+        let elf_instant_id = create_object(
+            &mut state,
+            CardId(404),
+            PlayerId(0),
+            "Elvish Promise".to_string(),
+            Zone::Stack,
+        );
+        {
+            let i = state.objects.get_mut(&elf_instant_id).unwrap();
+            i.card_types.core_types.push(CoreType::Instant);
+            i.card_types.subtypes.push("Elf".to_string());
+        }
+
+        let trigger_ability = crate::types::ability::AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Activated,
+            Effect::Scry {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        let unit = ManaUnit {
+            color: ManaType::Green,
+            source_id: path,
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: vec![],
+            grants: vec![ManaSpellGrant::TriggerOnSpend {
+                restriction: Some(ManaRestriction::SharesCreatureTypeWithCommander),
+                ability: Box::new(trigger_ability),
+            }],
+            expiry: None,
+        };
+
+        let base = state.deferred_triggers.len();
+        // Elf creature spell shares the Elf creature type → reflexive scry queued.
+        apply_mana_spell_grants(&mut state, elf_id, std::slice::from_ref(&unit));
+        assert_eq!(
+            state.deferred_triggers.len(),
+            base + 1,
+            "an Elf creature spell shares a type with the Elf commander"
+        );
+        // Goblin creature spell shares no creature type → no trigger.
+        apply_mana_spell_grants(&mut state, goblin_id, std::slice::from_ref(&unit));
+        assert_eq!(
+            state.deferred_triggers.len(),
+            base + 1,
+            "a Goblin creature spell shares no type with the Elf commander"
+        );
+        // Elf-typed noncreature spell is not a creature → no trigger.
+        apply_mana_spell_grants(&mut state, elf_instant_id, &[unit]);
+        assert_eq!(
+            state.deferred_triggers.len(),
+            base + 1,
+            "a noncreature spell never qualifies even when it shares a subtype"
         );
     }
 

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -214,6 +214,72 @@ fn push_identity_color(identity: &mut Vec<ManaColor>, color: ManaColor) {
     }
 }
 
+/// CR 205.3m + CR 903.3: The set of creature subtypes ("creature types") across
+/// `player`'s commander(s).
+///
+/// CR 205.3m: creature types are the subtypes shared by creatures and kindreds,
+/// so only commanders that are creatures contribute. Reads
+/// `deck_pools.current_commander` first (pre-game registration), falling back to
+/// live `is_commander && owner == player` objects — the same precedence as
+/// [`commander_color_identity`]. Partner commanders merge their type sets.
+/// Subtypes are deduplicated case-insensitively, preserving first-seen casing.
+///
+/// Returns an empty vector when the player has no commander (CR 903.3: a card
+/// must be designated a commander for this reference to resolve). Callers that
+/// gate a spend on "shares a creature type with your commander" treat an empty
+/// set as "no type shared" — the spend simply doesn't qualify.
+//
+// TODO(strict): CR 702.73a — a Changeling commander is every creature type and
+// should match any creature subtype. Mirrors the color-identity helper's scope:
+// printed/effective subtypes only, no CDA expansion, until that is generalized.
+pub fn commander_creature_types(state: &GameState, player: PlayerId) -> Vec<String> {
+    let mut types: Vec<String> = Vec::new();
+
+    if let Some(pool) = state.deck_pools.iter().find(|pool| pool.player == player) {
+        for entry in pool.current_commander.iter() {
+            if entry
+                .card
+                .card_type
+                .core_types
+                .contains(&crate::types::card_type::CoreType::Creature)
+            {
+                for subtype in &entry.card.card_type.subtypes {
+                    push_creature_type(&mut types, subtype);
+                }
+            }
+        }
+        if !types.is_empty() {
+            return types;
+        }
+    }
+
+    for obj in state
+        .objects
+        .values()
+        .filter(|obj| obj.is_commander && obj.owner == player)
+    {
+        if obj
+            .card_types
+            .core_types
+            .contains(&crate::types::card_type::CoreType::Creature)
+        {
+            for subtype in &obj.card_types.subtypes {
+                push_creature_type(&mut types, subtype);
+            }
+        }
+    }
+    types
+}
+
+fn push_creature_type(types: &mut Vec<String>, subtype: &str) {
+    if !types
+        .iter()
+        .any(|existing| existing.eq_ignore_ascii_case(subtype))
+    {
+        types.push(subtype.to_string());
+    }
+}
+
 /// CR 903.4: Each card must be within the commander's color identity.
 ///
 /// Color identity includes colors from mana cost symbols (CR 903.4) plus the card's
@@ -678,6 +744,61 @@ mod tests {
         assert_eq!(identity.len(), 2);
         assert!(identity.contains(&ManaColor::White));
         assert!(identity.contains(&ManaColor::Black));
+    }
+
+    #[test]
+    fn commander_creature_types_empty_without_commander() {
+        // CR 903.3: No commander designated → empty creature-type set.
+        let state = setup_commander_game();
+        assert!(commander_creature_types(&state, PlayerId(0)).is_empty());
+    }
+
+    #[test]
+    fn commander_creature_types_returns_live_commander_subtypes() {
+        // CR 205.3m: a creature commander contributes its subtypes as creature types.
+        let mut state = setup_commander_game();
+        let cmd_id = create_commander_in_command_zone(
+            &mut state,
+            PlayerId(0),
+            "Elf Lord",
+            vec![ManaColor::Green],
+        );
+        state.objects.get_mut(&cmd_id).unwrap().card_types.subtypes =
+            vec!["Elf".to_string(), "Warrior".to_string()];
+
+        let types = commander_creature_types(&state, PlayerId(0));
+        assert_eq!(types.len(), 2);
+        assert!(types.iter().any(|t| t.eq_ignore_ascii_case("Elf")));
+        assert!(types.iter().any(|t| t.eq_ignore_ascii_case("Warrior")));
+    }
+
+    #[test]
+    fn commander_creature_types_merges_partner_commanders() {
+        // CR 205.3m + CR 903.3: partner commanders union their creature-type sets.
+        let mut state = setup_commander_game();
+        let a = create_commander_in_command_zone(&mut state, PlayerId(0), "Partner A", vec![]);
+        state.objects.get_mut(&a).unwrap().card_types.subtypes = vec!["Elf".to_string()];
+        let b = create_commander_in_command_zone(&mut state, PlayerId(0), "Partner B", vec![]);
+        state.objects.get_mut(&b).unwrap().card_types.subtypes = vec!["Goblin".to_string()];
+
+        let types = commander_creature_types(&state, PlayerId(0));
+        assert_eq!(types.len(), 2);
+        assert!(types.iter().any(|t| t.eq_ignore_ascii_case("Elf")));
+        assert!(types.iter().any(|t| t.eq_ignore_ascii_case("Goblin")));
+    }
+
+    #[test]
+    fn commander_creature_types_ignores_noncreature_commander() {
+        // CR 205.3m: creature types only belong to creatures. A Vehicle commander
+        // (permitted by CR 903.3) that is not a creature contributes no creature
+        // types.
+        let mut state = setup_commander_game();
+        let cmd_id = create_commander_in_command_zone(&mut state, PlayerId(0), "Vehicle", vec![]);
+        let obj = state.objects.get_mut(&cmd_id).unwrap();
+        obj.card_types.core_types = vec![CoreType::Artifact];
+        obj.card_types.subtypes = vec!["Vehicle".to_string()];
+
+        assert!(commander_creature_types(&state, PlayerId(0)).is_empty());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -9121,6 +9121,71 @@ mod tests {
         );
     }
 
+    /// CR 106.6 + CR 205.3m + CR 903.3: Path of Ancestry — the passive-voice
+    /// "When that mana is spent to cast a creature spell that shares a creature
+    /// type with your commander, scry 1" clause folds into the
+    /// commander-color-identity mana ability's `grants` as a `TriggerOnSpend`
+    /// with the relational `SharesCreatureTypeWithCommander` restriction. The
+    /// whole card parses with no `Effect::Unimplemented` anywhere.
+    #[test]
+    fn path_of_ancestry_full_parse_no_unimplemented() {
+        use crate::types::ability::ManaProduction;
+        use crate::types::mana::{ManaRestriction, ManaSpellGrant};
+        let r = parse(
+            "This land enters tapped.\n{T}: Add one mana of any color in your commander's color identity. When that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+            "Path of Ancestry",
+            &[],
+            &["Land"],
+            &["Path of Ancestry"],
+        );
+        assert_eq!(r.abilities.len(), 1, "abilities: {:?}", r.abilities);
+        let Effect::Mana {
+            produced, grants, ..
+        } = &*r.abilities[0].effect
+        else {
+            panic!("expected Effect::Mana, got {:?}", r.abilities[0].effect);
+        };
+        assert!(
+            matches!(
+                produced,
+                ManaProduction::AnyInCommandersColorIdentity { .. }
+            ),
+            "expected commander-color-identity mana, got {produced:?}"
+        );
+        // CR 605.1a: the delayed-trigger rider doesn't disqualify the mana ability.
+        assert!(
+            crate::game::mana_abilities::is_mana_ability(&r.abilities[0]),
+            "must stay a mana ability"
+        );
+        assert_eq!(grants.len(), 1, "grants: {grants:?}");
+        let ManaSpellGrant::TriggerOnSpend {
+            restriction,
+            ability,
+        } = &grants[0]
+        else {
+            panic!("expected TriggerOnSpend, got {:?}", grants[0]);
+        };
+        assert_eq!(
+            *restriction,
+            Some(ManaRestriction::SharesCreatureTypeWithCommander)
+        );
+        assert!(matches!(*ability.effect, Effect::Scry { .. }));
+        assert!(
+            r.abilities[0].sub_ability.is_none(),
+            "the spend-trigger clause must be folded out of the chain"
+        );
+        // No Unimplemented anywhere in the ability tree.
+        assert!(
+            !matches!(*r.abilities[0].effect, Effect::Unimplemented { .. }),
+            "ability effect must not be Unimplemented"
+        );
+        // The "enters tapped" replacement is preserved.
+        assert!(
+            !r.replacements.is_empty(),
+            "enters-tapped replacement must be present"
+        );
+    }
+
     /// CR 106.6 + CR 603.3: a spell-referencing reflexive effect (Jade Orb of
     /// Dragonkind — "it enters with an additional +1/+1 counter on it") is NOT
     /// folded into a grant in the first pass — it stays a loud gap rather than

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -1663,9 +1663,16 @@ fn parse_conditional_keyword_grant(lower: &str) -> Option<ManaSpellGrant> {
 /// standard effect-chain parser. Returns `None` for unsupported filters or when
 /// the effect is unparseable, so the clause stays a loud gap.
 pub(crate) fn parse_mana_spend_trigger(lower: &str) -> Option<ManaSpellGrant> {
-    let (rest, _) = tag::<_, _, OracleError<'_>>("when you spend this mana to cast ")
-        .parse(lower.trim())
-        .ok()?;
+    // CR 106.6: Both the active ("when you spend this mana to cast …") and the
+    // passive ("when that mana is spent to cast …") subject phrasings name the
+    // same delayed-trigger-on-spend event. One `alt()` over the two equivalent
+    // openings — parameterize, don't proliferate.
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("when you spend this mana to cast "),
+        tag::<_, _, OracleError<'_>>("when that mana is spent to cast "),
+    ))
+    .parse(lower.trim())
+    .ok()?;
     // Split "[filter], [effect]" on the first ", ".
     let (after, filter_part) = terminated(
         take_until::<_, _, OracleError<'_>>(", "),
@@ -1708,6 +1715,27 @@ fn parse_spend_trigger_filter(filter: &str) -> Option<ManaRestriction> {
     // "a spell with mana value N or greater/less" (keeps its article).
     if let Some((comparator, value)) = parse_mana_value_threshold(filter) {
         return Some(ManaRestriction::OnlyForSpellWithManaValue { comparator, value });
+    }
+    // CR 205.3m: "[a|an] creature spell that shares a creature type with your
+    // commander" — a relational filter resolved against live commander state at
+    // the spend site. `all_consuming` rejects any trailing text so the whole
+    // clause stays a loud gap if the phrasing drifts.
+    if all_consuming(value(
+        ManaRestriction::SharesCreatureTypeWithCommander,
+        (
+            opt(alt((
+                tag::<_, _, OracleError<'_>>("a "),
+                tag::<_, _, OracleError<'_>>("an "),
+            ))),
+            tag::<_, _, OracleError<'_>>(
+                "creature spell that shares a creature type with your commander",
+            ),
+        ),
+    ))
+    .parse(filter)
+    .is_ok()
+    {
+        return Some(ManaRestriction::SharesCreatureTypeWithCommander);
     }
     // "[a|an] [subtype] creature spell".
     let (rest, _) = opt(alt((
@@ -2588,6 +2616,58 @@ mod tests {
                 restriction: Some(ManaRestriction::OnlyForCreatureType("Dragon".to_string())),
             }]
         );
+    }
+
+    /// CR 106.6 + CR 205.3m + CR 903.3: Path of Ancestry's passive-voice
+    /// "when that mana is spent to cast a creature spell that shares a creature
+    /// type with your commander, scry 1" must parse to a `TriggerOnSpend` with the
+    /// relational `SharesCreatureTypeWithCommander` restriction.
+    #[test]
+    fn parses_path_of_ancestry_spend_trigger() {
+        let grant = parse_mana_spend_trigger(
+            "when that mana is spent to cast a creature spell that shares a creature type with your commander, scry 1",
+        )
+        .expect("Path of Ancestry spend trigger must parse");
+        match grant {
+            ManaSpellGrant::TriggerOnSpend {
+                restriction,
+                ability,
+            } => {
+                assert_eq!(
+                    restriction,
+                    Some(ManaRestriction::SharesCreatureTypeWithCommander)
+                );
+                assert!(matches!(*ability.effect, Effect::Scry { .. }));
+            }
+            other => panic!("expected TriggerOnSpend, got {other:?}"),
+        }
+    }
+
+    /// The active-voice subject phrasing parses identically to the passive voice,
+    /// confirming the `alt()` over both openings (parameterize-don't-proliferate).
+    #[test]
+    fn parses_active_voice_shares_commander_spend_trigger() {
+        let grant = parse_mana_spend_trigger(
+            "when you spend this mana to cast a creature spell that shares a creature type with your commander, scry 1",
+        )
+        .expect("active-voice equivalent must parse");
+        assert!(matches!(
+            grant,
+            ManaSpellGrant::TriggerOnSpend {
+                restriction: Some(ManaRestriction::SharesCreatureTypeWithCommander),
+                ..
+            }
+        ));
+    }
+
+    /// A malformed relational filter must decline so the clause stays a loud gap
+    /// rather than flipping to a wrong-but-supported parse.
+    #[test]
+    fn shares_commander_filter_rejects_trailing_text() {
+        assert!(parse_mana_spend_trigger(
+            "when that mana is spent to cast a creature spell that shares a creature type with your commander or an opponent's commander, scry 1",
+        )
+        .is_none());
     }
 
     /// CR 505.1 + CR 106.4: a subject-led mana clause ("the active player adds

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -304,6 +304,16 @@ pub enum ManaRestriction {
     /// "Spend this mana only to cast a creature spell of the chosen type."
     /// The `String` is the chosen creature type (e.g., "Elf").
     OnlyForCreatureType(String),
+    /// CR 106.6 + CR 205.3m + CR 903.3: "a creature spell that shares a creature
+    /// type with your commander" — relational spend filter for Path of Ancestry.
+    /// This is a distinct *relational-to-commander* axis, not a fixed-subtype
+    /// parameterization of `OnlyForCreatureType`: the matching subtype set is
+    /// computed from live commander state per spend, so it cannot be evaluated
+    /// from `SpellMeta` alone. `allows_spell` returns `false` (no commander
+    /// context here); the real relational evaluation happens at the
+    /// `apply_mana_spell_grants` spend-check site, which has game-state access —
+    /// mirroring how `OnlyForXCosts` defers full detection to its call site.
+    SharesCreatureTypeWithCommander,
     /// CR 106.6: "Spend this mana only to cast creature spells or activate abilities of creatures."
     /// Allows spending for spells of `spell_type` (checked via `allows_spell`) OR for ability
     /// activations whose scope is described by `ability` (checked via `allows_activation`):
@@ -388,6 +398,14 @@ impl ManaRestriction {
                     .any(|s| s.eq_ignore_ascii_case(required_subtype));
                 is_creature && has_subtype
             }
+            // CR 106.6 + CR 903.3: Relational commander-subtype filter. `SpellMeta`
+            // carries no commander context, so this restriction can never
+            // independently authorize a spend here — it returns `false` and the
+            // authoritative relational evaluation (comparing the spell's creature
+            // subtypes against the controller's commander's creature types) is done
+            // at the `apply_mana_spell_grants` call site, which has `&GameState`.
+            // Mirrors the deferral contract of `OnlyForXCosts`.
+            ManaRestriction::SharesCreatureTypeWithCommander => false,
             // CR 106.6: The spell-casting half of the OR — allows if the spell has the
             // required type, consulting both core card types (Creature, Instant, ...)
             // and subtypes (Elemental, Goblin, ...). Flamebraider's "Elemental" names
@@ -443,6 +461,7 @@ impl ManaRestriction {
             ManaRestriction::OnlyForSpell
             | ManaRestriction::OnlyForSpellType(_)
             | ManaRestriction::OnlyForCreatureType(_)
+            | ManaRestriction::SharesCreatureTypeWithCommander
             | ManaRestriction::OnlyForSpellWithKeywordKind(_)
             | ManaRestriction::OnlyForSpellWithKeywordKindFromZone(_, _)
             | ManaRestriction::OnlyForSpellWithManaValue { .. }
@@ -1523,6 +1542,28 @@ mod tests {
         assert!(restriction.allows_spell(&elf_creature));
         assert!(!restriction.allows_spell(&goblin_creature));
         assert!(!restriction.allows_spell(&elf_instant));
+    }
+
+    #[test]
+    fn shares_creature_type_with_commander_defers_to_call_site() {
+        // CR 106.6 + CR 903.3: The relational commander-subtype filter carries no
+        // commander context in `SpellMeta`, so `allows_spell`/`allows_activation`
+        // must return `false` for every payment context. The authoritative
+        // relational evaluation happens at the `apply_mana_spell_grants` spend
+        // site (game-state aware). This documents the deferral contract.
+        let restriction = ManaRestriction::SharesCreatureTypeWithCommander;
+        let elf_creature = SpellMeta {
+            types: vec!["Creature".to_string()],
+            subtypes: vec!["Elf".to_string()],
+            keyword_kinds: vec![],
+            cast_from_zone: None,
+            mana_value: None,
+            color_count: None,
+        };
+        assert!(!restriction.allows_spell(&elf_creature));
+        let source_types = vec!["Creature".to_string()];
+        let source_subtypes = vec!["Elf".to_string()];
+        assert!(!restriction.allows_activation(&source_types, &source_subtypes));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** Path of Ancestry (Commander-staple land) is UNSUPPORTED — implement full support, not a misparse fix.

## Cards corrected
- Path of Ancestry

## Fix
Path of Ancestry supported

## Files changed
- types/mana.rs
- game/commander.rs
- game/casting.rs
- parser/oracle_effect/mana.rs
- parser/oracle.rs

## CR references
- CR 106.6
- CR 205.3m
- CR 603.7a
- CR 605.1a
- CR 903.3
- CR 702.73a

## Verification
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo fmt --all` — pass
- `cd /Users/ntindle/code/random/magic/phase-main-base && ./scripts/check-parser-combinators.sh "$(git merge-base upstream/main HEAD)"` — pass
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo clippy -p engine --all-targets -- -D warnings` — pass
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo test -p engine` — pass
- `cd /Users/ntindle/code/random/magic/phase-main-base && cargo run --profile tool --features cli --bin oracle-gen -- data --filter "path of ancestry"` — pass
Cards confirmed re-parsed correctly: Path of Ancestry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
