### PR TITLE
fix(parser): split second "target … gets/gains/loses" conjunct (Skulduggery, Armistice, Game of Chaos)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1447,6 +1447,29 @@ fn starts_they_continuous_clause_lower(input: &str) -> OracleResult<'_, ()> {
     .parse(input)
 }
 
+/// CR 601.2c + CR 611.2c: A second `"target <noun>"` clause joined by a bare
+/// `" and "` opens its OWN target (each instance of the word "target" is a
+/// distinct target — CR 601.2c) and applies a continuous modification
+/// (CR 611.2c). Skulduggery: "... target creature you control gets +1/+1 and
+/// target creature an opponent controls gets -1/-1." (also Monoist
+/// Circuit-Feeder). Without this arm the second conjunct is not recognized as a
+/// clause start and is swallowed by the first `Pump`, so the opponent-debuff is
+/// dropped. The discriminator is a conjugated continuous-modification verb
+/// (gets/gains/has/loses) somewhere after the `"target <noun>"` subject — a
+/// genuine noun-phrase continuation ("... and target land") has no such verb
+/// and is left un-split. `take_until` consumes the intervening qualifier
+/// ("creature you control", "creature an opponent controls") up to the verb.
+fn starts_target_continuous_clause_lower(s: &str) -> OracleResult<'_, ()> {
+    let (rest, _) = tag("target ").parse(s)?;
+    alt((
+        value((), (take_until(" gets "), tag(" gets "))),
+        value((), (take_until(" gains "), tag(" gains "))),
+        value((), (take_until(" has "), tag(" has "))),
+        value((), (take_until(" loses "), tag(" loses "))),
+    ))
+    .parse(rest)
+}
+
 /// Inner implementation operating on pre-lowercased input.
 fn starts_bare_and_clause_lower(s: &str) -> bool {
     // CR 613.1b + CR 110.2: "<player-subject> gains control of …" control-handoff
@@ -1675,6 +1698,12 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
             ),
         ),
     )))
