### PR TITLE
fix: wire proliferate through the CR 614 replacement pipeline for Tekuthal

### DIFF
--- a/crates/engine/src/game/effects/proliferate.rs
+++ b/crates/engine/src/game/effects/proliferate.rs
@@ -1,12 +1,15 @@
+use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{EffectError, EffectKind, ResolvedAbility, TargetRef};
 use crate::types::counter::{
     has_positive_counters, positive_counter_types, prune_zero_counters, CounterType,
 };
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
-    GameState, PendingCounterAddition, PendingEffectResolved, WaitingFor,
+    GameState, PendingCounterAddition, PendingEffectResolved, PendingProliferateActions, WaitingFor,
 };
+use crate::types::identifiers::ObjectId;
 use crate::types::player::{Player, PlayerCounterKind, PlayerId};
+use crate::types::proposed_event::ProposedEvent;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PlayerCounterSource {
@@ -33,15 +36,18 @@ fn proliferatable_player_counters(player: &Player) -> Vec<PlayerCounterSource> {
     counters
 }
 
-/// CR 701.34a: Proliferate — controller chooses any number of permanents and/or
-/// players that already have counters, then gives each another counter of a kind
-/// already there. Sets `WaitingFor::ProliferateChoice` for the player to choose.
-pub fn resolve(
-    state: &mut GameState,
-    ability: &ResolvedAbility,
-    events: &mut Vec<GameEvent>,
-) -> Result<(), EffectError> {
-    // CR 701.34a: Collect eligible permanents (with counters on them).
+/// Outcome of routing proliferate through the CR 614 replacement pipeline.
+pub(crate) enum ProliferateThroughReplacementOutcome {
+    /// All proliferate actions completed synchronously (no target choice needed).
+    Completed,
+    /// A `ProliferateChoice` prompt is open; remaining actions may be queued in
+    /// `pending_proliferate_actions`.
+    PausedForChoice,
+    /// CR 614.6: the proliferate event was fully replaced away.
+    Prevented,
+}
+
+fn collect_proliferate_eligible(state: &GameState) -> Vec<TargetRef> {
     let mut eligible: Vec<TargetRef> = state
         .battlefield
         .iter()
@@ -55,33 +61,167 @@ pub fn resolve(
         .map(|id| TargetRef::Object(*id))
         .collect();
 
-    // CR 701.34a + CR 107.14: players with any counter, including energy, are eligible.
     for player in &state.players {
         if !proliferatable_player_counters(player).is_empty() {
             eligible.push(TargetRef::Player(player.id));
         }
     }
 
+    eligible
+}
+
+fn emit_empty_proliferate_action(actor: PlayerId, events: &mut Vec<GameEvent>) {
+    events.push(GameEvent::PlayerPerformedAction {
+        player_id: actor,
+        action: PlayerActionKind::Proliferate,
+    });
+}
+
+/// CR 701.34a: Drive one proliferate action for `actor`. Returns `true` when the
+/// action completed synchronously, `false` when a `ProliferateChoice` was opened.
+fn drive_single_proliferate_action(
+    state: &mut GameState,
+    actor: PlayerId,
+    source_id: ObjectId,
+    remaining_after_this: u32,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    let eligible = collect_proliferate_eligible(state);
     if eligible.is_empty() {
-        // Nothing to proliferate — skip choice and resolve immediately.
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::from(&ability.effect),
-            source_id: ability.source_id,
-        });
-        // CR 701.34a: Emit player-action event so proliferate triggers fire
-        // even when there are no eligible targets.
-        events.push(GameEvent::PlayerPerformedAction {
-            player_id: ability.controller,
-            action: PlayerActionKind::Proliferate,
-        });
-        return Ok(());
+        emit_empty_proliferate_action(actor, events);
+        return true;
     }
 
-    // Set WaitingFor so the player can choose which to proliferate.
+    if remaining_after_this > 0 {
+        state.pending_proliferate_actions = Some(PendingProliferateActions {
+            actor,
+            source_id,
+            remaining: remaining_after_this,
+        });
+    } else {
+        state.pending_proliferate_actions = Some(PendingProliferateActions {
+            actor,
+            source_id,
+            remaining: 0,
+        });
+    }
+
     state.waiting_for = WaitingFor::ProliferateChoice {
-        player: ability.controller,
+        player: actor,
         eligible,
     };
+    false
+}
+
+/// CR 701.34a + CR 614.1a: Perform `count` proliferate actions after replacement
+/// effects have modified the count. Returns `false` when paused on a choice.
+pub(crate) fn drive_proliferate_actions(
+    state: &mut GameState,
+    actor: PlayerId,
+    source_id: ObjectId,
+    count: u32,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    if count == 0 {
+        return true;
+    }
+
+    for index in 0..count {
+        let remaining_after_this = count - index - 1;
+        if !drive_single_proliferate_action(state, actor, source_id, remaining_after_this, events) {
+            return false;
+        }
+    }
+    true
+}
+
+/// CR 614.6 + CR 614.11: Apply a post-replacement `ProposedEvent::Proliferate`.
+pub fn apply_proliferate_after_replacement(
+    state: &mut GameState,
+    event: ProposedEvent,
+    events: &mut Vec<GameEvent>,
+) {
+    let ProposedEvent::Proliferate {
+        player_id, count, ..
+    } = event
+    else {
+        debug_assert!(
+            false,
+            "apply_proliferate_after_replacement called with non-Proliferate ProposedEvent"
+        );
+        return;
+    };
+
+    let _ = drive_proliferate_actions(state, player_id, ObjectId(0), count, events);
+}
+
+/// CR 701.34a + CR 614.1a: Resume proliferate actions stashed while waiting for
+/// a `ProliferateChoice`. Returns `true` when all remaining actions completed.
+pub fn resume_pending_proliferate_actions(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> bool {
+    let Some(pending) = state.pending_proliferate_actions.take() else {
+        return true;
+    };
+    drive_proliferate_actions(
+        state,
+        pending.actor,
+        pending.source_id,
+        pending.remaining,
+        events,
+    )
+}
+
+/// CR 614.6 + CR 614.11: Single authority for propose → replace → apply.
+pub(crate) fn proliferate_through_replacement(
+    state: &mut GameState,
+    actor: PlayerId,
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> ProliferateThroughReplacementOutcome {
+    let proposed = ProposedEvent::proliferate(actor, 1);
+    match replacement::replace_event(state, proposed, events) {
+        ReplacementResult::Execute(ProposedEvent::Proliferate {
+            player_id, count, ..
+        }) => {
+            if count == 0 {
+                return ProliferateThroughReplacementOutcome::Prevented;
+            }
+            if drive_proliferate_actions(state, player_id, source_id, count, events) {
+                ProliferateThroughReplacementOutcome::Completed
+            } else {
+                ProliferateThroughReplacementOutcome::PausedForChoice
+            }
+        }
+        ReplacementResult::Execute(_) => ProliferateThroughReplacementOutcome::Completed,
+        ReplacementResult::Prevented => ProliferateThroughReplacementOutcome::Prevented,
+        ReplacementResult::NeedsChoice(player) => {
+            state.waiting_for =
+                crate::game::replacement::replacement_choice_waiting_for(player, state);
+            ProliferateThroughReplacementOutcome::PausedForChoice
+        }
+    }
+}
+
+/// CR 701.34a: Proliferate — controller chooses any number of permanents and/or
+/// players that already have counters, then gives each another counter of a kind
+/// already there. Sets `WaitingFor::ProliferateChoice` for the player to choose.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    match proliferate_through_replacement(state, ability.controller, ability.source_id, events) {
+        ProliferateThroughReplacementOutcome::Completed
+        | ProliferateThroughReplacementOutcome::Prevented => {
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::from(&ability.effect),
+                source_id: ability.source_id,
+            });
+        }
+        ProliferateThroughReplacementOutcome::PausedForChoice => {}
+    }
 
     Ok(())
 }
