### PR TITLE
fix(engine): resolve fight-back clause damage for self-reference recipients

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -988,10 +988,57 @@ pub(crate) fn parent_referent_context_from_events(
 
     // CR 608.2c: a later instruction's "that creature" may refer to a single
     // creature an earlier instruction in the same resolution tapped — e.g.
-    // Enlist's "+X/+0 … where X is the tapped creature's power". Tried last so
-    // sacrifice/move/reveal referents continue to take precedence. The tapped
-    // permanent stays on the battlefield, so it is snapshot live.
-    tapped_object_context_from_events(state, events)
+    // Enlist's "+X/+0 … where X is the tapped creature's power". Tried before
+    // the damage referent so sacrifice/move/reveal/tap referents continue to
+    // take precedence. The tapped permanent stays on the battlefield, so it is
+    // snapshot live.
+    if let Some(snapshot) = tapped_object_context_from_events(state, events) {
+        return Some(snapshot);
+    }
+
+    // CR 608.2c: the weakest referent — a later instruction's "that creature"
+    // may refer to the single creature an earlier instruction in the same
+    // resolution dealt damage to (e.g. fight-back templates: "~ deals damage
+    // equal to its power to target creature. That creature deals damage equal
+    // to its power to ~"). A damaged permanent stays on the battlefield, so its
+    // claim is the weakest; sacrifice/move/reveal/tap referents from the same
+    // resolution still win.
+    damaged_object_context_from_events(state, events)
+}
+
+/// CR 608.2c: capture a single creature an earlier instruction dealt damage to
+/// as the resolution's anaphoric referent (the "fight-back clause"). A
+/// multi-target damage parent (e.g. Living Inferno, which deals damage to each
+/// creature) has no singular "that creature", so it yields no snapshot —
+/// Living Inferno is intentionally NOT fixed here; it needs distributive
+/// per-creature resolution this referent does not attempt. Player-targeted
+/// damage (`TargetRef::Player`) is filtered out. The damaged permanent stays on
+/// the battlefield, so it is snapshot live.
+fn damaged_object_context_from_events(
+    state: &GameState,
+    events: &[GameEvent],
+) -> Option<CostPaidObjectSnapshot> {
+    let mut seen = HashSet::new();
+    let mut damaged = events.iter().filter_map(|event| match event {
+        // CR 608.2c: only object-targeted damage introduces a "that creature".
+        GameEvent::DamageDealt {
+            target: TargetRef::Object(object_id),
+            ..
+        } if seen.insert(*object_id) => {
+            state
+                .objects
+                .get(object_id)
+                .map(|obj| CostPaidObjectSnapshot {
+                    object_id: *object_id,
+                    lki: obj.snapshot_for_mana_spent(),
+                })
+        }
+        _ => None,
+    });
+    // CR 608.2c: single-object guard — a multi-target damage parent has no
+    // singular referent.
+    let first = damaged.next()?;
+    damaged.next().is_none().then_some(first)
 }
 
 /// CR 608.2c: capture a single creature tapped by the parent instruction as the
@@ -9048,6 +9095,85 @@ mod tests {
             card_names: vec!["A".into(), "B".into()],
         }];
         assert!(revealed_object_context_from_events(&state, &events).is_none());
+    }
+
+    /// CR 608.2c: a single object-targeted `DamageDealt` introduces a
+    /// fight-back referent ("that creature deals damage equal to its power").
+    #[test]
+    fn damaged_object_context_reads_single_object_damage() {
+        let mut state = GameState::new_two_player(42);
+        let creature = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Five Power Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let events = vec![GameEvent::DamageDealt {
+            source_id: ObjectId(99),
+            target: TargetRef::Object(creature),
+            amount: 3,
+            is_combat: false,
+            excess: 0,
+        }];
+
+        let snapshot = damaged_object_context_from_events(&state, &events)
+            .expect("a single object-targeted damage event should provide a referent");
+        assert_eq!(snapshot.object_id, creature);
+        assert_eq!(snapshot.lki.name, "Five Power Creature");
+    }
+
+    /// CR 608.2c: a multi-target damage parent (e.g. Living Inferno) has no
+    /// singular "that creature" — the single-object guard declines it.
+    #[test]
+    fn damaged_object_context_ignores_multi_target_damage() {
+        let mut state = GameState::new_two_player(42);
+        let a = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "A".into(),
+            Zone::Battlefield,
+        );
+        let b = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "B".into(),
+            Zone::Battlefield,
+        );
+        let events = vec![
+            GameEvent::DamageDealt {
+                source_id: ObjectId(99),
+                target: TargetRef::Object(a),
+                amount: 1,
+                is_combat: false,
+                excess: 0,
+            },
+            GameEvent::DamageDealt {
+                source_id: ObjectId(99),
+                target: TargetRef::Object(b),
+                amount: 1,
+                is_combat: false,
+                excess: 0,
+            },
+        ];
+        assert!(damaged_object_context_from_events(&state, &events).is_none());
+        assert!(parent_referent_context_from_events(&state, &events).is_none());
+    }
+
+    /// CR 608.2c: player-targeted damage carries no "that creature" referent.
+    #[test]
+    fn damaged_object_context_ignores_player_damage() {
+        let state = GameState::new_two_player(42);
+        let events = vec![GameEvent::DamageDealt {
+            source_id: ObjectId(99),
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 3,
+            is_combat: false,
+            excess: 0,
+        }];
+        assert!(damaged_object_context_from_events(&state, &events).is_none());
     }
 
     /// Two separate `CardsRevealed` events → ambiguous "it" → no referent.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11156,6 +11156,28 @@ fn damage_clause_has_fresh_opponent_recipient(effect: &Effect) -> bool {
     }
 }
 
