### PR TITLE
fix(parser): parse "gained or lost life this turn" disjunctive condition

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -4073,13 +4073,14 @@ fn parse_defending_player_controls(input: &str) -> OracleResult<'_, StaticCondit
 /// and an object ("life this turn"). Each verb maps to a QuantityRef, and the result
 /// is `StaticCondition::And { conditions: [lhs >= 1, rhs >= 1] }`.
 ///
-/// Example: "you gained and lost life this turn" → And(LifeGainedThisTurn >= 1, LifeLostThisTurn >= 1)
+/// "you [verb1] (and|or) [verb2] life this turn" where each verb is gained/lost.
+/// Example: "you gained and lost life this turn" → And(LifeGainedThisTurn >= 1,
+/// LifeLostThisTurn >= 1); "you gained or lost life this turn" → Or(...) (Star
+/// Charter, Starseer Mentor, Starlit Soothsayer).
 fn parse_compound_verb_condition(input: &str) -> OracleResult<'_, StaticCondition> {
-    let (rest, _) = alt((tag("you "), tag("you've "))).parse(input)?;
-
-    // Map event verbs to their QuantityRef for the shared "life this turn" object.
-    fn life_verb(v: &str) -> Option<QuantityRef> {
-        let result: nom::IResult<&str, QuantityRef, OracleError<'_>> = alt((
+    // "gained"/"lost" → the matching controller-scoped "life this turn" QuantityRef.
+    fn life_verb(i: &str) -> OracleResult<'_, QuantityRef> {
+        alt((
             value(
                 QuantityRef::LifeGainedThisTurn {
                     player: PlayerScope::Controller,
@@ -4093,34 +4094,25 @@ fn parse_compound_verb_condition(input: &str) -> OracleResult<'_, StaticConditio
                 tag("lost"),
             ),
         ))
-        .parse(v);
-        let (rest, qty) = result.ok()?;
-        rest.is_empty().then_some(qty)
+        .parse(i)
     }
 
-    // Try "[verb1] and [verb2] life this turn"
-    if let Some(and_pos) = rest.find(" and ") {
-        let verb1 = &rest[..and_pos];
-        let after_and = &rest[and_pos + " and ".len()..];
-        // Find the shared object: " life this turn"
-        if let Some(obj_pos) = after_and.find(" life this turn") {
-            let verb2 = &after_and[..obj_pos];
-            if let (Some(lhs), Some(rhs)) = (life_verb(verb1), life_verb(verb2)) {
-                let remainder = &after_and[obj_pos + " life this turn".len()..];
-                return Ok((
-                    remainder,
-                    StaticCondition::And {
-                        conditions: vec![make_quantity_ge(lhs, 1), make_quantity_ge(rhs, 1)],
-                    },
-                ));
-            }
-        }
-    }
+    let (rest, _) = alt((tag("you "), tag("you've "))).parse(input)?;
+    let (rest, lhs) = life_verb(rest)?;
+    // CR 119: the connective selects the boolean shape — "and" requires both
+    // life changes, "or" requires either — over the shared LifeGained/LifeLost
+    // ThisTurn QuantityRef building blocks.
+    let (rest, is_or) = alt((value(false, tag(" and ")), value(true, tag(" or ")))).parse(rest)?;
+    let (rest, rhs) = life_verb(rest)?;
+    let (rest, _) = tag(" life this turn").parse(rest)?;
 
-    Err(nom::Err::Error(nom::error::Error::new(
-        input,
-        nom::error::ErrorKind::Fail,
-    )))
+    let conditions = vec![make_quantity_ge(lhs, 1), make_quantity_ge(rhs, 1)];
+    let condition = if is_or {
+        StaticCondition::Or { conditions }
+    } else {
+        StaticCondition::And { conditions }
+    };
+    Ok((rest, condition))
 }
 
 /// Parse "you gained [N or more] life this turn".

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -16179,6 +16179,41 @@ mod tests {
     }
 
     #[test]
+    fn trigger_if_gained_or_lost_life_compound() {
+        // CR 119: "you gained or lost life this turn" (Star Charter, Starseer
+        // Mentor, Starlit Soothsayer) is the disjunctive sibling of the "and"
+        // compound — either life change satisfies it.
+        let def = parse_trigger_line(
+            "At the beginning of your end step, if you gained or lost life this turn, surveil 1.",
+            "Starlit Soothsayer",
+        );
+        match &def.condition {
+            Some(TriggerCondition::Or { conditions }) if conditions.len() == 2 => {
+                assert!(conditions.iter().any(|c| matches!(
+                    c,
+                    TriggerCondition::QuantityComparison {
+                        lhs: QuantityExpr::Ref {
+                            qty: QuantityRef::LifeGainedThisTurn { .. }
+                        },
+                        ..
+                    }
+                )));
+                assert!(conditions.iter().any(|c| matches!(
+                    c,
+                    TriggerCondition::QuantityComparison {
+                        lhs: QuantityExpr::Ref {
+                            qty: QuantityRef::LifeLostThisTurn { .. }
+                        },
+                        ..
+                    }
+                )));
+            }
+            other => panic!("Expected Or with LifeGained+LifeLost conditions, got {other:?}"),
+        }
+        assert!(def.execute.is_some(), "surveil effect must not be dropped");
+    }
+
+    #[test]
     fn shared_animosity_attack_pump_for_each_other_attacker_sharing_type() {
         let def = parse_trigger_line(
             "Whenever a creature you control attacks, it gets +1/+0 until end of turn for each other attacking creature that shares a creature type with it.",


### PR DESCRIPTION
`parse_compound_verb_condition` recognized only the conjunctive "you gained **and** lost life this turn" form → `And(LifeGainedThisTurn >= 1, LifeLostThisTurn >= 1)`. The disjunctive "gained **or** lost" form (Star Charter, Starseer Mentor, Starlit Soothsayer) fell through unparsed, swallowing the intervening-if and leaving the three cards unsupported.

CR 119: gaining or losing life are both life-total changes; the connective selects the boolean shape over the shared `LifeGainedThisTurn` / `LifeLostThisTurn` QuantityRef building blocks. Rewrote the function with nom combinators to dispatch on `and` → `StaticCondition::And` / `or` → `StaticCondition::Or` (bridged to `TriggerCondition::Or`), reusing existing primitives with **no new variant**.

**Verified** (local regen): swallowed-clause count decreases by 3, the three Star* cards flip to supported with 0 gaps, and **0 new swallow handlers** are introduced. Discriminating trigger test added (`trigger_if_gained_or_lost_life_compound`); the existing "and" test still passes.

Closes #3536