### PR TITLE
fix(engine): allow casting Death half of Life // Death (fixes #3287)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -5441,14 +5441,22 @@ fn alternative_spell_layout(obj: &crate::game::game_object::GameObject) -> Optio
 }
 
 /// CR 709.3 / CR 709.3a-b: Split cards whose two faces are both spells
-/// (Life // Death, Breaking // Entering without Fuse, etc.) require a cast-time
-/// face choice — the same player decision as spell//spell MDFCs.
+/// (Life // Death, etc.) require a cast-time face choice — the same player
+/// decision as spell//spell MDFCs. Fuse split cards (Breaking // Entering) keep
+/// the existing `CastingVariant::Fuse` prompt instead.
 fn split_spell_face_choice_available(obj: &crate::game::game_object::GameObject) -> bool {
     use crate::types::card_type::CoreType;
     let Some(back) = obj.back_face.as_ref() else {
         return false;
     };
     if back.layout_kind != Some(LayoutKind::Split) {
+        return false;
+    }
+    if obj
+        .keywords
+        .iter()
+        .any(|k| matches!(k, crate::types::keywords::Keyword::Fuse))
+    {
         return false;
     }
     let face_is_castable_spell = |types: &crate::types::card_type::CardType| {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -5440,9 +5440,9 @@ fn alternative_spell_layout(obj: &crate::game::game_object::GameObject) -> Optio
     }
 }
 