@@ -258,6 +398,50 @@ mod tests {
 
     fn make_proliferate_ability() -> ResolvedAbility {
         ResolvedAbility::new(Effect::Proliferate, vec![], ObjectId(100), PlayerId(0))
+    }
+
+    /// CR 701.34a + CR 614.1a: Tekuthal-style proliferate replacement doubles
+    /// the action count via `repeat_for` on the execute ability.
+    #[test]
+    fn proliferate_replacement_doubles_action_count() {
+        use crate::game::replacement::{replace_event, ReplacementResult};
+        use crate::types::ability::{
+            AbilityDefinition, AbilityKind, QuantityExpr, ReplacementDefinition,
+            ReplacementPlayerScope,
+        };
+        use crate::types::proposed_event::ProposedEvent;
+        use crate::types::replacements::ReplacementEvent;
+
+        let mut state = GameState::new_two_player(42);
+        let tekuthal = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Tekuthal".to_string(),
+            Zone::Battlefield,
+        );
+        let mut execute = AbilityDefinition::new(AbilityKind::Spell, Effect::Proliferate);
+        execute.repeat_for = Some(QuantityExpr::Fixed { value: 2 });
+        let mut replacement =
+            ReplacementDefinition::new(ReplacementEvent::Proliferate).execute(execute);
+        replacement.valid_player = Some(ReplacementPlayerScope::You);
+        state
+            .objects
+            .get_mut(&tekuthal)
+            .unwrap()
+            .replacement_definitions = vec![replacement].into();
+
+        let mut events = Vec::new();
+        match replace_event(
+            &mut state,
+            ProposedEvent::proliferate(PlayerId(0), 1),
+            &mut events,
+        ) {
+            ReplacementResult::Execute(ProposedEvent::Proliferate { count, .. }) => {
+                assert_eq!(count, 2);
+            }
+            other => panic!("expected doubled proliferate event, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4377,14 +4377,26 @@ fn apply_action(
                     log_entries: vec![],
                 });
             }
