### PR TITLE
feat(engine): resolve "total mana value of those exiled cards" via TrackedSetAggregate

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1214,6 +1214,19 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         QuantityRef::FilteredTrackedSetSize { filter, .. } => {
             format!("filtered tracked set ({})", fmt_target(filter))
         }
+        QuantityRef::TrackedSetAggregate { function, property } => {
+            let func = match function {
+                AggregateFunction::Max => "max",
+                AggregateFunction::Min => "min",
+                AggregateFunction::Sum => "total",
+            };
+            let prop = match property {
+                ObjectProperty::Power => "power",
+                ObjectProperty::Toughness => "toughness",
+                ObjectProperty::ManaValue => "mana value",
+            };
+            format!("{func} {prop} of those cards")
+        }
         QuantityRef::ExiledFromHandThisResolution => "cards exiled from hand this way".into(),
         QuantityRef::LifeLostThisTurn { player } => {
             format!("life lost this turn ({})", fmt_player_scope(player))
@@ -5710,6 +5723,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::PreviousEffectAmount => ("PreviousEffectAmount", Handled),
         QuantityRef::TrackedSetSize => ("TrackedSetSize", Handled),
         QuantityRef::FilteredTrackedSetSize { .. } => ("FilteredTrackedSetSize", Handled),
+        QuantityRef::TrackedSetAggregate { .. } => ("TrackedSetAggregate", Handled),
         QuantityRef::ExiledFromHandThisResolution => ("ExiledFromHandThisResolution", Handled),
         QuantityRef::LifeLostThisTurn { .. } => ("LifeLostThisTurn", Handled),
         QuantityRef::EventContextAmount => ("EventContextAmount", Handled),

--- a/crates/engine/src/game/effects/exile_top.rs
+++ b/crates/engine/src/game/effects/exile_top.rs
@@ -111,9 +111,9 @@ mod tests {
 
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, CardTypeSetSource, ControllerRef, FilterProp,
-        LinkedExileScope, ManaProduction, QuantityExpr, QuantityRef, TargetFilter, TargetRef,
-        TypeFilter, TypedFilter,
+        AbilityDefinition, AbilityKind, AggregateFunction, CardTypeSetSource, ControllerRef,
+        FilterProp, LinkedExileScope, ManaProduction, ObjectProperty, QuantityExpr, QuantityRef,
+        TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
     use crate::types::identifiers::{CardId, ObjectId};
@@ -640,6 +640,92 @@ mod tests {
         assert!(
             obj.face_down,
             "expected face_down=true on the exiled object after `Effect::ExileTop {{ face_down: true }}`",
+        );
+    }
+
+    /// CR 609.3 + CR 202.3 + CR 120.1: Ensnared by the Mara's losing branch —
+    /// "that player exiles the top four cards of their library and ~ deals
+    /// damage equal to the total mana value of those exiled cards to that
+    /// player." The `ExileTop` publishes a tracked set (because its `DealDamage`
+    /// sub-ability references it via `TrackedSetAggregate`); the chained
+    /// `DealDamage` then sums the exiled cards' mana values from that set.
+    /// Discriminating: a fifth library card (MV 8) is NOT among the exiled four
+    /// and must not be summed.
+    #[test]
+    fn exile_top_then_deal_damage_sums_mana_value_of_those_exiled_cards() {
+        let mut state = GameState::new_two_player(42);
+
+        // Top four cards (exiled): mana values 1, 2, 3, 4 → sum 10.
+        for (i, mv) in [1u32, 2, 3, 4].iter().enumerate() {
+            let id = create_object(
+                &mut state,
+                CardId(i as u64 + 1),
+                PlayerId(0),
+                format!("Card{i}"),
+                Zone::Library,
+            );
+            state.objects.get_mut(&id).unwrap().mana_cost =
+                crate::types::mana::ManaCost::generic(*mv);
+        }
+        // Fifth card (NOT exiled): mana value 8 — must be excluded from the sum.
+        let untouched = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(0),
+            "Untouched".to_string(),
+            Zone::Library,
+        );
+        state.objects.get_mut(&untouched).unwrap().mana_cost =
+            crate::types::mana::ManaCost::generic(8);
+
+        let damage = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::TrackedSetAggregate {
+                        function: AggregateFunction::Sum,
+                        property: ObjectProperty::ManaValue,
+                    },
+                },
+                target: TargetFilter::Controller,
+                damage_source: None,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+
+        let mut exile = make_exile_top_ability(4);
+        exile.sub_ability = Some(Box::new(damage));
+
+        let starting_life = state
+            .players
+            .iter()
+            .find(|p| p.id == PlayerId(0))
+            .unwrap()
+            .life;
+
+        // CR 603.7: Drive through `resolve_ability_chain` so the chain processor
+        // publishes ExileTop's tracked set before the DealDamage sub-ability
+        // reads it (mirrors live resolution).
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &exile, &mut events, 0).unwrap();
+
+        let ending_life = state
+            .players
+            .iter()
+            .find(|p| p.id == PlayerId(0))
+            .unwrap()
+            .life;
+        assert_eq!(
+            starting_life - ending_life,
+            10,
+            "TrackedSetAggregate must sum exactly the four exiled cards' mana values (1+2+3+4=10), excluding the untouched MV-8 card",
+        );
+
+        // Sanity: the fifth card stayed in the library (only four were exiled).
+        assert_eq!(
+            state.objects.get(&untouched).map(|obj| obj.zone),
+            Some(Zone::Library)
         );
     }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2732,6 +2732,7 @@ fn quantity_expr_references_tracked_set(qty: &QuantityExpr) -> bool {
                 qty,
                 QuantityRef::TrackedSetSize
                     | QuantityRef::FilteredTrackedSetSize { .. }
+                    | QuantityRef::TrackedSetAggregate { .. }
                     | QuantityRef::DistinctCardTypes {
                         source: CardTypeSetSource::TrackedSet { .. }
                     }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -291,6 +291,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::ZoneCardCount { .. }
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
+        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount
         | QuantityRef::LifeLostThisTurn { .. }
@@ -468,6 +469,7 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::ZoneCardCount { .. }
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
+        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount
         | QuantityRef::LifeLostThisTurn { .. }
@@ -1775,6 +1777,42 @@ fn resolve_ref(
                 })
                 .count();
             usize_to_i32_saturating(count)
