### PR TITLE
fix(parser): route "deals N to each opponent and …" player damage (Dagger Caster)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2457,6 +2457,18 @@ pub(super) fn parse_damage_player_scope(
 /// "each other player" excludes the controller (the only "other" antecedent
 /// available outside trigger context) and reduces to plain `Opponent`.
 pub(crate) fn parse_damage_each_player_scope(text: &str) -> Option<PlayerFilter> {
+    let (filter, rest) = parse_damage_each_player_scope_with_remainder(text)?;
+    rest.chars()
+        .all(|c| c.is_ascii_whitespace() || c.is_ascii_punctuation())
+        .then_some(filter)
+}
+
+/// CR 120.2b + CR 120.3 + CR 102.2: leading "each opponent/player/foe/other
+/// opponent/other player" damage scope, returning the matched filter AND the
+/// unconsumed remainder. Unlike `parse_damage_each_player_scope` it is NOT
+/// all-consuming — used only by the multi-target damage CHAIN primary, which
+/// hands the trailing " and M damage to ..." segment back to the loop.
+fn parse_damage_each_player_scope_with_remainder(text: &str) -> Option<(PlayerFilter, &str)> {
     let (rest, filter) = preceded(
         tag("each "),
         alt((
@@ -2473,9 +2485,7 @@ pub(crate) fn parse_damage_each_player_scope(text: &str) -> Option<PlayerFilter>
     )
     .parse(text)
     .ok()?;
-    rest.chars()
-        .all(|c| c.is_ascii_whitespace() || c.is_ascii_punctuation())
-        .then_some(filter)
+    Some((filter, rest))
 }
 
 pub(super) fn strip_leading_duration(text: &str) -> Option<(Duration, &str)> {
@@ -4350,6 +4360,27 @@ pub(super) fn try_parse_damage_with_remainder<'a>(
                     player_filter,
                 },
                 "",
+            ));
+        }
+        // CR 120.2b + CR 120.3: multi-target chain whose FIRST segment is an
+        // each-player scope with a repeated-amount continuation (Dagger Caster:
+        // "deals 1 damage to each opponent and 1 damage to each creature your
+        // opponents control"). The all-consuming arm above rejected it because
+        // the continuation isn't punctuation-only; emit DamageEachPlayer for the
+        // player half and hand the continuation back to the chain loop (CR 120.2b
+        // independent events). NOT the " and each " compound (caught upstream by
+        // the compound parser); the chain joins two separately-amounted segments.
+        if let Some((player_filter, rem)) =
+            parse_damage_each_player_scope_with_remainder(after_to_for_classification)
+        {
+            let consumed = after_to_for_classification.len() - rem.len();
+            let rem_full = &after_to[consumed..];
+            return Some((
+                Effect::DamageEachPlayer {
+                    amount,
+                    player_filter,
+                },
+                rem_full,
             ));
         }
         let (target, rem) = parse_target_with_ctx(after_to_for_classification, ctx);

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22041,6 +22041,63 @@ mod tests {
         }
     }
 
