### PR TITLE
refactor(engine): unify Vote + ChooseOneOf onto a ResolutionFrame::Iterate

### DIFF
--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -187,7 +187,7 @@ fn prompt_next_each_player(
 /// pick, extended on each subsequent pick) so a downstream "put those cards
 /// onto the battlefield" reads exactly the cards chosen across all players,
 /// then prompts the next eligible player. Mirrors
-/// `vote::drain_pending_vote_ballot_iteration`.
+/// `vote::advance_vote_ballot_iterate`.
 pub(crate) fn drain_pending_per_player_zone_choice(
     state: &mut GameState,
     chosen: &[ObjectId],

--- a/crates/engine/src/game/effects/choose_one_of.rs
+++ b/crates/engine/src/game/effects/choose_one_of.rs
@@ -4,9 +4,13 @@ use crate::types::ability::{
     AbilityDefinition, Effect, EffectError, EffectKind, ResolvedAbility, TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, PendingChooseOneOf, WaitingFor};
+use crate::types::game_state::{
+    GameState, IterCtx, IterItem, IterKind, ResolutionFrame, WaitingFor,
+};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
+
+use std::collections::VecDeque;
 
 /// CR 701.55a-b + CR 608.2d: Prompt the instructed player to choose one
 /// branch at resolution. The branch itself is not pre-validated for
@@ -29,7 +33,7 @@ pub fn resolve(
         return Ok(());
     }
 
-    let players = choosing_players(state, ability, chooser);
+    let mut players: VecDeque<PlayerId> = VecDeque::from(choosing_players(state, ability, chooser));
     if players.is_empty() {
         // CR 608.2d: A branch choice must be made by an eligible player. An
         // empty chooser set means the effect cannot legally begin — fail loud
@@ -38,15 +42,31 @@ pub fn resolve(
             "ChooseOneOf: no eligible player for chooser {chooser:?}"
         )));
     }
