### PR TITLE
feat(ai): add reanimator/graveyard-recursion deck-feature axis and payoff-gated policy

### DIFF
--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -323,6 +323,18 @@ pub struct PolicyPenalties {
     /// payoff-gated so this never applies to decks with no enchantment payoff.
     #[serde(default = "default_enchantment_cast_bonus")]
     pub enchantment_cast_bonus: f64,
+    /// CR 404.1 + CR 110.1: Bonus for casting a reanimation spell (graveyard →
+    /// battlefield) in a reanimator deck that has a worthwhile target — cheating
+    /// a fat body into play ahead of curve. Consumed by `ReanimatorPayoffPolicy`,
+    /// which is payoff-gated so this never applies to non-reanimator decks.
+    #[serde(default = "default_reanimation_cast_bonus")]
+    pub reanimation_cast_bonus: f64,
+    /// CR 701.17a / CR 701.9a: Bonus for casting a graveyard enabler (self-mill /
+    /// discard outlet) in a reanimator deck — loading the graveyard so a
+    /// reanimation has fuel. Consumed by `ReanimatorPayoffPolicy`; smaller than
+    /// the reanimation bonus because it is setup, not the payoff.
+    #[serde(default = "default_graveyard_enabler_bonus")]
+    pub graveyard_enabler_bonus: f64,
 }
 
 impl Default for PolicyPenalties {
@@ -368,6 +380,8 @@ impl Default for PolicyPenalties {
             deploy_artifact_bonus: default_deploy_artifact_bonus(),
             lifegain_source_bonus: default_lifegain_source_bonus(),
             enchantment_cast_bonus: default_enchantment_cast_bonus(),
+            reanimation_cast_bonus: default_reanimation_cast_bonus(),
+            graveyard_enabler_bonus: default_graveyard_enabler_bonus(),
         }
     }
 }
@@ -444,6 +458,12 @@ fn default_lifegain_source_bonus() -> f64 {
 fn default_enchantment_cast_bonus() -> f64 {
     0.4
 }
+fn default_reanimation_cast_bonus() -> f64 {
+    0.5
+}
+fn default_graveyard_enabler_bonus() -> f64 {
+    0.3
+}
 
 /// Policy penalty fields present in the active CMA-ES `--group penalties`
 /// vector. Adding a `PolicyPenalties` field requires listing it here or in
@@ -505,6 +525,14 @@ pub const UNTUNED_POLICY_PENALTY_FIELDS: &[(&str, &str)] = &[
     (
         "lifegain_source_bonus",
         "new LifegainPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "reanimation_cast_bonus",
+        "new ReanimatorPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "graveyard_enabler_bonus",
+        "new ReanimatorPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
     ),
 ];
 

--- a/crates/phase-ai/src/duel_suite/mod.rs
+++ b/crates/phase-ai/src/duel_suite/mod.rs
@@ -41,6 +41,7 @@ pub enum FeatureKind {
     TokensWide,
     PlusOneCounters,
     SpellslingerProwess,
+    Reanimator,
 }
 
 impl FeatureKind {
@@ -58,6 +59,7 @@ impl FeatureKind {
         FeatureKind::TokensWide,
         FeatureKind::PlusOneCounters,
         FeatureKind::SpellslingerProwess,
+        FeatureKind::Reanimator,
     ];
 }
 

--- a/crates/phase-ai/src/duel_suite/spec.rs
+++ b/crates/phase-ai/src/duel_suite/spec.rs
@@ -234,7 +234,14 @@ pub static MATCHUPS: &[MatchupSpec] = &[
         p1_label: "Orzhov Greasefang (P1)",
         p0: snap("pioneer", "orzhov-greasefang.json"),
         p1: snap("pioneer", "orzhov-greasefang.json"),
-        exercises: &[FeatureKind::Aristocrats],
+        // Orzhov Greasefang is the canonical reanimator list: discard outlets
+        // (Fleeting Spirit, Iron-Shield Elf, Guardian of New Benalia) pitch
+        // Parhelion II, then Greasefang / Lively Dirge return it from the
+        // graveyard to the battlefield. It clears `reanimator::COMMITMENT_FLOOR`,
+        // so this matchup is the gate's exercise of `ReanimatorPayoffPolicy`
+        // (verified by `greasefang_mirror_deck_activates_reanimator_payoff`
+        // below). It also exercises the aristocrats axis via its sacrifice value.
+        exercises: &[FeatureKind::Aristocrats, FeatureKind::Reanimator],
         expected: Expected::Mirror {
             tolerance: MIRROR_TOLERANCE,
         },

--- a/crates/phase-ai/src/duel_suite/tests.rs
+++ b/crates/phase-ai/src/duel_suite/tests.rs
@@ -21,14 +21,15 @@ fn every_feature_kind_is_exercised() {
 
 /// Cross-check against the gate-covered `DeckFeatures` axes: landfall,
 /// mana_ramp, tribal, control, aristocrats, artifacts, enchantments,
-/// aggro_pressure, tokens_wide, plus_one_counters, spellslinger_prowess — 11
-/// axes, each with a dedicated `MatchupSpec`. When a new gate-covered axis is
-/// added, this assertion fails until `FeatureKind::ALL` is updated to match.
+/// aggro_pressure, tokens_wide, plus_one_counters, spellslinger_prowess,
+/// reanimator — 12 axes, each with a dedicated `MatchupSpec`. When a new
+/// gate-covered axis is added, this assertion fails until `FeatureKind::ALL` is
+/// updated to match.
 #[test]
 fn feature_kind_matches_deck_features_field_count() {
     assert_eq!(
         FeatureKind::ALL.len(),
-        11,
+        12,
         "FeatureKind::ALL is out of sync with DeckFeatures — add the new variant."
     );
 }
@@ -226,6 +227,65 @@ fn enchantress_mirror_deck_activates_enchantments_payoff() {
         feature.commitment,
         feature.payoff_count,
         feature.enchantment_count
+    );
+}
+
+/// Reanimator sibling of `affinity_mirror_deck_activates_artifact_synergy`:
+/// guards that the `greasefang-mirror` matchup tagged `FeatureKind::Reanimator`
+/// actually clears `reanimator::COMMITMENT_FLOOR`, so the required gate runs
+/// `ReanimatorPayoffPolicy` active (not dormant). Resolves the real snapshot
+/// through the card database and asserts the feature detects a reanimation
+/// payoff and a target, and crosses the activation floor.
+///
+/// `#[ignore]` because it needs the full `card-data.json` export. Run with:
+///   `cargo test -p phase-ai -- --ignored greasefang_mirror_deck_activates_reanimator_payoff`
+#[test]
+#[ignore = "needs full card-data.json export; run with --ignored"]
+fn greasefang_mirror_deck_activates_reanimator_payoff() {
+    use crate::features::reanimator::{detect, COMMITMENT_FLOOR};
+    use engine::database::CardDatabase;
+    use engine::game::{resolve_player_deck_list, PlayerDeckList};
+    use std::path::PathBuf;
+
+    let data_root = std::env::var("PHASE_CARDS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../data")));
+    let db_path = data_root.join("card-data.json");
+    let db = CardDatabase::from_export(&db_path)
+        .unwrap_or_else(|e| panic!("failed to load card database from {db_path:?}: {e}"));
+
+    let spec = find_matchup("greasefang-mirror").expect("greasefang-mirror matchup must resolve");
+    assert!(
+        spec.exercises.contains(&FeatureKind::Reanimator),
+        "greasefang-mirror must claim to exercise FeatureKind::Reanimator"
+    );
+
+    let names = resolve_deck_ref(&spec.p0).expect("greasefang-mirror p0 snapshot must resolve");
+    let payload = resolve_player_deck_list(
+        &db,
+        &PlayerDeckList {
+            main_deck: names,
+            ..Default::default()
+        },
+    );
+    let feature = detect(&payload.main_deck);
+
+    assert!(
+        feature.reanimation_count >= 1 && feature.target_count >= 1,
+        "greasefang deck must contain a reanimation payoff and a target, got \
+         reanimation_count={} target_count={}",
+        feature.reanimation_count,
+        feature.target_count
+    );
+    assert!(
+        feature.commitment >= COMMITMENT_FLOOR,
+        "greasefang deck must clear COMMITMENT_FLOOR ({COMMITMENT_FLOOR}) so \
+         ReanimatorPayoffPolicy activates during the gate; got commitment={} \
+         (reanimation={}, target={}, enabler={})",
+        feature.commitment,
+        feature.reanimation_count,
+        feature.target_count,
+        feature.enabler_count
     );
 }
 

