### PR TITLE
fix(engine): Queen Marchesa upkeep only when opponent is monarch (#1539)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -563,6 +563,21 @@ fn parse_player_state_conditions(input: &str) -> OracleResult<'_, StaticConditio
             StaticCondition::IsMonarch,
             alt((tag("you're the monarch"), tag("you are the monarch"))),
         ),
+        // CR 725.1: "if an opponent is the monarch" — a monarch exists and it
+        // is not the controller. Distinct from `Not(IsMonarch)` (also true when
+        // no monarch exists) and from `NoMonarch` (true only when vacant).
+        map(tag("an opponent is the monarch"), |_| {
+            StaticCondition::And {
+                conditions: vec![
+                    StaticCondition::Not {
+                        condition: Box::new(StaticCondition::IsMonarch),
+                    },
+                    StaticCondition::Not {
+                        condition: Box::new(StaticCondition::NoMonarch),
+                    },
+                ],
+            }
+        }),
         // CR 726.3: Initiative status
         value(
             StaticCondition::IsInitiative,
@@ -8591,6 +8606,25 @@ mod tests {
         let (rest, c) = parse_inner_condition("you are the monarch").unwrap();
         assert_eq!(rest, "");
         assert_eq!(c, StaticCondition::IsMonarch);
+    }
+
+    #[test]
+    fn test_an_opponent_is_the_monarch() {
+        let (rest, c) = parse_inner_condition("an opponent is the monarch").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            c,
+            StaticCondition::And {
+                conditions: vec![
+                    StaticCondition::Not {
+                        condition: Box::new(StaticCondition::IsMonarch),
+                    },
+                    StaticCondition::Not {
+                        condition: Box::new(StaticCondition::NoMonarch),
+                    },
+                ],
+            }
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2672,6 +2672,14 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
             StaticCondition::SourceIsTapped => Some(TriggerCondition::Not {
                 condition: Box::new(TriggerCondition::SourceIsTapped),
             }),
+            // CR 725.1: "if you're not the monarch" / "if an opponent is the monarch".
+            StaticCondition::IsMonarch => Some(TriggerCondition::Not {
+                condition: Box::new(TriggerCondition::IsMonarch),
+            }),
+            // CR 725.1: "if there is a monarch" (negated no-monarch check).
+            StaticCondition::NoMonarch => Some(TriggerCondition::Not {
+                condition: Box::new(TriggerCondition::NoMonarch),
+            }),
             // CR 103.1: "you weren't the starting player" → Not(WasStartingPlayer).
             StaticCondition::WasStartingPlayer { controller } => Some(TriggerCondition::Not {
                 condition: Box::new(TriggerCondition::WasStartingPlayer {
@@ -26038,6 +26046,60 @@ mod tests {
             static_condition_to_trigger_condition(&StaticCondition::IsMonarch),
             Some(TriggerCondition::IsMonarch),
         );
+    }
+
+    #[test]
+    fn bridge_opponent_is_monarch_intervening_if() {
+        let sc = StaticCondition::And {
+            conditions: vec![
+                StaticCondition::Not {
+                    condition: Box::new(StaticCondition::IsMonarch),
+                },
+                StaticCondition::Not {
+                    condition: Box::new(StaticCondition::NoMonarch),
+                },
+            ],
+        };
+        assert_eq!(
+            static_condition_to_trigger_condition(&sc),
+            Some(TriggerCondition::And {
+                conditions: vec![
+                    TriggerCondition::Not {
+                        condition: Box::new(TriggerCondition::IsMonarch),
+                    },
+                    TriggerCondition::Not {
+                        condition: Box::new(TriggerCondition::NoMonarch),
+                    },
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn queen_marchesa_upkeep_attaches_opponent_monarch_intervening_if() {
+        let oracle = "At the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with haste.";
+        let def = parse_trigger_line(oracle, "Queen Marchesa");
+        assert_eq!(def.mode, TriggerMode::Phase);
+        assert_eq!(def.phase, Some(Phase::Upkeep));
+        let condition = def.condition.as_ref().expect("intervening-if must parse");
+        assert!(matches!(
+            condition,
+            TriggerCondition::And {
+                conditions,
+            } if conditions.len() == 2
+                && matches!(
+                    conditions[0],
+                    TriggerCondition::Not {
+                        condition: ref inner,
+                    } if matches!(inner.as_ref(), TriggerCondition::IsMonarch)
+                )
+                && matches!(
+                    conditions[1],
+                    TriggerCondition::Not {
+                        condition: ref inner,
+                    } if matches!(inner.as_ref(), TriggerCondition::NoMonarch)
+                )
+        ));
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_1539_queen_marchesa.rs
+++ b/crates/engine/tests/integration/issue_1539_queen_marchesa.rs
@@ -1,0 +1,69 @@
+//! Issue #1539: Queen Marchesa must only create an Assassin token at your
+//! upkeep when an opponent is the monarch (CR 603.4 intervening-if).
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::PlayerId;
+
+const QUEEN_MARCHESA_UPKEEP: &str =
+    "At the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with haste.";
+
+fn build_runner(
+    monarch: Option<PlayerId>,
+) -> engine::game::scenario::GameRunner {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    scenario
+        .add_creature(P0, "Queen Marchesa", 3, 3)
+        .from_oracle_text(QUEEN_MARCHESA_UPKEEP);
+    let mut runner = scenario.build();
+    runner.state_mut().monarch = monarch;
+    runner
+}
+
+#[test]
+fn queen_marchesa_skips_assassin_when_controller_is_monarch() {
+    let mut runner = build_runner(Some(P0));
+    let before = runner.battlefield_count(P0);
+    runner.advance_to_upkeep();
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.battlefield_count(P0),
+        before,
+        "Queen Marchesa must not create an Assassin when you are the monarch"
+    );
+}
+
+#[test]
+fn queen_marchesa_creates_assassin_when_opponent_is_monarch() {
+    let mut runner = build_runner(Some(P1));
+    let before = runner.battlefield_count(P0);
+    runner.advance_to_upkeep();
+    runner.advance_until_stack_empty();
+    assert!(
+        runner.battlefield_count(P0) > before,
+        "Queen Marchesa must create an Assassin when an opponent is the monarch"
+    );
+}
+
+#[test]
+fn queen_marchesa_upkeep_trigger_parses_with_condition() {
+    let parsed = parse_oracle_text(
+        QUEEN_MARCHESA_UPKEEP,
+        "Queen Marchesa",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::Phase && t.phase == Some(Phase::Upkeep))
+        .expect("upkeep trigger");
+    assert!(
+        trigger.condition.is_some(),
+        "intervening-if must be present"
+    );
+}

--- a/crates/engine/tests/integration/issue_1539_queen_marchesa.rs
+++ b/crates/engine/tests/integration/issue_1539_queen_marchesa.rs
@@ -10,9 +10,7 @@ use engine::types::PlayerId;
 const QUEEN_MARCHESA_UPKEEP: &str =
     "At the beginning of your upkeep, if an opponent is the monarch, create a 1/1 black Assassin creature token with haste.";
 
-fn build_runner(
-    monarch: Option<PlayerId>,
-) -> engine::game::scenario::GameRunner {
+fn build_runner(monarch: Option<PlayerId>) -> engine::game::scenario::GameRunner {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::Untap);
     scenario

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -141,6 +141,7 @@ mod issue_1499_arabella;
 mod issue_1509_sorcery_main_phase_cast;
 mod issue_1524_serpents_soul_jar;
 mod issue_1526_harvest_season;
+mod issue_1539_queen_marchesa;
 mod issue_1549_legend_of_roku_impulse;
 mod issue_1961_joel_token_dies;
 mod issue_1963_lotleth_troll;


### PR DESCRIPTION
## Summary
- Parse `"if an opponent is the monarch"` as an intervening-if condition (controller is not monarch and a monarch exists).
- Bridge `Not(IsMonarch)` / `Not(NoMonarch)` through the static→trigger condition mapper so the compound condition evaluates at trigger time.
- Add integration tests covering Queen Marchesa's upkeep Assassin token when P0 vs P1 holds the monarch designation.

fix #1539

## Test plan
- [x] `cargo test -p engine --test integration issue_1539`
- [x] `cargo clippy -p engine -- -D warnings`
- [x] `cargo fmt --check`


Made with [Cursor](https://cursor.com)