-    prompt_next(
+    // CR 701.55d + CR 608.2: Prompt the first eligible chooser, then push an
+    // `Iterate` frame carrying the rest. The driver re-prompts the next player
+    // each time the previous player's branch finishes resolving.
+    let first = players.pop_front().expect("players is non-empty");
+    prompt_player(
         state,
+        first,
         ability.controller,
         ability.source_id,
-        branches,
+        branches.clone(),
         ability.targets.clone(),
         ability.context.clone(),
-        players,
+        players.iter().copied().collect(),
     );
+    if !players.is_empty() {
+        push_choose_one_of_iterate(
+            state,
+            ability.controller,
+            ability.source_id,
+            branches,
+            ability.targets.clone(),
+            ability.context.clone(),
+            players,
+        );
+    }
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::ChooseOneOf,
@@ -55,19 +75,50 @@ pub fn resolve(
     Ok(())
 }
 
-pub(crate) fn prompt_next(
+/// CR 701.55d + CR 608.2: Push a `ResolutionFrame::Iterate` carrying the players
+/// still awaiting their branch prompt. The body is the branch-choice prompt; the
+/// driver re-prompts the next player after each branch resolves.
+fn push_choose_one_of_iterate(
     state: &mut GameState,
     controller: PlayerId,
     source_id: ObjectId,
     branches: Vec<AbilityDefinition>,
     parent_targets: Vec<TargetRef>,
     context: crate::types::ability::SpellContext,
-    mut players: Vec<PlayerId>,
+    remaining_players: VecDeque<PlayerId>,
 ) {
-    let Some(player) = players.first().copied() else {
-        return;
-    };
-    players.remove(0);
+    state.resolution_stack.push(ResolutionFrame::Iterate {
+        remaining: remaining_players
+            .into_iter()
+            .map(IterItem::Player)
+            .collect(),
+        ctx: IterCtx {
+            source_id,
+            controller,
+            kind: IterKind::ChooseOneOf {
+                branches,
+                parent_targets,
+                context,
+            },
+        },
+    });
+}
+
+/// CR 701.55d: Prompt one player to choose a branch, parking
+/// `WaitingFor::ChooseOneOfBranch`. `remaining_players` is carried on the
+/// WaitingFor purely for legacy compatibility with consumers that read it; the
+/// authoritative remainder lives on the `Iterate` frame.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prompt_player(
+    state: &mut GameState,
+    player: PlayerId,
+    controller: PlayerId,
+    source_id: ObjectId,
+    branches: Vec<AbilityDefinition>,
+    parent_targets: Vec<TargetRef>,
+    context: crate::types::ability::SpellContext,
+    remaining_players: Vec<PlayerId>,
+) {
     let branch_descriptions = branch_descriptions(&branches);
     state.waiting_for = WaitingFor::ChooseOneOfBranch {
         player,
@@ -77,7 +128,7 @@ pub(crate) fn prompt_next(
         branch_descriptions,
         parent_targets,
         context,
-        remaining_players: players,
+        remaining_players,
     };
     // `priority_player` routing to the chooser is owned by the centralized
     // post-apply sync (`public_state::sync_priority_player_from_waiting_for`),
@@ -85,22 +136,30 @@ pub(crate) fn prompt_next(
     // `turn_control::authorized_submitter_for_player` (CR 608.2d).
 }
 
-pub(crate) fn resume_pending(state: &mut GameState, _events: &mut Vec<GameEvent>) {
-    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-        return;
-    }
-    let Some(pending) = state.pending_choose_one_of.take() else {
-        return;
-    };
-    prompt_next(
+/// CR 701.55d + CR 608.2: Advance a choose-one-of `Iterate` frame: prompt the
+/// next remaining player for a branch choice. Returns the shortened remaining
+/// players (frame must be re-pushed), or `None` when no players remain.
+pub(crate) fn advance_choose_one_of_iterate(
+    state: &mut GameState,
+    controller: PlayerId,
+    source_id: ObjectId,
+    branches: Vec<AbilityDefinition>,
+    parent_targets: Vec<TargetRef>,
+    context: crate::types::ability::SpellContext,
+    mut remaining_players: VecDeque<PlayerId>,
+) -> Option<VecDeque<PlayerId>> {
+    let player = remaining_players.pop_front()?;
+    prompt_player(
         state,
-        pending.controller,
-        pending.source_id,
-        pending.branches,
-        pending.parent_targets,
-        pending.context,
-        pending.remaining_players,
+        player,
+        controller,
+        source_id,
+        branches,
+        parent_targets,
+        context,
+        remaining_players.iter().copied().collect(),
     );
+    Some(remaining_players)
 }
 
 pub(crate) struct BranchSelection {
@@ -126,7 +185,7 @@ pub(crate) fn resolve_branch(
         branches,
         parent_targets,
         context,
-        remaining_players,
+        remaining_players: _remaining_players,
         index,
     } = selection;
     let Some(branch) = branches.get(index) else {
@@ -135,15 +194,11 @@ pub(crate) fn resolve_branch(
         )));
     };
 
-    state.pending_choose_one_of = (!remaining_players.is_empty()).then(|| PendingChooseOneOf {
-        controller,
-        source_id,
-        branches: branches.clone(),
-        parent_targets: parent_targets.clone(),
-        context: context.clone(),
-        remaining_players,
-    });
-
+    // CR 701.55d + CR 608.2: The remaining players awaiting their prompt are
+    // carried on the `Iterate` frame already pushed at initial resolution (or on
+    // the prior frame advance). The driver re-prompts the next player after this
+    // branch finishes resolving, so this resolver no longer stashes a pending
+    // struct or calls a resume helper itself.
     let mut resolved = build_resolved_from_def(branch, source_id, controller);
     resolved.context = context;
     resolved.targets = parent_targets;
@@ -157,7 +212,6 @@ pub(crate) fn resolve_branch(
     }
 
     super::resolve_ability_chain(state, &resolved, events, 1)?;
-    resume_pending(state, events);
     Ok(())
 }
 

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -2411,7 +2411,7 @@ mod tests {
             );
             state.waiting_for = WaitingFor::Priority { player };
             state.priority_player = player;
-            crate::game::effects::drain_pending_continuation(&mut state, &mut events);
+            crate::game::effects::drive_resolution(&mut state, &mut events);
         }
 
         // Exactly two spell copies (base 1 + Twinning Staff's additional 1).

--- a/crates/engine/src/game/effects/endure.rs
+++ b/crates/engine/src/game/effects/endure.rs
@@ -77,16 +77,18 @@ pub fn resolve(
     counter_branch.description = Some(format!("Put {amount} +1/+1 counters on it."));
 
     // CR 701.63a: "that permanent's controller" makes the choice — a single
-    // chooser. Delegate to the modal machine, which sets
-    // `WaitingFor::ChooseOneOfBranch` and owns AI/multiplayer/frontend wiring.
-    choose_one_of::prompt_next(
+    // chooser, so no per-player `Iterate` frame is needed. Delegate to the modal
+    // machine, which sets `WaitingFor::ChooseOneOfBranch` and owns
+    // AI/multiplayer/frontend wiring.
+    choose_one_of::prompt_player(
         state,
+        ability.controller,
         ability.controller,
         ability.source_id,
         vec![token_branch, counter_branch],
         ability.targets.clone(),
         ability.context.clone(),
-        vec![ability.controller],
+        Vec::new(),
     );
 
     events.push(GameEvent::EffectResolved {

--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -185,7 +185,7 @@ pub fn handle_choose_mana_effect(
 
     state.waiting_for = WaitingFor::Priority { player: recipient };
     state.priority_player = recipient;
-    super::drain_pending_continuation(state, events);
+    super::drive_resolution(state, events);
     Ok(state.waiting_for.clone())
 }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -483,6 +483,154 @@ pub(crate) fn mark_pending_continuation_parent(state: &mut GameState, kind: Effe
 /// All `pending_continuation.take()` sites should use this helper rather
 /// than rolling their own `take + resolve_ability_chain`, so the parent
 /// event is never silently dropped.
+/// CR 608.2 + CR 609.3: Single entry point that drives the resolution-
+/// continuation machinery after an interactive choice resolves.
+///
+/// Slice 0: this is a PURE 1:1 alias for [`drain_pending_continuation`] — a
+/// single delegation with NO outer loop. `drain_pending_continuation` already
+/// self-loops/defers internally (e.g. `drain_pending_repeat_iteration`
+/// re-stashes and relies on external re-entry), so wrapping it in an outer loop
+/// would over-drain. Slices 1-3 move the drain bodies onto `resolution_stack`
+/// and turn this into the stack driver; until then it must remain
+/// behavior-identical to the legacy path.
+pub(crate) fn drive_resolution(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    drain_pending_continuation(state, events);
+}
+
+/// CR 701.38d + CR 608.2: Advance the top `ResolutionFrame::Iterate` frame iff it
+/// is a Vote iteration. Pops the frame, resolves remaining voters' ballots one at
+/// a time, and re-pushes the frame (with the shortened remainder) if a ballot
+/// parks an interactive choice. When all ballots resolve, the frame is consumed
+/// and `EffectResolved { Vote }` is emitted (by `advance_vote_ballot_iterate`).
+fn advance_top_iterate_vote(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    use crate::types::game_state::{IterCtx, IterItem, IterKind, ResolutionFrame};
+    // Only act when the top frame is a Vote iteration; otherwise leave the stack
+    // untouched so other frame kinds (or none) are handled at their own site.
+    if !matches!(
+        state.resolution_stack.last(),
+        Some(ResolutionFrame::Iterate {
+            ctx: IterCtx {
+                kind: IterKind::Vote { .. },
+                ..
+            },
+            ..
+        })
+    ) {
+        return;
+    }
+    let Some(ResolutionFrame::Iterate {
+        remaining,
+        ctx:
+            IterCtx {
+                source_id,
+                controller,
+                kind: IterKind::Vote { template },
+            },
+    }) = state.resolution_stack.pop()
+    else {
+        return;
+    };
+    let remaining_voters = remaining
+        .into_iter()
+        .map(|item| match item {
+            IterItem::Player(p) => p,
+        })
+        .collect();
+    if let Some(rest) = vote::advance_vote_ballot_iterate(
+        state,
+        &template,
+        remaining_voters,
+        source_id,
+        controller,
+        events,
+    ) {
+        // Parked mid-flight — re-push the frame with the shortened remainder.
+        state.resolution_stack.push(ResolutionFrame::Iterate {
+            remaining: rest.into_iter().map(IterItem::Player).collect(),
+            ctx: IterCtx {
+                source_id,
+                controller,
+                kind: IterKind::Vote { template },
+            },
+        });
+    }
+}
+
+/// CR 701.55d + CR 608.2: Advance the top `ResolutionFrame::Iterate` frame iff it
+/// is a ChooseOneOf iteration and the game has returned to priority (mirroring
+/// the legacy `choose_one_of::resume_pending` guard). Prompts the next remaining
+/// player for a branch choice; the frame is consumed once no players remain.
+fn advance_top_iterate_choose_one_of(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    use crate::types::game_state::{IterCtx, IterItem, IterKind, ResolutionFrame};
+    // CR 608.2c: Only re-prompt the next player once the previous branch's
+    // resolution has fully drained back to priority (legacy `resume_pending`
+    // required `WaitingFor::Priority`).
+    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+        return;
+    }
+    if !matches!(
+        state.resolution_stack.last(),
+        Some(ResolutionFrame::Iterate {
+            ctx: IterCtx {
+                kind: IterKind::ChooseOneOf { .. },
+                ..
+            },
+            ..
+        })
+    ) {
+        return;
+    }
+    let Some(ResolutionFrame::Iterate {
+        remaining,
+        ctx:
+            IterCtx {
+                source_id,
+                controller,
+                kind:
+                    IterKind::ChooseOneOf {
+                        branches,
+                        parent_targets,
+                        context,
+                    },
+            },
+    }) = state.resolution_stack.pop()
+    else {
+        return;
+    };
+    let _ = events; // ChooseOneOf advance only re-parks a prompt; emits no event.
+    let remaining_players = remaining
+        .into_iter()
+        .map(|item| match item {
+            IterItem::Player(p) => p,
+        })
+        .collect();
+    if let Some(rest) = choose_one_of::advance_choose_one_of_iterate(
+        state,
+        controller,
+        source_id,
+        branches.clone(),
+        parent_targets.clone(),
+        context.clone(),
+        remaining_players,
+    ) {
+        // A player was prompted; keep the frame for the players still queued.
+        if !rest.is_empty() {
+            state.resolution_stack.push(ResolutionFrame::Iterate {
+                remaining: rest.into_iter().map(IterItem::Player).collect(),
+                ctx: IterCtx {
+                    source_id,
+                    controller,
+                    kind: IterKind::ChooseOneOf {
+                        branches,
+                        parent_targets,
+                        context,
+                    },
+                },
+            });
+        }
+    }
+}
+
 pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec<GameEvent>) {
     counters::drain_pending_counter_moves(state, events);
     counters::drain_pending_counter_additions(state, events);
@@ -515,11 +663,14 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
     if !waits_for_resolution_choice(&state.waiting_for) {
         drain_pending_change_zone_iteration(state, events);
     }
-    // CR 701.38d: Resume per-ballot vote iteration after an interactive
-    // choice resolves. Must run after change_zone_iteration (which may be
-    // nested inside a ballot body) and before repeat_iteration.
+    // CR 701.38d + CR 608.2: Resume per-ballot vote iteration after an
+    // interactive choice resolves. Must run after change_zone_iteration (which
+    // may be nested inside a ballot body) and before repeat_iteration. Ported
+    // (slice 1/5) onto `ResolutionFrame::Iterate`: advance the top Vote frame at
+    // this sequence position to preserve the legacy interleaving with
+    // change_zone/repeat_iteration.
     if !waits_for_resolution_choice(&state.waiting_for) {
-        vote::drain_pending_vote_ballot_iteration(state, events);
+        advance_top_iterate_vote(state, events);
     }
     // CR 609.3 + CR 109.5: After the per-iteration chain drains, drive any
     // remaining `repeat_for` iterations. Each resumed iteration may itself
@@ -528,8 +679,13 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
     if !waits_for_resolution_choice(&state.waiting_for) {
         drain_pending_repeat_iteration(state, events);
     }
+    // CR 701.55d + CR 608.2: Resume per-player choose-one-of branch prompting.
+    // Ported (slice 1/5) onto `ResolutionFrame::Iterate`: advance the top
+    // ChooseOneOf frame (re-prompt the next player) at this sequence position,
+    // mirroring the legacy `choose_one_of::resume_pending` guard that only
+    // re-prompts once the previous branch resolution returns to Priority.
     if !waits_for_resolution_choice(&state.waiting_for) {
-        choose_one_of::resume_pending(state, events);
+        advance_top_iterate_choose_one_of(state, events);
     }
     // CR 608.2c + CR 107.1c: After the iteration's choice and any chained
     // continuation have fully drained (state is back at priority), resume a
@@ -11169,7 +11325,7 @@ mod tests {
         });
 
         let mut events = Vec::new();
-        drain_pending_continuation(&mut state, &mut events);
+        drive_resolution(&mut state, &mut events);
 
         assert!(
             state.pending_repeat_until.is_none(),

--- a/crates/engine/src/game/effects/vote.rs
+++ b/crates/engine/src/game/effects/vote.rs
@@ -24,9 +24,12 @@ use crate::types::ability::{
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    GameState, PendingContinuation, PendingVoteBallotIteration, VoteActor, WaitingFor,
+    GameState, IterCtx, IterItem, IterKind, PendingContinuation, ResolutionFrame, VoteActor,
+    WaitingFor,
 };
 use crate::types::player::PlayerId;
+
+use std::collections::VecDeque;
 
 use super::resolve_ability_chain;
 
@@ -347,22 +350,25 @@ pub fn resolve_tally(
             // If a ballot parks an interactive choice (e.g. ChooseFromZoneChoice),
             // stash remaining voters and return early; the drain function resumes.
             let initial_waiting_for = state.waiting_for.clone();
-            let mut remaining_voters: Vec<PlayerId> = choice_ballots.clone();
+            let mut remaining_voters: VecDeque<PlayerId> = VecDeque::from(choice_ballots.clone());
 
-            while let Some(voter) = remaining_voters.first().copied() {
-                remaining_voters.remove(0);
+            while let Some(voter) = remaining_voters.pop_front() {
                 let ballot_ability =
                     build_per_ballot_ability(&per_choice_effect[idx], voter, source_id, controller);
                 resolve_ability_chain(state, &ballot_ability, events, 1)?;
 
-                // If the inner effect parked an interactive choice, suspend.
+                // CR 701.38d + CR 608.2: If the inner effect parked an
+                // interactive choice, suspend by pushing an `Iterate` frame
+                // carrying the remaining voters. The driver resumes it after
+                // the parked choice resolves.
                 if state.waiting_for != initial_waiting_for {
-                    state.pending_vote_ballot_iteration = Some(PendingVoteBallotIteration {
-                        ability_template: Box::new(per_choice_effect[idx].as_ref().clone()),
+                    push_vote_ballot_iterate(
+                        state,
+                        &per_choice_effect[idx],
                         remaining_voters,
                         source_id,
                         controller,
-                    });
+                    );
                     return Ok(());
                 }
             }
@@ -532,41 +538,57 @@ fn build_per_ballot_ability(
     ability
 }
 
-/// CR 701.38d: Resume per-ballot vote iteration after an interactive choice
-/// resolves. Processes the next voter's ballot; if it pauses again, re-stashes
-/// remaining voters. When all voters are processed, emits `EffectResolved`.
-pub(crate) fn drain_pending_vote_ballot_iteration(
+/// CR 701.38d + CR 608.2: Push a `ResolutionFrame::Iterate` carrying the voters
+/// whose per-ballot interactive body has not yet resolved. The frame's body is
+/// the per-choice ability template; the driver instantiates it per voter via
+/// [`build_per_ballot_ability`].
+fn push_vote_ballot_iterate(
     state: &mut GameState,
-    events: &mut Vec<GameEvent>,
+    template: &AbilityDefinition,
+    remaining_voters: VecDeque<PlayerId>,
+    source_id: crate::types::identifiers::ObjectId,
+    controller: PlayerId,
 ) {
-    let pending = match state.pending_vote_ballot_iteration.take() {
-        Some(p) => p,
-        None => return,
-    };
+    state.resolution_stack.push(ResolutionFrame::Iterate {
+        remaining: remaining_voters.into_iter().map(IterItem::Player).collect(),
+        ctx: IterCtx {
+            source_id,
+            controller,
+            kind: IterKind::Vote {
+                template: Box::new(template.clone()),
+            },
+        },
+    });
+}
 
+/// CR 701.38d: Advance a vote-ballot `Iterate` frame after an interactive choice
+/// resolves. Processes remaining voters' ballots one at a time; if a ballot
+/// parks again, the caller re-pushes the frame with the shortened remainder.
+/// When all voters are processed, emits the deferred `EffectResolved { Vote }`.
+///
+/// Returns the (possibly shortened) remaining voters if the iteration parked
+/// mid-flight (frame must be re-pushed), or `None` when the iteration completed.
+pub(crate) fn advance_vote_ballot_iterate(
+    state: &mut GameState,
+    template: &AbilityDefinition,
+    mut remaining_voters: VecDeque<PlayerId>,
+    source_id: crate::types::identifiers::ObjectId,
+    controller: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Option<VecDeque<PlayerId>> {
     let initial_waiting_for = state.waiting_for.clone();
-    let mut remaining_voters = pending.remaining_voters;
-    let source_id = pending.source_id;
-    let controller = pending.controller;
-    let template = pending.ability_template;
 
-    while let Some(voter) = remaining_voters.first().copied() {
-        remaining_voters.remove(0);
-        let ballot_ability = build_per_ballot_ability(&template, voter, source_id, controller);
+    while let Some(voter) = remaining_voters.pop_front() {
+        let ballot_ability = build_per_ballot_ability(template, voter, source_id, controller);
         if resolve_ability_chain(state, &ballot_ability, events, 1).is_err() {
-            // On error, drop remaining ballots (matches existing error handling).
-            return;
+            // On error, drop remaining ballots (matches existing error handling)
+            // and do not re-push the frame.
+            return None;
         }
 
         if state.waiting_for != initial_waiting_for {
-            // Re-stash remaining voters for the next drain cycle.
-            state.pending_vote_ballot_iteration = Some(PendingVoteBallotIteration {
-                ability_template: template,
-                remaining_voters,
-                source_id,
-                controller,
-            });
-            return;
+            // Parked again — caller re-pushes the frame with the remainder.
+            return Some(remaining_voters);
         }
     }
 
@@ -575,6 +597,7 @@ pub(crate) fn drain_pending_vote_ballot_iteration(
         kind: EffectKind::Vote,
         source_id,
     });
+    None
 }
 
 #[cfg(test)]
@@ -1304,9 +1327,9 @@ mod tests {
     /// per ballot. Uses the production parser path (`parse_vote_block`) to
     /// build the Vote effect from Expropriate's real Oracle text. With two
     /// opponents both choosing money, the first ballot pauses at
-    /// `ChooseFromZoneChoice`, remaining voters are stashed in
-    /// `pending_vote_ballot_iteration`, and `EffectResolved { Vote }` is NOT
-    /// emitted until all ballots resolve.
+    /// `ChooseFromZoneChoice`, remaining voters are stashed on a
+    /// `ResolutionFrame::Iterate` (Vote kind), and `EffectResolved { Vote }` is
+    /// NOT emitted until all ballots resolve.
     #[test]
     fn expropriate_money_votes_suspend_and_resume_per_ballot() {
         use crate::game::zones::create_object;
@@ -1443,18 +1466,24 @@ mod tests {
             ),
         }
 
-        // Remaining voters should be stashed.
-        assert!(
-            state.pending_vote_ballot_iteration.is_some(),
-            "remaining voters must be stashed in pending_vote_ballot_iteration"
-        );
+        // Remaining voters should be carried on a Vote Iterate frame.
+        let remaining = match state.resolution_stack.last() {
+            Some(ResolutionFrame::Iterate {
+                remaining,
+                ctx:
+                    IterCtx {
+                        kind: IterKind::Vote { .. },
+                        ..
+                    },
+                ..
+            }) => remaining,
+            other => panic!(
+                "remaining voters must be carried on a Vote Iterate frame, got {:?}",
+                other
+            ),
+        };
         assert_eq!(
-            state
-                .pending_vote_ballot_iteration
-                .as_ref()
-                .unwrap()
-                .remaining_voters
-                .len(),
+            remaining.len(),
             2,
             "two voters (opp1 + opp2) remain after controller's ballot"
         );
@@ -1470,5 +1499,94 @@ mod tests {
             )),
             "EffectResolved(Vote) must NOT be emitted while ballots remain"
         );
+
+        // CR 101.4 + CR 608.2c: Drive all three ballots to completion via the
+        // production choice handler (`apply`), proving the `Iterate` frame
+        // resumes the next voter in APNAP order after each ChooseFromZone
+        // resolves — the discriminating end-to-end behavior the slice-1 port
+        // must preserve. The controller's ballot is parked now; resolve it,
+        // then opp1's, then opp2's, asserting the scoped voter at each step via
+        // the candidate set (each ballot only offers the voter's own permanent).
+        use crate::game::engine::apply;
+        use crate::types::actions::GameAction;
+
+        // Controller's ballot — gains control of perm_ctrl.
+        apply(
+            &mut state,
+            controller,
+            GameAction::SelectCards {
+                cards: vec![perm_ctrl],
+            },
+        )
+        .expect("controller selects their permanent");
+        // The Iterate frame advanced to opp1's ballot, which parked its own
+        // ChooseFromZone offering ONLY opp1's permanent.
+        match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+                assert_eq!(
+                    *player, controller,
+                    "controller is the chooser for every ballot"
+                );
+                assert!(
+                    cards.contains(&perm_opp1) && !cards.contains(&perm_ctrl),
+                    "second ballot (opp1, APNAP order) must offer opp1's permanent only, got {cards:?}"
+                );
+            }
+            other => panic!("expected ChooseFromZoneChoice for opp1's ballot, got {other:?}"),
+        }
+        match state.resolution_stack.last() {
+            Some(ResolutionFrame::Iterate { remaining, .. }) => assert_eq!(
+                remaining.len(),
+                1,
+                "one voter (opp2) remains after opp1's ballot parks"
+            ),
+            other => panic!("expected a Vote Iterate frame, got {other:?}"),
+        }
+
+        // opp1's ballot — gains control of perm_opp1; frame advances to opp2.
+        apply(
+            &mut state,
+            controller,
+            GameAction::SelectCards {
+                cards: vec![perm_opp1],
+            },
+        )
+        .expect("opp1's permanent selected");
+        match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice { cards, .. } => assert!(
+                cards.contains(&perm_opp2) && !cards.contains(&perm_opp1),
+                "third ballot (opp2, APNAP order) must offer opp2's permanent only, got {cards:?}"
+            ),
+            other => panic!("expected ChooseFromZoneChoice for opp2's ballot, got {other:?}"),
+        }
+
+        // opp2's ballot — the iteration completes.
+        let outcome = apply(
+            &mut state,
+            controller,
+            GameAction::SelectCards {
+                cards: vec![perm_opp2],
+            },
+        )
+        .expect("opp2's permanent selected");
+        let _ = outcome;
+
+        // The Iterate frame is consumed and the controller now controls all
+        // three permanents (gained control of each voter's chosen permanent).
+        assert!(
+            state.resolution_stack.is_empty(),
+            "resolution stack must be empty after all ballots resolve"
+        );
+        for (label, perm) in [
+            ("controller", perm_ctrl),
+            ("opp1", perm_opp1),
+            ("opp2", perm_opp2),
+        ] {
+            assert_eq!(
+                state.objects.get(&perm).unwrap().controller,
+                controller,
+                "controller must control {label}'s permanent after the vote resolves"
+            );
+        }
     }
 }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -285,7 +285,7 @@ pub(super) fn resume_pending_continuation_if_priority(
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
     if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-        effects::drain_pending_continuation(state, events);
+        effects::drive_resolution(state, events);
     }
     Ok(())
 }
@@ -379,7 +379,7 @@ fn pass_priority_once_with_pipeline(
     // until an unrelated action, by which point referenced stack objects may
     // have left the stack.
     if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-        effects::drain_pending_continuation(state, events);
+        effects::drive_resolution(state, events);
     }
 
     let skip_triggers =
@@ -1288,12 +1288,12 @@ fn finalize_copy_retarget(
     {
         state.waiting_for = wf;
         state.priority_player = player;
-        effects::drain_pending_continuation(state, events);
+        effects::drive_resolution(state, events);
         return Ok(());
     }
     state.waiting_for = WaitingFor::Priority { player };
     state.priority_player = player;
-    effects::drain_pending_continuation(state, events);
+    effects::drive_resolution(state, events);
     Ok(())
 }
 
@@ -2619,7 +2619,7 @@ fn apply_action(
             });
             state.waiting_for = WaitingFor::Priority { player: *player };
             state.priority_player = *player;
-            effects::drain_pending_continuation(state, &mut events);
+            effects::drive_resolution(state, &mut events);
             state.waiting_for.clone()
         }
         (
@@ -3686,7 +3686,7 @@ fn apply_action(
                     if state.pending_batch_deliveries.is_some() {
                         super::zone_pipeline::drain_pending_batch_deliveries(state, &mut events);
                     }
-                    effects::drain_pending_continuation(state, &mut events);
+                    effects::drive_resolution(state, &mut events);
                     return Ok(ActionResult {
                         events,
                         waiting_for: state.waiting_for.clone(),
@@ -3724,7 +3724,7 @@ fn apply_action(
             if state.pending_batch_deliveries.is_some() {
                 super::zone_pipeline::drain_pending_batch_deliveries(state, &mut events);
             }
-            effects::drain_pending_continuation(state, &mut events);
+            effects::drive_resolution(state, &mut events);
             state.waiting_for.clone()
         }
         (
@@ -4388,7 +4388,7 @@ fn apply_action(
             });
             state.waiting_for = WaitingFor::Priority { player: p };
             state.priority_player = p;
-            effects::drain_pending_continuation(state, &mut events);
+            effects::drive_resolution(state, &mut events);
             state.waiting_for.clone()
         }
         // CR 701.56a: Time travel — player selected objects for the current phase
@@ -4436,7 +4436,7 @@ fn apply_action(
                     });
                     state.waiting_for = WaitingFor::Priority { player: p };
                     state.priority_player = p;
-                    effects::drain_pending_continuation(state, &mut events);
+                    effects::drive_resolution(state, &mut events);
                     state.waiting_for.clone()
                 }
             } else {
@@ -4446,7 +4446,7 @@ fn apply_action(
                 });
                 state.waiting_for = WaitingFor::Priority { player: p };
                 state.priority_player = p;