--- a/crates/phase-ai/src/features/mod.rs
+++ b/crates/phase-ai/src/features/mod.rs
@@ -16,6 +16,7 @@ pub mod landfall;
 pub mod lifegain;
 pub mod mana_ramp;
 pub mod plus_one_counters;
+pub mod reanimator;
 pub mod spellslinger_prowess;
 pub mod tokens_wide;
 pub mod tribal;
@@ -32,6 +33,7 @@ pub use landfall::LandfallFeature;
 pub use lifegain::LifegainFeature;
 pub use mana_ramp::ManaRampFeature;
 pub use plus_one_counters::PlusOneCountersFeature;
+pub use reanimator::ReanimatorFeature;
 pub use spellslinger_prowess::SpellslingerProwessFeature;
 pub use tokens_wide::TokensWideFeature;
 pub use tribal::TribalFeature;
@@ -63,6 +65,7 @@ pub struct DeckFeatures {
     pub tokens_wide: TokensWideFeature,
     pub plus_one_counters: PlusOneCountersFeature,
     pub spellslinger_prowess: SpellslingerProwessFeature,
+    pub reanimator: ReanimatorFeature,
     /// Declaration-derived: the deck's declared bracket tier. Unlike the
     /// other fields here, this is not structurally detected from card text —
     /// it is a per-deck declaration set at deck-analysis time from deck
@@ -102,6 +105,7 @@ impl DeckFeatures {
             tokens_wide: tokens_wide::detect(deck),
             plus_one_counters: plus_one_counters::detect(deck),
             spellslinger_prowess: spellslinger_prowess::detect(deck),
+            reanimator: reanimator::detect(deck),
             bracket_tier: tier,
         }
     }