-            events.push(GameEvent::EffectResolved {
-                kind: crate::types::ability::EffectKind::Proliferate,
-                source_id: ObjectId(0), // Source not tracked through choice state
-            });
             // CR 701.34a: Emit player-action event so proliferate triggers fire.
             events.push(GameEvent::PlayerPerformedAction {
                 player_id: p,
                 action: PlayerActionKind::Proliferate,
+            });
+            let completion_source = state
+                .pending_proliferate_actions
+                .as_ref()
+                .map(|pending| pending.source_id)
+                .unwrap_or(ObjectId(0));
+            if !effects::proliferate::resume_pending_proliferate_actions(state, &mut events) {
+                return Ok(ActionResult {
+                    events,
+                    waiting_for: state.waiting_for.clone(),
+                    log_entries: vec![],
+                });
+            }
+            events.push(GameEvent::EffectResolved {
+                kind: crate::types::ability::EffectKind::Proliferate,
+                source_id: completion_source,
             });
             state.waiting_for = WaitingFor::Priority { player: p };
             state.priority_player = p;

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -287,6 +287,14 @@ pub(super) fn handle_replacement_choice(
                 // CR 701.37a: Explore accepted after replacement choice — the
                 // explore resolver handles the actual explore logic; this is a no-op here.
                 ProposedEvent::Explore { .. } => {}
+                // CR 701.34a: Proliferate accepted after replacement choice.
+                proliferate @ ProposedEvent::Proliferate { .. } => {
+                    crate::game::effects::proliferate::apply_proliferate_after_replacement(
+                        state,
+                        proliferate,
+                        events,
+                    );
+                }
                 // CR 701.17a: Mill accepted after replacement choice — delegate
                 // to the shared helper so count clamping and library movement
                 // match the non-choice delivery.

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1681,6 +1681,52 @@ fn coin_flip_applier(
     })
 }
 
