### PR TITLE
fix(ai+ui): activation patience (Mother of Runes, fetch lands) + stack-label mana symbols

### DIFF
--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -15,6 +15,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { renderDescription } from "../../utils/description.ts";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
+import { RichLabel } from "../mana/RichLabel.tsx";
 import type { StackEntry as StackEntryType, StackEntryDisplay, StackPaidFactView } from "../../adapter/types.ts";
 
 interface StackEntryProps {
@@ -214,11 +215,17 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
           className="absolute inset-x-0 bottom-0 rounded-b-lg border-t border-white/10 bg-gray-900/95 px-1.5 py-1 backdrop-blur-sm"
           title={stackEntryTitle(abilityLabel, triggerDescription, targetLabels, paidLabels, contextLabels, t)}
         >
-          <div className="truncate pr-8 text-[9px] font-semibold text-purple-300">{abilityLabel}</div>
+          <RichLabel
+            text={abilityLabel}
+            size="xs"
+            className="block truncate pr-8 text-[9px] font-semibold text-purple-300"
+          />
           {triggerDescription && (
-            <div className="mt-0.5 line-clamp-3 pr-6 text-[8px] leading-tight text-gray-300">
-              {triggerDescription}
-            </div>
+            <RichLabel
+              text={triggerDescription}
+              size="xs"
+              className="mt-0.5 line-clamp-3 pr-6 text-[8px] leading-tight text-gray-300"
+            />
           )}
         </div>
       )}

--- a/crates/phase-ai/src/features/mana_ramp.rs
+++ b/crates/phase-ai/src/features/mana_ramp.rs
@@ -272,7 +272,7 @@ fn chain_puts_land_to_safe_zone(ability: &AbilityDefinition) -> bool {
     })
 }
 
