### PR TITLE
test(engine): Bloodletter lose-life doubler runtime regression

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -10454,6 +10454,44 @@ mod tests {
         assert_eq!(count, 2, "five tokens halved (rounded down) → two");
     }
 
+    /// CR 614.1a: Bloodletter of Aclazotz doubles opponent life loss on the
+    /// source controller's turn via the LoseLife replacement pipeline.
+    #[test]
+    fn bloodletter_doubles_opponent_life_loss_during_your_turn() {
+        let bloodletter = ObjectId(10);
+        let repl = {
+            let mut repl = ReplacementDefinition::new(ReplacementEvent::LoseLife)
+                .quantity_modification(QuantityModification::Double);
+            repl.valid_player = Some(ReplacementPlayerScope::Opponent);
+            repl
+        };
+
+        let mut state = GameState::new_two_player(42);
+        state.active_player = PlayerId(0);
+        let mut card = GameObject::new(
+            bloodletter,
+            CardId(1),
+            PlayerId(0),
+            "Bloodletter of Aclazotz".to_string(),
+            Zone::Battlefield,
+        );
+        card.replacement_definitions = vec![repl].into();
+        state.objects.insert(bloodletter, card);
+        state.battlefield.push_back(bloodletter);
+
+        let proposed = ProposedEvent::LifeLoss {
+            player_id: PlayerId(1),
+            amount: 3,
+            applied: HashSet::new(),
+        };
+        let mut events = Vec::new();
+        let result = replace_event(&mut state, proposed, &mut events);
+        let ReplacementResult::Execute(ProposedEvent::LifeLoss { amount, .. }) = result else {
+            panic!("expected doubled LifeLoss, got {:?}", result);
+        };
+        assert_eq!(amount, 6);
+    }
+
     /// CR 616.1: Mixed `Double` and `Plus` quantity modifications do NOT commute
     /// and should trigger a CR 616.1 ordering prompt. Doubling Season (`Double`)
     /// and Hardened Scales (`Plus{1}`) on a counter placement must prompt the player.


### PR DESCRIPTION
## Summary
- Add runtime test verifying opponent life loss doubles during the Bloodletter controller's turn

Fixes #3516

## Test plan
- [x] `cargo test -p engine --lib bloodletter_doubles`


Made with [Cursor](https://cursor.com)