### PR TITLE
Fix Delve mana payment overlay hint (fixes #2920)

### DIFF
--- a/client/src/components/mana/ManaPaymentUI.tsx
+++ b/client/src/components/mana/ManaPaymentUI.tsx
@@ -296,7 +296,9 @@ export function ManaPaymentUI() {
                     ? t("mana.convokeHint")
                     : convokeMode === "Improvise"
                       ? t("mana.improviseHint")
-                      : t("mana.convokeOrImproviseHint")}
+                      : convokeMode === "Delve"
+                        ? t("mana.delveHint")
+                        : t("mana.convokeOrImproviseHint")}
                 </p>
               )}
 

--- a/client/src/components/mana/__tests__/ManaPaymentUI.test.tsx
+++ b/client/src/components/mana/__tests__/ManaPaymentUI.test.tsx
@@ -155,6 +155,77 @@ describe("ManaPaymentUI", () => {
     expect(outerShell?.querySelector(".pointer-events-auto")).not.toBeNull();
   });
 
+  it("shows the delve payment hint during delve mana payment", () => {
+    const dispatch = vi.fn().mockResolvedValue([]);
+    const spellObj = {
+      id: 301,
+      name: "Dig Through Time",
+      controller: 0,
+      owner: 0,
+      card_id: 4,
+      mana_cost: {
+        type: "Cost",
+        shards: ["Blue", "Blue"],
+        generic: 6,
+      },
+      zone: "Stack",
+      tapped: false,
+      card_types: { core_types: ["Instant"], subtypes: [], supertypes: [] },
+      abilities: [],
+      colors: ["Blue"],
+      counters: {},
+      damage: 0,
+      is_summon_sick: false,
+      attached_to: null,
+      cast_from_zone: null,
+      face_down: false,
+      is_commander: false,
+      is_attacking: null,
+      is_blocking: null,
+      mana_spent_to_cast: false,
+      colors_spent_to_cast: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
+    } as unknown as GameState["objects"][number];
+    const gameState = createGameState({
+      objects: { 301: spellObj },
+      stack: [
+        {
+          id: 301,
+          source_id: 301,
+          controller: 0,
+          kind: {
+            type: "Spell",
+            card_id: 4,
+            ability: null,
+            casting_variant: { type: "Normal" },
+            actual_mana_spent: 0,
+          },
+        },
+      ] as unknown as GameState["stack"],
+      waiting_for: {
+        type: "ManaPayment",
+        data: { player: 0, convoke_mode: "Delve" },
+      },
+    });
+
+    act(() => {
+      useGameStore.setState({
+        gameState,
+        waitingFor: gameState.waiting_for,
+        dispatch,
+        legalActions: [{ type: "CancelCast" }, { type: "PassPriority" }],
+      });
+    });
+
+    render(<ManaPaymentUI />);
+
+    expect(
+      screen.getByText("Exile cards from your graveyard to help pay."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Tap creatures or artifacts to help pay."),
+    ).not.toBeInTheDocument();
+  });
+
   // CR 107.4f + CR 601.2f: When the engine reports PhyrexianPayment, clicking Pay
   // dispatches SubmitPhyrexianChoices with one choice per shard (default: PayMana).
   it("dispatches SubmitPhyrexianChoices with defaults for PhyrexianPayment", () => {

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -387,6 +387,7 @@
     "payMana": "Manakosten bezahlen",
     "convokeHint": "Tappe Kreaturen, um die Bezahlung zu unterstützen.",
     "improviseHint": "Tappe Artefakte, um die Bezahlung zu unterstützen.",
+    "delveHint": "Exiliere Karten aus deinem Friedhof, um die Bezahlung zu unterstützen.",
     "convokeOrImproviseHint": "Tappe Kreaturen oder Artefakte, um die Bezahlung zu unterstützen.",
     "convokeStaged": "Getappt:",
     "lifeAmount": "2 Leben",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -387,6 +387,7 @@
     "payMana": "Pay Mana Cost",
     "convokeHint": "Tap creatures to help pay.",
     "improviseHint": "Tap artifacts to help pay.",
+    "delveHint": "Exile cards from your graveyard to help pay.",
     "convokeOrImproviseHint": "Tap creatures or artifacts to help pay.",
     "convokeStaged": "Tapped:",
     "lifeAmount": "2 life",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -387,6 +387,7 @@
     "payMana": "Pagar el coste de maná",
     "convokeHint": "Gira criaturas para ayudar a pagar.",
     "improviseHint": "Gira artefactos para ayudar a pagar.",
+    "delveHint": "Exilia cartas de tu cementerio para ayudar a pagar.",
     "convokeOrImproviseHint": "Gira criaturas o artefactos para ayudar a pagar.",
     "convokeStaged": "Giradas:",
     "lifeAmount": "2 vidas",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -387,6 +387,7 @@
     "payMana": "Payer le coût de mana",
     "convokeHint": "Engagez des créatures pour aider à payer.",
     "improviseHint": "Engagez des artefacts pour aider à payer.",
+    "delveHint": "Exilez des cartes de votre cimetière pour aider à payer.",
     "convokeOrImproviseHint": "Engagez des créatures ou des artefacts pour aider à payer.",
     "convokeStaged": "Engagés :",
     "lifeAmount": "2 points de vie",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -387,6 +387,7 @@
     "payMana": "Paga il costo di mana",
     "convokeHint": "TAPpa le creature per aiutare a pagare.",
     "improviseHint": "TAPpa gli artefatti per aiutare a pagare.",
+    "delveHint": "Esilia carte dal tuo cimitero per aiutare a pagare.",
     "convokeOrImproviseHint": "TAPpa creature o artefatti per aiutare a pagare.",
     "convokeStaged": "TAPpate:",
     "lifeAmount": "2 punti vita",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -387,6 +387,7 @@
     "payMana": "Zapłać koszt many",
     "convokeHint": "Obróć stwory, aby pomóc zapłacić.",
     "improviseHint": "Obróć artefakty, aby pomóc zapłacić.",
+    "delveHint": "Wygnaj karty ze swojego cmentarza, aby pomóc zapłacić.",
     "convokeOrImproviseHint": "Obróć stwory lub artefakty, aby pomóc zapłacić.",
     "convokeStaged": "Obrócone:",
     "lifeAmount": "2 życia",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -387,6 +387,7 @@
     "payMana": "Pagar Custo de Mana",
     "convokeHint": "Vire criaturas para ajudar a pagar.",
     "improviseHint": "Vire artefatos para ajudar a pagar.",
+    "delveHint": "Exile cards do seu cemitério para ajudar a pagar.",
     "convokeOrImproviseHint": "Vire criaturas ou artefatos para ajudar a pagar.",
     "convokeStaged": "Viradas:",
     "lifeAmount": "2 de vida",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -387,7 +387,7 @@
     "payMana": "Pagar Custo de Mana",
     "convokeHint": "Vire criaturas para ajudar a pagar.",
     "improviseHint": "Vire artefatos para ajudar a pagar.",
-    "delveHint": "Exile cards do seu cemitério para ajudar a pagar.",
+    "delveHint": "Exile cartas do seu cemitério para ajudar a pagar.",
     "convokeOrImproviseHint": "Vire criaturas ou artefatos para ajudar a pagar.",
     "convokeStaged": "Viradas:",
     "lifeAmount": "2 de vida",


### PR DESCRIPTION
## Summary
- Show a Delve-specific payment hint ("Exile cards from your graveyard to help pay.") instead of the generic convoke/improvise tap hint when `convoke_mode` is `Delve`.
- Add i18n keys for all supported locales and a unit test covering the Delve branch.

## Test plan
- [x] `npm test -- --run src/components/mana/__tests__/ManaPaymentUI.test.tsx`
- [ ] Cast a Delve spell in-game and confirm the overlay shows the graveyard exile hint; use the peek tab to slide the panel aside and select graveyard cards.


fix #2920 