### PR TITLE
fix(parser): bind "for each 1 life you gained/lost" to the event amount

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -13146,6 +13146,106 @@ mod tests {
         }
     }
 
+    /// CR 119.3 + CR 603.2c: "for each 1 life you gained/lost" on a
+    /// `Whenever you gain/lose life` trigger binds the per-1 multiplier to the
+    /// triggering `LifeChanged` amount via `EventContextAmount`. Regression gate
+    /// for Cradle of Vitality / Transcendence / Lich's Tomb: previously the
+    /// for-each parse failed and the count stayed `Fixed{1}` (or `Fixed{2}`).
+    #[test]
+    fn parse_for_each_one_life_changed_full_cards() {
+        use crate::types::ability::{AbilityDefinition, Effect, QuantityExpr, QuantityRef};
+
+        // Walk an ability-definition chain (effect + sub_ability) collecting the
+        // first matching effect predicate hit.
+        fn find_effect<'a>(
+            def: &'a AbilityDefinition,
+            pred: &dyn Fn(&Effect) -> bool,
+        ) -> Option<&'a Effect> {
+            if pred(def.effect.as_ref()) {
+                return Some(def.effect.as_ref());
+            }
+            if let Some(sub) = def.sub_ability.as_deref() {
+                if let Some(found) = find_effect(sub, pred) {
+                    return Some(found);
+                }
+            }
+            def.else_ability
+                .as_deref()
+                .and_then(|else_def| find_effect(else_def, pred))
+        }
+
+        fn execute_effect<'a>(
+            r: &'a ParsedAbilities,
+            pred: &dyn Fn(&Effect) -> bool,
+        ) -> &'a Effect {
+            r.triggers
+                .iter()
+                .filter_map(|t| t.execute.as_deref())
+                .find_map(|exec| find_effect(exec, pred))
+                .expect("expected matching effect in a trigger execute chain")
+        }
+
+        let event_amount = QuantityExpr::Ref {
+            qty: QuantityRef::EventContextAmount,
+        };
+
+        // Cradle of Vitality — reflexive PutCounter for each 1 life gained.
+        let cradle = parse(
+            "Whenever you gain life, you may pay {1}{W}. If you do, put a +1/+1 \
+             counter on target creature for each 1 life you gained.",
+            "Cradle of Vitality",
+            &[],
+            &["Enchantment"],
+            &[],
+        );
+        let put = execute_effect(&cradle, &|e| matches!(e, Effect::PutCounter { .. }));
+        let Effect::PutCounter { count, .. } = put else {
+            unreachable!()
+        };
+        assert_eq!(
+            count, &event_amount,
+            "Cradle of Vitality PutCounter.count must be the life-gained amount, not Fixed{{1}}"
+        );
+
+        // Transcendence — gain 2 life for each 1 life lost ⇒ Multiply{2, amount}.
+        let transcendence = parse(
+            "Whenever you lose life, you gain 2 life for each 1 life you lost.",
+            "Transcendence",
+            &[],
+            &["Enchantment"],
+            &[],
+        );
+        let gain = execute_effect(&transcendence, &|e| matches!(e, Effect::GainLife { .. }));
+        let Effect::GainLife { amount, .. } = gain else {
+            unreachable!()
+        };
+        assert_eq!(
+            amount,
+            &QuantityExpr::Multiply {
+                factor: 2,
+                inner: Box::new(event_amount.clone()),
+            },
+            "Transcendence GainLife.amount must be 2 × life-lost, not Fixed{{2}}"
+        );
+
+        // Lich's Tomb — sacrifice a permanent for each 1 life lost.
+        let lichs_tomb = parse(
+            "Whenever you lose life, sacrifice a permanent for each 1 life you lost.",
+            "Lich's Tomb",
+            &[],
+            &["Enchantment"],
+            &[],
+        );
+        let sac = execute_effect(&lichs_tomb, &|e| matches!(e, Effect::Sacrifice { .. }));
+        let Effect::Sacrifice { count, .. } = sac else {
+            unreachable!()
+        };
+        assert_eq!(
+            count, &event_amount,
+            "Lich's Tomb Sacrifice.count must be the life-lost amount, not Fixed{{1}}"
+        );
+    }
+
     #[test]
     fn parse_harmonize_wild_ride() {
         // Harmonize with lower cost

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1369,6 +1369,24 @@ fn parse_for_each_opponents_life_change(input: &str) -> OracleResult<'_, Quantit
     Ok((rest, QuantityRef::PlayerCount { filter }))
 }
 