-fn target_filter_references_land(filter: &TargetFilter) -> bool {
+pub(crate) fn target_filter_references_land(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::Typed(typed) => typed.type_filters.iter().any(type_filter_is_land),
         TargetFilter::Or { filters } | TargetFilter::And { filters } => {

--- a/crates/phase-ai/src/policies/fetch_land_patience.rs
+++ b/crates/phase-ai/src/policies/fetch_land_patience.rs
@@ -1,0 +1,304 @@
+//! Fetch-land patience tactical policy.
+//!
+//! Report (Discord #ai-suggestions): the AI cracks Evolving Wilds the instant
+//! it resolves, with no patience. Evolving Wilds ("{T}, Sacrifice this land:
+//! Search your library for a basic land card, put it onto the battlefield
+//! tapped, then shuffle.") and its class (Terramorphic Expanse, Terminal
+//! Moraine, …) sacrifice themselves to fetch a land that enters **tapped**.
+//!
+//! Because the fetched land enters tapped (CR 305.4 — it is *put* onto the
+//! battlefield, not played), cracking the fetch yields **zero mana this turn**.
+//! The only payoff is fixing/thinning for a *later* turn. So there is never a
+//! same-turn reason to crack early: the patient line is to hold the fetch until
+//! the AI's own end step, by which point it has seen the whole turn and knows
+//! which basic it actually wants. Cracking earlier gives up that information for
+//! no tempo gain.
+//!
+//! This policy rejects cracking a tapped self-sacrifice land-fetch outside the
+//! AI's own end step, and gives a small nudge to crack it *at* the end step (the
+//! source produces no mana on its own, so leaving it uncracked strands a dead
+//! land). It deliberately ignores untapped true fetchlands (Wooded Foothills,
+//! Flooded Strand): those produce mana the turn they are cracked, so early
+//! cracking is correct and must not be gated.
+
+use engine::types::ability::{AbilityCost, Effect, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::{EtbTapState, Zone};
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::features::mana_ramp::target_filter_references_land;
+use crate::features::DeckFeatures;
+
+/// Small positive nudge to crack the fetch at the AI's own end step. The source
+/// produces no mana itself, so converting it to a (tapped) basic is strictly
+/// card-neutral and readies a real mana source for next turn — leaving it
+/// uncracked strands a dead land. Nudge-band: enough to beat `PassPriority`,
+/// never enough to override a genuinely better line.
+const END_STEP_CRACK_NUDGE: f64 = 0.3;
+
+pub struct FetchLandPatiencePolicy;
+
+impl TacticalPolicy for FetchLandPatiencePolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::FetchLandPatience
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::ActivateAbility]
+    }
+
+    fn activation(
+        &self,
+        _features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        // Applies to every deck — Evolving Wilds shows up anywhere. The verdict's
+        // classifier self-gates to the tapped fetch-sacrifice land class.
+        // activation-constant: classifier-gated fetch-land patience policy.
+        Some(1.0)
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let na = || PolicyVerdict::neutral(PolicyReason::new("fetch_patience_na"));
+
+        let GameAction::ActivateAbility {
+            source_id,
+            ability_index,
+        } = &ctx.candidate.action
+        else {
+            return na();
+        };
+
+        let Some(def) = ctx
+            .state
+            .objects
+            .get(source_id)
+            .and_then(|obj| obj.abilities.get(*ability_index))
+        else {
+            return na();
+        };
+
+        // The Evolving Wilds class: a self-sacrifice cost whose effect chain
+        // fetches a land that enters the battlefield tapped.
+        if !cost_sacrifices_self(def.cost.as_ref())
+            || !effects_are_tapped_land_fetch(&ctx.effects())
+        {
+            return na();
+        }
+
+        // CR 513 / CR 514: the AI's own end step is the patient window. The land
+        // enters tapped, so cracking now vs. at end step is identical for this
+        // turn's mana — but end step preserves information until the last moment.
+        let own_end_step =
+            ctx.state.phase == Phase::End && ctx.state.active_player == ctx.ai_player;
+        if own_end_step {
+            return PolicyVerdict::nudge(
+                END_STEP_CRACK_NUDGE,
+                PolicyReason::new("fetch_patience_end_step"),
+            );
+        }
+
+        // Any earlier window: hold the fetch. Hard-`Reject` rather than penalise —
+        // the end-step nudge above guarantees it still cracks eventually, so the
+        // land is never stranded.
+        PolicyVerdict::reject(PolicyReason::new("fetch_patience_hold"))
+    }
+}
+
+/// True if `cost` sacrifices the source permanent itself (CR 701.21) — the
+/// signature of a one-shot fetch land. Recurses into composite costs so it
+/// matches "{T}, Sacrifice ~" and "{1}, {T}, Sacrifice ~" alike.
+fn cost_sacrifices_self(cost: Option<&AbilityCost>) -> bool {
+    fn check(c: &AbilityCost) -> bool {
+        match c {
+            AbilityCost::Sacrifice(sac) => matches!(sac.target, TargetFilter::SelfRef),
+            AbilityCost::Composite { costs } => costs.iter().any(check),
+            _ => false,
+        }
+    }
+    cost.is_some_and(check)
+}
+
+/// True if the effect chain searches the library for a land and puts a land
+/// onto the battlefield **tapped** (the Evolving Wilds signature, as opposed to
+/// untapped true fetchlands which produce mana the turn they are cracked).
+///
+/// The two predicates are checked independently across the chain rather than
+/// proving the *searched* card is the one entering tapped — the fetch-land class
+/// always co-locates them (search land → put that land in tapped → shuffle), and
+/// the self-sacrifice gate in `cost_sacrifices_self` already isolates the class.
+/// If a future composite ability searches a land *and* separately drops some
+/// other tapped permanent, tighten this to the `ChangeZone` whose `target`
+/// references land.
+fn effects_are_tapped_land_fetch(effects: &[&Effect]) -> bool {
+    let searches_land = effects.iter().copied().any(|e| {
+        matches!(e, Effect::SearchLibrary { filter, .. } if target_filter_references_land(filter))
+    });
+    let puts_tapped_land = effects.iter().copied().any(|e| {
+        matches!(
+            e,
+            Effect::ChangeZone {
+                destination: Zone::Battlefield,
+                enter_tapped: EtbTapState::Tapped,
+                ..
+            }
+        )
+    });
+    searches_land && puts_tapped_land
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AiConfig;
+    use crate::context::AiContext;
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::zones::create_object;
+    use engine::types::ability::{
+        AbilityDefinition, AbilityKind, ControllerRef, QuantityExpr, SacrificeCost, TypedFilter,
+    };
+    use engine::types::game_state::WaitingFor;
+    use engine::types::identifiers::{CardId, ObjectId};
+    use std::sync::Arc;
+
+    const AI: PlayerId = PlayerId(0);
+
+    /// Build an Evolving Wilds-shaped activated ability: `{T}, Sacrifice ~`
+    /// searching for a land that enters the battlefield with the given tap state.
+    fn fetch_land_ability(enter_tapped: EtbTapState) -> AbilityDefinition {
+        let mut ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::SearchLibrary {
+                filter: TargetFilter::Typed(TypedFilter::land()),
+                count: QuantityExpr::Fixed { value: 1 },
+                reveal: false,
+                target_player: None,
+                selection_constraint: engine::types::ability::SearchSelectionConstraint::None,
+                split: None,
+                source_zones: vec![Zone::Library],
+            },
+        );
+        ability.cost = Some(AbilityCost::Composite {
+            costs: vec![
+                AbilityCost::Tap,
+                AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1)),
+            ],
+        });
+        ability.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                origin: Some(Zone::Library),
+                destination: Zone::Battlefield,
+                target: TargetFilter::Typed(TypedFilter::land()),
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: Some(ControllerRef::You),
+                enter_tapped,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+        )));
+        ability
+    }
+
+    fn ai_land_with_ability(state: &mut GameState, ability: AbilityDefinition) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(1),
+            AI,
+            "Evolving Wilds".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types
+            .core_types
+            .push(engine::types::card_type::CoreType::Land);
+        Arc::make_mut(&mut obj.abilities).push(ability);
+        id
+    }
+
+    fn verdict_for(state: &GameState, source_id: ObjectId) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Ability,
+            },
+        };
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        FetchLandPatiencePolicy.verdict(&ctx)
+    }
+
+    /// Cracking Evolving Wilds during the AI's own precombat main (the reported
+    /// "instant pop") is rejected — the fetched land enters tapped, so there is
+    /// no same-turn payoff to justify giving up information now.
+    #[test]
+    fn evolving_wilds_main_phase_rejected() {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        state.phase = Phase::PreCombatMain;
+        let id = ai_land_with_ability(&mut state, fetch_land_ability(EtbTapState::Tapped));
+        match verdict_for(&state, id) {
+            PolicyVerdict::Reject { reason } => assert_eq!(reason.kind, "fetch_patience_hold"),
+            PolicyVerdict::Score { .. } => panic!("expected reject during main phase"),
+        }
+    }
+
+    /// At the AI's own end step the fetch is nudged to crack — leaving the
+    /// no-mana source uncracked strands a dead land.
+    #[test]
+    fn evolving_wilds_own_end_step_nudged() {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        state.phase = Phase::End;
+        let id = ai_land_with_ability(&mut state, fetch_land_ability(EtbTapState::Tapped));
+        match verdict_for(&state, id) {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "fetch_patience_end_step");
+                assert!(delta > 0.0);
+            }
+            PolicyVerdict::Reject { .. } => panic!("expected nudge at end step"),
+        }
+    }
+
+    /// An untapped true fetchland (Wooded Foothills shape) is NOT gated — it
+    /// produces mana the turn it is cracked, so early cracking is correct.
+    #[test]
+    fn untapped_fetchland_unaffected() {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        state.phase = Phase::PreCombatMain;
+        let id = ai_land_with_ability(&mut state, fetch_land_ability(EtbTapState::Untapped));
+        match verdict_for(&state, id) {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "fetch_patience_na");
+                assert_eq!(delta, 0.0);
+            }
+            PolicyVerdict::Reject { .. } => panic!("untapped fetch must not be gated"),
+        }
+    }
+}

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -19,6 +19,7 @@ mod effect_timing;
 mod equipment_priority;
 mod etb_value;
 mod evasion_removal_priority;
