### PR TITLE
Add Unravel

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1787,6 +1787,10 @@ pub(super) fn strip_suffix_conditional(
         return (Some(cond), effect_text);
     }
 
+    if let Some(cond) = parse_mana_spent_vs_mana_value_target_condition_text(condition_core) {
+        return (Some(cond), effect_text);
+    }
+
     if let Some(condition) = parse_triggering_spell_targets_filter_ability_condition(condition_core)
         .or_else(|| try_nom_condition_as_ability_condition(condition_core, ctx))
         .or_else(|| parse_condition_text(condition_core))
@@ -1850,10 +1854,57 @@ fn parse_no_mana_spent_to_cast_target_condition(input: &str) -> OracleResult<'_,
     ))
 }
 
+/// CR 601.2h + CR 608.2c: "if the amount of mana spent to cast it/that spell
+/// was less than its mana value" on a targeted spell effect — the spell
+/// anaphors to the ability's object target (Unravel-class riders).
+fn parse_mana_spent_vs_mana_value_target_condition_text(text: &str) -> Option<AbilityCondition> {
+    let lower = text.to_ascii_lowercase();
+    nom_parse_lower(&lower, |input| {
+        all_consuming(parse_mana_spent_vs_mana_value_target_condition).parse(input)
+    })
+}
+
+fn parse_mana_spent_vs_mana_value_target_condition(
+    input: &str,
+) -> OracleResult<'_, AbilityCondition> {
+    let (rest, (_, _, _, comparator, _)) = (
+        tag("the amount of mana spent to cast "),
+        alt((tag("it"), tag("that spell"), tag("this spell"))),
+        alt((tag(" was "), tag(" is "))),
+        alt((
+            value(Comparator::LT, tag("less than")),
+            value(Comparator::GT, tag("greater than")),
+        )),
+        tag(" its mana value"),
+    )
+        .parse(input)?;
+    Ok((
+        rest,
+        AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ManaSpentToCast {
+                    scope: CastManaObjectScope::AbilityTarget,
+                    metric: CastManaSpentMetric::Total,
+                },
+            },
+            comparator,
+            rhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectManaValue {
+                    scope: ObjectScope::Target,
+                },
+            },
+        },
+    ))
+}
+
 pub(super) fn parse_condition_text(text: &str) -> Option<AbilityCondition> {
     let text = text.trim().trim_end_matches('.');
 
     if let Some(condition) = parse_no_mana_spent_to_cast_target_condition_text(text) {
+        return Some(condition);
+    }
+
+    if let Some(condition) = parse_mana_spent_vs_mana_value_target_condition_text(text) {
         return Some(condition);
     }
 
@@ -4287,6 +4338,38 @@ mod tests {
             &mut ParseContext::default(),
         );
         assert_eq!(text, "Counter target spell");
+        assert!(matches!(cond, Some(AbilityCondition::QuantityCheck { .. })));
+    }
+
+    #[test]
+    fn parse_mana_spent_vs_mana_value_target_condition_reads_ability_target_mana() {
+        let cond = parse_mana_spent_vs_mana_value_target_condition_text(
+            "the amount of mana spent to cast that spell was less than its mana value",
+        )
+        .expect("should parse target mana-spent comparison");
+        assert!(matches!(
+            cond,
+            AbilityCondition::QuantityCheck {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::ManaSpentToCast {
+                        scope: CastManaObjectScope::AbilityTarget,
+                        metric: CastManaSpentMetric::Total,
+                    },
+                },
+                comparator: Comparator::LT,
+                rhs: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectManaValue {
+                        scope: ObjectScope::Target,
+                    },
+                },
+            }
+        ));
+
+        let (cond, text) = strip_leading_general_conditional(
+            "If the amount of mana spent to cast that spell was less than its mana value, you draw a card.",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(text, "you draw a card.");
         assert!(matches!(cond, Some(AbilityCondition::QuantityCheck { .. })));
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -368,6 +368,7 @@ mod turn_control_priority_softlock;
 mod twice_instead_repeat_for;
 mod tyvar_activate_as_though_haste;
 mod unstoppable_slasher_half_life;
+mod unravel_counter_mana_value;
 mod ureni_attack_trigger;
 mod urge_to_feed_regression;
 mod urza_lord_high_artificer_shuffle_exile_free_cast;

--- a/crates/engine/tests/integration/unravel_counter_mana_value.rs
+++ b/crates/engine/tests/integration/unravel_counter_mana_value.rs
@@ -1,0 +1,47 @@
+//! Unravel — "Counter target spell. If the amount of mana spent to cast that
+//! spell was less than its mana value, you draw a card."
+//!
+//! Parser regression: the intervening-if on the draw rider must lower to a
+//! `QuantityCheck` over targeted-spell mana spent vs mana value.
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityCondition, CastManaObjectScope, CastManaSpentMetric, Comparator, Effect, ObjectScope,
+    QuantityExpr, QuantityRef,
+};
+
+const UNRAVEL_ORACLE: &str = "Counter target spell. If the amount of mana spent to cast that spell was less than its mana value, you draw a card.";
+
+#[test]
+fn unravel_parses_counter_and_conditional_draw() {
+    let parsed = parse_oracle_text(UNRAVEL_ORACLE, "Unravel", &[], &["Instant".to_string()], &[]);
+    let counter = parsed
+        .abilities
+        .first()
+        .expect("Unravel must parse a counter ability");
+    assert!(matches!(counter.effect.as_ref(), Effect::Counter { .. }));
+    assert!(counter.condition.is_none());
+
+    let draw = counter
+        .sub_ability
+        .as_ref()
+        .expect("Unravel must chain a conditional draw sub-ability");
+    assert!(matches!(draw.effect.as_ref(), Effect::Draw { .. }));
+    assert!(matches!(
+        draw.condition.as_ref(),
+        Some(AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ManaSpentToCast {
+                    scope: CastManaObjectScope::AbilityTarget,
+                    metric: CastManaSpentMetric::Total,
+                },
+            },
+            comparator: Comparator::LT,
+            rhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectManaValue {
+                    scope: ObjectScope::Target,
+                },
+            },
+        })
+    ));
+}


### PR DESCRIPTION
## Summary
Adds engine support for **Unravel**.

## Files changed
- crates/engine/src/parser/oracle_effect/conditions.rs
- crates/engine/tests/integration/main.rs
- crates/engine/tests/integration/unravel_counter_mana_value.rs

## CR references
CR 118.9 (mana spent vs mana value), CR 701.59a

## Track
Developer

## LLM
Model: claude-sonnet-4-6
Thinking: high
Tier: Standard

## Gate A
./scripts/check-parser-combinators.sh — clean (exit 0)

## Anchored on
- crates/engine/src/parser/oracle_effect/conditions.rs — existing conditional spell-effect parsers using `parse_*_condition`
- crates/engine/tests/integration/ — integration test pattern for counter + conditional draw cards

## Verification
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine --test integration unravel_counter_mana_value` — 1 pass / 0 fail

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
