### PR TITLE
ci: hardened gzip MTGJSON downloads + weekly-refresh cache namespacing

### DIFF
--- a/.github/workflows/ai-gate.yml
+++ b/.github/workflows/ai-gate.yml
@@ -42,7 +42,8 @@ jobs:
         if: steps.cardgen-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p data/mtgjson
-          curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+          source scripts/lib/mtgjson-fetch.sh
+          mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
       - name: Run quick AI gate
@@ -73,7 +74,8 @@ jobs:
         if: steps.cardgen-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p data/mtgjson
-          curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+          source scripts/lib/mtgjson-fetch.sh
+          mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
       - name: Run full AI gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,21 @@ jobs:
         run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache MTGJSON data
+        # Scoped to AtomicCards.json under its own `mtgjson-atomic-` namespace —
+        # this job needs nothing else from data/mtgjson. The per-content
+        # namespace stops draft-pools (which populates only SetList + sets/,
+        # never AtomicCards) from clobbering this job's key with a partial dir.
+        #
+        # Exact weekly key, NO restore-keys: a new week misses, so the download
+        # step re-fetches fresh MTGJSON data (the weekly refresh we want); a
+        # restore-keys fallback would pin us to last week's AtomicCards forever
+        # because the download is file-existence-gated. Same-week runs reuse the
+        # exact-key hit.
         id: mtgjson-cache
         uses: actions/cache@v4
         with:
-          path: data/mtgjson
-          key: mtgjson-${{ steps.cache-keys.outputs.week }}
-          restore-keys: mtgjson-
+          path: data/mtgjson/AtomicCards.json
+          key: mtgjson-atomic-${{ steps.cache-keys.outputs.week }}
 
       - name: Download MTGJSON data
         # Gate on file existence, not cache-hit: actions/cache restore-keys can
@@ -133,7 +142,8 @@ jobs:
         run: |
           if [ ! -f data/mtgjson/AtomicCards.json ]; then
             mkdir -p data/mtgjson
-            curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+            source scripts/lib/mtgjson-fetch.sh
+            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
           fi
 
       - name: Cache generated card data
@@ -251,20 +261,25 @@ jobs:
         run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
 
       - name: Cache MTGJSON data
-        # Shares the weekly mtgjson key with card-data-gate so per-set files
-        # fetched by fetch-draft-sets.sh persist across runs.
+        # Scoped to SetList.json + the per-set files this job populates, under
+        # its own `mtgjson-sets-` namespace so it can't collide with
+        # card-data-gate's `mtgjson-atomic-` key (this job never fetches
+        # AtomicCards). Exact weekly key, NO restore-keys: a new week misses and
+        # re-fetches fresh set data; same-week runs reuse the exact-key hit.
         uses: actions/cache@v4
         with:
-          path: data/mtgjson
-          key: mtgjson-${{ steps.cache-keys.outputs.week }}
-          restore-keys: mtgjson-
+          path: |
+            data/mtgjson/SetList.json
+            data/mtgjson/sets
+          key: mtgjson-sets-${{ steps.cache-keys.outputs.week }}
 
       - name: Download MTGJSON SetList data
         # fetch-draft-sets.sh enumerates draftable sets from SetList.json.
         run: |
           mkdir -p data/mtgjson
           if [ ! -f data/mtgjson/SetList.json ]; then
-            curl -fSL -o data/mtgjson/SetList.json "https://mtgjson.com/api/v5/SetList.json"
+            source scripts/lib/mtgjson-fetch.sh
+            mtgjson_download SetList.json data/mtgjson/SetList.json
           fi
 
       - name: Download draft set data

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,12 +54,21 @@ jobs:
           echo "day=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Cache MTGJSON data
