### PR TITLE
fix(ui): show affinity-adjusted costs in Choose X overlay (#1538)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1121,7 +1121,13 @@ export type WaitingFor =
   | { type: "ManaPayment"; data: { player: PlayerId; convoke_mode?: ConvokeMode } }
   | {
       type: "ChooseXValue";
-      data: { player: PlayerId; min?: number; max: number; pending_cast: PendingCast };
+      data: {
+        player: PlayerId;
+        min?: number;
+        max: number;
+        pending_cast: PendingCast;
+        x_cost_previews?: [number, ManaCost][];
+      };
     }
   | { type: "PayAmountChoice"; data: { player: PlayerId; resource: PayableResource; min: number; max: number; accumulated?: number; source_id: ObjectId; pending_mana_ability?: unknown } }
   | { type: "TargetSelection"; data: { player: PlayerId; pending_cast: PendingCast; target_slots: TargetSelectionSlot[]; mode_labels?: (string | null)[]; selection: TargetSelectionProgress } }

--- a/client/src/components/mana/ChooseXValueUI.tsx
+++ b/client/src/components/mana/ChooseXValueUI.tsx
@@ -29,19 +29,22 @@ export function ChooseXValueUI() {
   const hasValidBounds = min <= max;
   const defaultValue = hasValidBounds ? Math.max(min, 0) : 0;
   const pendingCast = isChooseX ? waitingFor.data.pending_cast : null;
+  const xCostPreviews = isChooseX ? waitingFor.data.x_cost_previews : undefined;
+
+  const [value, setValue] = useState(0);
 
   const pendingCostShards = useMemo(() => {
     if (!pendingCast) return null;
-    const shards = manaCostToShards(pendingCast.cost);
+    const previewCost = xCostPreviews?.find(([x]) => x === value)?.[1];
+    const cost = previewCost ?? pendingCast.cost;
+    const shards = manaCostToShards(cost);
     return shards.length > 0 ? shards : null;
-  }, [pendingCast]);
+  }, [pendingCast, xCostPreviews, value]);
 
   const cardName = useMemo(() => {
     if (!gameState || !pendingCast) return null;
     return gameState.objects[pendingCast.object_id]?.name ?? null;
   }, [gameState, pendingCast]);
-
-  const [value, setValue] = useState(0);
 
   useEffect(() => {
     if (isChooseX) setValue(defaultValue);

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4345,6 +4345,32 @@ pub(super) fn concrete_cost_for_x(
     cost
 }
 
+/// CR 601.2f + CR 702.41a: Build per-X total cost previews for the Choose-X UI.
+/// Each entry is `(x, concrete_cost)` after Affinity/reductions/floors. Empty
+/// when `base_cost` is unavailable or the legal range exceeds 100 values.
+pub(super) fn build_choose_x_cost_previews(
+    state: &GameState,
+    player: PlayerId,
+    pending: &PendingCast,
+    min: u32,
+    max: u32,
+) -> Vec<(u32, ManaCost)> {
+    let Some(base) = pending.base_cost.as_ref() else {
+        return Vec::new();
+    };
+    if min > max || max.saturating_sub(min) > 100 {
+        return Vec::new();
+    }
+    (min..=max)
+        .map(|x| {
+            (
+                x,
+                concrete_cost_for_x(state, player, pending.object_id, &pending.ability, base, x),
+            )
+        })
+        .collect()
+}
+
 /// CR 601.2f + CR 107.3g: Re-derive a pending `{X}` spell's full concrete cost
 /// AFTER the chosen X is known. Rebuilds from the captured tax-inclusive base
 /// via `concrete_cost_for_x`, re-applying all reductions, target-dependent
@@ -20466,6 +20492,37 @@ mod tests {
         // affordable X effectively costs 1 less mana — max X is 3 higher.
         let (mut affinity_state, affinity_spell) = build_state(3);
         let affinity_max = choose_max(&mut affinity_state, affinity_spell);
+
+        match &affinity_state.waiting_for {
+            WaitingFor::ChooseXValue {
+                x_cost_previews,
+                min,
+                max,
+                ..
+            } => {
+                assert_eq!(*min, 0);
+                assert_eq!(*max, affinity_max);
+                assert_eq!(
+                    x_cost_previews.len(),
+                    (max - min + 1) as usize,
+                    "Choose-X UI must receive per-X cost previews"
+                );
+                let cost_at_3 = x_cost_previews
+                    .iter()
+                    .find(|(x, _)| *x == 3)
+                    .map(|(_, cost)| cost.clone())
+                    .expect("preview for X=3");
+                assert_eq!(
+                    cost_at_3,
+                    ManaCost::Cost {
+                        shards: vec![ManaCostShard::Black, ManaCostShard::Black],
+                        generic: 0,
+                    },
+                    "3 creature Affinity on {{X}}{{B}}{{B}} at X=3 must preview as two black mana"
+                );
+            }
+            other => panic!("expected ChooseXValue with previews, got {other:?}"),
+        }
 
         assert_eq!(
             affinity_max,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -3641,12 +3641,15 @@ fn pay_additional_cost_with_source(
             let cost = prepend_deferred_required_cost(cost, &mut pending);
             pending.additional_cost_flow = Some(AdditionalCost::Required(cost));
             state.pending_cast = Some(Box::new(pending.clone()));
+            let x_cost_previews =
+                super::casting::build_choose_x_cost_previews(state, player, &pending, min, max);
             return Ok(WaitingFor::ChooseXValue {
                 player,
                 min,
                 max,
                 pending_cast: Box::new(pending),
                 convoke_mode: None,
+                x_cost_previews,
             });
         }
     }
@@ -6973,12 +6976,20 @@ pub fn enter_payment_step(
                 )));
             }
             let pending_cast = pending.clone();
