### PR TITLE
fix(parser): one-shot damage-replacement shield carries inherent this-turn lifetime

### DIFF
--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2356,6 +2356,14 @@ fn detect_duration_this_turn(
         // by "prevent [damage] this turn"; the lifetime is inherent to the
         // one-shot prevention effect.
         "PreventDamage",
+        // CR 614.9 + CR 615.1: `CreateDamageReplacement` is the typed prevention
+        // /redirection shield for "the next [N] damage that would be dealt to ~
+        // this turn is [prevented/dealt to <recipient>] instead" (the en-Kor
+        // cycle, General's Regalia). Like `PreventDamage` and the `DamageDone`
+        // replacement event above, the shield's "this turn" lifetime is inherent
+        // to the one-shot effect (it expires at cleanup, CR 514.2), not a
+        // separate `duration` slot.
+        "CreateDamageReplacement",
         "AddTargetReplacement",
         // CR 603.7c: A `CreateDelayedTrigger` with `WhenNextEvent` condition
         // IS the "next [event] this turn" delayed-trigger scope (Chandra,
@@ -3274,6 +3282,33 @@ mod tests {
         );
 
         assert!(!has_swallowed_detector(&parsed, "Duration_ThisTurn"));
+    }
+
+    /// CR 614.9 + CR 615.1: the en-Kor cycle (Nomads / Spirit / Warrior / Shaman
+    /// / Lancers en-Kor) and General's Regalia parse the redirection clause into
+    /// a `CreateDamageReplacement` shield whose "this turn" lifetime is inherent
+    /// to the one-shot effect — it must NOT be reported as a swallowed duration.
+    #[test]
+    fn duration_this_turn_accepts_one_shot_damage_replacement_shield() {
+        for (oracle, name) in [
+            (
+                "{0}: The next 1 damage that would be dealt to this creature this turn \
+                 is dealt to target creature you control instead.",
+                "Nomads en-Kor",
+            ),
+            (
+                "{3}: The next time a source of your choice would deal damage to you this turn, \
+                 that damage is dealt to target creature you control instead.",
+                "General's Regalia",
+            ),
+        ] {
+            let parsed = parse_named(oracle, name, &["Creature"]);
+            assert!(
+                !has_swallowed_detector(&parsed, "Duration_ThisTurn"),
+                "{name}: one-shot damage-replacement shield must not report a swallowed this-turn duration: {:?}",
+                parsed.parse_warnings
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
The en-Kor cycle (Nomads / Spirit / Warrior / Shaman / Lancers / Outrider en-Kor), General's Regalia, and the other one-shot damage prevention/redirection cards (Soltari Guerrillas, Jade Monolith, Beacon of Destiny, Goblin Psychopath, Nova Pentacle, Zealous Inquisitor) parse their "the next N damage that would be dealt to ~ this turn is dealt to <recipient> instead" clause correctly into a `CreateDamageReplacement` shield.

But `detect_duration_this_turn` did not list `CreateDamageReplacement` among the effects whose `this turn` lifetime is inherent (it already exempts the sibling `PreventDamage` and the `DamageDone` replacement event). The shield's `this turn` window was therefore falsely reported as a swallowed duration, leaving all 13 cards unsupported despite their effect being fully represented.

Per CR 615.1 / CR 614.9, a one-shot prevention/redirection shield expires at cleanup (CR 514.2) — its `this turn` scope is structural, not a separate `duration` slot. Adding the marker resolves the false positive.

**Verified** (local regen): swallowed-clause count decreases, **0 new swallow handlers** introduced, and 13 cards flip false-positive `Duration_ThisTurn` swallow removed → all en-Kor cards + General's Regalia become supported. Discriminating unit test added in `swallow_check.rs`.

Closes #3533