### PR TITLE
Add Ertai's Trickery

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1787,6 +1787,10 @@ pub(super) fn strip_suffix_conditional(
         return (Some(cond), effect_text);
     }
 
+    if let Some(cond) = parse_was_kicked_condition_text(condition_core) {
+        return (Some(cond), effect_text);
+    }
+
     if let Some(condition) = parse_triggering_spell_targets_filter_ability_condition(condition_core)
         .or_else(|| try_nom_condition_as_ability_condition(condition_core, ctx))
         .or_else(|| parse_condition_text(condition_core))
@@ -1850,10 +1854,30 @@ fn parse_no_mana_spent_to_cast_target_condition(input: &str) -> OracleResult<'_,
     ))
 }
 
+/// CR 702.33d + CR 608.2c: "if it/that spell was kicked" suffix on a targeted
+/// spell effect (Ertai's Trickery).
+fn parse_was_kicked_condition_text(text: &str) -> Option<AbilityCondition> {
+    let lower = text.to_ascii_lowercase();
+    nom_parse_lower(&lower, |input| all_consuming(parse_was_kicked_condition).parse(input))
+}
+
+fn parse_was_kicked_condition(input: &str) -> OracleResult<'_, AbilityCondition> {
+    let (rest, _) = (
+        alt((tag("it"), tag("that spell"), tag("this spell"))),
+        tag(" was kicked"),
+    )
+        .parse(input)?;
+    Ok((rest, AbilityCondition::additional_cost_paid_any()))
+}
+
 pub(super) fn parse_condition_text(text: &str) -> Option<AbilityCondition> {
     let text = text.trim().trim_end_matches('.');
 
     if let Some(condition) = parse_no_mana_spent_to_cast_target_condition_text(text) {
+        return Some(condition);
+    }
+
+    if let Some(condition) = parse_was_kicked_condition_text(text) {
         return Some(condition);
     }
 
@@ -4288,6 +4312,16 @@ mod tests {
         );
         assert_eq!(text, "Counter target spell");
         assert!(matches!(cond, Some(AbilityCondition::QuantityCheck { .. })));
+    }
+
+    #[test]
+    fn parse_was_kicked_suffix_condition_on_counter() {
+        let (cond, text) = strip_suffix_conditional(
+            "Counter target spell if it was kicked",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(text, "Counter target spell");
+        assert_eq!(cond, Some(AbilityCondition::additional_cost_paid_any()));
     }
 
     /// CR 508.1a: filtered attack-history condition — "you attacked with <X>"

--- a/crates/engine/tests/integration/ertai_trickery_counter_kicked.rs
+++ b/crates/engine/tests/integration/ertai_trickery_counter_kicked.rs
@@ -1,0 +1,29 @@
+//! Ertai's Trickery — "Counter target spell if it was kicked."
+//!
+//! Parser regression: the trailing intervening-if must lower to
+//! `AdditionalCostPaid`, not remain as swallowed `Condition_If` text.
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityCondition, Effect};
+
+const ERTAI_TRICKERY_ORACLE: &str = "Counter target spell if it was kicked.";
+
+#[test]
+fn ertai_trickery_parses_counter_with_kicked_condition() {
+    let parsed = parse_oracle_text(
+        ERTAI_TRICKERY_ORACLE,
+        "Ertai's Trickery",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let ability = parsed
+        .abilities
+        .first()
+        .expect("Ertai's Trickery must parse a spell ability");
+    assert!(matches!(ability.effect.as_ref(), Effect::Counter { .. }));
+    assert!(matches!(
+        ability.condition.as_ref(),
+        Some(AbilityCondition::AdditionalCostPaid { .. })
+    ));
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -68,6 +68,7 @@ mod emrakul_control_turn_crash;
 #[cfg(feature = "proptest")]
 mod engine_invariants;
 mod enlightened_tutor_regression;
+mod ertai_trickery_counter_kicked;
 mod evelyn_regression;
 mod exchange_life_totals_cards;
 mod exhibition_tidecaller_target_player_mill;


### PR DESCRIPTION
## Summary
Adds engine support for **Ertai's Trickery**.

## Files changed
- crates/engine/src/parser/oracle_effect/conditions.rs
- crates/engine/tests/integration/main.rs
- crates/engine/tests/integration/ertai_trickery_counter_kicked.rs

## CR references
CR 702.32 (kicked spells)

## Track
Developer

## LLM
Model: claude-sonnet-4-6
Thinking: high
Tier: Standard

## Gate A
./scripts/check-parser-combinators.sh — clean (exit 0)

## Anchored on
- crates/engine/src/parser/oracle_effect/conditions.rs — `parse_was_kicked_condition` pattern
- crates/engine/tests/integration/ertai_trickery_counter_kicked.rs — counter-with-condition integration test

## Verification
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine --test integration ertai_trickery_counter_kicked` — 1 pass / 0 fail

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