-                effects::drain_pending_continuation(state, &mut events);
+                effects::drive_resolution(state, &mut events);
                 state.waiting_for.clone()
             }
         }
@@ -4504,7 +4504,7 @@ fn apply_action(
             let previous_trigger_match_count = state.current_trigger_match_count;
             state.current_trigger_event = pending_event;
             state.current_trigger_match_count = state.pending_optional_trigger_match_count.take();
-            effects::drain_pending_continuation(state, &mut events);
+            effects::drive_resolution(state, &mut events);
             state.current_trigger_event = previous_trigger_event;
             state.current_trigger_match_count = previous_trigger_match_count;
             state.waiting_for.clone()
@@ -4754,7 +4754,7 @@ fn apply_action(
                 // Resolution-time distribution continuation path.
                 state.waiting_for = WaitingFor::Priority { player: p };
                 state.priority_player = p;
-                effects::drain_pending_continuation(state, &mut events);
+                effects::drive_resolution(state, &mut events);
                 state.waiting_for.clone()
             }
         }
@@ -4783,7 +4783,7 @@ fn apply_action(
             state.priority_player = p;
             effects::counters::drain_pending_counter_moves(state, &mut events);
             if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                effects::drain_pending_continuation(state, &mut events);
+                effects::drive_resolution(state, &mut events);
             }
             state.waiting_for.clone()
         }