+        # Full data/mtgjson dir under the `mtgjson-full-` namespace: this job
+        # runs gen-card-data.sh, which populates every file (AtomicCards, Meta,
+        # SetList, token sets, decks). Kept distinct from ci.yml's partial
+        # `mtgjson-atomic-`/`mtgjson-sets-` caches; all stay under the
+        # `mtgjson-` prefix that clear-caches.yml deletes.
+        #
+        # Exact weekly key, NO restore-keys: a new week misses so gen-card-data.sh
+        # re-fetches fresh MTGJSON data (its `[ ! -f ]` guards download whatever
+        # the empty dir is missing); a restore-keys fallback would pin the
+        # file-existence-gated fetches to last week's data forever.
         id: mtgjson-cache
         uses: actions/cache@v4
         with:
           path: data/mtgjson
-          key: mtgjson-${{ steps.cache-keys.outputs.week }}
-          restore-keys: mtgjson-
+          key: mtgjson-full-${{ steps.cache-keys.outputs.week }}
 
       # Daily key with NO restore-keys: the gen-scryfall-*.sh scripts skip the
       # download when the file already exists, so a stale restore-key hit would
@@ -82,7 +91,8 @@ jobs:
         run: |
           if [ ! -f data/mtgjson/AtomicCards.json ]; then
             mkdir -p data/mtgjson
-            curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+            source scripts/lib/mtgjson-fetch.sh
+            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
           fi
 
       - name: Generate card data and coverage (from source)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,12 +203,19 @@ jobs:
           echo "day=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Cache MTGJSON data
+        # Full data/mtgjson dir under the `mtgjson-full-` namespace (shared with
+        # deploy.yml — both run gen-card-data.sh and populate every file). Kept
+        # distinct from ci.yml's partial `mtgjson-atomic-`/`mtgjson-sets-`
+        # caches; all stay under the `mtgjson-` prefix clear-caches.yml deletes.
+        #
+        # Exact weekly key, NO restore-keys: a new week misses so gen-card-data.sh
+        # re-fetches fresh MTGJSON data; a restore-keys fallback would pin the
+        # file-existence-gated fetches to last week's data forever.
         id: mtgjson-cache
         uses: actions/cache@v4
         with:
           path: data/mtgjson
-          key: mtgjson-${{ steps.cache-keys.outputs.week }}
-          restore-keys: mtgjson-
+          key: mtgjson-full-${{ steps.cache-keys.outputs.week }}
 
       # Daily key with NO restore-keys: the gen-scryfall-*.sh scripts skip the
       # download when the file already exists, so a stale restore-key hit would
@@ -222,10 +229,17 @@ jobs:
           key: scryfall-${{ steps.cache-keys.outputs.day }}
 
       - name: Download MTGJSON data
-        if: steps.mtgjson-cache.outputs.cache-hit != 'true'
+        # Gate on file existence, not cache-hit: a restore-keys (non-exact) hit
+        # leaves cache-hit=false even though AtomicCards.json is already present,
+        # so the old `if: cache-hit != true` re-downloaded it every new week.
+        # File-existence gating fetches only when genuinely missing and lets a
+        # poisoned cache self-heal (matches ci.yml / deploy.yml).
         run: |
-          mkdir -p data/mtgjson
-          curl -fSL -o data/mtgjson/AtomicCards.json "https://mtgjson.com/api/v5/AtomicCards.json"
+          if [ ! -f data/mtgjson/AtomicCards.json ]; then
+            mkdir -p data/mtgjson
+            source scripts/lib/mtgjson-fetch.sh
+            mtgjson_download AtomicCards.json data/mtgjson/AtomicCards.json
+          fi
 
       - name: Generate card data and coverage report
         # Single source of truth: gen-card-data.sh produces all 7 public JSON

--- a/scripts/fetch-draft-sets.sh
+++ b/scripts/fetch-draft-sets.sh
@@ -15,7 +15,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SETS_DIR="$REPO_ROOT/data/mtgjson/sets"
 SET_LIST="$REPO_ROOT/data/mtgjson/SetList.json"
-MTGJSON_BASE="https://mtgjson.com/api/v5"
+# shellcheck source=scripts/lib/mtgjson-fetch.sh
+source "$SCRIPT_DIR/lib/mtgjson-fetch.sh"
 
 FORCE=false
 REQUESTED_SETS=()
