### PR TITLE
feat(ai): add equipment/voltron deck-feature axis and payoff-gated policy

### DIFF
--- a/crates/phase-ai/duel_decks/modern/mono-white-equipment.json
+++ b/crates/phase-ai/duel_decks/modern/mono-white-equipment.json
@@ -1,0 +1,22 @@
+{
+  "name": "Mono-White Equipment",
+  "format": "modern",
+  "frozen_date": "2026-06-17",
+  "source": "https://www.mtggoldfish.com/metagame/modern",
+  "main": [
+    { "name": "Bonesplitter", "count": 3 },
+    { "name": "Vulshok Morningstar", "count": 3 },
+    { "name": "Trusty Machete", "count": 2 },
+    { "name": "Captain's Claws", "count": 2 },
+    { "name": "Sai of the Shinobi", "count": 2 },
+    { "name": "Armory of Iroas", "count": 2 },
+    { "name": "Stoneforge Mystic", "count": 4 },
+    { "name": "Puresteel Paladin", "count": 4 },
+    { "name": "Sram, Senior Edificer", "count": 3 },
+    { "name": "Kor Outfitter", "count": 3 },
+    { "name": "Steelshaper's Gift", "count": 2 },
+    { "name": "Savannah Lions", "count": 4 },
+    { "name": "Kor Duelist", "count": 4 },
+    { "name": "Plains", "count": 22 }
+  ]
+}

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -335,6 +335,17 @@ pub struct PolicyPenalties {
     /// the reanimation bonus because it is setup, not the payoff.
     #[serde(default = "default_graveyard_enabler_bonus")]
     pub graveyard_enabler_bonus: f64,
+    /// CR 301.5: Bonus for deploying an Equipment in an equipment-committed deck
+    /// (one with both Equipment density and payoffs) — growing the voltron
+    /// package. Consumed by `EquipmentPayoffPolicy`, which is payoff-gated so
+    /// this never applies to decks running incidental Equipment.
+    #[serde(default = "default_deploy_equipment_bonus")]
+    pub deploy_equipment_bonus: f64,
+    /// CR 701.23 / CR 702.6: Bonus for casting an equipment-matters support card
+    /// (tutor / auto-attacher / equip-cost grant / equipment-cast payoff) in an
+    /// equipment-committed deck. Consumed by `EquipmentPayoffPolicy`.
+    #[serde(default = "default_equipment_payoff_cast_bonus")]
+    pub equipment_payoff_cast_bonus: f64,
 }
 
 impl Default for PolicyPenalties {
@@ -382,6 +393,8 @@ impl Default for PolicyPenalties {
             enchantment_cast_bonus: default_enchantment_cast_bonus(),
             reanimation_cast_bonus: default_reanimation_cast_bonus(),
             graveyard_enabler_bonus: default_graveyard_enabler_bonus(),
+            deploy_equipment_bonus: default_deploy_equipment_bonus(),
+            equipment_payoff_cast_bonus: default_equipment_payoff_cast_bonus(),
         }
     }
 }
@@ -464,6 +477,12 @@ fn default_reanimation_cast_bonus() -> f64 {
 fn default_graveyard_enabler_bonus() -> f64 {
     0.3
 }
+fn default_deploy_equipment_bonus() -> f64 {
+    0.3
+}
+fn default_equipment_payoff_cast_bonus() -> f64 {
+    0.4
+}
 
 /// Policy penalty fields present in the active CMA-ES `--group penalties`
 /// vector. Adding a `PolicyPenalties` field requires listing it here or in
@@ -533,6 +552,14 @@ pub const UNTUNED_POLICY_PENALTY_FIELDS: &[(&str, &str)] = &[
     (
         "graveyard_enabler_bonus",
         "new ReanimatorPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "deploy_equipment_bonus",
+        "new EquipmentPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "equipment_payoff_cast_bonus",
+        "new EquipmentPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
     ),
 ];
 

--- a/crates/phase-ai/src/duel_suite/mod.rs
+++ b/crates/phase-ai/src/duel_suite/mod.rs
@@ -42,6 +42,7 @@ pub enum FeatureKind {
     PlusOneCounters,
     SpellslingerProwess,
     Reanimator,
+    Equipment,
 }
 
 impl FeatureKind {
@@ -60,6 +61,7 @@ impl FeatureKind {
         FeatureKind::PlusOneCounters,
         FeatureKind::SpellslingerProwess,
         FeatureKind::Reanimator,
+        FeatureKind::Equipment,
     ];
 }
 

--- a/crates/phase-ai/src/duel_suite/spec.rs
+++ b/crates/phase-ai/src/duel_suite/spec.rs
@@ -351,6 +351,23 @@ pub static MATCHUPS: &[MatchupSpec] = &[
         },
     },
     MatchupSpec {
+        id: "equipment-mirror",
+        p0_label: "Mono-White Equipment (P0)",
+        p1_label: "Mono-White Equipment (P1)",
+        p0: snap("modern", "mono-white-equipment.json"),
+        p1: snap("modern", "mono-white-equipment.json"),
+        // Mono-White Equipment is the canonical voltron list: a dense Equipment
+        // package (Bonesplitter, Vulshok Morningstar, Armory of Iroas, …) plus
+        // equipment-matters support (Stoneforge Mystic, Puresteel Paladin, Kor
+        // Outfitter, Steelshaper's Gift). It clears `equipment::COMMITMENT_FLOOR`,
+        // so this matchup is the gate's exercise of `EquipmentPayoffPolicy`
+        // (verified by `equipment_mirror_deck_activates_equipment_payoff` below).
+        exercises: &[FeatureKind::Equipment],
+        expected: Expected::Mirror {
+            tolerance: MIRROR_TOLERANCE,
+        },
+    },
+    MatchupSpec {
         id: "landfall-vs-niv",
         p0_label: "Mono-Green Landfall",
         p1_label: "Niv to Light",

--- a/crates/phase-ai/src/duel_suite/tests.rs
+++ b/crates/phase-ai/src/duel_suite/tests.rs
@@ -22,14 +22,14 @@ fn every_feature_kind_is_exercised() {
 /// Cross-check against the gate-covered `DeckFeatures` axes: landfall,
 /// mana_ramp, tribal, control, aristocrats, artifacts, enchantments,
 /// aggro_pressure, tokens_wide, plus_one_counters, spellslinger_prowess,
-/// reanimator — 12 axes, each with a dedicated `MatchupSpec`. When a new
-/// gate-covered axis is added, this assertion fails until `FeatureKind::ALL` is
-/// updated to match.
+/// reanimator, equipment — 13 axes, each with a dedicated `MatchupSpec`. When a
+/// new gate-covered axis is added, this assertion fails until `FeatureKind::ALL`
+/// is updated to match.
 #[test]
 fn feature_kind_matches_deck_features_field_count() {
     assert_eq!(
         FeatureKind::ALL.len(),
-        12,
+        13,
         "FeatureKind::ALL is out of sync with DeckFeatures — add the new variant."
     );
 }
@@ -286,6 +286,64 @@ fn greasefang_mirror_deck_activates_reanimator_payoff() {
         feature.reanimation_count,
         feature.target_count,
         feature.enabler_count
+    );
+}
+
+/// Equipment sibling of `affinity_mirror_deck_activates_artifact_synergy`:
+/// guards that the `equipment-mirror` matchup tagged `FeatureKind::Equipment`
+/// actually clears `equipment::COMMITMENT_FLOOR`, so the required gate runs
+/// `EquipmentPayoffPolicy` active (not dormant). Resolves the real snapshot
+/// through the card database and asserts the feature detects Equipment density
+/// and a payoff, and crosses the activation floor.
+///
+/// `#[ignore]` because it needs the full `card-data.json` export. Run with:
+///   `cargo test -p phase-ai -- --ignored equipment_mirror_deck_activates_equipment_payoff`
+#[test]
+#[ignore = "needs full card-data.json export; run with --ignored"]
+fn equipment_mirror_deck_activates_equipment_payoff() {
+    use crate::features::equipment::{detect, COMMITMENT_FLOOR};
+    use engine::database::CardDatabase;
+    use engine::game::{resolve_player_deck_list, PlayerDeckList};
+    use std::path::PathBuf;
+
+    let data_root = std::env::var("PHASE_CARDS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../data")));
+    let db_path = data_root.join("card-data.json");
+    let db = CardDatabase::from_export(&db_path)
+        .unwrap_or_else(|e| panic!("failed to load card database from {db_path:?}: {e}"));
+
+    let spec = find_matchup("equipment-mirror").expect("equipment-mirror matchup must resolve");
+    assert!(
+        spec.exercises.contains(&FeatureKind::Equipment),
+        "equipment-mirror must claim to exercise FeatureKind::Equipment"
+    );
+
+    let names = resolve_deck_ref(&spec.p0).expect("equipment-mirror p0 snapshot must resolve");
+    let payload = resolve_player_deck_list(
+        &db,
+        &PlayerDeckList {
+            main_deck: names,
+            ..Default::default()
+        },
+    );
+    let feature = detect(&payload.main_deck);
+
+    assert!(
+        feature.equipment_count >= 1 && feature.payoff_count >= 1,
+        "equipment deck must contain Equipment and a payoff, got \
+         equipment_count={} payoff_count={}",
+        feature.equipment_count,
+        feature.payoff_count
+    );
+    assert!(
+        feature.commitment >= COMMITMENT_FLOOR,
+        "equipment deck must clear COMMITMENT_FLOOR ({COMMITMENT_FLOOR}) so \
+         EquipmentPayoffPolicy activates during the gate; got commitment={} \
+         (equipment={}, payoff={})",
+        feature.commitment,
+        feature.equipment_count,
+        feature.payoff_count
     );
 }
 

