### PR TITLE
Skip blocker prompt when no attackers remain in play (#1555)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -2849,6 +2849,7 @@ pub fn get_valid_block_targets(state: &GameState) -> HashMap<ObjectId, Vec<Objec
             .attackers
             .iter()
             .filter(|a| a.defending_player == blocker_controller)
+            .filter(|a| is_attacker_in_play(state, a.object_id))
             .filter(|a| can_block_pair(state, blocker_id, a.object_id))
             .map(|a| a.object_id)
             .collect();
@@ -3127,6 +3128,42 @@ pub fn get_valid_attack_targets(state: &GameState) -> Vec<AttackTarget> {
     }
 
     targets
+}
+
+/// CR 506.4: A creature stops being an attacker when it leaves the battlefield
+/// or phases out. Attackers that left during the declare-attackers step may
+/// remain listed until pruned.
+pub fn is_attacker_in_play(state: &GameState, attacker_id: ObjectId) -> bool {
+    state.objects.get(&attacker_id).is_some_and(|obj| {
+        obj.zone == Zone::Battlefield
+            && !obj.is_phased_out()
+            && obj.card_types.core_types.contains(&CoreType::Creature)
+    })
+}
+
+/// CR 508.8: True when at least one declared attacker is still on the battlefield.
+pub fn has_attackers_in_play(state: &GameState) -> bool {
+    state.combat.as_ref().is_some_and(|combat| {
+        combat
+            .attackers
+            .iter()
+            .any(|attacker| is_attacker_in_play(state, attacker.object_id))
+    })
+}
+
+/// CR 506.4: Drop attackers that are no longer on the battlefield.
+pub fn prune_attackers_not_in_play(state: &mut GameState) {
+    if let Some(combat) = state.combat.as_ref() {
+        let stale: Vec<ObjectId> = combat
+            .attackers
+            .iter()
+            .filter(|attacker| !is_attacker_in_play(state, attacker.object_id))
+            .map(|attacker| attacker.object_id)
+            .collect();
+        for attacker_id in stale {
+            super::effects::remove_from_combat::remove_object_from_combat(state, attacker_id);
+        }
+    }
 }
 
 /// Check if the active player controls any creatures that could legally attack.
@@ -4367,6 +4404,26 @@ mod tests {
     fn has_potential_attackers_false_when_no_creatures() {
         let state = setup();
         assert!(!has_potential_attackers(&state));
+    }
+
+    #[test]
+    fn has_attackers_in_play_false_when_attacker_left_battlefield() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+        assert!(has_attackers_in_play(&state));
+
+        state.objects.get_mut(&attacker).unwrap().zone = Zone::Graveyard;
+        assert!(
+            !has_attackers_in_play(&state),
+            "attackers in the graveyard must not count as in play (#1555)"
+        );
+
+        prune_attackers_not_in_play(&mut state);
+        assert!(state.combat.as_ref().unwrap().attackers.is_empty());
     }
 
     #[test]

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1208,7 +1208,10 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
                 player,
                 valid_blocker_ids,
                 ..
-            } if !phase_stop_hit(state, *player) && valid_blocker_ids.is_empty() => {
+            } if !phase_stop_hit(state, *player)
+                && (valid_blocker_ids.is_empty()
+                    || !super::combat::has_attackers_in_play(state)) =>
+            {
                 let mut events = Vec::new();
                 match engine_combat::handle_empty_blockers(state, *player, &mut events) {
                     Ok(wf) => {

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -2044,9 +2044,23 @@ mod tests {
         let mut state = GameState::new(crate::types::format::FormatConfig::free_for_all(), 4, 42);
         state.active_player = PlayerId(0);
         state.phase = Phase::DeclareBlockers;
+        let attacker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
         state.combat = Some(combat::CombatState {
             attackers: vec![combat::AttackerInfo::new(
-                ObjectId(1),
+                attacker,
                 combat::AttackTarget::Player(PlayerId(2)),
                 PlayerId(2),
             )],

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1885,10 +1885,8 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
             }
             Phase::DeclareBlockers => {
                 // CR 509.1: Defending player declares blockers as a turn-based action.
-                let has_attackers = state
-                    .combat
-                    .as_ref()
-                    .is_some_and(|c| !c.attackers.is_empty());
+                super::combat::prune_attackers_not_in_play(state);
+                let has_attackers = super::combat::has_attackers_in_play(state);
                 if has_attackers {
                     // CR 509.1 + CR 117.1c: The declare blockers turn-based action always
                     // runs — even when no legal blocks are available — and the active


### PR DESCRIPTION
## Summary

- Treat attackers that left the battlefield before the declare blockers step as no longer attacking (CR 506.4)
- Skip the declare blockers step when no attackers remain in play (CR 508.8)
- Auto-submit empty blockers when all declared attackers are gone

fix #1555

## Test plan

- [x] `cargo test -p engine --lib has_attackers_in_play_false_when_attacker_left_battlefield`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p engine -- -D warnings`

Made with [Cursor](https://cursor.com)