+            let x_cost_previews = super::casting::build_choose_x_cost_previews(
+                state,
+                player,
+                &pending_cast,
+                min,
+                max,
+            );
             return Ok(WaitingFor::ChooseXValue {
                 player,
                 min,
                 max,
                 pending_cast,
                 convoke_mode,
+                x_cost_previews,
             });
         }
 

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1256,6 +1256,7 @@ mod tests {
             max: 5,
             pending_cast: pending.clone(),
             convoke_mode: None,
+            x_cost_previews: vec![],
         };
         state.pending_cast = Some(pending);
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2679,6 +2679,10 @@ pub enum WaitingFor {
     /// `convoke_mode` passes through to the subsequent `ManaPayment` step.
     /// `pending_cast` is embedded so filtered state snapshots (multiplayer)
     /// still carry enough context for the UI to render the spell name/cost.
+    /// `x_cost_previews` maps each legal X in `[min, max]` to the engine-
+    /// authoritative total mana cost after concretizing X and applying cost
+    /// modifiers (Affinity, reductions, floors). Display-only for the Choose-X
+    /// UI — omitted when the range is empty or unreasonably large.
     ChooseXValue {
         player: PlayerId,
         #[serde(default)]
@@ -2687,6 +2691,8 @@ pub enum WaitingFor {
         pending_cast: Box<PendingCast>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         convoke_mode: Option<ConvokeMode>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        x_cost_previews: Vec<(u32, ManaCost)>,
     },
     TargetSelection {
         player: PlayerId,
@@ -8237,6 +8243,7 @@ mod tests {
             max: 5,
             pending_cast: pending,
             convoke_mode: None,
+            x_cost_previews: vec![],
         };
         assert!(choose_x.pending_cast_ref().is_some());
         assert!(choose_x.has_pending_cast());

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -2323,6 +2323,7 @@ mod tests {
                     max: 3,
                     pending_cast: dummy_pending_cast(),
                     convoke_mode: None,
+                    x_cost_previews: vec![],
                 },
             ),
             (

--- a/crates/phase-ai/src/policies/copy_value.rs
+++ b/crates/phase-ai/src/policies/copy_value.rs
@@ -472,6 +472,7 @@ mod tests {
                 max: 3,
                 pending_cast: Box::new(pending_cast),
                 convoke_mode: None,
+                x_cost_previews: vec![],
             },
             candidates: Vec::new(),
         };
@@ -540,6 +541,7 @@ mod tests {
                 max: 3,
                 pending_cast: Box::new(pending_cast),
                 convoke_mode: None,
+                x_cost_previews: vec![],
             },
             candidates: Vec::new(),
         };

--- a/crates/phase-ai/src/policies/x_value.rs
+++ b/crates/phase-ai/src/policies/x_value.rs
@@ -284,6 +284,7 @@ mod tests {
                 max: 4,
                 pending_cast: Box::new(fireball_pending_cast()),
                 convoke_mode: None,
+                x_cost_previews: vec![],
             },
             candidates: Vec::new(),
         };
@@ -348,6 +349,7 @@ mod tests {
                 max: 5,
                 pending_cast: Box::new(fireball_pending_cast()),
                 convoke_mode: None,
+                x_cost_previews: vec![],
             },
             candidates: Vec::new(),
         };
@@ -424,6 +426,7 @@ mod tests {
                 max: 3,
                 pending_cast: Box::new(pending_cast),
                 convoke_mode: None,
+                x_cost_previews: vec![],
             },
             candidates: Vec::new(),
         };


### PR DESCRIPTION
## Summary
- Attach engine-computed `x_cost_previews` to `WaitingFor::ChooseXValue` for each legal X value after Affinity/reductions/floors.
- Update `ChooseXValueUI` to display the preview cost for the currently selected X instead of the symbolic `{X}` cost.
- Extend the granted-Affinity X-cap regression test to assert previews are present and correct.

fix #1538

## Test plan
- [x] `cargo test --lib x_cost_max_accounts_for_granted_affinity_exceeding_fixed_generic`
- [x] `npm test -- --run ChooseXValueUI`
- [x] `cargo clippy -p engine -- -D warnings`


Made with [Cursor](https://cursor.com)