### PR TITLE
fix(draft): replace cube Deck Addables native select with anchored MenuSelect on mobile

### DIFF
--- a/client/src/components/draft/CubeSetupPanel.tsx
+++ b/client/src/components/draft/CubeSetupPanel.tsx
@@ -169,7 +169,7 @@ export function CubeSetupPanel({ onStart, startLabel, disabled }: CubeSetupPanel
             fitContainer
             menuLayout="dropdown"
             wrapperClassName="w-full min-w-0"
-            className="min-h-[44px] rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white shadow-none hover:bg-black/30 focus-visible:ring-emerald-400/50"
+            className="min-h-[44px] !rounded-lg border border-white/10 !bg-black/30 px-3 !py-2 text-sm text-white shadow-none !hover:bg-black/30 !focus-visible:ring-emerald-400/50"
           />
         </label>
         <label className="flex flex-col gap-1">

--- a/client/src/components/draft/CubeSetupPanel.tsx
+++ b/client/src/components/draft/CubeSetupPanel.tsx
@@ -5,10 +5,10 @@
  * (DraftPodPage) flows can mount it.
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { SelectField } from "../ui/SelectField";
+import { MenuSelect } from "../ui/MenuSelect";
 
 import type { CubeDraftSettings } from "../../adapter/draft-adapter";
 import { menuButtonClass } from "../menu/buttonStyles";
@@ -100,8 +100,20 @@ export function CubeSetupPanel({ onStart, startLabel, disabled }: CubeSetupPanel
   const busy = loading || disabled === true;
   const canStart = cubeText.trim().length > 0 && !busy;
 
+  const addablesPolicyItems = useMemo(
+    () => [
+      { value: "StandardBasics", label: t("cubeSetup.addablesStandardBasics") },
+      { value: "StandardBasicsPlusCustom", label: t("cubeSetup.addablesBasicsPlusCustom") },
+      { value: "CustomOnly", label: t("cubeSetup.addablesCustomOnly") },
+    ],
+    [t],
+  );
+  const addablesPolicyLabel =
+    addablesPolicyItems.find((item) => item.value === settings.addable_cards.policy)?.label ??
+    t("cubeSetup.addablesStandardBasics");
+
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex min-w-0 flex-col gap-4">
       <div className="grid gap-3 md:grid-cols-[1fr_220px_220px_220px]">
         <label className="flex flex-col gap-1">
           <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.cubeName")}</span>
@@ -137,27 +149,28 @@ export function CubeSetupPanel({ onStart, startLabel, disabled }: CubeSetupPanel
         </button>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-[260px_1fr]">
-        <label className="flex flex-col gap-1">
+      <div className="grid min-w-0 gap-3 md:grid-cols-[260px_1fr]">
+        <label className="flex min-w-0 flex-col gap-1">
           <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.deckAddables")}</span>
-          <SelectField
-            wrapperClassName="w-full"
-            value={settings.addable_cards.policy}
-            onChange={(e) =>
+          <MenuSelect
+            ariaLabel={t("cubeSetup.deckAddables")}
+            label={addablesPolicyLabel}
+            selectedValue={settings.addable_cards.policy}
+            items={addablesPolicyItems}
+            onSelect={(value) =>
               setSettings((prev) => ({
                 ...prev,
                 addable_cards: {
                   ...prev.addable_cards,
-                  policy: e.target.value as CubeDraftSettings["addable_cards"]["policy"],
+                  policy: value as CubeDraftSettings["addable_cards"]["policy"],
                 },
               }))
             }
-            className="w-full rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400/50"
-          >
-            <option value="StandardBasics">{t("cubeSetup.addablesStandardBasics")}</option>
-            <option value="StandardBasicsPlusCustom">{t("cubeSetup.addablesBasicsPlusCustom")}</option>
-            <option value="CustomOnly">{t("cubeSetup.addablesCustomOnly")}</option>
-          </SelectField>
+            fitContainer
+            menuLayout="dropdown"
+            wrapperClassName="w-full min-w-0"
+            className="min-h-[44px] rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white shadow-none hover:bg-black/30 focus-visible:ring-emerald-400/50"
+          />
         </label>
         <label className="flex flex-col gap-1">
           <span className="text-xs uppercase tracking-[0.16em] text-white/35">{t("cubeSetup.customAddableCards")}</span>


### PR DESCRIPTION
## Summary

Replaces the native `SelectField` in the cube draft Deck Addables control with the existing `MenuSelect` component. This keeps the menu anchored within the mobile viewport and makes it behave like a standard dropdown instead of overflowing or opening as a bottom sheet.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> Frontend-only UI fix in `CubeSetupPanel.tsx`. This swaps `SelectField` for the existing `MenuSelect` component with `menuLayout="dropdown"` and `fitContainer`. No engine, parser, rules, resolver, targeting, or game-logic behavior changed.

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

None — frontend-only change.

## Screenshots

### Before

<img width="382" height="741" alt="image" src="https://github.com/user-attachments/assets/a83db349-b72f-4b2e-a6dd-98ee9da09d0e" />

### After

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/16893e03-c8ea-4428-9a94-b7bf2752d89a" />

## Verification

- `pnpm run type-check` — passed
- Manual: on a mobile-width viewport, opened Draft → Cube tab → Deck Addables and confirmed the dropdown anchors below the field, stays within screen bounds, and does not open as a bottom sheet
- Manual: verified the same behavior on solo draft (`DraftPage`) and pod draft (`DraftPodPage`), since both mount `CubeSetupPanel`