@@ -82,25 +83,17 @@ for CODE in "${CODES[@]}"; do
         continue
     fi
 
-    # Download gzipped file, decompress
-    if curl -fsSL "${MTGJSON_BASE}/${CODE}.json.gz" 2>/dev/null | gunzip > "$DEST.tmp" 2>/dev/null; then
-        mv "$DEST.tmp" "$DEST"
+    # Prefer the gzipped artifact, decompress locally, retry transient resets.
+    if mtgjson_download "${CODE}.json" "$DEST"; then
         SIZE=$(du -h "$DEST" | cut -f1 | tr -d ' ')
         echo "Downloaded ${CODE}.json (${SIZE})"
         DOWNLOADED=$((DOWNLOADED + 1))
     else
-        # Try uncompressed fallback
-        if curl -fsSL "${MTGJSON_BASE}/${CODE}.json" -o "$DEST.tmp" 2>/dev/null; then
-            mv "$DEST.tmp" "$DEST"
-            SIZE=$(du -h "$DEST" | cut -f1 | tr -d ' ')
-            echo "Downloaded ${CODE}.json (${SIZE})"
-            DOWNLOADED=$((DOWNLOADED + 1))
-        else
-            rm -f "$DEST.tmp"
-            echo "Warning: failed to download ${CODE}.json, skipping" >&2
-            FAILED=$((FAILED + 1))
-        fi
+        echo "Warning: failed to download ${CODE}.json, skipping" >&2
+        FAILED=$((FAILED + 1))
     fi
+    # Throttle the sweep so mtgjson doesn't reset later connections.
+    mtgjson_rate_limit
 done
 
 echo ""

--- a/scripts/fetch-token-sets.sh
+++ b/scripts/fetch-token-sets.sh
@@ -5,7 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SETS_DIR="$REPO_ROOT/data/mtgjson/sets"
 SET_LIST="$REPO_ROOT/data/mtgjson/SetList.json"
-MTGJSON_BASE="https://mtgjson.com/api/v5"
+# shellcheck source=scripts/lib/mtgjson-fetch.sh
+source "$SCRIPT_DIR/lib/mtgjson-fetch.sh"
 
 mkdir -p "$SETS_DIR"
 
@@ -48,18 +49,15 @@ for CODE in "${CODES[@]}"; do
   fi
   rm -f "$MISSING"
 
-  if curl -fsSL "$MTGJSON_BASE/$CODE.json.gz" 2>/dev/null | gunzip > "$DEST.tmp" 2>/dev/null; then
-    mv "$DEST.tmp" "$DEST"
-    DOWNLOADED=$((DOWNLOADED + 1))
-  elif curl -fsSL "$MTGJSON_BASE/$CODE.json" -o "$DEST.tmp" 2>/dev/null; then
-    mv "$DEST.tmp" "$DEST"
+  if mtgjson_download "$CODE.json" "$DEST"; then
     DOWNLOADED=$((DOWNLOADED + 1))
   else
-    rm -f "$DEST.tmp"
     touch "$MISSING"
     echo "Warning: failed to download $CODE.json" >&2
     FAILED=$((FAILED + 1))
   fi
+  # Throttle the sweep so mtgjson doesn't reset later connections.
+  mtgjson_rate_limit
 done
 
 echo "Token sets: downloaded $DOWNLOADED, skipped $SKIPPED, failed $FAILED"

--- a/scripts/gen-card-data.sh
+++ b/scripts/gen-card-data.sh
@@ -6,6 +6,10 @@ if [ -f ".env" ]; then
   set -a; source .env; set +a
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/mtgjson-fetch.sh
+source "$SCRIPT_DIR/lib/mtgjson-fetch.sh"
+
 DATA_DIR="data"
 OUTPUT_DIR="client/public"
 OUTPUT="${OUTPUT_DIR}/card-data.json"
@@ -19,12 +23,14 @@ DECKS_OUTPUT="${OUTPUT_DIR}/decks.json"
 
 echo "=== Card Data Generation ==="
 