+/// CR 201.5 + CR 608.2c: a damage clause whose recipient is the source object's
+/// self-reference ("this creature" / "~", `TargetFilter::SelfRef`) declares its
+/// own recipient — the fight-back recipient class (Karplusan Yeti and siblings:
+/// "... That creature deals damage equal to its power to this creature."). Per
+/// CR 201.5 the self-reference names just the source object, so the blanket
+/// anaphoric parent-rewrite must not collapse it to `ParentTarget` (which would
+/// re-aim the fight-back at clause 1's chosen target). The `Anaphoric` amount is
+/// resolved by the resolver's CR 608.2c `effect_context_object` referent, so no
+/// source/amount rebind is needed here.
+fn damage_clause_has_self_ref_recipient(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::DealDamage {
+            target: TargetFilter::SelfRef,
+            ..
+        } | Effect::DamageAll {
+            target: TargetFilter::SelfRef,
+            ..
+        }
+    )
+}
+
 /// Coerce a per-object `QuantityRef` whose scope is `ObjectScope::Source` to
 /// `ObjectScope::Target`. The mirror of `rebind_anaphoric_ref` for the one-sided
 /// fight class: a "Then it deals damage equal to its power" sub-clause whose
@@ -11222,7 +11244,20 @@ fn rebind_source_amount_to_target(expr: &mut QuantityExpr) {
 /// deals..." subject was classified `SelfRef` (Wolf Strike/Burrog Barrage),
 /// which would otherwise read the ability source (the spell, power 0). Returns
 /// true (= decline the blanket `replace_target_with_parent`) when handled.
+///
+/// Covers two recipient shapes: (1) the fresh-opponent recipient — rebind the
+/// damage source/amount to the parent target while preserving the recipient;
+/// (2) the self-reference recipient ("to this creature"/"to ~",
+/// `TargetFilter::SelfRef`, the Karplusan Yeti fight-back class) — preserve the
+/// recipient verbatim with NO source/amount rebind.
 fn bind_anaphoric_damage_subject_keep_recipient(effect: &mut Effect) -> bool {
+    // CR 201.5 + CR 608.2c: a self-reference recipient ("to this creature"/"to ~")
+    // is the source itself and must be preserved verbatim (fight-back class). No
+    // source/amount rebind: the resolver seeds the `Anaphoric` amount from the
+    // prior clause's damaged-object event (effect_context_object).
+    if damage_clause_has_self_ref_recipient(effect) {
+        return true;
+    }
     if !damage_clause_has_fresh_opponent_recipient(effect) {
         return false;
     }

--- a/crates/engine/tests/karplusan_yeti_fight_back.rs
+++ b/crates/engine/tests/karplusan_yeti_fight_back.rs
@@ -1,0 +1,118 @@
+//! Regression for the fight-back-clause cross-context anaphora bug (CR 608.2c).
+//!
+//! Karplusan Yeti — Oracle:
+//!   `{T}: This creature deals damage equal to its power to target creature.
+//!    That creature deals damage equal to its power to this creature.`
+//!
+//! Clause 2 parses to `DealDamage { amount: Power{Anaphoric}, target: SelfRef }`:
+//! "to this creature" is the source object's self-reference (CR 201.5), so the
+//! recipient is the Yeti itself, and the `Anaphoric` amount is the power of the
+//! creature clause 1 damaged ("that creature", CR 608.2c).
+//!
+//! The fix is TWO-part:
+//!   1. Resolver: `damaged_object_context_from_events` is the weakest
+//!      `parent_referent_context_from_events` referent — a single object-targeted
+//!      `DamageDealt` event from the parent instruction introduces the "that
+//!      creature" antecedent, seeding the `Anaphoric` amount (without it, the
+//!      amount resolved to 0 and the Yeti took 0 damage).
+//!   2. Parser: `bind_anaphoric_damage_subject_keep_recipient` preserves a
+//!      `TargetFilter::SelfRef` recipient verbatim (CR 201.5), so the blanket
+//!      anaphoric parent-rewrite no longer clobbers clause 2's recipient to
+//!      `ParentTarget` (which would re-aim the fight-back at clause 1's chosen
+//!      target instead of the source).
+//!
+//! This test drives the real `apply` pipeline (activate `{T}`, select target,
+//! resolve) and asserts both damage prongs. It FAILS on revert of either half
+//! (the Yeti takes 0 without the resolver half; the fought creature is hit
+//! twice and the Yeti takes 0 without the parser half).
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+const YETI_ORACLE: &str = "{T}: This creature deals damage equal to its power to target creature. That creature deals damage equal to its power to this creature.";
+
+/// CR 608.2c: the fight-back clause's "that creature" binds to the creature the
+/// earlier clause damaged. Karplusan Yeti (3/3) fights a 5/5: the 5/5 takes the
+/// Yeti's power (3), then the Yeti takes the 5/5's power (5) — not 0, not 3.
+#[test]
+fn karplusan_yeti_fight_back_deals_fought_creatures_power() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let yeti = scenario
+        .add_creature_from_oracle(P0, "Karplusan Yeti", 3, 3, YETI_ORACLE)
+        .id();
+    // A 5/5 under the opponent: power (5) differs from the Yeti's power (3), so a
+    // spurious self-power referent would read 3, not 5 — distinguishing the fix.
+    let opponent = scenario.add_creature(P1, "Hulking Brute", 5, 5).id();
+
+    let mut runner = scenario.build();
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: yeti,
+            ability_index: 0,
+        })
+        .expect("activating Karplusan Yeti's {T} ability must succeed");
+
+    // Target the opponent's 5/5.
+    let target = match &runner.state().waiting_for {
+        WaitingFor::TargetSelection { target_slots, .. } => target_slots[0]
+            .legal_targets
+            .iter()
+            .find(|t| matches!(t, TargetRef::Object(id) if *id == opponent))
+            .cloned()
+            .expect("the opponent's 5/5 must be a legal target"),
+        other => panic!("expected target selection for the fight, got {other:?}"),
+    };
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![target],
+        })
+        .expect("choosing the fight target must succeed");
+
+    // Drain the stack, collecting the damage events across resolution so the
+    // exact amounts are observable even though 5 damage is lethal to the 3/3.
+    let mut damage: Vec<(TargetRef, u32)> = Vec::new();
+    for _ in 0..40 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        let result = runner
+            .act(GameAction::PassPriority)
+            .expect("passing priority to resolve the fight must succeed");
+        for event in &result.events {
+            if let GameEvent::DamageDealt { target, amount, .. } = event {
+                damage.push((target.clone(), *amount));
+            }
+        }
+    }
+
+    let damage_to = |id: ObjectId| -> u32 {
+        damage
+            .iter()
+            .filter(|(t, _)| matches!(t, TargetRef::Object(o) if *o == id))
+            .map(|(_, amt)| *amt)
+            .sum()
+    };
+
+    // Clause 1: the Yeti deals its power (3) to the fought creature.
+    assert_eq!(
+        damage_to(opponent),
+        3,
+        "the fought 5/5 must take the Yeti's power (3); damage = {damage:?}",
+    );
+    // Clause 2 (the fix): the fought creature deals ITS power (5) back to the
+    // Yeti via the CR 608.2c "that creature" referent — not 0 (no referent) and
+    // not 3 (a wrong self-power referent).
+    assert_eq!(
+        damage_to(yeti),
+        5,
+        "the Yeti must take the fought creature's power (5) via the fight-back \
+         referent, not 0 (the pre-fix bug); damage = {damage:?}",
+    );
+}