@@ -4980,7 +4980,7 @@ fn apply_retarget(
     });
     state.waiting_for = WaitingFor::Priority { player };
     state.priority_player = player;
-    effects::drain_pending_continuation(state, events);
+    effects::drive_resolution(state, events);
     Ok(state.waiting_for.clone())
 }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -548,7 +548,7 @@ pub(super) fn handle_replacement_choice(
                 // paused on this replacement choice (issue #535). The drain
                 // helper covers both: it runs the continuation chain (if any)
                 // then the ChangeZone iteration drain hook.
-                effects::drain_pending_continuation(state, events);
+                effects::drive_resolution(state, events);
                 // CR 616.1e: The continuation may itself pause on another replacement
                 // (e.g., the second direction of fight damage hitting the same shield),
                 // in which case it sets `state.waiting_for` to the next ReplacementChoice.
@@ -632,7 +632,7 @@ pub(super) fn handle_replacement_choice(
                 };
                 effects::counters::drain_pending_counter_moves(state, events);
                 if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                    effects::drain_pending_continuation(state, events);
+                    effects::drive_resolution(state, events);
                 }
                 return Ok(state.waiting_for.clone());
             }
@@ -819,7 +819,7 @@ pub(super) fn replay_deferred_entry_events(
         let delayed_events = super::triggers::check_delayed_triggers(state, &deferred);
         events.extend(delayed_events);
     }