+        }
+        // CR 608.2c + CR 609.3 + CR 107.3e + CR 202.3: Reduce a numeric property
+        // over the most recent chain tracked set. Mirrors `FilteredTrackedSetSize`'s set
+        // selection (highest id = the set the preceding chain effect published)
+        // but aggregates a per-member value instead of counting. The members are
+        // addressed by identity, so cards the producer moved to exile are read in
+        // place (mirrors the `Aggregate` extract: live object first, LKI cache
+        // fallback). Drives "deals damage equal to the total mana value of those
+        // exiled cards" (Ensnared by the Mara).
+        QuantityRef::TrackedSetAggregate { function, property } => {
+            let Some((_, ids)) = state.tracked_object_sets.iter().max_by_key(|(id, _)| id.0) else {
+                return 0;
+            };
+            let extract = |id: ObjectId| -> Option<i32> {
+                let live = state.objects.get(&id).and_then(|obj| match property {
+                    ObjectProperty::Power => obj.power,
+                    ObjectProperty::Toughness => obj.toughness,
+                    // CR 202.3e: include X when on the stack (cost_x_paid).
+                    ObjectProperty::ManaValue => Some(u32_to_i32_saturating(
+                        obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid),
+                    )),
+                });
+                live.or_else(|| {
+                    state.lki_cache.get(&id).and_then(|lki| match property {
+                        ObjectProperty::Power => lki.power,
+                        ObjectProperty::Toughness => lki.toughness,
+                        ObjectProperty::ManaValue => Some(u32_to_i32_saturating(lki.mana_value)),
+                    })
+                })
+            };
+            let values = ids.iter().filter_map(|&id| extract(id));
+            match function {
+                AggregateFunction::Max => values.max().unwrap_or(0),
+                AggregateFunction::Min => values.min().unwrap_or(0),
+                AggregateFunction::Sum => values.sum(),
+            }
         }
         // CR 400.7 + CR 608.2c: Read the per-resolution counter populated by
         // ChangeZoneAll when it exiles cards from a hand. Used by "draws a card

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -50861,17 +50861,17 @@ mod tests {
         }
     }
 