--- a/crates/phase-ai/src/features/equipment.rs
+++ b/crates/phase-ai/src/features/equipment.rs
@@ -181,7 +181,7 @@ pub(crate) fn parts_are_equipment_payoff(
 /// CR 701.23 / CR 301.5: an effect that fetches an Equipment (tutor) or attaches
 /// one for free (auto-attacher). The Equipment's own equip ability attaches
 /// `SelfRef`, not an Equipment-filtered target, so it does not match here.
-fn effect_is_equipment_support(effect: &Effect) -> bool {
+pub(crate) fn effect_is_equipment_support(effect: &Effect) -> bool {
     match effect {
         Effect::SearchLibrary { filter, .. } => target_filter_references_equipment(filter),
         Effect::Attach { attachment, .. } => target_filter_references_equipment(attachment),
@@ -191,7 +191,7 @@ fn effect_is_equipment_support(effect: &Effect) -> bool {
 
 /// CR 601.2: a trigger that fires off your Equipment (cast or ETB) — the
 /// equipment-cast payoff (Puresteel Paladin's draw).
-fn trigger_references_equipment(trigger: &TriggerDefinition) -> bool {
+pub(crate) fn trigger_references_equipment(trigger: &TriggerDefinition) -> bool {
     trigger
         .valid_card
         .as_ref()
@@ -200,7 +200,7 @@ fn trigger_references_equipment(trigger: &TriggerDefinition) -> bool {
 
 /// CR 702.6: a static that grants the Equip keyword (typically a cheaper equip,
 /// e.g. Puresteel Paladin's `equip {0}`) to your Equipment.
-fn static_grants_equip(static_def: &StaticDefinition) -> bool {
+pub(crate) fn static_grants_equip(static_def: &StaticDefinition) -> bool {
     static_def.modifications.iter().any(|modification| {
         matches!(
             modification,

--- a/crates/phase-ai/src/features/equipment.rs
+++ b/crates/phase-ai/src/features/equipment.rs
@@ -1,0 +1,253 @@
+//! Equipment / Voltron feature — structural detection over a deck's typed AST.
+//!
+//! Parser AST verification — VERIFIED (no parser remediation required; every
+//! axis classifies from the existing typed AST, never by card name):
+//! - Equipment density: a face whose `card_type.subtypes` contains `"Equipment"`
+//!   (CR 301.5 — the artifact subtype that attaches to a creature). Detected via
+//!   `TypeFilter::Subtype("Equipment")`; there is no `TypeFilter::Equipment`.
+//! - Equipment-support payoffs (the "equipment-matters" intent signal), all on
+//!   NON-Equipment cards so the two pillars stay distinct:
+//!   - tutor: `Effect::SearchLibrary { filter }` referencing Equipment
+//!     (CR 701.23 — Stoneforge Mystic, Steelshaper's Gift);
+//!   - free/triggered attach: `Effect::Attach { attachment }` referencing
+//!     Equipment (CR 301.5 — Kor Outfitter, Brass Squire), distinct from an
+//!     Equipment's own equip ability (`attachment` is `SelfRef`, and the
+//!     `!Equipment` guard excludes it regardless);
+//!   - equipment-cast / ETB trigger: a `TriggerDefinition.valid_card` referencing
+//!     Equipment (CR 601.2 — Puresteel Paladin's draw on equipment ETB);
+//!   - equip-cost grant: a `StaticDefinition` whose `modifications` add the
+//!     `Equip` keyword to your Equipment (CR 702.6 — Puresteel's `equip {0}`).
+//!
+//! Why this is not redundant with existing handling: `features/artifacts.rs`
+//! values artifact *count* / affinity-improvise payoffs with zero equip or
+//! voltron awareness, and `policies/equipment_priority.rs` is an *anti-over-
+//! equipping guard* that only rejects wasteful re-equips and never rewards
+//! equipping or recognizes the deck-level voltron plan. This axis fills that gap;
+//! the companion `EquipmentPayoffPolicy` is payoff-gated and acts only on
+//! `CastSpell`, deferring the equip-activation decision to `EquipmentPriority`.
+
+use engine::types::ability::{
+    ContinuousModification, Effect, StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter,
+    TypedFilter,
+};
+use engine::types::card::CardFace;
+use engine::types::card_type::CoreType;
+use engine::types::keywords::Keyword;
+
+use engine::game::DeckEntry;
+
+use crate::ability_chain::collect_chain_effects;
+use crate::features::commitment;
+
+/// Commitment floor below which `EquipmentPayoffPolicy` opts out. Matches the
+/// reanimator / lifegain / enchantments payoff-axis convention.
+pub const COMMITMENT_FLOOR: f32 = 0.30;
+
+/// Per-60-nonland Equipment density at which the fuel pillar saturates. Voltron /
+/// Hammer shells run ~12–16 Equipment per 60 nonland; the divisor is set so that
+/// two incidental swords (2 Equipment / 36 nonland) stay below the floor.
+const EQUIPMENT_FULL_DENSITY: f32 = 12.0;
+
+/// Per-60-nonland payoff density at which the intent pillar saturates. A
+/// committed equipment deck runs ~6–10 support cards (tutors, equip-cost
+/// reducers, auto-attachers, equipment-cast payoffs).
+const PAYOFF_FULL_DENSITY: f32 = 7.0;
+
+/// CR 301.5: the artifact subtype that marks an Equipment. Compared
+/// case-insensitively against `TypeFilter::Subtype` and `CardType.subtypes`.
+const EQUIPMENT_SUBTYPE: &str = "Equipment";
+
+/// Per-deck equipment / voltron classification.
+///
+/// Populated once per game from `DeckEntry` data. Detection is structural over
+/// `CardFace.{card_type,abilities,triggers,static_abilities}` — never by card
+/// name. The companion `EquipmentPayoffPolicy` consumes this to value deploying
+/// Equipment and casting equipment payoffs when the deck is equipment-committed.
+#[derive(Debug, Clone, Default)]
+pub struct EquipmentFeature {
+    /// Equipment-subtype cards. CR 301.5. The fuel / voltron package.
+    pub equipment_count: u32,
+    /// Equipment-matters support cards — equipment tutors, free/triggered
+    /// attachers, equipment-cast/ETB payoffs, and equip-cost grants. The intent
+    /// signal that distinguishes a voltron deck from incidental Equipment.
+    pub payoff_count: u32,
+    /// `0.0..=1.0` — how central the equipment plan is to this deck. Requires
+    /// both Equipment density and a payoff; missing either collapses to inert.
+    /// Consumed by `EquipmentPayoffPolicy::activation` as the scaling knob.
+    pub commitment: f32,
+}
+
+/// Structural detection — walks each `DeckEntry`'s `CardFace` AST and counts
+/// Equipment and equipment-support payoffs.
+pub fn detect(deck: &[DeckEntry]) -> EquipmentFeature {
+    if deck.is_empty() {
+        return EquipmentFeature::default();
+    }
+
+    let mut equipment_count = 0u32;
+    let mut payoff_count = 0u32;
+    let mut total_nonland = 0u32;
+
+    for entry in deck {
+        let face = &entry.card;
+        if !face.card_type.core_types.contains(&CoreType::Land) {
+            total_nonland = total_nonland.saturating_add(entry.count);
+        }
+        if is_equipment(face) {
+            equipment_count = equipment_count.saturating_add(entry.count);
+        }
+        if is_equipment_payoff(face) {
+            payoff_count = payoff_count.saturating_add(entry.count);
+        }
+    }
+
+    let commitment = equipment_commitment(equipment_count, payoff_count, total_nonland);
+
+    EquipmentFeature {
+        equipment_count,
+        payoff_count,
+        commitment,
+    }
+}
+
+/// Geometric-mean commitment over the two required pillars (Equipment density
+/// and equipment-support payoffs).
+///
+/// A voltron deck needs BOTH a dense Equipment package AND support that makes
+/// equipment matter; missing either pillar means it is not an equipment-matters
+/// deck, so commitment collapses to `0.0` (which keeps the policy opted out for
+/// decks that merely run a couple of swords).
+///
+/// Calibration — Mono-White Equipment (≈38 nonland: 14 Equipment, 13 support):
+/// both pillar densities saturate → geometric mean 1.0, well above the floor.
+/// Anti-calibration — two incidental swords with no support collapse to 0.0.
+fn equipment_commitment(equipment_count: u32, payoff_count: u32, total_nonland: u32) -> f32 {
+    if equipment_count == 0 || payoff_count == 0 {
+        return 0.0;
+    }
+
+    let equipment = (commitment::density_per_60(equipment_count, total_nonland)
+        / EQUIPMENT_FULL_DENSITY)
+        .min(1.0);
+    let payoff =
+        (commitment::density_per_60(payoff_count, total_nonland) / PAYOFF_FULL_DENSITY).min(1.0);
+
+    commitment::geometric_mean(&[equipment, payoff]).min(1.0)
+}
+
+/// True if this face is an Equipment. CR 301.5.
+pub fn is_equipment(face: &CardFace) -> bool {
+    subtypes_contain_equipment(&face.card_type.subtypes)
+}
+
+/// True if this face is an equipment-matters support card: a NON-Equipment card
+/// that tutors / auto-attaches Equipment, triggers off your Equipment, or grants
+/// cheaper equip. These are the intent signal that the deck is built around
+/// equipment.
+pub fn is_equipment_payoff(face: &CardFace) -> bool {
+    let effects = collect_face_effects(face);
+    let triggers: Vec<&TriggerDefinition> = face.triggers.iter().collect();
+    let statics: Vec<&StaticDefinition> = face.static_abilities.iter().collect();
+    parts_are_equipment_payoff(&face.card_type.subtypes, &effects, &triggers, &statics)
+}
+
+/// Single authority — true if `subtypes` contains the Equipment subtype.
+/// Shared by deck-time `CardFace` detection and the live-game
+/// `EquipmentPayoffPolicy` (which reads `GameObject.card_types.subtypes`).
+pub(crate) fn subtypes_contain_equipment(subtypes: &[String]) -> bool {
+    subtypes
+        .iter()
+        .any(|sub| sub.eq_ignore_ascii_case(EQUIPMENT_SUBTYPE))
+}
+
+/// Single authority — true if these parts describe an equipment-matters support
+/// card. A card that is itself an Equipment is density, not support, so it is
+/// rejected here. Shared by the detector and the live policy so the two never
+/// drift; operates on the slices both a `CardFace` and a `GameObject` can supply.
+pub(crate) fn parts_are_equipment_payoff(
+    subtypes: &[String],
+    effects: &[&Effect],
+    triggers: &[&TriggerDefinition],
+    statics: &[&StaticDefinition],
+) -> bool {
+    if subtypes_contain_equipment(subtypes) {
+        return false;
+    }
+    effects.iter().copied().any(effect_is_equipment_support)
+        || triggers.iter().copied().any(trigger_references_equipment)
+        || statics.iter().copied().any(static_grants_equip)
+}
+
+/// CR 701.23 / CR 301.5: an effect that fetches an Equipment (tutor) or attaches
+/// one for free (auto-attacher). The Equipment's own equip ability attaches
+/// `SelfRef`, not an Equipment-filtered target, so it does not match here.
+fn effect_is_equipment_support(effect: &Effect) -> bool {
+    match effect {
+        Effect::SearchLibrary { filter, .. } => target_filter_references_equipment(filter),
+        Effect::Attach { attachment, .. } => target_filter_references_equipment(attachment),
+        _ => false,
+    }
+}
+
+/// CR 601.2: a trigger that fires off your Equipment (cast or ETB) — the
+/// equipment-cast payoff (Puresteel Paladin's draw).
+fn trigger_references_equipment(trigger: &TriggerDefinition) -> bool {
+    trigger
+        .valid_card
+        .as_ref()
+        .is_some_and(target_filter_references_equipment)
+}
+
+/// CR 702.6: a static that grants the Equip keyword (typically a cheaper equip,
+/// e.g. Puresteel Paladin's `equip {0}`) to your Equipment.
+fn static_grants_equip(static_def: &StaticDefinition) -> bool {
+    static_def.modifications.iter().any(|modification| {
+        matches!(
+            modification,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Equip(_),
+            }
+        )
+    })
+}
+
+/// CR 608.2b: unwrap a target filter and report whether it references the
+/// Equipment subtype.
+fn target_filter_references_equipment(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed_filter_references_equipment(typed),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(target_filter_references_equipment)
+        }
+        _ => false,
+    }
+}
+
+fn typed_filter_references_equipment(typed: &TypedFilter) -> bool {
+    typed.type_filters.iter().any(type_filter_is_equipment)
+}
+
+/// CR 205.3 / CR 301.5: the Equipment subtype, including inside an `AnyOf`
+/// disjunction ("an Aura or Equipment card", Steelshaper's Gift / Open the
+/// Armory).
+fn type_filter_is_equipment(tf: &TypeFilter) -> bool {
+    match tf {
+        TypeFilter::Subtype(sub) => sub.eq_ignore_ascii_case(EQUIPMENT_SUBTYPE),
+        TypeFilter::AnyOf(inner) => inner.iter().any(type_filter_is_equipment),
+        _ => false,
+    }
+}
+
+/// Flatten a face's ability chains and trigger-executed chains into the effect
+/// slice the support predicate inspects. An equipment tutor/attach can live in a
+/// Spell ability (Steelshaper's Gift), an activated ability (Brass Squire), or a
+/// trigger's executed chain (Kor Outfitter's ETB), so all are walked.
+fn collect_face_effects(face: &CardFace) -> Vec<&Effect> {
+    let ability_effects = face.abilities.iter().flat_map(collect_chain_effects);
+    let trigger_effects = face
+        .triggers
+        .iter()
+        .filter_map(|trigger| trigger.execute.as_deref())
+        .flat_map(collect_chain_effects);
+    ability_effects.chain(trigger_effects).collect()
+}

--- a/crates/phase-ai/src/features/mod.rs
+++ b/crates/phase-ai/src/features/mod.rs
@@ -12,6 +12,7 @@ pub mod artifacts;
 pub mod commitment;
 pub mod control;
 pub mod enchantments;
+pub mod equipment;
 pub mod landfall;
 pub mod lifegain;
 pub mod mana_ramp;
@@ -29,6 +30,7 @@ pub use aristocrats::AristocratsFeature;
 pub use artifacts::ArtifactsFeature;
 pub use control::ControlFeature;
 pub use enchantments::EnchantmentsFeature;
+pub use equipment::EquipmentFeature;
 pub use landfall::LandfallFeature;
 pub use lifegain::LifegainFeature;
 pub use mana_ramp::ManaRampFeature;
@@ -59,6 +61,7 @@ pub struct DeckFeatures {
     pub tribal: TribalFeature,
     pub control: ControlFeature,
     pub enchantments: EnchantmentsFeature,
+    pub equipment: EquipmentFeature,
     pub aristocrats: AristocratsFeature,
     pub artifacts: ArtifactsFeature,
     pub aggro_pressure: AggroPressureFeature,
@@ -99,6 +102,7 @@ impl DeckFeatures {
             tribal: tribal::detect(deck),
             control: control::detect(deck),
             enchantments: enchantments::detect(deck),
+            equipment: equipment::detect(deck),
             aristocrats: aristocrats::detect(deck),
             artifacts: artifacts::detect(deck),
             aggro_pressure: aggro_pressure::detect(deck),

--- a/crates/phase-ai/src/features/tests/equipment.rs
+++ b/crates/phase-ai/src/features/tests/equipment.rs
@@ -1,0 +1,265 @@
+//! Tests for the equipment / voltron feature detector. Live in a sibling test
+//! module (declared from `features/tests/mod.rs`) so `features/equipment.rs`
+//! stays implementation-only and SOURCE-classified.
+//!
+//! Detection is verified structurally — every test builds a `CardFace` AST and
+//! asserts the detector's counts. No card-name classification is used.
+
+use engine::game::DeckEntry;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, ContinuousModification, Effect, QuantityExpr,
+    SearchSelectionConstraint, StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter,
+    TypedFilter,
+};
+use engine::types::card::CardFace;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::keywords::Keyword;
+use engine::types::mana::ManaCost;
+use engine::types::statics::StaticMode;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+use crate::features::equipment::{detect, is_equipment, is_equipment_payoff, COMMITMENT_FLOOR};
+
+fn face(name: &str, core: Vec<CoreType>, subtypes: Vec<&str>) -> CardFace {
+    CardFace {
+        name: name.to_string(),
+        card_type: CardType {
+            supertypes: Vec::new(),
+            core_types: core,
+            subtypes: subtypes.into_iter().map(String::from).collect(),
+        },
+        ..Default::default()
+    }
+}
+
+fn entry(card: CardFace, count: u32) -> DeckEntry {
+    DeckEntry { card, count }
+}
+
+fn spell(effect: Effect) -> AbilityDefinition {
+    AbilityDefinition::new(AbilityKind::Spell, effect)
+}
+
+fn equipment_filter() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype(
+        "Equipment".to_string(),
+    )))
+}
+
+/// A plain Equipment — Artifact with the Equipment subtype.
+fn equipment(name: &str) -> CardFace {
+    face(name, vec![CoreType::Artifact], vec!["Equipment"])
+}
+
+/// "Search your library for an Equipment card" — a tutor payoff (Stoneforge).
+fn search_equipment() -> Effect {
+    Effect::SearchLibrary {
+        source_zones: vec![Zone::Library],
+        filter: equipment_filter(),
+        count: QuantityExpr::Fixed { value: 1 },
+        reveal: true,
+        target_player: None,
+        selection_constraint: SearchSelectionConstraint::None,
+        split: None,
+    }
+}
+
+/// "Attach an Equipment you control to a creature" — an auto-attacher payoff.
+fn attach_equipment() -> Effect {
+    Effect::Attach {
+        attachment: equipment_filter(),
+        target: TargetFilter::Any,
+    }
+}
+
+/// A static that grants `equip {0}` to your Equipment (Puresteel-shape payoff).
+fn equip_grant_static() -> StaticDefinition {
+    let mut def = StaticDefinition::new(StaticMode::Continuous);
+    def.affected = Some(equipment_filter());
+    def.modifications = vec![ContinuousModification::AddKeyword {
+        keyword: Keyword::Equip(ManaCost::generic(0)),
+    }];
+    def
+}
+
+// ─── density ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn equipment_subtype_is_density() {
+    let f = detect(&[entry(equipment("Bonesplitter"), 1)]);
+    assert_eq!(f.equipment_count, 1);
+    assert_eq!(f.payoff_count, 0);
+}
+
+#[test]
+fn equipment_with_its_own_equip_ability_is_not_payoff() {
+    // An Equipment's own equip ability attaches `SelfRef`; the `!Equipment` guard
+    // also excludes it. It must count as density, never as support.
+    let mut e = equipment("Vulshok Morningstar");
+    e.abilities.push(AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Attach {
+            attachment: TargetFilter::SelfRef,
+            target: TargetFilter::Any,
+        },
+    ));
+    assert!(is_equipment(&e));
+    assert!(!is_equipment_payoff(&e));
+}
+
+// ─── payoff detection ─────────────────────────────────────────────────────────
+
+#[test]
+fn equipment_tutor_is_payoff() {
+    let mut c = face("Stoneforge Mystic", vec![CoreType::Creature], vec![]);
+    c.triggers
+        .push(TriggerDefinition::new(TriggerMode::ChangesZone).execute(spell(search_equipment())));
+    assert!(is_equipment_payoff(&c));
+}
+
+#[test]
+fn auto_attacher_is_payoff() {
+    let mut c = face("Kor Outfitter", vec![CoreType::Creature], vec![]);
+    c.triggers
+        .push(TriggerDefinition::new(TriggerMode::ChangesZone).execute(spell(attach_equipment())));
+    assert!(is_equipment_payoff(&c));
+}
+
+#[test]
+fn equipment_cast_trigger_is_payoff() {
+    let mut c = face("Equipment Drawer", vec![CoreType::Creature], vec![]);
+    c.triggers
+        .push(TriggerDefinition::new(TriggerMode::SpellCast).valid_card(equipment_filter()));
+    assert!(is_equipment_payoff(&c));
+}
+
+#[test]
+fn equip_cost_grant_static_is_payoff() {
+    let mut c = face("Puresteel Paladin", vec![CoreType::Creature], vec![]);
+    c.static_abilities.push(equip_grant_static());
+    assert!(is_equipment_payoff(&c));
+}
+
+#[test]
+fn anyof_equipment_tutor_is_payoff() {
+    // "Search for an Aura or Equipment card" (Steelshaper's Gift / Open the
+    // Armory) — Equipment inside a `TypeFilter::AnyOf` must still be recognized.
+    let mut c = face("Open the Armory", vec![CoreType::Sorcery], vec![]);
+    c.abilities.push(spell(Effect::SearchLibrary {
+        source_zones: vec![Zone::Library],
+        filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::AnyOf(vec![
+            TypeFilter::Subtype("Aura".to_string()),
+            TypeFilter::Subtype("Equipment".to_string()),
+        ]))),
+        count: QuantityExpr::Fixed { value: 1 },
+        reveal: true,
+        target_player: None,
+        selection_constraint: SearchSelectionConstraint::None,
+        split: None,
+    }));
+    assert!(is_equipment_payoff(&c));
+}
+
+#[test]
+fn vanilla_creature_is_not_payoff() {
+    let c = face("Savannah Lions", vec![CoreType::Creature], vec![]);
+    assert!(!is_equipment(&c));
+    assert!(!is_equipment_payoff(&c));
+}
+
+// ─── default / inert ──────────────────────────────────────────────────────────
+
+#[test]
+fn empty_deck_defaults() {
+    let f = detect(&[]);
+    assert_eq!(f.equipment_count, 0);
+    assert_eq!(f.payoff_count, 0);
+    assert_eq!(f.commitment, 0.0);
+}
+
+// ─── calibration anchors ──────────────────────────────────────────────────────
+
+#[test]
+fn positive_calibration_real_equipment_deck_activates() {
+    // 14 Equipment + 8 support in a 38-nonland deck must clear the floor.
+    let mut deck = vec![entry(face("Filler", vec![CoreType::Creature], vec![]), 16)];
+    for i in 0..14 {
+        deck.push(entry(equipment(&format!("Equip {i}")), 1));
+    }
+    for i in 0..8 {
+        let mut c = face(&format!("Support {i}"), vec![CoreType::Creature], vec![]);
+        c.triggers.push(
+            TriggerDefinition::new(TriggerMode::ChangesZone).execute(spell(search_equipment())),
+        );
+        deck.push(entry(c, 1));
+    }
+    let f = detect(&deck);
+    assert_eq!(f.equipment_count, 14);
+    assert_eq!(f.payoff_count, 8);
+    assert!(
+        f.commitment >= COMMITMENT_FLOOR,
+        "real equipment deck must activate, got {}",
+        f.commitment
+    );
+}
+
+#[test]
+fn anti_calibration_equipment_without_payoff_inert() {
+    // A pile of swords with no support is not an equipment-matters deck.
+    let mut deck = vec![entry(face("Filler", vec![CoreType::Creature], vec![]), 24)];
+    for i in 0..12 {
+        deck.push(entry(equipment(&format!("Equip {i}")), 1));
+    }
+    let f = detect(&deck);
+    assert_eq!(f.equipment_count, 12);
+    assert_eq!(f.payoff_count, 0);
+    assert!(
+        f.commitment < COMMITMENT_FLOOR,
+        "equipment without support must stay inert, got {}",
+        f.commitment
+    );
+}
+
+#[test]
+fn anti_calibration_payoff_without_equipment_inert() {
+    // Equipment-support cards with no Equipment to enable are inert.
+    let mut deck = vec![entry(face("Filler", vec![CoreType::Creature], vec![]), 30)];
+    for i in 0..6 {
+        let mut c = face(&format!("Support {i}"), vec![CoreType::Creature], vec![]);
+        c.triggers.push(
+            TriggerDefinition::new(TriggerMode::ChangesZone).execute(spell(search_equipment())),
+        );
+        deck.push(entry(c, 1));
+    }
+    let f = detect(&deck);
+    assert_eq!(f.equipment_count, 0);
+    assert_eq!(f.payoff_count, 6);
+    assert!(
+        f.commitment < COMMITMENT_FLOOR,
+        "support without Equipment must stay inert, got {}",
+        f.commitment
+    );
+}
+
+#[test]
+fn anti_calibration_two_incidental_swords_inert() {
+    // Two swords + one tutor in an otherwise unrelated 36-nonland deck must not
+    // cross the floor (the false-positive guard).
+    let mut deck = vec![entry(face("Filler", vec![CoreType::Creature], vec![]), 33)];
+    deck.push(entry(equipment("Sword A"), 1));
+    deck.push(entry(equipment("Sword B"), 1));
+    let mut tutor = face("Lone Tutor", vec![CoreType::Creature], vec![]);
+    tutor
+        .triggers
+        .push(TriggerDefinition::new(TriggerMode::ChangesZone).execute(spell(search_equipment())));
+    deck.push(entry(tutor, 1));
+    let f = detect(&deck);
+    assert_eq!(f.equipment_count, 2);
+    assert_eq!(f.payoff_count, 1);
+    assert!(
+        f.commitment < COMMITMENT_FLOOR,
+        "two incidental swords + one tutor must stay inert, got {}",
+        f.commitment
+    );
+}

--- a/crates/phase-ai/src/features/tests/mod.rs
+++ b/crates/phase-ai/src/features/tests/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod artifacts;
 pub mod enchantments;
+pub mod equipment;
 pub mod lifegain;
 pub mod no_name_matching;
 pub mod reanimator;

--- a/crates/phase-ai/src/policies/equipment_payoff.rs
+++ b/crates/phase-ai/src/policies/equipment_payoff.rs
@@ -17,7 +17,6 @@
 //! `EquipmentPriorityPolicy`, which vetoes wasteful same-host re-equips. Keeping
 //! this policy on the cast step avoids fighting that anti-over-equip guard.
 
-use engine::types::ability::{Effect, StaticDefinition, TriggerDefinition};
 use engine::types::actions::GameAction;
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
@@ -26,7 +25,8 @@ use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
 use crate::ability_chain::collect_chain_effects;
 use crate::features::equipment::{
-    parts_are_equipment_payoff, subtypes_contain_equipment, COMMITMENT_FLOOR,
+    effect_is_equipment_support, static_grants_equip, subtypes_contain_equipment,
+    trigger_references_equipment, COMMITMENT_FLOOR,
 };
 use crate::features::DeckFeatures;
 
@@ -78,25 +78,31 @@ impl TacticalPolicy for EquipmentPayoffPolicy {
             );
         }
 
-        // Re-classify the live object structurally (shared with the deck-time
-        // detector) to value casting an equipment-matters support card.
-        let effects: Vec<&Effect> = object
-            .abilities
-            .iter()
-            .flat_map(collect_chain_effects)
-            .chain(
-                object
-                    .trigger_definitions
-                    .iter_unchecked()
-                    .filter_map(|trigger| trigger.execute.as_deref())
-                    .flat_map(collect_chain_effects),
-            )
-            .collect();
-        let triggers: Vec<&TriggerDefinition> =
-            object.trigger_definitions.iter_unchecked().collect();
-        let statics: Vec<&StaticDefinition> = object.static_definitions.iter_unchecked().collect();
+        // Re-classify the live object lazily — statics, triggers, then effects —
+        // short-circuiting as soon as any condition passes. The Equipment guard
+        // above already returned, so checking subtypes again is not needed.
+        let is_payoff = object
+            .static_definitions
+            .iter_unchecked()
+            .any(static_grants_equip)
+            || object
+                .trigger_definitions
+                .iter_unchecked()
+                .any(trigger_references_equipment)
+            || object
+                .abilities
+                .iter()
+                .flat_map(collect_chain_effects)
+                .chain(
+                    object
+                        .trigger_definitions
+                        .iter_unchecked()
+                        .filter_map(|trigger| trigger.execute.as_deref())
+                        .flat_map(collect_chain_effects),
+                )
+                .any(effect_is_equipment_support);
 
-        if parts_are_equipment_payoff(&object.card_types.subtypes, &effects, &triggers, &statics) {
+        if is_payoff {
             return PolicyVerdict::score(
                 ctx.penalties().equipment_payoff_cast_bonus,
                 PolicyReason::new("equipment_payoff_cast"),

--- a/crates/phase-ai/src/policies/equipment_payoff.rs
+++ b/crates/phase-ai/src/policies/equipment_payoff.rs
@@ -1,0 +1,108 @@
+//! Equipment / Voltron payoff tactical policy.
+//!
+//! For decks committed to the equipment axis *and* containing both an Equipment
+//! package and equipment-matters support, values two kinds of casts:
+//!   1. deploying an Equipment — growing the voltron package (CR 301.5); and
+//!   2. casting an equipment payoff — a tutor / auto-attacher / equip-cost
+//!      grant / equipment-cast trigger that makes the package matter (CR 701.23
+//!      / CR 702.6 / CR 601.2).
+//!
+//! Strictly **payoff-gated**: it opts out entirely unless the deck has both
+//! Equipment density and a payoff, so a deck that merely runs a couple of swords
+//! is unaffected.
+//!
+//! Coexistence with `EquipmentPriorityPolicy`: this policy acts only on
+//! `CastSpell`. It deliberately does NOT reward the equip activation itself
+//! (`ActivateAbility` / `WaitingFor::EquipTarget`) — that decision is owned by
+//! `EquipmentPriorityPolicy`, which vetoes wasteful same-host re-equips. Keeping
+//! this policy on the cast step avoids fighting that anti-over-equip guard.
+
+use engine::types::ability::{Effect, StaticDefinition, TriggerDefinition};
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::ability_chain::collect_chain_effects;
+use crate::features::equipment::{
+    parts_are_equipment_payoff, subtypes_contain_equipment, COMMITMENT_FLOOR,
+};
+use crate::features::DeckFeatures;
+
+pub struct EquipmentPayoffPolicy;
+
+impl TacticalPolicy for EquipmentPayoffPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::EquipmentPayoff
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::CastSpell]
+    }
+
+    fn activation(
+        &self,
+        features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        let equipment = &features.equipment;
+        // Payoff-gated: Equipment with no support is not an equipment-matters
+        // deck, and support with no Equipment has nothing to enable — either way
+        // the plan is absent, so the policy is inert (keeps non-equipment decks
+        // unaffected).
+        if equipment.equipment_count == 0
+            || equipment.payoff_count == 0
+            || equipment.commitment < COMMITMENT_FLOOR
+        {
+            None
+        } else {
+            Some(equipment.commitment)
+        }
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let GameAction::CastSpell { object_id, .. } = &ctx.candidate.action else {
+            return PolicyVerdict::neutral(PolicyReason::new("equipment_payoff_na"));
+        };
+        let Some(object) = ctx.state.objects.get(object_id) else {
+            return PolicyVerdict::neutral(PolicyReason::new("equipment_payoff_na"));
+        };
+
+        // Deploying an Equipment grows the voltron package. CR 301.5.
+        if subtypes_contain_equipment(&object.card_types.subtypes) {
+            return PolicyVerdict::score(
+                ctx.penalties().deploy_equipment_bonus,
+                PolicyReason::new("deploy_equipment_for_payoff"),
+            );
+        }
+
+        // Re-classify the live object structurally (shared with the deck-time
+        // detector) to value casting an equipment-matters support card.
+        let effects: Vec<&Effect> = object
+            .abilities
+            .iter()
+            .flat_map(collect_chain_effects)
+            .chain(
+                object
+                    .trigger_definitions
+                    .iter_unchecked()
+                    .filter_map(|trigger| trigger.execute.as_deref())
+                    .flat_map(collect_chain_effects),
+            )
+            .collect();
+        let triggers: Vec<&TriggerDefinition> =
+            object.trigger_definitions.iter_unchecked().collect();
+        let statics: Vec<&StaticDefinition> = object.static_definitions.iter_unchecked().collect();
+
+        if parts_are_equipment_payoff(&object.card_types.subtypes, &effects, &triggers, &statics) {
+            return PolicyVerdict::score(
+                ctx.penalties().equipment_payoff_cast_bonus,
+                PolicyReason::new("equipment_payoff_cast"),
+            );
+        }
+
+        PolicyVerdict::neutral(PolicyReason::new("equipment_payoff_inert"))
+    }
+}

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -18,6 +18,7 @@ mod downside_awareness;
 pub(crate) mod effect_classify;
 mod effect_timing;
 mod enchantments_payoff;
+mod equipment_payoff;
 mod equipment_priority;
 mod etb_value;
 mod evasion_removal_priority;

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -12,6 +12,7 @@ use super::context::PolicyContext;
 use super::copy_value::CopyValuePolicy;
 use super::effect_timing::EffectTimingPolicy;
 use super::enchantments_payoff::EnchantmentsPayoffPolicy;
+use super::equipment_payoff::EquipmentPayoffPolicy;
 use super::etb_value::EtbValuePolicy;
 use super::evasion_removal_priority::EvasionRemovalPriorityPolicy;
 use super::fetch_land_patience::FetchLandPatiencePolicy;
@@ -56,6 +57,7 @@ pub enum PolicyId {
     BoardDevelopment,
     EtbValue,
     EnchantmentsPayoff,
+    EquipmentPayoff,
     CopyValue,
     Tutor,
     HandDisruption,
@@ -278,6 +280,7 @@ impl Default for PolicyRegistry {
             Box::new(BoardDevelopmentPolicy),
             Box::new(EtbValuePolicy),
             Box::new(EnchantmentsPayoffPolicy),
+            Box::new(EquipmentPayoffPolicy),
             Box::new(CopyValuePolicy),
             Box::new(TutorPolicy),
             Box::new(HandDisruptionPolicy),

--- a/crates/phase-ai/src/policies/tests/equipment_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/equipment_payoff.rs
@@ -1,0 +1,233 @@
+//! Tests for `EquipmentPayoffPolicy`. Live in a sibling test module (declared
+//! from `policies/tests/mod.rs`) so `policies/equipment_payoff.rs` stays
+//! implementation-only and SOURCE-classified.
+
+use std::sync::Arc;
+
+use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, QuantityExpr, SearchSelectionConstraint, TargetFilter,
+    TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::game_state::{CastPaymentMode, GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+use crate::config::AiConfig;
+use crate::context::AiContext;
+use crate::features::equipment::EquipmentFeature;
+use crate::features::DeckFeatures;
+use crate::session::AiSession;
+
+use super::super::context::PolicyContext;
+use super::super::equipment_payoff::EquipmentPayoffPolicy;
+use super::super::registry::{DecisionKind, PolicyId, PolicyVerdict, TacticalPolicy};
+
+const AI: PlayerId = PlayerId(0);
+
+fn features(commitment: f32, equipment_count: u32, payoff_count: u32) -> DeckFeatures {
+    DeckFeatures {
+        equipment: EquipmentFeature {
+            equipment_count,
+            payoff_count,
+            commitment,
+        },
+        ..DeckFeatures::default()
+    }
+}
+
+fn ai_context(commitment: f32, equipment_count: u32, payoff_count: u32) -> (AiContext, AiConfig) {
+    let config = AiConfig::default();
+    let mut session = AiSession::empty();
+    session
+        .features
+        .insert(AI, features(commitment, equipment_count, payoff_count));
+    let mut context = AiContext::empty(&config.weights);
+    context.session = Arc::new(session);
+    context.player = AI;
+    (context, config)
+}
+
+fn decision() -> AiDecisionContext {
+    AiDecisionContext {
+        waiting_for: WaitingFor::Priority { player: AI },
+        candidates: Vec::new(),
+    }
+}
+
+fn cast_candidate(object_id: ObjectId) -> CandidateAction {
+    CandidateAction {
+        action: GameAction::CastSpell {
+            object_id,
+            card_id: CardId(object_id.0),
+            targets: Vec::new(),
+            payment_mode: CastPaymentMode::default(),
+        },
+        metadata: ActionMetadata {
+            actor: Some(AI),
+            tactical_class: TacticalClass::Spell,
+        },
+    }
+}
+
+fn spell_object(
+    state: &mut GameState,
+    idx: u64,
+    core: Vec<CoreType>,
+    subtypes: Vec<&str>,
+) -> ObjectId {
+    let oid = create_object(state, CardId(idx), AI, format!("Spell {idx}"), Zone::Stack);
+    state.objects.get_mut(&oid).unwrap().card_types = CardType {
+        supertypes: Vec::new(),
+        core_types: core,
+        subtypes: subtypes.into_iter().map(String::from).collect(),
+    };
+    oid
+}
+
+fn push_ability(state: &mut GameState, oid: ObjectId, ability: AbilityDefinition) {
+    Arc::make_mut(&mut state.objects.get_mut(&oid).unwrap().abilities).push(ability);
+}
+
+fn search_equipment_ability() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::SearchLibrary {
+            source_zones: vec![Zone::Library],
+            filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype(
+                "Equipment".to_string(),
+            ))),
+            count: QuantityExpr::Fixed { value: 1 },
+            reveal: true,
+            target_player: None,
+            selection_constraint: SearchSelectionConstraint::None,
+            split: None,
+        },
+    )
+}
+
+fn ctx<'a>(
+    state: &'a GameState,
+    candidate: &'a CandidateAction,
+    decision: &'a AiDecisionContext,
+    context: &'a AiContext,
+    config: &'a AiConfig,
+) -> PolicyContext<'a> {
+    PolicyContext {
+        state,
+        decision,
+        candidate,
+        ai_player: AI,
+        config,
+        context,
+        cast_facts: None,
+    }
+}
+
+fn delta_of(verdict: PolicyVerdict) -> (f64, String) {
+    match verdict {
+        PolicyVerdict::Score { delta, reason } => (delta, reason.kind.to_string()),
+        PolicyVerdict::Reject { .. } => panic!("unexpected Reject"),
+    }
+}
+
+// ─── identity ────────────────────────────────────────────────────────────────
+
+#[test]
+fn policy_identity() {
+    assert_eq!(EquipmentPayoffPolicy.id(), PolicyId::EquipmentPayoff);
+    assert!(EquipmentPayoffPolicy
+        .decision_kinds()
+        .contains(&DecisionKind::CastSpell));
+}
+
+// ─── activation gate ─────────────────────────────────────────────────────────
+
+#[test]
+fn opts_out_with_no_equipment() {
+    let features = features(0.9, 0, 6);
+    let state = GameState::new_two_player(7);
+    assert!(EquipmentPayoffPolicy
+        .activation(&features, &state, AI)
+        .is_none());
+}
+
+#[test]
+fn opts_out_with_no_payoff() {
+    let features = features(0.9, 12, 0);
+    let state = GameState::new_two_player(7);
+    assert!(EquipmentPayoffPolicy
+        .activation(&features, &state, AI)
+        .is_none());
+}
+
+#[test]
+fn opts_out_below_commitment_floor() {
+    let features = features(0.1, 12, 6);
+    let state = GameState::new_two_player(7);
+    assert!(EquipmentPayoffPolicy
+        .activation(&features, &state, AI)
+        .is_none());
+}
+
+#[test]
+fn opts_in_with_equipment_and_payoff_above_floor() {
+    let features = features(0.6, 12, 6);
+    let state = GameState::new_two_player(7);
+    assert_eq!(
+        EquipmentPayoffPolicy.activation(&features, &state, AI),
+        Some(0.6)
+    );
+}
+
+// ─── verdict ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn deploy_equipment_scored() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 1, vec![CoreType::Artifact], vec!["Equipment"]);
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(0.8, 12, 6);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, kind) = delta_of(EquipmentPayoffPolicy.verdict(&ctx));
+    assert_eq!(kind, "deploy_equipment_for_payoff");
+    assert!(delta > 0.0, "expected a positive delta, got {delta}");
+}
+
+#[test]
+fn equipment_payoff_cast_scored() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 2, vec![CoreType::Creature], vec![]);
+    push_ability(&mut state, oid, search_equipment_ability());
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(0.8, 12, 6);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, kind) = delta_of(EquipmentPayoffPolicy.verdict(&ctx));
+    assert_eq!(kind, "equipment_payoff_cast");
+    assert!(delta > 0.0, "expected a positive delta, got {delta}");
+}
+
+#[test]
+fn non_equipment_spell_inert() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 3, vec![CoreType::Sorcery], vec![]);
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(0.8, 12, 6);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, kind) = delta_of(EquipmentPayoffPolicy.verdict(&ctx));
+    assert_eq!(kind, "equipment_payoff_inert");
+    assert_eq!(delta, 0.0);
+}