+mod fetch_land_patience;
 mod free_outlet_activation;
 pub(crate) mod hand_disruption;
 mod hold_mana_up;

--- a/crates/phase-ai/src/policies/reactive_self_protection.rs
+++ b/crates/phase-ai/src/policies/reactive_self_protection.rs
@@ -1,7 +1,8 @@
 //! Reactive self-protection tactical policy.
 //!
-//! Penalises the AI for casting OR activating "save yourself" effects when
-//! there is no immediate threat to react to. Empirically observed: AI casting
+//! Rejects the AI casting OR activating "save yourself" effects when there is
+//! no immediate threat to react to and it is not the combat phase. Empirically
+//! observed: AI casting
 //! Teferi's Protection on turn 3 against an empty board; AI repeatedly paying
 //! "discard a card: ~ gains protection from everything" until its hand is
 //! empty; AI activating Sylvan Safekeeper ("sacrifice a land: target creature
@@ -30,6 +31,7 @@ use engine::types::ability::{
 use engine::types::actions::GameAction;
 use engine::types::game_state::GameState;
 use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
 
@@ -42,9 +44,6 @@ use crate::features::DeckFeatures;
 /// `threat_level` is normalised 0..1; 0.45 corresponds to a meaningfully
 /// developed opposing board (creatures + power) or a low life total.
 const THREAT_FLOOR: f64 = 0.45;
-
-/// Penalty applied when the AI tries to cast self-protection with no threat.
-const NO_THREAT_PENALTY: f64 = -8.0;
 
 pub struct ReactiveSelfProtectionPolicy;
 
@@ -98,9 +97,33 @@ impl TacticalPolicy for ReactiveSelfProtectionPolicy {
             };
         }
 
