### PR TITLE
fix(engine): stop ExploreAll sub-ability double-handling (Hakbal infinite explore)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5357,6 +5357,21 @@ fn resolve_chain_body(
         return Ok(());
     }
 
+    // CR 701.44d: `ExploreAll` is the single authority for its own sub_ability
+    // chain. `explore::resolve_single_explorer` carries `ability.sub_ability`
+    // onto the terminal explorer (and synthesizes the per-explorer `TrackedSet`
+    // continuation between explorers). If the generic chain walker ALSO
+    // processed the sub here, a paused explore (the nonland `DigChoice`) would
+    // re-prepend the sub onto `pending_continuation` a SECOND time. For a
+    // synthesized `ExploreAll { TrackedSet }` continuation that second prepend
+    // chains it to itself, producing a self-renewing loop that re-explores the
+    // same permanent every time the choice resolves — Hakbal of the Surging
+    // Soul accrued unbounded +1/+1 counters this way. Mirror the
+    // `ExileFromTopUntil` guard above and skip the outer chain.
+    if matches!(ability.effect, Effect::ExploreAll { .. }) {
+        return Ok(());
+    }
+
     // CR 615.5: `PreventDamage` with a chained `ContinuationStep` sub-ability
     // installs the sub as the shield's `runtime_execute` continuation — it runs
     // once per fired damage prevention event (Gatta and Luzzu's "prevent that

--- a/crates/engine/tests/explore_all_sub_runs_once.rs
+++ b/crates/engine/tests/explore_all_sub_runs_once.rs
@@ -1,0 +1,106 @@
+//! Regression: `ExploreAll`'s sub-ability must resolve exactly once.
+//!
+//! The bug: `explore::resolve_single_explorer` is the authority for an
+//! `ExploreAll`'s sub-ability chain (it carries the printed tail onto the
+//! terminal explorer and synthesizes the per-explorer `TrackedSet`
+//! continuation). The generic chain walker in `resolve_chain_body` ALSO
+//! processed `ExploreAll.sub_ability`, so on a paused explore (the nonland
+//! `DigChoice`) the sub was stashed onto `pending_continuation` a SECOND time.
+//!
+//! When the sub is a benign tail (gain life) it double-executes. When the sub
+//! is the synthesized `ExploreAll { TrackedSet }` continuation, the second
+//! prepend chains it to itself, producing a self-renewing loop that re-explores
+//! the same permanent forever (Hakbal of the Surging Soul: unbounded +1/+1
+//! counters — the reported Discord bug).
+use engine::game::scenario::GameScenario;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, ControllerRef, Effect, QuantityExpr, TargetFilter,
+    TriggerConstraint, TriggerDefinition, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+use engine::types::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+#[test]
+fn explore_all_tail_effect_runs_exactly_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 20);
+
+    // A Merfolk with a begin-combat trigger: "each Merfolk you control
+    // explores, then you gain 3 life." The gain-life tail is the observable
+    // proxy for "the ExploreAll sub-ability resolved".
+    let trigger = TriggerDefinition::new(TriggerMode::Phase)
+        .phase(Phase::BeginCombat)
+        .trigger_zones(vec![Zone::Battlefield])
+        .constraint(TriggerConstraint::OnlyDuringYourTurn)
+        .execute(
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::ExploreAll {
+                    filter: TargetFilter::Typed(
+                        TypedFilter::creature()
+                            .subtype("Merfolk".to_string())
+                            .controller(ControllerRef::You),
+                    ),
+                },
+            )
+            .sub_ability(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 3 },
+                    player: TargetFilter::Controller,
+                },
+            )),
+        );
+
+    let explorer = {
+        let mut b = scenario.add_creature(P0, "Test Merfolk", 2, 2);
+        b.with_subtypes(vec!["Merfolk"]);
+        b.with_trigger_definition(trigger);
+        b.id()
+    };
+    let _ = explorer;
+
+    // Nonland on top so the explore takes the +1/+1 / DigChoice branch (the
+    // pausing path that triggered the double-stash).
+    scenario.with_library_top(P0, &["Lightning Bolt", "Lightning Bolt"]);
+
+    let mut runner = scenario.build();
+    assert_eq!(runner.state().players[0].life, 20);
+
+    runner.advance_to_combat();
+
+    // Resolve any explore prompts; bounded so an infinite loop is a test failure.
+    for step in 0..40 {
+        let waiting = runner.state().waiting_for.clone();
+        let action = match waiting {
+            WaitingFor::ExploreChoice { choosable, .. } => GameAction::ChooseTarget {
+                target: Some(engine::types::ability::TargetRef::Object(choosable[0])),
+            },
+            WaitingFor::DigChoice { cards, .. } => GameAction::SelectCards {
+                cards: vec![cards[0]],
+            },
+            WaitingFor::Priority { .. } | WaitingFor::DeclareAttackers { .. } => break,
+            other => panic!("unexpected prompt at step {step}: {other:?}"),
+        };
+        if runner.act(action).is_err() {
+            break;
+        }
+        assert!(step < 39, "explore did not terminate — infinite loop");
+    }
+
+    // CR 119.3: the gain-life tail must fire exactly once → 20 + 3 = 23.
+    // The double-stash made it fire twice (26) or, for a self-referencing
+    // explore continuation, loop forever.
+    assert_eq!(
+        runner.state().players[0].life,
+        23,
+        "ExploreAll sub-ability (gain 3 life) must resolve exactly once"
+    );
+}


### PR DESCRIPTION
ExploreAll drives its own sub_ability chain in explore::resolve_single_explorer
(it synthesizes the per-explorer ExploreAll { TrackedSet } continuation and
carries any printed tail onto the terminal explorer). The generic chain walker
in resolve_chain_body ALSO processed ExploreAll.sub_ability, so on the nonland
explore DigChoice pause it re-prepended the synthesized continuation onto
pending_continuation a second time — chaining it to itself into a self-renewing
loop that re-explored the same permanent on every choice resolution. Hakbal of
the Surging Soul accrued unbounded +1/+1 counters this way (Discord report).

Add ExploreAll to the early-return guard cluster in resolve_chain_body, mirroring
the existing ExileFromTopUntil guard, so explore remains the single authority for
its sub-chain. Single Effect::Explore is unaffected (it does not own its sub).

Regression test: an ExploreAll trigger with a gain-life tail must fire the tail
exactly once (life 23, not 26); without the fix it double-runs or loops.