--- a/crates/phase-ai/src/policies/tests/mod.rs
+++ b/crates/phase-ai/src/policies/tests/mod.rs
@@ -3,6 +3,7 @@
 pub mod activation_marker_lint;
 pub mod artifact_synergy;
 pub mod enchantments_payoff;
+pub mod equipment_payoff;
 pub mod lifegain_payoff;
 pub mod mulligan_input_lint;
 pub mod reanimator_payoff;

--- a/crates/phase-ai/tests/duel_suite_attribution.rs
+++ b/crates/phase-ai/tests/duel_suite_attribution.rs
@@ -57,6 +57,7 @@ fn expected_policies(kind: FeatureKind) -> &'static [&'static str] {
         FeatureKind::PlusOneCounters => &["PlusOneCountersTactical"],
         FeatureKind::SpellslingerProwess => &["SpellslingerCasting"],
         FeatureKind::Reanimator => &["ReanimatorPayoff"],
+        FeatureKind::Equipment => &["EquipmentPayoff"],
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #3597

Adds an equipment / voltron deck-feature axis (`EquipmentFeature`) and a payoff-gated `EquipmentPayoffPolicy` to `phase-ai`, so the AI recognizes the voltron plan: it values deploying Equipment and casting equipment-matters support (tutors, auto-attachers, equip-cost grants, equipment-cast payoffs) when the deck has both a dense Equipment package and that support, and stays inert otherwise.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> AI-only change scoped entirely to `crates/phase-ai/` (deck-feature detection + a tactical policy + a duel-deck snapshot + gate wiring). It touches **no** `crates/engine/` game logic — no parser, effect, resolver, targeting, or rules behavior. It was built against the repo's `add-ai-feature-policy` skill checklist, mirroring the just-merged reanimator axis (#3595).

## CR references

Annotations added in the new modules (all grep-verified against `docs/MagicCompRules.txt`):
- `CR 301.5` — Equipment artifact subtype (density + attach target)
- `CR 702.6` — Equip (keyword ability; equip-cost grant detection)
- `CR 701.23` — Search (equipment tutor detection)
- `CR 601.2` — casting a spell (equipment-cast trigger payoffs)
- `CR 205.3` — subtypes (Equipment inside `TypeFilter::AnyOf`)

## Verification

Tilt was down, so checks were run directly against `phase-ai` (no target-lock contention):

- `cargo fmt --all --check` — clean
- `cargo clippy -p phase-ai --all-targets -- -D warnings` — clean (incl. `no_name_matching`, `score_contract`, `activation_marker` lints)
- `cargo test -p phase-ai --lib` — **985 passed, 0 failed** (22 new equipment detector/policy tests; `PolicyPenalties` field-coverage test and all duel-suite invariants pass, incl. `feature_kind_matches_deck_features_field_count` 12→13, `every_feature_kind_is_exercised`, and `every_snapshot_loads` validating the new `mono-white-equipment.json`)
- `cargo test -p phase-ai --lib equipment_mirror_deck_activates_equipment_payoff -- --ignored` — **passes against real `card-data.json`**: the gate-tagged Mono-White Equipment deck clears `COMMITMENT_FLOOR`, so `EquipmentPayoffPolicy` runs **active, not dormant**.

### Notes
- New `PolicyPenalties` knobs (`deploy_equipment_bonus`, `equipment_payoff_cast_bonus`) are registered **UNTUNED**, pending a paired-seed `cargo ai-gate` calibration. A mirror matchup demonstrates non-regression + policy-active, not "improvement."
- Coexistence: `EquipmentPayoffPolicy` acts only on `CastSpell` and defers the equip activation to the existing `EquipmentPriorityPolicy` (the anti-over-equip guard), so the two don't fight on the equip decision.
- New duel-deck snapshot `crates/phase-ai/duel_decks/modern/mono-white-equipment.json` is the floor-crossing anchor (every card verified resolvable + deck verified to cross the floor before commit).