-        PolicyVerdict::Score {
-            delta: NO_THREAT_PENALTY,
-            reason: PolicyReason::new("reactive_self_protection_no_threat"),
+        // CR 508/509 + CR 510: a protective grant has a real payoff only once
+        // creatures are actually in combat — to dodge a blocker's color
+        // (CR 509.1b), survive a block, or shrug off combat damage. Restrict the
+        // carve-out to the declare-attackers/declare-blockers/combat-damage
+        // steps: at beginning- and end-of-combat there are no attackers or
+        // blockers (yet / any longer), so activating there is the same wasted
+        // tap as the main phase. Opponent-turn board pressure is already covered
+        // by `any_immediate_threat`; this preserves the AI's *own* combat, where
+        // CR 508.1a board pressure is intentionally ignored.
+        if matches!(
+            ctx.state.phase,
+            Phase::DeclareAttackers | Phase::DeclareBlockers | Phase::CombatDamage
+        ) {
+            return PolicyVerdict::Score {
+                delta: 0.0,
+                reason: PolicyReason::new("reactive_self_protection_combat_payoff"),
+            };
+        }
+
+        // CR 117.1a + CR 514.2: outside combat, with no threat on the stack and
+        // healthy life, an "until end of turn" protective grant expires before
+        // it can ever matter — spending a tap / sacrifice / discard on it is
+        // strictly wasted. Hard-`Reject` rather than soft-penalise: as a prior,
+        // an -8.0 penalty was repeatedly overridden by the value search, which
+        // fired Mother of Runes (and friends) every turn for no reason.
+        PolicyVerdict::Reject {
+            reason: PolicyReason::new("reactive_self_protection_no_payoff"),
         }
     }
 }
@@ -573,30 +596,29 @@ mod tests {
     }
 
     /// Runtime: activating a SelfRef defensive grant ("~ gains indestructible")