-# Download MTGJSON AtomicCards if not present
+# Download MTGJSON AtomicCards if not present. mtgjson_download prefers the
+# gzipped artifact (~50 MB vs ~156 MB uncompressed) and retries the
+# mid-transfer connection resets mtgjson hands out on large anonymous reads.
 MTGJSON_FILE="$DATA_DIR/mtgjson/AtomicCards.json"
 if [ ! -f "$MTGJSON_FILE" ]; then
   echo "Downloading MTGJSON AtomicCards..."
   mkdir -p "$DATA_DIR/mtgjson"
-  curl -L -o "$MTGJSON_FILE" "https://mtgjson.com/api/v5/AtomicCards.json"
+  mtgjson_download "AtomicCards.json" "$MTGJSON_FILE"
   echo "Downloaded MTGJSON data."
 fi
 
@@ -33,14 +39,14 @@ MTGJSON_META_FILE="$DATA_DIR/mtgjson/Meta.json"
 if [ ! -f "$MTGJSON_META_FILE" ]; then
   echo "Downloading MTGJSON Meta..."
   mkdir -p "$DATA_DIR/mtgjson"
-  curl -L -o "$MTGJSON_META_FILE" "https://mtgjson.com/api/v5/Meta.json"
+  mtgjson_download "Meta.json" "$MTGJSON_META_FILE"
 fi
 
 MTGJSON_SET_LIST_FILE="$DATA_DIR/mtgjson/SetList.json"
 if [ ! -f "$MTGJSON_SET_LIST_FILE" ]; then
   echo "Downloading MTGJSON SetList..."
   mkdir -p "$DATA_DIR/mtgjson"
-  curl -L -o "$MTGJSON_SET_LIST_FILE" "https://mtgjson.com/api/v5/SetList.json"
+  mtgjson_download "SetList.json" "$MTGJSON_SET_LIST_FILE"
 fi
 
 echo "Ensuring MTGJSON token set files..."
@@ -53,7 +59,7 @@ if [ ! -d "$MTGJSON_DECKS_DIR" ]; then
   echo "Downloading MTGJSON AllDeckFiles..."
   mkdir -p "$MTGJSON_DECKS_DIR"
   MTGJSON_DECKS_ARCHIVE="$DATA_DIR/mtgjson/AllDeckFiles.tar.gz"
-  curl -L -o "$MTGJSON_DECKS_ARCHIVE" "https://mtgjson.com/api/v5/AllDeckFiles.tar.gz"
+  "${MTGJSON_CURL[@]}" -o "$MTGJSON_DECKS_ARCHIVE" "$MTGJSON_BASE/AllDeckFiles.tar.gz"
   tar -xzf "$MTGJSON_DECKS_ARCHIVE" -C "$MTGJSON_DECKS_DIR" --strip-components=1
   rm -f "$MTGJSON_DECKS_ARCHIVE"
 fi