--- a/crates/phase-ai/src/features/reanimator.rs
+++ b/crates/phase-ai/src/features/reanimator.rs
@@ -1,0 +1,316 @@
+//! Reanimator / graveyard-recursion feature — structural detection over a
+//! deck's typed AST.
+//!
+//! Parser AST verification — VERIFIED (no parser remediation required; every
+//! axis classifies from the existing typed AST, never by card name):
+//! - Reanimation payoff: `Effect::ChangeZone { origin: Some(Zone::Graveyard),
+//!   destination: Zone::Battlefield, target, .. }` at `ability.rs:7147` —
+//!   CR 404.1 (graveyard is the discard pile) + CR 110.1 (the card becomes a
+//!   permanent as it enters the battlefield). The reanimated body is a creature
+//!   (`TypeFilter::Creature`) or a Vehicle (`TypeFilter::Subtype("Vehicle")`,
+//!   CR 301.7 / CR 205.3) — the two card classes a reanimation effect cheats
+//!   onto the battlefield ahead of curve (Reanimate, Unburial Rites, Exhume,
+//!   Goryo's Vengeance, Greasefang's vehicle return).
+//! - Self-mill enabler: `Effect::Mill { target, destination: Zone::Graveyard }`
+//!   at `ability.rs:7075` (CR 701.17a) scoped to the controller — loads your own
+//!   graveyard (Stitcher's Supplier, Stinkweed Imp).
+//! - Discard-as-resource enabler: `Effect::Discard { target, .. }` at
+//!   `ability.rs:7861` (CR 701.9a) scoped to the controller, or an activated
+//!   ability whose cost discards from hand (`CostCategory::Discards`) — the
+//!   looting / rummaging outlets that pitch fat bodies into the graveyard
+//!   (Faithless Looting, "Discard a card:" outlets).
+//! - Reanimation target/fuel: a creature or Vehicle face whose mana value is at
+//!   least [`REANIMATION_TARGET_MV_FLOOR`] — the expensive body worth reanimating.
+//!
+//! Why this is not redundant with existing graveyard handling: `mill_targeting`
+//! optimizes *who* to mill (and penalizes self-mill when not obviously useful)
+//! and `recursion_awareness` is a *targeting* heuristic that avoids feeding an
+//! opponent's recursive creature to removal — neither recognizes a deck whose
+//! plan is "fill the graveyard, then reanimate a threat." This axis fills that
+//! gap; the companion `ReanimatorPayoffPolicy` is payoff-gated so non-reanimator
+//! decks (and the `mill_targeting` self-mill penalty) are unaffected.
+
+use engine::game::DeckEntry;
+use engine::types::ability::{
+    AbilityDefinition, ControllerRef, CostCategory, Effect, TargetFilter, TypeFilter, TypedFilter,
+};
+use engine::types::card::CardFace;
+use engine::types::card_type::CoreType;
+use engine::types::zones::Zone;
+
+use crate::ability_chain::collect_chain_effects;
+use crate::features::commitment;
+
+/// Commitment floor below which `ReanimatorPayoffPolicy` opts out. Matches the
+/// lifegain/enchantments payoff-axis convention.
+pub const COMMITMENT_FLOOR: f32 = 0.30;
+
+/// Mana value at or above which a creature/Vehicle face is considered a
+/// worthwhile reanimation target — the "ahead of curve" body a reanimation
+/// spell cheats onto the battlefield. Five keeps the class to genuine payoffs
+/// (Archon of Cruelty, Parhelion II, Griselbrand) and excludes the cheap
+/// creatures every deck runs.
+pub const REANIMATION_TARGET_MV_FLOOR: u32 = 5;
+
+/// Per-60-nonland payoff density at which the reanimation pillar saturates.
+/// Dedicated reanimator shells run ~6–10 reanimation spells per 60 nonland.
+const PAYOFF_FULL_DENSITY: f32 = 6.0;
+
+/// Per-60-nonland target density at which the fuel pillar saturates.
+const TARGET_FULL_DENSITY: f32 = 6.0;
+
+/// Additive commitment per graveyard enabler, capped by [`ENABLER_BONUS_CAP`].
+/// Enablers are supporting fuel, not the intent signal, so they only nudge.
+const ENABLER_BONUS_PER_CARD: f32 = 0.03;
+
+/// Maximum commitment contributed by enablers alone.
+const ENABLER_BONUS_CAP: f32 = 0.20;
+
+/// CR 205.3 / CR 301.7: the artifact subtype a reanimation target/payoff can be
+/// besides a creature. Compared case-insensitively against `TypeFilter::Subtype`
+/// and `CardType.subtypes`.
+const VEHICLE_SUBTYPE: &str = "Vehicle";
+
+/// Per-deck reanimator classification.
+///
+/// Populated once per game from `DeckEntry` data. Detection is structural over
+/// `CardFace.{abilities,triggers,card_type,mana_cost}` — never by card name. The
+/// companion `ReanimatorPayoffPolicy` consumes this to value reanimation spells
+/// and graveyard enablers when the deck contains both payoffs and targets.
+#[derive(Debug, Clone, Default)]
+pub struct ReanimatorFeature {
+    /// Cards that put a creature/Vehicle from a graveyard onto the battlefield.
+    /// CR 404.1 + CR 110.1. The payoff — the reanimation itself.
+    pub reanimation_count: u32,
+    /// Cards that load your graveyard: self-mill (CR 701.17a) or discard-as-
+    /// resource (CR 701.9a). The fuel that fills the graveyard to reanimate from.
+    pub enabler_count: u32,
+    /// Expensive creature/Vehicle bodies worth reanimating
+    /// ([`REANIMATION_TARGET_MV_FLOOR`]+ mana value). Without a target, a pile of
+    /// reanimation spells has nothing to cheat out, so this is a required pillar.
+    pub target_count: u32,
+    /// `0.0..=1.0` — how central the reanimator plan is to this deck. Requires
+    /// both reanimation payoffs and targets; enablers add a bounded bonus.
+    /// Consumed by `ReanimatorPayoffPolicy::activation` as the scaling knob.
+    pub commitment: f32,
+}
+
+/// Structural detection — walks each `DeckEntry`'s `CardFace` AST and counts
+/// reanimation payoffs, graveyard enablers, and reanimation targets.
+pub fn detect(deck: &[DeckEntry]) -> ReanimatorFeature {
+    if deck.is_empty() {
+        return ReanimatorFeature::default();
+    }
+
+    let mut reanimation_count = 0u32;
+    let mut enabler_count = 0u32;
+    let mut target_count = 0u32;
+    let mut total_nonland = 0u32;
+
+    for entry in deck {
+        let face = &entry.card;
+        if !face.card_type.core_types.contains(&CoreType::Land) {
+            total_nonland = total_nonland.saturating_add(entry.count);
+        }
+        if is_reanimation_payoff(face) {
+            reanimation_count = reanimation_count.saturating_add(entry.count);
+        }
+        if is_graveyard_enabler(face) {
+            enabler_count = enabler_count.saturating_add(entry.count);
+        }
+        if is_reanimation_target(face) {
+            target_count = target_count.saturating_add(entry.count);
+        }
+    }
+
+    let commitment = reanimator_commitment(
+        reanimation_count,
+        target_count,
+        enabler_count,
+        total_nonland,
+    );
+
+    ReanimatorFeature {
+        reanimation_count,
+        enabler_count,
+        target_count,
+        commitment,
+    }
+}
+
+/// Geometric-mean commitment over the two required pillars (reanimation payoffs
+/// and reanimation targets) plus a bounded enabler bonus.
+///
+/// A reanimator deck needs BOTH a way to reanimate AND a body worth reanimating;
+/// missing either pillar means it is not a reanimator deck, so commitment
+/// collapses to the small enabler bonus (which keeps the policy opted out for
+/// graveyard-value decks that merely self-mill).
+///
+/// Calibration — Legacy Reanimate (≈36 nonland: 8 reanimation spells, 6 fat
+/// targets, 6 looting/Entomb enablers): payoff density ≈13.3 and target density
+/// ≈10 both saturate their pillars → geometric mean 1.0 + capped enabler bonus →
+/// commitment ≈1.0, well above the floor.
+///
+/// Anti-calibration — a midrange deck with one incidental reanimation spell and
+/// no fat target collapses to the enabler bonus (≤0.20), staying inert.
+fn reanimator_commitment(
+    reanimation_count: u32,
+    target_count: u32,
+    enabler_count: u32,
+    total_nonland: u32,
+) -> f32 {
+    let enabler_bonus = (ENABLER_BONUS_PER_CARD * enabler_count as f32).min(ENABLER_BONUS_CAP);
+
+    // Both pillars are mandatory — a reanimation spell with nothing worth
+    // reanimating, or a fat creature with no way to cheat it out, is not the
+    // reanimator plan.
+    if reanimation_count == 0 || target_count == 0 {
+        return enabler_bonus.min(1.0);
+    }
+
+    let payoff = (commitment::density_per_60(reanimation_count, total_nonland)
+        / PAYOFF_FULL_DENSITY)
+        .min(1.0);
+    let target =
+        (commitment::density_per_60(target_count, total_nonland) / TARGET_FULL_DENSITY).min(1.0);
+
+    (commitment::geometric_mean(&[payoff, target]) + enabler_bonus).min(1.0)
+}
+
+/// True if this face can reanimate — its ability/trigger effect chains put a
+/// creature or Vehicle from a graveyard onto the battlefield. CR 404.1 + CR 110.1.
+pub fn is_reanimation_payoff(face: &CardFace) -> bool {
+    effects_include_reanimation(&collect_face_effects(face))
+}
+
+/// True if this face loads your graveyard — a controller-scoped self-mill or
+/// discard effect (CR 701.17a / CR 701.9a), or an activated ability whose cost
+/// discards from hand. These are the enablers that fill the graveyard to
+/// reanimate from.
+pub fn is_graveyard_enabler(face: &CardFace) -> bool {
+    effects_include_self_graveyard_fill(&collect_face_effects(face))
+        || face.abilities.iter().any(ability_is_discard_outlet)
+}
+
+/// True if this face is a worthwhile reanimation target: a creature or Vehicle
+/// body whose mana value is at least [`REANIMATION_TARGET_MV_FLOOR`].
+pub fn is_reanimation_target(face: &CardFace) -> bool {
+    face_is_reanimatable_body(face) && face.mana_cost.mana_value() >= REANIMATION_TARGET_MV_FLOOR
+}
+
+/// Single authority — true if any effect in the slice is a reanimation effect.
+/// Shared by deck-time `CardFace` detection ([`is_reanimation_payoff`]) and the
+/// live-game `ReanimatorPayoffPolicy` so the two never drift.
+pub(crate) fn effects_include_reanimation(effects: &[&Effect]) -> bool {
+    effects.iter().copied().any(effect_is_reanimation)
+}
+
+/// Single authority — true if any effect in the slice fills the controller's own
+/// graveyard (self-mill or self-discard). Shared with the live policy.
+pub(crate) fn effects_include_self_graveyard_fill(effects: &[&Effect]) -> bool {
+    effects.iter().copied().any(effect_fills_own_graveyard)
+}
+
+/// Single authority — true if this ability discards from hand as part of its
+/// cost (a looting / rummaging outlet). CR 701.9a. Shared with the live policy.
+/// Uses `cost_categories()` per the single-authority cost rule — never
+/// destructures `AbilityCost::Discard`.
+pub(crate) fn ability_is_discard_outlet(ability: &AbilityDefinition) -> bool {
+    ability.cost_categories().contains(&CostCategory::Discards)
+}
+
+/// CR 404.1 + CR 110.1: a reanimation effect moves a creature/Vehicle card from
+/// a graveyard onto the battlefield. Origin must be the graveyard; destination
+/// the battlefield. An unset origin (`None`) is "from anywhere" and does not
+/// qualify as a *reanimation* signature on its own.
+fn effect_is_reanimation(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Battlefield,
+            target,
+            ..
+        } if target_filter_is_reanimatable_body(target)
+    )
+}
+
+/// CR 701.17a / CR 701.9a: an effect that fills the controller's own graveyard.
+/// A self-mill must deposit into the graveyard (not exile); a discard always
+/// goes to the graveyard. Both must be controller-scoped — a `Player`-targeted
+/// mill/discard is opponent disruption (Mind Rot, Glimpse the Unthinkable), not
+/// a self-enabler.
+fn effect_fills_own_graveyard(effect: &Effect) -> bool {
+    match effect {
+        Effect::Mill {
+            target,
+            destination,
+            ..
+        } => *destination == Zone::Graveyard && target_fills_own_graveyard(target),
+        Effect::Discard { target, .. } => target_fills_own_graveyard(target),
+        _ => false,
+    }
+}
+
+/// CR 608.2c: "you mill/discard" (`Controller`) and the unspecified default
+/// (`Any`, e.g. "discard two cards" / "mill three cards") load the resolving
+/// player's own graveyard. An explicitly targeted `Player` is opponent-facing.
+fn target_fills_own_graveyard(filter: &TargetFilter) -> bool {
+    matches!(filter, TargetFilter::Controller | TargetFilter::Any)
+}
+
+/// CR 608.2b: unwrap a reanimation target filter. Accepts a filter that
+/// references a creature/Vehicle body controlled by you or unscoped; rejects
+/// opponent-scoped filters. `And` requires every conjunct to match (CR 608.2c).
+fn target_filter_is_reanimatable_body(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed_filter_is_reanimatable_body(typed),
+        TargetFilter::Or { filters } => filters.iter().any(target_filter_is_reanimatable_body),
+        TargetFilter::And { filters } => filters.iter().all(target_filter_is_reanimatable_body),
+        _ => false,
+    }
+}
+
+fn typed_filter_is_reanimatable_body(typed: &TypedFilter) -> bool {
+    // Reject opponent-scoped reanimation (rare; not the AI's own payoff).
+    if matches!(typed.controller, Some(ControllerRef::Opponent)) {
+        return false;
+    }
+    typed.type_filters.iter().any(type_filter_is_body)
+}
+
+/// CR 301.7 / CR 205.3: a reanimatable body is a creature or a Vehicle.
+fn type_filter_is_body(tf: &TypeFilter) -> bool {
+    match tf {
+        TypeFilter::Creature => true,
+        TypeFilter::Subtype(sub) => sub.eq_ignore_ascii_case(VEHICLE_SUBTYPE),
+        TypeFilter::AnyOf(inner) => inner.iter().any(type_filter_is_body),
+        _ => false,
+    }
+}
+
+/// CR 301.7: a face is a reanimatable body if it is a creature card or carries
+/// the Vehicle subtype (an artifact Vehicle becomes a creature once crewed, and
+/// is the body a vehicle-reanimator returns).
+fn face_is_reanimatable_body(face: &CardFace) -> bool {
+    face.card_type.core_types.contains(&CoreType::Creature)
+        || face
+            .card_type
+            .subtypes
+            .iter()
+            .any(|sub| sub.eq_ignore_ascii_case(VEHICLE_SUBTYPE))
+}
+
+/// Flatten a face's ability chains and trigger-executed chains into the effect
+/// slice the payoff/enabler predicates inspect. A reanimation effect can live in
+/// a `Spell` ability (Reanimate), an activated ability, or a trigger's executed
+/// chain (Greasefang's attack trigger), so all are walked.
+fn collect_face_effects(face: &CardFace) -> Vec<&Effect> {
+    let ability_effects = face.abilities.iter().flat_map(collect_chain_effects);
+    let trigger_effects = face
+        .triggers
+        .iter()
+        .filter_map(|trigger| trigger.execute.as_deref())
+        .flat_map(collect_chain_effects);
+    ability_effects.chain(trigger_effects).collect()
+}

