### PR TITLE
fix(engine): replace stale keyword value on single-authoritative-value grants

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -21594,6 +21594,163 @@ mod crew_tests {
             other => panic!("Expected CrewVehicle, got {:?}", other),
         }
     }
+
+    /// Build a Vehicle (Artifact + "Vehicle" subtype) with a printed
+    /// `Crew { power }` in BOTH `base_keywords` and `keywords`, so the printed
+    /// keyword survives the `obj.keywords = obj.base_keywords.clone()` reset
+    /// at the top of every `evaluate_layers` pass.
+    fn make_printed_crew_vehicle(
+        state: &mut GameState,
+        card: CardId,
+        controller: PlayerId,
+        crew_power: u32,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            card,
+            controller,
+            "Printed Vehicle".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.subtypes.push("Vehicle".to_string());
+        let crew = crate::types::keywords::Keyword::Crew {
+            power: crew_power,
+            once_per_turn: None,
+        };
+        obj.base_keywords.push(crew.clone());
+        obj.keywords.push(crew);
+        obj.base_power = Some(6);
+        obj.base_toughness = Some(5);
+        obj.power = Some(6);
+        obj.toughness = Some(5);
+        id
+    }
+
+    /// Attach a "Vehicles you control have crew N" continuous static (the
+    /// Kotori, Pilot Prodigy class) to `source`, scoped to Vehicles controlled
+    /// by `source`'s controller.
+    fn attach_crew_grant_static(state: &mut GameState, source: ObjectId, granted_power: u32) {
+        use crate::types::ability::{
+            ContinuousModification, ControllerRef, TargetFilter, TypedFilter,
+        };
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .controller(ControllerRef::You)
+                    .subtype("Vehicle".to_string()),
+            ))
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: crate::types::keywords::Keyword::Crew {
+                    power: granted_power,
+                    once_per_turn: None,
+                },
+            }]);
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(def);
+    }
+
+    fn crew_powers(state: &GameState, vehicle: ObjectId) -> Vec<u32> {
+        state.objects[&vehicle]
+            .keywords
+            .iter()
+            .filter_map(|kw| match kw {
+                crate::types::keywords::Keyword::Crew { power, .. } => Some(*power),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Issue #2342 — Kotori, Pilot Prodigy: "Vehicles you control have crew 2."
+    /// A granted single-authoritative-value Crew must REPLACE the printed Crew
+    /// rather than coexist with it, so `handle_crew_activation`'s `find_map`
+    /// reads the granted value. Before the CR 613.7 override branch in
+    /// `apply_keyword_modification`, the printed `Crew { power: 3 }` and granted
+    /// `Crew { power: 2 }` would both survive (PartialEq sees them as distinct),
+    /// leaving two Crew entries and letting the stale printed `3` win the read.
+    #[test]
+    fn granted_crew_value_overrides_printed_value() {
+        let mut state = setup_game_at_main_phase();
+        let vehicle = make_printed_crew_vehicle(&mut state, CardId(300), PlayerId(0), 3);
+        let kotori = create_object(
+            &mut state,
+            CardId(301),
+            PlayerId(0),
+            "Kotori".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&kotori).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+        }
+        attach_crew_grant_static(&mut state, kotori, 2);
+
+        crate::game::layers::evaluate_layers(&mut state);
+
+        // Exactly one Crew entry, carrying the granted value (2), not the
+        // printed value (3) — the printed duplicate was removed, not appended.
+        assert_eq!(
+            crew_powers(&state, vehicle),
+            vec![2],
+            "granted crew 2 must replace printed crew 3, leaving a single Crew entry"
+        );
+    }
+
+    /// Negative control: with no granting static in play, the printed Crew
+    /// value is left untouched by the override branch. Proves the fix does not
+    /// regress the default (single printed keyword) case.
+    #[test]
+    fn printed_crew_value_unchanged_without_granting_static() {
+        let mut state = setup_game_at_main_phase();
+        let vehicle = make_printed_crew_vehicle(&mut state, CardId(310), PlayerId(0), 3);
+
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(
+            crew_powers(&state, vehicle),
+            vec![3],
+            "without a granting static the printed crew 3 must be preserved"
+        );
+    }
+
+    /// Filter-scope exclusion: the "Vehicles you control" static grant must
+    /// compose with the existing `TargetFilter`/`ControllerRef` scoping — an
+    /// opponent-controlled Vehicle is outside the `controller=You` scope and
+    /// must keep its printed crew value, proving the override branch does not
+    /// blindly rewrite every Crew entry engine-wide.
+    #[test]
+    fn granted_crew_does_not_override_opponents_vehicle() {
+        let mut state = setup_game_at_main_phase();
+        // Opponent's Vehicle with printed Crew 4.
+        let opp_vehicle = make_printed_crew_vehicle(&mut state, CardId(320), PlayerId(1), 4);
+        // Granting static controlled by PlayerId(0) — "you control" excludes
+        // the opponent's Vehicle.
+        let kotori = create_object(
+            &mut state,
+            CardId(321),
+            PlayerId(0),
+            "Kotori".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&kotori).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+        }
+        attach_crew_grant_static(&mut state, kotori, 2);
+
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert_eq!(
+            crew_powers(&state, opp_vehicle),
+            vec![4],
+            "opponent's Vehicle is outside the 'you control' scope and must keep printed crew 4"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3766,17 +3766,32 @@ fn apply_continuous_effect_filtered(
                     },
                     other => other.clone(),
                 };
+                // Three-way grant policy:
                 // CR 702.164b: summing keywords (Toxic) accumulate even when an
                 // identical instance is already present (granted Toxic 1 on
-                // printed Toxic 1 -> total 2). All other parameterized keywords
-                // keep deduping identical instances per CR 702.16g (Protection
-                // A+B are separate abilities; Ward/Annihilator each apply
-                // independently). `evaluate_layers` resets `obj.keywords =
-                // obj.base_keywords.clone()` each pass, so this never accumulates
-                // unbounded across re-evaluations.
-                if resolved_keyword.sums_across_instances()
-                    || !obj.keywords.contains(&resolved_keyword)
-                {
+                // printed Toxic 1 -> total 2).
+                // CR 613.7: single-authoritative-value keywords (Crew/Saddle/Enchant,
+                // see `overrides_same_kind_on_grant`) replace any earlier same-kind
+                // instance so a "first match" reader never sees a stale value.
+                // All other parameterized keywords keep deduping identical instances
+                // per CR 702.16g (Protection A+B are separate abilities;
+                // Ward/Annihilator each apply independently). `evaluate_layers` resets
+                // `obj.keywords = obj.base_keywords.clone()` each pass, so this never
+                // accumulates unbounded across re-evaluations.
+                if resolved_keyword.sums_across_instances() {
+                    obj.keywords.push(resolved_keyword.clone());
+                } else if resolved_keyword.overrides_same_kind_on_grant() {
+                    // CR 613.7: this grant is a single-authoritative-value keyword — the
+                    // most recently applied instance (this one, since modifications are
+                    // applied in ascending timestamp order, see `order_by_timestamp`)
+                    // replaces any earlier same-discriminant instance (printed or a prior
+                    // grant) rather than coexisting with it. Mirrors `RemoveKeyword`'s
+                    // discriminant technique below, but replaces instead of strips.
+                    obj.keywords.retain(|k| {
+                        std::mem::discriminant(k) != std::mem::discriminant(&resolved_keyword)
+                    });
+                    obj.keywords.push(resolved_keyword.clone());
+                } else if !obj.keywords.contains(&resolved_keyword) {
                     obj.keywords.push(resolved_keyword.clone());
                 }
                 for trigger in KeywordTriggerInstaller::triggers_for(&resolved_keyword) {

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1376,6 +1376,25 @@ impl Keyword {
     pub fn sums_across_instances(&self) -> bool {
         matches!(self, Keyword::Toxic(_))
     }
+
+    /// CR 613.7: When multiple effects grant the same single-authoritative-value
+    /// keyword (one whose payload is the *current* effective value, not an
+    /// accumulating count), the most recently applied grant must replace any
+    /// earlier instance of the same kind rather than coexist with it — otherwise
+    /// readers that pick "the first match" (e.g. `find_map`) can read a stale
+    /// value while a different one is intended to be authoritative. Crew/Saddle
+    /// (CR 702.122/702.171, vehicle/mount crew-power) and Enchant (CR 702.5a,
+    /// an Aura's current legal-attachment filter, reachable via
+    /// `AddKeyword{Enchant(_)}` from `install_aura_continuous_effect`) are the
+    /// currently known members. Contrast `sums_across_instances` (Toxic, which
+    /// accumulates) and the default (Protection/Ward/Annihilator, which coexist
+    /// as separate instances per CR 702.16g).
+    pub fn overrides_same_kind_on_grant(&self) -> bool {
+        matches!(
+            self,
+            Keyword::Crew { .. } | Keyword::Enchant(_) | Keyword::Saddle(_)
+        )
+    }
 }
 
 /// Capitalize the first character of a string (for type name normalization).


### PR DESCRIPTION
## Summary

Kotori, Pilot Prodigy's static ability "Vehicles you control have crew 2" parses correctly but didn't work at runtime: the layer system's `AddKeyword` continuous-modification arm only deduped granted keywords by exact `PartialEq`, so a granted `Crew{power:2}` got pushed alongside the printed `Crew{N}` instead of replacing it. `handle_crew_activation`'s `find_map` over the keyword list then kept returning whichever entry came first — the stale printed value.

This generalizes the fix rather than special-casing Crew: `Keyword::overrides_same_kind_on_grant()` classifies any single-authoritative-value keyword (`Crew`, `Saddle`, `Enchant`) whose payload represents the *current* effective value rather than an independently-meaningful instance (contrast `Protection`/`Ward`/`Annihilator`, which coexist per CR 702.16g, or `Toxic`, which sums). The `AddKeyword` arm now retains-by-discriminant then pushes for these, mirroring the discriminant technique `RemoveKeyword` already uses a few lines below in the same match statement.

A 40-site sweep of every `find_map`-over-keywords call site in the engine confirmed `Crew`/`Saddle`/`Enchant` are the only runtime-reachable members of this class today (cast-time alt-cost keywords like Dash/Blitz/Miracle/Mutate and build-time-only synthesis reads were ruled out as not reachable via `AddKeyword`).

## Test plan

- `granted_crew_value_overrides_printed_value`: a Vehicle with printed Crew 3 plus a Kotori-equivalent static granting Crew 2 ends up with exactly one effective `Crew{power: 2}` entry after `evaluate_layers`.
- `printed_crew_value_unchanged_without_granting_static`: same Vehicle, no granting static — printed Crew 3 is preserved (negative control).
- `granted_crew_does_not_override_opponents_vehicle`: the controller-scoped grant doesn't leak onto an opponent's separate Vehicle (filter-boundary control).
- Full `crew_tests` module (15 tests) and the `layers.rs` keyword-dedup/grant tests (Ward grant, Protection dedup) pass unmodified, confirming no regression to the other two branches of the dedup/sum/override decision.

Closes #2342