### PR TITLE
test(parser): planeswalker inverted counter prohibition regression

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -12347,6 +12347,41 @@ mod tests {
     }
 
     #[test]
+    fn inverted_counter_prohibition_planeswalkers() {
+        let def = parse_replacement_line(
+            "Planeswalkers can't have counters put on them.",
+            "Test Card",
+        )
+        .expect("planeswalker counter prohibition must parse");
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Prevent)
+        );
+        assert!(matches!(
+            def.valid_card,
+            Some(TargetFilter::Typed(tf))
+                if tf.type_filters == vec![TypeFilter::Planeswalker]
+        ));
+    }
+
+    #[test]
+    fn inverted_counter_prohibition_artifacts() {
+        let def = parse_replacement_line("Artifacts can't have counters put on them.", "Test Card")
+            .expect("artifact counter prohibition must parse");
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Prevent)
+        );
+        assert!(matches!(
+            def.valid_card,
+            Some(TargetFilter::Typed(tf))
+                if tf.type_filters == vec![TypeFilter::Artifact]
+        ));
+    }
+
+    #[test]
     fn parses_halving_season_opponent_counter_replacement() {
         let def = parse_replacement_line(
             "If an opponent would put one or more counters on a permanent or player, they put half that many of those counters on that permanent or player instead, rounded down.",


### PR DESCRIPTION
## Summary
- Add `inverted_counter_prohibition_planeswalkers` regression test

## Test plan
- [x] `cargo test -p engine --lib inverted_counter_prohibition_planeswalkers`

Closes https://github.com/phase-rs/phase/issues/3500. Closes #3453.

Made with [Cursor](https://cursor.com)