### PR TITLE
fix(parser): drop trailing prose sentence from keyword-grant clauses

### DIFF
--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -887,6 +887,19 @@ pub(crate) fn push_grant_clause_modifications(
     part: &str,
     where_x_expression: Option<&str>,
 ) {
+    // CR 702.16n / 702.16p: a keyword-grant clause reaching this fn is a single
+    // BARE (unquoted) keyword token — granted activated/triggered abilities are
+    // quoted and stripped to a separate path (strip_quoted_segments at :645 +
+    // parse_quoted_ability_modifications at :798) before extract_keyword_clause
+    // runs, so any ". " here can only introduce a trailing inert prose sentence
+    // (e.g. Benevolent Blessing's SBA-exemption "This effect doesn't remove ...").
+    // Drop it so the keyword sentence reaches map_keyword clean.
+    let part =
+        match super::oracle_nom::bridge::split_once_on_lower(part, &part.to_lowercase(), ". ") {
+            Some((first, _)) => first,
+            None => part,
+        };
+
     let part_trimmed = part.trim().trim_end_matches('.');
     let (part_without_duration, _) = strip_trailing_duration(part_trimmed);
     let part_trimmed = part_without_duration.trim().trim_end_matches('.');

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -17602,3 +17602,217 @@ fn aura_static_does_not_bind_it_pronoun_to_source() {
         );
     }
 }
+
+/// CR 702.16p: Benevolent Blessing — "Enchanted creature has protection from the
+/// chosen color. This effect doesn't remove Auras and Equipment you control that
+/// are already attached to it." The trailing inert SBA-exemption sentence must be
+/// dropped so the keyword token reaches `parse_protection_target` clean and yields
+/// `Protection(ChosenColor)` — NOT a bogus `Protection(CardType(_))` swallowing
+/// the trailing prose. (fail-if-reverted)
+#[test]
+fn protection_chosen_color_drops_trailing_sba_exemption_benevolent_blessing() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+
+    let mods = parse_continuous_modifications(
+        "Enchanted creature has protection from the chosen color. This effect doesn't remove Auras and Equipment you control that are already attached to it.",
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::ChosenColor),
+        }),
+        "expected Protection(ChosenColor), got {mods:?}"
+    );
+    assert!(
+        !mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Protection(ProtectionTarget::CardType(_)),
+            }
+        )),
+        "trailing prose must not be swallowed into Protection(CardType(_)), got {mods:?}"
+    );
+}
+
+/// CR 702.16n: Pentarch Ward variant — the trailing sentence references "this
+/// Aura" (no internal " and "), exercising the single-leg split path. Must still
+/// yield `Protection(ChosenColor)`. (fail-if-reverted)
+#[test]
+fn protection_chosen_color_drops_trailing_this_aura_exemption() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+
+    let mods = parse_continuous_modifications(
+        "Enchanted creature has protection from the chosen color. This effect doesn't remove this Aura.",
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::ChosenColor),
+        }),
+        "expected Protection(ChosenColor), got {mods:?}"
+    );
+    assert!(
+        !mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Protection(ProtectionTarget::CardType(_)),
+            }
+        )),
+        "trailing prose must not be swallowed into Protection(CardType(_)), got {mods:?}"
+    );
+}
+
+/// Building-block: `push_grant_clause_modifications` must drop the trailing prose
+/// sentence directly on the bare keyword leg and emit one
+/// `Protection(ChosenColor)`. (fail-if-reverted)
+#[test]
+fn push_grant_clause_drops_trailing_sentence_chosen_color() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+
+    let mut mods = Vec::new();
+    push_grant_clause_modifications(
+        &mut mods,
+        "protection from the chosen color. this effect doesn't remove auras",
+        None,
+    );
+    assert_eq!(
+        mods,
+        vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::ChosenColor),
+        }],
+        "expected exactly one Protection(ChosenColor), got {mods:?}"
+    );
+}
+
+/// No-regression: a plain chosen-color grant with NO trailing ". " sentence is
+/// unchanged (split returns None).
+#[test]
+fn protection_chosen_color_plain_unchanged() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+
+    let mods =
+        parse_continuous_modifications("Enchanted creature has protection from the chosen color.");
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::ChosenColor),
+        }),
+        "expected Protection(ChosenColor), got {mods:?}"
+    );
+}
+
+/// No-regression: Glory's duration form "protection from the chosen color until
+/// end of turn" — the duration is stripped, no truncation, still ChosenColor.
+#[test]
+fn protection_chosen_color_duration_form_glory() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+
+    let mods = parse_continuous_modifications(
+        "Creatures you control gain protection from the chosen color until end of turn",
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::ChosenColor),
+        }),
+        "expected Protection(ChosenColor), got {mods:?}"
+    );
+}
+
+/// No-regression: single-color protection still parses to Color(Red).
+#[test]
+fn protection_single_color_unchanged() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+    use crate::types::mana::ManaColor;
+
+    let mods = parse_continuous_modifications("Enchanted creature has protection from red.");
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::Color(ManaColor::Red)),
+        }),
+        "expected Protection(Color(Red)), got {mods:?}"
+    );
+}
+
+/// Broader Ward-cycle class: a single-color Ward with a trailing sentence (Red
+/// Ward form) recovers the keyword via the same ". " split → Color(Red).
+#[test]
+fn protection_single_color_with_trailing_sentence_red_ward() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+    use crate::types::mana::ManaColor;
+
+    let mods = parse_continuous_modifications(
+        "Enchanted creature has protection from red. This effect doesn't remove this Aura.",
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::Color(ManaColor::Red)),
+        }),
+        "expected Protection(Color(Red)), got {mods:?}"
+    );
+}
+
+/// No-regression: Spectra Ward's "protection from each color" still fans out to
+/// the five WUBRG protection entries (via expand_protection_parts) through the
+/// new split (the leg has no ". ").
+#[test]
+fn protection_each_color_fanout_unchanged_spectra_ward() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+    use crate::types::mana::ManaColor;
+
+    let mods = parse_continuous_modifications("Enchanted creature has protection from each color.");
+    let prot: Vec<_> = mods
+        .iter()
+        .filter_map(|m| match m {
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Protection(pt),
+            } => Some(pt.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        prot,
+        vec![
+            ProtectionTarget::Color(ManaColor::White),
+            ProtectionTarget::Color(ManaColor::Blue),
+            ProtectionTarget::Color(ManaColor::Black),
+            ProtectionTarget::Color(ManaColor::Red),
+            ProtectionTarget::Color(ManaColor::Green),
+        ],
+        "expected five WUBRG protection entries, got {mods:?}"
+    );
+}
+
+/// No-regression: a multi-keyword grant where one leg is protection still emits
+/// BOTH keywords (the " and " pre-split happens before the per-leg ". " split).
+#[test]
+fn multi_keyword_flying_and_protection_unchanged() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+    use crate::types::mana::ManaColor;
+
+    let mods =
+        parse_continuous_modifications("Enchanted creature has flying and protection from red.");
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Flying,
+        }),
+        "missing Flying, got {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::Color(ManaColor::Red)),
+        }),
+        "missing Protection(Color(Red)), got {mods:?}"
+    );
+}
+
+/// CR 604.1 / 613.1f: a granted QUOTED activated ability whose body contains an
+/// internal ". " must reach the quoted-ability path (GrantAbility) and NOT be
+/// truncated by the new bare-keyword ". " split — proving quoted text bypasses it.
+#[test]
+fn granted_quoted_ability_with_internal_period_bypasses_split() {
+    let mods = parse_continuous_modifications(
+        "Enchanted creature has \"{T}: Add one mana of any color. Activate this ability only as a sorcery.\"",
+    );
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::GrantAbility { .. })),
+        "expected a GrantAbility from the quoted ability, got {mods:?}"
+    );
+}