-    effects::drain_pending_continuation(state, events);
+    effects::drive_resolution(state, events);
     // CR 113.2c + CR 603.3b + CR 707.10: `process_triggers` above may have
     // paused on an interactive replayed ETB trigger fired by the realized
     // entry. When it pauses it sets `state.pending_trigger` for the active

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1091,7 +1091,7 @@ pub(super) fn handle_resolution_choice(
             // sub_ability here and hand priority back to the clashing player.
             if !matches!(state.waiting_for, WaitingFor::ClashCardPlacement { .. }) {
                 set_priority(state, player);
-                effects::drain_pending_continuation(state, events);
+                effects::drive_resolution(state, events);
             }
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
@@ -1617,7 +1617,7 @@ pub(super) fn handle_resolution_choice(
                 }
                 set_priority(state, player);
                 if decline_runs_continuation {
-                    effects::drain_pending_continuation(state, events);
+                    effects::drive_resolution(state, events);
                 } else {
                     state.pending_continuation = None;
                 }
@@ -1668,7 +1668,7 @@ pub(super) fn handle_resolution_choice(
                     cont.chain.context.optional_effect_performed = true;
                 }
             }
-            effects::drain_pending_continuation(state, events);
+            effects::drive_resolution(state, events);
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -1774,7 +1774,7 @@ pub(super) fn handle_resolution_choice(
                 // the primary destination and the rest is empty. No second prompt.
                 apply_search_partition(state, &chosen, &[], &split, source_id, player, events)?;
                 set_priority(state, player);
-                effects::drain_pending_continuation(state, events);
+                effects::drive_resolution(state, events);
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
                     state.waiting_for.clone(),
                 ));