+    // CR 601.2c + CR 611.2c: a fresh "target <noun> gets/gains/has/loses ..."
+    // conjunct opens its own target and continuous modification (Skulduggery).
+    // Wired as a trailing `.or()` arm (mirroring the
+    // `starts_they_continuous_clause_lower` helper) rather than a new tuple
+    // element so the enclosing `alt(...)` cluster stays under nom's 21-arm limit.
+    .or(value((), starts_target_continuous_clause_lower))
     .parse(s)
     .is_ok();
     if has_verb_prefix {
@@ -7630,6 +7659,168 @@ mod tests {
         assert!(!starts_bare_and_clause("they attack this turn"));
         assert!(!starts_bare_and_clause("they get +1/+1 until end of turn"));
         assert!(!starts_bare_and_clause("they lose 6 life"));
+    }
+
+    /// CR 601.2c + CR 611.2c: A second `"target <noun>"` conjunct joined by a
+    /// bare `" and "` is a fresh clause start (its own target + continuous
+    /// modification), not a noun-phrase continuation of the first Pump.
+    /// Skulduggery / Monoist Circuit-Feeder: "... target creature you control
+    /// gets +1/+1 and target creature an opponent controls gets -1/-1". The
+    /// conjugated CM verb (gets/gains/has/loses) after the subject is the
+    /// discriminator; a bare noun continuation ("target land") has no such verb.
+    #[test]
+    fn bare_and_clause_starts_on_second_target_continuous_subject() {
+        // Skulduggery's two conjuncts.
+        assert!(starts_bare_and_clause(
+            "target creature an opponent controls gets -1/-1"
+        ));
+        assert!(starts_bare_and_clause(
+            "target creature you control gets +1/+1"
+        ));
+        // Monoist Circuit-Feeder's debuff conjunct (X distributes downstream).
+        assert!(starts_bare_and_clause(
+            "target creature an opponent controls gets -0/-x"
+        ));
+        // Verb-axis coverage: gains / has / loses.
+        assert!(starts_bare_and_clause(
+            "target creature an opponent controls gains flying"
+        ));
+        assert!(starts_bare_and_clause(
+            "target creature an opponent controls has flying"
+        ));
+        assert!(starts_bare_and_clause(
+            "target creature an opponent controls loses flying"
+        ));
+        // NO-REGRESSION negatives:
+        // Anaphoric shared-target rider — no fresh "target", must NOT split.
+        assert!(!starts_bare_and_clause("gains flying"));
+        // Genuine noun-phrase continuation — "target land" with no CM verb.
+        assert!(!starts_bare_and_clause("target land"));
+        assert!(!starts_bare_and_clause("target creature you control"));
+    }
+
+    /// CR 602.5 + CR 611.2c: Skulduggery — symmetric dual-target pump. The
+    /// bare `" and "` between the two `"target creature ... gets +/-"` conjuncts
+    /// must split so BOTH Pumps survive; previously the second (opponent-debuff)
+    /// conjunct was swallowed by the first Pump and dropped. Conjunct 2's
+    /// "an opponent controls" resolves the target's controller to
+    /// `ControllerRef::Opponent`. Pump carries no duration field — the leading
+    /// "Until end of turn," applies at resolution (Pump defaults to until end of
+    /// turn), so this test asserts only the two Pump shapes + controllers.
+    #[test]
+    fn skulduggery_parses_both_pump_targets() {
+        use super::super::parse_effect_chain;
+
+        // Real Oracle text (AtomicCards.json), leading "Until end of turn,".
+        let def = parse_effect_chain(
+            "Until end of turn, target creature you control gets +1/+1 and target creature an opponent controls gets -1/-1.",
+            AbilityKind::Spell,
+        );
+
+        let mut pumps: Vec<(&PtValue, &PtValue, &TargetFilter)> = Vec::new();
+        let mut node = Some(&def);
+        while let Some(d) = node {
+            if let Effect::Pump {
+                power,
+                toughness,
+                target,
+            } = &*d.effect
+            {
+                pumps.push((power, toughness, target));
+            }
+            node = d.sub_ability.as_deref();
+        }
+
+        assert_eq!(
+            pumps.len(),
+            2,
+            "Skulduggery must produce TWO Pumps (second conjunct was dropped before the fix); got {pumps:?}"
+        );
+
+        // Conjunct 1: +1/+1 on a creature you control.
+        let (p0, t0, tgt0) = pumps[0];
+        assert_eq!(*p0, PtValue::Fixed(1));
+        assert_eq!(*t0, PtValue::Fixed(1));
+        let TargetFilter::Typed(f0) = tgt0 else {
+            panic!("conjunct 1 target should be Typed, got {tgt0:?}");
+        };
+        assert_eq!(f0.controller, Some(ControllerRef::You));
+
+        // Conjunct 2: -1/-1 on a creature an opponent controls (the dropped one).
+        let (p1, t1, tgt1) = pumps[1];
+        assert_eq!(*p1, PtValue::Fixed(-1));
+        assert_eq!(*t1, PtValue::Fixed(-1));
+        let TargetFilter::Typed(f1) = tgt1 else {
+            panic!("conjunct 2 target should be Typed, got {tgt1:?}");
+        };
+        assert_eq!(
+            f1.controller,
+            Some(ControllerRef::Opponent),
+            "conjunct 2 must target an opponent's creature"
+        );
+    }
+
+    /// CR 611.2c: No-regression guard for the shared-target rider shape. A
+    /// "gets +1/+1 and gains <kw>" rider with NO second "target" must stay a
+    /// SINGLE shared-target continuous effect — one `GenericEffect` whose one
+    /// target (Typed Creature you control) carries both the P/T and keyword
+    /// modifications — and must NOT be split into a second targeted clause. The
+    /// new `starts_target_continuous_clause_lower` arm only fires on a fresh
+    /// "target <noun>" after the bare " and "; this rider's "gains flying ..."
+    /// remainder has no such "target", so the arm must leave it un-split.
+    #[test]
+    fn shared_target_pump_then_keyword_rider_is_not_split() {
+        use super::super::parse_effect_chain;
+
+        let def = parse_effect_chain(
+            "Target creature you control gets +1/+1 and gains flying until end of turn.",
+            AbilityKind::Spell,
+        );
+
+        // Exactly one effect node — not split into two targeted clauses.
+        let mut effects: Vec<&AbilityDefinition> = Vec::new();
+        let mut node = Some(&def);
+        while let Some(d) = node {
+            effects.push(d);
+            node = d.sub_ability.as_deref();
+        }
+        assert_eq!(
+            effects.len(),
+            1,
+            "rider must stay a single shared-target clause, got {effects:?}"
+        );
+
+        let Effect::GenericEffect {
+            static_abilities,
+            target,
+            ..
+        } = &*effects[0].effect
+        else {
+            panic!(
+                "rider should lower to one GenericEffect, got {:?}",
+                effects[0].effect
+            );
+        };
+
+        // ONE shared target — Typed Creature you control (not a second target).
+        let Some(TargetFilter::Typed(f)) = target else {
+            panic!("rider target should be a single Typed filter, got {target:?}");
+        };
+        assert_eq!(f.controller, Some(ControllerRef::You));
+
+        // The single target carries BOTH the P/T pump and the keyword grant.
+        assert_eq!(static_abilities.len(), 1);
+        let mods = &static_abilities[0].modifications;
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::AddPower { value: 1 })),
+            "missing +1 power on shared target: {mods:?}"
+        );
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::AddKeyword { keyword } if *keyword == Keyword::Flying)),
+            "missing flying keyword on shared target: {mods:?}"
+        );
     }
 
     /// CR 702: "The same is true for <keyword list>." — Odric, Lunarch


