### PR TITLE
fix(parser): bind where-X to ChangeZone target's Cmc filter

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5254,6 +5254,17 @@ pub(super) fn apply_where_x_effect_expression(
             *filter = apply_where_x_to_filter(filter.clone(), where_x_expression);
             *count = apply_where_x_quantity_expression(count.clone(), where_x_expression);
         }
+        // CR 107.3i + CR 400.7: "return/put up to one target creature card with
+        // mana value X or less ..., where X is <expression>" binds the
+        // `ChangeZone` target filter's `Cmc` bound (Moseo, Vein's New Dean's
+        // Infusion ability). Without this arm the filter's bound stayed an
+        // unresolved bare `Variable("X")`, which resolves to 0 at runtime and
+        // makes the reanimation target only mana value 0 or less — silently
+        // breaking the trigger's intended behavior. Mirrors the
+        // `SearchLibrary`/`Seek` filter rewrite above.
+        Effect::ChangeZone { target, .. } => {
+            *target = apply_where_x_to_filter(target.clone(), where_x_expression);
+        }
         Effect::Scry { count, .. } => {
             *count = apply_where_x_quantity_expression(count.clone(), where_x_expression);
         }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -22269,6 +22269,55 @@ mod tests {
         }
     }
 
+    /// Issue #1307: Moseo, Vein's New Dean's Infusion ability — an end-step
+    /// trigger gated by an intervening-if condition whose effect's
+    /// `ChangeZone` target filter bears a `Cmc` bound defined by a trailing
+    /// "where X is …" clause. `apply_where_x_effect_expression` previously had
+    /// no `Effect::ChangeZone` arm, so the filter's bound stayed an unresolved
+    /// bare `Variable("X")` (resolves to 0 at runtime via
+    /// `QuantityRef::Variable`), making the reanimation target only mana value
+    /// 0 or less and the ability appear to never fire for any real graveyard
+    /// card. The fix threads the where-X rewrite into `ChangeZone`'s target
+    /// filter the same way `SearchLibrary`/`Seek` already do.
+    #[test]
+    fn moseo_infusion_end_step_reanimate_binds_cmc_to_life_gained_this_turn() {
+        let def = parse_trigger_line(
+            "At the beginning of your end step, if you gained life this turn, return up to one target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of life you gained this turn.",
+            "Moseo, Vein's New Dean",
+        );
+        assert_eq!(def.mode, TriggerMode::Phase);
+        assert_eq!(def.phase, Some(Phase::End));
+        let execute = def.execute.as_ref().expect("trigger execute ability");
+        match execute.effect.as_ref() {
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Battlefield,
+                target,
+                ..
+            } => match target {
+                TargetFilter::Typed(typed) => {
+                    assert!(
+                        typed.properties.iter().any(|prop| matches!(
+                            prop,
+                            FilterProp::Cmc {
+                                comparator: Comparator::LE,
+                                value: QuantityExpr::Ref {
+                                    qty: QuantityRef::LifeGainedThisTurn {
+                                        player: PlayerScope::Controller
+                                    }
+                                },
+                            }
+                        )),
+                        "expected Cmc{{LE, LifeGainedThisTurn{{Controller}}}} bound, got {:?}",
+                        typed.properties
+                    );
+                }
+                other => panic!("expected Typed target filter, got {other:?}"),
+            },
+            other => panic!("expected ChangeZone effect, got {other:?}"),
+        }
+    }
+
     #[test]
     fn phase_trigger_combat_on_your_turn() {
         let def = parse_trigger_line(


### PR DESCRIPTION
## Summary
- `apply_where_x_effect_expression` (lower.rs) had no `Effect::ChangeZone` arm, so a trailing "where X is …" clause never reached a `ChangeZone` target filter's `Cmc` bound.
- Moseo, Vein's New Dean's Infusion ability ("return up to one target creature card with mana value X or less from your graveyard to the battlefield, where X is the amount of life you gained this turn") parsed the bound as a bare `Variable("X")`, which resolves to 0 at runtime — silently limiting the reanimation target to mana value 0 or less and making the trigger look like it never fires.
- Added the missing arm, mirroring the existing `SearchLibrary`/`Seek` filter rewrite.

## Test plan
- [x] New regression test `moseo_infusion_end_step_reanimate_binds_cmc_to_life_gained_this_turn` using the card's exact Oracle text — asserts the `Cmc` filter now binds to `LifeGainedThisTurn { Controller }` instead of `Variable("X")`.
- [x] `cargo test -p engine --lib parser::oracle_trigger::` — 798 passed, 0 failed.
- [x] `cargo test -p engine --lib parser::oracle_effect::` — 1894 passed, 0 failed.
- [x] `cargo fmt --all` — no changes.

Fixes #1307
