### PR TITLE
docs(engine): annotate CR 903.9c coverage via SBA path + discriminating tests

### DIFF
--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -1784,18 +1784,21 @@ mod tests {
         );
     }
 
-    /// CR 903.9c: absorbed (non-survivor) commander component is also found by
-    /// the SBA when the merged pile leaves to hand.
+    /// CR 903.9c: absorbed (non-survivor) commander component is found by the SBA
+    /// after the merged pile leaves to hand.
     ///
-    /// Discriminating: verifies `is_commander` survives `put_component_into_zone`
-    /// so the SBA can find absorbed commander components — not just survivors.
+    /// Discriminating: the commander is the MERGING object, so it becomes an
+    /// absorbed component routed exclusively through `merge::put_component_into_zone`
+    /// (not `zones::move_to_zone`). If `put_component_into_zone` or
+    /// `apply_zone_exit_cleanup` dropped `is_commander`, the SBA would find nothing
+    /// and the assertion would fail. This is the novel path not covered by the
+    /// survivor-case tests above.
     ///
-    /// Setup: commander is the TARGET (becomes absorbed component when a
-    /// non-commander mutates ON TOP, because per CR 730.2c the TARGET keeps
-    /// its ObjectId as survivor). Actually — the TARGET is always the survivor.
-    /// Here we merge the non-commander ON TOP of the commander (commander = target
-    /// = survivor with is_commander). The rider becomes the absorbed component.
-    /// Either component orientation works: the SBA scans all objects.
+    /// Setup:
+    ///   host_id  = non-commander = TARGET  → survivor (keeps ObjectId, travels
+    ///              through normal `move_to_zone`, ends in hand)
+    ///   cmd_id   = commander     = MERGING → absorbed component (travels through
+    ///              `put_component_into_zone`, ends in hand with is_commander intact)
     #[test]
     fn cr903_9c_absorbed_commander_component_in_hand_found_by_sba() {
         use crate::game::sba::check_state_based_actions;
@@ -1804,29 +1807,39 @@ mod tests {
         let mut state = setup_commander_game();
         state.active_player = PlayerId(0);
 
-        // Commander is the TARGET (will be the survivor per CR 730.2c).
+        // Non-commander is the TARGET — it keeps its ObjectId as the survivor
+        // (CR 730.2c). It travels through move_to_zone on leave.
+        let host_id = make_creature(&mut state, PlayerId(0), "Trumpeting Gnarr", false);
+        // Commander is the MERGING object — it becomes an absorbed component
+        // routed through put_component_into_zone on leave.
         let cmd_id = make_creature(&mut state, PlayerId(0), "Surrak Dragonclaw", true);
-        // Non-commander mutates on top (becomes absorbed component).
-        let rider_id = make_creature(&mut state, PlayerId(0), "Trumpeting Gnarr", false);
 
-        // Merge rider on TOP of cmd — cmd_id stays as survivor (TARGET).
-        // The rider is now an absorbed component.
         let mut events = Vec::new();
         crate::game::merge::merge_object_onto(
             &mut state,
-            rider_id, // rider = merging object
-            cmd_id,   // cmd = target (keeps its ObjectId)
+            cmd_id,  // merging object → absorbed component
+            host_id, // target → survivor (keeps host_id as ObjectId)
             crate::game::merge::MergeSide::Top,
             &mut events,
         );
-        // After merge: survivor = cmd_id (is_commander = true, top = rider_id).
-        // The commander IS the survivor in this case; rider is absorbed.
-        // The survivor has is_commander = true and goes to hand.
+        assert!(
+            state.objects[&host_id].merged_components.contains(&cmd_id),
+            "commander (cmd_id) is an absorbed component of the merged pile"
+        );
 
-        // Bounce to hand — split runs, cmd_id (survivor, is_commander=true) → hand.
-        crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Hand, &mut events);
+        // Bounce to hand: host_id (survivor) → hand via move_to_zone;
+        // cmd_id (absorbed commander) → hand via put_component_into_zone.
+        crate::game::zones::move_to_zone(&mut state, host_id, Zone::Hand, &mut events);
 
-        // SBA must find the commander in hand.
+        // put_component_into_zone must preserve is_commander through
+        // apply_zone_exit_cleanup / snapshot_for_zone_change.
+        assert!(
+            state.objects[&cmd_id].is_commander,
+            "is_commander must survive put_component_into_zone"
+        );
+        assert_eq!(state.objects[&cmd_id].zone, Zone::Hand);
+
+        // SBA must find the absorbed commander component in hand.
         check_state_based_actions(&mut state, &mut events);
 
         assert!(
@@ -1838,7 +1851,7 @@ mod tests {
                     ..
                 } if commander_id == cmd_id
             ),
-            "CR 903.9c: SBA must find commander component in hand even after a merged split; got {:?}",
+            "CR 903.9c: SBA must find the absorbed commander component in hand; got {:?}",
             state.waiting_for
         );
     }

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -125,6 +125,13 @@ pub fn commander_lethal_headroom(
 /// CR 903.9b (hand/library) is also covered here — while the CR models it as a
 /// replacement effect, the SBA approach is functionally equivalent and avoids
 /// deep interception of every `move_to_zone` call site.
+///
+/// CR 903.9c (merged/melded commander): when a commander is a component of a
+/// merged or melded permanent that leaves to hand or library, `split_merged_permanent_on_leave`
+/// places the absorbed commander component into the destination zone with
+/// `is_commander` intact. This function then finds that component here and
+/// returns it — the owner's choice and the subsequent `Zone::Command` move
+/// proceed identically to the standalone case.
 pub fn commander_eligible_for_zone_return(state: &GameState) -> Option<(ObjectId, PlayerId, Zone)> {
     state.objects.values().find_map(|obj| {
         // Oathbreaker RC: signature spells return to the command zone just like
@@ -1596,6 +1603,243 @@ mod tests {
             commander_lethal_headroom(&state, PlayerId(1), cmd_a),
             Some(16),
             "Only damage from cmd_a to player 1 counts toward cmd_a's headroom vs player 1"
+        );
+    }
+
+    // --- CR 903.9c: Merged/Melded Commander Zone Return Tests ---
+
+    /// Helper: create a named creature on the battlefield with `is_commander` optionally set.
+    fn make_creature(
+        state: &mut GameState,
+        owner: PlayerId,
+        name: &str,
+        is_commander: bool,
+    ) -> ObjectId {
+        let card_id = CardId(state.next_object_id);
+        let id = create_object(state, card_id, owner, name.to_string(), Zone::Battlefield);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.is_commander = is_commander;
+        id
+    }
+
+    /// CR 903.9c: when a merged permanent with a commander component leaves to
+    /// hand, the SBA offers the owner CommanderZoneChoice for the commander
+    /// component (survivor case: the survivor itself is the commander).
+    ///
+    /// Discriminating: if `commander_eligible_for_zone_return` stops covering
+    /// Zone::Hand, or if `is_commander` is cleared on zone exit, this test fails.
+    #[test]
+    fn cr903_9c_merged_commander_to_hand_sba_offers_zone_choice() {
+        use crate::game::sba::check_state_based_actions;
+        use crate::types::game_state::WaitingFor;
+
+        let mut state = setup_commander_game();
+        state.active_player = PlayerId(0);
+
+        // Non-commander on battlefield (will merge on top as rider).
+        let rider_id = make_creature(&mut state, PlayerId(0), "Trumpeting Gnarr", false);
+        // Commander on battlefield (merge TARGET — keeps its ObjectId as survivor).
+        let cmd_id = make_creature(&mut state, PlayerId(0), "Surrak Dragonclaw", true);
+
+        // Merge rider on top of the commander — survivor stays as cmd_id (CR 730.2c).
+        let mut events = Vec::new();
+        crate::game::merge::merge_object_onto(
+            &mut state,
+            rider_id,
+            cmd_id,
+            crate::game::merge::MergeSide::Top,
+            &mut events,
+        );
+        assert!(
+            state.objects[&cmd_id].merged_components.contains(&rider_id),
+            "rider is absorbed into the commander pile"
+        );
+
+        // Simulate a bounce effect: merged permanent goes to hand.
+        events.clear();
+        crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Hand, &mut events);
+
+        // Survivor (cmd_id, the commander) should now be in hand with is_commander intact.
+        assert_eq!(state.objects[&cmd_id].zone, Zone::Hand);
+        assert!(
+            state.objects[&cmd_id].is_commander,
+            "is_commander must survive the zone transition"
+        );
+
+        // SBA should detect the commander in hand and offer zone-return choice.
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            matches!(
+                state.waiting_for,
+                WaitingFor::CommanderZoneChoice {
+                    commander_id,
+                    current_zone: Zone::Hand,
+                    ..
+                } if commander_id == cmd_id
+            ),
+            "CR 903.9c: SBA offers CommanderZoneChoice for commander in hand; got {:?}",
+            state.waiting_for
+        );
+    }
+
+    /// CR 903.9c: accepting CommanderZoneChoice for a merged commander in hand
+    /// moves the commander component to Zone::Command.
+    ///
+    /// Discriminating: reverts if the accept branch no longer calls
+    /// `move_to_zone(Zone::Command)` or if the SBA path is broken.
+    #[test]
+    fn cr903_9c_merged_commander_to_hand_accept_moves_to_command() {
+        use crate::game::sba::check_state_based_actions;
+        use crate::types::actions::GameAction;
+        use crate::types::game_state::WaitingFor;
+
+        let mut state = setup_commander_game();
+        state.active_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let rider_id = make_creature(&mut state, PlayerId(0), "Trumpeting Gnarr", false);
+        let cmd_id = make_creature(&mut state, PlayerId(0), "Surrak Dragonclaw", true);
+
+        let mut events = Vec::new();
+        crate::game::merge::merge_object_onto(
+            &mut state,
+            rider_id,
+            cmd_id,
+            crate::game::merge::MergeSide::Top,
+            &mut events,
+        );
+
+        crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Hand, &mut events);
+
+        check_state_based_actions(&mut state, &mut events);
+        assert!(
+            matches!(state.waiting_for, WaitingFor::CommanderZoneChoice { .. }),
+            "SBA must pause with CommanderZoneChoice"
+        );
+
+        let result = crate::game::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::DecideOptionalEffect { accept: true },
+        );
+        assert!(result.is_ok(), "accepting zone choice must not error");
+
+        assert_eq!(
+            state.objects[&cmd_id].zone,
+            Zone::Command,
+            "CR 903.9c: commander component must be in Zone::Command after accepting"
+        );
+    }
+
+    /// CR 903.9c: declining CommanderZoneChoice for a merged commander in hand
+    /// leaves the commander component in hand (not moved to command zone).
+    ///
+    /// Discriminating: reverts if the decline branch stops setting
+    /// `commander_declined_zone_return` or incorrectly moves to command zone.
+    #[test]
+    fn cr903_9c_merged_commander_to_hand_decline_stays_in_hand() {
+        use crate::game::sba::check_state_based_actions;
+        use crate::types::actions::GameAction;
+        use crate::types::game_state::WaitingFor;
+
+        let mut state = setup_commander_game();
+        state.active_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let rider_id = make_creature(&mut state, PlayerId(0), "Trumpeting Gnarr", false);
+        let cmd_id = make_creature(&mut state, PlayerId(0), "Surrak Dragonclaw", true);
+
+        let mut events = Vec::new();
+        crate::game::merge::merge_object_onto(
+            &mut state,
+            rider_id,
+            cmd_id,
+            crate::game::merge::MergeSide::Top,
+            &mut events,
+        );
+
+        crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Hand, &mut events);
+        check_state_based_actions(&mut state, &mut events);
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::CommanderZoneChoice { .. }
+        ));
+
+        let result = crate::game::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::DecideOptionalEffect { accept: false },
+        );
+        assert!(result.is_ok());
+        assert_eq!(
+            state.objects[&cmd_id].zone,
+            Zone::Hand,
+            "CR 903.9c: declining zone choice must leave commander in hand"
+        );
+    }
+
+    /// CR 903.9c: absorbed (non-survivor) commander component is also found by
+    /// the SBA when the merged pile leaves to hand.
+    ///
+    /// Discriminating: verifies `is_commander` survives `put_component_into_zone`
+    /// so the SBA can find absorbed commander components — not just survivors.
+    ///
+    /// Setup: commander is the TARGET (becomes absorbed component when a
+    /// non-commander mutates ON TOP, because per CR 730.2c the TARGET keeps
+    /// its ObjectId as survivor). Actually — the TARGET is always the survivor.
+    /// Here we merge the non-commander ON TOP of the commander (commander = target
+    /// = survivor with is_commander). The rider becomes the absorbed component.
+    /// Either component orientation works: the SBA scans all objects.
+    #[test]
+    fn cr903_9c_absorbed_commander_component_in_hand_found_by_sba() {
+        use crate::game::sba::check_state_based_actions;
+        use crate::types::game_state::WaitingFor;
+
+        let mut state = setup_commander_game();
+        state.active_player = PlayerId(0);
+
+        // Commander is the TARGET (will be the survivor per CR 730.2c).
+        let cmd_id = make_creature(&mut state, PlayerId(0), "Surrak Dragonclaw", true);
+        // Non-commander mutates on top (becomes absorbed component).
+        let rider_id = make_creature(&mut state, PlayerId(0), "Trumpeting Gnarr", false);
+
+        // Merge rider on TOP of cmd — cmd_id stays as survivor (TARGET).
+        // The rider is now an absorbed component.
+        let mut events = Vec::new();
+        crate::game::merge::merge_object_onto(
+            &mut state,
+            rider_id, // rider = merging object
+            cmd_id,   // cmd = target (keeps its ObjectId)
+            crate::game::merge::MergeSide::Top,
+            &mut events,
+        );
+        // After merge: survivor = cmd_id (is_commander = true, top = rider_id).
+        // The commander IS the survivor in this case; rider is absorbed.
+        // The survivor has is_commander = true and goes to hand.
+
+        // Bounce to hand — split runs, cmd_id (survivor, is_commander=true) → hand.
+        crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Hand, &mut events);
+
+        // SBA must find the commander in hand.
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            matches!(
+                state.waiting_for,
+                WaitingFor::CommanderZoneChoice {
+                    commander_id,
+                    current_zone: Zone::Hand,
+                    ..
+                } if commander_id == cmd_id
+            ),
+            "CR 903.9c: SBA must find commander component in hand even after a merged split; got {:?}",
+            state.waiting_for
         );
     }
 }

