### PR TITLE
fix(parser): UNSUPPORTED cluster: Granted 'next spell has cascade' + you-may-planeswalk rider, and g

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13350,6 +13350,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::GrantNextSpellAbility {
                 modifier: NextSpellModifier::WithoutPayingManaCost,
+                player: PlayerScope::Controller,
                 spell_filter: None,
             },
             vec![],
@@ -13393,6 +13394,83 @@ mod tests {
         }
         assert_eq!(state.stack.len(), 1);
         assert!(state.pending_next_spell_modifiers.is_empty());
+    }
+
+    /// CR 115.1: a `player: Target` grant (Bigger on the Inside) pushes the
+    /// pending modifier keyed to the TARGETED player, not the controller — so
+    /// "the next spell THEY cast" gains the keyword for the mana recipient.
+    #[test]
+    fn grant_next_spell_target_scope_keys_targeted_player() {
+        use crate::types::ability::ResolvedAbility;
+        use crate::types::keywords::Keyword;
+
+        let mut state = setup_game_at_main_phase();
+        let source = create_object(
+            &mut state,
+            CardId(79),
+            PlayerId(0),
+            "Bigger Source".to_string(),
+            Zone::Battlefield,
+        );
+        // Controller is player 0; the ability targets player 1.
+        let ability = ResolvedAbility::new(
+            Effect::GrantNextSpellAbility {
+                modifier: NextSpellModifier::HasKeyword {
+                    keyword: Keyword::Cascade,
+                },
+                player: PlayerScope::Target,
+                spell_filter: None,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        assert_eq!(state.pending_next_spell_modifiers.len(), 1);
+        assert_eq!(
+            state.pending_next_spell_modifiers[0].player,
+            PlayerId(1),
+            "Target-scope grant must key the targeted player, not the controller"
+        );
+    }
+
+    /// CR 109.5: a `player: Controller` grant keys the controller even when the
+    /// ability also has a player target (e.g. a "you cast" grant chained after
+    /// a targeted clause).
+    #[test]
+    fn grant_next_spell_controller_scope_keys_controller() {
+        use crate::types::ability::ResolvedAbility;
+        use crate::types::keywords::Keyword;
+
+        let mut state = setup_game_at_main_phase();
+        let source = create_object(
+            &mut state,
+            CardId(80),
+            PlayerId(0),
+            "Controller Grant Source".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::GrantNextSpellAbility {
+                modifier: NextSpellModifier::HasKeyword {
+                    keyword: Keyword::Cascade,
+                },
+                player: PlayerScope::Controller,
+                spell_filter: None,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+        assert_eq!(state.pending_next_spell_modifiers.len(), 1);
+        assert_eq!(
+            state.pending_next_spell_modifiers[0].player,
+            PlayerId(0),
+            "Controller-scope grant must key the controller even with a player target"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -6678,21 +6678,39 @@ fn resolve_grant_next_spell_ability(
     ability: &crate::types::ability::ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), crate::types::ability::EffectError> {
-    let (modifier, spell_filter) = match &ability.effect {
+    let (modifier, player_scope, spell_filter) = match &ability.effect {
         Effect::GrantNextSpellAbility {
             modifier,
+            player,
             spell_filter,
-        } => (modifier.clone(), spell_filter.clone()),
+        } => (modifier.clone(), player.clone(), spell_filter.clone()),
         _ => {
             return Err(crate::types::ability::EffectError::MissingParam(
                 "GrantNextSpellAbility".to_string(),
             ))
         }
     };
+    // CR 115.1: "they cast / that player casts" (PlayerScope::Target) = the
+    // player this ability targets — the mana-clause recipient on Bigger on the
+    // Inside, inherited onto this SequentialSibling via chain target
+    // propagation. CR 109.5: every other scope = the effect's controller
+    // ("the next spell you cast"). Exhaustive over PlayerScope (no `_`), so any
+    // future variant forces a maintainer to re-confirm its next-spell semantics.
+    let player = match player_scope {
+        PlayerScope::Target => ability.target_player(),
+        PlayerScope::Controller
+        | PlayerScope::ScopedPlayer
+        | PlayerScope::Opponent { .. }
+        | PlayerScope::AllPlayers { .. }
+        | PlayerScope::RecipientController
+        | PlayerScope::DefendingPlayer
+        | PlayerScope::ParentObjectTargetController
+        | PlayerScope::SourceChosenPlayer => ability.controller,
+    };
     state
         .pending_next_spell_modifiers
         .push(crate::types::game_state::PendingNextSpellModifier {
-            player: ability.controller,
+            player,
             modifier,
             spell_filter,
         });

--- a/crates/engine/src/game/gap_analysis.rs
+++ b/crates/engine/src/game/gap_analysis.rs
@@ -51,6 +51,7 @@ const IMPERATIVE_EXTRA_VERBS: &[&str] = &[
     "switch",
     "populate",
     "clash",
+    "planeswalk",
 ];
 
 /// Pre-dispatch verbs handled in `parse_effect_clause` before imperative dispatch.

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6536,6 +6536,26 @@ pub(super) fn parse_imperative_family_ast(
         .parse(lower)
         .ok()
         .map(|(_, ast)| ast),
+        // CR 701.31c: "planeswalk" — an ability instructs a player to
+        // planeswalk (TARDIS, Start the TARDIS, TARDIS Bay). Rules-correct
+        // no-op outside a Planechase game (CR 701.31a); handled by
+        // effects::planeswalk via game::planechase. The "you may " / "then "
+        // prefix and the `optional` flag are already stripped upstream, so the
+        // family parser sees only the bare verb body for both the optional
+        // (TARDIS, Start the TARDIS) and mandatory (TARDIS Bay) forms. The
+        // anchored all-consuming guard prevents matching a longer clause.
+        "planeswalk" | "planeswalks" => all_consuming(terminated(
+            // Longer alternative first so "planeswalks" matches the full token
+            // before the "planeswalk" prefix can short-circuit the `alt`.
+            alt((
+                tag::<_, _, OracleError<'_>>("planeswalks"),
+                tag("planeswalk"),
+            )),
+            opt(tag(".")),
+        ))
+        .parse(lower.trim())
+        .ok()
+        .map(|_| ImperativeFamilyAst::Planeswalk),
         // CR 500.7: "take an extra turn after this one"
         // CR 726.1: "take the initiative"
         "take" | "takes" => {
@@ -7790,6 +7810,8 @@ fn lower_imperative_family_effect(ast: ImperativeFamilyAst) -> Effect {
             dungeon: crate::game::dungeon::DungeonId::Undercity,
         },
         ImperativeFamilyAst::TakeTheInitiative => Effect::TakeTheInitiative,
+        // CR 701.31c: An ability instructs a player to planeswalk.
+        ImperativeFamilyAst::Planeswalk => Effect::Planeswalk,
         ImperativeFamilyAst::OpenAttractions { count } => Effect::OpenAttractions { count },
         ImperativeFamilyAst::RollToVisitAttractions => Effect::RollToVisitAttractions,
         ImperativeFamilyAst::Proliferate => Effect::Proliferate,
@@ -13086,6 +13108,67 @@ mod tests {
         assert_eq!(
             replace_fixed_quantity(dynamic_base.clone(), for_each),
             dynamic_base,
+        );
+    }
+
+    /// CR 701.31c: the bare "planeswalk" verb dispatches to the
+    /// `Planeswalk` imperative-family leaf (the "you may " / "then " prefix and
+    /// the optional flag are stripped upstream, so the family parser only ever
+    /// sees the bare verb body).
+    #[test]
+    fn planeswalk_verb_dispatches_to_planeswalk_leaf() {
+        // The family parser sees the bare verb body (subject + optional-prefix +
+        // trailing-period normalization happen upstream — see the end-to-end
+        // `parse_effect_chain` tests below for the "you may planeswalk." /
+        // "then planeswalk." forms). Both singular and plural verb tokens map to
+        // the same leaf.
+        for input in ["planeswalk", "planeswalks"] {
+            let ast = parse_imperative_family_ast(input, input, &mut ParseContext::default())
+                .unwrap_or_else(|| panic!("'{input}' should parse to a Planeswalk leaf"));
+            assert!(
+                matches!(ast, ImperativeFamilyAst::Planeswalk),
+                "expected Planeswalk leaf for '{input}', got {ast:?}"
+            );
+        }
+    }
+
+    /// CR 701.31c: "you may planeswalk" → optional `Effect::Planeswalk`
+    /// (TARDIS, Start the TARDIS rider). The optional shell is produced by the
+    /// upstream optional-prefix strip.
+    #[test]
+    fn effect_you_may_planeswalk_is_optional_planeswalk() {
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "You may planeswalk.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(*def.effect, Effect::Planeswalk),
+            "expected Effect::Planeswalk, got {:?}",
+            def.effect
+        );
+        assert!(
+            def.optional,
+            "expected optional: true for 'you may planeswalk'"
+        );
+    }
+
+    /// CR 701.31c: "Then planeswalk." → mandatory `Effect::Planeswalk`
+    /// (TARDIS Bay). The mandatory form must parse to the same effect with
+    /// `optional: false`.
+    #[test]
+    fn effect_then_planeswalk_is_mandatory_planeswalk() {
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "Then planeswalk.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(*def.effect, Effect::Planeswalk),
+            "expected Effect::Planeswalk, got {:?}",
+            def.effect
+        );
+        assert!(
+            !def.optional,
+            "expected optional: false for 'then planeswalk'"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1456,6 +1456,25 @@ fn try_parse_reduce_next_spell_cost(tp: TextPair) -> Option<ParsedEffectClause> 
     }))
 }
 
+/// CR 601.2f + CR 115.1: subject of a next-spell limiter — whose next spell is
+/// modified. "you cast" / "of the chosen type you cast" resolve to the
+/// controller; "they cast" / "that player casts" resolve to the player this
+/// ability targets. The two `Controller` arms come first so `ReduceNextSpellCost`
+/// and every existing "you cast" grant continue to parse under
+/// `PlayerScope::Controller`.
+fn parse_next_spell_subject(input: &str) -> OracleResult<'_, PlayerScope> {
+    alt((
+        value(PlayerScope::Controller, tag("you cast this turn ")),
+        value(
+            PlayerScope::Controller,
+            tag("of the chosen type you cast this turn "),
+        ),
+        value(PlayerScope::Target, tag("they cast this turn ")),
+        value(PlayerScope::Target, tag("that player casts this turn ")),
+    ))
+    .parse(input)
+}
+
 /// CR 601.2f: Parse "the next [type] spell you cast this turn [has keyword/can't be countered/etc.]"
 ///
 /// Handles patterns like:
@@ -1464,6 +1483,7 @@ fn try_parse_reduce_next_spell_cost(tp: TextPair) -> Option<ParsedEffectClause> 
 /// - "the next sorcery spell you cast this turn can be cast as though it had flash"
 /// - "the next instant or sorcery spell you cast this turn has cascade"
 /// - "the next face-down creature spell you cast this turn costs {3} less to cast"
+/// - "the next spell they cast this turn has cascade" (granted to a targeted player)
 fn try_parse_grant_next_spell_ability(tp: TextPair) -> Option<ParsedEffectClause> {
     // Must start with "the next "
     let rest = tag::<_, _, OracleError<'_>>("the next ")
@@ -1474,13 +1494,23 @@ fn try_parse_grant_next_spell_ability(tp: TextPair) -> Option<ParsedEffectClause
     // Extract optional spell type filter before "spell you cast this turn"
     // Patterns: "spell you cast this turn", "creature spell you cast this turn",
     // "instant or sorcery spell you cast this turn", "noncreature spell you cast this turn",
-    // "face-down creature spell you cast this turn"
-    let (ability_text, filter_text) = nom::sequence::terminated(
+    // "face-down creature spell you cast this turn", and the third-person
+    // subject variants ("spell they cast this turn", "spell that player casts
+    // this turn") for grants to a targeted player.
+    //
+    // `filter_text` is the `take_until("spell")` capture — the spell-type
+    // filter slice ("creature ", "instant or sorcery ", "noncreature ", …)
+    // fed to parse_type_phrase below. Preserving it is REQUIRED: dropping it
+    // regresses filtered next-spell grants to no filter. `scope` is the parsed
+    // subject (you = Controller, they/that player = Target). `pair` keeps BOTH
+    // the `take_until` slice and the `parse_next_spell_subject` output — unlike
+    // `terminated`, which would discard the subject scope.
+    let (ability_text, (filter_text, scope)) = nom::sequence::pair(
         take_until::<_, _, OracleError<'_>>("spell"),
-        alt((
-            tag::<_, _, OracleError<'_>>("spell you cast this turn "),
-            tag("spell of the chosen type you cast this turn "),
-        )),
+        preceded(
+            tag::<_, _, OracleError<'_>>("spell "),
+            parse_next_spell_subject,
+        ),
     )
     .parse(rest)
     .ok()?;
@@ -1503,6 +1533,7 @@ fn try_parse_grant_next_spell_ability(tp: TextPair) -> Option<ParsedEffectClause
     {
         return Some(parsed_clause(Effect::GrantNextSpellAbility {
             modifier: NextSpellModifier::CantBeCountered,
+            player: scope,
             spell_filter,
         }));
     }
@@ -1514,6 +1545,7 @@ fn try_parse_grant_next_spell_ability(tp: TextPair) -> Option<ParsedEffectClause
     {
         return Some(parsed_clause(Effect::GrantNextSpellAbility {
             modifier: NextSpellModifier::CastAsThoughFlash,
+            player: scope,
             spell_filter,
         }));
     }
@@ -1525,6 +1557,7 @@ fn try_parse_grant_next_spell_ability(tp: TextPair) -> Option<ParsedEffectClause
     {
         return Some(parsed_clause(Effect::GrantNextSpellAbility {
             modifier: NextSpellModifier::WithoutPayingManaCost,
+            player: scope,
             spell_filter,
         }));
     }
@@ -1556,6 +1589,7 @@ fn try_parse_grant_next_spell_ability(tp: TextPair) -> Option<ParsedEffectClause
         if let Some(kw) = keyword {
             return Some(parsed_clause(Effect::GrantNextSpellAbility {
                 modifier: NextSpellModifier::HasKeyword { keyword: kw },
+                player: scope,
                 spell_filter,
             }));
         }
@@ -44324,6 +44358,98 @@ mod tests {
             "Expected GrantNextSpellAbility(WithoutPayingManaCost), got {:?}",
             def.effect
         );
+    }
+
+    #[test]
+    fn parse_next_spell_you_cast_has_controller_scope() {
+        // CR 109.5: "you cast" subject → PlayerScope::Controller.
+        let def = parse_effect_chain(
+            "The next spell you cast this turn has cascade",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                *def.effect,
+                Effect::GrantNextSpellAbility {
+                    modifier: crate::types::game_state::NextSpellModifier::HasKeyword {
+                        keyword: Keyword::Cascade,
+                    },
+                    player: crate::types::ability::PlayerScope::Controller,
+                    ..
+                }
+            ),
+            "Expected GrantNextSpellAbility(Cascade, Controller), got {:?}",
+            def.effect
+        );
+    }
+
+    #[test]
+    fn parse_next_spell_they_cast_has_target_scope() {
+        // CR 115.1: "they cast" subject (Bigger on the Inside) →
+        // PlayerScope::Target (the targeted player whose mana clause precedes).
+        let def = parse_effect_chain(
+            "The next spell they cast this turn has cascade",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                *def.effect,
+                Effect::GrantNextSpellAbility {
+                    modifier: crate::types::game_state::NextSpellModifier::HasKeyword {
+                        keyword: Keyword::Cascade,
+                    },
+                    player: crate::types::ability::PlayerScope::Target,
+                    spell_filter: None,
+                }
+            ),
+            "Expected GrantNextSpellAbility(Cascade, Target), got {:?}",
+            def.effect
+        );
+    }
+
+    #[test]
+    fn parse_next_spell_that_player_casts_has_target_scope() {
+        // CR 115.1: "that player casts" subject → PlayerScope::Target.
+        let def = parse_effect_chain(
+            "The next spell that player casts this turn has cascade",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                *def.effect,
+                Effect::GrantNextSpellAbility {
+                    player: crate::types::ability::PlayerScope::Target,
+                    ..
+                }
+            ),
+            "Expected GrantNextSpellAbility(Target), got {:?}",
+            def.effect
+        );
+    }
+
+    #[test]
+    fn parse_filtered_next_spell_they_cast_preserves_filter() {
+        // Regression guard: the type-filter slice ("creature ") must survive the
+        // subject-combinator rewrite for the third-person subject too — a
+        // filtered "they" grant must keep both Target scope AND the spell filter.
+        let def = parse_effect_chain(
+            "The next creature spell they cast this turn has cascade",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::GrantNextSpellAbility {
+                player,
+                spell_filter,
+                ..
+            } => {
+                assert_eq!(*player, crate::types::ability::PlayerScope::Target);
+                assert!(
+                    spell_filter.is_some(),
+                    "Expected a creature spell_filter, got None"
+                );
+            }
+            other => panic!("Expected GrantNextSpellAbility, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -489,6 +489,10 @@ pub(crate) enum ImperativeFamilyAst {
     VentureIntoUndercity,
     /// CR 725: "take the initiative"
     TakeTheInitiative,
+    /// CR 701.31c: An ability instructs a player to planeswalk (TARDIS, Start
+    /// the TARDIS, TARDIS Bay). Resolves to a no-op outside a Planechase game
+    /// (CR 701.31a).
+    Planeswalk,
     /// CR 701.51b: "open N Attractions"
     OpenAttractions {
         count: u32,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8160,6 +8160,12 @@ pub enum Effect {
     /// Creates a one-shot modifier applied when the player casts their next qualifying spell.
     GrantNextSpellAbility {
         modifier: crate::types::game_state::NextSpellModifier,
+        /// CR 601.2f + CR 115.1: whose next spell receives the modifier.
+        /// `Controller` = "the next spell you cast"; `Target` = "the next
+        /// spell they cast / that player casts" (the player this ability
+        /// targets, e.g. the mana recipient on Bigger on the Inside).
+        #[serde(default = "default_player_scope_controller")]
+        player: PlayerScope,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         spell_filter: Option<TargetFilter>,
     },
@@ -9078,6 +9084,13 @@ fn default_quantity_one() -> QuantityExpr {
 
 fn default_duration_until_end_of_turn() -> Duration {
     Duration::UntilEndOfTurn
+}
+
+/// CR 109.5: backward-compatible serde default for `Effect::GrantNextSpellAbility`'s
+/// `player` field — pre-field data and "the next spell YOU cast" grants resolve to
+/// the controller.
+fn default_player_scope_controller() -> PlayerScope {
+    PlayerScope::Controller
 }
 
 fn default_comparator_ge() -> Comparator {


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 2 card(s) in the Doctor Who Commander precons.

**Root cause:** UNSUPPORTED cluster: Granted 'next spell has cascade' + you-may-planeswalk rider, and granting cascade to others' spells (NextSpellModifier / GrantNextSpellAbility)

## Cards corrected
- TARDIS
- Bigger on the Inside

## Fix
Implemented WHO misparse cluster #37 surgically on worktree phase-main-base @ 22387c5f1, exactly per the approved plan. Two independent parser-dispatch gaps were closed onto existing runtime, with no new effect/handler/runtime infrastructure required.

GAP 1 — "planeswalk" verb dispatch (covers TARDIS, Start the TARDIS, TARDIS Bay). Added an ImperativeFamilyAst::Planeswalk leaf (ast.rs), a nom verb arm in parse_imperative_family_ast mirroring the venture/end-the-turn precedent (all_consuming(terminated(alt((tag("planeswalks"), tag("planeswalk"))), opt(tag("."))))), a lowering arm to the pre-existing Effect::Planeswalk, and registered "planeswalk" in IMPERATIVE_EXTRA_VERBS. Both the optional ("you may planeswalk" -> optional:true) and mandatory ("then planeswalk" -> optional:false) forms now parse, because the optional shell is set upstream by strip_optional_effect_prefix.

GAP 2 — subject-scoped next-spell grant (covers Bigger on the Inside's "the next spell they cast this turn has cascade"). Added a player: PlayerScope field to Effect::GrantNextSpellAbility (serde-defaulted to Controller via a new default fn). Introduced a parse_next_spell_subject nom combinator (value/tag/alt; two Controller arms first so ReduceNextSpellCost and existing "you cast" grants are unaffected), and rewrote the subject parse to nom::sequence::pair(take_until("spell"), preceded(tag("spell "), parse_next_spell_subject)) — critically KEEPING the take_until("spell") capture as filter_text (used pair, not terminated, so both the type-filter slice AND the PlayerScope are captured; verified the creature/noncreature/instant-or-sorcery filter is preserved). Threaded player: scope through all four constructors. Rewrote resolve_grant_next_spell_ability to destructure player and resolve EXHAUSTIVELY over the 9 real PlayerScope variants (Target -> ability.target_player(); the other 8 -> ability.controller; no wildcard, no non-existent TargetController). The targeted player's TargetRef is inherited onto the SequentialSibling grant via the confirmed chain target-inheritance, and the casting-time application path (keyed entry.player == caster) was left untouched.

Re-parse after card-data regen: all 4 cards now yield ZERO Unimplemented/Unknown on the targeted clauses. TARDIS = GrantNextSpellAbility{HasKeyword Cascade} + sub Planeswalk{optional:true}; Start the TARDIS = Planeswalk; TARDIS Bay = Planeswalk{mandatory}; Bigger on the Inside granted ability = Mana{target:Player} + GrantNextSpellAbility{HasKeyword Cascade, player:Target}.

Constructor-edit set was exactly as the plan's reconciliation predicted: 5 explicit struct literals (mod.rs x4 + casting.rs #[cfg(test)] x1) + 1 resolver destructure; the 7 matches! test patterns use `..` and needed no edit (confirmed independently by codebase-wide grep — the only other GrantNextSpellAbility sites all use `{ .. }`).

Added building-block tests: parser (Controller/Target/that-player scopes + a filtered-"they" regression guard proving the type-filter slice survives), imperative (bare verb -> Planeswalk leaf; you-may/then end-to-end optional flag), and effect-handler resolver tests (Target-scope keys the targeted player; Controller-scope keys controller even with a player target).

VERIFICATION: cargo fmt clean; cargo clippy -p engine --all-targets -D warnings clean (exit 0); cargo test -p engine --lib = 12199 passed / 0 failed. Three tests (Cathars' Crusade, Walking Ballista, station synthesis) failed BEFORE my card-data regen due to a STALE on-disk card-data.json containing an orphaned StaticMode::CountersPersistAcrossZones variant (another agent's in-flight work — that variant does not exist in current source). Regenerating card-data from current source per the plan's verification cadence refreshed the export and all 3 pass; they never touched any code I modified. Parser combinator gate: my working-tree parser changes contain ZERO string dispatch (verified via targeted git diff HEAD); the repo-wide check-parser-combinators.sh exit 1 is driven entirely by pre-existing branch-history diffs in 12 parser files I never touched (it diffs against an ancient merge-base ff799f899). Did NOT commit. Left the pre-existing working-tree modification to known-tokens.toml untouched (it was M at session start, not my edit).

## Files changed
- crates/engine/src/parser/oracle_ir/ast.rs
- crates/engine/src/parser/oracle_effect/imperative.rs
- crates/engine/src/game/gap_analysis.rs
- crates/engine/src/types/ability.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/game/effects/mod.rs
- crates/engine/src/game/casting.rs

## CR references
- CR 701.31a (line 3564): planeswalk only during a Planechase game — no-op-outside-Planechase rationale
- CR 701.31c (line 3568): abilities may instruct a player to planeswalk — parser producing Effect::Planeswalk
- CR 601.2f (line 2466): total cost / next-spell-modifier creation — GrantNextSpellAbility
- CR 109.5 (line 610): 'you/your' refer to the object's controller — PlayerScope::Controller and the 7 other non-target scopes resolve to controller
- CR 115.1 (line 836): targets are object(s)/player(s) the spell or ability will affect — PlayerScope::Target resolves to the targeted player (corrected from the original plan's erroneous CR 109.4, which is actually 'only stack/battlefield objects have a controller')

## Verification
- `cargo fmt --all` — pass
- `./scripts/check-parser-combinators.sh <upstream/main merge-base 22387c5f>` — pass
- `cargo clippy -p engine --all-targets -- -D warnings` — pass
- `cargo test -p engine` — pass
- `cargo run --profile tool --features cli --bin oracle-gen -- data --filter "tardis|bigger on the inside"` — pass
Cards confirmed re-parsed correctly: tardis, bigger on the inside

🤖 Generated with [Claude Code](https://claude.com/claude-code)
