### PR TITLE
fix(parser): Adeline tokens enter tapped and attacking (issue #3303)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -300,6 +300,11 @@ fn parse_token_description_with_context(
     // Pakal, Thousandth Moon) — accept that as a valid terminator in addition
     // to EOF so the attacking flag is captured even when a variable-X binding
     // trails the clause.
+    // CR 508.4: trailing defender phrases ("that player or a planeswalker they
+    // control", "that opponent", etc. — Adeline, Resplendent Cathar / Myriad
+    // class) must not prevent the inline modifier from matching; accept a word
+    // boundary after "attacking" the same way `parse_battlefield_entry_qualifiers`
+    // does for put-onto-battlefield effects.
     let attacking_clause = |i| -> OracleResult<'_, bool> {
         let (i, _) = alt((
             tag(" that's"),
@@ -313,7 +318,14 @@ fn parse_token_description_with_context(
             value(false, tag(" attacking")),
         ))
         .parse(i)?;
-        let (i, _) = alt((value((), nom::combinator::eof), value((), tag(", where ")))).parse(i)?;
+        let (i, _) = alt((
+            value((), nom::combinator::eof),
+            value((), tag(", where ")),
+            value((), tag(" ")),
+            value((), tag(",")),
+            value((), tag(".")),
+        ))
+        .parse(i)?;
         Ok((i, tapped))
     };
     // Nom parses forward; scan byte positions (only those starting with the
@@ -2119,6 +2131,30 @@ mod tests {
             tf.type_filters.contains(&TypeFilter::Creature),
             "X must count controlled creatures, got {:?}",
             tf.type_filters
+        );
+    }
+
+    /// CR 508.4 + CR 506.3a: Adeline, Resplendent Cathar — "for each opponent,
+    /// create … token that's tapped and attacking that player or a planeswalker
+    /// they control." The trailing defender phrase must not defeat the inline
+    /// modifier (issue #3303).
+    #[test]
+    fn token_thats_tapped_and_attacking_that_player_suffix_sets_flags() {
+        let text = "create a 1/1 white human creature token that's tapped and attacking that player or a planeswalker they control";
+        let effect = try_parse_token(&text.to_lowercase(), text, &mut ParseContext::default())
+            .expect("expected Token effect");
+        let Effect::Token {
+            tapped,
+            enters_attacking,
+            ..
+        } = effect
+        else {
+            panic!("expected Token effect");
+        };
+        assert!(tapped, "Human token must enter tapped");
+        assert!(
+            enters_attacking,
+            "Human token must enter attacking despite trailing defender phrase"
         );
     }
 

--- a/crates/engine/tests/integration/issue_3303_adeline_tapped_attacking.rs
+++ b/crates/engine/tests/integration/issue_3303_adeline_tapped_attacking.rs
@@ -1,0 +1,107 @@
+//! GitHub issue #3303 — Adeline, Resplendent Cathar's attack tokens must enter
+//! tapped and attacking.
+//!
+//! Oracle text:
+//!   Vigilance
+//!   Adeline's power is equal to the number of creatures you control.
+//!   Whenever you attack, for each opponent, create a 1/1 white Human creature
+//!   token that's tapped and attacking that player or a planeswalker they control.
+//!
+//! CR 508.4: tokens that enter tapped and attacking must be registered on
+//! `combat.attackers` during a live combat step.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+const ADELINE_ORACLE: &str = "Vigilance\n\
+    Adeline's power is equal to the number of creatures you control.\n\
+    Whenever you attack, for each opponent, create a 1/1 white Human creature token that's tapped and attacking that player or a planeswalker they control.";
+
+fn human_tokens(runner: &GameRunner) -> Vec<ObjectId> {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| {
+            o.controller == P0
+                && o.zone == Zone::Battlefield
+                && o.is_token
+                && o.card_types
+                    .subtypes
+                    .iter()
+                    .any(|s| s.eq_ignore_ascii_case("human"))
+        })
+        .map(|o| o.id)
+        .collect()
+}
+
+fn resolve_attack_trigger(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    return;
+                }
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            other if matches!(other, WaitingFor::OrderTriggers { .. }) => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![] })
+                    .expect("order triggers");
+            }
+            other => panic!("unexpected waiting state during Adeline trigger: {other:?}"),
+        }
+    }
+    panic!("Adeline trigger did not resolve");
+}
+
+#[test]
+fn adeline_attack_tokens_enter_tapped_and_attacking() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let adeline = scenario
+        .add_creature_from_oracle(P0, "Adeline, Resplendent Cathar", 3, 3, ADELINE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(adeline, AttackTarget::Player(P1))])
+        .expect("declare Adeline attacking P1");
+
+    resolve_attack_trigger(&mut runner);
+
+    let tokens = human_tokens(&runner);
+    assert_eq!(
+        tokens.len(),
+        1,
+        "two-player game: one Human token per opponent"
+    );
+
+    let attacking: Vec<ObjectId> = runner
+        .state()
+        .combat
+        .as_ref()
+        .expect("combat must be live")
+        .attackers
+        .iter()
+        .map(|a| a.object_id)
+        .collect();
+
+    for token in tokens {
+        let obj = runner.state().objects.get(&token).expect("token exists");
+        assert!(obj.tapped, "issue #3303: Human token must enter tapped");
+        assert!(
+            attacking.contains(&token),
+            "issue #3303: Human token must enter attacking; attackers={attacking:?}"
+        );
+    }
+}

--- a/crates/engine/tests/integration/issue_3303_adeline_tapped_attacking.rs
+++ b/crates/engine/tests/integration/issue_3303_adeline_tapped_attacking.rs
@@ -50,7 +50,7 @@ fn resolve_attack_trigger(runner: &mut GameRunner) {
                 }
                 runner.act(GameAction::PassPriority).expect("pass priority");
             }
-            other if matches!(other, WaitingFor::OrderTriggers { .. }) => {
+            WaitingFor::OrderTriggers { .. } => {
                 runner
                     .act(GameAction::OrderTriggers { order: vec![] })
                     .expect("order triggers");

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -220,6 +220,7 @@ mod issue_3283_sevinne_reclamation_copy_no_self_copy;
 mod issue_3285_face_down_public_zone;
 mod issue_3295_scrapwork_mutt_unearth_zone;
 mod issue_3302_breach_multiverse;
+mod issue_3303_adeline_tapped_attacking;
 mod issue_3309_rise_etb_returns;
 mod issue_3311_manifest_dread_land;
 mod issue_3320_peregrine_drake_untap_prompt;


### PR DESCRIPTION
## Summary

- Extend the token inline `tapped and attacking` modifier to accept trailing defender phrases (`that player or a planeswalker they control`, etc.), matching the battlefield-entry qualifier behavior used by Kaalia/Ilharg-style effects.
- Add parser and integration tests for Adeline, Resplendent Cathar's attack trigger.

Fixes #3303.

## Test plan

- [x] `cargo test -p engine token_thats_tapped_and_attacking_that_player_suffix_sets_flags`
- [x] `cargo test -p engine adeline_attack_tokens_enter_tapped_and_attacking`
- [x] `cargo clippy -p engine -- -D warnings`


Made with [Cursor](https://cursor.com)