### PR TITLE
Fix Summon: Yojimbo chapter II/III attack tax (fixes #1303)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -33,7 +33,7 @@ use super::super::oracle_quantity;
 use super::super::oracle_static::{
     classify_block_exception, parse_additive_type_clause_modifications,
     parse_cant_be_activated_exemption_in_text, parse_chosen_qualifier_subject,
-    parse_continuous_modifications, parse_static_line_multi,
+    parse_continuous_modifications, parse_static_line, parse_static_line_multi,
 };
 use super::super::oracle_target::{parse_target, parse_target_with_ctx, parse_type_phrase};
 use super::super::oracle_util::{
@@ -338,10 +338,43 @@ fn try_parse_subject_become_clause(
     build_become_clause(application, &predicate, ctx)
 }
 
+/// CR 508.1d + CR 508.1h: "[creatures] can't attack [you] unless [player] pays
+/// {N} [for each of those creatures]" as a one-shot effect (Summon: Yojimbo
+/// chapters II/III). The static-side `parse_combat_tax_static` authority
+/// already lowers the UnlessPay payload; wrap it in `GrantStaticAbility` on
+/// `SelfRef` so `register_transient_effect` installs the tax on the resolving
+/// source for the effect's duration (mirrors quoted-static grant routing in
+/// `oracle_static/grammar.rs`).
+fn try_parse_combat_tax_effect_clause(text: &str) -> Option<ParsedEffectClause> {
+    let static_def = parse_static_line(text)?;
+    Some(ParsedEffectClause {
+        effect: Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::continuous().modifications(vec![
+                ContinuousModification::GrantStaticAbility {
+                    definition: Box::new(static_def),
+                },
+            ])],
+            duration: None,
+            target: Some(TargetFilter::SelfRef),
+        },
+        distribute: None,
+        multi_target: None,
+        duration: None,
+        sub_ability: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
 fn try_parse_subject_restriction_clause(
     text: &str,
     ctx: &mut ParseContext,
 ) -> Option<ParsedEffectClause> {
+    if let Some(clause) = try_parse_combat_tax_effect_clause(text) {
+        return Some(clause);
+    }
+
     let lower = text.to_lowercase();
 
     // CR 509.1c: "Target creature must be blocked [this turn] [if able]"
@@ -4009,6 +4042,39 @@ mod tests {
                 "chosen object is an anaphoric parent target, not a new target"
             );
         }
+    }
+
+    #[test]
+    fn combat_tax_effect_clause_yojimbo_chapter() {
+        use crate::types::ability::{ContinuousModification, StaticCondition};
+        use crate::types::statics::StaticMode;
+
+        let mut ctx = ParseContext::default();
+        let clause = try_parse_subject_restriction_clause(
+            "Creatures can't attack you unless their controller pays {2} for each of those creatures.",
+            &mut ctx,
+        )
+        .expect("Yojimbo chapter combat tax should parse");
+
+        let Effect::GenericEffect {
+            static_abilities,
+            target,
+            ..
+        } = clause.effect
+        else {
+            panic!("expected GenericEffect combat tax grant");
+        };
+        assert_eq!(target, Some(TargetFilter::SelfRef));
+        assert_eq!(static_abilities.len(), 1);
+        let mods = &static_abilities[0].modifications;
+        let ContinuousModification::GrantStaticAbility { definition } = &mods[0] else {
+            panic!("combat tax effect must grant static onto source");
+        };
+        assert!(matches!(definition.mode, StaticMode::CantAttack));
+        assert!(matches!(
+            definition.condition,
+            Some(StaticCondition::UnlessPay { .. })
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -16,7 +16,7 @@ use crate::parser::oracle_ir::ast::*;
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, ChosenSubtypeKind, ContinuousModification, ControllerRef,
     Duration, Effect, FilterProp, MultiTargetSpec, PlayerFilter, PlayerScope, PtValue,
-    QuantityExpr, QuantityRef, StaticDefinition, TargetFilter, TypedFilter,
+    QuantityExpr, QuantityRef, StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
 };
 use crate::types::game_state::DayNight;
 use crate::types::keywords::Keyword;
@@ -347,6 +347,12 @@ fn try_parse_subject_become_clause(
 /// `oracle_static/grammar.rs`).
 fn try_parse_combat_tax_effect_clause(text: &str) -> Option<ParsedEffectClause> {
     let static_def = parse_static_line(text)?;
+    if !matches!(
+        static_def.condition,
+        Some(StaticCondition::UnlessPay { .. })
+    ) {
+        return None;
+    }
     Some(ParsedEffectClause {
         effect: Effect::GenericEffect {
             static_abilities: vec![StaticDefinition::continuous().modifications(vec![

--- a/crates/engine/src/parser/oracle_saga.rs
+++ b/crates/engine/src/parser/oracle_saga.rs
@@ -395,6 +395,54 @@ mod tests {
     }
 
     #[test]
+    fn summon_yojimbo_chapter_combat_tax_parses() {
+        use crate::parser::oracle_effect::parse_effect;
+        use crate::types::ability::{ContinuousModification, StaticCondition};
+        use crate::types::statics::StaticMode;
+
+        let lines = vec!["II, III — Until your next turn, creatures can't attack you unless their controller pays {2} for each of those creatures."];
+        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Summon: Yojimbo");
+        assert_eq!(triggers.len(), 2);
+
+        for trigger in &triggers {
+            let exec = trigger.execute.as_ref().expect("chapter execute");
+            assert!(
+                matches!(exec.duration, Some(Duration::UntilNextTurnOf { .. })),
+                "expected UntilNextTurnOf, got {:?}",
+                exec.duration
+            );
+            match &*exec.effect {
+                Effect::GenericEffect {
+                    static_abilities,
+                    target,
+                    ..
+                } => {
+                    assert_eq!(target, &Some(TargetFilter::SelfRef));
+                    let ContinuousModification::GrantStaticAbility { definition } =
+                        &static_abilities[0].modifications[0]
+                    else {
+                        panic!("expected GrantStaticAbility combat tax");
+                    };
+                    assert!(matches!(definition.mode, StaticMode::CantAttack));
+                    assert!(matches!(
+                        definition.condition,
+                        Some(StaticCondition::UnlessPay { .. })
+                    ));
+                }
+                other => panic!("expected GenericEffect combat tax, got {other:?}"),
+            }
+        }
+
+        let effect = parse_effect(
+            "Until your next turn, creatures can't attack you unless their controller pays {2} for each of those creatures.",
+        );
+        assert!(
+            matches!(effect, Effect::GenericEffect { .. }),
+            "peeled duration combat tax must not be Unimplemented"
+        );
+    }
+
+    #[test]
     fn is_saga_chapter_extended() {
         assert!(is_saga_chapter("VI — Something"));
         assert!(is_saga_chapter("VII — Something"));

--- a/crates/engine/tests/integration/rules/combat.rs
+++ b/crates/engine/tests/integration/rules/combat.rs
@@ -670,6 +670,64 @@ fn ghostly_prison_decline_removes_taxed_attackers() {
     );
 }
 
+/// CR 508.1d + issue #1303: Summon: Yojimbo chapters II/III grant a transient
+/// combat tax via `GrantStaticAbility`. The tax must reach `compute_combat_tax`
+/// when attackers declare against the saga's controller.
+#[test]
+fn issue_1303_yojimbo_chapter_combat_tax_requires_payment() {
+    use engine::game::effects::effect::resolve;
+    use engine::game::layers::evaluate_layers;
+    use engine::parser::oracle_effect::parse_effect;
+    use engine::types::ability::{Duration, Effect, PlayerScope, ResolvedAbility};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let saga = scenario.add_creature(P1, "Summon: Yojimbo", 1, 1).id();
+    let attacker = scenario.add_creature(P0, "Bear", 2, 2).id();
+    for _ in 0..2 {
+        scenario.add_basic_land(P0, ManaColor::White);
+    }
+
+    let effect = parse_effect(
+        "Until your next turn, creatures can't attack you unless their controller pays {2} for each of those creatures.",
+    );
+    assert!(
+        matches!(effect, Effect::GenericEffect { .. }),
+        "Yojimbo chapter tax must parse to GenericEffect, got {effect:?}"
+    );
+
+    let ability =
+        ResolvedAbility::new(effect, vec![], saga, P1).duration(Duration::UntilNextTurnOf {
+            player: PlayerScope::Controller,
+        });
+
+    let mut runner = scenario.build();
+    resolve(runner.state_mut(), &ability, &mut Vec::new()).expect("resolve tax grant");
+    evaluate_layers(runner.state_mut());
+    runner.pass_both_players();
+
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("attack declaration should pause for combat tax");
+
+    match &runner.state().waiting_for {
+        WaitingFor::CombatTaxPayment {
+            player,
+            total_cost,
+            per_creature,
+            ..
+        } => {
+            assert_eq!(*player, P0);
+            assert_eq!(total_cost.mana_value(), 2);
+            assert_eq!(per_creature.len(), 1);
+        }
+        other => panic!("expected CombatTaxPayment, got {other:?}"),
+    }
+}
+
 /// CR 508.1h: Two Ghostly Prisons stacked aggregate to {4} per attacker.
 #[test]
 fn two_prisons_stack_tax() {


### PR DESCRIPTION
## Summary
- Parse saga/effect combat-tax clauses ("creatures can't attack you unless their controller pays {2} for each of those creatures") via the existing static combat-tax authority
- Wrap the lowered static in `GrantStaticAbility` on `SelfRef` so transient chapter effects install the UnlessPay tax on the resolving saga
- Add parser and integration regression coverage for Summon: Yojimbo chapters II/III

## Test plan
- [x] `cargo test -p engine --lib yojimbo_chapter`
- [x] `cargo test -p engine --test integration issue_1303_yojimbo`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #1303

Made with [Cursor](https://cursor.com)