-    /// CR 120.1 + CR 202.3 (cluster 32, Class C — Ensnared by the Mara): the
-    /// branch-1 damage amount "the total mana value of those exiled cards" is an
-    /// exiled-this-resolution aggregate the typed quantity parsers don't yet
-    /// model. It must NOT degrade to a verbatim `QuantityRef::Variable` carrying
-    /// raw Oracle text — that would silently resolve to 0 damage at runtime
-    /// (only `Variable{name:"X"}` / named choices resolve). Instead the
-    /// `DealDamage` step must strict-fail to `Effect::Unimplemented` so coverage
-    /// honestly flags the gap. The `ExileTop` branch head still parses, keeping
-    /// the two-branch `ChooseOneOf` intact.
+    /// CR 120.1 + CR 202.3 + CR 609.3 (cluster 32, Class C — Ensnared by the
+    /// Mara): the branch-1 damage amount "the total mana value of those exiled
+    /// cards" is an aggregate over the most recent chain tracked set — the cards
+    /// the branch-head `ExileTop` published. It parses to
+    /// `QuantityRef::TrackedSetAggregate { Sum, ManaValue }` (NOT a verbatim
+    /// `QuantityRef::Variable`, which would silently resolve to 0 damage). Because
+    /// the `DealDamage` is `ExileTop`'s sub-ability, the chain processor publishes
+    /// ExileTop's affected set before the damage step reads it (see
+    /// `exile_top_then_deal_damage_sums_mana_value_of_those_exiled_cards`).
     #[test]