--- a/crates/phase-ai/src/features/tests/mod.rs
+++ b/crates/phase-ai/src/features/tests/mod.rs
@@ -5,3 +5,4 @@ pub mod artifacts;
 pub mod enchantments;
 pub mod lifegain;
 pub mod no_name_matching;
+pub mod reanimator;

--- a/crates/phase-ai/src/features/tests/reanimator.rs
+++ b/crates/phase-ai/src/features/tests/reanimator.rs
@@ -1,0 +1,386 @@
+//! Tests for the reanimator / graveyard-recursion feature detector. Live in a
+//! sibling test module (declared from `features/tests/mod.rs`) so
+//! `features/reanimator.rs` stays implementation-only and SOURCE-classified.
+//!
+//! Detection is verified structurally — every test builds a `CardFace` AST and
+//! asserts the detector's counts. No card-name classification is used.
+
+use engine::game::DeckEntry;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, ControllerRef,
+    DiscardSelfScope, Effect, QuantityExpr, TargetFilter, TriggerDefinition, TypeFilter,
+    TypedFilter,
+};
+use engine::types::card::CardFace;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::mana::ManaCost;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::{EtbTapState, Zone};
+
+use crate::features::reanimator::{
+    detect, effects_include_reanimation, is_graveyard_enabler, is_reanimation_payoff,
+    is_reanimation_target, COMMITMENT_FLOOR, REANIMATION_TARGET_MV_FLOOR,
+};
+
+fn card_face(name: &str, core: Vec<CoreType>) -> CardFace {
+    CardFace {
+        name: name.to_string(),
+        card_type: CardType {
+            supertypes: Vec::new(),
+            core_types: core,
+            subtypes: Vec::new(),
+        },
+        ..Default::default()
+    }
+}
+
+fn entry(card: CardFace, count: u32) -> DeckEntry {
+    DeckEntry { card, count }
+}
+
+fn spell(effect: Effect) -> AbilityDefinition {
+    AbilityDefinition::new(AbilityKind::Spell, effect)
+}
+
+/// A reanimation effect: graveyard → battlefield, for the given target body.
+fn reanimation_effect(target: TargetFilter) -> Effect {
+    Effect::ChangeZone {
+        origin: Some(Zone::Graveyard),
+        destination: Zone::Battlefield,
+        target,
+        owner_library: false,
+        enter_transformed: false,
+        enters_under: Some(ControllerRef::You),
+        enter_tapped: EtbTapState::Unspecified,
+        enters_attacking: false,
+        up_to: false,
+        enter_with_counters: Vec::new(),
+        face_down_profile: None,
+    }
+}
+
+fn creature_target() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::creature())
+}
+
+fn vehicle_target() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype("Vehicle".to_string())))
+}
+
+/// "You mill N cards" — a self-mill enabler.
+fn self_mill_effect() -> Effect {
+    Effect::Mill {
+        count: QuantityExpr::Fixed { value: 3 },
+        target: TargetFilter::Controller,
+        destination: Zone::Graveyard,
+    }
+}
+
+/// "You discard a card" — a self-discard (looting) enabler.
+fn self_discard_effect() -> Effect {
+    Effect::Discard {
+        count: QuantityExpr::Fixed { value: 1 },
+        target: TargetFilter::Controller,
+        selection: CardSelectionMode::Chosen,
+        unless_filter: None,
+        filter: None,
+    }
+}
+
+/// A "Reanimate"-shape sorcery: one Spell ability that reanimates a creature.
+fn reanimate_spell(name: &str) -> CardFace {
+    let mut face = card_face(name, vec![CoreType::Sorcery]);
+    face.abilities
+        .push(spell(reanimation_effect(creature_target())));
+    face
+}
+
+/// A high-mana creature body worth reanimating.
+fn fat_creature(name: &str, mana_value: u32) -> CardFace {
+    let mut face = card_face(name, vec![CoreType::Creature]);
+    face.mana_cost = ManaCost::generic(mana_value);
+    face
+}
+
+fn vanilla(name: &str) -> CardFace {
+    let mut face = card_face(name, vec![CoreType::Creature]);
+    face.mana_cost = ManaCost::generic(2);
+    face
+}
+
+// ─── payoff detection ─────────────────────────────────────────────────────────
+
+#[test]
+fn reanimation_spell_is_payoff() {
+    let f = detect(&[entry(reanimate_spell("Reanimate"), 1)]);
+    assert_eq!(f.reanimation_count, 1);
+}
+
+#[test]
+fn trigger_borne_reanimation_is_payoff() {
+    // Greasefang-shape: the reanimation lives in a trigger's executed chain, not
+    // a Spell ability. The detector is trigger-mode-agnostic — it walks the
+    // executed effect chain.
+    let mut face = card_face("Okiba Boss", vec![CoreType::Creature]);
+    face.triggers.push(
+        TriggerDefinition::new(TriggerMode::Attacks)
+            .execute(spell(reanimation_effect(vehicle_target()))),
+    );
+    assert!(is_reanimation_payoff(&face));
+    let f = detect(&[entry(face, 1)]);
+    assert_eq!(f.reanimation_count, 1);
+}
+
+#[test]
+fn vehicle_reanimation_is_payoff() {
+    let mut face = card_face("Vehicle Raiser", vec![CoreType::Sorcery]);
+    face.abilities
+        .push(spell(reanimation_effect(vehicle_target())));
+    let f = detect(&[entry(face, 1)]);
+    assert_eq!(f.reanimation_count, 1);
+}
+
+#[test]
+fn non_graveyard_changezone_is_not_payoff() {
+    // "Put target creature from your hand onto the battlefield" (origin Hand) is
+    // a cheat-into-play effect but NOT reanimation — origin must be the graveyard.
+    let mut face = card_face("Sneak Attack", vec![CoreType::Sorcery]);
+    face.abilities.push(spell(Effect::ChangeZone {
+        origin: Some(Zone::Hand),
+        destination: Zone::Battlefield,
+        target: creature_target(),
+        owner_library: false,
+        enter_transformed: false,
+        enters_under: Some(ControllerRef::You),
+        enter_tapped: EtbTapState::Unspecified,
+        enters_attacking: false,
+        up_to: false,
+        enter_with_counters: Vec::new(),
+        face_down_profile: None,
+    }));
+    assert!(!is_reanimation_payoff(&face));
+}
+
+#[test]
+fn opponent_scoped_reanimation_ignored() {
+    let mut face = card_face("Opponent's Boon", vec![CoreType::Sorcery]);
+    face.abilities
+        .push(spell(reanimation_effect(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::Opponent),
+        ))));
+    assert!(!is_reanimation_payoff(&face));
+    let f = detect(&[entry(face, 1)]);
+    assert_eq!(f.reanimation_count, 0);
+}
+
+// ─── enabler detection ────────────────────────────────────────────────────────
+
+#[test]
+fn self_mill_is_enabler() {
+    let mut face = card_face("Stitcher", vec![CoreType::Creature]);
+    face.abilities.push(spell(self_mill_effect()));
+    assert!(is_graveyard_enabler(&face));
+}
+
+#[test]
+fn self_discard_is_enabler() {
+    let mut face = card_face("Faithless Looting", vec![CoreType::Sorcery]);
+    face.abilities.push(spell(self_discard_effect()));
+    assert!(is_graveyard_enabler(&face));
+}
+
+#[test]
+fn discard_cost_outlet_is_enabler() {
+    // "Discard a card: draw a card" — the discard is the ability *cost*, caught
+    // via `CostCategory::Discards` (the looting outlets reanimator decks run).
+    let mut face = card_face("Looter Outlet", vec![CoreType::Creature]);
+    let mut ability = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    );
+    ability.cost = Some(AbilityCost::Discard {
+        count: QuantityExpr::Fixed { value: 1 },
+        filter: None,
+        selection: CardSelectionMode::Chosen,
+        self_scope: DiscardSelfScope::FromHand,
+    });
+    face.abilities.push(ability);
+    assert!(is_graveyard_enabler(&face));
+}
+
+#[test]
+fn opponent_mill_is_not_self_enabler() {
+    // "Target player mills three" (Glimpse the Unthinkable) loads an opponent's
+    // graveyard, not yours — it is not a reanimator enabler.
+    let mut face = card_face("Glimpse", vec![CoreType::Sorcery]);
+    face.abilities.push(spell(Effect::Mill {
+        count: QuantityExpr::Fixed { value: 3 },
+        target: TargetFilter::Player,
+        destination: Zone::Graveyard,
+    }));
+    assert!(!is_graveyard_enabler(&face));
+}
+
+#[test]
+fn opponent_discard_is_not_self_enabler() {
+    // "Target player discards" (Mind Rot) is hand disruption, not a self-enabler.
+    let mut face = card_face("Mind Rot", vec![CoreType::Sorcery]);
+    face.abilities.push(spell(Effect::Discard {
+        count: QuantityExpr::Fixed { value: 2 },
+        target: TargetFilter::Player,
+        selection: CardSelectionMode::Chosen,
+        unless_filter: None,
+        filter: None,
+    }));
+    assert!(!is_graveyard_enabler(&face));
+}
+
+// ─── target detection ─────────────────────────────────────────────────────────
+
+#[test]
+fn fat_creature_is_target() {
+    let face = fat_creature("Archon of Cruelty", REANIMATION_TARGET_MV_FLOOR + 1);
+    assert!(is_reanimation_target(&face));
+}
+
+#[test]
+fn vehicle_body_is_target() {
+    let mut face = card_face("Parhelion II", vec![CoreType::Artifact]);
+    face.card_type.subtypes = vec!["Vehicle".to_string()];
+    face.mana_cost = ManaCost::generic(8);
+    assert!(is_reanimation_target(&face));
+}
+
+#[test]
+fn small_creature_is_not_target() {
+    let face = fat_creature("Grizzly Bears", REANIMATION_TARGET_MV_FLOOR - 1);
+    assert!(!is_reanimation_target(&face));
+}
+
+#[test]
+fn noncreature_high_mv_is_not_target() {
+    // An expensive sorcery is not a reanimatable body.
+    let mut face = card_face("Expensive Sorcery", vec![CoreType::Sorcery]);
+    face.mana_cost = ManaCost::generic(7);
+    assert!(!is_reanimation_target(&face));
+}
+
+// ─── shared predicate ─────────────────────────────────────────────────────────
+
+#[test]
+fn shared_reanimation_predicate_matches_and_rejects() {
+    // Single authority shared by the detector and `ReanimatorPayoffPolicy`.
+    let creature = reanimation_effect(creature_target());
+    let vehicle = reanimation_effect(vehicle_target());
+    assert!(effects_include_reanimation(&[&creature]));
+    assert!(effects_include_reanimation(&[&vehicle]));
+
+    let mill = self_mill_effect();
+    assert!(!effects_include_reanimation(&[&mill]));
+    assert!(!effects_include_reanimation(&[]));
+}
+
+// ─── default / inert ──────────────────────────────────────────────────────────
+
+#[test]
+fn empty_deck_defaults() {
+    let f = detect(&[]);
+    assert_eq!(f.reanimation_count, 0);
+    assert_eq!(f.enabler_count, 0);
+    assert_eq!(f.target_count, 0);
+    assert_eq!(f.commitment, 0.0);
+}
+
+#[test]
+fn vanilla_creature_inert() {
+    let f = detect(&[entry(vanilla("Bear"), 1)]);
+    assert_eq!(f.reanimation_count, 0);
+    assert_eq!(f.enabler_count, 0);
+    assert_eq!(f.target_count, 0);
+    assert_eq!(f.commitment, 0.0);
+}
+
+// ─── calibration anchors ──────────────────────────────────────────────────────
+
+#[test]
+fn positive_calibration_real_reanimator_deck_activates() {
+    // A genuine reanimator shell: 8 reanimation spells + 6 fat targets + 6
+    // self-mill enablers in a 36-nonland deck must clear the activation floor.
+    let mut deck = vec![entry(vanilla("Filler"), 16)];
+    for i in 0..8 {
+        deck.push(entry(reanimate_spell(&format!("Reanimation {i}")), 1));
+    }
+    for i in 0..6 {
+        deck.push(entry(fat_creature(&format!("Threat {i}"), 7), 1));
+    }
+    for i in 0..6 {
+        let mut enabler = card_face(&format!("Mill {i}"), vec![CoreType::Sorcery]);
+        enabler.abilities.push(spell(self_mill_effect()));
+        deck.push(entry(enabler, 1));
+    }
+    let f = detect(&deck);
+    assert_eq!(f.reanimation_count, 8);
+    assert_eq!(f.target_count, 6);
+    assert_eq!(f.enabler_count, 6);
+    assert!(
+        f.commitment >= COMMITMENT_FLOOR,
+        "real reanimator deck must activate, got {}",
+        f.commitment
+    );
+}
+
+#[test]
+fn anti_calibration_reanimation_without_targets_inert() {
+    // Reanimation spells with no fat body to cheat out collapse to inert — the
+    // target pillar is mandatory.
+    let mut deck = vec![entry(vanilla("Filler"), 28)];
+    for i in 0..8 {
+        deck.push(entry(reanimate_spell(&format!("Reanimation {i}")), 1));
+    }
+    let f = detect(&deck);
+    assert_eq!(f.reanimation_count, 8);
+    assert_eq!(f.target_count, 0);
+    assert!(
+        f.commitment < COMMITMENT_FLOOR,
+        "reanimation without a target must stay inert, got {}",
+        f.commitment
+    );
+}
+
+#[test]
+fn anti_calibration_fat_creatures_without_reanimation_inert() {
+    // A ramp/midrange deck full of fat creatures but no way to reanimate is not
+    // a reanimator deck — the payoff pillar is mandatory.
+    let mut deck = vec![entry(vanilla("Filler"), 30)];
+    for i in 0..6 {
+        deck.push(entry(fat_creature(&format!("Threat {i}"), 7), 1));
+    }
+    let f = detect(&deck);
+    assert_eq!(f.reanimation_count, 0);
+    assert_eq!(f.target_count, 6);
+    assert!(
+        f.commitment < COMMITMENT_FLOOR,
+        "fat creatures without reanimation must stay inert, got {}",
+        f.commitment
+    );
+}
+
+#[test]
+fn anti_calibration_single_incidental_pair_inert() {
+    // One reanimation spell + one fat creature in an otherwise unrelated
+    // 36-nonland deck must NOT cross the floor (the false-positive guard).
+    let mut deck = vec![entry(vanilla("Filler"), 34)];
+    deck.push(entry(reanimate_spell("Lone Reanimation"), 1));
+    deck.push(entry(fat_creature("Lone Threat", 7), 1));
+    let f = detect(&deck);
+    assert_eq!(f.reanimation_count, 1);
+    assert_eq!(f.target_count, 1);
+    assert!(
+        f.commitment < COMMITMENT_FLOOR,
+        "a single incidental reanimation pair must stay inert, got {}",
+        f.commitment
+    );
+}

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -40,6 +40,7 @@ mod planeswalker_loyalty;
 mod plus_one_counters;
 mod ramp_timing;
 mod reactive_self_protection;
