### PR TITLE
fix(parser): recognize the Villain creature subtype

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -6668,6 +6668,16 @@ mod tests {
         assert!(matches!(c, StaticCondition::IsPresent { filter: Some(_) }));
     }
 
+    /// The "Villain" creature subtype (Marvel set) must be recognized so that
+    /// "you control a Villain" conditions parse — e.g. the conditional self
+    /// cost-reduction on Visions of Villainy / Venom's Hunger.
+    #[test]
+    fn test_you_control_a_villain_subtype() {
+        let (rest, c) = parse_inner_condition("you control a villain").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(c, StaticCondition::IsPresent { filter: Some(_) }));
+    }
+
     #[test]
     fn test_you_control_compound_presence() {
         let (rest, c) =

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1184,6 +1184,7 @@ const SUBTYPES: &[&str] = &[
     "Vampire",
     "Vedalken",
     "Viashino",
+    "Villain",
     "Volver",
     "Wall",
     "Walrus",


### PR DESCRIPTION
"Villain" (Marvel Universe Beyond creature subtype) was missing from the `SUBTYPES` list, so `parse_type_phrase` did not recognize it and oracle-text references were dropped. Most visibly, the conditional self cost-reduction "This spell costs {N} less to cast if you control a Villain" (Visions of Villainy, Venom's Hunger) had its condition swallowed, leaving the cards unsupported.

**Verified** (local regen): ~12 cards flip to supported, swallowed-clause count decreases by 6, with **0 new swallowed clauses and 0 engine regressions**. Adds a `parse_inner_condition` building-block test for "you control a villain".

Closes #3553