### PR TITLE
fix(parser): Electrolyze second target slot (issue #3288)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3146,6 +3146,46 @@ fn strip_bounded_targets_placeholder(text: &str) -> Option<(&str, MultiTargetSpe
     None
 }
 
+/// CR 115.1d: "one or two target X" / "one, two, or three target X" before a
+/// targeted phrase (Electrolyze: "among one or two target creatures and/or
+/// players").
+fn strip_bounded_target_prefix(text: &str) -> Option<(&str, MultiTargetSpec)> {
+    let lower = text.to_ascii_lowercase();
+    for (prefix, min, max) in [
+        ("one or two target ", 1usize, 2usize),
+        ("one, two, or three target ", 1, 3),
+    ] {
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(prefix).parse(lower.as_str()) {
+            let consumed = lower.len() - rest.len();
+            return Some((
+                text[consumed..].trim_start(),
+                MultiTargetSpec::fixed(min, max),
+            ));
+        }
+    }
+    None
+}
+
+fn strip_distribute_among_target_quantifier<'a>(
+    text: &'a str,
+    pool: &QuantityExpr,
+) -> (&'a str, Option<MultiTargetSpec>) {
+    let target_lower = text.to_lowercase();
+    if let Ok((rest, _)) =
+        tag::<_, _, OracleError<'_>>("any number of ").parse(target_lower.as_str())
+    {
+        let skip = target_lower.len() - rest.len();
+        return (&text[skip..], Some(multi_target_for_distribute_among(pool)));
+    }
+    if let Some((rest, spec)) = strip_bounded_targets_placeholder(text) {
+        return (rest, Some(spec));
+    }
+    if let Some((rest, spec)) = strip_bounded_target_prefix(text) {
+        return (rest, Some(spec));
+    }
+    strip_optional_target_prefix(text)
+}
+
 /// CR 115.1d: Strip optional target-count prefixes before a targeted phrase.
 /// "up to one target creature" → ("target creature", Some { min: 0, max: Some(1) })
 /// "up to one other target creature or spell" → ("other target creature or spell", Some { ... })
@@ -3822,24 +3862,8 @@ pub(super) fn try_parse_distribute_damage(lower: &str, text: &str) -> Option<Par
     let target_text = target_tp.original.trim();
 
     // CR 115.1d: Detect the target-count quantifier before the target phrase.