+// --- 4c2. Proliferate (Tekuthal, Inquiry Dominus) ---
+
+// CR 701.34a + CR 614.1a: A proliferate action is about to happen. Count-
+// modifying replacements ("proliferate twice instead") substitute the action
+// count before the chooser opens.
+fn proliferate_matcher(event: &ProposedEvent, _source: ObjectId, _state: &GameState) -> bool {
+    matches!(event, ProposedEvent::Proliferate { count, .. } if *count > 0)
+}
+
+fn proliferate_applier(
+    event: ProposedEvent,
+    rid: ReplacementId,
+    state: &mut GameState,
+    _events: &mut Vec<GameEvent>,
+) -> ApplyResult {
+    let ProposedEvent::Proliferate {
+        player_id,
+        count,
+        applied,
+    } = event
+    else {
+        return ApplyResult::Modified(event);
+    };
+
+    let new_count = state
+        .objects
+        .get(&rid.source)
+        .and_then(|source| source.replacement_definitions.get(rid.index))
+        .and_then(|def| def.execute.as_deref())
+        .and_then(|execute| match &*execute.effect {
+            Effect::Proliferate if execute.sub_ability.is_none() => execute
+                .repeat_for
+                .as_ref()
+                .and_then(|qty| resolve_event_replacement_quantity(qty, count)),
+            _ => None,
+        })
+        .map(|resolved| resolved.max(0) as u32)
+        .unwrap_or(count);
+
+    ApplyResult::Modified(ProposedEvent::Proliferate {
+        player_id,
+        count: new_count,
+        applied,
+    })
+}
+
 fn resolve_event_replacement_quantity(expr: &QuantityExpr, event_count: u32) -> Option<i32> {
     match expr {
         QuantityExpr::Ref {
@@ -2742,6 +2788,13 @@ pub fn build_replacement_registry() -> IndexMap<ReplacementEvent, ReplacementHan
             applier: coin_flip_applier,
         },
     );
+    registry.insert(
+        ReplacementEvent::Proliferate,
+        ReplacementHandlerEntry {
+            matcher: proliferate_matcher,
+            applier: proliferate_applier,
+        },
+    );
     registry.insert(ReplacementEvent::DrawCards, stub()); // stays stub (alias for Draw)
     registry.insert(
         ReplacementEvent::GainLife,
@@ -3764,6 +3817,7 @@ pub fn find_applicable_replacements(
                     | ProposedEvent::Draw { player_id, .. }
                     | ProposedEvent::Scry { player_id, .. }
                     | ProposedEvent::Mill { player_id, .. }
+                    | ProposedEvent::Proliferate { player_id, .. }
                     | ProposedEvent::CoinFlip { player_id, .. } = event
                     {
                         let player_ok = match &repl_def.valid_player {
@@ -4601,6 +4655,7 @@ fn apply_single_replacement(
                     (ProposedEvent::Draw { .. }, Effect::Draw { .. })
                         | (ProposedEvent::Scry { .. }, Effect::Draw { .. })
                         | (ProposedEvent::Scry { .. }, Effect::Scry { .. })
+                        | (ProposedEvent::Proliferate { .. }, Effect::Proliferate)
                         | (ProposedEvent::LifeGain { .. }, Effect::GainLife { .. })
                 )
             });

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -287,6 +287,29 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         return Some(def);
     }
 
+    if let Some(def) = parse_proliferate_count_replacement(&lower, &text) {
+        return Some(def);
+    }
+
+    // --- "If [player] would proliferate, {effect}" ---
+    // CR 701.34a + CR 614.1a: Generic proliferate replacement (Tekuthal class).
+    if nom_primitives::scan_contains(&lower, "would proliferate") {
+        let effect_text = extract_replacement_effect(&normalized);
+        let mut def =
+            ReplacementDefinition::new(ReplacementEvent::Proliferate).description(text.to_string());
+        if let Some(e) = effect_text {
+            let (optional_modal_present, effect_after_modal) = strip_optional_instead_lead_in(&e);
+            if optional_modal_present {
+                def = def.mode(ReplacementMode::Optional { decline: None });
+            }
+            def = def.execute(parse_effect_chain(effect_after_modal, AbilityKind::Spell));
+        } else {
+            return None;
+        }
+        apply_proliferate_player_scope(&lower, &mut def);
+        return Some(def);
+    }
+
     // --- Explore replacement: "If a creature you control would explore, instead …"
     // (Twists and Turns / Topography Tracker class).
     if nom_primitives::scan_contains(&lower, "would explore") {
@@ -4724,6 +4747,80 @@ fn parse_mill_replacement_count(input: &str) -> nom::IResult<&str, QuantityExpr,
         ),
     ))
     .parse(input)
