### PR TITLE
fix(parser): bind "target creature attacks if able" to the chosen creature

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -7943,16 +7943,23 @@ mod tests {
             &[],
         );
         assert!(!r.abilities.is_empty());
+        // CR 508.1d + CR 608.2c + CR 611.2c: the targeted creature must be bound —
+        // `target` carries the creature slot and the embedded static's `affected`
+        // resolves to `ParentTarget` so the MustAttack requirement attaches to the
+        // chosen creature (not silently dropped). On reverted main both are None.
         assert!(
             matches!(
                 &*r.abilities[0].effect,
                 crate::types::ability::Effect::GenericEffect {
                     static_abilities,
+                    target: Some(crate::types::ability::TargetFilter::Typed(_)),
                     ..
                 } if !static_abilities.is_empty()
                     && static_abilities[0].mode == crate::types::statics::StaticMode::MustAttack
+                    && static_abilities[0].affected
+                        == Some(crate::types::ability::TargetFilter::ParentTarget)
             ),
-            "Expected GenericEffect with MustAttack, got {:?}",
+            "Expected GenericEffect with MustAttack bound to ParentTarget + Typed(Creature) target, got {:?}",
             r.abilities[0].effect
         );
     }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -8521,7 +8521,7 @@ fn try_parse_adapt(lower: &str) -> Option<Effect> {
 /// Bare forms ("attacks this turn if able") emit a temporary `MustAttack`.
 /// Player-bound "attacks you ..." forms emit `ForceAttack`, whose resolver binds
 /// "you" to the resolving ability controller and grants `MustAttackPlayer`.
-fn try_parse_attack_if_able(lower: &str) -> Option<ImperativeFamilyAst> {
+pub(super) fn try_parse_attack_if_able(lower: &str) -> Option<ImperativeFamilyAst> {
     let trimmed = lower.trim_end_matches('.');
 
     // First try: bare forms without a player reference.
@@ -8611,7 +8611,7 @@ fn try_parse_attack_if_able(lower: &str) -> Option<ImperativeFamilyAst> {
 /// must be carried by an explicit `AddStaticMode` modification to actually reach
 /// the layer system and `combat.rs` enforcement. Mirrors the block path's
 /// `ImperativeFamilyAst::MustBeBlocked` lowering.
-fn must_attack_static_definition() -> StaticDefinition {
+pub(super) fn must_attack_static_definition() -> StaticDefinition {
     use crate::types::statics::StaticMode;
     StaticDefinition::new(StaticMode::MustAttack).modifications(vec![
         ContinuousModification::AddStaticMode {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -28907,6 +28907,102 @@ mod tests {
         ));
     }
 
+    /// CR 508.1d + CR 608.2c + CR 611.2c: standalone "Target creature attacks
+    /// this turn if able" (Boiling Blood, Heckling Fiends, Incite, …). The
+    /// subject-layer interceptor must bind the targeted creature: `target =
+    /// Some(Typed(Creature))` and the embedded MustAttack static's `affected =
+    /// Some(ParentTarget)`. On reverted main both are None (the requirement is
+    /// silently dropped) — this is the discriminating gate.
+    #[test]
+    fn target_creature_attacks_if_able_binds_to_parent_target() {
+        use crate::types::statics::StaticMode;
+        let def = parse_effect_chain(
+            "Target creature attacks this turn if able.",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::GenericEffect {
+                static_abilities,
+                duration,
+                target,
+            } => {
+                assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+                assert!(
+                    matches!(target, Some(TargetFilter::Typed(tf)) if tf.type_filters.contains(&TypeFilter::Creature)),
+                    "target must be the chosen creature, got {target:?}"
+                );
+                assert_eq!(static_abilities.len(), 1);
+                assert_eq!(static_abilities[0].mode, StaticMode::MustAttack);
+                assert_eq!(
+                    static_abilities[0].affected,
+                    Some(TargetFilter::ParentTarget),
+                    "MustAttack must bind to the chosen creature, not nothing"
+                );
+            }
+            other => panic!("expected GenericEffect, got {other:?}"),
+        }
+    }
+
+    /// CR 508.1d: the combat-duration wording variant — "attacks this combat if
+    /// able" → UntilEndOfCombat, with the same ParentTarget binding.
+    #[test]
+    fn target_creature_attacks_this_combat_if_able_binds_with_combat_duration() {
+        use crate::types::statics::StaticMode;
+        let def = parse_effect_chain(
+            "Target creature attacks this combat if able.",
+            AbilityKind::Spell,
+        );
+        match &*def.effect {
+            Effect::GenericEffect {
+                static_abilities,
+                duration,
+                target,
+            } => {
+                assert_eq!(*duration, Some(Duration::UntilEndOfCombat));
+                assert!(
+                    matches!(target, Some(TargetFilter::Typed(tf)) if tf.type_filters.contains(&TypeFilter::Creature)),
+                    "target must be the chosen creature, got {target:?}"
+                );
+                assert_eq!(static_abilities[0].mode, StaticMode::MustAttack);
+                assert_eq!(
+                    static_abilities[0].affected,
+                    Some(TargetFilter::ParentTarget)
+                );
+            }
+            other => panic!("expected GenericEffect, got {other:?}"),
+        }
+    }
+
+    /// CR 508.1d: activated representative through the full `parse_oracle_text`
+    /// path — Heckling Fiends ("{2}{R}: Target creature attacks this turn if
+    /// able."). The activated ability's effect must bind the target.
+    #[test]
+    fn activated_attacks_if_able_binds_target_via_full_parse() {
+        use crate::types::statics::StaticMode;
+        let r = crate::parser::parse_oracle_text(
+            "{2}{R}: Target creature attacks this turn if able.",
+            "Heckling Fiends",
+            &[],
+            &["Creature".to_string()],
+            &["Goblin".to_string()],
+        );
+        assert!(!r.abilities.is_empty(), "expected an activated ability");
+        let effect = &r.abilities[0].effect;
+        assert!(
+            matches!(
+                &**effect,
+                Effect::GenericEffect {
+                    static_abilities,
+                    target: Some(TargetFilter::Typed(tf)),
+                    ..
+                } if tf.type_filters.contains(&TypeFilter::Creature)
+                    && static_abilities[0].mode == StaticMode::MustAttack
+                    && static_abilities[0].affected == Some(TargetFilter::ParentTarget)
+            ),
+            "activated ability must bind the targeted creature, got {effect:?}"
+        );
+    }
+
     #[test]
     fn effect_target_creature_cant_block_uses_rule_static() {
         let e = parse_effect("Target creature can't block this turn");

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -9,6 +9,7 @@ use nom::Parser;
 use super::animation::{
     animation_modifications_with_replacement, has_in_addition_to_other_types, parse_animation_spec,
 };
+use super::imperative;
 use super::lower::BOUNDED_TARGET_PHRASES;
 use super::{resolve_it_pronoun, ParseContext};
 use crate::parser::oracle_ir::ast::*;
@@ -397,6 +398,52 @@ fn try_parse_subject_restriction_clause(
             optional: false,
             unless_pay: None,
         });
+    }
+
+    // CR 508.1d (must-attack declaration) + CR 608.2c (one-shot anaphora binding)
+    // + CR 611.2c (continuous effect affected-set) — mirrors the " must be blocked"
+    // subject form (CR 509.1c). "[subject] attacks/attack this turn/combat if able"
+    // for a targeted or set subject (Boiling Blood, Heckling Fiends, Incite, …):
+    // the bare imperative recognizer drops the subject (target: None, affected:
+    // None), silently un-binding the MustAttack requirement. Split off the subject
+    // here and re-bind: target = the typed/targeted subject, static affected =
+    // ParentTarget so `register_transient_effect` produces a per-target
+    // SpecificObject TCE. Use `find_predicate_start`/`deconjugate_verb` (NOT
+    // `split_around`, which consumes the "attack" needle and leaves a tail the
+    // recognizer rejects) to yield subject + deconjugated "attack … if able"
+    // predicate, exactly as `try_parse_subject_become_clause` does.
+    if let Some(verb_start) = find_predicate_start(text) {
+        let subject = text[..verb_start].trim();
+        let predicate = deconjugate_verb(text[verb_start..].trim());
+        // Classify via the existing recognizer. Only the bare GenericEffect form
+        // (MustAttack) is re-bound here; the player-bound `ForceAttack` form
+        // ("attacks you/that player …") has its own targeted handling and must
+        // NOT be captured.
+        if let Some(ImperativeFamilyAst::GainKeyword(Effect::GenericEffect { duration, .. })) =
+            imperative::try_parse_attack_if_able(&predicate)
+        {
+            // `?` here makes a bare/source-granted "attacks this turn if able"
+            // (empty subject, granted ability) fall through to None, preserving
+            // the existing target:None behavior for that class.
+            let application = parse_subject_application(subject, ctx)?;
+            let affected = static_affected_for_application(&application);
+            return Some(ParsedEffectClause {
+                effect: Effect::GenericEffect {
+                    static_abilities: vec![
+                        imperative::must_attack_static_definition().affected(affected)
+                    ],
+                    duration: duration.clone(),
+                    target: application.target,
+                },
+                distribute: None,
+                multi_target: application.multi_target,
+                duration,
+                sub_ability: None,
+                condition: None,
+                optional: application.is_optional,
+                unless_pay: None,
+            });
+        }
     }
 
     // CR 602.5 + CR 603.2a: "[subject] activated abilities can't be activated" —


### PR DESCRIPTION
Fixes #3557.

## Summary

Single-sentence targeted combat requirements — "**Target creature** attacks this turn if able." — silently dropped the chosen creature: the clause lowered to `GenericEffect { target: None, static_abilities: [MustAttack { affected: None }] }`, so the requirement bound to nothing and no creature was forced to attack.

Cards: Boiling Blood, Heckling Fiends, Rage Nimbus, Courtly Provocateur, Basandra Battle Seraph, Imps' Taunt, Incite, Into the Fray, Shipwreck Singer, Koma and Toski Compleated.

## Root cause

For a single sentence with a targeted subject, the clause reaches `inject_subject_target` (mod.rs), whose `GenericEffect` arm is gated `if subject.target.is_none()` — so a targeted subject skips injection and the `try_parse_attack_if_able` bare arm's `target: None` / `affected: None` survives. The block-side analogs already bind their target: "Target creature blocks this turn if able" lowers to `ForceBlock { target }`, and the subject form "... must be blocked this turn if able" is intercepted at the subject layer (subject.rs) and built with `affected = static_affected_for_application(..)`. Only the attack / `MustAttack` path lacked an equivalent — the asymmetry is the bug.

## Fix (parser-only; no new engine variant)

Add a subject-layer interceptor in `try_parse_subject_restriction_clause` (oracle_effect/subject.rs), directly after the " must be blocked" arm, mirroring it:

- Split subject + deconjugated predicate via `find_predicate_start` / `deconjugate_verb` (the idiom `try_parse_subject_become_clause` uses — not `split_around`, which would consume the verb and leave a tail the recognizer rejects).
- Classify the predicate by calling the existing `try_parse_attack_if_able` recognizer, matching **only** the bare `GainKeyword(GenericEffect { duration, .. })` shape — the player-bound `ForceAttack` form ("attacks you/that player ...") is deliberately excluded and keeps its own targeted handling.
- Build `GenericEffect { static_abilities: [must_attack_static_definition().affected(affected)], duration, target: application.target }` with `affected = static_affected_for_application(&application)` (→ `ParentTarget` for a targeted subject). The `?` on `parse_subject_application` makes the bare/source-granted "attacks this turn if able" (no subject) fall through unchanged (`target: None` preserved).

`StaticMode::MustAttack`, `TargetFilter::ParentTarget`, the transient-effect resolver, and `combat.rs` enforcement all already exist — `register_transient_effect` binds `affected: ParentTarget` to a per-target `SpecificObject` TCE, the same path the must-be-blocked subject form already uses. No runtime change. CR 508.1d (must-attack declaration), CR 608.2c (one-shot anaphora binding), CR 611.2c (continuous-effect affected-set), mirroring the must-block form (CR 509.1c).

## Tests

- Strengthened `attack_this_turn_if_able_parses_as_effect` (oracle.rs) to assert `target == Some(Typed(Creature))` and `affected == Some(ParentTarget)` — it previously asserted only the `MustAttack` mode and passed despite the bug (revert-discriminating).
- New `target_creature_attacks_if_able_binds_to_parent_target`, a combat-duration variant (`UntilEndOfCombat`), and an activated-ability representative (Heckling Fiends `{2}{R}:`) driven through the real parse pipeline.
- No-regression: player-bound `ForceAttack` still routes correctly, bare/source-granted form stays `target: None`, block / must-be-blocked / "becomes red ... and attacks if able" conjunction all unaffected.

## Verification

`cargo +nightly test -p engine --lib`: 12274 passed, 0 failed. `clippy -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean for this diff.
