### PR TITLE
fix(parser): bind "that attacking player" for attack-trigger token creation

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1080,10 +1080,18 @@ pub(super) fn parse_subject_application(
     // TriggeringPlayer branch here to the two player-referencing forms.
     let player_subject = all_consuming(alt((
         value(
+            ("that attacking player", true),
+            tag::<_, _, OracleError<'_>>("that attacking player may"),
+        ),
+        value(
             ("that player", true),
             tag::<_, _, OracleError<'_>>("that player may"),
         ),
         value(("the player", true), tag("the player may")),
+        value(
+            ("that attacking player", false),
+            tag("that attacking player"),
+        ),
         value(("that player", false), tag("that player")),
         value(("the player", false), tag("the player")),
     )))
@@ -1093,7 +1101,10 @@ pub(super) fn parse_subject_application(
         else {
             return None;
         };
-        if matches!(ctx_filter, TargetFilter::TriggeringPlayer) {
+        if matches!(
+            ctx_filter,
+            TargetFilter::TriggeringPlayer | TargetFilter::DefendingPlayer
+        ) {
             // CR 608.2c + CR 109.4 (issue #534): "That player" after a
             // `Choose(Player)`/`Choose(Opponent)` clause binds to the
             // just-chosen player — mirrors the `resolve_they_pronoun`
@@ -3518,7 +3529,9 @@ fn add_another_property(filter: TargetFilter) -> TargetFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{AbilityKind, ContinuousModification, Effect, TypeFilter};
+    use crate::types::ability::{
+        AbilityKind, ContinuousModification, ControllerRef, Effect, TypeFilter,
+    };
     use crate::types::card_type::Supertype;
     use crate::types::statics::BlockExceptionKind;
 
@@ -4470,6 +4483,56 @@ mod tests {
         let result = parse_subject_application("that player", &mut ctx);
         assert!(result.is_some());
         assert_eq!(result.unwrap().affected, TargetFilter::TriggeringPlayer);
+    }
+
+    #[test]
+    fn parse_subject_that_attacking_player_trigger_context_is_triggering_player() {
+        // Issue #1325: "that attacking player" is synonymous with the attack
+        // event's declaring player (CR 506.2 + CR 603.7c).
+        let mut ctx = ParseContext {
+            subject: Some(TargetFilter::Player),
+            relative_player_scope: Some(ControllerRef::DefendingPlayer),
+            card_name: Some("Ellie, Brick Master".to_string()),
+            ..ParseContext::default()
+        };
+        let result = parse_subject_application("that attacking player", &mut ctx);
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap().affected,
+            TargetFilter::TriggeringPlayer,
+            "that attacking player must bind to TriggeringPlayer in trigger context"
+        );
+    }
+
+    #[test]
+    fn parse_subject_predicate_that_attacking_player_creates_token() {
+        use crate::parser::oracle_effect::parse_effect_clause;
+        use crate::types::ability::Effect;
+
+        let mut ctx = ParseContext {
+            subject: Some(TargetFilter::Player),
+            relative_player_scope: Some(ControllerRef::DefendingPlayer),
+            card_name: Some("Ellie, Brick Master".to_string()),
+            ..ParseContext::default()
+        };
+        let clause = parse_effect_clause(
+            "that attacking player creates a tapped 1/1 black Fungus Zombie creature token named Cordyceps Infected that's attacking that opponent",
+            &mut ctx,
+        );
+        let Effect::Token {
+            owner,
+            name,
+            tapped,
+            enters_attacking,
+            ..
+        } = &clause.effect
+        else {
+            panic!("expected Token effect, got {:?}", clause.effect);
+        };
+        assert_eq!(*owner, TargetFilter::TriggeringPlayer);
+        assert_eq!(name, "Cordyceps Infected");
+        assert!(*tapped);
+        assert!(*enters_attacking);
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -276,6 +276,20 @@ fn parse_itself_self_reference(input: &str) -> OracleResult<'_, TargetFilter> {
 
 /// Parse an event context reference from Oracle text.
 ///
+/// CR 506.2 + CR 603.7c: "that attacking player" — the player who declared
+/// attackers in the triggering `AttackersDeclared` event (Ellie, Brick Master;
+/// Breena, the Demagogue).
+pub fn parse_attacking_player_event_ref(input: &str) -> OracleResult<'_, TargetFilter> {
+    value(TargetFilter::TriggeringPlayer, tag("that attacking player")).parse(input)
+}
+
+/// CR 506.3d + CR 508.1: "that opponent" inside an attack trigger's effect —
+/// the opponent being attacked in the triggering event (token enters attacking
+/// that opponent; Adeline / Ellie class).
+pub fn parse_attacked_opponent_event_ref(input: &str) -> OracleResult<'_, TargetFilter> {
+    value(TargetFilter::DefendingPlayer, tag("that opponent")).parse(input)
+}
+
 /// Matches "that spell", "that player", "that creature", "defending player",
 /// "the defending player", "that card", "that permanent".
 /// Returns a `TargetFilter` for the referenced entity.
@@ -294,6 +308,9 @@ pub fn parse_event_context_ref(input: &str) -> OracleResult<'_, TargetFilter> {
         value(TargetFilter::TriggeringSource, tag("that creature")),
         value(TargetFilter::TriggeringSource, tag("that permanent")),
         value(TargetFilter::TriggeringSource, tag("that card")),
+        parse_attacking_player_event_ref,
+        // CR 506.3d: "that opponent" before the shorter "that player" arm.
+        parse_attacked_opponent_event_ref,
         value(TargetFilter::TriggeringPlayer, tag("that player")),
         // CR 506.3d: "defending player" / "the defending player"
         value(TargetFilter::DefendingPlayer, tag("the defending player")),
@@ -834,6 +851,16 @@ mod tests {
         let (rest6, f6) = parse_event_context_ref("the defending player gains").unwrap();
         assert_eq!(rest6, " gains");
         assert_eq!(f6, TargetFilter::DefendingPlayer);
+
+        // CR 506.2 + CR 603.7c: attack-trigger actor anaphor (Ellie, Breena).
+        let (rest7, f7) = parse_event_context_ref("that attacking player creates").unwrap();
+        assert_eq!(rest7, " creates");
+        assert_eq!(f7, TargetFilter::TriggeringPlayer);
+
+        // CR 506.3d: attacked opponent anaphor in token-enter-attacking clauses.
+        let (rest8, f8) = parse_event_context_ref("that opponent.").unwrap();
+        assert_eq!(rest8, ".");
+        assert_eq!(f8, TargetFilter::DefendingPlayer);
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -26118,6 +26118,72 @@ mod tests {
                 "Breena must gate on defending player life exceeding another opponent, got {other:?}"
             ),
         }
+        let execute = def.execute.as_deref().expect("Breena must have execute");
+        let Effect::Draw { target, .. } = execute.effect.as_ref() else {
+            panic!(
+                "Breena draw clause must lower to Draw, got {:?}",
+                execute.effect
+            );
+        };
+        assert_eq!(
+            *target,
+            TargetFilter::TriggeringPlayer,
+            "that attacking player draws must bind to TriggeringPlayer"
+        );
+    }
+
+    #[test]
+    fn ellie_brick_master_attack_token_trigger() {
+        // Issue #1325: attack trigger creates Cordyceps Infected for the attacking player.
+        let def = parse_trigger_line(
+            "Whenever a player attacks one of your opponents, that attacking player creates a tapped 1/1 black Fungus Zombie creature token named Cordyceps Infected that's attacking that opponent.",
+            "Ellie, Brick Master",
+        );
+        assert_eq!(def.mode, TriggerMode::Attacks);
+        assert_eq!(def.valid_source, Some(TargetFilter::Player));
+        assert_eq!(
+            def.valid_target,
+            Some(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::Opponent)
+            ))
+        );
+        let execute = def.execute.as_deref().expect("Ellie must have execute");
+        let Effect::Token {
+            owner,
+            name,
+            tapped,
+            enters_attacking,
+            types,
+            colors,
+            power,
+            toughness,
+            ..
+        } = execute.effect.as_ref()
+        else {
+            panic!("Ellie must lower to Token, got {:?}", execute.effect);
+        };
+        assert_eq!(
+            *owner,
+            TargetFilter::TriggeringPlayer,
+            "that attacking player creates must bind token owner to TriggeringPlayer"
+        );
+        assert_eq!(name, "Cordyceps Infected");
+        assert!(*tapped, "Cordyceps Infected must enter tapped");
+        assert!(
+            *enters_attacking,
+            "Cordyceps Infected must enter attacking that opponent"
+        );
+        assert!(
+            types.iter().any(|t| t.eq_ignore_ascii_case("Fungus"))
+                && types.iter().any(|t| t.eq_ignore_ascii_case("Zombie")),
+            "Cordyceps Infected must be Fungus Zombie, got {types:?}"
+        );
+        assert!(
+            colors.contains(&crate::types::mana::ManaColor::Black),
+            "Cordyceps Infected must be black"
+        );
+        assert_eq!(power, &crate::types::ability::PtValue::Fixed(1));
+        assert_eq!(toughness, &crate::types::ability::PtValue::Fixed(1));
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_1325_ellie_brick_master.rs
+++ b/crates/engine/tests/integration/issue_1325_ellie_brick_master.rs
@@ -1,0 +1,150 @@
+//! Issue #1325 — Ellie, Brick Master must create a Cordyceps Infected token for
+//! the attacking player when any player attacks one of your opponents.
+//!
+//! Oracle text (Distract the Horde):
+//!   Whenever a player attacks one of your opponents, that attacking player
+//!   creates a tapped 1/1 black Fungus Zombie creature token named Cordyceps
+//!   Infected that's attacking that opponent.
+//!
+//! CR 508.4: the token must enter tapped and attacking the defended opponent.
+//! CR 506.2 + CR 603.7c: "that attacking player" is the player who declared
+//! attackers in the triggering event, not Ellie's controller.
+//!
+//! https://github.com/phase-rs/phase/issues/1325
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+const ELLIE_ORACLE: &str = "Partner—Survivors\n\
+Distract the Horde — Whenever a player attacks one of your opponents, that attacking player creates a tapped 1/1 black Fungus Zombie creature token named Cordyceps Infected that's attacking that opponent.";
+
+fn cordyceps_tokens(runner: &GameRunner, controller: PlayerId) -> Vec<ObjectId> {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| {
+            o.controller == controller
+                && o.zone == Zone::Battlefield
+                && o.is_token
+                && o.name.eq_ignore_ascii_case("Cordyceps Infected")
+        })
+        .map(|o| o.id)
+        .collect()
+}
+
+fn resolve_attack_triggers(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    return;
+                }
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![] })
+                    .expect("order triggers");
+            }
+            other => panic!("unexpected waiting state during Ellie trigger: {other:?}"),
+        }
+    }
+    panic!("Ellie trigger did not resolve");
+}
+
+#[test]
+fn ellie_creates_token_when_you_attack_opponent() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let ellie = scenario
+        .add_creature_from_oracle(P0, "Ellie, Brick Master", 2, 1, ELLIE_ORACLE)
+        .id();
+
+    let attacker = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+        .expect("declare attack on opponent");
+
+    resolve_attack_triggers(&mut runner);
+
+    let tokens = cordyceps_tokens(&runner, P0);
+    assert_eq!(
+        tokens.len(),
+        1,
+        "issue #1325: P0 attacking P1 must create exactly one Cordyceps Infected"
+    );
+
+    let token = runner.state().objects.get(&tokens[0]).expect("token");
+    assert!(token.tapped, "Cordyceps Infected must enter tapped");
+    assert!(
+        token.color.contains(&ManaColor::Black),
+        "Cordyceps Infected must be black"
+    );
+
+    let attacking: Vec<ObjectId> = runner
+        .state()
+        .combat
+        .as_ref()
+        .expect("combat must be live")
+        .attackers
+        .iter()
+        .map(|a| a.object_id)
+        .collect();
+    assert!(
+        attacking.contains(&tokens[0]),
+        "Cordyceps Infected must enter attacking; attackers={attacking:?}"
+    );
+
+    // Sanity: Ellie herself did not create the token — the attacking player did.
+    assert_ne!(ellie, tokens[0]);
+}
+
+#[test]
+fn ellie_creates_token_for_other_attacking_player_in_three_player_game() {
+    const P2: PlayerId = PlayerId(2);
+
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature_from_oracle(P0, "Ellie, Brick Master", 2, 1, ELLIE_ORACLE)
+        .id();
+
+    let p1_attacker = scenario.add_creature(P1, "Hill Giant", 3, 3).id();
+
+    let mut runner = scenario.build();
+    // P1's combat step — P2 is also an opponent of Ellie's controller (P0).
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(p1_attacker, AttackTarget::Player(P2))])
+        .expect("P1 attacks P2");
+
+    resolve_attack_triggers(&mut runner);
+
+    assert_eq!(
+        cordyceps_tokens(&runner, P1).len(),
+        1,
+        "issue #1325: when P1 attacks P0's opponent P2, P1 must create Cordyceps Infected"
+    );
+    assert!(
+        cordyceps_tokens(&runner, P0).is_empty(),
+        "Ellie's controller must not create the token when another player attacks"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -117,6 +117,7 @@ mod issue_1302_final_parting;
 mod issue_1305_thalisse_tokens_created_this_turn;
 mod issue_1308_unstoppable_plan;
 mod issue_1312_prepared_spell_cast_triggers;
+mod issue_1325_ellie_brick_master;
 mod issue_1326_tabernacle_upkeep_destroy;
 mod issue_1327_zack_fair;
 mod issue_1328_inti;


### PR DESCRIPTION
## Summary

- Fixes [#1325](https://github.com/phase-rs/phase/issues/1325): Ellie, Brick Master did not create a Cordyceps Infected token when a player attacked one of your opponents.
- Adds parser building blocks for **"that attacking player"** → `TriggeringPlayer` and **"that opponent"** → `DefendingPlayer` in attack-trigger effect bodies.
- Wires subject-predicate parsing so token `owner` resolves to the attacking player instead of Ellie's controller.
- Also covers Breena's **"that attacking player draws a card"** phrasing (same anaphor, previously untested at the effect layer).

## Root cause

The trigger condition (`Whenever a player attacks one of your opponents`) parsed correctly, but the effect body failed because `"that attacking player creates…"` was not recognized — only the shorter `"that player"` form was.

## Test plan

- [x] `ellie_brick_master_attack_token_trigger` — full trigger AST: `Token` with `TriggeringPlayer` owner, tapped, enters attacking, Cordyceps Infected identity
- [x] `parse_subject_that_attacking_player_*` — subject application in trigger context
- [x] `parse_subject_predicate_that_attacking_player_creates_token` — effect-clause lowering
- [x] `ellie_creates_token_when_you_attack_opponent` — 2-player runtime: token enters tapped and attacking
- [x] `ellie_creates_token_for_other_attacking_player_in_three_player_game` — 3-player runtime: attacking player (not Ellie controller) creates the token