@@ -1796,7 +1796,7 @@ pub(super) fn handle_resolution_choice(
                 cont.chain.targets = continuation_targets.clone();
                 propagate_targets_through_search_shuffle(&mut cont.chain, &continuation_targets);
             }
-            effects::drain_pending_continuation(state, events);
+            effects::drive_resolution(state, events);
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -1851,7 +1851,7 @@ pub(super) fn handle_resolution_choice(
                 events,
             )?;
             set_priority(state, player);
-            effects::drain_pending_continuation(state, events);
+            effects::drive_resolution(state, events);
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -2095,7 +2095,7 @@ pub(super) fn handle_resolution_choice(
                     }
                 }
             }
-            effects::drain_pending_continuation(state, events);
+            effects::drive_resolution(state, events);
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -2161,7 +2161,7 @@ pub(super) fn handle_resolution_choice(
             // slots). Required so a `repeat_for: DistinctCounterKindsAmong` loop
             // paused on `ChooseOneOfBranch` advances past the first counter kind to
             // prompt for each remaining kind (Bribe Taker).
-            effects::drain_pending_continuation(state, events);
+            effects::drive_resolution(state, events);
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -3058,7 +3058,7 @@ pub(super) fn handle_resolution_choice(
                     state.waiting_for.clone(),
                 ));
             } else {
-                effects::drain_pending_continuation(state, events);
+                effects::drive_resolution(state, events);
             }
             state.last_named_choice = None;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
@@ -3107,7 +3107,7 @@ pub(super) fn handle_resolution_choice(
                 source_filter,
             });
             set_priority(state, player);
-            effects::drain_pending_continuation(state, events);
+            effects::drive_resolution(state, events);
             state.last_chosen_damage_source = None;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
