### PR TITLE
Add Nix

### DIFF
--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -760,6 +760,13 @@ fn resolve_event_scoped_ref(
                 &FilterContext::from_source(state, id),
             )
         }
+        QuantityExpr::Ref {
+            qty:
+                QuantityRef::ManaSpentToCast {
+                    scope: CastManaObjectScope::AbilityTarget,
+                    metric: _,
+                },
+        } => None,
         _ => None,
     }
 }
@@ -1805,6 +1812,13 @@ fn resolve_ref(
                     .current_trigger_event
                     .as_ref()
                     .and_then(crate::game::targeting::extract_source_from_event),
+                CastManaObjectScope::AbilityTarget => targets.iter().find_map(|target| {
+                    if let crate::types::ability::TargetRef::Object(id) = target {
+                        Some(*id)
+                    } else {
+                        None
+                    }
+                }),
             };
             cast_object
                 .and_then(|id| resolve_mana_spent_to_cast_metric(state, id, metric, &filter_ctx))

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -18,9 +18,10 @@ use super::super::oracle_util::{parse_comparison_suffix, parse_subtype, TextPair
 use super::{parse_effect_chain, scan_contains_phrase, ParseContext};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, AbilityKind, CastVariantPaid, Comparator, ControllerRef,
-    CountScope, Duration, Effect, FilterProp, ObjectScope, ParsedCondition, PlayerScope,
-    QuantityExpr, QuantityRef, StaticCondition, TargetFilter, TypeFilter, TypedFilter,
+    AbilityCondition, AbilityDefinition, AbilityKind, CastManaObjectScope, CastManaSpentMetric,
+    CastVariantPaid, Comparator, ControllerRef, CountScope, Duration, Effect, FilterProp,
+    ObjectScope, ParsedCondition, PlayerScope, QuantityExpr, QuantityRef, StaticCondition,
+    TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
@@ -1653,6 +1654,10 @@ pub(super) fn strip_suffix_conditional(
         return (Some(cond), effect_text);
     }
 
+    if let Some(cond) = parse_no_mana_spent_to_cast_target_condition_text(condition_core) {
+        return (Some(cond), effect_text);
+    }
+
     if let Some(condition) = parse_triggering_spell_targets_filter_ability_condition(condition_core)
         .or_else(|| try_nom_condition_as_ability_condition(condition_core, ctx))
         .or_else(|| parse_condition_text(condition_core))
@@ -1685,8 +1690,43 @@ pub(super) fn parse_quantity_comparison(text: &str) -> Option<(Comparator, Quant
     None
 }
 
+/// CR 601.2h + CR 608.2c: "if no mana was spent to cast it/that spell" on a
+/// targeted spell effect — the "it" anaphors to the ability's object target
+/// (Nix, Defabricate-class riders).
+fn parse_no_mana_spent_to_cast_target_condition_text(text: &str) -> Option<AbilityCondition> {
+    let lower = text.to_ascii_lowercase();
+    nom_parse_lower(&lower, |input| {
+        all_consuming(parse_no_mana_spent_to_cast_target_condition).parse(input)
+    })
+}
+
+fn parse_no_mana_spent_to_cast_target_condition(input: &str) -> OracleResult<'_, AbilityCondition> {
+    let (rest, _) = (
+        tag("no mana was spent to cast "),
+        alt((tag("it"), tag("that spell"), tag("this spell"), tag("them"))),
+    )
+        .parse(input)?;
+    Ok((
+        rest,
+        AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ManaSpentToCast {
+                    scope: CastManaObjectScope::AbilityTarget,
+                    metric: CastManaSpentMetric::Total,
+                },
+            },
+            comparator: Comparator::EQ,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        },
+    ))
+}
+
 pub(super) fn parse_condition_text(text: &str) -> Option<AbilityCondition> {
     let text = text.trim().trim_end_matches('.');
+
+    if let Some(condition) = parse_no_mana_spent_to_cast_target_condition_text(text) {
+        return Some(condition);
+    }
 
     if let Some(condition) = parse_you_control_urza_land_types_condition_text(text) {
         return Some(condition);
@@ -4059,6 +4099,33 @@ mod tests {
     use super::*;
     use crate::parser::oracle_nom::condition::parse_inner_condition;
     use crate::types::counter::{CounterMatch, CounterType};
+
+    #[test]
+    fn parse_no_mana_spent_to_cast_target_condition_reads_ability_target_mana() {
+        let cond =
+            parse_no_mana_spent_to_cast_target_condition_text("no mana was spent to cast it")
+                .expect("should parse target no-mana-spent condition");
+        assert!(matches!(
+            cond,
+            AbilityCondition::QuantityCheck {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::ManaSpentToCast {
+                        scope: CastManaObjectScope::AbilityTarget,
+                        metric: CastManaSpentMetric::Total,
+                    },
+                },
+                comparator: Comparator::EQ,
+                rhs: QuantityExpr::Fixed { value: 0 },
+            }
+        ));
+
+        let (cond, text) = strip_suffix_conditional(
+            "Counter target spell if no mana was spent to cast it",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(text, "Counter target spell");
+        assert!(matches!(cond, Some(AbilityCondition::QuantityCheck { .. })));
+    }
 
     /// CR 508.1a: filtered attack-history condition — "you attacked with <X>"
     /// resolves to a QuantityCheck over the (optionally filtered) AttackedThisTurn

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3282,6 +3282,10 @@ pub enum CastManaObjectScope {
     SelfObject,
     /// The spell object referenced by the current trigger event.
     TriggeringSpell,
+    /// CR 115.1 + CR 601.2h: The first object target of the resolving ability —
+    /// "it"/"that spell" when the condition gates on the targeted spell
+    /// (Nix: "Counter target spell if no mana was spent to cast it").
+    AbilityTarget,
 }
 
 /// CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -230,6 +230,7 @@ mod morophon_chosen_type_1653;
 mod multi_upkeep_triggers_suspend;
 mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;
+mod nix_counter_no_mana_spent;
 mod ob_nixilis_captive_kingpin_life_loss;
 mod obeka_splitter_additional_phases;
 mod obliterate_regression;

--- a/crates/engine/tests/integration/nix_counter_no_mana_spent.rs
+++ b/crates/engine/tests/integration/nix_counter_no_mana_spent.rs
@@ -4,11 +4,20 @@
 //! `QuantityCheck` over `ManaSpentToCast { scope: AbilityTarget }`, not
 //! remain as swallowed `Condition_If` text.
 
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::create_object;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
     AbilityCondition, CastManaObjectScope, CastManaSpentMetric, Comparator, Effect, QuantityExpr,
     QuantityRef,
 };
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
 
 const NIX_ORACLE: &str = "Counter target spell if no mana was spent to cast it.";
 
@@ -33,4 +42,127 @@ fn nix_parses_counter_with_target_no_mana_spent_condition() {
             rhs: QuantityExpr::Fixed { value: 0 },
         })
     ));
