### PR TITLE
fix(casting): hide illegal modal spell modes by target legality (issue #3301)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1152,7 +1152,7 @@ export type WaitingFor =
   | { type: "NamedChoice"; data: { player: PlayerId; choice_type: string | Record<string, unknown>; options: string[]; source_id?: ObjectId } }
   | { type: "SpellbookDraft"; data: { player: PlayerId; source_id: ObjectId; options: string[]; destination: Zone; tapped?: boolean } }
   | { type: "DamageSourceChoice"; data: { player: PlayerId; source_filter: TargetFilter; options: ObjectId[] } }
-  | { type: "ModeChoice"; data: { player: PlayerId; modal: ModalChoice; pending_cast: PendingCast } }
+  | { type: "ModeChoice"; data: { player: PlayerId; modal: ModalChoice; pending_cast: PendingCast; unavailable_modes?: number[] } }
   | { type: "AbilityModeChoice"; data: { player: PlayerId; modal: ModalChoice; source_id: ObjectId; mode_abilities: unknown[]; is_activated: boolean; ability_index?: number; ability_cost?: unknown; unavailable_modes?: number[] } }
   | { type: "DiscardToHandSize"; data: { player: PlayerId; count: number; cards: ObjectId[] } }
   | { type: "OptionalCostChoice"; data: { player: PlayerId; cost: AdditionalCost; times_kicked: number; pending_cast: PendingCast } }

--- a/client/src/components/modal/ModeChoiceModal.tsx
+++ b/client/src/components/modal/ModeChoiceModal.tsx
@@ -23,10 +23,10 @@ export function ModeChoiceModal() {
       : waitingFor.data.pending_cast.object_id;
   const unavailableModes: number[] = useMemo(
     () =>
-      isAbilityMode && "unavailable_modes" in waitingFor.data
+      isModeChoice && "unavailable_modes" in waitingFor.data
         ? (waitingFor.data.unavailable_modes ?? [])
         : [],
-    [isAbilityMode, waitingFor],
+    [isModeChoice, waitingFor],
   );
   const isMyChoice = isModeChoice && canActForWaitingState;
 

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1287,12 +1287,24 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             player,
             modal,
             pending_cast,
+            unavailable_modes,
         } => {
+            let available: Vec<usize> = (0..modal.mode_count)
+                .filter(|i| !unavailable_modes.contains(i))
+                .collect();
             let actions = if modal.allow_repeat_modes {
-                // CR 700.2d: Use sequence generation that allows repeated indices.
-                crate::game::ability_utils::generate_modal_index_sequences(modal)
+                // Build a filtered ModalChoice for sequence generation with repeats.
+                let filtered = crate::types::ability::ModalChoice {
+                    mode_count: available.len(),
+                    min_choices: modal.min_choices,
+                    max_choices: modal.max_choices,
+                    allow_repeat_modes: true,
+                    ..modal.clone()
+                };
+                crate::game::ability_utils::generate_modal_index_sequences(&filtered)
                     .into_iter()
-                    .map(|indices| {
+                    .map(|local_indices| {
+                        let indices = local_indices.into_iter().map(|i| available[i]).collect();
                         candidate(
                             GameAction::SelectModes { indices },
                             TacticalClass::Selection,
@@ -1301,9 +1313,9 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
                     })
                     .collect()
             } else {
-                mode_actions(
+                mode_actions_from_available(
                     *player,
-                    modal.mode_count,
+                    &available,
                     modal.min_choices,
                     modal.max_choices,
                 )
@@ -3620,16 +3632,6 @@ fn remove_counter_cost_distribution_candidate(
     } else {
         Vec::new()
     }
-}
-
-fn mode_actions(
-    player: PlayerId,
-    mode_count: usize,
-    min: usize,
-    max: usize,
-) -> Vec<CandidateAction> {
-    let indices: Vec<usize> = (0..mode_count).collect();
-    mode_actions_from_available(player, &indices, min, max)
 }
 
 fn mode_actions_from_available(

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -619,14 +619,28 @@ pub fn spell_modal_unavailable_modes(
     mode_abilities: &[AbilityDefinition],
 ) -> Vec<usize> {
     let mut unavailable_modes = compute_unavailable_modes(state, source_id, modal);
-    filter_modes_by_target_legality(
-        state,
-        source_id,
-        controller,
-        mode_abilities,
-        modal,
-        &mut unavailable_modes,
-    );
+    let x_dependent_modal_targets = state
+        .objects
+        .get(&source_id)
+        .map(|obj| super::casting_costs::cost_has_x(&obj.mana_cost))
+        .unwrap_or(false)
+        && mode_abilities.iter().any(|mode| {
+            let resolved = build_resolved_from_def(mode, source_id, controller);
+            ability_target_legality_needs_chosen_x(&resolved, mode.distribute.as_ref())
+        });
+    // CR 601.2b/c: When modal spell target legality depends on announced X,
+    // modes cannot be pre-disabled before ChooseXValue — same deferral as
+    // activated modal abilities (casting.rs AbilityModeChoice path).
+    if !x_dependent_modal_targets {
+        filter_modes_by_target_legality(
+            state,
+            source_id,
+            controller,
+            mode_abilities,
+            modal,
+            &mut unavailable_modes,
+        );
+    }
     unavailable_modes
 }
 

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use crate::types::ability::TapStateChange;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, CardTypeSetSource, CastManaSpentMetric,
+    AbilityCondition, AbilityDefinition, AbilityKind, CardTypeSetSource, CastManaSpentMetric,
     CombatRelationSubject, ControllerRef, CounterMoveSelection, Effect, EffectScope, FilterProp,
     GameRestriction, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
     MultiTargetSpec, ObjectScope, PlayerFilter, QuantityExpr, QuantityRef, ResolvedAbility,
@@ -607,6 +607,38 @@ pub fn compute_unavailable_modes(
     unavailable.sort_unstable();
     unavailable.dedup();
     unavailable
+}
+
+/// CR 700.2a-b: Mode indices a modal spell cannot choose — repeat constraints
+/// plus modes whose targeting requirements have no legal assignment.
+pub fn spell_modal_unavailable_modes(
+    state: &GameState,
+    source_id: ObjectId,
+    controller: PlayerId,
+    modal: &ModalChoice,
+    mode_abilities: &[AbilityDefinition],
+) -> Vec<usize> {
+    let mut unavailable_modes = compute_unavailable_modes(state, source_id, modal);
+    filter_modes_by_target_legality(
+        state,
+        source_id,
+        controller,
+        mode_abilities,
+        modal,
+        &mut unavailable_modes,
+    );
+    unavailable_modes
+}
+
+/// Spell-kind abilities on a modal spell object — one entry per printed mode.
+pub fn modal_spell_mode_abilities(
+    obj: &crate::game::game_object::GameObject,
+) -> Vec<AbilityDefinition> {
+    obj.abilities
+        .iter()
+        .filter(|a| a.kind == AbilityKind::Spell)
+        .cloned()
+        .collect()
 }
 
 /// CR 700.2a-b + CR 700.2f: Extends `unavailable_modes` with mode indices

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -8482,10 +8482,23 @@ fn continue_with_prepared(
             // "an opponent chooses —"). Target selection still belongs to the
             // controller (CR 115.1) — `pending_cast` keeps the caster.
             let mode_chooser = resolve_modal_chooser(state, &capped, player, prepared.object_id);
+            let mode_abilities = state
+                .objects
+                .get(&prepared.object_id)
+                .map(super::ability_utils::modal_spell_mode_abilities)
+                .unwrap_or_default();
+            let unavailable_modes = super::ability_utils::spell_modal_unavailable_modes(
+                state,
+                prepared.object_id,
+                player,
+                &capped,
+                &mode_abilities,
+            );
             return Ok(WaitingFor::ModeChoice {
                 player: mode_chooser,
                 modal: capped,
                 pending_cast: Box::new(pending_modal),
+                unavailable_modes,
             });
         }
 
@@ -9139,9 +9152,25 @@ pub fn spell_has_legal_targets(
         });
     }
 
-    // Modal spells defer target checking until after mode selection
-    if obj.modal.is_some() {
-        return true;
+    // CR 700.2a-b: Modal spells are castable only when at least one mode has a
+    // legal targeting assignment (or needs no targets).
+    if let Some(ref modal) = obj.modal {
+        let mode_abilities = super::ability_utils::modal_spell_mode_abilities(obj);
+        let capped = modal_choice_for_player(
+            &simulated,
+            player,
+            obj.id,
+            modal,
+            &crate::types::ability::SpellContext::default(),
+        );
+        let unavailable = super::ability_utils::spell_modal_unavailable_modes(
+            &simulated,
+            obj.id,
+            player,
+            &capped,
+            &mode_abilities,
+        );
+        return unavailable.len() < capped.mode_count;
     }
 
     // Only Spell-kind abilities contribute targets when casting.

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -840,10 +840,23 @@ fn finish_pending_cost_or_cast(
         );
         capped.max_choices = capped.max_choices.min(capped.mode_count);
         pending.target_constraints = target_constraints_from_modal(&capped);
+        let mode_abilities = state
+            .objects
+            .get(&pending.object_id)
+            .map(super::ability_utils::modal_spell_mode_abilities)
+            .unwrap_or_default();
+        let unavailable_modes = super::ability_utils::spell_modal_unavailable_modes(
+            state,
+            pending.object_id,
+            player,
+            &capped,
+            &mode_abilities,
+        );
         return Ok(WaitingFor::ModeChoice {
             player,
             modal: capped,
             pending_cast: Box::new(pending),
+            unavailable_modes,
         });
     }
 
@@ -2534,10 +2547,23 @@ pub(super) fn begin_modal_additional_cost_declaration(
         pending.origin_zone = origin_zone;
         pending.payment_mode = payment_mode;
         pending.target_constraints = target_constraints_from_modal(&capped);
+        let mode_abilities = state
+            .objects
+            .get(&object_id)
+            .map(super::ability_utils::modal_spell_mode_abilities)
+            .unwrap_or_default();
+        let unavailable_modes = super::ability_utils::spell_modal_unavailable_modes(
+            state,
+            object_id,
+            player,
+            &capped,
+            &mode_abilities,
+        );
         return Ok(WaitingFor::ModeChoice {
             player,
             modal: capped,
             pending_cast: Box::new(pending),
+            unavailable_modes,
         });
     };
 

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -39,12 +39,17 @@ pub(crate) fn handle_select_modes(
     indices: Vec<usize>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    let (modal, pending) = match &state.waiting_for {
+    let (modal, pending, unavailable_modes) = match &state.waiting_for {
         WaitingFor::ModeChoice {
             modal,
             pending_cast,
+            unavailable_modes,
             ..
-        } => (modal.clone(), *pending_cast.clone()),
+        } => (
+            modal.clone(),
+            *pending_cast.clone(),
+            unavailable_modes.clone(),
+        ),
         _ => {
             return Err(EngineError::InvalidAction(
                 "Not waiting for mode selection".to_string(),
@@ -52,8 +57,8 @@ pub(crate) fn handle_select_modes(
         }
     };
 
-    // Spells resolve once — no cross-resolution mode constraints apply.
-    validate_modal_indices(&modal, &indices, &[])?;
+    // CR 700.2a-b: Reject unavailable modes (repeat constraints or no legal targets).
+    validate_modal_indices(&modal, &indices, &unavailable_modes)?;
 
     // CR 700.2 + CR 601.2c: Sorted ascending to match the slot order produced by
     // `build_chained_resolved` and `build_target_slots_labelled`. Persisted on

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1301,6 +1301,7 @@ mod tests {
                 ..Default::default()
             },
             pending_cast: pending.clone(),
+            unavailable_modes: vec![],
         };
         state.pending_cast = Some(pending);
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3190,6 +3190,10 @@ pub enum WaitingFor {
         player: PlayerId,
         modal: ModalChoice,
         pending_cast: Box<PendingCast>,
+        /// Mode indices unavailable due to NoRepeat constraints or unsatisfied
+        /// targeting requirements (CR 700.2a-b). Mirrors `AbilityModeChoice`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        unavailable_modes: Vec<usize>,
     },
     /// Player must choose which cards to discard down to maximum hand size (cleanup step).
     DiscardToHandSize {
@@ -8004,6 +8008,7 @@ mod tests {
                 ..Default::default()
             },
             pending_cast: dummy_pending(),
+            unavailable_modes: vec![],
         }));
         variants.push(Box::new(WaitingFor::DiscardToHandSize {
             player: PlayerId(0),

--- a/crates/engine/tests/integration/issue_3301_izzet_charm_counter.rs
+++ b/crates/engine/tests/integration/issue_3301_izzet_charm_counter.rs
@@ -1,0 +1,130 @@
+//! GitHub issue #3301 — Izzet Charm counter mode must counter noncreature spells.
+//!
+//! Mode 1 oracle:
+//!   Counter target noncreature spell unless its controller pays {2}.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::Effect;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{CastingVariant, StackEntry, StackEntryKind, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const IZZET_CHARM_ORACLE: &str = "Choose one —\n\
+    • Counter target noncreature spell unless its controller pays {2}.\n\
+    • Izzet Charm deals 2 damage to target creature.\n\
+    • Draw two cards, then discard two cards.";
+
+fn put_instant_on_stack(
+    runner: &mut engine::game::scenario::GameRunner,
+    controller: engine::types::player::PlayerId,
+) -> ObjectId {
+    let spell = engine::game::zones::create_object(
+        runner.state_mut(),
+        CardId(501),
+        controller,
+        "Shock".to_string(),
+        Zone::Stack,
+    );
+    if let Some(obj) = runner.state_mut().objects.get_mut(&spell) {
+        obj.card_types.core_types = vec![CoreType::Instant];
+    }
+    runner.state_mut().stack.push_back(StackEntry {
+        id: spell,
+        source_id: spell,
+        controller,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(501),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    spell
+}
+
+#[test]
+fn izzet_charm_parsed_counter_mode_carries_unless_pay() {
+    let mut scenario = GameScenario::new();
+    let charm = scenario
+        .add_spell_to_hand_from_oracle(P0, "Izzet Charm", true, IZZET_CHARM_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let ability = &runner.state().objects[&charm].abilities[0];
+    assert!(
+        matches!(ability.effect.as_ref(), Effect::Counter { .. }),
+        "mode 1 must parse to Counter"
+    );
+    assert!(
+        ability.unless_pay.is_some(),
+        "unless_pay {{2}} must live on the spell ability definition"
+    );
+}
+
+#[test]
+fn izzet_charm_counters_noncreature_spell_when_controller_declines_two() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let charm = scenario
+        .add_spell_to_hand_from_oracle(P0, "Izzet Charm", true, IZZET_CHARM_ORACLE)
+        .id();
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Blue);
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Red);
+
+    let mut runner = scenario.build();
+    let opponent_spell = put_instant_on_stack(&mut runner, P1);
+
+    runner
+        .cast(charm)
+        .modes(&[0])
+        .target_objects(&[opponent_spell])
+        .resolve();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player: P1, .. }
+        ),
+        "counter resolution must prompt P1 to pay {{2}}, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: false })
+        .expect("P1 declines to pay {2}");
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "declining the unless cost must counter the spell"
+    );
+    assert_eq!(
+        runner.state().objects.get(&opponent_spell).map(|o| o.zone),
+        Some(Zone::Graveyard),
+        "countered spell must move to graveyard"
+    );
+}
+
+#[test]
+fn izzet_charm_counter_mode_rejected_without_noncreature_spell_on_stack() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let charm = scenario
+        .add_spell_to_hand_from_oracle(P0, "Izzet Charm", true, IZZET_CHARM_ORACLE)
+        .id();
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Blue);
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Red);
+
+    let mut runner = scenario.build();
+
+    let err = runner.cast(charm).modes(&[0]).resolve();
+
+    assert!(
+        matches!(
+            err.final_waiting_for(),
+            WaitingFor::ModeChoice { .. } | WaitingFor::TargetSelection { .. }
+        ) || runner.state().stack.is_empty(),
+        "counter mode must not fully resolve without a legal stack target"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -219,6 +219,7 @@ mod issue_3260_phantasmal_image_persist;
 mod issue_3283_sevinne_reclamation_copy_no_self_copy;
 mod issue_3285_face_down_public_zone;
 mod issue_3295_scrapwork_mutt_unearth_zone;
+mod issue_3301_izzet_charm_counter;
 mod issue_3302_breach_multiverse;
 mod issue_3309_rise_etb_returns;
 mod issue_3311_manifest_dread_land;

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -669,10 +669,15 @@ pub fn build_prompt(
             insert_json(&mut fields, "numToDiscard", count);
             "chooseDiscard"
         }
-        WaitingFor::ModeChoice { modal, .. } => {
+        WaitingFor::ModeChoice {
+            modal,
+            unavailable_modes,
+            ..
+        } => {
             insert_json(&mut fields, "options", modal_options(modal));
             insert_json(&mut fields, "minChoices", modal.min_choices);
             insert_json(&mut fields, "maxChoices", modal.max_choices);
+            insert_json(&mut fields, "unavailableModes", unavailable_modes);
             "chooseMode"
         }
         WaitingFor::AbilityModeChoice { modal, .. } => {
@@ -2243,6 +2248,7 @@ mod tests {
                         ..Default::default()
                     },
                     pending_cast: dummy_pending_cast(),
+                    unavailable_modes: vec![],
                 },
             ),
             (


### PR DESCRIPTION
## Summary
- Modal spells now compute `unavailable_modes` using the same target-legality filtering as activated modal abilities.
- Izzet Charm's "counter target noncreature spell" mode is disabled when no legal noncreature spell is on the stack.
- Frontend mode choice UI and AI candidate generation respect unavailable modes for spell casts.

Fixes #3301.

## Test plan
- [x] `cargo test -p engine --test integration issue_3301`
- [x] `cargo clippy -p engine -p manabrew-compat -- -D warnings`

Made with [Cursor](https://cursor.com)