@@ -3595,7 +3595,7 @@ fn finish_with_continuation(
     events: &mut Vec<GameEvent>,
 ) -> WaitingFor {
     set_priority(state, player);
-    effects::drain_pending_continuation(state, events);
+    effects::drive_resolution(state, events);
     state.waiting_for.clone()
 }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -831,6 +831,78 @@ pub struct CommanderDamageEntry {
 /// cannot go out of sync; two parallel `Option`s would let one be set
 /// without the other and break the "pause emits the same event as
 /// non-pause" invariant.
+/// CR 608.2 + CR 609.3: A single parked step in the resolution-continuation
+/// stack ([`GameState::resolution_stack`]). The unification replaces the flat
+/// `pending_*` continuation fields with one LIFO stack so nesting becomes stack
+/// depth rather than a hand-tuned drain order in `drain_pending_continuation`.
+///
+/// This slice introduces the carrier plus the generic `Iterate`
+/// (per-player/per-iteration) frame and ports the two cleanest per-player
+/// iteration drains (vote ballots, choose-one-of branches) onto it. Later work
+/// can add resolver-resume and queue variants and migrate the remaining
+/// `drain_pending_*` functions onto the stack.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolutionFrame {
+    /// CR 608.2 + CR 701.38d + CR 701.55d: A per-item iteration that instantiates
+    /// one body per remaining `IterItem` in turn (APNAP order for player items),
+    /// parking on the body's interactive `WaitingFor` between items. Replaces the
+    /// hand-stashed `Pending*Iteration` structs whose `remaining` lists and resume
+    /// loops are byte-identical modulo the per-iteration body.
+    Iterate {
+        /// Items not yet processed. The driver advances one per resume; when this
+        /// empties, the frame is popped and any completion event is emitted.
+        remaining: VecDeque<IterItem>,
+        /// Source/controller plus the iteration-kind-specific body to instantiate.
+        ctx: IterCtx,
+    },
+}
+
+/// CR 608.2: One unit of work in a [`ResolutionFrame::Iterate`]. Currently only
+/// `Player` is needed (vote ballots, choose-one-of branches both iterate per
+/// player); future index/object kinds can be added for the repeat-iteration and
+/// zone-choice ports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IterItem {
+    /// A player whose body resolves next (APNAP order for votes/branches).
+    Player(PlayerId),
+}
+
+/// CR 608.2: Source/controller context plus the iteration-kind-specific body for
+/// a [`ResolutionFrame::Iterate`]. The vote and choose-one-of bodies are shaped
+/// differently (one ability template vs. a branch-choice prompt), so the body is
+/// carried in a typed [`IterKind`] rather than forced into one `AbilityDefinition`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IterCtx {
+    /// The object that initiated the iteration (vote/choose-one-of source).
+    pub source_id: ObjectId,
+    /// The controller of the initiating spell/ability.
+    pub controller: PlayerId,
+    /// The iteration-kind-specific per-item body.
+    pub kind: IterKind,
+}
+
+/// CR 701.38d / CR 701.55d: The per-item body shape for a
+/// [`ResolutionFrame::Iterate`]. Each variant carries exactly the data its
+/// resume step needs to instantiate one item's body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IterKind {
+    /// CR 701.38d: Per-ballot vote iteration. Each remaining voter resolves an
+    /// instantiation of `template` with `scoped_player` bound to the voter.
+    /// On completion the frame emits `EffectResolved { Vote, source_id }`.
+    Vote {
+        /// The ability template instantiated per voter (`build_per_ballot_ability`).
+        template: Box<AbilityDefinition>,
+    },
+    /// CR 701.55d: Per-player choose-one-of iteration. Each remaining player is
+    /// prompted (`WaitingFor::ChooseOneOfBranch`) to choose among `branches`; the
+    /// chosen branch resolves with `parent_targets` + `context` threaded through.
+    ChooseOneOf {
+        branches: Vec<AbilityDefinition>,
+        parent_targets: Vec<TargetRef>,
+        context: super::ability::SpellContext,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingContinuation {
     pub chain: Box<ResolvedAbility>,
@@ -6058,6 +6130,14 @@ pub struct GameState {
     // fires at the tail of its resolver.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_continuation: Option<PendingContinuation>,
+    /// CR 608.2 + CR 609.3: Unified resolution-continuation stack. Currently
+    /// carries the per-player vote-ballot and choose-one-of `Iterate` frames,
+    /// driven by `drive_resolution`; future work can migrate the remaining flat
+    /// `pending_*` continuation fields onto this LIFO stack. The
+    /// `#[serde(default)]` keeps old saves (no `resolution_stack` key) loading
+    /// to an empty stack for back-compat.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resolution_stack: Vec<ResolutionFrame>,
 
     /// CR 609.3 + CR 109.5: Pending `repeat_for` iteration loop paused mid-flight
     /// because the inner effect entered an interactive `WaitingFor` state.
@@ -7046,6 +7126,7 @@ impl GameState {
             revealed_cards: HashSet::new(),
             public_revealed_cards: HashSet::new(),
             pending_continuation: None,
+            resolution_stack: Vec::new(),
             pending_repeat_iteration: None,
             pending_change_zone_iteration: None,
             devour_eligible_snapshot: None,
@@ -7503,6 +7584,7 @@ impl PartialEq for GameState {
             && self.revealed_cards == other.revealed_cards
             && self.public_revealed_cards == other.public_revealed_cards
             && self.pending_continuation == other.pending_continuation
+            && self.resolution_stack == other.resolution_stack
             && self.pending_repeat_iteration == other.pending_repeat_iteration
             && self.pending_change_zone_iteration == other.pending_change_zone_iteration
             // `devour_eligible_snapshot` is INTENTIONALLY excluded from PartialEq.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -305,6 +305,7 @@ mod primo_unbounded_fractal_counters;
 mod proliferate_zero_counter;
 mod quirion_ranger_activation;
 mod refurbished_familiar;
+mod resolution_stack_iterate;
 mod riot_control_regression;
 mod ripples_of_undeath_regression;
 mod rite_of_consumption_damage;

--- a/crates/engine/tests/integration/resolution_stack_iterate.rs
+++ b/crates/engine/tests/integration/resolution_stack_iterate.rs
@@ -1,0 +1,212 @@
+//! Slice 1/5 acceptance: `ResolutionFrame::Iterate` faithfully reproduces the
+//! per-player iteration the legacy `pending_vote_ballot_iteration` and
+//! `pending_choose_one_of` fields used to hand-stash, and survives a serde
+//! round-trip (the frame is on the save/load + multiplayer wire).
+//!
+//! The end-to-end vote-ballot iteration (3 voters each parking an interactive
+//! per-ballot body, resumed in APNAP order) is exercised through the production
+//! parser in the in-crate test
+//! `effects::vote::tests::expropriate_money_votes_suspend_and_resume_per_ballot`
+//! (that path needs the `pub(crate)` vote-block parser). Here we cover the
+//! choose-one-of per-player iteration end-to-end through the public `apply`
+//! pipeline, plus a serde round-trip of a live Vote `Iterate` frame.
+//!
+//! CR 701.55d (per-player choose-one-of), CR 701.38d (voting), CR 608.2c
+//! (resolution continuation).
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::engine::apply;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, PlayerFilter, QuantityExpr, ResolvedAbility,
+    TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::{
+    GameState, IterCtx, IterItem, IterKind, ResolutionFrame, WaitingFor,
+};
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+use std::collections::VecDeque;
+
+/// A two-branch `ChooseOneOf` whose chooser is every opponent of the controller:
+/// branch 0 draws a card, branch 1 gains 1 life. Each opponent is prompted in
+/// turn (CR 701.55d) — the per-player iteration the `Iterate` frame drives.
+fn each_opponent_choose_one_of(controller: PlayerId, source_id: ObjectId) -> ResolvedAbility {
+    let draw = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    );
+    let gain = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+    );
+    let def = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::ChooseOneOf {
+            chooser: PlayerFilter::Opponent,
+            branches: vec![draw, gain],
+        },
+    );
+    build_resolved_from_def(&def, source_id, controller)
+}
+
+/// CR 701.55d + CR 608.2c: In a 3-player game, both opponents must be prompted
+/// for their branch choice in APNAP order, one after the other. The `Iterate`
+/// frame carries the not-yet-prompted opponents; each `ChooseBranch` resolves
+/// one branch and the driver re-prompts the next opponent.
+#[test]
+fn choose_one_of_prompts_each_opponent_in_turn_via_iterate_frame() {
+    let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+    let controller = state.players[0].id;
+    let opp1 = state.players[1].id;
+    let opp2 = state.players[2].id;
+    let ability = each_opponent_choose_one_of(controller, ObjectId(9100));
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    // First opponent (APNAP after controller) is prompted; the second is queued
+    // on the Iterate frame.
+    let first_prompted = match &state.waiting_for {
+        WaitingFor::ChooseOneOfBranch { player, .. } => *player,
+        other => panic!("expected ChooseOneOfBranch, got {other:?}"),
+    };
+    assert!(first_prompted == opp1 || first_prompted == opp2);
+    let queued = choose_one_of_iterate_remaining(&state)
+        .expect("a ChooseOneOf Iterate frame must carry the second opponent");
+    assert_eq!(queued.len(), 1, "one opponent remains queued on the frame");
+    let second_expected = queued[0];
+    assert_ne!(first_prompted, second_expected);
+
+    // First opponent chooses branch 0 (draw a card).
+    apply(
+        &mut state,
+        first_prompted,
+        GameAction::ChooseBranch { index: 0 },
+    )
+    .expect("first opponent chooses a branch");
+
+    // The driver re-prompted the second opponent; the frame is now consumed.
+    match &state.waiting_for {
+        WaitingFor::ChooseOneOfBranch { player, .. } => {
+            assert_eq!(*player, second_expected, "second opponent prompted next");
+        }
+        other => panic!("expected ChooseOneOfBranch for second opponent, got {other:?}"),
+    }
+    assert!(
+        choose_one_of_iterate_remaining(&state).is_none(),
+        "the Iterate frame must be consumed once the last opponent is prompted"
+    );
+
+    // Second opponent chooses branch 1 (gain life); the effect fully resolves.
+    apply(
+        &mut state,
+        second_expected,
+        GameAction::ChooseBranch { index: 1 },
+    )
+    .expect("second opponent chooses a branch");
+
+    assert!(
+        state.resolution_stack.is_empty(),
+        "resolution stack must be empty once both opponents have chosen"
+    );
+    assert!(!matches!(
+        state.waiting_for,
+        WaitingFor::ChooseOneOfBranch { .. }
+    ));
+}
+
+/// CR 608.2: A live Vote `Iterate` frame must survive a serde round-trip
+/// (save/load + multiplayer state are serialized). The frame carries a boxed
+/// `AbilityDefinition` template and a `VecDeque<IterItem>` of remaining voters;
+/// both must reconstruct byte-identically.
+#[test]
+fn iterate_frame_serde_round_trip() {
+    let template = Box::new(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::ScopedPlayer,
+        },
+    ));
+    let frame = ResolutionFrame::Iterate {
+        remaining: VecDeque::from(vec![
+            IterItem::Player(PlayerId(1)),
+            IterItem::Player(PlayerId(2)),
+        ]),
+        ctx: IterCtx {
+            source_id: ObjectId(42),
+            controller: PlayerId(0),
+            kind: IterKind::Vote { template },
+        },
+    };
+
+    let json = serde_json::to_string(&frame).expect("frame serializes");
+    let restored: ResolutionFrame = serde_json::from_str(&json).expect("frame deserializes");
+    assert_eq!(frame, restored, "Iterate frame must round-trip via serde");
+}
+
+/// A whole `GameState` carrying an `Iterate` frame on its `resolution_stack`
+/// must serialize and restore with the stack intact (back-compat: old saves
+/// with no `resolution_stack` key default to empty, covered by the field's
+/// `#[serde(default)]`).
+#[test]
+fn game_state_with_iterate_frame_round_trips() {
+    let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+    state.resolution_stack.push(ResolutionFrame::Iterate {
+        remaining: VecDeque::from(vec![IterItem::Player(PlayerId(2))]),
+        ctx: IterCtx {
+            source_id: ObjectId(7),
+            controller: PlayerId(0),
+            kind: IterKind::ChooseOneOf {
+                branches: vec![AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
+                )],
+                parent_targets: Vec::new(),
+                context: Default::default(),
+            },
+        },
+    });
+
+    let json = serde_json::to_string(&state).expect("state serializes");
+    let restored: GameState = serde_json::from_str(&json).expect("state deserializes");
+    assert_eq!(
+        restored.resolution_stack, state.resolution_stack,
+        "resolution_stack (with an Iterate frame) must round-trip"
+    );
+}
+
+/// Extract the remaining players carried on a top ChooseOneOf `Iterate` frame.
+fn choose_one_of_iterate_remaining(state: &GameState) -> Option<Vec<PlayerId>> {
+    match state.resolution_stack.last() {
+        Some(ResolutionFrame::Iterate {
+            remaining,
+            ctx:
+                IterCtx {
+                    kind: IterKind::ChooseOneOf { .. },
+                    ..
+                },
+            ..
+        }) => Some(
+            remaining
+                .iter()
+                .map(|item| match item {
+                    IterItem::Player(p) => *p,
+                })
+                .collect(),
+        ),
+        _ => None,
+    }
+}