+}
+
+/// Place an opponent **creature** spell on the stack as a fixture, recording the
+/// amount of mana spent to cast it. Returns the stack object's id.
+///
+/// A creature (permanent) spell gives a clean, unambiguous counter signal:
+/// - countered (CR 701.6a) → its owner's graveyard;
+/// - resolved normally (CR 608.3a) → the battlefield.
+///
+/// An instant/sorcery fixture would be useless here, because a *resolved*
+/// instant also ends in the graveyard (CR 608.2m) — indistinguishable from a
+/// countered one.
+///
+/// CR 601.2a + CR 106.6: the cast pipeline records the mana actually spent on
+/// the spell object (`mana_spent_to_cast_amount`); Nix reads that tally from the
+/// *targeted* spell via `CastManaObjectScope::AbilityTarget`.
+fn put_creature_spell_on_stack(
+    runner: &mut engine::game::scenario::GameRunner,
+    controller: PlayerId,
+    name: &str,
+    card_id: CardId,
+    mana_spent_to_cast: u32,
+) -> ObjectId {
+    let id = create_object(
+        runner.state_mut(),
+        card_id,
+        controller,
+        name.to_string(),
+        Zone::Stack,
+    );
+    {
+        let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(2);
+        obj.toughness = Some(2);
+        obj.base_power = Some(2);
+        obj.base_toughness = Some(2);
+        // CR 106.6 / CR 601.2h: the spell's recorded mana-spent tally — the
+        // exact value Nix's intervening-if reads via `AbilityTarget`.
+        obj.mana_spent_to_cast = mana_spent_to_cast > 0;
+        obj.mana_spent_to_cast_amount = mana_spent_to_cast;
+    }
+    // `ability: None` — a vanilla permanent spell with no on-resolution effect;
+    // it simply enters the battlefield when it resolves.
+    runner.state_mut().stack.push_back(StackEntry {
+        id,
+        source_id: id,
+        controller,
+        kind: StackEntryKind::Spell {
+            card_id,
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: mana_spent_to_cast,
+        },
+    });
+    id
+}
+
+/// Drive Nix through the cast pipeline at a target creature spell and report the
+/// target's final zone after both spells leave the stack.
+///
+/// Nix is always cast paying its printed {U} (so Nix's *own* recorded
+/// mana-spent tally is 1). Only the targeted spell's tally varies. This isolates
+/// the scope under test: a `SelfObject`/controller-scoped read would always see
+/// Nix's `1` and never satisfy `== 0`, so the counter would never fire and the
+/// creature would always reach the battlefield.
+fn nix_at_target_with_mana_spent(target_mana_spent: u32) -> Zone {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let mut nix_builder = scenario.add_spell_to_hand_from_oracle(P0, "Nix", true, NIX_ORACLE);
+    nix_builder.with_mana_cost(ManaCost::Cost {
+        generic: 0,
+        shards: vec![ManaCostShard::Blue],
+    });
+    let nix = nix_builder.id();
+    // CR 601.2g: fund exactly Nix's {U} so the pipeline records 1 mana spent to
+    // cast Nix itself — the value a mis-scoped read would pick up.
+    scenario.with_mana_pool(P0, vec![ManaUnit::new(ManaType::Blue, nix, false, vec![])]);
+
+    let mut runner = scenario.build();
+
+    let target = put_creature_spell_on_stack(
+        &mut runner,
+        P1,
+        "Opponent Bear",
+        CardId(777),
+        target_mana_spent,
+    );
+
+    let outcome = runner.cast(nix).target_objects(&[target]).resolve();
+    outcome.zone_of(target)
+}
+
+/// Discriminating runtime test for `CastManaObjectScope::AbilityTarget`.
+///
+/// CR 115.1 + CR 601.2h + CR 608.2c: Nix's "if no mana was spent to cast it"
+/// must read the *targeted* spell's mana tally, not Nix's own. The two cases
+/// below straddle the `== 0` boundary on the **target's** tally while Nix's own
+/// tally is held fixed at 1:
+///
+/// - target cast for free (0 mana) → countered → graveyard.
+/// - target cast paying 2 mana → not countered → battlefield.
+///
+/// Were the scope `SelfObject` (Nix itself, tally 1), both cases would read 1,
+/// `1 == 0` would be false, the counter would never fire, and BOTH targets
+/// would reach the battlefield — so the first assertion below would fail. That
+/// makes this test red on a scope revert.
+#[test]
+fn nix_counter_gates_on_targeted_spell_mana_not_nix_own() {
+    // CR 701.6a: countered because the *target's* tally is 0 (read via AbilityTarget).
+    assert_eq!(
+        nix_at_target_with_mana_spent(0),
+        Zone::Graveyard,
+        "Nix must counter a target spell cast with no mana spent"
+    );
+    // CR 608.3a: not countered (target's tally is 2 ≠ 0), so the creature resolves.
+    assert_eq!(
+        nix_at_target_with_mana_spent(2),
+        Zone::Battlefield,
+        "Nix must NOT counter a target spell cast paying mana — it resolves to the battlefield"
+    );
 }

