### PR TITLE
Regression tests: phased-out CDA P/T freeze (fix #2877)

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1556,7 +1556,6 @@ pub fn evaluate_layers(state: &mut GameState) {
     // CR 613.11: Rule-changing continuous effects are applied after object
     // characteristics are determined. These flags feed CR 510.1 combat damage
     // assignment and must observe final post-layer characteristics.
-    apply_phased_out_self_cda_characteristics(state);
     apply_combat_assignment_rule_effects(state);
 
     // CR 302.6: Re-apply summoning sickness for any permanent whose effective
@@ -2134,89 +2133,6 @@ fn apply_prototype_characteristics(state: &mut GameState, ids: impl IntoIterator
         obj.power = Some(form.power);
         obj.toughness = Some(form.toughness);
         obj.color = form.colors;
-    }
-}
-
-/// True when a continuous modification adjusts power and/or toughness.
-fn is_pt_continuous_modification(modification: &ContinuousModification) -> bool {
-    matches!(
-        modification,
-        ContinuousModification::AddPower { .. }
-            | ContinuousModification::AddToughness { .. }
-            | ContinuousModification::AddDynamicPower { .. }
-            | ContinuousModification::AddDynamicToughness { .. }
-            | ContinuousModification::SetPower { .. }
-            | ContinuousModification::SetToughness { .. }
-            | ContinuousModification::SetPowerDynamic { .. }
-            | ContinuousModification::SetToughnessDynamic { .. }
-            | ContinuousModification::SetDynamicPower { .. }
-            | ContinuousModification::SetDynamicToughness { .. }
-            | ContinuousModification::SwitchPowerToughness
-    )
-}
-
-/// CR 604.3 + CR 702.26: Phased-out permanents are excluded from the main
-/// layer pass (CR 702.26e), but their own characteristic-defining P/T
-/// abilities still define their power and toughness (e.g. Lumra, Bellow of
-/// the Woods). Without this pass, a */* CDA creature can remain at base 0/0
-/// and die to CR 704.5f when it phases in or after a layer reset.
-fn apply_phased_out_self_cda_characteristics(state: &mut GameState) {
-    use crate::types::statics::StaticMode;
-    use std::collections::HashSet;
-
-    let phased_out: Vec<ObjectId> = state
-        .battlefield
-        .iter()
-        .copied()
-        .filter(|id| state.objects.get(id).is_some_and(|o| o.is_phased_out()))
-        .collect();
-
-    for id in phased_out {
-        let has_self_cda_pt = state.objects.get(&id).is_some_and(|obj| {
-            obj.static_definitions.iter_all().any(|def| {
-                def.characteristic_defining
-                    && def.mode == StaticMode::Continuous
-                    && def.modifications.iter().any(is_pt_continuous_modification)
-            })
-        });
-        if !has_self_cda_pt {
-            continue;
-        }
-
-        if let Some(obj) = state.objects.get_mut(&id) {
-            obj.power = obj.base_power;
-            obj.toughness = obj.base_toughness;
-        }
-
-        let effects: Vec<ActiveContinuousEffect> = state
-            .objects
-            .get(&id)
-            .map(|obj| active_continuous_effects_from_static_source(state, obj))
-            .unwrap_or_default();
-
-        let mut cda_pt_effects: Vec<&ActiveContinuousEffect> = effects
-            .iter()
-            .filter(|e| {
-                e.source_id == id
-                    && is_pt_continuous_modification(&e.modification)
-                    && e.def_index.is_some_and(|idx| {
-                        state.objects.get(&id).is_some_and(|obj| {
-                            obj.static_definitions
-                                .get(idx)
-                                .is_some_and(|def| def.characteristic_defining)
-                        })
-                    })
-            })
-            .collect();
-
-        cda_pt_effects.sort_by_key(|e| (e.layer, e.timestamp));
-
-        let restrict = HashSet::from([id]);
-        for effect in cda_pt_effects {
-            apply_continuous_effect_to(state, effect, &restrict);
-        }
-
-        apply_pt_counter_modifications(state, std::iter::once(id));
     }
 }
 
@@ -3533,19 +3449,7 @@ fn apply_continuous_effect_filtered(
         .affected_filter
         .extract_in_zone()
         .unwrap_or(crate::types::zones::Zone::Battlefield);
-    let scan_ids: Vec<ObjectId> = if let Some(restrict) = restrict_to {
-        // Incremental fast path (and the phased-out self-CDA pass): the caller
-        // names the exact recipients. `zone_object_ids` excludes phased-out
-        // permanents (CR 702.26b), so scanning it would drop them even when
-        // `restrict_to` explicitly includes a phased-out self-CDA object.
-        restrict
-            .iter()
-            .filter(|&&id| state.objects.get(&id).is_some_and(|o| o.zone == scan_zone))
-            .copied()
-            .collect()
-    } else {
-        super::targeting::zone_object_ids(state, scan_zone)
-    };
+    let scan_ids = super::targeting::zone_object_ids(state, scan_zone);
     let ctx = FilterContext::from_source(state, effect.source_id);
     let affected_ids: Vec<ObjectId> = scan_ids
         .iter()
@@ -3553,18 +3457,7 @@ fn apply_continuous_effect_filtered(
         // The rest of the battlefield was not reset and keeps its prior derived
         // values, so re-applying to it would double-apply.
         .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
-        .filter(|&&id| {
-            if state.objects.get(&id).is_some_and(|o| o.is_phased_out()) {
-                super::filter::matches_target_filter_including_phased_out(
-                    state,
-                    id,
-                    &effect.affected_filter,
-                    &ctx,
-                )
-            } else {
-                matches_target_filter(state, id, &effect.affected_filter, &ctx)
-            }
-        })
+        .filter(|&&id| matches_target_filter(state, id, &effect.affected_filter, &ctx))
         .filter(|&&id| {
             effect.condition.as_ref().is_none_or(|condition| {
                 evaluate_condition_with_recipient(

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1556,6 +1556,7 @@ pub fn evaluate_layers(state: &mut GameState) {
     // CR 613.11: Rule-changing continuous effects are applied after object
     // characteristics are determined. These flags feed CR 510.1 combat damage
     // assignment and must observe final post-layer characteristics.
+    apply_phased_out_self_cda_characteristics(state);
     apply_combat_assignment_rule_effects(state);
 
     // CR 302.6: Re-apply summoning sickness for any permanent whose effective
@@ -2133,6 +2134,89 @@ fn apply_prototype_characteristics(state: &mut GameState, ids: impl IntoIterator
         obj.power = Some(form.power);
         obj.toughness = Some(form.toughness);
         obj.color = form.colors;
+    }
+}
+
+/// True when a continuous modification adjusts power and/or toughness.
+fn is_pt_continuous_modification(modification: &ContinuousModification) -> bool {
+    matches!(
+        modification,
+        ContinuousModification::AddPower { .. }
+            | ContinuousModification::AddToughness { .. }
+            | ContinuousModification::AddDynamicPower { .. }
+            | ContinuousModification::AddDynamicToughness { .. }
+            | ContinuousModification::SetPower { .. }
+            | ContinuousModification::SetToughness { .. }
+            | ContinuousModification::SetPowerDynamic { .. }
+            | ContinuousModification::SetToughnessDynamic { .. }
+            | ContinuousModification::SetDynamicPower { .. }
+            | ContinuousModification::SetDynamicToughness { .. }
+            | ContinuousModification::SwitchPowerToughness
+    )
+}
+
+/// CR 604.3 + CR 702.26: Phased-out permanents are excluded from the main
+/// layer pass (CR 702.26e), but their own characteristic-defining P/T
+/// abilities still define their power and toughness (e.g. Lumra, Bellow of
+/// the Woods). Without this pass, a */* CDA creature can remain at base 0/0
+/// and die to CR 704.5f when it phases in or after a layer reset.
+fn apply_phased_out_self_cda_characteristics(state: &mut GameState) {
+    use crate::types::statics::StaticMode;
+    use std::collections::HashSet;
+
+    let phased_out: Vec<ObjectId> = state
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|id| state.objects.get(id).is_some_and(|o| o.is_phased_out()))
+        .collect();
+
+    for id in phased_out {
+        let has_self_cda_pt = state.objects.get(&id).is_some_and(|obj| {
+            obj.static_definitions.iter_all().any(|def| {
+                def.characteristic_defining
+                    && def.mode == StaticMode::Continuous
+                    && def.modifications.iter().any(is_pt_continuous_modification)
+            })
+        });
+        if !has_self_cda_pt {
+            continue;
+        }
+
+        if let Some(obj) = state.objects.get_mut(&id) {
+            obj.power = obj.base_power;
+            obj.toughness = obj.base_toughness;
+        }
+
+        let effects: Vec<ActiveContinuousEffect> = state
+            .objects
+            .get(&id)
+            .map(|obj| active_continuous_effects_from_static_source(state, obj))
+            .unwrap_or_default();
+
+        let mut cda_pt_effects: Vec<&ActiveContinuousEffect> = effects
+            .iter()
+            .filter(|e| {
+                e.source_id == id
+                    && is_pt_continuous_modification(&e.modification)
+                    && e.def_index.is_some_and(|idx| {
+                        state.objects.get(&id).is_some_and(|obj| {
+                            obj.static_definitions
+                                .get(idx)
+                                .is_some_and(|def| def.characteristic_defining)
+                        })
+                    })
+            })
+            .collect();
+
+        cda_pt_effects.sort_by_key(|e| (e.layer, e.timestamp));
+
+        let restrict = HashSet::from([id]);
+        for effect in cda_pt_effects {
+            apply_continuous_effect_to(state, effect, &restrict);
+        }
+
+        apply_pt_counter_modifications(state, std::iter::once(id));
     }
 }
 
@@ -3449,7 +3533,19 @@ fn apply_continuous_effect_filtered(
         .affected_filter
         .extract_in_zone()
         .unwrap_or(crate::types::zones::Zone::Battlefield);
-    let scan_ids = super::targeting::zone_object_ids(state, scan_zone);
+    let scan_ids: Vec<ObjectId> = if let Some(restrict) = restrict_to {
+        // Incremental fast path (and the phased-out self-CDA pass): the caller
+        // names the exact recipients. `zone_object_ids` excludes phased-out
+        // permanents (CR 702.26b), so scanning it would drop them even when
+        // `restrict_to` explicitly includes a phased-out self-CDA object.
+        restrict
+            .iter()
+            .filter(|&&id| state.objects.get(&id).is_some_and(|o| o.zone == scan_zone))
+            .copied()
+            .collect()
+    } else {
+        super::targeting::zone_object_ids(state, scan_zone)
+    };
     let ctx = FilterContext::from_source(state, effect.source_id);
     let affected_ids: Vec<ObjectId> = scan_ids
         .iter()
@@ -3457,7 +3553,18 @@ fn apply_continuous_effect_filtered(
         // The rest of the battlefield was not reset and keeps its prior derived
         // values, so re-applying to it would double-apply.
         .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
-        .filter(|&&id| matches_target_filter(state, id, &effect.affected_filter, &ctx))
+        .filter(|&&id| {
+            if state.objects.get(&id).is_some_and(|o| o.is_phased_out()) {
+                super::filter::matches_target_filter_including_phased_out(
+                    state,
+                    id,
+                    &effect.affected_filter,
+                    &ctx,
+                )
+            } else {
+                matches_target_filter(state, id, &effect.affected_filter, &ctx)
+            }
+        })
         .filter(|&&id| {
             effect.condition.as_ref().is_none_or(|condition| {
                 evaluate_condition_with_recipient(

--- a/crates/engine/tests/integration/issue_2877_phased_out_cda_pt.rs
+++ b/crates/engine/tests/integration/issue_2877_phased_out_cda_pt.rs
@@ -1,13 +1,19 @@
-//! [#2877](https://github.com/phase-rs/phase/issues/2877): a */* CDA creature
-//! (e.g. Lumra, Bellow of the Woods) must retain its characteristic-defining
-//! power/toughness while phased out instead of staying at base 0/0.
+//! [#2877](https://github.com/phase-rs/phase/issues/2877): regression coverage for
+//! */* CDA creatures (e.g. Lumra) while phased out.
+//!
+//! CR 702.26b + CR 702.26e: phased-out permanents are excluded from the layer
+//! pass and SBA scans — their last-computed P/T is frozen, not re-derived and
+//! not reset to base */*.
 
 use engine::game::game_object::PhaseOutCause;
 use engine::game::layers::{evaluate_layers, flush_layers};
 use engine::game::phasing::phase_out_object;
 use engine::game::sba::check_state_based_actions;
 use engine::game::zones::create_object;
-use engine::types::ability::{ContinuousModification, StaticDefinition, TargetFilter};
+use engine::types::ability::{
+    ContinuousModification, ControllerRef, QuantityExpr, QuantityRef, StaticDefinition,
+    TargetFilter, TypedFilter,
+};
 use engine::types::card_type::CoreType;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::{CardId, ObjectId};
@@ -29,7 +35,17 @@ fn setup_land(state: &mut GameState, controller: PlayerId) -> ObjectId {
     id
 }
 
-fn setup_star_star_cda_creature(state: &mut GameState, pt: i32, controller: PlayerId) -> ObjectId {
+fn land_count_pt_expr() -> QuantityExpr {
+    QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount {
+            filter: TargetFilter::Typed(
+                TypedFilter::land().controller(ControllerRef::You),
+            ),
+        },
+    }
+}
+
+fn setup_lumra_like_cda_creature(state: &mut GameState, controller: PlayerId) -> ObjectId {
     let id = create_object(
         state,
         CardId(2),
@@ -45,12 +61,13 @@ fn setup_star_star_cda_creature(state: &mut GameState, pt: i32, controller: Play
         obj.base_power = Some(0);
         obj.base_toughness = Some(0);
 
+        let pt = land_count_pt_expr();
         let def = StaticDefinition::continuous()
             .affected(TargetFilter::SelfRef)
             .cda()
             .modifications(vec![
-                ContinuousModification::SetPower { value: pt },
-                ContinuousModification::SetToughness { value: pt },
+                ContinuousModification::SetDynamicPower { value: pt.clone() },
+                ContinuousModification::SetDynamicToughness { value: pt },
             ]);
         obj.static_definitions = vec![def.clone()].into();
         obj.base_static_definitions = std::sync::Arc::new(vec![def]);
@@ -59,13 +76,13 @@ fn setup_star_star_cda_creature(state: &mut GameState, pt: i32, controller: Play
 }
 
 #[test]
-fn phased_out_star_star_cda_creature_keeps_cda_power_toughness() {
+fn phased_out_star_star_cda_creature_freezes_last_computed_pt() {
     let mut state = GameState::new_two_player(42);
     let controller = PlayerId(0);
     for _ in 0..3 {
         setup_land(&mut state, controller);
     }
-    let creature = setup_star_star_cda_creature(&mut state, 3, controller);
+    let creature = setup_lumra_like_cda_creature(&mut state, controller);
 
     state.layers_dirty.mark_full();
     evaluate_layers(&mut state);
@@ -76,21 +93,13 @@ fn phased_out_star_star_cda_creature_keeps_cda_power_toughness() {
     phase_out_object(&mut state, creature, PhaseOutCause::Directly, &mut events);
     assert!(state.objects[&creature].is_phased_out());
 
-    // Simulate the post-reset state a */* creature can be left in when excluded
-    // from the main layer pass: base 0/0 with no CDA re-application.
-    {
-        let obj = state.objects.get_mut(&creature).unwrap();
-        obj.power = Some(0);
-        obj.toughness = Some(0);
-    }
-
     state.layers_dirty.mark_full();
     flush_layers(&mut state);
 
     assert_eq!(
         state.objects[&creature].power,
         Some(3),
-        "phased-out */* CDA creature must re-derive P/T from its own CDA"
+        "phased-out CDA creature must keep its last-computed P/T (CR 702.26e freeze)"
     );
     assert_eq!(state.objects[&creature].toughness, Some(3));
 
@@ -98,6 +107,36 @@ fn phased_out_star_star_cda_creature_keeps_cda_power_toughness() {
     assert_eq!(
         state.objects[&creature].zone,
         Zone::Battlefield,
-        "phased-out creature must not die to CR 704.5f while its CDA P/T applies"
+        "phased-out creature is excluded from CR 704.5f zero-toughness SBAs"
     );
+}
+
+#[test]
+fn phased_out_cda_pt_does_not_track_board_changes_while_phased_out() {
+    let mut state = GameState::new_two_player(42);
+    let controller = PlayerId(0);
+    for _ in 0..3 {
+        setup_land(&mut state, controller);
+    }
+    let creature = setup_lumra_like_cda_creature(&mut state, controller);
+
+    state.layers_dirty.mark_full();
+    evaluate_layers(&mut state);
+
+    let mut events = Vec::new();
+    phase_out_object(&mut state, creature, PhaseOutCause::Directly, &mut events);
+
+    // Board changes while phased out must not re-derive the CDA (CR 702.26e).
+    setup_land(&mut state, controller);
+    setup_land(&mut state, controller);
+
+    state.layers_dirty.mark_full();
+    flush_layers(&mut state);
+
+    assert_eq!(
+        state.objects[&creature].power,
+        Some(3),
+        "P/T must stay frozen at phase-out value, not track new lands"
+    );
+    assert_eq!(state.objects[&creature].toughness, Some(3));
 }

--- a/crates/engine/tests/integration/issue_2877_phased_out_cda_pt.rs
+++ b/crates/engine/tests/integration/issue_2877_phased_out_cda_pt.rs
@@ -38,9 +38,7 @@ fn setup_land(state: &mut GameState, controller: PlayerId) -> ObjectId {
 fn land_count_pt_expr() -> QuantityExpr {
     QuantityExpr::Ref {
         qty: QuantityRef::ObjectCount {
-            filter: TargetFilter::Typed(
-                TypedFilter::land().controller(ControllerRef::You),
-            ),
+            filter: TargetFilter::Typed(TypedFilter::land().controller(ControllerRef::You)),
         },
     }
 }

--- a/crates/engine/tests/integration/issue_2877_phased_out_cda_pt.rs
+++ b/crates/engine/tests/integration/issue_2877_phased_out_cda_pt.rs
@@ -1,0 +1,103 @@
+//! [#2877](https://github.com/phase-rs/phase/issues/2877): a */* CDA creature
+//! (e.g. Lumra, Bellow of the Woods) must retain its characteristic-defining
+//! power/toughness while phased out instead of staying at base 0/0.
+
+use engine::game::game_object::PhaseOutCause;
+use engine::game::layers::{evaluate_layers, flush_layers};
+use engine::game::phasing::phase_out_object;
+use engine::game::sba::check_state_based_actions;
+use engine::game::zones::create_object;
+use engine::types::ability::{ContinuousModification, StaticDefinition, TargetFilter};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+fn setup_land(state: &mut GameState, controller: PlayerId) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(1),
+        controller,
+        "Forest".to_string(),
+        Zone::Battlefield,
+    );
+    if let Some(obj) = state.objects.get_mut(&id) {
+        obj.card_types.core_types = vec![CoreType::Land];
+        obj.base_card_types = obj.card_types.clone();
+    }
+    id
+}
+
+fn setup_star_star_cda_creature(state: &mut GameState, pt: i32, controller: PlayerId) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(2),
+        controller,
+        "Lumra Stand-in".to_string(),
+        Zone::Battlefield,
+    );
+    if let Some(obj) = state.objects.get_mut(&id) {
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(0);
+        obj.toughness = Some(0);
+        obj.base_power = Some(0);
+        obj.base_toughness = Some(0);
+
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .cda()
+            .modifications(vec![
+                ContinuousModification::SetPower { value: pt },
+                ContinuousModification::SetToughness { value: pt },
+            ]);
+        obj.static_definitions = vec![def.clone()].into();
+        obj.base_static_definitions = std::sync::Arc::new(vec![def]);
+    }
+    id
+}
+
+#[test]
+fn phased_out_star_star_cda_creature_keeps_cda_power_toughness() {
+    let mut state = GameState::new_two_player(42);
+    let controller = PlayerId(0);
+    for _ in 0..3 {
+        setup_land(&mut state, controller);
+    }
+    let creature = setup_star_star_cda_creature(&mut state, 3, controller);
+
+    state.layers_dirty.mark_full();
+    evaluate_layers(&mut state);
+    assert_eq!(state.objects[&creature].power, Some(3));
+    assert_eq!(state.objects[&creature].toughness, Some(3));
+
+    let mut events = Vec::new();
+    phase_out_object(&mut state, creature, PhaseOutCause::Directly, &mut events);
+    assert!(state.objects[&creature].is_phased_out());
+
+    // Simulate the post-reset state a */* creature can be left in when excluded
+    // from the main layer pass: base 0/0 with no CDA re-application.
+    {
+        let obj = state.objects.get_mut(&creature).unwrap();
+        obj.power = Some(0);
+        obj.toughness = Some(0);
+    }
+
+    state.layers_dirty.mark_full();
+    flush_layers(&mut state);
+
+    assert_eq!(
+        state.objects[&creature].power,
+        Some(3),
+        "phased-out */* CDA creature must re-derive P/T from its own CDA"
+    );
+    assert_eq!(state.objects[&creature].toughness, Some(3));
+
+    check_state_based_actions(&mut state, &mut events);
+    assert_eq!(
+        state.objects[&creature].zone,
+        Zone::Battlefield,
+        "phased-out creature must not die to CR 704.5f while its CDA P/T applies"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -194,6 +194,7 @@ mod issue_2866_professor_onyx_magecraft_copy;
 mod issue_2871_currency_converter;
 mod issue_2872_drc_flashback_cast_trigger;
 mod issue_2874_vow_of_lightning;
+mod issue_2877_phased_out_cda_pt;
 mod issue_2881_infamous_cruelclaw;
 mod issue_2888_unbreathing_horde_self_prevention;
 mod issue_2890_reality_shift;


### PR DESCRIPTION
## Summary

Addresses review feedback on the original approach:

- **Reverted** the `apply_phased_out_self_cda_characteristics` layer-pass change — it violated CR 702.26e by re-deriving CDAs on phased-out permanents.
- **Added** integration regression tests documenting the engine's existing correct behavior: phased-out Lumra-like `*/*` land-count CDAs keep their last-computed P/T through layer recomputation, do not track board changes while phased out, and are excluded from zero-toughness SBAs.

The original Discord report does not reproduce on `main`; these tests lock in the freeze semantics matthewevans described.

## Test plan

- [x] `cargo test -p engine --test integration issue_2877`
- [x] `cargo clippy -p engine -- -D warnings`

fix #2877