### PR DESCRIPTION
Re-scoped per the maintainer review: this now delivers only the genuinely-unifying slice and defers the storage-relocation work.

## What this does

Introduces `GameState::resolution_stack` with a generic `ResolutionFrame::Iterate` frame (`IterItem` / `IterCtx` / `IterKind`) and ports the two per-player continuation drains — **Vote** and **ChooseOneOf** — onto it. This collapses two near-identical hand-stashed `Pending*Iteration` structs + their resume loops into one iteration frame, advanced by `drive_resolution`.

## Scope (deliberately narrow)

- **In:** the `Iterate` frame family + the Vote and ChooseOneOf ports + the Expropriate end-to-end vote test (3 ballots through `apply` in APNAP order) and the `resolution_stack_iterate` integration test.
- **Deferred** (to the slice that actually consumes LIFO nesting, per the review): the storage relocation of `change_zone_iteration` / `copy_token_resolution` / `counter_moves` / `counter_additions` / `batch_deliveries`, the unused `Chain` variant, and `Accumulator::TrackedSet`. Those continuations stay on their existing flat `pending_*` fields here.

Net: **13 files, +752/−127** (the prior broad version was 25 files / +1365). Rebased on current `main` (conflict resolved).

## Verification

`cargo test -p engine`: 13,480 passed, 0 failed · `cargo clippy -p engine --all-targets -- -D warnings`: 0 warnings · phase-ai + mtgish-import lib suites green.
