### PR TITLE
fix(keywords): round-trip Specialize and Offering through serde

### DIFF
--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -2885,6 +2885,16 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Afterlife" => Ok(Keyword::Afterlife(uint(data))),
         "Fading" => Ok(Keyword::Fading(uint(data))),
         "Vanishing" => Ok(Keyword::Vanishing(uint(data))),
+        // CR 702.48: Offering — `Offering(String)` serializes as
+        // {"Offering": "<quality>"}; round-trip it back rather than dropping
+        // the keyword to Unknown on reload of card-data.json.
+        "Offering" => Ok(Keyword::Offering(
+            data.as_str().unwrap_or_default().to_string(),
+        )),
+        // Specialize (Alchemy Horizons: Baldur's Gate) — `Specialize(ManaCost)`
+        // serializes as {"Specialize": <ManaCost>}; round-trip it back to the
+        // typed variant so the synthesized specialize ability is not lost.
+        "Specialize" => mana(data).map(Keyword::Specialize),
         "Crew" => {
             // Struct variant: {"Crew": {"power": N, "once_per_turn": {...}}}.
             // A bare number is also accepted for forward/back compatibility.
@@ -4089,6 +4099,22 @@ mod tests {
         match kw {
             Keyword::Freerunning(_) => {} // cost shape validated by ManaCost deser
             other => panic!("expected Keyword::Freerunning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parameterized_keywords_survive_serde_round_trip() {
+        // Serialize emits these as externally-tagged objects
+        // ({"Specialize": <ManaCost>}, {"Offering": "<quality>"}); the custom
+        // Deserialize must route them back through keyword_from_tagged rather
+        // than dropping them to Unknown on reload of card-data.json.
+        for kw in [
+            Keyword::Specialize(parse_keyword_mana_cost("{2}")),
+            Keyword::Offering("Fox".to_string()),
+        ] {
+            let json = serde_json::to_value(&kw).unwrap();
+            let deserialized: Keyword = serde_json::from_value(json.clone()).unwrap();
+            assert_eq!(kw, deserialized, "round-trip failed for {json}");
         }
     }
 


### PR DESCRIPTION
## Problem

21 cards that fully parse and resolve are reported `supported=false` with a lone `Keyword:Unknown` gap — the Specialize Backgrounds (Gale, Wyll, Viconia, Klement, Rasaad, Vhal, Sarevok, Lae'zel, Shadowheart, Ambergris, Lukamina, Lulu, Skanos, Jaheira, …) and the Kamigawa Offering creatures (Patron of the Kitsune/Nezumi/Akki/Moon/Orochi, Blast-Furnace Hellkite, …).

## Root cause (serde round-trip, not a parser gap)

`Keyword`'s derived `Serialize` emits parameterized variants as externally-tagged objects — `{"Specialize": <ManaCost>}` and `{"Offering": "<quality>"}` — but `keyword_from_tagged` (the object-path deserializer) had no arm for either, so reloading `card-data.json` fell through to `Keyword::Unknown`. The coverage report then counted these as unsupported.

Both mechanics are implemented at runtime: Specialize synthesizes a sorcery-speed `Effect::Specialize` activated ability (`game/effects/specialize.rs`, `WaitingFor::SpecializeColor`), and Offering wires `CastTimingPermission::Offering` + `SpellCostSource::Offering` alternative-cost casting (`game/casting_costs.rs`). Only the deserialize arms were missing — the same round-trip class as the For Mirrodin! fix (#3596), on the tagged-object path.

## Fix

Add `keyword_from_tagged` arms for `Specialize` (→ `Specialize(ManaCost)`) and `Offering` (→ `Offering(String)`), plus a serde round-trip test over the parameterized variants.

## Verification

- New test `parameterized_keywords_survive_serde_round_trip` passes (fails before the fix: both round-trip to `Unknown`).
- Local regen: **21 cards flip to supported, 0 regressions**; every flip is attributable to a Specialize/Offering keyword.
- `cargo clippy -p engine --all-targets -- -D warnings`: clean. `scripts/check-parser-combinators.sh`: clean.

Closes #3598