### PR TITLE
fix(engine): make stacked proliferate doublers compound (Tekuthal x2)

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -5028,6 +5028,22 @@ fn candidate_materiality(
         }
         return CandidateMateriality::Disjoint;
     };
+    // CR 616.1: a proliferate count-doubler ("proliferate twice instead",
+    // Tekuthal) multiplies the proliferate action count via a `Multiply`
+    // `repeat_for`. Two such doublers commute (x2 then x2 == x2 then x2 == x4),
+    // so the ordering is immaterial and they must auto-apply — mirroring the
+    // `QuantityModification::Double` -> `Multiplicative` count-write path. Without
+    // this they fall to the conservative `Unconditional` default below and force
+    // a degenerate CR 616.1 ordering choice. (A non-`Multiply` `repeat_for` is not
+    // a doubler and correctly falls through to the conservative default.)
+    if matches!(&*execute.effect, Effect::Proliferate)
+        && matches!(execute.repeat_for, Some(QuantityExpr::Multiply { .. }))
+    {
+        return CandidateMateriality::Writes {
+            field: EventField::Count,
+            commute: CommuteClass::Multiplicative,
+        };
+    }
     let mut field: Option<EventField> = None;
     let mut current = Some(execute);
     while let Some(def) = current {

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4778,7 +4778,21 @@ fn parse_proliferate_replacement_count(
         nom::combinator::map(nom_primitives::parse_number, |value| QuantityExpr::Fixed {
             value: value as i32,
         }),
-        value(QuantityExpr::Fixed { value: 2 }, tag("twice")),
+        // CR 616.1: "proliferate twice" is a *multiplicative* replacement, not a
+        // set-to-2. Modeling it as `Multiply` (double the in-flight count) instead
+        // of `Fixed { value: 2 }` lets two doublers compound through the
+        // replacement pipeline's re-evaluation: two Tekuthal, Inquiry Dominus
+        // proliferate 1 -> 2 -> 4 times (per the MOM ruling), not a flat 2. The
+        // single-doubler case is unchanged (1 * 2 == 2).
+        value(
+            QuantityExpr::Multiply {
+                factor: 2,
+                inner: Box::new(QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                }),
+            },
+            tag("twice"),
+        ),
         value(
             QuantityExpr::Ref {
                 qty: QuantityRef::EventContextAmount,
@@ -12288,8 +12302,13 @@ mod tests {
         assert!(matches!(*execute.effect, Effect::Proliferate));
         assert_eq!(
             execute.repeat_for,
-            Some(QuantityExpr::Fixed { value: 2 }),
-            "proliferate twice instead → repeat_for Fixed(2)"
+            Some(QuantityExpr::Multiply {
+                factor: 2,
+                inner: Box::new(QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                }),
+            }),
+            "proliferate twice instead → repeat_for Multiply(2 × event count) so stacked doublers compound"
         );
     }
 

--- a/crates/engine/tests/integration/issue_1337_tekuthal_proliferate_twice.rs
+++ b/crates/engine/tests/integration/issue_1337_tekuthal_proliferate_twice.rs
@@ -62,8 +62,13 @@ fn parses_tekuthal_proliferate_replacement() {
     assert!(matches!(*execute.effect, Effect::Proliferate));
     assert_eq!(
         execute.repeat_for,
-        Some(engine::types::ability::QuantityExpr::Fixed { value: 2 }),
-        "Tekuthal doubles proliferate via repeat_for"
+        Some(engine::types::ability::QuantityExpr::Multiply {
+            factor: 2,
+            inner: Box::new(engine::types::ability::QuantityExpr::Ref {
+                qty: engine::types::ability::QuantityRef::EventContextAmount,
+            }),
+        }),
+        "Tekuthal doubles proliferate via repeat_for (Multiply so stacked doublers compound)"
     );
 }
 
@@ -187,5 +192,58 @@ fn proliferate_without_tekuthal_remains_single_choice() {
     assert_eq!(
         runner.state().objects[&creature].counters[&CounterType::Plus1Plus1],
         2
+    );
+}
+
+#[test]
+fn two_tekuthals_compound_proliferate_to_four() {
+    // CR 616.1 + the MOM ruling: two Tekuthal each apply once to the proliferate
+    // event, re-evaluating between applications, so the controller proliferates
+    // 1 -> 2 -> 4 times — four +1/+1 counters added (1 base -> 5). With the prior
+    // `Fixed { value: 2 }` model the second doubler discarded the in-flight count
+    // and yielded a flat 2 (-> 3); `Multiply { factor: 2, EventContextAmount }`
+    // compounds through the pipeline's re-evaluation.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    add_tekuthal(&mut scenario);
+    add_tekuthal(&mut scenario);
+    let creature = scenario.add_creature(P1, "Pumped", 2, 2).id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .counters
+        .insert(CounterType::Plus1Plus1, 1);
+
+    let ability = ResolvedAbility::new(Effect::Proliferate, vec![], creature, P0);
+    resolve(runner.state_mut(), &ability, &mut Vec::new()).expect("proliferate resolves");
+
+    // Drive the CR 616.1 ordering of the two doublers, then each proliferate
+    // action, to completion. Bounded to guard against a non-terminating loop.
+    // Two ×2 doublers commute, so CR 616.1 ordering is immaterial: the pipeline
+    // auto-applies both (no ReplacementChoice prompt) and resolve opens one
+    // ProliferateChoice per action. Drive each to completion (bounded guard).
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 32, "proliferate choice loop did not terminate");
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ProliferateChoice { .. } => {
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Object(creature)],
+                    })
+                    .expect("proliferate target choice");
+            }
+            _ => break,
+        }
+    }
+
+    assert_eq!(
+        runner.state().objects[&creature].counters[&CounterType::Plus1Plus1],
+        5,
+        "two Tekuthal compound to four proliferations (1 base + 4), not two"
     );
 }


### PR DESCRIPTION
Two Tekuthal, Inquiry Dominus should proliferate four times (1->2->4, per
the MOM ruling and CR 616.1 — each replacement applies once, re-evaluating
between applications). Two bugs prevented this:

1. The parser modeled "proliferate twice" as QuantityExpr::Fixed { value: 2 },
   which resolve_event_replacement_quantity returns verbatim, discarding the
   in-flight count — so a second doubler could not compound. Model it as
   Multiply { factor: 2, EventContextAmount } (the expression the sibling
   "twice that many" arm already builds), so x2 composes through the
   replacement pipeline's re-evaluation. Single-doubler behavior is unchanged
   (1 * 2 == 2).

2. candidate_materiality classified Effect::Proliferate via the conservative
   _ => Unconditional fallthrough, forcing a CR 616.1 ordering choice for two
   doublers. That multi-candidate choice path was mis-wired and dropped the
   proliferate entirely (two Tekuthal proliferated *zero* times). Two x2
   doublers commute (x4 either order), so classify a multiplicative-repeat_for
   proliferate as Writes { Count, Multiplicative } — mirroring the existing
   QuantityModification::Double path — so they auto-apply without a (degenerate)
   prompt, which is both rules-correct and sidesteps the broken path.

Adds a discriminating two-Tekuthal runtime test driving resolve -> proliferate
choices to a 4-counter end state (fails on revert of either fix). Fixes the
stacked case left open by #3555.
