### PR TITLE
fix(engine): resolve Kain combat-damage GiveControl and if-they-do riders

### DIFF
--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -208,6 +208,8 @@ pub fn resolve_give(
             return Err(EffectError::ObjectNotFound(obj_id));
         }
 
+        let old_controller = state.objects.get(&obj_id).map(|obj| obj.controller);
+
         // CR 613.3: Create a transient continuous effect at Layer 2 (Control)
         // with the recipient as the new controller.
         state.add_transient_continuous_effect(
@@ -219,6 +221,16 @@ pub fn resolve_give(
             None,
         );
         mark_echo_due_for_new_controller(state, obj_id);
+
+        // CR 110.2: Record the handoff for downstream "if they do" riders and
+        // `ControllerChanged` triggers (mirrors `resolve_all`).
+        if old_controller.is_some_and(|old| old != recipient_id) {
+            events.push(GameEvent::ControllerChanged {
+                object_id: obj_id,
+                old_controller: old_controller.unwrap(),
+                new_controller: recipient_id,
+            });
+        }
     }
 
     events.push(GameEvent::EffectResolved {
@@ -1273,6 +1285,137 @@ mod tests {
 
         let result = resolve(&mut state, &ability, &mut events);
         assert!(result.is_err());
+    }
+
+    /// CR 603.7c + CR 608.2c (issue #1335): `TriggeringPlayer` on combat-damage
+    /// triggers must bind from `DamageDealt`, not only `AttackersDeclared`.
+    #[test]
+    fn give_control_triggering_player_recipient_resolves_from_damage_dealt_event() {
+        use crate::types::events::GameEvent;
+
+        let mut state = GameState::new_two_player(42);
+        let kain = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Kain, Traitorous Dragoon".to_string(),
+            Zone::Battlefield,
+        );
+        state.current_trigger_event = Some(GameEvent::DamageDealt {
+            source_id: kain,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 2,
+            is_combat: true,
+            excess: 0,
+        });
+        let ability = ResolvedAbility::new(
+            Effect::GiveControl {
+                target: TargetFilter::SelfRef,
+                recipient: TargetFilter::TriggeringPlayer,
+            },
+            vec![],
+            kain,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_give(&mut state, &ability, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(
+            state.objects.get(&kain).unwrap().controller,
+            PlayerId(1),
+            "TriggeringPlayer on DamageDealt must be the damaged player"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, GameEvent::ControllerChanged { .. })),
+            "successful handoff must emit ControllerChanged"
+        );
+    }
+
+    /// Issue #1335: end-to-end parsed Kain trigger chain through
+    /// `resolve_ability_chain` with a combat-damage trigger event.
+    #[test]
+    fn issue_1335_kain_full_chain_transfers_control_and_riders() {
+        use crate::game::ability_utils::build_resolved_from_def;
+        use crate::game::effects::resolve_ability_chain;
+        use crate::parser::oracle::parse_oracle_text;
+        use crate::types::card_type::CoreType;
+        use crate::types::events::GameEvent;
+
+        const KAIN_ORACLE: &str = "Jump — During your turn, Kain has flying.\n\
+Whenever Kain deals combat damage to a player, that player gains control of Kain. \
+If they do, you draw that many cards, create that many tapped Treasure tokens, \
+then lose that much life.";
+
+        let parsed = parse_oracle_text(
+            KAIN_ORACLE,
+            "Kain, Traitorous Dragoon",
+            &[],
+            &["Creature".to_string()],
+            &["Human".to_string(), "Knight".to_string()],
+        );
+        let execute = parsed.triggers[0]
+            .execute
+            .as_ref()
+            .expect("combat damage trigger");
+
+        let mut state = GameState::new_two_player(42);
+        for (idx, name) in ["Card A", "Card B", "Card C"].into_iter().enumerate() {
+            create_object(
+                &mut state,
+                CardId((idx + 10) as u64),
+                PlayerId(0),
+                name.to_string(),
+                Zone::Library,
+            );
+        }
+        let kain = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Kain, Traitorous Dragoon".to_string(),
+            Zone::Battlefield,
+        );
+        state.current_trigger_event = Some(GameEvent::DamageDealt {
+            source_id: kain,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 2,
+            is_combat: true,
+            excess: 0,
+        });
+
+        let resolved = build_resolved_from_def(execute, kain, PlayerId(0));
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &resolved, &mut events, 0).expect("Kain chain");
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(state.objects[&kain].controller, PlayerId(1));
+        assert_eq!(state.players[0].hand.len(), 2);
+        assert_eq!(state.players[0].life, 18);
+
+        let treasures = state
+            .battlefield
+            .iter()
+            .filter_map(|id| state.objects.get(id))
+            .filter(|obj| {
+                obj.controller == PlayerId(0)
+                    && obj.card_types.subtypes.iter().any(|st| st == "Treasure")
+                    && obj.card_types.core_types.contains(&CoreType::Artifact)
+            })
+            .count();
+        assert_eq!(treasures, 2, "attacker receives two tapped Treasures");
+        assert!(
+            state
+                .battlefield
+                .iter()
+                .filter_map(|id| state.objects.get(id))
+                .filter(|obj| obj.card_types.subtypes.iter().any(|st| st == "Treasure"))
+                .all(|obj| obj.tapped),
+            "Kain's Treasures must enter tapped"
+        );
     }
 
     /// Issue #1987: chained GiveControl with `target: SelfRef` and empty

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3132,6 +3132,20 @@ fn mandatory_parent_effect_performed(effect: &Effect, events: &[GameEvent]) -> b
                 }
             )
         }),
