### PR TITLE
fix(parser): parse tiered ETB counter statics

### DIFF
--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -418,6 +418,10 @@ pub(crate) fn is_static_pattern(lower: &str) -> bool {
         return false;
     }
 
+    if super::oracle_static::is_tiered_enters_with_additional_counters_static(lower) {
+        return true;
+    }
+
     if STATIC_CONTAINS_PATTERNS
         .iter()
         .any(|pattern| scan_contains(lower, pattern))
@@ -825,5 +829,12 @@ mod tests {
         assert!(!is_cast_spells_alternative_cost_pattern(
             "you may pay {0} rather than pay the mana cost for zombie creature spells you cast."
         ));
+    }
+
+    #[test]
+    fn classifies_tiered_enters_with_additional_counters_static() {
+        let lower = "each other vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. otherwise, it enters with three additional +1/+1 counters on it.";
+        assert!(is_static_pattern(lower));
+        assert!(is_replacement_pattern(lower));
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -14,9 +14,20 @@ fn parse_two_layer(
     types: &[&str],
     subtypes: &[&str],
 ) -> (OracleDocIr, ParsedAbilities) {
+    parse_two_layer_with_keywords(oracle_text, card_name, &[], types, subtypes)
+}
+
+fn parse_two_layer_with_keywords(
+    oracle_text: &str,
+    card_name: &str,
+    keywords: &[&str],
+    types: &[&str],
+    subtypes: &[&str],
+) -> (OracleDocIr, ParsedAbilities) {
+    let keywords: Vec<String> = keywords.iter().map(|s| s.to_string()).collect();
     let types: Vec<String> = types.iter().map(|s| s.to_string()).collect();
     let subtypes: Vec<String> = subtypes.iter().map(|s| s.to_string()).collect();
-    let ir = parse_oracle_ir(oracle_text, card_name, &[], &types, &subtypes);
+    let ir = parse_oracle_ir(oracle_text, card_name, &keywords, &types, &subtypes);
     let lowered = lower_oracle_ir(&ir);
     (ir, lowered)
 }
@@ -259,6 +270,19 @@ fn smugglers_copter() {
     );
     insta::assert_json_snapshot!("smugglers_copter_ir", &ir);
     insta::assert_json_snapshot!("smugglers_copter_lowered", &lowered);
+}
+
+#[test]
+fn thunderous_velocipede() {
+    let (ir, lowered) = parse_two_layer_with_keywords(
+        "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
+        "Thunderous Velocipede",
+        &["trample", "crew"],
+        &["Artifact"],
+        &["Vehicle"],
+    );
+    insta::assert_json_snapshot!("thunderous_velocipede_ir", &ir);
+    insta::assert_json_snapshot!("thunderous_velocipede_lowered", &lowered);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_ir.snap
@@ -1,0 +1,156 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "PreLoweredStatic": {
+        "mode": {
+          "EntersWithAdditionalCounters": {
+            "counter_type": "P1P1",
+            "count": 1
+          }
+        },
+        "affected": {
+          "type": "And",
+          "filters": [
+            {
+              "type": "Typed",
+              "type_filters": [],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "Cmc",
+                  "comparator": "LE",
+                  "value": {
+                    "type": "Fixed",
+                    "value": 4
+                  }
+                }
+              ]
+            },
+            {
+              "type": "Or",
+              "filters": [
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Artifact",
+                    {
+                      "Subtype": "Vehicle"
+                    }
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "Another"
+                    }
+                  ]
+                },
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "Another"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "modifications": [],
+        "condition": null,
+        "affected_zone": null,
+        "effect_zone": null,
+        "active_zones": [],
+        "characteristic_defining": false,
+        "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+      }
+    },
+    {
+      "PreLoweredStatic": {
+        "mode": {
+          "EntersWithAdditionalCounters": {
+            "counter_type": "P1P1",
+            "count": 3
+          }
+        },
+        "affected": {
+          "type": "And",
+          "filters": [
+            {
+              "type": "Typed",
+              "type_filters": [],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "Cmc",
+                  "comparator": "GT",
+                  "value": {
+                    "type": "Fixed",
+                    "value": 4
+                  }
+                }
+              ]
+            },
+            {
+              "type": "Or",
+              "filters": [
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Artifact",
+                    {
+                      "Subtype": "Vehicle"
+                    }
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "Another"
+                    }
+                  ]
+                },
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "Another"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "modifications": [],
+        "condition": null,
+        "affected_zone": null,
+        "effect_zone": null,
+        "active_zones": [],
+        "characteristic_defining": false,
+        "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+      }
+    },
+    {
+      "Keyword": {
+        "Crew": {
+          "power": 3,
+          "once_per_turn": null
+        }
+      }
+    }
+  ],
+  "source_text": "Trample\nEach other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\nCrew 3",
+  "card_name": "Thunderous Velocipede"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_lowered.snap
@@ -1,0 +1,153 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [],
+  "statics": [
+    {
+      "mode": {
+        "EntersWithAdditionalCounters": {
+          "counter_type": "P1P1",
+          "count": 1
+        }
+      },
+      "affected": {
+        "type": "And",
+        "filters": [
+          {
+            "type": "Typed",
+            "type_filters": [],
+            "controller": null,
+            "properties": [
+              {
+                "type": "Cmc",
+                "comparator": "LE",
+                "value": {
+                  "type": "Fixed",
+                  "value": 4
+                }
+              }
+            ]
+          },
+          {
+            "type": "Or",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Artifact",
+                  {
+                    "Subtype": "Vehicle"
+                  }
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "Another"
+                  }
+                ]
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "Another"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "modifications": [],
+      "condition": null,
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+    },
+    {
+      "mode": {
+        "EntersWithAdditionalCounters": {
+          "counter_type": "P1P1",
+          "count": 3
+        }
+      },
+      "affected": {
+        "type": "And",
+        "filters": [
+          {
+            "type": "Typed",
+            "type_filters": [],
+            "controller": null,
+            "properties": [
+              {
+                "type": "Cmc",
+                "comparator": "GT",
+                "value": {
+                  "type": "Fixed",
+                  "value": 4
+                }
+              }
+            ]
+          },
+          {
+            "type": "Or",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Artifact",
+                  {
+                    "Subtype": "Vehicle"
+                  }
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "Another"
+                  }
+                ]
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "Another"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "modifications": [],
+      "condition": null,
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": [
+    {
+      "Crew": {
+        "power": 3,
+        "once_per_turn": null
+      }
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2473,18 +2473,3 @@ fn parse_enters_with_additional_counters(
         .description(text.to_string()),
     )
 }
-
-/// CR 109.5: True when `filter` is anchored to the source's controller via a
-/// `ControllerRef::You` constraint (directly or within an Or/And composition).
-/// Stricter than `filter_has_source_or_controller_anchor`, which also accepts
-/// `Opponent` — "enters with an additional counter" statics are always
-/// "you control" scoped, so an opponent anchor must NOT match.
-fn filter_is_controller_you(filter: &TargetFilter) -> bool {
-    match filter {
-        TargetFilter::Typed(typed) => typed.controller == Some(ControllerRef::You),
-        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
-            filters.iter().all(filter_is_controller_you)
-        }
-        _ => false,
-    }
-}

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -145,6 +145,10 @@ pub(crate) use restriction::parse_cant_be_activated_exemption_in_text;
 pub use shared::parse_static_line_multi;
 pub(crate) use shared::parse_subtype_or_list_insensitive_prefix;
 pub(crate) use shared::GraveyardGrantedKeywordKind;
+pub(crate) use shared::{
+    is_tiered_enters_with_additional_counters_static,
+    parse_tiered_enters_with_additional_counters_pattern,
+};
 pub(crate) use type_change::{
     parse_additive_type_clause_modifications, parse_chosen_creature_type_static_prefix,
     parse_every_creature_type_static_prefix,

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -729,10 +729,166 @@ fn split_static_sentences(text: &str) -> Vec<String> {
     segments
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TieredEntersWithAdditionalCountersPattern {
+    pub counter_type: crate::types::counter::CounterType,
+    pub threshold: u32,
+    pub first_count: u32,
+    pub otherwise_count: u32,
+}
+
+fn parse_enter_with_an_additional_counter_prefix(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((
+            tag::<_, _, OracleError<'_>>("enter with an additional "),
+            tag("enters with an additional "),
+        )),
+    )
+    .parse(input)
+}
+
+fn parse_counter_carrier_pronoun(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag("it"), tag("them")))).parse(input)
+}
+
+fn parse_counter_on_phrase(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag(" counter on "), tag(" counters on ")))).parse(input)
+}
+
+fn parse_tiered_mana_value_clause(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = tag("if ").parse(input)?;
+    let (input, _) = alt((tag("its"), tag("their"))).parse(input)?;
+    let (input, _) = tag(" mana value is ").parse(input)?;
+    Ok((input, ()))
+}
+
+fn parse_tiered_enters_with_additional_counters_predicate(
+    input: &str,
+) -> OracleResult<'_, TieredEntersWithAdditionalCountersPattern> {
+    let (input, _) = parse_enter_with_an_additional_counter_prefix(input)?;
+    let (input, counter_type) = nom_primitives::parse_strict_counter_type(input)?;
+    let (input, _) = parse_counter_on_phrase(input)?;
+    let (input, _) = parse_counter_carrier_pronoun(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = parse_tiered_mana_value_clause(input)?;
+    let (input, threshold) = nom_primitives::parse_number(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = tag("or less.").parse(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = tag("otherwise,").parse(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = alt((tag("it enters with "), tag("they enter with "))).parse(input)?;
+    let (input, otherwise_count) = nom_primitives::parse_number(input)?;
+    let (input, _) = space1.parse(input)?;
+    let (input, _) = tag("additional ").parse(input)?;
+    let (input, otherwise_counter_type) = nom_primitives::parse_strict_counter_type(input)?;
+    let (input, _) = parse_counter_on_phrase(input)?;
+    let (input, _) = parse_counter_carrier_pronoun(input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+
+    if otherwise_counter_type != counter_type {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    Ok((
+        input,
+        TieredEntersWithAdditionalCountersPattern {
+            counter_type,
+            threshold,
+            first_count: 1,
+            otherwise_count,
+        },
+    ))
+}
+
+fn parse_tiered_enters_with_additional_counters_parts(
+    tp: &TextPair<'_>,
+) -> Option<(TargetFilter, TieredEntersWithAdditionalCountersPattern)> {
+    let (subject_lower, predicate_lower) = nom_primitives::scan_split_at_phrase(tp.lower, |i| {
+        parse_enter_with_an_additional_counter_prefix(i)
+    })?;
+    let (_, pattern) = all_consuming(terminated(
+        parse_tiered_enters_with_additional_counters_predicate,
+        space0,
+    ))
+    .parse(predicate_lower)
+    .ok()?;
+
+    let subject_original = tp.original[..subject_lower.len()].trim();
+    let affected = parse_continuous_subject_filter(subject_original)?;
+    if !filter_is_controller_you(&affected) {
+        return None;
+    }
+
+    Some((affected, pattern))
+}
+
+fn cmc_filter_prop(comparator: Comparator, threshold: u32) -> Option<FilterProp> {
+    Some(FilterProp::Cmc {
+        comparator,
+        value: QuantityExpr::Fixed {
+            value: i32::try_from(threshold).ok()?,
+        },
+    })
+}
+
+fn parse_tiered_enters_with_additional_counters_static(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<Vec<StaticDefinition>> {
+    let (base, pattern) = parse_tiered_enters_with_additional_counters_parts(tp)?;
+    let le_filter = add_property(
+        base.clone(),
+        cmc_filter_prop(Comparator::LE, pattern.threshold)?,
+    )
+    .normalized();
+    let gt_filter =
+        add_property(base, cmc_filter_prop(Comparator::GT, pattern.threshold)?).normalized();
+
+    Some(vec![
+        StaticDefinition::new(StaticMode::EntersWithAdditionalCounters {
+            counter_type: pattern.counter_type.clone(),
+            count: pattern.first_count,
+        })
+        .affected(le_filter)
+        .description(text.to_string()),
+        StaticDefinition::new(StaticMode::EntersWithAdditionalCounters {
+            counter_type: pattern.counter_type,
+            count: pattern.otherwise_count,
+        })
+        .affected(gt_filter)
+        .description(text.to_string()),
+    ])
+}
+
+pub(crate) fn is_tiered_enters_with_additional_counters_static(lower: &str) -> bool {
+    let tp = TextPair::new(lower, lower);
+    parse_tiered_enters_with_additional_counters_parts(&tp).is_some()
+}
+
+pub(crate) fn parse_tiered_enters_with_additional_counters_pattern(
+    lower: &str,
+) -> Option<TieredEntersWithAdditionalCountersPattern> {
+    let tp = TextPair::new(lower, lower);
+    parse_tiered_enters_with_additional_counters_parts(&tp).map(|(_, pattern)| pattern)
+}
+
 pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition> {
     let stripped = strip_reminder_text(text);
     let lower = stripped.to_lowercase();
     let tp = TextPair::new(&stripped, &lower);
+
+    // CR 604.1 + CR 614.1c + CR 122.1 + CR 202.3: Tiered ETB-counter
+    // replacement static. The otherwise sentence is a semantic companion to
+    // the first sentence, so it must bind before generic multi-sentence
+    // splitting can treat "Otherwise" as independent prose.
+    if let Some(defs) = parse_tiered_enters_with_additional_counters_static(&tp, &stripped) {
+        return defs;
+    }
 
     // CR 611.3 + CR 613.1: A static ability whose Oracle text is several
     // independent sentences (each a self-contained continuous effect) defines
@@ -1607,6 +1763,64 @@ pub(crate) fn parse_qualified_creatures_you_control_suffix<'a>(
     Some((filter, predicate_text))
 }
 
+fn parse_shared_controller_compound_subject_filter(subject: &TextPair<'_>) -> Option<TargetFilter> {
+    let (descriptor, suffix) = parse_subject_suffix(subject, " you control")
+        .map(|descriptor| (descriptor, " you control"))
+        .or_else(|| {
+            parse_subject_suffix(subject, " your opponents control")
+                .map(|descriptor| (descriptor, " your opponents control"))
+        })?;
+
+    let (left_lower, _, right_lower) = nom_primitives::scan_preceded(descriptor.lower, |input| {
+        value((), tag::<_, _, OracleError<'_>>("and ")).parse(input)
+    })?;
+    let right_start = descriptor.lower.len() - right_lower.len();
+    let left_original = descriptor.original[..left_lower.len()].trim();
+    let right_original = descriptor.original[right_start..].trim();
+    if left_original.is_empty() || right_original.is_empty() {
+        return None;
+    }
+
+    let left_lower_owned = left_original.to_lowercase();
+    let left_tp = TextPair::new(left_original, &left_lower_owned);
+    let (left_core, distribute_other) = if let Some(rest) = nom_tag_tp(&left_tp, "each other ") {
+        (rest.original.trim(), true)
+    } else if let Some(rest) = nom_tag_tp(&left_tp, "other ") {
+        (rest.original.trim(), true)
+    } else if let Some(rest) = nom_tag_tp(&left_tp, "each ") {
+        (rest.original.trim(), false)
+    } else {
+        (left_original, false)
+    };
+    if left_core.is_empty() {
+        return None;
+    }
+
+    let left_subject = if distribute_other {
+        format!("other {left_core}{suffix}")
+    } else {
+        format!("{left_core}{suffix}")
+    };
+    let right_subject = if distribute_other {
+        format!("other {right_original}{suffix}")
+    } else {
+        format!("{right_original}{suffix}")
+    };
+
+    let left_filter = parse_continuous_subject_filter(&left_subject)?;
+    let right_filter = parse_continuous_subject_filter(&right_subject)?;
+    if !filter_has_source_or_controller_anchor(&left_filter)
+        || !filter_has_source_or_controller_anchor(&right_filter)
+    {
+        return None;
+    }
+
+    let mut filters = Vec::new();
+    push_or_filter_branch(&mut filters, left_filter);
+    push_or_filter_branch(&mut filters, right_filter);
+    Some(TargetFilter::Or { filters })
+}
+
 pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFilter> {
     let trimmed = subject.trim();
     let lower = trimmed.to_lowercase();
@@ -1619,6 +1833,10 @@ pub(crate) fn parse_continuous_subject_filter(subject: &str) -> Option<TargetFil
     // string and matches zero real creatures.
     if let Some(rest_tp) = nom_tag_tp(&tp, "each ").or_else(|| nom_tag_tp(&tp, "all ")) {
         return parse_continuous_subject_filter(rest_tp.original.trim());
+    }
+
+    if let Some(filter) = parse_shared_controller_compound_subject_filter(&tp) {
+        return Some(filter);
     }
 
     if let Some(filter) = parse_controlled_compound_continuous_subject_filter(&tp) {
@@ -2320,6 +2538,21 @@ pub(crate) fn add_property(filter: TargetFilter, prop: FilterProp) -> TargetFilt
                 TargetFilter::Typed(TypedFilter::default().properties(vec![prop])),
             ],
         },
+    }
+}
+
+/// CR 109.5: True when `filter` is anchored to the source's controller via a
+/// `ControllerRef::You` constraint (directly or within an Or/And composition).
+/// Stricter than `filter_has_source_or_controller_anchor`, which also accepts
+/// `Opponent` — "enters with an additional counter" statics are always
+/// "you control" scoped, so an opponent anchor must NOT match.
+pub(crate) fn filter_is_controller_you(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed.controller == Some(ControllerRef::You),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().all(filter_is_controller_you)
+        }
+        _ => false,
     }
 }
 

--- a/crates/engine/src/parser/oracle_static/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_static/snapshot_tests.rs
@@ -30,6 +30,14 @@ fn static_granted_keyword() {
     insta::assert_json_snapshot!(def);
 }
 
+#[test]
+fn static_tiered_enters_with_additional_counters() {
+    let defs = parse_static_line_multi(
+        "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.",
+    );
+    insta::assert_json_snapshot!("static_tiered_enters_with_additional_counters", &defs);
+}
+
 /// Issue #327: "of that color" anaphor (post-Choose) is the equivalent of
 /// "of the chosen color" and must lower to a filter with IsChosenColor.
 #[test]

--- a/crates/engine/src/parser/oracle_static/snapshots/engine__parser__oracle_static__snapshot_tests__static_tiered_enters_with_additional_counters.snap
+++ b/crates/engine/src/parser/oracle_static/snapshots/engine__parser__oracle_static__snapshot_tests__static_tiered_enters_with_additional_counters.snap
@@ -1,0 +1,140 @@
+---
+source: crates/engine/src/parser/oracle_static/snapshot_tests.rs
+expression: "&defs"
+---
+[
+  {
+    "mode": {
+      "EntersWithAdditionalCounters": {
+        "counter_type": "P1P1",
+        "count": 1
+      }
+    },
+    "affected": {
+      "type": "And",
+      "filters": [
+        {
+          "type": "Typed",
+          "type_filters": [],
+          "controller": null,
+          "properties": [
+            {
+              "type": "Cmc",
+              "comparator": "LE",
+              "value": {
+                "type": "Fixed",
+                "value": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "Or",
+          "filters": [
+            {
+              "type": "Typed",
+              "type_filters": [
+                "Artifact",
+                {
+                  "Subtype": "Vehicle"
+                }
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "Another"
+                }
+              ]
+            },
+            {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "Another"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "modifications": [],
+    "condition": null,
+    "affected_zone": null,
+    "effect_zone": null,
+    "active_zones": [],
+    "characteristic_defining": false,
+    "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+  },
+  {
+    "mode": {
+      "EntersWithAdditionalCounters": {
+        "counter_type": "P1P1",
+        "count": 3
+      }
+    },
+    "affected": {
+      "type": "And",
+      "filters": [
+        {
+          "type": "Typed",
+          "type_filters": [],
+          "controller": null,
+          "properties": [
+            {
+              "type": "Cmc",
+              "comparator": "GT",
+              "value": {
+                "type": "Fixed",
+                "value": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "Or",
+          "filters": [
+            {
+              "type": "Typed",
+              "type_filters": [
+                "Artifact",
+                {
+                  "Subtype": "Vehicle"
+                }
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "Another"
+                }
+              ]
+            },
+            {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "Another"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "modifications": [],
+    "condition": null,
+    "affected_zone": null,
+    "effect_zone": null,
+    "active_zones": [],
+    "characteristic_defining": false,
+    "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+  }
+]

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5,10 +5,10 @@ use super::restriction::*;
 use super::support::*;
 use super::*;
 use crate::types::ability::{
-    ActivationRestriction, AggregateFunction, CardTypeSetSource, CountScope, DamageKindFilter,
-    Duration, Effect, FilterProp, ObjectProperty, ObjectScope, PlayerFilter, PlayerScope, PtStat,
-    PtValueScope, QuantityExpr, QuantityRef, SharedQuality, SharedQualityRelation, TypeFilter,
-    ZoneRef,
+    ActivationRestriction, AggregateFunction, CardTypeSetSource, Comparator, CountScope,
+    DamageKindFilter, Duration, Effect, FilterProp, ObjectProperty, ObjectScope, PlayerFilter,
+    PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, SharedQuality,
+    SharedQualityRelation, TypeFilter, ZoneRef,
 };
 use crate::types::counter::CounterType;
 use crate::types::keywords::Keyword;
@@ -16558,6 +16558,191 @@ fn enters_with_dynamic_count_not_matched_as_fixed() {
             def.mode
         );
     }
+}
+
+const THUNDEROUS_TIERED_COUNTER_LINE: &str =
+    "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.";
+
+fn filter_has_typed(filter: &TargetFilter, pred: impl Fn(&TypedFilter) -> bool + Copy) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => pred(typed),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(|filter| filter_has_typed(filter, pred))
+        }
+        _ => false,
+    }
+}
+
+fn filter_has_cmc(filter: &TargetFilter, comparator: Comparator, threshold: u32) -> bool {
+    filter_has_typed(filter, |typed| {
+        typed.properties.iter().any(|prop| {
+            matches!(
+                prop,
+                FilterProp::Cmc {
+                    comparator: parsed_comparator,
+                    value: QuantityExpr::Fixed { value },
+                } if *parsed_comparator == comparator
+                    && u32::try_from(*value).ok() == Some(threshold)
+            )
+        })
+    })
+}
+
+fn has_tiered_plus1_branch(
+    defs: &[StaticDefinition],
+    count: u32,
+    comparator: Comparator,
+    threshold: u32,
+) -> bool {
+    defs.iter().any(|def| {
+        matches!(
+            &def.mode,
+            StaticMode::EntersWithAdditionalCounters {
+                counter_type,
+                count: parsed_count,
+            } if counter_type == &CounterType::Plus1Plus1 && *parsed_count == count
+        ) && def
+            .affected
+            .as_ref()
+            .is_some_and(|filter| filter_has_cmc(filter, comparator, threshold))
+    })
+}
+
+fn filter_has_other_vehicle_you_control(filter: &TargetFilter) -> bool {
+    filter_has_typed(filter, |typed| {
+        typed.controller == Some(ControllerRef::You)
+            && typed.properties.contains(&FilterProp::Another)
+            && typed
+                .type_filters
+                .contains(&TypeFilter::Subtype("Vehicle".to_string()))
+    })
+}
+
+fn filter_has_other_creature_you_control(filter: &TargetFilter) -> bool {
+    filter_has_typed(filter, |typed| {
+        typed.controller == Some(ControllerRef::You)
+            && typed.properties.contains(&FilterProp::Another)
+            && typed.type_filters.contains(&TypeFilter::Creature)
+    })
+}
+
+#[test]
+fn continuous_subject_filter_distributes_shared_you_control_suffix() {
+    let filter = parse_continuous_subject_filter("Each other Vehicle and creature you control")
+        .expect("shared-suffix compound subject should parse");
+    assert!(
+        filter_has_other_vehicle_you_control(&filter),
+        "Vehicle branch must preserve Other + controller you, got {filter:?}"
+    );
+    assert!(
+        filter_has_other_creature_you_control(&filter),
+        "creature branch must preserve Other + controller you, got {filter:?}"
+    );
+}
+
+#[test]
+fn tiered_enters_with_additional_counters_static_thunderous_line() {
+    let defs = parse_static_line_multi(THUNDEROUS_TIERED_COUNTER_LINE);
+    assert_eq!(
+        defs.len(),
+        2,
+        "tiered ETB-counter line must emit exactly two statics, got {defs:?}"
+    );
+    assert!(
+        defs.iter().all(|def| def.condition.is_none()),
+        "tiered statics must not carry StaticCondition; CMC belongs in affected filters: {defs:?}"
+    );
+
+    let first = defs
+        .iter()
+        .find(|def| {
+            matches!(
+                def.mode,
+                StaticMode::EntersWithAdditionalCounters {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: 1,
+                }
+            )
+        })
+        .expect("expected <=4 branch with one +1/+1 counter");
+    let otherwise = defs
+        .iter()
+        .find(|def| {
+            matches!(
+                def.mode,
+                StaticMode::EntersWithAdditionalCounters {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: 3,
+                }
+            )
+        })
+        .expect("expected >4 branch with three +1/+1 counters");
+
+    let first_filter = first.affected.as_ref().expect("first branch affected");
+    let otherwise_filter = otherwise
+        .affected
+        .as_ref()
+        .expect("otherwise branch affected");
+    assert!(
+        filter_has_cmc(first_filter, Comparator::LE, 4),
+        "first branch must carry Cmc <= 4, got {first_filter:?}"
+    );
+    assert!(
+        filter_has_cmc(otherwise_filter, Comparator::GT, 4),
+        "otherwise branch must carry Cmc > 4, got {otherwise_filter:?}"
+    );
+    for filter in [first_filter, otherwise_filter] {
+        assert!(
+            filter_has_other_vehicle_you_control(filter),
+            "affected filter must include other Vehicle you control, got {filter:?}"
+        );
+        assert!(
+            filter_has_other_creature_you_control(filter),
+            "affected filter must include other creature you control, got {filter:?}"
+        );
+    }
+}
+
+#[test]
+fn tiered_enters_with_additional_counters_static_plural_their_mana_value() {
+    let defs = parse_static_line_multi(
+        "Each other Vehicle and creature you control enter with an additional +1/+1 counter on them if their mana value is 4 or less. Otherwise, they enter with three additional +1/+1 counters on them.",
+    );
+
+    assert_eq!(
+        defs.len(),
+        2,
+        "plural tiered ETB-counter line must emit two statics, got {defs:?}"
+    );
+    assert!(
+        has_tiered_plus1_branch(&defs, 1, Comparator::LE, 4),
+        "plural first branch must parse their mana value as Cmc <= 4, got {defs:?}"
+    );
+    assert!(
+        has_tiered_plus1_branch(&defs, 3, Comparator::GT, 4),
+        "plural otherwise branch must parse as Cmc > 4, got {defs:?}"
+    );
+}
+
+#[test]
+fn tiered_enters_with_additional_counters_static_one_counter_otherwise_singular() {
+    let defs = parse_static_line_multi(
+        "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with one additional +1/+1 counter on it.",
+    );
+
+    assert_eq!(
+        defs.len(),
+        2,
+        "one-counter otherwise tiered ETB-counter line must emit two statics, got {defs:?}"
+    );
+    assert!(
+        has_tiered_plus1_branch(&defs, 1, Comparator::LE, 4),
+        "first branch must still parse with one counter and Cmc <= 4, got {defs:?}"
+    );
+    assert!(
+        has_tiered_plus1_branch(&defs, 1, Comparator::GT, 4),
+        "otherwise branch must accept singular 'counter on' and carry Cmc > 4, got {defs:?}"
+    );
 }
 
 /// CR 205.3 + CR 604.1 + CR 702.18a: "All Slivers have shroud." (Crystalline

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -24,7 +24,7 @@
 use super::oracle::ParsedAbilities;
 use super::oracle_ir::diagnostic::{CascadeSlot, OracleDiagnostic};
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, ActivationRestriction, ContinuousModification,
+    AbilityCondition, AbilityDefinition, ActivationRestriction, Comparator, ContinuousModification,
     CopyRetargetPermission, Effect, FilterProp, ModalSelectionConstraint, OpponentMayScope,
     PlayerFilter, QuantityExpr, ReplacementDefinition, ReplacementMode, StaticDefinition,
     TargetFilter, TriggerDefinition,
@@ -1872,6 +1872,8 @@ fn detect_condition_if(
     //               with `ReplacementMode::Optional { decline: Tap(SelfRef) }`,
     //               i.e., the decline branch IS the "if you don't" gate.
     let stripped = strip_cr_implicit_if_phrases(cleaned);
+    let stripped =
+        strip_represented_tiered_enters_with_additional_counter_if_pairs(&stripped, parsed);
     // CR 702.170c: "[you may] exile a card. If you do, it becomes plotted." —
     // the "if you do" is the optional-exile linkage, represented by the
     // chained `Plotted` casting-permission grant (see `any_ability_has_plotted_grant`).
@@ -2058,6 +2060,123 @@ fn strip_cr_implicit_if_phrases(cleaned: &str) -> String {
         out.push('.');
     }
     out
+}
+
+fn strip_represented_tiered_enters_with_additional_counter_if_pairs(
+    cleaned: &str,
+    parsed: &ParsedAbilities,
+) -> String {
+    let mut out = String::with_capacity(cleaned.len());
+    for (line_index, line) in cleaned.lines().enumerate() {
+        if line_index > 0 {
+            out.push('\n');
+        }
+        out.push_str(&strip_represented_tiered_pairs_from_line(line, parsed));
+    }
+    out
+}
+
+fn strip_represented_tiered_pairs_from_line(line: &str, parsed: &ParsedAbilities) -> String {
+    let mut kept = Vec::new();
+    let segments: Vec<&str> = line.split('.').collect();
+    let mut index = 0usize;
+    while index < segments.len() {
+        let current = segments[index].trim();
+        if current.is_empty() {
+            index += 1;
+            continue;
+        }
+        if let Some(next_raw) = segments.get(index + 1) {
+            let next = next_raw.trim();
+            if sentence_starts_with_otherwise(next) {
+                let pair = format!("{current}. {next}.");
+                if represented_tiered_counter_pair(&pair, parsed) {
+                    index += 2;
+                    continue;
+                }
+            }
+        }
+        kept.push(format!("{current}."));
+        index += 1;
+    }
+    kept.join(" ")
+}
+
+fn sentence_starts_with_otherwise(sentence: &str) -> bool {
+    tag::<_, _, nom::error::Error<_>>("otherwise,")
+        .parse(sentence)
+        .is_ok()
+}
+
+fn represented_tiered_counter_pair(pair: &str, parsed: &ParsedAbilities) -> bool {
+    let Some(pattern) =
+        super::oracle_static::parse_tiered_enters_with_additional_counters_pattern(pair)
+    else {
+        return false;
+    };
+
+    let has_first = parsed.statics.iter().any(|static_def| {
+        static_matches_tiered_counter_branch(
+            static_def,
+            &pattern.counter_type,
+            pattern.first_count,
+            Comparator::LE,
+            pattern.threshold,
+        )
+    });
+    let has_otherwise = parsed.statics.iter().any(|static_def| {
+        static_matches_tiered_counter_branch(
+            static_def,
+            &pattern.counter_type,
+            pattern.otherwise_count,
+            Comparator::GT,
+            pattern.threshold,
+        )
+    });
+
+    has_first && has_otherwise
+}
+
+fn static_matches_tiered_counter_branch(
+    static_def: &StaticDefinition,
+    counter_type: &crate::types::counter::CounterType,
+    count: u32,
+    comparator: Comparator,
+    threshold: u32,
+) -> bool {
+    let StaticMode::EntersWithAdditionalCounters {
+        counter_type: parsed_counter_type,
+        count: parsed_count,
+    } = &static_def.mode
+    else {
+        return false;
+    };
+    if parsed_counter_type != counter_type || *parsed_count != count {
+        return false;
+    }
+    static_def
+        .affected
+        .as_ref()
+        .is_some_and(|filter| target_filter_has_cmc(filter, comparator, threshold))
+}
+
+fn target_filter_has_cmc(filter: &TargetFilter, comparator: Comparator, threshold: u32) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed.properties.iter().any(|prop| {
+            matches!(
+                prop,
+                FilterProp::Cmc {
+                    comparator: parsed_comparator,
+                    value: QuantityExpr::Fixed { value },
+                } if *parsed_comparator == comparator
+                    && u32::try_from(*value).ok() == Some(threshold)
+            )
+        }),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => filters
+            .iter()
+            .any(|filter| target_filter_has_cmc(filter, comparator, threshold)),
+        _ => false,
+    }
 }
 
 // ── Detector H: Condition_Unless ────────────────────────────────────────
@@ -2742,7 +2861,10 @@ fn effect_name(effect: &Effect) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{def_tree_has_optional, def_tree_has_unimplemented, trigger_tree_has_optional};
+    use super::{
+        check_swallowed_clauses, def_tree_has_optional, def_tree_has_unimplemented,
+        trigger_tree_has_optional,
+    };
     use crate::parser::oracle::parse_oracle_text;
     use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
     use crate::types::ability::{AbilityDefinition, Effect, OutsideGameSourcePool, TargetFilter};
@@ -3351,6 +3473,56 @@ mod tests {
         );
 
         assert!(!has_swallowed_detector(&parsed, "Condition_If"));
+    }
+
+    #[test]
+    fn condition_if_accepts_tiered_enters_with_counter_static() {
+        let parsed = parse_named(
+            "Trample\n\
+             Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.\n\
+             Crew 3",
+            "Thunderous Velocipede",
+            &["Artifact"],
+        );
+
+        assert!(
+            !has_swallowed_detector(&parsed, "Condition_If"),
+            "represented tiered ETB-counter static must not report Condition_If: {:?}",
+            parsed.parse_warnings
+        );
+        assert!(
+            parsed
+                .statics
+                .iter()
+                .filter(|static_def| {
+                    matches!(
+                        static_def.mode,
+                        StaticMode::EntersWithAdditionalCounters { .. }
+                    )
+                })
+                .count()
+                >= 2,
+            "expected tiered ETB-counter statics, got {:?}",
+            parsed.statics
+        );
+    }
+
+    #[test]
+    fn represented_tiered_counter_pair_does_not_hide_unrelated_if() {
+        let tiered_line = "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.";
+        let parsed = parse_named(tiered_line, "Thunderous Velocipede", &["Artifact"]);
+        let synthetic = format!("{tiered_line}\nDraw a card if the moon is bright.");
+        let mut diagnostics = Vec::new();
+
+        check_swallowed_clauses(&synthetic, &parsed, &mut diagnostics);
+
+        assert!(
+            diagnostics.iter().any(|warning| matches!(
+                warning,
+                OracleDiagnostic::SwallowedClause { detector, .. } if detector == "Condition_If"
+            )),
+            "separate unrelated if text must remain visible to Condition_If, got {diagnostics:?}"
+        );
     }
 
     /// CR 608.2c: Mister Negative's "If you lost life this way, draw that many


### PR DESCRIPTION
## Summary

Fixes #753.

Parse tiered enters-with-additional-counter static abilities like Thunderous Velocipede as two `EntersWithAdditionalCounters` static abilities split by mana value, instead of malformed self-ref replacements plus a swallowed `Condition_If` warning.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [x] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [ ] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> _N/A_

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

CR 109.5, CR 122.1, CR 202.3, CR 604.1, CR 614.1c.

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `./scripts/check-parser-combinators.sh`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p engine`
- `./scripts/gen-card-data.sh`
- `jq '."thunderous velocipede" | {static_abilities, replacements, parse_warnings}' client/public/card-data.json` confirmed two static abilities, no replacements, and no parse warnings.