+mod reanimator_payoff;
 mod recursion_awareness;
 mod redundancy_avoidance;
 pub mod registry;

--- a/crates/phase-ai/src/policies/reanimator_payoff.rs
+++ b/crates/phase-ai/src/policies/reanimator_payoff.rs
@@ -1,0 +1,108 @@
+//! Reanimator-payoff tactical policy.
+//!
+//! For decks committed to the reanimator axis *and* containing both reanimation
+//! payoffs and worthwhile targets, values two kinds of casts:
+//!   1. the reanimation itself — cheating a fat body out of a graveyard ahead of
+//!      curve (CR 404.1 + CR 110.1); and
+//!   2. graveyard enablers — self-mill / discard that load the graveyard so a
+//!      reanimation has fuel (CR 701.17a / CR 701.9a).
+//!
+//! Strictly **payoff-gated**: it opts out entirely unless the deck has both a
+//! reanimation payoff and a target, so incidental graveyard interaction in
+//! non-reanimator decks is unaffected — and it only adds value to self-mill
+//! where there is genuinely something to reanimate, so it does not blindly fight
+//! `mill_targeting`'s self-mill penalty on non-reanimator decks.
+
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::ability_chain::collect_chain_effects;
+use crate::features::reanimator::{
+    ability_is_discard_outlet, effects_include_reanimation, effects_include_self_graveyard_fill,
+    COMMITMENT_FLOOR,
+};
+use crate::features::DeckFeatures;
+
+pub struct ReanimatorPayoffPolicy;
+
+impl TacticalPolicy for ReanimatorPayoffPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::ReanimatorPayoff
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::CastSpell]
+    }
+
+    fn activation(
+        &self,
+        features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        let reanimator = &features.reanimator;
+        // Payoff-gated: a reanimation with no target has nothing to cheat out,
+        // and a target with no reanimation can't be cheated out — either way the
+        // plan is absent, so the policy is inert (keeps non-reanimator decks, and
+        // the `mill_targeting` self-mill penalty, unaffected).
+        if reanimator.reanimation_count == 0
+            || reanimator.target_count == 0
+            || reanimator.commitment < COMMITMENT_FLOOR
+        {
+            None
+        } else {
+            Some(reanimator.commitment)
+        }
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let GameAction::CastSpell { object_id, .. } = &ctx.candidate.action else {
+            return PolicyVerdict::neutral(PolicyReason::new("reanimator_payoff_na"));
+        };
+        let Some(object) = ctx.state.objects.get(object_id) else {
+            return PolicyVerdict::neutral(PolicyReason::new("reanimator_payoff_na"));
+        };
+
+        // Re-classify the live object structurally (not by deck-time tag) using
+        // the predicates shared with the deck-time detector, so the two never
+        // drift. A reanimation effect can live in a Spell/activated ability or a
+        // trigger's executed chain, so both are walked.
+        let effects: Vec<_> = object
+            .abilities
+            .iter()
+            .flat_map(collect_chain_effects)
+            .chain(
+                object
+                    .trigger_definitions
+                    .iter_unchecked()
+                    .filter_map(|trigger| trigger.execute.as_deref())
+                    .flat_map(collect_chain_effects),
+            )
+            .collect();
+
+        // Casting the reanimation itself is the marquee play — ensured by
+        // `activation` that the deck has a target worth reanimating.
+        if effects_include_reanimation(&effects) {
+            return PolicyVerdict::score(
+                ctx.penalties().reanimation_cast_bonus,
+                PolicyReason::new("reanimation_cast_for_payoff"),
+            );
+        }
+
+        // Otherwise, casting a graveyard enabler (self-mill / discard outlet)
+        // sets up a future reanimation — a smaller, supporting bonus.
+        if effects_include_self_graveyard_fill(&effects)
+            || object.abilities.iter().any(ability_is_discard_outlet)
+        {
+            return PolicyVerdict::score(
+                ctx.penalties().graveyard_enabler_bonus,
+                PolicyReason::new("graveyard_enabler_for_reanimation"),
+            );
+        }
+
+        PolicyVerdict::neutral(PolicyReason::new("reanimator_payoff_inert"))
+    }
+}

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -27,6 +27,7 @@ use super::payment_selection::PaymentSelectionPolicy;
 use super::plus_one_counters::PlusOneCountersPolicy;
 use super::ramp_timing::RampTimingPolicy;
 use super::reactive_self_protection::ReactiveSelfProtectionPolicy;