+        // CR 110.2 + CR 608.2c: "that player gains control of ~. If they do, …"
+        // gates the rider on whether control actually changed (Kain, Traitorous
+        // Dragoon). `resolve_give` emits `EffectResolved` and, when the
+        // recipient differs from the object's current controller,
+        // `ControllerChanged`.
+        Effect::GiveControl { .. } => events.iter().any(|event| {
+            matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: crate::types::ability::EffectKind::GiveControl,
+                    ..
+                } | GameEvent::ControllerChanged { .. }
+            )
+        }),
         _ => true,
     }
 }
@@ -3814,10 +3828,41 @@ fn hydrate_event_context_targets<'a>(
     Cow::Owned(resolved)
 }
 
+/// CR 603.2: Filters that auto-resolve from `state.current_trigger_event` during
+/// hydration / unless-pay payer resolution (issue #2361, Kain #1335).
+fn hydratable_event_context_filter(filter: &TargetFilter) -> bool {
+    matches!(
+        filter,
+        TargetFilter::TriggeringSpellController
+            | TargetFilter::TriggeringSpellOwner
+            | TargetFilter::TriggeringPlayer
+            | TargetFilter::TriggeringSource
+            | TargetFilter::DefendingPlayer
+            | TargetFilter::ParentTargetController
+            | TargetFilter::ParentTarget
+            | TargetFilter::StackSpell
+    )
+}
+
 /// CR 603.2: Extract an event-context target filter from an effect, if present.
 /// Returns the filter only for event-context variants (TriggeringSpellController, etc.)
 /// that auto-resolve from `state.current_trigger_event` at resolution time.
 fn extract_event_context_filter(effect: &Effect) -> Option<&TargetFilter> {
+    // CR 110.2 + CR 603.7c: `GiveControl` carries both an object `target` and a
+    // `recipient`. Kain ("that player gains control of Kain") binds the recipient
+    // to `TriggeringPlayer` while the object is `SelfRef` — only the recipient
+    // is an event-context player ref and must be hydrated into `ability.targets`
+    // when empty (issue #1335).
+    if let Effect::GiveControl { target, recipient } = effect {
+        if hydratable_event_context_filter(recipient) {
+            return Some(recipient);
+        }
+        if hydratable_event_context_filter(target) {
+            return Some(target);
+        }
+        return None;
+    }
+
     let filter = match effect {
         Effect::DealDamage { target, .. }
         | Effect::Pump { target, .. }
@@ -3876,7 +3921,6 @@ fn extract_event_context_filter(effect: &Effect) -> Option<&TargetFilter> {
         | Effect::SkipNextStep { target, .. }
         | Effect::ControlNextTurn { target, .. }
         | Effect::AdditionalPhase { target, .. }
-        | Effect::GiveControl { target, .. }
         | Effect::Detain { target, .. }
         | Effect::TargetOnly { target } => target,
         // CR 701.26a/b + CR 603.7c: only the single-permanent tap/untap exposes
@@ -3910,17 +3954,7 @@ fn extract_event_context_filter(effect: &Effect) -> Option<&TargetFilter> {
         _ => return None,
     };
 
-    if matches!(
-        filter,
-        TargetFilter::TriggeringSpellController
-            | TargetFilter::TriggeringSpellOwner
-            | TargetFilter::TriggeringPlayer
-            | TargetFilter::TriggeringSource
-            | TargetFilter::DefendingPlayer
-            | TargetFilter::ParentTargetController
-            | TargetFilter::ParentTarget
-            | TargetFilter::StackSpell
-    ) {
+    if hydratable_event_context_filter(filter) {
         Some(filter)
     } else {
         None
@@ -17614,6 +17648,34 @@ mod tests {
         assert!(
             !mandatory_parent_effect_performed(&copy, &not_made),
             "a CopySpell that made no copy is NOT 'performed' — the draw rider must run"
+        );
+    }
+
+    /// CR 110.2 + CR 608.2c (issue #1335): Kain's "that player gains control of
+    /// Kain. If they do, …" gates the rider on whether control actually
+    /// transferred. `GiveControl` counts as performed only when
+    /// `ControllerChanged` or a `GiveControl` `EffectResolved` is emitted.
+    #[test]
+    fn give_control_performed_tracks_controller_changed_event() {
+        let give = Effect::GiveControl {
+            target: TargetFilter::SelfRef,
+            recipient: TargetFilter::TriggeringPlayer,
+        };
+
+        let transferred = [GameEvent::ControllerChanged {
+            object_id: ObjectId(1),
+            old_controller: PlayerId(0),
+            new_controller: PlayerId(1),
+        }];
+        assert!(
+            mandatory_parent_effect_performed(&give, &transferred),
+            "GiveControl that changed controllers is 'performed'"
+        );
+
+        let not_transferred: [GameEvent; 0] = [];
+        assert!(
+            !mandatory_parent_effect_performed(&give, &not_transferred),
+            "GiveControl that failed must not seed the if-they-do rider"
         );
     }
 

--- a/crates/engine/tests/integration/issue_1335_kain_traitorous_dragoon.rs
+++ b/crates/engine/tests/integration/issue_1335_kain_traitorous_dragoon.rs
@@ -1,0 +1,402 @@
+//! GitHub issue #1335 — Kain, Traitorous Dragoon combat-damage trigger.
+//!
+//! Oracle:
+//! > Jump — During your turn, Kain has flying.
+//! > Whenever Kain deals combat damage to a player, that player gains control of
+//! > Kain. If they do, you draw that many cards, create that many tapped Treasure
+//! > tokens, then lose that much life.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{DamageKindFilter, Effect, TargetFilter, TargetRef};
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+
+use super::rules::run_combat;
+
+const KAIN_ORACLE: &str = "Jump — During your turn, Kain has flying.\n\
+Whenever Kain deals combat damage to a player, that player gains control of Kain. \
+If they do, you draw that many cards, create that many tapped Treasure tokens, \
+then lose that much life.";
+
+fn effect_chain_contains<F>(ability: &engine::types::ability::AbilityDefinition, pred: F) -> bool
+where
+    F: Fn(&Effect) -> bool + Copy,
+{
+    if pred(ability.effect.as_ref()) {
+        return true;
+    }
+    ability
+        .sub_ability
+        .as_ref()
+        .is_some_and(|sub| effect_chain_contains(sub, pred))
+}
+
+#[test]
+fn kain_parses_jump_static_and_combat_damage_trigger() {
+    let parsed = parse_oracle_text(
+        KAIN_ORACLE,
+        "Kain, Traitorous Dragoon",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Knight".to_string()],
+    );
+
+    assert!(
+        !parsed.statics.is_empty(),
+        "Jump reminder static should parse; statics={:?}",
+        parsed.statics
+    );
+
+    assert_eq!(
+        parsed.triggers.len(),
+        1,
+        "Kain should have exactly one trigger"
+    );
+
+    let combat_trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::DamageDone)
+        .expect("combat damage trigger must parse");
+
+    assert_eq!(
+        combat_trigger.valid_source,
+        Some(TargetFilter::SelfRef),
+        "source must be SelfRef, got {:?}",
+        combat_trigger.valid_source
+    );
+    assert_eq!(
+        combat_trigger.valid_target,
+        Some(TargetFilter::Player),
+        "recipient filter must be Player, got {:?}",
+        combat_trigger.valid_target
+    );
+    assert_eq!(
+        combat_trigger.damage_kind,
+        DamageKindFilter::CombatOnly,
+        "must require combat damage"
+    );
+    assert!(
+        combat_trigger.execute.is_some(),
+        "trigger must have executable effect chain"
+    );
+
+    let execute = combat_trigger
+        .execute
+        .as_ref()
+        .expect("trigger should have execute");
+
+    assert!(
+        matches!(
+            execute.effect.as_ref(),
+            Effect::GiveControl {
+                target: TargetFilter::SelfRef,
+                recipient: TargetFilter::TriggeringPlayer,
+            }
+        ),
+        "root effect must be GiveControl; got {:?}",
+        execute.effect
+    );
+    let rider = execute
+        .sub_ability
+        .as_ref()
+        .expect("If they do rider must be a sub_ability");
+    assert!(
+        rider
+            .condition
+            .as_ref()
+            .is_some_and(|c| c.is_optional_effect_performed()),
+        "rider must be gated by effect_performed; got {:?}",
+        rider.condition
+    );
+
+    assert!(
+        effect_chain_contains(execute, |effect| {
+            matches!(
+                effect,
+                Effect::GiveControl {
+                    target: TargetFilter::SelfRef,
+                    recipient: TargetFilter::TriggeringPlayer,
+                }
+            )
+        }),
+        "expected GiveControl(SelfRef, TriggeringPlayer); chain={execute:?}"
+    );
+
+    assert!(
+        effect_chain_contains(execute, |effect| matches!(effect, Effect::Draw { .. })),
+        "expected Draw in if-they-do chain"
+    );
+    assert!(
+        effect_chain_contains(execute, |effect| matches!(effect, Effect::Token { .. })),
+        "expected Token in if-they-do chain"
+    );
+    assert!(
+        effect_chain_contains(execute, |effect| matches!(effect, Effect::LoseLife { .. })),
+        "expected LoseLife in if-they-do chain"
+    );
+}
+
+#[test]
+fn kain_object_carries_parsed_combat_damage_trigger() {
+    let mut scenario = GameScenario::new();
+    let kain = scenario
+        .add_creature_from_oracle(P0, "Kain, Traitorous Dragoon", 2, 4, KAIN_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let obj = &runner.state().objects[&kain];
+
+    let triggers: Vec<_> = obj.trigger_definitions.iter_unchecked().collect();
+    assert_eq!(triggers.len(), 1, "object should carry one trigger");
+    let trig = triggers[0];
+    assert_eq!(trig.mode, TriggerMode::DamageDone);
+    assert!(
+        trig.execute.is_some(),
+        "object trigger must have executable effect chain"
+    );
+    let execute = trig.execute.as_ref().unwrap();
+    assert!(
+        matches!(execute.effect.as_ref(), Effect::GiveControl { .. }),
+        "runtime trigger root must be GiveControl, got {:?}",
+        execute.effect
+    );
+}
+
+#[test]
+fn kain_resolve_chain_transfers_control_from_damage_dealt_event() {
+    use engine::game::ability_utils::build_resolved_from_def;
+    use engine::game::effects::resolve_ability_chain;
+    use engine::game::layers::evaluate_layers;
+    use engine::game::zones::create_object;
+    use engine::types::ability::TargetRef;
+    use engine::types::events::GameEvent;
+    use engine::types::game_state::GameState;
+    use engine::types::identifiers::CardId;
+    use engine::types::player::PlayerId;
+    use engine::types::zones::Zone;
+
+    let parsed = parse_oracle_text(
+        KAIN_ORACLE,
+        "Kain, Traitorous Dragoon",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Knight".to_string()],
+    );
+    let trig = &parsed.triggers[0];
+    let execute = trig.execute.as_ref().expect("execute");
+
+    let mut state = GameState::new_two_player(42);
+    for (idx, name) in ["Card A", "Card B", "Card C"].into_iter().enumerate() {
+        create_object(
+            &mut state,
+            CardId((idx + 10) as u64),
+            PlayerId(0),
+            name.to_string(),
+            Zone::Library,
+        );
+    }
+    let kain = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Kain, Traitorous Dragoon".to_string(),
+        Zone::Battlefield,
+    );
+    state.current_trigger_event = Some(GameEvent::DamageDealt {
+        source_id: kain,
+        target: TargetRef::Player(PlayerId(1)),
+        amount: 2,
+        is_combat: true,
+        excess: 0,
+    });
+
+    let resolved = build_resolved_from_def(execute, kain, PlayerId(0));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &resolved, &mut events, 0).expect("chain resolves");
+    evaluate_layers(&mut state);
+
+    assert!(
+        state.transient_continuous_effects.iter().any(|effect| {
+            effect.modifications.iter().any(|m| {
+                matches!(
+                    m,
+                    engine::types::ability::ContinuousModification::ChangeController
+                )
+            })
+        }),
+        "GiveControl must install ChangeController TCE; events={events:?}"
+    );
+    assert_eq!(
+        state.objects[&kain].controller, P1,
+        "damaged player must control Kain after layers"
+    );
+    assert_eq!(
+        state.players[P0.0 as usize].hand.len(),
+        2,
+        "attacker should draw two after control transfer"
+    );
+}
+
+#[test]
+fn kain_stack_trigger_resolution_transfers_control_and_rewards_attacker() {
+    use engine::game::layers::evaluate_layers;
+    use engine::game::stack;
+    use engine::game::triggers::{drain_order_triggers_with_identity, process_triggers};
+    use engine::game::zones::create_object;
+    use engine::types::events::GameEvent;
+    use engine::types::game_state::GameState;
+    use engine::types::identifiers::CardId;
+    use engine::types::player::PlayerId;
+    use engine::types::zones::Zone;
+
+    let parsed = parse_oracle_text(
+        KAIN_ORACLE,
+        "Kain, Traitorous Dragoon",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Knight".to_string()],
+    );
+    let trigger = parsed.triggers[0].clone();
+
+    let mut state = GameState::new_two_player(42);
+    for (idx, name) in ["Card A", "Card B", "Card C"].into_iter().enumerate() {
+        create_object(
+            &mut state,
+            CardId((idx + 10) as u64),
+            PlayerId(0),
+            name.to_string(),
+            Zone::Library,
+        );
+    }
+    let kain = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Kain, Traitorous Dragoon".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&kain).unwrap();
+        obj.trigger_definitions.push(trigger.clone());
+        obj.base_trigger_definitions = std::sync::Arc::new(vec![trigger.clone()]);
+    }
+    state.trigger_index.remove(kain);
+    let defs: smallvec::SmallVec<[engine::types::ability::TriggerDefinition; 4]> =
+        smallvec::smallvec![trigger];
+    state.trigger_index.add(kain, &defs, false);
+
+    let event = GameEvent::DamageDealt {
+        source_id: kain,
+        target: TargetRef::Player(PlayerId(1)),
+        amount: 2,
+        is_combat: true,
+        excess: 0,
+    };
+    process_triggers(&mut state, &[event]);
+    drain_order_triggers_with_identity(&mut state);
+
+    let mut events = Vec::new();
+    while !state.stack.is_empty() {
+        stack::resolve_top(&mut state, &mut events);
+    }
+    evaluate_layers(&mut state);
+
+    assert!(
+        state.transient_continuous_effects.iter().any(|effect| {
+            effect.modifications.iter().any(|m| {
+                matches!(
+                    m,
+                    engine::types::ability::ContinuousModification::ChangeController
+                )
+            })
+        }),
+        "stack path must install ChangeController TCE"
+    );
+    assert_eq!(state.objects[&kain].controller, P1);
+    assert_eq!(state.players[P0.0 as usize].hand.len(), 2);
+}
+
+#[test]
+fn kain_combat_damage_transfers_control_and_rewards_attacker() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Card A", "Card B", "Card C", "Card D"]);
+    let kain = scenario
+        .add_creature_from_oracle(P0, "Kain, Traitorous Dragoon", 2, 4, KAIN_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    let p0_hand_before = runner.state().players[P0.0 as usize].hand.len();
+    let p0_life_before = runner.state().players[P0.0 as usize].life;
+
+    run_combat(&mut runner, vec![kain], vec![]);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "Kain's combat damage trigger should be on the stack after damage"
+    );
+    runner.advance_until_stack_empty();
+
+    let has_control_effect = runner
+        .state()
+        .transient_continuous_effects
+        .iter()
+        .any(|effect| {
+            effect.modifications.iter().any(|m| {
+                matches!(
+                    m,
+                    engine::types::ability::ContinuousModification::ChangeController
+                )
+            })
+        });
+    assert!(
+        has_control_effect,
+        "GiveControl should install a Layer-2 ChangeController effect"
+    );
+
+    let p1_life = runner.state().players[P1.0 as usize].life;
+    assert_eq!(p1_life, 18, "Kain should deal 2 combat damage to P1");
+
+    assert!(
+        !runner.state().objects[&kain].trigger_definitions.is_empty(),
+        "Kain must register at least one trigger"
+    );
+
+    let p0_hand_after = runner.state().players[P0.0 as usize].hand.len();
+    assert_eq!(
+        p0_hand_after - p0_hand_before,
+        2,
+        "attacker should draw cards equal to combat damage dealt (Kain is 2/4)"
+    );
+
+    assert_eq!(
+        runner.state().objects[&kain].controller,
+        P1,
+        "damaged player must gain control of Kain"
+    );
+
+    let p0_treasures = runner
+        .state()
+        .objects
+        .values()
+        .filter(|obj| {
+            obj.controller == P0
+                && obj
+                    .card_types
+                    .subtypes
+                    .iter()
+                    .any(|st| st.eq_ignore_ascii_case("Treasure"))
+        })
+        .count();
+    assert_eq!(
+        p0_treasures, 2,
+        "attacker should receive two tapped Treasure tokens"
+    );
+
+    let p0_life_after = runner.state().players[P0.0 as usize].life;
+    assert_eq!(
+        p0_life_before - p0_life_after,
+        2,
+        "attacker should lose life equal to damage dealt"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -124,6 +124,7 @@ mod issue_1328_inti;
 mod issue_1332_bronzehide_lion;
 mod issue_1333_brain_in_a_jar;
 mod issue_1334_marchesa;
+mod issue_1335_kain_traitorous_dragoon;
 mod issue_1337_tekuthal_proliferate_twice;
 mod issue_1353_body_of_knowledge;
 mod issue_1353_death_pits_observer;


### PR DESCRIPTION
## Summary

- Fixes [#1335](https://github.com/phase-rs/phase/issues/1335) — **Kain, Traitorous Dragoon** combat-damage trigger now transfers control to the damaged player and correctly resolves the "If they do" rider (draw / tapped Treasures / life loss).
- Parser output was already correct (`GiveControl(SelfRef, TriggeringPlayer)`); the bug was in runtime resolution and "if they do" gating.
- `resolve_give` now emits `ControllerChanged` when control actually changes; `mandatory_parent_effect_performed` no longer treats `GiveControl` as unconditionally successful.
- `extract_event_context_filter` hydrates `GiveControl` **recipient** refs (e.g. `TriggeringPlayer`) from the combat-damage trigger event, not only the object `target`.

## Changes

| Area | What |
|------|------|
| `gain_control.rs` | Emit `ControllerChanged` on successful handoff; unit tests for `DamageDealt` + full Kain chain |
| `effects/mod.rs` | GiveControl "performed" check; recipient-aware event-context hydration |
| `issue_1335_kain_traitorous_dragoon.rs` | Parse, object, chain, stack, and combat integration tests |

## Test plan

- [x] `cargo test -p engine issue_1335`
- [x] `cargo test -p engine give_control_performed`
- [x] `cargo test -p engine issue_1335_kain_full`
- [x] `cargo fmt --all`