### PR TITLE
fix(parser): bind "that has a … counter on it" target-filter

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4998,6 +4998,94 @@ mod tests {
     use crate::parser::oracle_effect::parse_effect_chain;
     use crate::types::ability::CountScope;
 
+    /// Issue #69 (Banewhip Punisher): "Destroy target creature that has a -1/-1
+    /// counter on it" — the relative-clause counter restriction was dropped, so
+    /// the activated ability destroyed ANY creature. The target filter must now
+    /// carry `FilterProp::Counters{OfType(Minus1Minus1), GE, 1}`. CR 122.1 /
+    /// CR 122.1a.
+    #[test]
+    fn banewhip_punisher_destroy_creature_with_minus_counter() {
+        use crate::types::counter::{CounterMatch, CounterType};
+        let r = parse(
+            "{B}, Sacrifice this creature: Destroy target creature that has a -1/-1 counter on it.",
+            "Banewhip Punisher",
+            &[],
+            &["Creature"],
+            &[],
+        );
+        assert_eq!(r.abilities.len(), 1, "{r:#?}");
+        let Effect::Destroy { target, .. } = &*r.abilities[0].effect else {
+            panic!("expected Destroy effect, got {:?}", r.abilities[0].effect);
+        };
+        let TargetFilter::Typed(tf) = target else {
+            panic!("expected typed target, got {target:?}");
+        };
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
+        assert!(
+            tf.properties.contains(&FilterProp::Counters {
+                counters: CounterMatch::OfType(CounterType::Minus1Minus1),
+                comparator: Comparator::GE,
+                count: QuantityExpr::Fixed { value: 1 },
+            }),
+            "counter restriction must survive, got {:?}",
+            tf.properties
+        );
+    }
+
+    /// Issue #69 (Triad of Fates): "Exile target creature that has a fate counter
+    /// on it, then return it to the battlefield…" — the exile target ChangeZone
+    /// filter must carry the fate-counter restriction, and the "then return it"
+    /// tail must still fully parse (the ability stays supported, not
+    /// Unimplemented). CR 122.1.
+    #[test]
+    fn triad_of_fates_exile_creature_with_fate_counter() {
+        use crate::types::counter::{CounterMatch, CounterType};
+        let r = parse(
+            "{W}, {T}: Exile target creature that has a fate counter on it, then return it to the battlefield under its owner's control.",
+            "Triad of Fates",
+            &[],
+            &["Creature"],
+            &[],
+        );
+        assert_eq!(r.abilities.len(), 1, "{r:#?}");
+        let ability = &r.abilities[0];
+        let Effect::ChangeZone {
+            destination,
+            target,
+            ..
+        } = &*ability.effect
+        else {
+            panic!(
+                "expected ChangeZone (exile) effect, got {:?}",
+                ability.effect
+            );
+        };
+        assert_eq!(*destination, Zone::Exile);
+        let TargetFilter::Typed(tf) = target else {
+            panic!("expected typed exile target, got {target:?}");
+        };
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
+        assert!(
+            tf.properties.contains(&FilterProp::Counters {
+                counters: CounterMatch::OfType(CounterType::Generic("fate".to_string())),
+                comparator: Comparator::GE,
+                count: QuantityExpr::Fixed { value: 1 },
+            }),
+            "fate-counter restriction must survive, got {:?}",
+            tf.properties
+        );
+        // The "then return it…" tail must parse as the return sub-ability, so the
+        // card stays supported (no Unimplemented effect anywhere).
+        assert!(
+            ability.sub_ability.is_some(),
+            "the return-to-battlefield tail must parse as a sub-ability"
+        );
+        assert!(
+            !matches!(&*ability.effect, Effect::Unimplemented { .. }),
+            "ability must not be Unimplemented"
+        );
+    }
+
     /// Test helper: pull the graveyard-exile sub-cost count out of a compound
     /// `Keyword::Escape(EscapeCost::NonMana(Composite[Mana, Exile{count,...}]))`.
     /// Asserts exactly one `Exile` sub-cost is present and returns its count.

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3875,8 +3875,8 @@ fn parse_bare_any_counter_suffix(input: &str) -> super::oracle_nom::error::Oracl
 /// `FilterContext::from_ability`.
 pub(crate) fn parse_counter_suffix(text: &str) -> Option<(FilterProp, usize)> {
     use nom::branch::alt;
-    use nom::bytes::complete::{tag as tag_e, take_until};
-    use nom::combinator::{opt, value};
+    use nom::bytes::complete::tag as tag_e;
+    use nom::combinator::value;
 
     let trimmed = text.trim_start();
     let leading_ws = text.len() - trimmed.len();
@@ -3893,6 +3893,31 @@ pub(crate) fn parse_counter_suffix(text: &str) -> Option<(FilterProp, usize)> {
     .ok()?;
     let lead_len = trimmed.len() - rest.len();
 
+    // The shared counter-spec body, with offsets relative to `rest`. The public
+    // entry adds back the leading whitespace and the consumed lead length to
+    // preserve the absolute (FilterProp, bytes-from-`text`) contract.
+    let (prop, consumed) = parse_counter_spec_after_lead(rest, comparator)?;
+    Some((prop, leading_ws + lead_len + consumed))
+}
+
+/// CR 122.1 / CR 122.1a: parse the counter spec AFTER the lead is consumed and
+/// the comparator decided. `rest` begins at "[a/an/<count>] <type> counter(s) on
+/// it/them" / "counter(s) on it/them" / "no counters …". Returns `(FilterProp,
+/// bytes consumed from `rest`)`.
+///
+/// The EQ-vs-GE selection is gated purely on the `comparator` parameter — no
+/// lead-specific state leaks in — so both the `with`/`without` entry
+/// (`parse_counter_suffix`) and the relative-clause entry
+/// (`parse_that_clause_suffix`'s "that has a … counter on it" arm) share this
+/// body and produce identical `FilterProp::Counters` shapes.
+fn parse_counter_spec_after_lead(
+    rest: &str,
+    comparator: Comparator,
+) -> Option<(FilterProp, usize)> {
+    use nom::branch::alt;
+    use nom::bytes::complete::{tag as tag_e, take_until};
+    use nom::combinator::{opt, value};
+
     // CR 122.1: Negated branch — untyped FIRST, before any `take_until`. The
     // untyped negated case ("with no counters on them", "without counters")
     // never touches the typed suffix loop, so the empty-`counter_text` guard
@@ -3907,7 +3932,7 @@ pub(crate) fn parse_counter_suffix(text: &str) -> Option<(FilterProp, usize)> {
         ))
         .parse(rest);
         if let Ok((after, _)) = untyped {
-            let consumed = leading_ws + lead_len + (rest.len() - after.len());
+            let consumed = rest.len() - after.len();
             return Some((
                 FilterProp::Counters {
                     counters: CounterMatch::Any,
@@ -3926,7 +3951,7 @@ pub(crate) fn parse_counter_suffix(text: &str) -> Option<(FilterProp, usize)> {
         // it". Must precede the typed-counter branch so the empty-counter-type
         // guard there doesn't fire.
         if let Ok((after, _)) = parse_bare_any_counter_suffix(rest) {
-            let consumed = leading_ws + lead_len + (rest.len() - after.len());
+            let consumed = rest.len() - after.len();
             return Some((
                 FilterProp::Counters {
                     counters: CounterMatch::Any,
@@ -3953,7 +3978,7 @@ pub(crate) fn parse_counter_suffix(text: &str) -> Option<(FilterProp, usize)> {
             Ok((input, expr))
         },
     ));
-    let (rest, count_opt) = opt(count_parser).parse(rest).ok()?;
+    let (after_count, count_opt) = opt(count_parser).parse(rest).ok()?;
     let count = count_opt.unwrap_or(QuantityExpr::Fixed { value: 1 });
 
     // Try each counter suffix; pick the first that matches via `take_until`.
@@ -3965,7 +3990,8 @@ pub(crate) fn parse_counter_suffix(text: &str) -> Option<(FilterProp, usize)> {
         " counter on them",
         " counter on it",
     ] {
-        let Ok((after, counter_text)) = take_until::<_, _, OracleError<'_>>(suffix).parse(rest)
+        let Ok((after, counter_text)) =
+            take_until::<_, _, OracleError<'_>>(suffix).parse(after_count)
         else {
             continue;
         };
@@ -3973,7 +3999,7 @@ pub(crate) fn parse_counter_suffix(text: &str) -> Option<(FilterProp, usize)> {
         if counter_type.is_empty() {
             continue;
         }
-        let consumed = text.len() - after.len() + suffix.len();
+        let consumed = rest.len() - after.len() + suffix.len();
         // CR 122.1: negated typed filter means exactly 0 counters of the type;
         // positive filter is the parsed (or implicit-1) threshold.
         let count = if comparator == Comparator::EQ {
@@ -4777,6 +4803,26 @@ pub(crate) fn parse_that_clause_suffix<'a>(
             if at_clause_boundary {
                 return Some((props, consumed_at(after_disjunction)));
             }
+        }
+    }
+
+    // CR 122.1 / CR 122.1a: "that has a/an <type> counter on it" / "that have …
+    // on them" — relative-clause counter predicate; positive (GE). Reuses the
+    // shared counter-spec combinator the with-form (parse_counter_suffix) uses,
+    // so the FilterProp::Counters is identical to "creature with a … counter on
+    // it" (Crumbling Ashes). The article a/an is consumed inside
+    // parse_counter_spec_after_lead, so the lead here is just "has "/"have ".
+    // Banewhip Punisher: "Destroy target creature that has a -1/-1 counter on
+    // it"; Triad of Fates: "Exile target creature that has a fate counter on it".
+    if let Ok((after_verb, _)) = alt((
+        tag::<_, _, OracleError<'_>>("has "),
+        tag::<_, _, OracleError<'_>>("have "),
+    ))
+    .parse(after_that)
+    {
+        if let Some((prop, consumed)) = parse_counter_spec_after_lead(after_verb, Comparator::GE) {
+            let verb_len = after_that.len() - after_verb.len();
+            return Some((vec![prop], that_len + verb_len + consumed));
         }
     }
 
@@ -8899,6 +8945,60 @@ mod tests {
                 }
             );
         }
+    }
+
+    /// "that has a <type> counter on it" relative clause — must lower to the
+    /// same `FilterProp::Counters` shape as the `with`-form (Banewhip Punisher,
+    /// Triad of Fates). Previously this clause was dropped entirely.
+    #[test]
+    fn parse_that_clause_has_minus_counter() {
+        let phrase = " that has a -1/-1 counter on it";
+        let (props, consumed) =
+            parse_that_clause_suffix(phrase, None).expect("relative counter clause must parse");
+        assert_eq!(consumed, phrase.len());
+        assert_eq!(
+            props,
+            vec![FilterProp::Counters {
+                counters: CounterMatch::OfType(CounterType::Minus1Minus1),
+                comparator: Comparator::GE,
+                count: QuantityExpr::Fixed { value: 1 },
+            }]
+        );
+    }
+
+    /// Plural relative-clause form "that have a +1/+1 counter on them" → the
+    /// same positive (GE) typed counter filter (Plus1Plus1).
+    #[test]
+    fn parse_that_clause_have_plus_counter_plural() {
+        let phrase = " that have a +1/+1 counter on them";
+        let (props, consumed) =
+            parse_that_clause_suffix(phrase, None).expect("plural relative counter clause");
+        assert_eq!(consumed, phrase.len());
+        assert_eq!(
+            props,
+            vec![FilterProp::Counters {
+                counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+                comparator: Comparator::GE,
+                count: QuantityExpr::Fixed { value: 1 },
+            }]
+        );
+    }
+
+    /// "that has a fate counter on it" → Generic("fate") (Triad of Fates).
+    #[test]
+    fn parse_that_clause_has_fate_counter() {
+        let phrase = " that has a fate counter on it";
+        let (props, consumed) =
+            parse_that_clause_suffix(phrase, None).expect("generic relative counter clause");
+        assert_eq!(consumed, phrase.len());
+        assert_eq!(
+            props,
+            vec![FilterProp::Counters {
+                counters: CounterMatch::OfType(CounterType::Generic("fate".to_string())),
+                comparator: Comparator::GE,
+                count: QuantityExpr::Fixed { value: 1 },
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3578.

## Summary

A relative-clause counter restriction on a target — "... target creature **that has a/an `<type>` counter on it**" — was silently dropped, so the effect could hit any creature:

- **Banewhip Punisher** — "Destroy target creature that has a -1/-1 counter on it." destroyed any creature.
- **Triad of Fates** — "Exile target creature that has a fate counter on it[...]" exiled any creature (both activated abilities).

The target lowered to `Typed { type_filters: [Creature], properties: [] }` — the counter clause produced no `FilterProp`.

## Root cause

`parse_that_clause_suffix` (the relative-clause site for target noun phrases) had no counter arm, and `parse_counter_suffix` only recognized the prepositional "with …" / "with no …" / "without …" leads — never the relative-pronoun "that has a … counter on it". So the clause was unreachable from the relative-clause site and the property was discarded.

## Fix (parser-only; no new engine variant)

In `oracle_target.rs`:

1. **Behavior-preserving refactor** — extract the post-lead body of `parse_counter_suffix` into a shared `parse_counter_spec_after_lead(rest, comparator) -> Option<(FilterProp, usize)>`. `parse_counter_suffix` keeps its `with`/`without`/`with no` lead dispatch and its exact `(FilterProp, bytes-from-input)` contract (it adds back `leading_ws + lead_len`); the EQ-vs-GE branch selection is gated purely on the `comparator` argument, so no lead-specific state leaks.
2. **New arm** — add a `"that has " / "that have "` arm to `parse_that_clause_suffix` that consumes the verb lead with `tag`/`alt` and delegates to `parse_counter_spec_after_lead(after_verb, Comparator::GE)`, returning the resulting `FilterProp::Counters`. The article ("a"/"an") and count are consumed inside the shared combinator. This produces the **same** `FilterProp::Counters` the existing "with a … counter on it" form yields (e.g. Crumbling Ashes).

`FilterProp::Counters` / `CounterMatch::OfType` already exist and are runtime-evaluated — no runtime change. No synthetic-string rewrite or manual byte-offset math. CR 122.1 / 122.1a (counters), CR 109.2 (a creature description with no zone word is a battlefield permanent).

## Tests

- Card-level (full parse pipeline): Banewhip Punisher's `Destroy` target carries `FilterProp::Counters { OfType(Minus1Minus1), GE, 1 }`; Triad of Fates' exile (`ChangeZone{Exile}`) target carries `Counters { OfType(Generic("fate")), GE, 1 }`, and the "then return it to the battlefield" tail still parses as a sub-ability (the card stays supported). Revert-discriminating — without the new arm the target properties are empty.
- Unit tests on `parse_that_clause_suffix`: singular "-1/-1 counter on it", plural "+1/+1 counters on them", and the generic "fate counter on it".
- No-regression: the existing `with`/`without`/`with no`/bare-any counter-suffix tests (Crumbling Ashes, stun, oil, etc.) all stay green after the refactor.

## Verification

`cargo +nightly test -p engine --lib`: 0 failures (783 counter-suite + new tests pass). `--test integration`: 1119 passed, no fixture diff. `clippy -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean for this diff.