+use super::reanimator_payoff::ReanimatorPayoffPolicy;
 use super::recursion_awareness::RecursionAwarenessPolicy;
 use super::redundancy_avoidance::RedundancyAvoidancePolicy;
 use super::sacrifice_value::SacrificeValuePolicy;
@@ -70,6 +71,7 @@ pub enum PolicyId {
     BlightValue,
     EvasionRemovalPriority,
     RecursionAwareness,
+    ReanimatorPayoff,
     BoardWipeTelegraph,
     LifeTotalResource,
     LifegainPayoff,
@@ -323,6 +325,7 @@ impl Default for PolicyRegistry {
             Box::new(ChaliceAvoidancePolicy),
             Box::new(PaymentSelectionPolicy),
             Box::new(SeparatePilesTimingPolicy),
+            Box::new(ReanimatorPayoffPolicy),
         ];
         let mut by_kind: HashMap<DecisionKind, Vec<usize>> = HashMap::new();
         for (idx, policy) in policies.iter().enumerate() {

--- a/crates/phase-ai/src/policies/tests/mod.rs
+++ b/crates/phase-ai/src/policies/tests/mod.rs
@@ -5,4 +5,5 @@ pub mod artifact_synergy;
 pub mod enchantments_payoff;
 pub mod lifegain_payoff;
 pub mod mulligan_input_lint;
+pub mod reanimator_payoff;
 pub mod score_contract_lint;

--- a/crates/phase-ai/src/policies/tests/reanimator_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/reanimator_payoff.rs
@@ -1,0 +1,306 @@
+//! Tests for `ReanimatorPayoffPolicy`. Live in a sibling test module (declared
+//! from `policies/tests/mod.rs`) so `policies/reanimator_payoff.rs` stays
+//! implementation-only and SOURCE-classified.
+
+use std::sync::Arc;
+
+use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, ControllerRef,
+    DiscardSelfScope, Effect, QuantityExpr, TargetFilter, TriggerDefinition, TypeFilter,
+    TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::game_state::{CastPaymentMode, GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::{EtbTapState, Zone};
+
+use crate::config::AiConfig;
+use crate::context::AiContext;
+use crate::features::reanimator::ReanimatorFeature;
+use crate::features::DeckFeatures;
+use crate::session::AiSession;
+
+use super::super::context::PolicyContext;
+use super::super::reanimator_payoff::ReanimatorPayoffPolicy;
+use super::super::registry::{DecisionKind, PolicyId, PolicyVerdict, TacticalPolicy};
+
+const AI: PlayerId = PlayerId(0);
+
+fn features(commitment: f32, reanimation_count: u32, target_count: u32) -> DeckFeatures {
+    DeckFeatures {
+        reanimator: ReanimatorFeature {
+            reanimation_count,
+            enabler_count: 6,
+            target_count,
+            commitment,
+        },
+        ..DeckFeatures::default()
+    }
+}
+
+fn ai_context(commitment: f32, reanimation_count: u32, target_count: u32) -> (AiContext, AiConfig) {
+    let config = AiConfig::default();
+    let mut session = AiSession::empty();
+    session
+        .features
+        .insert(AI, features(commitment, reanimation_count, target_count));
+    let mut context = AiContext::empty(&config.weights);
+    context.session = Arc::new(session);
+    context.player = AI;
+    (context, config)
+}
+
+fn decision() -> AiDecisionContext {
+    AiDecisionContext {
+        waiting_for: WaitingFor::Priority { player: AI },
+        candidates: Vec::new(),
+    }
+}
+
+fn cast_candidate(object_id: ObjectId) -> CandidateAction {
+    CandidateAction {
+        action: GameAction::CastSpell {
+            object_id,
+            card_id: CardId(object_id.0),
+            targets: Vec::new(),
+            payment_mode: CastPaymentMode::default(),
+        },
+        metadata: ActionMetadata {
+            actor: Some(AI),
+            tactical_class: TacticalClass::Spell,
+        },
+    }
+}
+
+fn spell_object(state: &mut GameState, idx: u64, core: Vec<CoreType>) -> ObjectId {
+    let oid = create_object(state, CardId(idx), AI, format!("Spell {idx}"), Zone::Stack);
+    state.objects.get_mut(&oid).unwrap().card_types = CardType {
+        supertypes: Vec::new(),
+        core_types: core,
+        subtypes: Vec::new(),
+    };
+    oid
+}
+
+fn reanimation_effect(target: TargetFilter) -> Effect {
+    Effect::ChangeZone {
+        origin: Some(Zone::Graveyard),
+        destination: Zone::Battlefield,
+        target,
+        owner_library: false,
+        enter_transformed: false,
+        enters_under: Some(ControllerRef::You),
+        enter_tapped: EtbTapState::Unspecified,
+        enters_attacking: false,
+        up_to: false,
+        enter_with_counters: Vec::new(),
+        face_down_profile: None,
+    }
+}
+
+fn push_ability(state: &mut GameState, oid: ObjectId, ability: AbilityDefinition) {
+    Arc::make_mut(&mut state.objects.get_mut(&oid).unwrap().abilities).push(ability);
+}
+
+fn ctx<'a>(
+    state: &'a GameState,
+    candidate: &'a CandidateAction,
+    decision: &'a AiDecisionContext,
+    context: &'a AiContext,
+    config: &'a AiConfig,
+) -> PolicyContext<'a> {
+    PolicyContext {
+        state,
+        decision,
+        candidate,
+        ai_player: AI,
+        config,
+        context,
+        cast_facts: None,
+    }
+}
+
+fn delta_of(verdict: PolicyVerdict) -> (f64, String) {
+    match verdict {
+        PolicyVerdict::Score { delta, reason } => (delta, reason.kind.to_string()),
+        PolicyVerdict::Reject { .. } => panic!("unexpected Reject"),
+    }
+}
+
+// ─── identity ────────────────────────────────────────────────────────────────
+
+#[test]
+fn policy_identity() {
+    assert_eq!(ReanimatorPayoffPolicy.id(), PolicyId::ReanimatorPayoff);
+    assert!(ReanimatorPayoffPolicy
+        .decision_kinds()
+        .contains(&DecisionKind::CastSpell));
+}
+
+// ─── activation gate ─────────────────────────────────────────────────────────
+
+#[test]
+fn opts_out_with_no_reanimation_even_at_high_commitment() {
+    let features = features(0.9, 0, 6);
+    let state = GameState::new_two_player(7);
+    assert!(ReanimatorPayoffPolicy
+        .activation(&features, &state, AI)
+        .is_none());
+}
+
+#[test]
+fn opts_out_with_no_target() {
+    let features = features(0.9, 6, 0);
+    let state = GameState::new_two_player(7);
+    assert!(ReanimatorPayoffPolicy
+        .activation(&features, &state, AI)
+        .is_none());
+}
+
+#[test]
+fn opts_out_below_commitment_floor() {
+    let features = features(0.1, 6, 6);
+    let state = GameState::new_two_player(7);
+    assert!(ReanimatorPayoffPolicy
+        .activation(&features, &state, AI)
+        .is_none());
+}
+
+#[test]
+fn opts_in_with_payoff_and_target_above_floor() {
+    let features = features(0.6, 6, 6);
+    let state = GameState::new_two_player(7);
+    assert_eq!(
+        ReanimatorPayoffPolicy.activation(&features, &state, AI),
+        Some(0.6)
+    );
+}
+
+// ─── verdict ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn reanimation_spell_scored() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 1, vec![CoreType::Sorcery]);
+    push_ability(
+        &mut state,
+        oid,
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            reanimation_effect(TargetFilter::Typed(TypedFilter::creature())),
+        ),
+    );
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(0.8, 6, 6);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, kind) = delta_of(ReanimatorPayoffPolicy.verdict(&ctx));
+    assert_eq!(kind, "reanimation_cast_for_payoff");
+    assert!(delta > 0.0, "expected a positive delta, got {delta}");
+}
+
+#[test]
+fn trigger_borne_reanimation_scored() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 2, vec![CoreType::Creature]);
+    state
+        .objects
+        .get_mut(&oid)
+        .unwrap()
+        .trigger_definitions
+        .push(
+            TriggerDefinition::new(TriggerMode::Attacks).execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                reanimation_effect(TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype(
+                    "Vehicle".to_string(),
+                )))),
+            )),
+        );
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(0.8, 6, 6);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, kind) = delta_of(ReanimatorPayoffPolicy.verdict(&ctx));
+    assert_eq!(kind, "reanimation_cast_for_payoff");
+    assert!(delta > 0.0, "expected a positive delta, got {delta}");
+}
+
+#[test]
+fn self_mill_enabler_scored() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 3, vec![CoreType::Sorcery]);
+    push_ability(
+        &mut state,
+        oid,
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Mill {
+                count: QuantityExpr::Fixed { value: 3 },
+                target: TargetFilter::Controller,
+                destination: Zone::Graveyard,
+            },
+        ),
+    );
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(0.8, 6, 6);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, kind) = delta_of(ReanimatorPayoffPolicy.verdict(&ctx));
+    assert_eq!(kind, "graveyard_enabler_for_reanimation");
+    assert!(delta > 0.0, "expected a positive delta, got {delta}");
+}
+
+#[test]
+fn discard_outlet_enabler_scored() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 4, vec![CoreType::Creature]);
+    let mut ability = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    );
+    ability.cost = Some(AbilityCost::Discard {
+        count: QuantityExpr::Fixed { value: 1 },
+        filter: None,
+        selection: CardSelectionMode::Chosen,
+        self_scope: DiscardSelfScope::FromHand,
+    });
+    push_ability(&mut state, oid, ability);
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(0.8, 6, 6);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, kind) = delta_of(ReanimatorPayoffPolicy.verdict(&ctx));
+    assert_eq!(kind, "graveyard_enabler_for_reanimation");
+    assert!(delta > 0.0, "expected a positive delta, got {delta}");
+}
+
+#[test]
+fn non_reanimator_spell_inert() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 5, vec![CoreType::Sorcery]);
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(0.8, 6, 6);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, kind) = delta_of(ReanimatorPayoffPolicy.verdict(&ctx));
+    assert_eq!(kind, "reanimator_payoff_inert");
+    assert_eq!(delta, 0.0);
+}