+    /// CR 120.2b + CR 120.3: Dagger Caster — "deals 1 damage to each opponent
+    /// and 1 damage to each creature your opponents control" is a two-segment
+    /// damage CHAIN (two independently-amounted recipients joined by "and"), not
+    /// the " and each " compound. The first segment is an each-opponent PLAYER
+    /// scope; it must emit `DamageEachPlayer{Opponent}` and chain the second
+    /// "1 damage to each creature your opponents control" segment as a
+    /// sub_ability — NOT collapse to an empty-Typed `DamageAll{Opponent}` (which
+    /// would silently deal the opponents NO damage). Regression guard: on revert
+    /// of the `parse_damage_each_player_scope_with_remainder` chain arm, the
+    /// primary becomes `DamageAll{Typed{empty}, player_filter:None}` and this
+    /// fails.
+    #[test]
+    fn dagger_caster_each_opponent_chain_emits_damage_each_player() {
+        let def = parse_effect_chain(
+            "~ deals 1 damage to each opponent and 1 damage to each creature your opponents control",
+            AbilityKind::Spell,
+        );
+        // Primary: the each-opponent player half must route to DamageEachPlayer,
+        // NOT an empty-Typed DamageAll.
+        match &*def.effect {
+            Effect::DamageEachPlayer {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player_filter: PlayerFilter::Opponent,
+            } => {}
+            other => panic!(
+                "primary must be DamageEachPlayer{{Fixed 1, Opponent}} (not empty-Typed DamageAll), got {other:?}"
+            ),
+        }
+        // Sub-ability: the second "1 damage to each creature your opponents
+        // control" segment chains as a mass-damage effect at opponents' creatures.
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("expected chained damage sub_ability for the second segment");
+        match &*sub.effect {
+            Effect::DamageAll {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target,
+                ..
+            } => match target {
+                TargetFilter::Typed(tf) => {
+                    assert_eq!(tf.controller, Some(ControllerRef::Opponent));
+                    assert!(tf
+                        .type_filters
+                        .iter()
+                        .any(|t| matches!(t, TypeFilter::Creature)));
+                }
+                other => panic!("expected Typed{{Creature, Opponent}} sub-target, got {other:?}"),
+            },
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 1 },
+                ..
+            } => {}
+            other => panic!("expected DamageAll/DealDamage(1) sub_ability, got {other:?}"),
+        }
+    }
+
     #[test]
     fn damage_each_player_scope_rejects_compound_phrase() {
         assert_eq!(


### PR DESCRIPTION
## Summary

Fixes #3547.

**Dagger Caster** — "When this creature enters, it deals 1 damage to each opponent **and** 1 damage to each creature your opponents control." — dealt **no** damage to opponents: the each-opponent (player) half was mis-parsed onto an empty permanent filter (`DamageAll{Typed{type_filters:[], controller:Opponent}}`, matches nothing) instead of `Effect::DamageEachPlayer{player_filter: Opponent}`.

## Root cause

In a multi-target damage chain (`deals N to X and M to Y`), the primary segment's "each …" classifier (`parse_damage_each_player_scope`) is **all-consuming** — it only matches when the each-player phrase is the whole remainder. Dagger Caster repeats the amount ("… **and 1 damage to** each creature …"), so the continuation makes the all-consuming match fail, and it falls through to the generic target parser → the empty-permanent `DamageAll`. (The all-consuming guard is intentional so the dedicated " and each " single-event compound parser wins for that shape — left untouched.)

## Fix (parser-only; no new engine variant)

- New `parse_damage_each_player_scope_with_remainder` — the same inner `preceded(tag("each "), alt((…)))` combinator, **without** the all-consuming guard, returning `(PlayerFilter, remainder)`.
- `parse_damage_each_player_scope` now **delegates** to it and re-applies the punctuation-only guard — behavior-preserving for all existing callers.
- A new arm in the chain primary classifier, placed **strictly between** the all-consuming arm and the generic `parse_target` fallthrough: a leading each-player scope emits `Effect::DamageEachPlayer{amount, player_filter}` and hands the continuation back to the chain loop, which already parses the creature-damage conjunct.

`DamageEachPlayer` and `PlayerFilter::Opponent` already exist (Boltwave's encoding); the runtime resolves the player damage from the ability source (the entering creature). The fix generalizes to the class "deals N damage to each opponent/player and [more]" where the amount repeats. CR 120.2b (independent damage events), CR 120.3, CR 102.2 (opponent = the other player).

## Tests

- Dagger Caster chain: the primary effect is `DamageEachPlayer{1, Opponent}` (asserted **not** the empty-`Typed` `DamageAll`), and the sub-ability is creature damage (`Typed[Creature]`, opponent-controlled). Revert-proof: without the new arm the primary falls back to the empty `DamageAll` and the assertion fails.
- No-regression: standalone "deals N damage to each opponent" still → `DamageEachPlayer` (all-consuming path unchanged); the " and each " single-event compound ("each opponent and each creature they control" → one `DamageAll{player_filter: Opponent, Typed[Creature]}`) still routes through its own parser (runs upstream of the chain); a plain multi-target chain ("4 to any target and 2 to you") unchanged.

## Verification

- `cargo +nightly test -p engine --lib`: dagger (1) + each_opponent (66) + each_player (54) pass; `--test integration`: 1097 passed (no fixture diff).
- `cargo +nightly clippy -p engine --lib -- -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean for this diff.

The standalone all-consuming `parse_damage_each_player_scope` and the " and each " single-event compound path are byte-identical (the refactor only factors out a remainder-returning variant).