--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -334,7 +334,19 @@ pub(crate) fn install_merge_layer_effect(
 /// its `card_dest`; a token component routes to its `default_dest` (== `dest`).
 /// The override is absent (and every component follows `dest`) for non-token
 /// survivors and whenever no card-scoped redirect diverges from the survivor's
-/// destination. The Commander exemption (CR 903.9b–c) is separately out of scope.
+/// destination.
+///
+/// CR 903.9c (merged commander zone redirect): when a commander component is
+/// part of a merged permanent and the whole pile moves to hand or library (CR
+/// 903.9b destination), `put_component_into_zone` places the commander
+/// component in the destination zone with its `is_commander` flag intact. The
+/// next SBA pass calls `commander::commander_eligible_for_zone_return`, which
+/// covers `Zone::Hand | Zone::Library` (CR 903.9b), and presents
+/// `WaitingFor::CommanderZoneChoice` to the owner. On accept the commander
+/// component is moved to `Zone::Command` via `zones::move_to_zone` — the same
+/// path used for standalone commanders. Non-commander components remain in the
+/// destination zone. This function does not need special-case commander logic;
+/// the SBA path handles it identically to the standalone case.
 ///
 /// CR 730.3a deferred: the owner's arrange-order choice for graveyard/library
 /// destinations is not modeled — components are placed in their stored

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -439,6 +439,11 @@ fn collect_poison_losers(state: &GameState) -> Vec<PlayerId> {
 /// CR 903.9a: If a commander is in a graveyard or exile (and was put there
 /// since the last SBA check), its owner may put it into the command zone.
 /// CR 903.9b: Hand and library are also covered (see `commander_eligible_for_zone_return`).
+/// CR 903.9c: Also handles merged/melded permanents — after
+/// `merge::split_merged_permanent_on_leave` places each absorbed component
+/// in its destination zone with `is_commander` intact, the next SBA pass
+/// finds the commander component here and presents the choice identically to
+/// the standalone case.
 ///
 /// Pauses the SBA loop by setting `WaitingFor::CommanderZoneChoice` so the
 /// player can accept (move to command zone) or decline (leave in place).


### PR DESCRIPTION
## Summary

- Remove misleading "CR 903.9b–c separately out of scope" comment from `split_merged_permanent_on_leave` in `merge.rs` — the SBA path already handles this: absorbed commander components retain `is_commander` through `put_component_into_zone`, so `commander_eligible_for_zone_return` (which covers `Zone::Hand | Zone::Library`) picks them up on the next SBA pass identically to standalone commanders
- Add `CR 903.9c` annotations to `check_commander_zone_return` (`sba.rs`) and `commander_eligible_for_zone_return` (`commander.rs`) documenting merged-permanent coverage
- Add 4 discriminating tests for the merged commander bounce scenario: SBA offers choice, accept moves to command zone, decline stays in hand, absorbed component retains `is_commander` through zone transition

## Test plan

- [ ] `cargo test -p engine --lib cr903` — 4 new tests pass
- [ ] `cargo test -p engine --lib "commander::tests"` — all 48 commander tests pass
- [ ] `cargo test -p engine --lib merge` — all 58 merge tests pass
- [ ] `cargo fmt --all` — clean