### PR DESCRIPTION
## Summary

Fixes #3535.

A spell/ability joining two **separately-targeted** clauses with a bare " and " — `target <A> gets/gains/has/loses … and target <B> gets/gains/loses …` — silently dropped the **second** targeted conjunct. Only the first effect was parsed.

- **Skulduggery** — "Until end of turn, target creature you control gets +1/+1 **and target creature an opponent controls gets -1/-1**." → only your +1/+1 applied; the opponent's −1/−1 was lost.
- Also fixes (same bug class): **Armistice** ("… and target opponent gains 3 life"), **Game of Chaos** ("… and target opponent loses 1 life"), and covers **Monoist Circuit-Feeder** / **Gurmag Rakshasa**.

## Root cause

The bare-" and " clause splitter `starts_bare_and_clause_lower` (`parser/oracle_effect/sequence.rs`) recognizes anaphoric subjects (`it gets`, `that creature gains`, `those creatures …`, `you get`, …) but had **no arm for a fresh `target <noun> gets/gains/has/loses` subject**, so the second conjunct wasn't split off and was absorbed/dropped by the first effect.

## Fix (parser-only; no new engine variant)

Add a `starts_target_continuous_clause_lower` helper — `tag("target ")` + `alt` over `(take_until(" gets "/" gains "/" has "/" loses "), tag(verb))` — mirroring the existing `starts_they_continuous_clause_lower` idiom, wired as a trailing `.or()` arm (tried last, so it can't pre-empt existing arms).

Once split, the second conjunct already parses correctly downstream (`parse_subject_application` resolves "an opponent controls" → `ControllerRef::Opponent` → `Pump` on an opponent-controlled creature). `Effect::Pump` with no explicit duration defaults to until-end-of-turn at resolution, so the opponent's pump is correctly UEOT with no duration plumbing.

The discriminator is the conjugated continuous-modification verb after `target <noun>` — a genuine noun continuation ("… and target land") has no such verb and is not split.

CR 601.2c (each "target" is its own target); CR 611.2c (continuous modification).

## Tests

- Splitter units: `target creature an opponent controls gets -1/-1` / `… gains trample` / `… has flying` / `… loses flying` split; negatives `gains flying` (anaphoric rider, no leading "target") and `target land` (no CM verb) do **not** split.
- Skulduggery full-parse: the chain has **two** `Effect::Pump` — `+1/+1` on `Typed{Creature, You}` and `-1/-1` on `Typed{Creature, Opponent}` (the previously-dropped conjunct).
- No-regression: `target creature you control gets +1/+1 and gains flying until end of turn` stays a **single** effect with both the P/T buff and the keyword on the **same** target (not split into a second target).

## Verification

- `cargo +nightly test -p engine --lib bare_and`: 49 passed; `--lib skulduggery`: passed; `--test integration`: 1093 passed (no fixture diff).
- `cargo +nightly clippy -p engine --lib -- -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean for this diff.

## Note

Monoist Circuit-Feeder's second conjunct now splits (its debuff shape is covered by a unit test); its full trigger-body + "where X is …" lowering is exercised by the existing X-distribution but not asserted end-to-end here — a possible follow-up, not a regression.
