### PR TITLE
Fix duplicate enter-untapped replacement prompt (#1340)

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -5086,6 +5086,10 @@ enum CommuteClass {
     Multiplicative,
     Additive,
     Subtractive,
+    /// Two `SetTapState::Tap` replacements commute (same outcome).
+    EnterTap,
+    /// Two `SetTapState::Untap` replacements commute (same outcome).
+    EnterUntap,
 }
 
 impl CommuteClass {
@@ -5252,6 +5256,7 @@ fn candidate_materiality(
         };
     }
     let mut field: Option<EventField> = None;
+    let mut enter_tapped_commute: Option<CommuteClass> = None;
     let mut current = Some(execute);
     while let Some(def) = current {
         match &*def.effect {
@@ -5275,9 +5280,14 @@ fn candidate_materiality(
             // scope is not an ETB modifier and is not matched here.
             Effect::SetTapState {
                 scope: EffectScope::Single,
+                state,
                 ..
             } => {
                 field = Some(EventField::EnterTapped);
+                enter_tapped_commute = Some(match state {
+                    TapStateChange::Tap => CommuteClass::EnterTap,
+                    TapStateChange::Untap => CommuteClass::EnterUntap,
+                });
             }
             // ETB-counter replacements (`PutCounter`) only *append* to
             // `enter_with_counters`, so they never conflict. `Effect::Choose`
@@ -5295,7 +5305,7 @@ fn candidate_materiality(
     match field {
         Some(field) => CandidateMateriality::Writes {
             field,
-            commute: CommuteClass::NonCommuting,
+            commute: enter_tapped_commute.unwrap_or(CommuteClass::NonCommuting),
         },
         None => CandidateMateriality::Disjoint,
     }
@@ -6263,6 +6273,41 @@ mod tests {
             panic!("expected NeedsChoice for enter_tapped field collision, got {result:?}");
         };
         assert_eq!(player, PlayerId(0));
+    }
+
+    #[test]
+    fn two_identical_untap_replacements_auto_apply_without_choice() {
+        // CR 616.1f: Duplicate "lands enter untapped" replacements commute (#1340).
+        let untap_repl = ReplacementDefinition::new(ReplacementEvent::Moved)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::SetTapState {
+                    target: TargetFilter::SelfRef,
+                    scope: EffectScope::Single,
+                    state: TapStateChange::Untap,
+                },
+            ))
+            .valid_card(TargetFilter::Typed(TypedFilter::land().controller(ControllerRef::You)))
+            .destination_zone(Zone::Battlefield);
+        let mut state = test_state_with_object(
+            ObjectId(1),
+            Zone::Battlefield,
+            vec![untap_repl.clone(), untap_repl],
+        );
+        let land_id = ObjectId(10);
+        state.objects.insert(
+            land_id,
+            GameObject::new(land_id, CardId(2), PlayerId(0), "Forest".to_string(), Zone::Hand),
+        );
+
+        let mut events = Vec::new();
+        let proposed =
+            ProposedEvent::zone_change(land_id, Zone::Hand, Zone::Battlefield, None);
+        let result = replace_event(&mut state, proposed, &mut events);
+        assert!(
+            matches!(result, ReplacementResult::Execute(_)),
+            "identical untap replacements must auto-apply without ordering prompt, got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -5284,6 +5284,7 @@ fn candidate_materiality(
                 ..
             } => {
                 field = Some(EventField::EnterTapped);
+                // CR 616.1f: Duplicate tap/untap state replacements commute.
                 enter_tapped_commute = Some(match state {
                     TapStateChange::Tap => CommuteClass::EnterTap,
                     TapStateChange::Untap => CommuteClass::EnterUntap,
@@ -6287,7 +6288,9 @@ mod tests {
                     state: TapStateChange::Untap,
                 },
             ))
-            .valid_card(TargetFilter::Typed(TypedFilter::land().controller(ControllerRef::You)))
+            .valid_card(TargetFilter::Typed(
+                TypedFilter::land().controller(ControllerRef::You),
+            ))
             .destination_zone(Zone::Battlefield);
         let mut state = test_state_with_object(
             ObjectId(1),
@@ -6297,12 +6300,17 @@ mod tests {
         let land_id = ObjectId(10);
         state.objects.insert(
             land_id,
-            GameObject::new(land_id, CardId(2), PlayerId(0), "Forest".to_string(), Zone::Hand),
+            GameObject::new(
+                land_id,
+                CardId(2),
+                PlayerId(0),
+                "Forest".to_string(),
+                Zone::Hand,
+            ),
         );
 
         let mut events = Vec::new();
-        let proposed =
-            ProposedEvent::zone_change(land_id, Zone::Hand, Zone::Battlefield, None);
+        let proposed = ProposedEvent::zone_change(land_id, Zone::Hand, Zone::Battlefield, None);
         let result = replace_event(&mut state, proposed, &mut events);
         assert!(
             matches!(result, ReplacementResult::Execute(_)),

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -5086,8 +5086,6 @@ enum CommuteClass {
     Multiplicative,
     Additive,
     Subtractive,
-    /// Two `SetTapState::Tap` replacements commute (same outcome).
-    EnterTap,
     /// Two `SetTapState::Untap` replacements commute (same outcome).
     EnterUntap,
 }
@@ -5284,9 +5282,9 @@ fn candidate_materiality(
                 ..
             } => {
                 field = Some(EventField::EnterTapped);
-                // CR 616.1f: Duplicate tap/untap state replacements commute.
+                // CR 616.1f: Duplicate untap state replacements commute (#1340).
                 enter_tapped_commute = Some(match state {
-                    TapStateChange::Tap => CommuteClass::EnterTap,
+                    TapStateChange::Tap => CommuteClass::NonCommuting,
                     TapStateChange::Untap => CommuteClass::EnterUntap,
                 });
             }


### PR DESCRIPTION
## Summary

* Classify identical `SetTapState::Untap` replacements as commuting so duplicate Horizon Explorer effects do not surface a degenerate replacement-order prompt
* Adds a unit regression test for two identical untap replacements

fix #1340

## Test plan

* [x] `cargo test -p engine two_identical_untap`
* [x] `cargo test -p engine tap_untap_field_collision`