### PR TITLE
fix(keywords): round-trip For Mirrodin! through serde

### DIFF
--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -2182,7 +2182,12 @@ impl FromStr for Keyword {
             "riot" => Ok(Keyword::Riot),
             "livingweapon" => Ok(Keyword::LivingWeapon),
             "jobselect" => Ok(Keyword::JobSelect),
-            "formirrodin!" => Ok(Keyword::ForMirrodin),
+            // Accept both the Oracle spelling ("For Mirrodin!") and the
+            // serialized variant name ("ForMirrodin"). `Serialize` emits the
+            // bare variant name (no "!"), so card-data.json round-trips through
+            // this path as "formirrodin"; without the second spelling it would
+            // fall to `Keyword::Unknown` and drop the keyword on reload.
+            "formirrodin!" | "formirrodin" => Ok(Keyword::ForMirrodin),
             // CR 702.89a/b: "umbra armor" is the current name; "totem armor" is the
             // obsolete printing both Oracle text and MTGJSON may still carry.
             "totemarmor" | "totem armor" | "umbra armor" | "umbraarmor" => Ok(Keyword::TotemArmor),
@@ -3093,6 +3098,26 @@ mod tests {
         );
         assert_eq!(Keyword::from_str("Battle Cry").unwrap(), Keyword::Battlecry);
         assert_eq!(Keyword::from_str("Aftermath").unwrap(), Keyword::Aftermath);
+    }
+
+    #[test]
+    fn unit_keywords_survive_serde_round_trip() {
+        // `Serialize` emits the bare variant name; the custom `Deserialize`
+        // routes plain strings through `FromStr`. Every unit keyword must
+        // round-trip back to itself rather than degrading to `Unknown`.
+        // ForMirrodin regressed here: its variant name "ForMirrodin" lacks the
+        // "!" that the Oracle-spelling `FromStr` arm required.
+        for kw in [
+            Keyword::Flying,
+            Keyword::LivingWeapon,
+            Keyword::JobSelect,
+            Keyword::TotemArmor,
+            Keyword::ForMirrodin,
+        ] {
+            let value = serde_json::to_value(&kw).unwrap();
+            let back: Keyword = serde_json::from_value(value.clone()).unwrap();
+            assert_eq!(back, kw, "round-trip failed for {value:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

14 "For Mirrodin!" Equipment (Glimmer Lens, Mirran Bardiche, Barbed Batterfist, Bladehold Cleaver, Hexgold Halberd/Hoverwings/Sledge, Hexplate Wallbreaker, Goldwarden's Helm, Bladehold War-Whip, Dragonwing Glider, Kemba's Banner, Sylvok Battle-Chair, Vulshok Splitter) were reported `supported=false` with a lone `Keyword:Unknown` gap — even though the keyword, its synthesized ETB Rebel-token + attach trigger, Equip, and the static buff all parse and resolve correctly.

## Root cause (serde round-trip, not a parser gap)

`Keyword`'s derived `Serialize` emits the bare variant name `"ForMirrodin"` (no "!"). The custom `Deserialize` routes plain strings through `FromStr`, which lowercases and strips spaces, yielding `"formirrodin"`. But the only matching arm was `"formirrodin!"` (the Oracle spelling, with "!"), so reloading `card-data.json` deserialized the keyword to `Keyword::Unknown("ForMirrodin")`, which the coverage report counts as unsupported.

Oracle-text parsing was unaffected ("For Mirrodin!" normalizes to `"formirrodin!"`, which matched). Of 90 unit `Keyword` variants, `ForMirrodin` is the only one whose serialized name fails to round-trip — its variant name lacks the "!" baked into the `FromStr` arm.

## Fix

Accept the serialized variant name `"formirrodin"` alongside the Oracle spelling `"formirrodin!"`. Adds a serde round-trip test over representative unit keywords (including the previously-broken `ForMirrodin`) to lock the contract.

## Verification

- New test `unit_keywords_survive_serde_round_trip` passes (fails before the fix: `ForMirrodin` round-trips to `Unknown`).
- Local regen: **14 cards flip to supported, 0 regressions** (coverage 85.575% → 85.614%).
- `cargo clippy -p engine --all-targets -- -D warnings`: clean. `scripts/check-parser-combinators.sh`: clean.

Closes #3592