--- a/scripts/lib/mtgjson-fetch.sh
+++ b/scripts/lib/mtgjson-fetch.sh
@@ -1,0 +1,68 @@
+# shellcheck shell=bash
+# Shared hardened fetch helpers for MTGJSON downloads — used by
+# gen-card-data.sh, fetch-token-sets.sh, fetch-draft-sets.sh, and the CI
+# card-data jobs. Mirrors scripts/lib/scryfall-fetch.sh.
+#
+# MTGJSON serves its bulk files (AtomicCards.json is ~156 MB uncompressed)
+# from a host that drops large/bursty anonymous connections mid-transfer —
+# `curl: (56) Recv failure: Connection reset by peer` part way through a
+# multi-minute download. A bare `curl -fSL` has no retry, so a single reset
+# fails the whole CI job, and re-downloading 156 MB on every cache miss makes
+# the reset far more likely.
+#
+# These helpers close that gap by:
+#   1. Preferring the gzipped artifact (AtomicCards.json.gz is ~50 MB — 3x
+#      less to transfer and 3x less reset surface) and decompressing locally.
+#   2. Retrying transient resets/throttles with backoff via --retry-all-errors
+#      (curl >= 7.71), which retries the mid-transfer reset (exit 56) that
+#      plain --retry classes as non-transient and skips.
+#   3. Downloading through a temp file + atomic rename, so an interrupted
+#      transfer never leaves a truncated JSON in place for a later run to
+#      "cache-hit" on.
+#   4. A polite inter-request delay (mtgjson_rate_limit) for the per-set fetch
+#      loops, so a long sweep doesn't trip mtgjson's connection throttling.
+#
+# Source this file; do not execute it. Callers keep their own `set -euo
+# pipefail`; a non-zero return propagates as a fail-fast exit.
+
+MTGJSON_BASE="${MTGJSON_BASE:-https://mtgjson.com/api/v5}"
+
+MTGJSON_CURL=(
+  curl --fail --retry 5 --retry-all-errors --retry-delay 3
+  --connect-timeout 30 -sSL
+  -H 'User-Agent: phase-rs-card-data/1.0 (+https://github.com/phase-rs/phase)'
+)
+
+# Delay between successive per-set requests. Override with MTGJSON_RATE_DELAY.
+MTGJSON_RATE_DELAY="${MTGJSON_RATE_DELAY:-1}"
+
+# mtgjson_rate_limit — sleep MTGJSON_RATE_DELAY seconds between per-set fetches.
+mtgjson_rate_limit() {
+  sleep "$MTGJSON_RATE_DELAY"
+}
+
+# mtgjson_download NAME DEST — download MTGJSON file NAME (e.g. AtomicCards.json)
+# to DEST, preferring the gzipped artifact and decompressing locally. Retries
+# transient failures, writes through a temp, and only renames a complete file
+# into place. gzip's CRC validates the compressed path end-to-end; curl --fail
+# guards the uncompressed fallback against a truncated/error body. Returns
+# non-zero only if both the compressed and uncompressed artifacts fail.
+mtgjson_download() {
+  local name="$1" dest="$2" tmp
+  tmp=$(mktemp "${dest}.XXXXXX")
+  # Preferred path: gzipped artifact -> file (retryable), then decompress.
+  if "${MTGJSON_CURL[@]}" -o "$tmp.gz" "$MTGJSON_BASE/$name.gz" 2>/dev/null \
+     && gunzip -c "$tmp.gz" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp.gz"
+    mv -f "$tmp" "$dest"
+    return 0
+  fi
+  rm -f "$tmp.gz"
+  # Fallback: uncompressed artifact (a few legacy files lack a .gz sibling).
+  if "${MTGJSON_CURL[@]}" -o "$tmp" "$MTGJSON_BASE/$name"; then
+    mv -f "$tmp" "$dest"
+    return 0
+  fi
+  rm -f "$tmp"
+  return 1
+}


### PR DESCRIPTION
MTGJSON drops large anonymous transfers mid-stream (curl exit 56), failing
the no-retry 156 MB AtomicCards.json download. Two compounding cache bugs
made it worse: card-data-gate and draft-pools shared one mtgjson-${week}
key over disjoint subsets (whichever saved first won, leaving an
AtomicCards-less cache the other re-downloaded all week), and a greedy
restore-keys fallback pinned the file-existence-gated fetches to stale data
so the weekly key never actually refreshed.

- Add scripts/lib/mtgjson-fetch.sh: prefer the gzip artifact (~50 MB vs
  156 MB), retry transient resets via --retry-all-errors, temp+atomic
  rename, and a per-set throttle (mtgjson_rate_limit). Mirrors
  scripts/lib/scryfall-fetch.sh.
- Route every MTGJSON download through it (gen-card-data.sh, fetch-{token,
  draft}-sets.sh, and the ci/deploy/release/ai-gate workflow steps).
- Namespace the caches per content subset (mtgjson-atomic-/-sets-/-full-)
  so partial writers can't poison each other, and drop restore-keys so a
  new ISO week genuinely re-fetches fresh data.
