### PR TITLE
feat(parser): Halving Season opponent token halving replacement

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4877,6 +4877,9 @@ fn parse_token_replacement(lower: &str, original_text: &str) -> Option<Replaceme
         TokenReplacementShape::Double => {
             def = def.quantity_modification(QuantityModification::Double);
         }
+        TokenReplacementShape::Half => {
+            def = def.quantity_modification(QuantityModification::Half);
+        }
         TokenReplacementShape::PlusSpec { spec } => {
             def = def.additional_token_spec(*spec);
         }
@@ -4886,6 +4889,12 @@ fn parse_token_replacement(lower: &str, original_text: &str) -> Option<Replaceme
     if nom_primitives::scan_contains(lower, "under your control") {
         def = def.token_owner_scope(ControllerRef::You);
     }
+    // Halving Season class: "If an opponent would create …"
+    if nom_primitives::scan_contains(lower, "an opponent would create")
+        || nom_primitives::scan_contains(lower, "opponent would create")
+    {
+        def = def.token_owner_scope(ControllerRef::Opponent);
+    }
 
     Some(def)
 }
@@ -4893,6 +4902,8 @@ fn parse_token_replacement(lower: &str, original_text: &str) -> Option<Replaceme
 enum TokenReplacementShape {
     /// "twice that many tokens … are created instead" (Doubling Season).
     Double,
+    /// "half that many … tokens … instead, rounded down" (Halving Season).
+    Half,
     /// "those tokens plus [spec] are created instead" (Chatterfang, Donatello).
     PlusSpec {
         spec: Box<crate::types::proposed_event::TokenSpec>,
@@ -4903,6 +4914,11 @@ enum TokenReplacementShape {
 /// `nom_on_lower` for case-preserving parsing and delegates token-spec
 /// extraction to the existing `parse_token_description` building block.
 fn parse_token_replacement_shape(lower: &str) -> Option<TokenReplacementShape> {
+    // "half that many" → Halving Season token-halving pattern.
+    if nom_primitives::scan_contains(lower, "half that many") {
+        return Some(TokenReplacementShape::Half);
+    }
+
     // "twice that many" → Doubling Season pattern.
     if nom_on_lower(lower, lower, |i| {
         let (i, _) = take_until::<_, _, OracleError<'_>>("twice that many").parse(i)?;
@@ -12355,6 +12371,18 @@ mod tests {
         .expect("halving season");
         assert_eq!(def.quantity_modification, Some(QuantityModification::Half));
         assert_eq!(def.valid_player, Some(ReplacementPlayerScope::Opponent));
+    }
+
+    #[test]
+    fn parses_halving_season_opponent_token_replacement() {
+        let def = parse_replacement_line(
+            "If an opponent would create one or more tokens, they create half that many of each of those kinds of tokens instead, rounded down.",
+            "Halving Season",
+        )
+        .expect("Halving Season token halving must parse");
+        assert_eq!(def.event, ReplacementEvent::CreateToken);
+        assert_eq!(def.quantity_modification, Some(QuantityModification::Half));
+        assert_eq!(def.token_owner_scope, Some(ControllerRef::Opponent));
     }
 }
 


### PR DESCRIPTION
## Summary
- Parse opponent-scoped token creation halving via `QuantityModification::Half`
- Set `token_owner_scope: Opponent` for Halving Season wording

## Token score
Completes Halving Season CreateToken arm — high leverage shared half-that-many token primitive.

## Test plan
- [x] `cargo test -p engine --lib parses_halving_season_opponent_token`

Closes https://github.com/phase-rs/phase/issues/3494. Related #3396.

Made with [Cursor](https://cursor.com)