--- a/crates/engine/tests/integration/nix_counter_no_mana_spent.rs
+++ b/crates/engine/tests/integration/nix_counter_no_mana_spent.rs
@@ -1,0 +1,36 @@
+//! Nix — "Counter target spell if no mana was spent to cast it."
+//!
+//! Parser regression: the trailing intervening-if must lower to a
+//! `QuantityCheck` over `ManaSpentToCast { scope: AbilityTarget }`, not
+//! remain as swallowed `Condition_If` text.
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityCondition, CastManaObjectScope, CastManaSpentMetric, Comparator, Effect, QuantityExpr,
+    QuantityRef,
+};
+
+const NIX_ORACLE: &str = "Counter target spell if no mana was spent to cast it.";
+
+#[test]
+fn nix_parses_counter_with_target_no_mana_spent_condition() {
+    let parsed = parse_oracle_text(NIX_ORACLE, "Nix", &[], &["Instant".to_string()], &[]);
+    let ability = parsed
+        .abilities
+        .first()
+        .expect("Nix must parse a spell ability");
+    assert!(matches!(ability.effect.as_ref(), Effect::Counter { .. }));
+    assert!(matches!(
+        ability.condition.as_ref(),
+        Some(AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ManaSpentToCast {
+                    scope: CastManaObjectScope::AbilityTarget,
+                    metric: CastManaSpentMetric::Total,
+                },
+            },
+            comparator: Comparator::EQ,
+            rhs: QuantityExpr::Fixed { value: 0 },
+        })
+    ));
+}


### PR DESCRIPTION
## Summary
- Parse Nix's trailing condition `if no mana was spent to cast it` as `AbilityCondition::QuantityCheck` over `ManaSpentToCast { scope: AbilityTarget }`.
- Add `CastManaObjectScope::AbilityTarget` so resolve-time checks read the targeted spell's recorded mana payment (CR 601.2h + CR 608.2c).
- Nix coverage: supported (gap_count 0).

## Test plan
- [x] `cargo test -p engine no_mana_spent`
- [x] `cargo coverage -- Nix` → supported
- [x] Parser + integration tests for Nix oracle text

## Anchored on
- `oracle_trigger.rs:3504` — `parse_no_mana_spent_clause` trigger intervening-if pattern
- `triggers.rs:5155` — `ManaSpentCondition` runtime evaluation on cast object mana tally

Model: composer-2.5-fast