-    /// with no threat present is penalized. Discriminating for the
-    /// decision_kinds/guard widening (revert → `_na`).
+    /// with no threat present and outside combat is hard-rejected — the grant
+    /// expires (CR 514.2) before it can matter, so the AI must not burn the cost.
     #[test]
-    fn activation_self_ref_protection_no_threat_penalized() {
+    fn activation_self_ref_protection_no_threat_rejected() {
         let mut state = GameState::new_two_player(42);
         let id = ai_object_with_activated(
             &mut state,
             grant_effect(Some(TargetFilter::SelfRef), None, Keyword::Indestructible),
         );
         match activate_verdict(&state, id) {
-            PolicyVerdict::Score { delta, reason } => {
-                assert_eq!(reason.kind, "reactive_self_protection_no_threat");
-                assert_eq!(delta, NO_THREAT_PENALTY);
+            PolicyVerdict::Reject { reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_no_payoff");
             }
-            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+            PolicyVerdict::Score { .. } => panic!("expected reject for no-payoff activation"),
         }
     }
 
     /// Runtime: activating a ParentTarget grant to a creature you control
     /// ("sac a land: target creature you control gains shroud", Sylvan
-    /// Safekeeper) with no threat is penalized. Discriminating for part 3
-    /// (revert the ParentTarget classifier branch → `_na`).
+    /// Safekeeper) with no threat outside combat is hard-rejected. This is the
+    /// Mother of Runes shape (ParentTarget + controller You + defensive grant).
     #[test]
-    fn activation_parent_target_protection_no_threat_penalized() {
+    fn activation_parent_target_protection_no_threat_rejected() {
         let mut state = GameState::new_two_player(42);
         let id = ai_object_with_activated(
             &mut state,
@@ -609,11 +631,10 @@ mod tests {
             ),
         );
         match activate_verdict(&state, id) {
-            PolicyVerdict::Score { delta, reason } => {
-                assert_eq!(reason.kind, "reactive_self_protection_no_threat");
-                assert_eq!(delta, NO_THREAT_PENALTY);
+            PolicyVerdict::Reject { reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_no_payoff");
             }
-            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+            PolicyVerdict::Score { .. } => panic!("expected reject for no-payoff activation"),
         }
     }
 
@@ -728,14 +749,14 @@ mod tests {
             grant_effect(Some(TargetFilter::SelfRef), None, Keyword::Indestructible),
         );
 
-        // AI's own turn: board pressure must NOT waive the no-threat penalty.
+        // AI's own (non-combat) turn: board pressure must NOT waive the gate —
+        // the grant expires before the opponent can attack, so it is rejected.
         state.active_player = AI;
         match activate_verdict(&state, id) {
-            PolicyVerdict::Score { delta, reason } => {
-                assert_eq!(reason.kind, "reactive_self_protection_no_threat");
-                assert_eq!(delta, NO_THREAT_PENALTY);
+            PolicyVerdict::Reject { reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_no_payoff");
             }
-            PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+            PolicyVerdict::Score { .. } => panic!("expected reject on own non-combat turn"),
         }
 
         // Opponent's turn: the same board IS an immediate threat → allowed.
@@ -746,6 +767,97 @@ mod tests {
                 assert_eq!(delta, 0.0);
             }
             PolicyVerdict::Reject { .. } => panic!("unexpected reject"),
+        }
+    }
+
+    /// Regression (reported bug): Mother of Runes ("{T}: Target creature you
+    /// control gains protection from the color of your choice until end of
+    /// turn.") parses to a `GenericEffect` with `affected = ParentTarget`, a
+    /// parent `target` of `controller: You`, and an `AddKeyword` of
+    /// `Protection(ChosenColor)`. On the AI's own main phase with no stack
+    /// threat, the AI tapped it every turn for nothing. It must now be rejected.
+    #[test]
+    fn mother_of_runes_own_main_phase_rejected() {
+        use engine::types::keywords::ProtectionTarget;
+
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        // Default phase is `Untap` (non-combat); the reported activations were
+        // on the precombat main phase — both are gated identically.
+        let id = ai_object_with_activated(
+            &mut state,
+            grant_effect(
+                Some(TargetFilter::ParentTarget),
+                Some(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+                Keyword::Protection(ProtectionTarget::ChosenColor),
+            ),
+        );
+        match activate_verdict(&state, id) {
+            PolicyVerdict::Reject { reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_no_payoff");
+            }
+            PolicyVerdict::Score { .. } => panic!("Mother of Runes must be rejected on own main"),
+        }
+    }
+
+    /// During the combat phase, the same protective grant has a real payoff
+    /// (save an attacker / push damage) even with an empty stack — so it is
+    /// allowed, not rejected. Discriminates the `phase.is_combat()` carve-out.
+    #[test]
+    fn protection_allowed_during_own_combat() {
+        use engine::types::keywords::ProtectionTarget;
+        use engine::types::phase::Phase;
+
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        state.phase = Phase::DeclareBlockers;
+        let id = ai_object_with_activated(
+            &mut state,
+            grant_effect(
+                Some(TargetFilter::ParentTarget),
+                Some(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+                Keyword::Protection(ProtectionTarget::ChosenColor),
+            ),
+        );
+        match activate_verdict(&state, id) {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_combat_payoff");
+                assert_eq!(delta, 0.0);
+            }
+            PolicyVerdict::Reject { .. } => panic!("combat protection must be allowed"),
+        }
+    }
+
+    /// The beginning-of-combat step has no attackers or blockers yet, so the
+    /// carve-out must NOT fire there — otherwise the reported "tap Mother every
+    /// turn" bug just relocates from the main phase to own BeginCombat.
+    #[test]
+    fn protection_rejected_at_begin_combat() {
+        use engine::types::keywords::ProtectionTarget;
+        use engine::types::phase::Phase;
+
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        state.phase = Phase::BeginCombat;
+        let id = ai_object_with_activated(
+            &mut state,
+            grant_effect(
+                Some(TargetFilter::ParentTarget),
+                Some(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+                Keyword::Protection(ProtectionTarget::ChosenColor),
+            ),
+        );
+        match activate_verdict(&state, id) {
+            PolicyVerdict::Reject { reason } => {
+                assert_eq!(reason.kind, "reactive_self_protection_no_payoff");
+            }
+            PolicyVerdict::Score { .. } => panic!("begin-of-combat has no payoff; must reject"),
         }
     }
 }

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -13,6 +13,7 @@ use super::copy_value::CopyValuePolicy;
 use super::effect_timing::EffectTimingPolicy;
 use super::etb_value::EtbValuePolicy;
 use super::evasion_removal_priority::EvasionRemovalPriorityPolicy;
+use super::fetch_land_patience::FetchLandPatiencePolicy;
 use super::free_outlet_activation::FreeOutletActivationPolicy;
 use super::hand_disruption::HandDisruptionPolicy;
 use super::hold_mana_up::HoldManaUpForInteractionPolicy;
@@ -81,6 +82,7 @@ pub enum PolicyId {
     HoldManaUpForInteraction,
     SweeperTiming,
     FreeOutletActivation,
+    FetchLandPatience,
     AristocratsKeepablesMulligan,
     AggroPressure,
     AggroKeepablesMulligan,
@@ -295,6 +297,7 @@ impl Default for PolicyRegistry {
             Box::new(HoldManaUpForInteractionPolicy),
             Box::new(SweeperTimingPolicy),
             Box::new(FreeOutletActivationPolicy),
+            Box::new(FetchLandPatiencePolicy),
             Box::new(AggroPressurePolicy),
             Box::new(TokensWidePolicy),
             Box::new(AnthemPriorityPolicy),


### PR DESCRIPTION
- **fix(ai): give the AI patience on reactive protection and fetch lands**
- **fix(ui): render mana/tap symbols in stack-card trigger label**