-    // "any number of" is capped by the distribution pool (each chosen target must
-    // receive at least one — CR 601.2d), while "up to N target ..." carries an
-    // explicit printed cap of N independent of the divided amount (Shatterskull
-    // Smashing: "X damage divided ... among up to two target creatures and/or
-    // planeswalkers"). `strip_optional_target_prefix` surfaces the latter as
-    // MultiTargetSpec { min: 0, max: N }.
-    let target_lower = target_text.to_lowercase();
-    let (stripped_target_text, multi_target) = if let Ok((rest, _)) =
-        tag::<_, _, OracleError<'_>>("any number of ").parse(target_lower.as_str())
-    {
-        let skip = target_lower.len() - rest.len();
-        (
-            &target_text[skip..],
-            Some(multi_target_for_distribute_among(&amount)),
-        )
-    } else {
-        strip_optional_target_prefix(target_text)
-    };
+    let (stripped_target_text, multi_target) =
+        strip_distribute_among_target_quantifier(target_text, &amount);
     let (target, _) = parse_target(stripped_target_text);
 
     Some(ParsedEffectClause {
@@ -3913,18 +3937,8 @@ pub(super) fn try_parse_distribute_counters(lower: &str, text: &str) -> Option<P
 
     // CR 115.1d: Detect "any number of" quantifier before the target phrase.
     let target_text = &text[target_offset..];
-    let target_text_lower = &lower[target_offset..];
-    let (stripped_target, multi_target) = if let Ok((rest, _)) =
-        tag::<_, _, OracleError<'_>>("any number of ").parse(target_text_lower)
-    {
-        let skip = target_text_lower.len() - rest.len();
-        (
-            &target_text[skip..],
-            Some(multi_target_for_distribute_among(&count_expr)),
-        )
-    } else {
-        strip_optional_target_prefix(target_text)
-    };
+    let (stripped_target, multi_target) =
+        strip_distribute_among_target_quantifier(target_text, &count_expr);
     let (target, _) = parse_target(stripped_target);
 
     // Verify the "among" comes after the counter word (sanity guard against false matches).
@@ -3994,20 +4008,8 @@ pub(super) fn try_parse_prevent_distribute(text: &str) -> Option<ParsedEffectCla
         .or_else(|| after_damage_tp.strip_after("distributed among "))?;
     let target_text = target_tp.original.trim();
 
-    // CR 601.2d: each divide target must receive at least one unit — "any number of"
-    // corresponds to multi_target with min:0 (player may assign zero to any target).
-    let target_lower = target_text.to_lowercase();
-    let (stripped_target, multi_target) = if let Ok((rest, _)) =
-        tag::<_, _, OracleError<'_>>("any number of ").parse(target_lower.as_str())
-    {
-        let skip = target_lower.len() - rest.len();
-        (
-            &target_text[skip..],
-            Some(multi_target_for_distribute_among(&qty)),
-        )
-    } else {
-        strip_optional_target_prefix(target_text)
-    };
+    let (stripped_target, multi_target) =
+        strip_distribute_among_target_quantifier(target_text, &qty);
     let (target, _) = parse_target(stripped_target);
 
     // Convert the parsed QuantityExpr to PreventionAmount.

--- a/crates/engine/tests/integration/issue_3288_electrolyze_second_target.rs
+++ b/crates/engine/tests/integration/issue_3288_electrolyze_second_target.rs
@@ -1,0 +1,51 @@
+//! Regression for GitHub issue #3288 — Electrolyze second target selection.
+//!
+//! Oracle: "Electrolyze deals 2 damage divided as you choose among one or two
+//! target creatures and/or players. Draw a card."
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::ability_utils::build_target_slots;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{AbilityKind, MultiTargetSpec};
+use engine::types::phase::Phase;
+
+const ELECTROLYZE_ORACLE: &str = "Electrolyze deals 2 damage divided as you choose among one or two target creatures and/or players.\nDraw a card.";
+
+#[test]
+fn electrolyze_parses_one_or_two_target_quantifier() {
+    let mut scenario = GameScenario::new();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Electrolyze", true, ELECTROLYZE_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let ability = &runner.state().objects[&spell].abilities[0];
+    assert_eq!(ability.kind, AbilityKind::Spell);
+    assert_eq!(
+        ability.multi_target,
+        Some(MultiTargetSpec::fixed(1, 2)),
+        "Electrolyze must offer one required and one optional target slot"
+    );
+}
+
+#[test]
+fn electrolyze_builds_two_target_slots_at_cast_time() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let _bear = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    let _elf = scenario.add_creature(P1, "Llanowar Elves", 1, 1).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Electrolyze", true, ELECTROLYZE_ORACLE)
+        .id();
+
+    let runner = scenario.build();
+    let ability = runner.state().objects[&spell].abilities[0].clone();
+    let resolved = build_resolved_from_def(&ability, spell, P0);
+    let slots = build_target_slots(runner.state(), &resolved).expect("target slots");
+    assert_eq!(
+        slots.len(),
+        2,
+        "Electrolyze must build two target slots so a second target can be chosen (issue #3288)"
+    );
+    assert!(!slots[0].optional, "first target is required");
+    assert!(slots[1].optional, "second target is optional");
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -225,6 +225,7 @@ mod issue_3245_abhorrent_oculus_manifest_dread;
 mod issue_3260_phantasmal_image_persist;
 mod issue_3283_sevinne_reclamation_copy_no_self_copy;
 mod issue_3285_face_down_public_zone;
+mod issue_3288_electrolyze_second_target;
 mod issue_3295_scrapwork_mutt_unearth_zone;
 mod issue_3296_hordewing_skaab_discard;
 mod issue_3297_rite_token_abilities;


### PR DESCRIPTION
## Summary
- Parse bounded "one or two target …" quantifiers on divided-as-you-choose damage lines.
- Wire the quantifier through distribute-damage, distribute-counter, and prevent-distribute parsers.
- Add regression tests for Electrolyze `multi_target` parsing and two-slot target building.

Fixes #3288

## Test plan
- [x] `cargo test -p engine --test integration electrolyze`
- [x] `cargo clippy -p engine --tests -- -D warnings`

Made with [Cursor](https://cursor.com)