### PR DESCRIPTION
Fixes #3688.

## Summary

Keyword-grant Auras whose grant clause is followed by a trailing rules-prose sentence misparse — the trailing sentence is glued onto the keyword's argument. The clearest class is **protection from the chosen color**:

- **Benevolent Blessing** — "Enchanted creature has protection from the chosen color. This effect doesn't remove Auras and Equipment you control that are already attached to it." conferred **no protection** (the quality became `"the chosen color. this effect doesn't remove auras…"`, which missed the `"the chosen color"` literal in `parse_protection_target` and fell through to a bogus `ProtectionTarget::CardType(...)`).
- ~14 cards: Cho-Manno's Blessing, Flickering Ward, Floating Shield, Pentarch Ward, Ward of Lights, the colored Ward cycle, Spectra Ward, Tattoo Ward, Pledge of Loyalty.

Keyword grants with a trailing sentence on other keywords (indestructible, trample, …) lost the keyword entirely, because the period-laden token failed to map to any keyword.

## Fix (parser-AST-only; no new engine variant, no runtime change)

`push_grant_clause_modifications` now takes only the first sentence of a grant clause when a `". "` boundary is present. A part reaching this function is a **bare, unquoted keyword token** — granted activated/triggered abilities are quoted and stripped to a separate path (`strip_quoted_segments` → `parse_quoted_ability_modifications`) before keyword extraction runs — so a `". "` here can only introduce a trailing inert prose sentence. The keyword sentence then reaches `map_keyword` clean and lowers to `Protection(ChosenColor)`, which the runtime already handles (sibling **Glory** parses correctly today).

The dropped trailing sentence is the CR 702.16n / 702.16p "this effect doesn't remove Auras…already attached" state-based-action exemption (702.16p names Benevolent Blessing) — modeled nowhere in the engine, so dropping it loses nothing currently represented.

## Tests

- Discriminating (real `parse_continuous_modifications` pipeline): Benevolent Blessing + Pentarch Ward → `AddKeyword{Protection(ChosenColor)}` and explicitly NOT `Protection(CardType(_))`; a building-block test feeding the glued leg directly. Revert-discriminating — without the split the quality stays glued and falls to `CardType`.
- No-regression: plain "protection from the chosen color" → ChosenColor; Glory duration form → ChosenColor (duration still stripped); "protection from red" → Color(Red); Spectra Ward "protection from each color" → 5 WUBRG entries (fan-out intact); "flying and protection from red" → both keywords; a granted **quoted** ability with an internal ". " → `GrantAbility` (proves the quoted path bypasses the split, not truncated).

## Verification

`cargo +nightly test -p engine --lib`: 12429 passed, 0 failed. `--test integration`: 1174 passed, no fixture diff. `clippy -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean (only the sanctioned `split_once_on_lower` structural splitter added).