-    fn ensnared_by_the_mara_unresolvable_damage_amount_strict_fails_not_verbatim_variable() {
+    fn ensnared_by_the_mara_damage_amount_is_tracked_set_aggregate() {
         let ability = parse_effect_chain(
             "Each opponent faces a villainous choice — They exile cards from the top of their library until they exile a nonland card, then you may cast that card without paying its mana cost, or that player exiles the top four cards of their library and ~ deals damage equal to the total mana value of those exiled cards to that player.",
             AbilityKind::Spell,
@@ -50883,8 +50883,8 @@ mod tests {
         assert_eq!(*chooser, PlayerFilter::Opponent);
         assert_eq!(branches.len(), 2);
 
-        // Branch 1 head exiles four cards (still parses); the chained damage
-        // step strict-fails rather than emitting a verbatim Variable.
+        // Branch 1 head exiles four cards; its chained sub-ability deals damage
+        // equal to the total mana value of that exiled (tracked) set.
         let branch1 = &branches[1];
         assert!(
             matches!(&*branch1.effect, Effect::ExileTop { .. }),
@@ -50895,17 +50895,28 @@ mod tests {
             .sub_ability
             .as_ref()
             .expect("branch 1 must retain its chained damage step");
+        let Effect::DealDamage { amount, .. } = &*damage.effect else {
+            panic!(
+                "branch 1 damage step must be DealDamage, got {:?}",
+                damage.effect
+            );
+        };
         assert!(
-            matches!(&*damage.effect, Effect::Unimplemented { .. }),
-            "branch 1 damage step must strict-fail to Unimplemented (unresolvable exiled-cards aggregate), got {:?}",
-            damage.effect
+            matches!(
+                amount,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::TrackedSetAggregate {
+                        function: AggregateFunction::Sum,
+                        property: ObjectProperty::ManaValue,
+                    }
+                }
+            ),
+            "branch 1 damage amount must be TrackedSetAggregate(Sum, ManaValue), got {amount:?}"
         );
 
-        // Belt-and-braces: no node anywhere in the parsed ability stores the raw
-        // Oracle aggregate phrase as a `QuantityRef::Variable` name (the
-        // prohibited verbatim-text-in-parser smell). The phrase legitimately
-        // survives in human-readable `description`/Unimplemented-trace fields —
-        // only its appearance as a resolvable `Variable` payload is the defect.
+        // The verbatim Oracle aggregate phrase must never be stored as a
+        // resolvable `QuantityRef::Variable` name (the prohibited
+        // verbatim-text-in-parser smell).
         let json = serde_json::to_string(&ability).expect("serialize ability");
         assert!(
             !json.contains(r#""Variable","name":"the total mana value"#),

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -267,6 +267,26 @@ pub(crate) fn parse_quantity_ref_with_context(
     ))
     .parse(trimmed)
     {
+        // CR 608.2c + CR 609.3 + CR 107.3e: "the total <property> of those exiled
+        // cards" is an aggregate over the most recent chain tracked set, not over live
+        // battlefield objects — the anaphor "those exiled cards" refers to the set
+        // the preceding effect published (e.g. Ensnared by the Mara's `ExileTop`).
+        // Matched before `parse_type_phrase_with_ctx` so the exile anaphor isn't
+        // mis-read as a type phrase. Reuses the established exile-anaphor pair from
+        // `oracle_effect::mod` (`those exiled cards` / `the exiled cards`).
+        if let Ok((anaphor_rest, _)) = alt((
+            tag::<_, _, OracleError<'_>>("those exiled cards"),
+            tag("the exiled cards"),
+        ))
+        .parse(rest)
+        {
+            if anaphor_rest.trim().is_empty() {
+                return Some(QuantityRef::TrackedSetAggregate {
+                    function: func,
+                    property: prop,
+                });
+            }
+        }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
         // CR 608.2h: present-tense aggregate. Accept a bare empty remainder
         // (existing no-snapshot behavior) or a trailing cast/activation-time
@@ -4063,6 +4083,43 @@ mod tests {
                 }
             }
         ));
+    }
+
+    #[test]
+    fn cda_quantity_total_mana_value_of_those_exiled_cards_is_tracked_set_aggregate() {
+        // CR 609.3 + CR 202.3: the plural anaphor "those exiled cards" aggregates
+        // over the most recent chain tracked set (the set the preceding effect
+        // published), NOT over live battlefield/exile objects via a type filter.
+        // Drives Ensnared by the Mara's "deals damage equal to the total mana
+        // value of those exiled cards".
+        let qty = parse_cda_quantity("the total mana value of those exiled cards").unwrap();
+        assert!(
+            matches!(
+                qty,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::TrackedSetAggregate {
+                        function: AggregateFunction::Sum,
+                        property: ObjectProperty::ManaValue,
+                    }
+                }
+            ),
+            "expected TrackedSetAggregate(Sum, ManaValue), got {qty:?}"
+        );
+
+        // The "the exiled cards" anaphor variant maps to the same set.
+        let qty2 = parse_cda_quantity("the total mana value of the exiled cards").unwrap();
+        assert!(
+            matches!(
+                qty2,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::TrackedSetAggregate {
+                        function: AggregateFunction::Sum,
+                        property: ObjectProperty::ManaValue,
+                    }
+                }
+            ),
+            "expected TrackedSetAggregate(Sum, ManaValue) for 'the exiled cards', got {qty2:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3735,6 +3735,19 @@ pub enum QuantityRef {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         caused_by: Option<ThisWayCause>,
     },
+    /// CR 608.2c + CR 609.3 + CR 107.3e + CR 202.3: Reduce a numeric property
+    /// over the most recent chain tracked set (sum/max/min), reading the same set as
+    /// [`QuantityRef::FilteredTrackedSetSize`] but aggregating a per-member value
+    /// instead of counting members. The set is selected by highest id (the set
+    /// the immediately-preceding chain effect published) and is zone-independent —
+    /// its members are addressed by identity, so cards the producer moved to exile
+    /// are read in place. Used by "deals damage equal to the total mana value of
+    /// those exiled cards" (Ensnared by the Mara — `Sum` over `ManaValue` of the
+    /// set the preceding `ExileTop` published).
+    TrackedSetAggregate {
+        function: AggregateFunction,
+        property: ObjectProperty,
+    },
     /// CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately
     /// preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's
     /// "draws a card for each card exiled from their hand this way." The counter


### PR DESCRIPTION
Ensnared by the Mara's losing villainous-choice branch deals damage equal to
the total mana value of the four cards it just exiled. That aggregate was
previously strict-failed to Unimplemented (it would otherwise degrade to a
verbatim QuantityRef::Variable that resolves to 0 damage).

Add QuantityRef::TrackedSetAggregate { function, property } — the aggregate
counterpart to FilteredTrackedSetSize. It reduces a numeric property
(sum/max/min over power/toughness/mana value) over the most recent chain
tracked set, addressing members by identity (live object then LKI fallback) so
the exiled cards are read in place regardless of zone. The producing ExileTop
publishes its set because the chained DealDamage references it through the
existing publish gate.

Registration points: QuantityRef variant + resolver + two perturbation
classifiers (game/quantity.rs), publish gate (effects/mod.rs), coverage
description + Handled class (coverage.rs), and the parser branch mapping
"the total <property> of those/the exiled cards" (oracle_quantity.rs).

CR 608.2c + CR 609.3 + CR 107.3e + CR 202.3.