+/// CR 119.3 + CR 603.2c: "1 life you gained" / "1 life you lost" — the per-1
+/// multiplier in a "for each 1 life you gained/lost" clause on a
+/// `Whenever you gain/lose life` trigger. The triggering `GameEvent::LifeChanged`
+/// carries the gained/lost magnitude, which `EventContextAmount` resolves via
+/// `extract_amount_from_event` (`game/targeting.rs`: `LifeChanged` => `amount.abs()`).
+/// The leading "1 "/"one " disambiguates from the duration class "life you
+/// gained/lost this turn" (`LifeGainedThisTurn`/`LifeLostThisTurn`, which has no
+/// "1 ") and from Blood Tyrant's "1 life lost or gained this way" (no "you";
+/// handled by the `TrackedSetSize` "this way" block).
+fn parse_for_each_one_life_changed(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = alt((tag("1 life you "), tag("one life you "))).parse(input)?;
+    value(
+        QuantityRef::EventContextAmount,
+        alt((tag("gained"), tag("lost"))),
+    )
+    .parse(rest)
+}
+
 /// Parse "your life total".
 fn parse_life_total_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     value(
@@ -2262,6 +2280,7 @@ fn parse_for_each_clause_ref_with_they_controller(
     they_controller: ControllerRef,
 ) -> OracleResult<'_, QuantityRef> {
     alt((
+        parse_for_each_one_life_changed,
         parse_for_each_opponents_life_change,
         parse_counter_added_this_turn_for_each,
         parse_object_colors_for_each,
@@ -3812,6 +3831,58 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    /// CR 119.3 + CR 603.2c: "for each 1 life you gained/lost" — the per-1
+    /// multiplier on a `Whenever you gain/lose life` trigger resolves to the
+    /// triggering event's amount via `EventContextAmount` (Cradle of Vitality,
+    /// Transcendence, Lich's Tomb). Without the dedicated arm the for-each parse
+    /// fails and the count silently stays `Fixed{1}`.
+    #[test]
+    fn parse_for_each_one_life_changed_yields_event_amount() {
+        use crate::parser::oracle_quantity::{parse_for_each_clause, parse_for_each_clause_expr};
+
+        for clause in ["1 life you gained", "1 life you lost"] {
+            assert_eq!(
+                parse_for_each_clause(clause),
+                Some(QuantityRef::EventContextAmount),
+                "{clause:?} must resolve to the triggering life-change amount",
+            );
+        }
+        // "one life you ..." spelled-out variant.
+        assert_eq!(
+            parse_for_each_clause("one life you lost"),
+            Some(QuantityRef::EventContextAmount),
+        );
+        // Expr wrapper used by the for-each effect path.
+        assert_eq!(
+            parse_for_each_clause_expr("1 life you lost"),
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            }),
+        );
+    }
+
+    /// No-regression: "life you gained/lost this turn" (no leading "1 ") must
+    /// keep its duration-class lower, NOT the per-1 event-amount arm.
+    #[test]
+    fn parse_for_each_one_life_changed_requires_one_prefix() {
+        let (rest, q) = parse_quantity_ref("life you gained this turn").unwrap();
+        assert_eq!(
+            q,
+            QuantityRef::LifeGainedThisTurn {
+                player: PlayerScope::Controller,
+            }
+        );
+        assert_eq!(rest, "");
+        let (rest, q) = parse_quantity_ref("life you lost this turn").unwrap();
+        assert_eq!(
+            q,
+            QuantityRef::LifeLostThisTurn {
+                player: PlayerScope::Controller,
+            }
+        );
+        assert_eq!(rest, "");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3587.

## Summary

The per-life multiplier "for each 1 life you gained" / "for each 1 life you lost" was silently dropped — the count/amount fell back to a literal, so these effects only did 1× regardless of the life change:

- **Cradle of Vitality** — "put a +1/+1 counter on target creature for each 1 life you gained" → put a single counter.
- **Transcendence** — "you gain 2 life for each 1 life you lost" → gained a flat 2 life.
- **Lich's Tomb** — "sacrifice a permanent for each 1 life you lost" → sacrificed a single permanent.

## Root cause

The for-each clause recognizer (`parse_for_each_clause_ref_with_they_controller`) had no arm for the trigger-bound "1 life you gained" / "1 life you lost" form — only a player-count arm ("opponents who lost life this turn"). So the for-each parse failed and the count/amount stayed `Fixed`.

## Fix (parser-only; no new engine variant)

Add `parse_for_each_one_life_changed` to the for-each clause alt: it matches a leading "1 "/"one " then "life you " then "gained"/"lost" → `QuantityRef::EventContextAmount` (the triggering `LifeChanged` magnitude). The existing for-each composition then yields a bare `Ref` (count 1 → Cradle, Lich's Tomb) or `Multiply { factor: N, inner: ref }` (Transcendence's "2 for each" → `Multiply{2, EventContextAmount}`).

The leading "1 "/"one " and first-person "you gained/lost" anchor the arm so it does **not** touch Blood Tyrant's "for each 1 life lost or gained this way" (a tracked-set count — no "you", carries "this way") or the "life you gained/lost this turn" duration forms (no "1 " prefix).

No runtime change — `EventContextAmount` already exists and the resolver maps it to the gained/lost amount (`LifeChanged => amount.abs()`); Cradle's "you may pay … if you do" reflexive restores the triggering event context before the deferred effect resolves, so the amount is live there too. CR 119.3 (life gain/loss), CR 603.2c (triggered-ability event amount).

## Tests

- Unit: `parse_for_each_clause("1 life you gained")` / `("1 life you lost")` → `EventContextAmount`; `parse_for_each_clause_expr` → `Ref{EventContextAmount}`; and a guard that "life you gained this turn" (no "1 ") still → `LifeGainedThisTurn`.
- Full-card (real parse pipeline): Cradle's reflexive `PutCounter.count == Ref{EventContextAmount}` (not `Fixed{1}`); Transcendence `GainLife.amount == Multiply{2, Ref{EventContextAmount}}`; Lich's Tomb `Sacrifice.count == Ref{EventContextAmount}`. Revert-discriminating — without the arm all three revert to `Fixed`.

## Verification

`cargo +nightly test -p engine --lib`: 0 failures (3 new + 240 for_each tests pass). `clippy -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean for this diff. Neither card appears in the integration fixtures (no fixture diff).
