### PR TITLE
Fix Cosima voyage trigger zone when exiled (fixes #1196)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -3067,12 +3067,13 @@ fn parse_source_in_zone_condition(input: &str) -> OracleResult<'_, StaticConditi
         value(false, tag(" is")),
     ))
     .parse(rest)?;
-    let rest = rest.trim_start();
     // CR 701.13a + CR 113.6b: passive "is exiled" is equivalent to "is in
     // exile" for source-referential intervening-if gates (Cosima, God of the
-    // Voyage's granted landfall trigger: "if ~ is exiled").
+    // Voyage's granted landfall trigger: "if ~ is exiled"). Match the leading
+    // space left by `tag(" is")` — do not trim_start or `parse_zone_phrase`
+    // loses its " in your graveyard" boundary.
     let (rest, first) =
-        alt((map(tag("exiled"), |_| Zone::Exile), parse_zone_phrase)).parse(rest)?;
+        alt((map(tag(" exiled"), |_| Zone::Exile), parse_zone_phrase)).parse(rest)?;
     // CR 113.6b: a single ability that names multiple zones functions in each
     // of them — the "or"-separated zone list composes disjunctively across the
     // listed zones. ("or" is English grammar, not a CR construct; the rules

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -3067,7 +3067,12 @@ fn parse_source_in_zone_condition(input: &str) -> OracleResult<'_, StaticConditi
         value(false, tag(" is")),
     ))
     .parse(rest)?;
-    let (rest, first) = parse_zone_phrase(rest)?;
+    let rest = rest.trim_start();
+    // CR 701.13a + CR 113.6b: passive "is exiled" is equivalent to "is in
+    // exile" for source-referential intervening-if gates (Cosima, God of the
+    // Voyage's granted landfall trigger: "if ~ is exiled").
+    let (rest, first) =
+        alt((map(tag("exiled"), |_| Zone::Exile), parse_zone_phrase)).parse(rest)?;
     // CR 113.6b: a single ability that names multiple zones functions in each
     // of them — the "or"-separated zone list composes disjunctively across the
     // listed zones. ("or" is English grammar, not a CR construct; the rules
@@ -7202,6 +7207,26 @@ mod tests {
     }
 
     // -- Zone condition tests (Phase 1) --
+
+    #[test]
+    fn test_source_is_exiled_passive() {
+        let (rest, c) = parse_zone_conditions("~ is exiled").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(
+            c,
+            StaticCondition::SourceInZone {
+                zone: crate::types::zones::Zone::Exile
+            }
+        ));
+        let (rest, c) = parse_inner_condition("~ is exiled").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(
+            c,
+            StaticCondition::SourceInZone {
+                zone: crate::types::zones::Zone::Exile
+            }
+        ));
+    }
 
     #[test]
     fn test_source_in_hand() {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -26164,6 +26164,21 @@ mod tests {
     }
 
     #[test]
+    fn trigger_intervening_if_source_is_exiled_sets_trigger_zone() {
+        let def = parse_trigger_line(
+            "Whenever a land you control enters, if ~ is exiled, you may put a voyage counter on it.",
+            "Cosima, God of the Voyage",
+        );
+
+        assert_eq!(def.mode, TriggerMode::ChangesZone);
+        assert_eq!(def.trigger_zones, vec![Zone::Exile]);
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::SourceInZone { zone: Zone::Exile }),
+        );
+    }
+
+    #[test]
     fn trigger_intervening_if_this_card_is_suspended() {
         let def = parse_trigger_line(
             "Whenever you cast a spell, if this card is suspended, remove a time counter from it.",


### PR DESCRIPTION
## Summary
- Parse passive source-referential "is exiled" as `SourceInZone(Exile)` in the shared condition grammar
- Intervening-if hoisting now sets `trigger_zones = [Exile]` for Cosima's granted landfall trigger so it fires while the card is in exile

## Test plan
- [x] `cargo test -p engine --lib source_is_exiled`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #1196

Made with [Cursor](https://cursor.com)