### PR TITLE
fix(parser): bind spell-form "that X doesn't untap" anaphor to the tapped object

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -15485,6 +15485,74 @@ mod tests {
         );
     }
 
+    /// Walk every parsed ability (and its `sub_ability` chain) looking for the
+    /// first `Effect::GenericEffect` whose `static_abilities` contains a
+    /// `CantUntap` static, and return that static's `affected` filter. Used to
+    /// assert the spell-form "that [type] doesn't untap" anaphor binds to the
+    /// single tapped object (`ParentTarget`) rather than broadcasting `Typed`.
+    fn first_cant_untap_affected(r: &ParsedAbilities) -> Option<TargetFilter> {
+        for ability in &r.abilities {
+            let mut cursor = Some(ability);
+            while let Some(def) = cursor {
+                if let Effect::GenericEffect {
+                    static_abilities, ..
+                } = def.effect.as_ref()
+                {
+                    if let Some(static_def) = static_abilities
+                        .iter()
+                        .find(|s| s.mode == crate::types::statics::StaticMode::CantUntap)
+                    {
+                        return static_def.affected.clone();
+                    }
+                }
+                cursor = def.sub_ability.as_deref();
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn spell_form_that_type_doesnt_untap_binds_parent_target() {
+        // CR 608.2c: spell-form "Tap target X. That X doesn't untap" is an
+        // anaphor to the single tapped object — the CantUntap static's
+        // `affected` must be `ParentTarget`, NOT a broadcast `Typed(...)` that
+        // would lock every matching permanent. Revert-discriminating: without
+        // `|| inherits_parent` in `static_affected_for_application`, `affected`
+        // is `Typed(Land)` / `Typed(Creature)` and these asserts fail.
+
+        // Chandra's Revolution: damage clause has its own target; the tap+lock
+        // clause binds the tapped LAND, not the damaged creature.
+        let chandra = parse(
+            "Chandra's Revolution deals 4 damage to target creature. Tap target land. That land doesn't untap during its controller's next untap step.",
+            "Chandra's Revolution",
+            &[],
+            &["Sorcery"],
+            &[],
+        );
+        assert_eq!(
+            first_cant_untap_affected(&chandra),
+            Some(TargetFilter::ParentTarget),
+            "Chandra's Revolution CantUntap static must bind ParentTarget, got {:?}",
+            first_cant_untap_affected(&chandra)
+        );
+
+        // Glacial Grasp: "Tap target creature. Its controller mills two cards.
+        // That creature doesn't untap…" → ParentTarget, not Typed(Creature).
+        let glacial = parse(
+            "Tap target creature. Its controller mills two cards. That creature doesn't untap during its controller's next untap step. Draw a card.",
+            "Glacial Grasp",
+            &[],
+            &["Instant"],
+            &[],
+        );
+        assert_eq!(
+            first_cant_untap_affected(&glacial),
+            Some(TargetFilter::ParentTarget),
+            "Glacial Grasp CantUntap static must bind ParentTarget, got {:?}",
+            first_cant_untap_affected(&glacial)
+        );
+    }
+
     #[test]
     fn spell_counter_tap_plus_doesnt_untap() {
         let r = parse(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -40451,13 +40451,17 @@ mod tests {
         let static_def = static_abilities
             .first()
             .expect("lifelink grant must carry a static definition");
-        assert!(
-            matches!(
-                static_def.affected.as_ref(),
-                Some(TargetFilter::Typed(tf))
-                    if tf.type_filters == [TypeFilter::Creature]
-            ),
-            "chain parser binds 'that creature' to a creature filter, got {:?}",
+        // CR 608.2c: "that creature" is an anaphor to the single chosen object,
+        // so `static_affected_for_application` binds the grant's `affected` to
+        // `ParentTarget` (via `inherits_parent`) — matching the outer
+        // GenericEffect `target` slot above. The runtime resolver
+        // (`generic_effect_application_filter`) treats both the inherited-ref
+        // `affected` and the `target` slot identically, so this is the
+        // self-consistent shape for an anaphoric grant.
+        assert_eq!(
+            static_def.affected.as_ref(),
+            Some(&TargetFilter::ParentTarget),
+            "chain parser binds 'that creature' to the parent target, got {:?}",
             static_def.affected
         );
         assert!(

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1747,8 +1747,18 @@ fn subject_filter_application(filter: TargetFilter, targeted: bool) -> Option<Su
 /// self-documenting and matches the convention used by sibling counter
 /// sub_abilities (`PutCounter { target: ParentTarget }`) and the
 /// `LastCreated` rewrite for token anaphors.
+///
+/// CR 608.2c + CR 502.3: also bind to the inherited target when the subject is
+/// an anaphor to a previously-mentioned single object (`inherits_parent`,
+/// e.g. spell-form "Tap target land. That land doesn't untap" — Chandra's
+/// Revolution, Glacial Grasp). Without this, the static's `affected` would
+/// broadcast the CantUntap lock over every matching permanent. The
+/// transient-effect resolver already binds `ParentTarget` to the inherited
+/// (immediately-preceding) object target, so this resolves to exactly the one
+/// tapped object. Mirrors `build_pump_effect`, which honors `inherits_parent`
+/// the same way for the Pump family.
 pub(super) fn static_affected_for_application(application: &SubjectApplication) -> TargetFilter {
-    if application.target.is_some() {
+    if application.target.is_some() || application.inherits_parent {
         TargetFilter::ParentTarget
     } else {
         application.affected.clone()

--- a/crates/engine/tests/integration/chandra_revolution_doesnt_untap_slot.rs
+++ b/crates/engine/tests/integration/chandra_revolution_doesnt_untap_slot.rs
@@ -1,0 +1,117 @@
+//! Spell-form "Tap target X. … That X doesn't untap during its controller's
+//! next untap step." must lock ONLY the single tapped object (CR 608.2c
+//! anaphor), not broadcast the CR 502.3 untap restriction over every matching
+//! permanent.
+//!
+//! Chandra's Revolution: "deals 4 damage to target creature. Tap target land.
+//! That land doesn't untap during its controller's next untap step." — the
+//! lock must bind the tapped land, leave a second land free to untap, and NOT
+//! bind the separately-targeted damaged creature.
+//!
+//! Glacial Grasp: "Tap target creature. Its controller mills two cards. That
+//! creature doesn't untap…" — the lock must bind the tapped creature and leave
+//! a second creature free to untap.
+//!
+//! Revert-discriminating: without `|| inherits_parent` in
+//! `static_affected_for_application`, the CantUntap static's `affected` is the
+//! broadcast `Typed(Land)` / `Typed(Creature)`, the engine installs a
+//! `SpecificObject` lock on EVERY matching permanent, and the "second
+//! permanent untaps" assertions below fail.
+//!
+//! CR 608.2c (anaphora), CR 502.3 (untap-step restriction).
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+
+const CHANDRA_REVOLUTION: &str = "Chandra's Revolution deals 4 damage to target creature. \
+Tap target land. That land doesn't untap during its controller's next untap step.";
+
+const GLACIAL_GRASP: &str = "Tap target creature. Its controller mills two cards. \
+That creature doesn't untap during its controller's next untap step. Draw a card.";
+
+#[test]
+fn chandra_revolution_locks_only_the_tapped_land() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Opponent (P1) controls two lands and a high-toughness creature so the 4
+    // damage doesn't kill it (we need it on the battlefield at P1's untap step).
+    let tapped_land = scenario.add_basic_land(P1, ManaColor::Red);
+    let other_land = scenario.add_basic_land(P1, ManaColor::Green);
+    let creature = scenario.add_creature(P1, "Stone Wall", 0, 9).id();
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Chandra's Revolution", false, CHANDRA_REVOLUTION)
+        .id();
+
+    let mut runner = scenario.build();
+    // Pre-tap the opponent's lands and creature so the untap step is observable.
+    for id in [tapped_land, other_land, creature] {
+        runner.state_mut().objects.get_mut(&id).unwrap().tapped = true;
+    }
+
+    // CR 601.2c: damage→creature, tap→land. Targets bind to slots in order.
+    runner
+        .cast(spell)
+        .target_objects(&[creature, tapped_land])
+        .resolve();
+
+    // Advance into the opponent's turn, past their untap step (CR 502.3), to
+    // the upkeep where priority is next granted.
+    runner.advance_to_phase(Phase::Upkeep);
+    assert_eq!(
+        runner.state().active_player,
+        P1,
+        "should now be the opponent's turn (their untap step has processed)"
+    );
+
+    assert!(
+        runner.state().objects[&tapped_land].tapped,
+        "the tapped land must stay tapped (its untap was locked)"
+    );
+    assert!(
+        !runner.state().objects[&other_land].tapped,
+        "a second land the opponent controls must UNTAP — the lock must not broadcast"
+    );
+    assert!(
+        !runner.state().objects[&creature].tapped,
+        "the damaged creature must UNTAP — the land lock must not bind the damage target"
+    );
+}
+
+#[test]
+fn glacial_grasp_locks_only_the_tapped_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let tapped_creature = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    let other_creature = scenario.add_creature(P1, "Hill Giant", 3, 3).id();
+    // Library content so the "mills two cards" clause has cards to mill, and a
+    // card for P0's "Draw a card" so the draw doesn't deck-out P0 (CR 104.3c).
+    scenario.with_library_top(P1, &["Plains", "Plains", "Plains"]);
+    scenario.with_library_top(P0, &["Island", "Island", "Island"]);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Glacial Grasp", true, GLACIAL_GRASP)
+        .id();
+
+    let mut runner = scenario.build();
+    for id in [tapped_creature, other_creature] {
+        runner.state_mut().objects.get_mut(&id).unwrap().tapped = true;
+    }
+
+    runner.cast(spell).target_object(tapped_creature).resolve();
+
+    runner.advance_to_phase(Phase::Upkeep);
+    assert_eq!(runner.state().active_player, P1);
+
+    assert!(
+        runner.state().objects[&tapped_creature].tapped,
+        "the tapped creature must stay tapped (its untap was locked)"
+    );
+    assert!(
+        !runner.state().objects[&other_creature].tapped,
+        "a second creature the opponent controls must UNTAP — the lock must not broadcast"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -32,6 +32,7 @@ mod cascade_intervening_if_pipeline;
 mod case_solve_condition;
 mod cast_during_resolution_pipeline;
 mod chain_of_smog_copy;
+mod chandra_revolution_doesnt_untap_slot;
 mod charging_cinderhorn_issue_2868;
 mod chatterstorm_storm;
 mod cleave_text_changing_cost;


### PR DESCRIPTION
Fixes #3604.

## Summary

Spell-form sequences "Tap target X. … That X doesn't untap during its controller's next untap step" broadcast the no-untap lock to every matching permanent instead of the single tapped object:

- **Chandra's Revolution** — "deals 4 damage to target creature. Tap target land. That land doesn't untap…" stopped EVERY land from untapping.
- **Glacial Grasp** — "Tap target creature. … That creature doesn't untap…" stopped EVERY creature.

The trailing `CantUntap` `GenericEffect` was emitted with `target: null` and `affected: Typed(Land)`/`Typed(Creature)` — a broadcast filter.

## Root cause

"That land"/"That creature" (CR 608.2c) is an anaphor to the single object tapped by the preceding clause. The spell-form "that [type]" subject parse sets `inherits_parent`, but `static_affected_for_application` ignored it and fell back to the broadcast typed filter — even though the helper's own doc-comment states the anaphor was meant to resolve via the parent target.

## Fix (parser-only; no new engine variant)

`static_affected_for_application` now honors `inherits_parent`:

```rust
if application.target.is_some() || application.inherits_parent {
    TargetFilter::ParentTarget
} else {
    application.affected.clone()
}
```

The transient-effect resolver already binds `ParentTarget` to the inherited (immediately-preceding, i.e. tapped) object, so the lock applies only to that object — never the chain's other targets (Chandra's separately-targeted damaged creature still untaps). This mirrors `build_pump_effect`, which already honors `inherits_parent` for the Pump family. No runtime change — bare `ParentTarget` is already an inherited-target filter the resolver recognizes.

This is the only set-site where the delta changes output: the other `inherits_parent` subjects already carry an explicit target slot (first branch) or already resolve to `ParentTarget`; no broadcast subject ("all Goblins", "each creature you control") sets `inherits_parent`. It also corrects the latent same-site broadcast on spell-form "that creature gains <keyword>" grants (which previously fell through to the broadcast arm), bringing the spell frame in line with the already-correct trigger frame. CR 608.2c (anaphora), CR 502.3 (untap-step restriction).

## Tests

- Parser-level: Chandra's Revolution / Glacial Grasp full-parse → the CantUntap static's `affected == ParentTarget` (not `Typed(...)`).
- Resolved-binding (GameRunner): cast each, advance to the opponent's untap step, assert the tapped permanent stays tapped, a second matching permanent untaps (no broadcast), and (Chandra's) the damaged creature untaps (the lock did not bind the damage target). Revert-discriminating — without the fix the broadcast keeps the second permanent tapped.

## Verification

`cargo +nightly test -p engine --lib`: 12358 passed, 0 failed. `--test integration`: 1128 passed, no fixture diff. `clippy -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean for this diff.