+}
+
+/// CR 614.1a: Apply `valid_player` scope to proliferate replacements from the
+/// antecedent subject ("an opponent", "a player", or default controller-only).
+fn apply_proliferate_player_scope(lower: &str, def: &mut ReplacementDefinition) {
+    if nom_primitives::scan_contains(lower, "an opponent would proliferate")
+        || nom_primitives::scan_contains(lower, "opponent would proliferate")
+    {
+        def.valid_player = Some(ReplacementPlayerScope::Opponent);
+    } else if nom_primitives::scan_contains(lower, "a player would proliferate") {
+        def.valid_player = Some(ReplacementPlayerScope::AnyPlayer);
+    } else if nom_primitives::scan_contains(lower, "you would proliferate") {
+        def.valid_player = Some(ReplacementPlayerScope::You);
+    }
+}
+
+fn parse_proliferate_replacement_count(
+    input: &str,
+) -> nom::IResult<&str, QuantityExpr, OracleError<'_>> {
+    alt((
+        value(
+            QuantityExpr::Multiply {
+                factor: 2,
+                inner: Box::new(QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                }),
+            },
+            tag("twice that many"),
+        ),
+        nom::combinator::map(nom_primitives::parse_number, |value| QuantityExpr::Fixed {
+            value: value as i32,
+        }),
+        value(QuantityExpr::Fixed { value: 2 }, tag("twice")),
+        value(
+            QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            },
+            tag("that many"),
+        ),
+    ))
+    .parse(input)
+}
+
+/// CR 701.34a + CR 614.1a: Parse count-modifying proliferate replacements such
+/// as Tekuthal, Inquiry Dominus ("proliferate twice instead").
+fn parse_proliferate_count_replacement(
+    lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    let (count, rest) = nom_on_lower(lower, lower, |input| {
+        let (input, _) = tag("if you would proliferate, proliferate ").parse(input)?;
+        let (input, count) = parse_proliferate_replacement_count.parse(input)?;
+        let (input, _) = alt((tag(" instead"), tag(" times instead"))).parse(input)?;
+        let (input, _) = opt(char('.')).parse(input)?;
+        Ok((input, count))
+    })?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    let repeat_for = match count {
+        QuantityExpr::Fixed { value: 1 } => None,
+        other => Some(other),
+    };
+    let mut execute = AbilityDefinition::new(AbilityKind::Spell, Effect::Proliferate);
+    if let Some(repeat) = repeat_for {
+        execute.repeat_for = Some(repeat);
+    }
+
+    let mut def = ReplacementDefinition::new(ReplacementEvent::Proliferate)
+        .execute(execute)
+        .description(original_text.to_string());
+    def.valid_player = Some(ReplacementPlayerScope::You);
+    Some(def)
 }
 
 fn parse_scry_count_replacement(lower: &str, original_text: &str) -> Option<ReplacementDefinition> {
@@ -12172,6 +12269,29 @@ mod tests {
         assert!(!super::has_except_first_draw_in_draw_step_clause(
             "except the first one you draw in each of your upkeeps"
         ));
+    }
+
+    #[test]
+    fn tekuthal_proliferate_replacement_parses() {
+        let def = parse_replacement_line(
+            "If you would proliferate, proliferate twice instead.",
+            "Tekuthal, Inquiry Dominus",
+        )
+        .expect("Tekuthal proliferate replacement");
+
+        assert_eq!(def.event, ReplacementEvent::Proliferate);
+        assert_eq!(
+            def.valid_player,
+            Some(ReplacementPlayerScope::You),
+            "controller-scoped proliferate replacement"
+        );
+        let execute = def.execute.expect("execute ability");
+        assert!(matches!(*execute.effect, Effect::Proliferate));
+        assert_eq!(
+            execute.repeat_for,
+            Some(QuantityExpr::Fixed { value: 2 }),
+            "proliferate twice instead → repeat_for Fixed(2)"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -297,14 +297,13 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         let effect_text = extract_replacement_effect(&normalized);
         let mut def =
             ReplacementDefinition::new(ReplacementEvent::Proliferate).description(text.to_string());
-        if let Some(e) = effect_text {
+        {
+            let e = effect_text?;
             let (optional_modal_present, effect_after_modal) = strip_optional_instead_lead_in(&e);
             if optional_modal_present {
                 def = def.mode(ReplacementMode::Optional { decline: None });
             }
             def = def.execute(parse_effect_chain(effect_after_modal, AbilityKind::Spell));
-        } else {
-            return None;
         }
         apply_proliferate_player_scope(&lower, &mut def);
         return Some(def);

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1527,6 +1527,17 @@ pub struct PendingCounterAdditionQueue {
     pub completion: Option<PendingEffectResolved>,
 }
 
+/// CR 701.34a + CR 614.1a: Remaining proliferate actions after a replacement
+/// effect (Tekuthal class) doubles the count. Each completed `ProliferateChoice`
+/// drains one action; when `remaining` reaches zero the originating effect
+/// resolves.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingProliferateActions {
+    pub actor: PlayerId,
+    pub source_id: ObjectId,
+    pub remaining: u32,
+}
+
 /// CR 603.7: A delayed triggered ability created during resolution of a spell or ability.
 /// Fires once at the specified condition, then is removed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -6183,6 +6194,12 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_counter_additions: Option<PendingCounterAdditionQueue>,
 
+    /// CR 701.34a + CR 614.1a: Remaining proliferate actions after a count-
+    /// modifying replacement (Tekuthal class). Resumed after each
+    /// `ProliferateChoice` completes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_proliferate_actions: Option<PendingProliferateActions>,
+
     /// Pending optional effect ability chain, awaiting player accept/decline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_optional_effect: Option<Box<crate::types::ability::ResolvedAbility>>,
@@ -7063,6 +7080,7 @@ impl GameState {
             pending_counter_moves: None,
             pending_batch_deliveries: None,
             pending_counter_additions: None,
+            pending_proliferate_actions: None,
             pending_optional_effect: None,
             pending_optional_trigger_event: None,
             pending_optional_trigger_match_count: None,
@@ -7533,6 +7551,7 @@ impl PartialEq for GameState {
             && self.pending_counter_moves == other.pending_counter_moves
             && self.pending_batch_deliveries == other.pending_batch_deliveries
             && self.pending_counter_additions == other.pending_counter_additions
+            && self.pending_proliferate_actions == other.pending_proliferate_actions
             && self.may_trigger_auto_choices == other.may_trigger_auto_choices
             && self.pending_begin_game_abilities == other.pending_begin_game_abilities
             && self.resolving_begin_game_abilities == other.resolving_begin_game_abilities

--- a/crates/engine/src/types/proposed_event.rs
+++ b/crates/engine/src/types/proposed_event.rs
@@ -259,6 +259,14 @@ pub enum ProposedEvent {
         object_id: ObjectId,
         applied: HashSet<ReplacementId>,
     },
+    /// CR 701.34a + CR 614.1a: A player is about to proliferate. Replacement
+    /// effects can modify how many times the proliferate action is performed
+    /// (Tekuthal, Inquiry Dominus — "proliferate twice instead").
+    Proliferate {
+        player_id: PlayerId,
+        count: u32,
+        applied: HashSet<ReplacementId>,
+    },
     LifeGain {
         player_id: PlayerId,
         amount: u32,
@@ -459,6 +467,15 @@ impl ProposedEvent {
         }
     }
 
+    /// CR 701.34a + CR 614.1a: Construct a `Proliferate` proposed event.
+    pub fn proliferate(player_id: PlayerId, count: u32) -> Self {
+        Self::Proliferate {
+            player_id,
+            count,
+            applied: HashSet::new(),
+        }
+    }
+
     /// CR 106.3 + CR 614.1a: Construct a `ProduceMana` proposed event.
     pub fn produce_mana(source_id: ObjectId, player_id: PlayerId, mana_type: ManaType) -> Self {
         Self::produce_mana_with_context(source_id, player_id, mana_type, false)
@@ -508,6 +525,7 @@ impl ProposedEvent {
             | ProposedEvent::Mill { applied, .. }
             | ProposedEvent::CoinFlip { applied, .. }
             | ProposedEvent::Explore { applied, .. }
+            | ProposedEvent::Proliferate { applied, .. }
             | ProposedEvent::LifeGain { applied, .. }
             | ProposedEvent::LifeLoss { applied, .. }
             | ProposedEvent::AddCounter { applied, .. }
@@ -535,6 +553,7 @@ impl ProposedEvent {
             | ProposedEvent::Mill { applied, .. }
             | ProposedEvent::CoinFlip { applied, .. }
             | ProposedEvent::Explore { applied, .. }
+            | ProposedEvent::Proliferate { applied, .. }
             | ProposedEvent::LifeGain { applied, .. }
             | ProposedEvent::LifeLoss { applied, .. }
             | ProposedEvent::AddCounter { applied, .. }
@@ -624,6 +643,7 @@ impl ProposedEvent {
             ProposedEvent::Draw { player_id, .. }
             | ProposedEvent::Scry { player_id, .. }
             | ProposedEvent::Mill { player_id, .. }
+            | ProposedEvent::Proliferate { player_id, .. }
             | ProposedEvent::CoinFlip { player_id, .. }
             | ProposedEvent::LifeGain { player_id, .. }
             | ProposedEvent::LifeLoss { player_id, .. }
@@ -668,6 +688,7 @@ impl ProposedEvent {
             ProposedEvent::Draw { .. }
             | ProposedEvent::Scry { .. }
             | ProposedEvent::Mill { .. }
+            | ProposedEvent::Proliferate { .. }
             | ProposedEvent::CoinFlip { .. }
             | ProposedEvent::LifeGain { .. }
             | ProposedEvent::LifeLoss { .. }

--- a/crates/engine/src/types/replacements.rs
+++ b/crates/engine/src/types/replacements.rs
@@ -95,6 +95,8 @@ pub enum ReplacementEvent {
     LoseMana,
     PlanarDiceResult,
     Planeswalk,
+    /// CR 701.34a + CR 614.1a: Replaces a proliferate action (count-modifying
+    /// "proliferate twice instead" effects such as Tekuthal, Inquiry Dominus).
     Proliferate,
 
     /// Fallback for truly unknown event strings.

--- a/crates/engine/tests/integration/issue_1337_tekuthal_proliferate_twice.rs
+++ b/crates/engine/tests/integration/issue_1337_tekuthal_proliferate_twice.rs
@@ -1,0 +1,191 @@
+//! Tekuthal, Inquiry Dominus — "If you would proliferate, proliferate twice
+//! instead." (GitHub issue #1337)
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 614.1a: "instead" marks a replacement effect.
+//!   - CR 614.6: a replacement applies only once to a given event.
+//!   - CR 701.34a: proliferate — choose targets, then add a counter of each kind.
+
+use engine::game::effects::proliferate::resolve;
+use engine::game::replacement::{replace_event, ReplacementResult};
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{Effect, ReplacementPlayerScope, ResolvedAbility, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::proposed_event::ProposedEvent;
+use engine::types::replacements::ReplacementEvent;
+
+const TEKUTHAL: &str = "If you would proliferate, proliferate twice instead.";
+const TEKUTHAL_FULL: &str = "Flying\nIf you would proliferate, proliferate twice instead.\n{1}{U/P}{U/P}, Remove three counters from among other artifacts, creatures, and planeswalkers you control: Put an indestructible counter on Tekuthal. ({U/P} can be paid with either {U} or 2 life.)";
+
+fn proliferate_action_count(events: &[GameEvent]) -> usize {
+    events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                GameEvent::PlayerPerformedAction {
+                    action: engine::types::events::PlayerActionKind::Proliferate,
+                    ..
+                }
+            )
+        })
+        .count()
+}
+
+fn add_tekuthal(scenario: &mut GameScenario) -> engine::types::identifiers::ObjectId {
+    scenario
+        .add_creature_from_oracle(P0, "Tekuthal, Inquiry Dominus", 2, 4, TEKUTHAL_FULL)
+        .id()
+}
+
+#[test]
+fn parses_tekuthal_proliferate_replacement() {
+    let parsed = parse_oracle_text(TEKUTHAL, "Tekuthal, Inquiry Dominus", &[], &[], &[]);
+    let repl = parsed
+        .replacements
+        .iter()
+        .find(|r| matches!(r.event, ReplacementEvent::Proliferate))
+        .expect("Tekuthal must parse a Proliferate replacement");
+
+    assert_eq!(
+        repl.valid_player,
+        Some(ReplacementPlayerScope::You),
+        "Tekuthal is controller-scoped"
+    );
+
+    let execute = repl.execute.as_ref().expect("execute ability");
+    assert!(matches!(*execute.effect, Effect::Proliferate));
+    assert_eq!(
+        execute.repeat_for,
+        Some(engine::types::ability::QuantityExpr::Fixed { value: 2 }),
+        "Tekuthal doubles proliferate via repeat_for"
+    );
+}
+
+#[test]
+fn applier_doubles_controllers_proliferate() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    add_tekuthal(&mut scenario);
+    let mut runner = scenario.build();
+
+    let mut events = Vec::new();
+    let proposed = ProposedEvent::proliferate(P0, 1);
+    match replace_event(runner.state_mut(), proposed, &mut events) {
+        ReplacementResult::Execute(ProposedEvent::Proliferate { count, .. }) => {
+            assert_eq!(count, 2, "Tekuthal doubles proliferate");
+        }
+        other => panic!("expected Execute(Proliferate {{ count: 2 }}), got {other:?}"),
+    }
+}
+
+#[test]
+fn tekuthal_proliferate_opens_two_choices_and_adds_two_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    add_tekuthal(&mut scenario);
+    let creature = scenario.add_creature(P1, "Pumped", 2, 2).id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .counters
+        .insert(CounterType::Plus1Plus1, 1);
+
+    let ability = ResolvedAbility::new(Effect::Proliferate, vec![], creature, P0);
+    let mut events = Vec::new();
+    resolve(runner.state_mut(), &ability, &mut events).expect("proliferate resolves");
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::ProliferateChoice { .. }
+        ),
+        "first proliferate choice should open"
+    );
+
+    let first = runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(creature)],
+        })
+        .expect("first proliferate choice");
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::ProliferateChoice { .. }
+        ),
+        "Tekuthal must open a second proliferate choice"
+    );
+    assert_eq!(
+        proliferate_action_count(&first.events),
+        1,
+        "first proliferate action should have fired"
+    );
+    assert_eq!(
+        runner.state().objects[&creature].counters[&CounterType::Plus1Plus1],
+        2,
+        "first proliferate should add one +1/+1 counter"
+    );
+
+    let second = runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(creature)],
+        })
+        .expect("second proliferate choice");
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "both proliferate actions should complete"
+    );
+    assert_eq!(
+        proliferate_action_count(&second.events),
+        1,
+        "second proliferate action should fire in its own step"
+    );
+    assert_eq!(
+        runner.state().objects[&creature].counters[&CounterType::Plus1Plus1],
+        3,
+        "two proliferates should add two +1/+1 counters total"
+    );
+}
+
+#[test]
+fn proliferate_without_tekuthal_remains_single_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let creature = scenario.add_creature(P1, "Pumped", 2, 2).id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .counters
+        .insert(CounterType::Plus1Plus1, 1);
+
+    let ability = ResolvedAbility::new(Effect::Proliferate, vec![], creature, P0);
+    resolve(runner.state_mut(), &ability, &mut Vec::new()).expect("proliferate resolves");
+
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(creature)],
+        })
+        .expect("proliferate choice");
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "baseline proliferate should not open a second choice"
+    );
+    assert_eq!(
+        runner.state().objects[&creature].counters[&CounterType::Plus1Plus1],
+        2
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -123,6 +123,7 @@ mod issue_1328_inti;
 mod issue_1332_bronzehide_lion;
 mod issue_1333_brain_in_a_jar;
 mod issue_1334_marchesa;
+mod issue_1337_tekuthal_proliferate_twice;
 mod issue_1353_body_of_knowledge;
 mod issue_1353_death_pits_observer;
 mod issue_1354_coveted_jewel;


### PR DESCRIPTION
## Summary

- Add `ProposedEvent::Proliferate` and promote `ReplacementEvent::Proliferate` from a stub to a first-class replacement handler
- Route `Effect::Proliferate` through the CR 614 pipeline (mirroring draw/scry/coin-flip), reading `execute.repeat_for` to double the action count
- Parse Tekuthal-style text: `"If you would proliferate, proliferate twice instead."` → `ReplacementEvent::Proliferate` with `repeat_for: Fixed(2)`
- Queue remaining proliferate actions via `PendingProliferateActions` so Tekuthal opens two separate `ProliferateChoice` prompts and emits two `PlayerPerformedAction::Proliferate` events

Fixes #1337

## Test plan

- [x] `cargo test -p engine --test integration issue_1337`
- [x] `cargo test -p engine proliferate_replacement_doubles`
- [x] `cargo test -p engine --test integration proliferate_zero`
- [x] `cargo fmt --all`
- [ ] Manual: Tekuthal on battlefield + Experimental Augury → two proliferate prompts, counters increase twice