### PR DESCRIPTION
Two-clause fight-back templates (Karplusan Yeti and ~14 siblings:
"~ deals damage equal to its power to target creature. That creature
deals damage equal to its power to ~") resolved clause 2 incorrectly:
the source took 0 and the fought creature was hit twice.

Two independent defects, fixed in lockstep:

- Resolver (game/effects/mod.rs): clause 2's "its power" (ObjectScope::
  Anaphoric) read 0 because DealDamage never seeded a CR 608.2c referent.
  Add damaged_object_context_from_events as the weakest parent referent
  (after sacrifice/move/reveal/tap), mirroring tapped_object_context_
  from_events. A single object-targeted DamageDealt becomes the "that
  creature" referent; multi-target parents (Living Inferno) and player
  damage are declined by the single-object guard.

- Parser (parser/oracle_effect/mod.rs): clause 2's recipient ("to this
  creature"/"to ~", TargetFilter::SelfRef) was clobbered to ParentTarget
  by the blanket anaphoric parent-rewrite, re-aiming the fight-back at
  clause 1's target. Add damage_clause_has_self_ref_recipient and an
  early-return in bind_anaphoric_damage_subject_keep_recipient so a
  self-reference recipient is preserved verbatim (CR 201.5).

The fresh-opponent / one-sided-fight class (Ambuscade, Clear Shot, Rabid
Gnaw) is disjoint (Typed opponent recipient) and unaffected.

Verified by karplusan_yeti_fight_back (non-degenerate 3/3 vs 5/5 fixture
driving the real apply() pipeline) + 3 resolver unit tests.