--- a/crates/phase-ai/tests/duel_suite_attribution.rs
+++ b/crates/phase-ai/tests/duel_suite_attribution.rs
@@ -56,6 +56,7 @@ fn expected_policies(kind: FeatureKind) -> &'static [&'static str] {
         FeatureKind::TokensWide => &["TokensWide", "AnthemPriority"],
         FeatureKind::PlusOneCounters => &["PlusOneCountersTactical"],
         FeatureKind::SpellslingerProwess => &["SpellslingerCasting"],
+        FeatureKind::Reanimator => &["ReanimatorPayoff"],
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #3593

Adds a reanimator / graveyard-recursion deck-feature axis (`ReanimatorFeature`) and a payoff-gated `ReanimatorPayoffPolicy` to `phase-ai`, so the AI recognizes the "fill the graveyard → reanimate a fat body" plan: it values self-mill/discard enablers and reanimation spells when the deck contains both a graveyard→battlefield payoff and a worthwhile target (creature or Vehicle), and stays inert otherwise.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> AI-only change scoped entirely to `crates/phase-ai/` (deck-feature detection + a tactical policy + duel-suite gate wiring). It touches **no** `crates/engine/` game logic — no parser, effect, resolver, targeting, or rules behavior. It was built against the repo's `add-ai-feature-policy` skill checklist instead, mirroring the existing thin `lifegain` / `enchantments` payoff-axis pattern.

## CR references

Annotations added in the new modules (all grep-verified against `docs/MagicCompRules.txt`):
- `CR 404.1` — graveyard is the discard pile (reanimation source zone)
- `CR 110.1` — a card becomes a permanent as it enters the battlefield (reanimation destination)
- `CR 701.17a` — Mill (self-mill enabler)
- `CR 701.9a` — Discard (discard-as-resource enabler)
- `CR 301.7` / `CR 205.3` — Vehicle subtype / subtypes (reanimatable body classification)
- `CR 608.2b` / `CR 608.2c` — target legality / "you" scoping (self-fill vs opponent disruption)

## Verification

Tilt was down, so checks were run directly against `phase-ai` (no target-lock contention):

- `cargo fmt --all --check` — clean
- `cargo clippy -p phase-ai --all-targets -- -D warnings` — clean (incl. `no_name_matching`, `score_contract`, `activation_marker` lints)
- `cargo test -p phase-ai --lib` — **964 passed, 0 failed** (31 new reanimator detector/policy tests; `PolicyPenalties` field-coverage test and all 5 duel-suite invariants pass, incl. `feature_kind_matches_deck_features_field_count` 11→12 and `every_feature_kind_is_exercised`)
- `cargo test -p phase-ai --lib greasefang_mirror_deck_activates_reanimator_payoff -- --ignored` — **passes against real `card-data.json`**: the gate-tagged Greasefang deck clears `COMMITMENT_FLOOR`, so `ReanimatorPayoffPolicy` runs **active, not dormant**.

New `PolicyPenalties` knobs (`reanimation_cast_bonus`, `graveyard_enabler_bonus`) are registered **UNTUNED**, pending a paired-seed `cargo ai-gate` calibration. Note: a mirror matchup demonstrates non-regression + policy-active, not "improvement."
