### PR TITLE
fix(parser): resolve self-pronoun "it" subject in self-static conditions

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -693,6 +693,35 @@ pub(crate) fn parse_typed_you_control_subject_filter(
 
 /// Parse "gets +N/+M [and has {keyword}]" after the subject.
 /// Also handles "gets +N/+M for each [clause]" dynamic P/T patterns.
+/// CR 611.3a: In a self-referential static the pronoun "it" co-refers with the
+/// source permanent, so rewrite a leading "it's "/"it is " subject to the
+/// canonical "~ is " before the condition is typed (e.g. Giant Tortoise's
+/// "as long as it's untapped").
+///
+/// Two guards keep this safe:
+/// 1. Callers MUST only apply it when the affected subject is `SelfRef` — for
+///    attached-subject statics (an Aura/Equipment whose "it" refers to the
+///    enchanted/equipped creature) the pronoun is not the source.
+/// 2. Only the bare source-STATE predicates that `~ is …` already resolves to a
+///    typed condition are rewritten. "it" is otherwise overloaded: "it's your
+///    turn" is impersonal (a turn reference, not the source); "it's a Wall" /
+///    "it's red" / "it's legendary" are type/characteristic gates with their own
+///    parse paths. Rewriting those would break or mis-bind them, so they are
+///    left untouched.
+///
+/// Returns the condition unchanged when neither guard matches.
+fn rewrite_self_pronoun_subject(condition: &str) -> String {
+    let lower = condition.to_lowercase();
+    if let Some(rest) =
+        nom_tag_lower(&lower, &lower, "it's ").or_else(|| nom_tag_lower(&lower, &lower, "it is "))
+    {
+        if matches!(rest.trim(), "tapped" | "untapped") {
+            return format!("~ is {}", rest.trim());
+        }
+    }
+    condition.to_string()
+}
+
 pub(crate) fn parse_continuous_gets_has(
     text: &str,
     affected: TargetFilter,
@@ -710,10 +739,17 @@ pub(crate) fn parse_continuous_gets_has(
         if let Some(mut def) =
             parse_continuous_gets_has(continuous_text, affected.clone(), description)
         {
-            let condition =
-                parse_static_condition(condition_text).unwrap_or(StaticCondition::Unrecognized {
-                    text: condition_text.to_string(),
-                });
+            // CR 611.3a: only resolve the self-pronoun "it" to the source when the
+            // static modifies itself; attached-subject statics keep "it" bound to
+            // the enchanted/equipped creature and stay an honest gap.
+            let typed = if matches!(affected, TargetFilter::SelfRef) {
+                parse_static_condition(&rewrite_self_pronoun_subject(condition_text))
+            } else {
+                parse_static_condition(condition_text)
+            };
+            let condition = typed.unwrap_or(StaticCondition::Unrecognized {
+                text: condition_text.to_string(),
+            });
             def.condition = Some(condition);
             return Some(def);
         }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -17564,3 +17564,41 @@ fn ratonhnhaketon_hasnt_dealt_damage_gates_hexproof_and_cant_be_blocked() {
     assert_eq!(evasion.affected, Some(TargetFilter::SelfRef));
     assert_eq!(evasion.condition, expected_condition);
 }
+
+#[test]
+fn self_static_resolves_it_pronoun_subject_to_source() {
+    // CR 611.3a: "it" in a self-referential static gate refers to the source, so
+    // "as long as it's untapped" must type to the same Not(SourceIsTapped) as the
+    // explicit "~ is untapped" form — not fall through to Unrecognized.
+    // Discriminating: before resolving the pronoun this came back Unrecognized.
+    let def = parse_static_line("This creature gets +0/+3 as long as it's untapped.")
+        .expect("self static def");
+    assert!(
+        matches!(
+            def.condition.as_ref(),
+            Some(StaticCondition::Not { condition })
+                if matches!(condition.as_ref(), StaticCondition::SourceIsTapped)
+        ),
+        "expected Not(SourceIsTapped), got {:?}",
+        def.condition
+    );
+}
+
+#[test]
+fn aura_static_does_not_bind_it_pronoun_to_source() {
+    // The Aura's "it" refers to the enchanted creature, NOT the Aura source, so it
+    // must NOT collapse to Not(SourceIsTapped) (which would silently check the
+    // Aura's own untapped state). An honest gap is correct here.
+    let defs = parse_static_line_multi("Enchanted creature has shroud as long as it's untapped.");
+    for d in &defs {
+        assert!(
+            !matches!(
+                d.condition.as_ref(),
+                Some(StaticCondition::Not { condition })
+                    if matches!(condition.as_ref(), StaticCondition::SourceIsTapped)
+            ),
+            "Aura 'it' must not resolve to the source, got {:?}",
+            d.condition
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Cards whose self-referential continuous static is gated by the pronoun form "as long as it's untapped" are reported `supported=false` even though the condition resolves at runtime: Dragonlord Ojutai, Giant Tortoise, Iymrith, Desert Doom, Paradise Druid, Illusion Spinners, Walking Skyscraper, Sokrates, Athenian Teacher.

`parse_continuous_gets_has` types the "as long as <cond>" clause via `parse_static_condition`, but the source-subject parser only accepts `~`/`this creature`/etc., so the contracted pronoun subject "it's untapped" falls through to `StaticCondition::Unrecognized` — despite `Not(SourceIsTapped)` being a fully layer-evaluated condition (the explicit "~ is untapped" form already works).

## Fix

In a **self-referential** static, resolve a leading "it's "/"it is " to the canonical "~ is " before typing the condition. Two guards keep it correct (and were both validated against a full regen):

1. **Only when affected == `SelfRef`.** An Aura/Equipment's "it" refers to the enchanted/equipped creature, not the source — e.g. Spectral Cloak ("enchanted creature has shroud as long as it's untapped") must NOT bind to the Aura. It stays an honest gap.
2. **Only for the bare source-state predicates `~ is …` resolves** (tapped/untapped). "it" is otherwise overloaded: "it's your turn" is impersonal; "it's a Wall"/"it's red"/"it's legendary" are characteristic gates with their own parse paths. An earlier unscoped version regressed exactly those (Faithful Pikemaster, Mistform Wall, Tenza, Sardian Cliffstomper, Gnoll Hunting Party, A-Triumphant Adventurer); the predicate guard removes all of them.

No change to the shared `parse_inner_condition`, so effect-condition/target anaphors ("destroy target creature if it's tapped") are untouched.

CR 611.3a: "it" in a self static gate refers to the source permanent.

## Verification

- 2 discriminating tests: self-static `it's untapped` → `Not(SourceIsTapped)`; Aura `it's untapped` stays unbound.
- Local regen (before/after on the exact base): **7 cards flip to supported, 0 regressions**; Spectral Cloak correctly stays gapped.
- `cargo clippy -p engine --all-targets -- -D warnings`: clean. `scripts/check-parser-combinators.sh`: clean.

Closes #3625