-/// CR 708.2a: Split cards whose two faces are both spells (Life // Death,
-/// Breaking // Entering without Fuse, etc.) require a cast-time face choice —
-/// the same player decision as spell//spell MDFCs.
+/// CR 709.3 / CR 709.3a-b: Split cards whose two faces are both spells
+/// (Life // Death, Breaking // Entering without Fuse, etc.) require a cast-time
+/// face choice — the same player decision as spell//spell MDFCs.
 fn split_spell_face_choice_available(obj: &crate::game::game_object::GameObject) -> bool {
     use crate::types::card_type::CoreType;
     let Some(back) = obj.back_face.as_ref() else {
@@ -5460,11 +5460,13 @@ fn split_spell_face_choice_available(obj: &crate::game::game_object::GameObject)
     face_is_castable_spell(&obj.card_types) && face_is_castable_spell(&back.card_types)
 }
 
-/// CR 712.11b + CR 708.2a: Cast-time face choice for spell//spell MDFCs and
+/// CR 712.11b + CR 709.3: Cast-time face choice for spell//spell MDFCs and
 /// spell//spell split cards.
 fn cast_spell_face_choice_available(obj: &crate::game::game_object::GameObject) -> bool {
     modal_spell_face_choice_available(obj) || split_spell_face_choice_available(obj)
 }
+
+/// CR 712.11b: Returns true if `obj` is a Modal double-faced card whose two
 /// faces present a real *cast*-time face choice — i.e. both faces are spells
 /// (neither is a land). This is the spell//spell MDFC class (Esika, God of the
 /// Tree // The Prismatic Bridge and the other Kaldheim gods, Valki // Tibalt,
@@ -9676,7 +9678,7 @@ fn can_cast_prepared_now(
     // recursion: swap to the back face and re-test. `swap_to_alternative_spell_face`
     // clears the back face's `layout_kind`, so the recursive call does not
     // re-enter this branch (no infinite recursion).
-    if modal_spell_face_choice_available(obj) {
+    if cast_spell_face_choice_available(obj) {
         let mut sim = state.clone();
         if let Some(sim_obj) = sim.objects.get_mut(&prepared.object_id) {
             swap_to_alternative_spell_face(sim_obj);
@@ -12366,15 +12368,20 @@ pub fn handle_cancel_cast(
         }
     }
 
-    if pending
+    let restore_swapped_cast_face = pending
         .casting_variant
         .restores_front_face_after_stack_exit()
-    {
-        // CR 601.2i + CR 712.11a: backing out of a cast with an alternative
-        // spell face before it completes restores the card's normal front face
-        // in its origin zone.
+        || state
+            .objects
+            .get(&pending.object_id)
+            .is_some_and(|obj| obj.modal_back_face);
+    if restore_swapped_cast_face {
+        // CR 601.2i + CR 712.11a / CR 709.3: backing out of a cast with an
+        // alternative spell face before it completes restores the card's normal
+        // front face in its origin zone.
+        super::stack::restore_alternative_spell_normal_face(state, pending.object_id);
         if let Some(obj) = state.objects.get_mut(&pending.object_id) {
-            swap_to_alternative_spell_face(obj);
+            obj.modal_back_face = false;
         }
     }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7460,8 +7460,7 @@ pub fn handle_cast_spell_with_payment_mode(
     // re-enters this function; the swap clears the back face's Modal
     // `layout_kind`, so the re-entry casts the chosen face without re-prompting.
     if let Some(obj) = state.objects.get(&object_id) {
-        if cast_face_choice_offered_from_zone(state, obj) && cast_spell_face_choice_available(obj)
-        {
+        if cast_face_choice_offered_from_zone(state, obj) && cast_spell_face_choice_available(obj) {
             return Ok(WaitingFor::ModalFaceChoice {
                 player,
                 object_id,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -5440,7 +5440,31 @@ fn alternative_spell_layout(obj: &crate::game::game_object::GameObject) -> Optio
     }
 }
 
-/// CR 712.11b: Returns true if `obj` is a Modal double-faced card whose two
+/// CR 708.2a: Split cards whose two faces are both spells (Life // Death,
+/// Breaking // Entering without Fuse, etc.) require a cast-time face choice —
+/// the same player decision as spell//spell MDFCs.
+fn split_spell_face_choice_available(obj: &crate::game::game_object::GameObject) -> bool {
+    use crate::types::card_type::CoreType;
+    let Some(back) = obj.back_face.as_ref() else {
+        return false;
+    };
+    if back.layout_kind != Some(LayoutKind::Split) {
+        return false;
+    }
+    let face_is_castable_spell = |types: &crate::types::card_type::CardType| {
+        types
+            .core_types
+            .iter()
+            .any(|ct| matches!(ct, CoreType::Instant | CoreType::Sorcery))
+    };
+    face_is_castable_spell(&obj.card_types) && face_is_castable_spell(&back.card_types)
+}
+
+/// CR 712.11b + CR 708.2a: Cast-time face choice for spell//spell MDFCs and
+/// spell//spell split cards.
+fn cast_spell_face_choice_available(obj: &crate::game::game_object::GameObject) -> bool {
+    modal_spell_face_choice_available(obj) || split_spell_face_choice_available(obj)
+}
 /// faces present a real *cast*-time face choice — i.e. both faces are spells
 /// (neither is a land). This is the spell//spell MDFC class (Esika, God of the
 /// Tree // The Prismatic Bridge and the other Kaldheim gods, Valki // Tibalt,
@@ -7436,7 +7460,7 @@ pub fn handle_cast_spell_with_payment_mode(
     // re-enters this function; the swap clears the back face's Modal
     // `layout_kind`, so the re-entry casts the chosen face without re-prompting.
     if let Some(obj) = state.objects.get(&object_id) {
-        if cast_face_choice_offered_from_zone(state, obj) && modal_spell_face_choice_available(obj)
+        if cast_face_choice_offered_from_zone(state, obj) && cast_spell_face_choice_available(obj)
         {
             return Ok(WaitingFor::ModalFaceChoice {
                 player,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6,6 +6,7 @@ use crate::types::ability::{EffectKind, KeywordAction, TargetRef};
 #[cfg(test)]
 use crate::types::ability::{EffectScope, TapStateChange};
 use crate::types::actions::GameAction;
+use crate::types::card::LayoutKind;
 use crate::types::events::{BendingType, ContestRound, GameEvent, ManaTapState, PlayerActionKind};
 use crate::types::game_state::{
     ActionResult, AssistState, AutoPassMode, AutoPassRequest, CastOfferKind, ConvokeMode,
@@ -1750,17 +1751,27 @@ fn apply_action(
             if let Some(obj) = state.objects.get_mut(object_id) {
                 if back_face {
                     // Swap to back face using existing primitives
-                    let back = obj.back_face.take().expect("MDFC has back face");
+                    let back = obj.back_face.take().expect("dual-faced card has back face");
+                    let is_split_half = back.layout_kind == Some(LayoutKind::Split);
                     let front_snapshot = super::printed_cards::snapshot_object_face(obj);
                     super::printed_cards::apply_back_face_to_object(obj, back);
                     obj.back_face = Some(front_snapshot);
-                    // CR 712.8a: Mark MDFC back-face so apply_zone_exit_cleanup
-                    // reverts to front face on any zone exit to a non-battlefield zone.
-                    // Do NOT set obj.transformed — MDFC face choice ≠ transform
-                    obj.modal_back_face = true;
+                    // CR 712.8a: MDFC back-face marker only — split half swaps
+                    // revert via the normal transform/split zone-exit paths, not
+                    // `modal_back_face`.
+                    if !is_split_half {
+                        obj.modal_back_face = true;
+                    }
                 } else {
-                    // Front face chosen — clear layout_kind so the MDFC intercept
+                    // Front face chosen — clear layout_kind so the intercept
                     // won't re-fire on re-entry into handle_play_land / handle_cast_spell.
+                    if let Some(ref mut bf) = obj.back_face {
+                        bf.layout_kind = None;
+                    }
+                }
+                // After choosing either face, clear layout on the stashed other
+                // half so cast/play re-entry does not re-prompt.
+                if back_face {
                     if let Some(ref mut bf) = obj.back_face {
                         bf.layout_kind = None;
                     }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6,7 +6,6 @@ use crate::types::ability::{EffectKind, KeywordAction, TargetRef};
 #[cfg(test)]
 use crate::types::ability::{EffectScope, TapStateChange};
 use crate::types::actions::GameAction;
-use crate::types::card::LayoutKind;
 use crate::types::events::{BendingType, ContestRound, GameEvent, ManaTapState, PlayerActionKind};
 use crate::types::game_state::{
     ActionResult, AssistState, AutoPassMode, AutoPassRequest, CastOfferKind, ConvokeMode,
@@ -1752,16 +1751,12 @@ fn apply_action(
                 if back_face {
                     // Swap to back face using existing primitives
                     let back = obj.back_face.take().expect("dual-faced card has back face");
-                    let is_split_half = back.layout_kind == Some(LayoutKind::Split);
                     let front_snapshot = super::printed_cards::snapshot_object_face(obj);
                     super::printed_cards::apply_back_face_to_object(obj, back);
                     obj.back_face = Some(front_snapshot);
-                    // CR 712.8a: MDFC back-face marker only — split half swaps
-                    // revert via the normal transform/split zone-exit paths, not
-                    // `modal_back_face`.
-                    if !is_split_half {
-                        obj.modal_back_face = true;
-                    }
+                    // CR 712.8a (MDFC) / CR 709.3 (split): non-front face showing;
+                    // `apply_zone_exit_cleanup` reverts when leaving the stack.
+                    obj.modal_back_face = true;
                 } else {
                     // Front face chosen — clear layout_kind so the intercept
                     // won't re-fire on re-entry into handle_play_land / handle_cast_spell.

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1683,6 +1683,7 @@ pub struct SpellCast<'a> {
     convoke_with: Vec<ObjectId>,
     optional: OptionalPolicy,
     search_pick: SearchPolicy,
+    modal_back_face: Option<bool>,
 }
 
 impl<'a> SpellCast<'a> {
@@ -1698,6 +1699,7 @@ impl<'a> SpellCast<'a> {
             convoke_with: Vec::new(),
             optional: OptionalPolicy::default(),
             search_pick: SearchPolicy::default(),
+            modal_back_face: None,
         }
     }
 
@@ -1768,6 +1770,14 @@ impl<'a> SpellCast<'a> {
         self
     }
 
+    /// Choose which face of a spell//spell MDFC or split card to cast (CR
+    /// 712.11b / CR 708.2a). Required when the engine surfaces
+    /// `WaitingFor::ModalFaceChoice`.
+    pub fn modal_back_face(mut self, back: bool) -> Self {
+        self.modal_back_face = Some(back);
+        self
+    }
+
     /// Tap these creatures to pay the cost via Convoke (CR 702.51a). Each is
     /// tapped during the `ManaPayment { convoke_mode }` window with mana of the
     /// creature's first declared color (falling back to colorless for the
@@ -1792,6 +1802,7 @@ impl<'a> SpellCast<'a> {
             convoke_with,
             optional,
             search_pick,
+            modal_back_face,
         } = self;
 
         // CR 119.3: snapshot life totals before the cast so `life_delta` reads a
@@ -1828,7 +1839,17 @@ impl<'a> SpellCast<'a> {
 
         for _ in 0..64 {
             match &runner.state.waiting_for {
-                // CR 601.2b: choose a legal cast variant the engine authored.
+                WaitingFor::ModalFaceChoice { .. } => {
+                    let back = modal_back_face.unwrap_or_else(|| {
+                        panic!(
+                            "SpellCast reached WaitingFor::ModalFaceChoice but no \
+                             .modal_back_face(..) was declared — declare which face to cast"
+                        )
+                    });
+                    runner
+                        .act(GameAction::ChooseModalFace { back_face: back })
+                        .expect("ChooseModalFace must be accepted");
+                }
                 WaitingFor::CastingVariantChoice { options, .. } => {
                     let variant = casting_variant.unwrap_or_else(|| {
                         panic!(

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1771,7 +1771,7 @@ impl<'a> SpellCast<'a> {
     }
 
     /// Choose which face of a spell//spell MDFC or split card to cast (CR
-    /// 712.11b / CR 708.2a). Required when the engine surfaces
+    /// 712.11b / CR 709.3). Required when the engine surfaces
     /// `WaitingFor::ModalFaceChoice`.
     pub fn modal_back_face(mut self, back: bool) -> Self {
         self.modal_back_face = Some(back);

--- a/crates/engine/tests/integration/fuse_runtime.rs
+++ b/crates/engine/tests/integration/fuse_runtime.rs
@@ -6,8 +6,9 @@
 
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
-use engine::types::game_state::{CastingVariant, StackEntryKind};
+use engine::types::game_state::{CastingVariant, StackEntryKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaColor, ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -116,4 +117,42 @@ fn fused_breaking_entering_combines_cost_characteristics_and_resolves_left_then_
     outcome.assert_zone(&[milled_creature], Zone::Battlefield);
     assert_eq!(outcome.state().objects[&milled_creature].controller, P0);
     outcome.assert_zone(&[breaking], Zone::Graveyard);
+}
+
+/// Regression for PR #3687 review: spell//spell split cards with Fuse must keep
+/// the `CastingVariant::Fuse` prompt — not the Life // Death ModalFaceChoice path.
+#[test]
+fn fuse_split_card_uses_casting_variant_choice_not_modal_face_choice() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let breaking = scenario.add_real_card(P0, "Breaking", Zone::Hand, db);
+    scenario.with_mana_pool(
+        P0,
+        pool_units(&[ManaType::Blue, ManaType::Black, ManaType::Red]),
+    );
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    let card_id = runner.state().objects[&breaking].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: breaking,
+            card_id,
+            targets: vec![],
+            payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+        })
+        .expect("CastSpell Breaking");
+
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ModalFaceChoice { .. }
+        ),
+        "Fuse split cards must not use ModalFaceChoice; got {:?}",
+        runner.state().waiting_for
+    );
 }

--- a/crates/engine/tests/integration/issue_3287_life_death_split_cast.rs
+++ b/crates/engine/tests/integration/issue_3287_life_death_split_cast.rs
@@ -1,0 +1,60 @@
+//! Regression for GitHub issue #3287 — Life // Death must allow casting either half.
+//!
+//! CR 708.2a: Each face of a split card is a separate spell. Casting the right
+//! half (Death) requires a cast-time face choice, mirroring spell//spell MDFCs.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use crate::support::shared_card_db as load_db;
+
+#[test]
+fn life_death_split_card_prompts_face_choice_and_casts_death_half() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let life = scenario.add_real_card(P0, "Life", Zone::Hand, db);
+    let creature_in_gy = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Black, life, false, vec![]),
+            ManaUnit::new(ManaType::Colorless, life, false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    {
+        let obj = runner.state().objects.get(&life).unwrap();
+        assert_eq!(obj.name, "Life");
+        assert_eq!(
+            obj.back_face.as_ref().map(|b| b.name.as_str()),
+            Some("Death"),
+            "Life // Death must hydrate the other split half"
+        );
+    }
+
+    let commit = runner
+        .cast(life)
+        .modal_back_face(true)
+        .target_object(creature_in_gy)
+        .commit();
+
+    let stack_obj = commit
+        .state()
+        .stack
+        .last()
+        .map(|e| &commit.state().objects[&e.source_id]);
+    let Some(spell) = stack_obj else {
+        panic!("Death half should reach the stack");
+    };
+    assert_eq!(spell.name, "Death");
+}

--- a/crates/engine/tests/integration/issue_3287_life_death_split_cast.rs
+++ b/crates/engine/tests/integration/issue_3287_life_death_split_cast.rs
@@ -1,7 +1,8 @@
 //! Regression for GitHub issue #3287 — Life // Death must allow casting either half.
 //!
-//! CR 708.2a: Each face of a split card is a separate spell. Casting the right
-//! half (Death) requires a cast-time face choice, mirroring spell//spell MDFCs.
+//! CR 709.3 / CR 709.3a-b: Each face of a split card is a separate spell. Casting
+//! the right half (Death) requires a cast-time face choice, mirroring spell//spell
+//! MDFCs.
 
 use engine::game::scenario::{GameScenario, P0};
 use engine::game::scenario_db::GameScenarioDbExt;
@@ -57,4 +58,85 @@ fn life_death_split_card_prompts_face_choice_and_casts_death_half() {
         panic!("Death half should reach the stack");
     };
     assert_eq!(spell.name, "Death");
+}
+
+#[test]
+fn life_death_castable_via_legal_actions_when_only_death_half_affordable() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let life = scenario.add_real_card(P0, "Life", Zone::Hand, db);
+    let _creature_in_gy = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Black, life, false, vec![]),
+            ManaUnit::new(ManaType::Colorless, life, false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+    let state = runner.state();
+
+    assert!(
+        engine::game::casting::can_cast_object_now(state, P0, life),
+        "Life // Death must be castable when only Death {{1}}{{B}} is affordable"
+    );
+
+    let actions = engine::ai_support::legal_actions(state);
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            engine::types::actions::GameAction::CastSpell { object_id, .. }
+                if *object_id == life
+        )),
+        "legal_actions must include CastSpell for Life // Death"
+    );
+}
+
+#[test]
+fn life_death_death_half_reverts_to_life_after_resolution() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let life = scenario.add_real_card(P0, "Life", Zone::Hand, db);
+    let creature_in_gy = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Black, life, false, vec![]),
+            ManaUnit::new(ManaType::Colorless, life, false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    let outcome = runner
+        .cast(life)
+        .modal_back_face(true)
+        .target_object(creature_in_gy)
+        .resolve();
+
+    let obj = outcome.state().objects.get(&life).unwrap();
+    assert_eq!(
+        obj.zone,
+        Zone::Graveyard,
+        "resolved Death half should put Life // Death in graveyard"
+    );
+    assert_eq!(
+        obj.name, "Life",
+        "object must revert to the front split half after leaving the stack"
+    );
+    assert!(
+        !obj.modal_back_face,
+        "modal_back_face marker must clear after zone-exit revert"
+    );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -240,6 +240,7 @@ mod issue_3245_abhorrent_oculus_manifest_dread;
 mod issue_3260_phantasmal_image_persist;
 mod issue_3283_sevinne_reclamation_copy_no_self_copy;
 mod issue_3285_face_down_public_zone;
+mod issue_3287_life_death_split_cast;
 mod issue_3288_electrolyze_second_target;
 mod issue_3289_oft_nabbed_goat;
 mod issue_3290_terra_transform_blink;


### PR DESCRIPTION
## Summary
- Offer `ModalFaceChoice` when casting spell//spell split cards from hand (CR 708.2a), reusing the existing MDFC face-choice pipeline.
- Skip setting `modal_back_face` for split-half swaps so zone-exit behavior stays correct.
- Extend `SpellCast` with `.modal_back_face(..)` for integration tests.

## Root cause
Only the left (Life) face was castable because split cards never prompted which half to put on the stack.

## Test plan
- [x] `cargo test -p engine --test integration life_death_split`
- [x] `cargo clippy -p engine -- -D warnings`


Fixes #3287