### PR TITLE
fix(engine): Ob Nixilis Casualty copy isn't legendary

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -2186,6 +2186,26 @@ pub fn casualty_copy_ability_definition() -> AbilityDefinition {
 }
 
 fn casualty_copy_ability_definition_for_ordinal(origin_ordinal: Option<u32>) -> AbilityDefinition {
+    casualty_copy_ability_definition_for_ordinal_with_rider(origin_ordinal, &[], false)
+}
+
+fn casualty_copy_rider_from_oracle(oracle: &str) -> (Vec<ContinuousModification>, bool) {
+    let lower = oracle.to_lowercase();
+    let mut modifications = Vec::new();
+    if lower.contains("the copy isn't legendary") || lower.contains("the copy is not legendary") {
+        modifications.push(ContinuousModification::RemoveSupertype {
+            supertype: Supertype::Legendary,
+        });
+    }
+    let starting_loyalty = lower.contains("has starting loyalty");
+    (modifications, starting_loyalty)
+}
+
+fn casualty_copy_ability_definition_for_ordinal_with_rider(
+    origin_ordinal: Option<u32>,
+    additional_modifications: &[ContinuousModification],
+    starting_loyalty_from_casualty_sacrifice: bool,
+) -> AbilityDefinition {
     AbilityDefinition::new(
         AbilityKind::Spell,
         // CR 702.153a: Casualty — "If the spell has any targets, you may choose
@@ -2194,6 +2214,8 @@ fn casualty_copy_ability_definition_for_ordinal(origin_ordinal: Option<u32>) -> 
             target: TargetFilter::SelfRef,
             retarget: CopyRetargetPermission::MayChooseNewTargets,
             copier: None,
+            additional_modifications: additional_modifications.to_vec(),
+            starting_loyalty_from_casualty_sacrifice,
         },
     )
     .condition(AbilityCondition::AdditionalCostPaid {
@@ -2246,9 +2268,18 @@ pub fn synthesize_casualty(face: &mut CardFace) {
 
     // CR 702.153a: "When you cast this spell, if a casualty cost was paid, copy it.
     // If the spell has any targets, you may choose new targets for the copy."
+    let (casualty_copy_mods, starting_loyalty) = face
+        .oracle_text
+        .as_deref()
+        .map(casualty_copy_rider_from_oracle)
+        .unwrap_or_default();
     for (casualty_ordinal, _) in casualty_thresholds.iter().enumerate() {
         let casualty_ordinal = u32::try_from(casualty_ordinal).unwrap_or(u32::MAX);
-        let execute = casualty_copy_ability_definition_for_ordinal(Some(casualty_ordinal));
+        let execute = casualty_copy_ability_definition_for_ordinal_with_rider(
+            Some(casualty_ordinal),
+            &casualty_copy_mods,
+            starting_loyalty,
+        );
         let already_has_trigger = face.triggers.iter().any(|t| {
             matches!(t.mode, TriggerMode::SpellCast)
                 && matches!(t.valid_card, Some(TargetFilter::SelfRef))
@@ -2299,6 +2330,8 @@ pub(crate) fn replicate_copy_ability_definition_for_ordinal(
             target: TargetFilter::SelfRef,
             retarget: CopyRetargetPermission::MayChooseNewTargets,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         },
     )
     // CR 702.56a: "if a replicate cost was paid for it". With zero payments the
@@ -2418,6 +2451,8 @@ pub fn demonstrate_copy_ability_definition() -> AbilityDefinition {
             target: TargetFilter::SelfRef,
             retarget: CopyRetargetPermission::MayChooseNewTargets,
             copier: Some(ControllerRef::Opponent),
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         },
     )
     .description(
@@ -2432,6 +2467,8 @@ pub fn demonstrate_copy_ability_definition() -> AbilityDefinition {
             target: TargetFilter::SelfRef,
             retarget: CopyRetargetPermission::MayChooseNewTargets,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         },
     )
     .optional()
@@ -2589,6 +2626,8 @@ pub fn conspire_copy_ability_definition() -> AbilityDefinition {
             target: TargetFilter::SelfRef,
             retarget: CopyRetargetPermission::MayChooseNewTargets,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         },
     )
     .condition(AbilityCondition::additional_cost_paid_any())
@@ -2631,6 +2670,8 @@ pub fn gravestorm_copy_ability_definition() -> AbilityDefinition {
             target: TargetFilter::SelfRef,
             retarget: CopyRetargetPermission::MayChooseNewTargets,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         },
     );
     // CR 702.69a: "copy it for each permanent that was put into a graveyard from
@@ -17580,6 +17621,48 @@ mod idempotency_tests {
              both intrinsic and dynamically-granted casualty"
         );
     }
+
+    #[test]
+    fn synthesize_casualty_ob_nixilis_rider_strips_legendary_and_sets_starting_loyalty() {
+        let mut face = CardFace::default();
+        face.card_type.core_types.push(CoreType::Planeswalker);
+        face.card_type.supertypes.push(Supertype::Legendary);
+        face.keywords.push(Keyword::Casualty(1));
+        face.oracle_text = Some(
+            "Casualty X. The copy isn't legendary and has starting loyalty X. \
+             (As you cast this spell, you may sacrifice a creature with power X. \
+             When you do, copy this spell. The copy becomes a token.)"
+                .to_string(),
+        );
+        synthesize_casualty(&mut face);
+
+        let execute = face
+            .triggers
+            .first()
+            .and_then(|t| t.execute.as_ref())
+            .expect("casualty trigger");
+        let Effect::CopySpell {
+            additional_modifications,
+            starting_loyalty_from_casualty_sacrifice,
+            ..
+        } = &*execute.effect
+        else {
+            panic!(
+                "expected CopySpell casualty execute, got {:?}",
+                execute.effect
+            );
+        };
+        assert!(
+            additional_modifications.contains(&ContinuousModification::RemoveSupertype {
+                supertype: Supertype::Legendary,
+            }),
+            "Ob Nixilis rider must strip legendary from the copy"
+        );
+        assert!(
+            *starting_loyalty_from_casualty_sacrifice,
+            "Ob Nixilis rider must set starting loyalty from the casualty sacrifice"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -24709,6 +24792,7 @@ mod demonstrate_synthesis_tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: None,
+                ..
             }
         ));
         // Opponent's copy — sub-ability with the opponent copier, may retarget.
@@ -24719,6 +24803,7 @@ mod demonstrate_synthesis_tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: Some(ControllerRef::Opponent),
+                ..
             }
         ));
     }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17469,6 +17469,8 @@ mod tests {
                     },
                     retarget: CopyRetargetPermission::MayChooseNewTargets,
                     copier: None,
+                    additional_modifications: Vec::new(),
+                    starting_loyalty_from_casualty_sacrifice: false,
                 },
             )
             .cost(AbilityCost::Composite {

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -2,7 +2,6 @@ use crate::types::ability::{
     ContinuousModification, ControllerRef, CopyRetargetPermission, Effect, EffectError, EffectKind,
     ResolvedAbility, TargetFilter, TargetRef,
 };
-use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{CopyTargetSlot, GameState, StackEntry, StackEntryKind, WaitingFor};
 use crate::types::identifiers::ObjectId;
@@ -235,9 +234,12 @@ fn apply_spell_copy_modifications(
             .and_then(|a| a.cost_paid_object.as_ref())
             .and_then(|snap| snap.lki.power)
         {
-            copy_obj
-                .counters
-                .insert(CounterType::Loyalty, power.max(0) as u32);
+            let loyalty = power.max(0) as u32;
+            // CR 306.5b: seed the entering face's printed loyalty, not live
+            // counters — stack objects lose counters at the zone-change boundary
+            // (CR 122.2), and ETB reads loyalty from the face values.
+            copy_obj.base_loyalty = Some(loyalty);
+            copy_obj.loyalty = Some(loyalty);
         }
     }
 }
@@ -2595,5 +2597,110 @@ mod tests {
             .filter(|o| o.is_token && o.zone == Zone::Stack)
             .count();
         assert_eq!(copies, 2);
+    }
+
+    /// CR 702.153a + CR 306.5b: Ob Nixilis Casualty copies stamp starting
+    /// loyalty on the entering face (not live counters) so ETB seeding survives
+    /// the stack → battlefield zone change.
+    #[test]
+    fn casualty_planeswalker_copy_enters_with_sacrifice_power_loyalty() {
+        use crate::game::game_object::GameObject;
+        use crate::game::stack::resolve_top;
+        use crate::types::ability::CostPaidObjectSnapshot;
+        use crate::types::card_type::{CardType, CoreType, Supertype};
+        use crate::types::counter::CounterType;
+        use crate::types::game_state::LKISnapshot;
+
+        let mut state = GameState::new_two_player(42);
+        let mut original = ResolvedAbility::new(
+            Effect::GenericEffect {
+                static_abilities: vec![],
+                duration: None,
+                target: None,
+            },
+            vec![],
+            ObjectId(10),
+            PlayerId(0),
+        );
+        original.cost_paid_object = Some(CostPaidObjectSnapshot {
+            object_id: ObjectId(99),
+            lki: LKISnapshot {
+                name: "Sacrifice".to_string(),
+                power: Some(4),
+                toughness: Some(4),
+                base_power: Some(4),
+                base_toughness: Some(4),
+                mana_value: 4,
+                controller: PlayerId(0),
+                owner: PlayerId(0),
+                card_types: vec![CoreType::Creature],
+                subtypes: vec![],
+                supertypes: vec![],
+                keywords: vec![],
+                colors: vec![],
+                chosen_attributes: vec![],
+                counters: Default::default(),
+            },
+        });
+
+        let mut obj = GameObject::new(
+            ObjectId(10),
+            CardId(1),
+            PlayerId(0),
+            "Ob Nixilis, the Adversary".to_string(),
+            Zone::Stack,
+        );
+        obj.card_types = CardType {
+            supertypes: vec![Supertype::Legendary],
+            core_types: vec![CoreType::Planeswalker],
+            subtypes: vec!["Nixilis".to_string()],
+        };
+        obj.base_loyalty = Some(3);
+        obj.loyalty = Some(3);
+        state.objects.insert(ObjectId(10), obj);
+        state.stack.push_back(StackEntry {
+            id: ObjectId(10),
+            source_id: ObjectId(10),
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(1),
+                ability: Some(original),
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+
+        let copy_ability = ResolvedAbility::new(
+            Effect::CopySpell {
+                target: TargetFilter::SelfRef,
+                retarget: CopyRetargetPermission::KeepOriginalTargets,
+                copier: None,
+                additional_modifications: vec![ContinuousModification::RemoveSupertype {
+                    supertype: Supertype::Legendary,
+                }],
+                starting_loyalty_from_casualty_sacrifice: true,
+            },
+            vec![],
+            ObjectId(10),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &copy_ability, &mut events).unwrap();
+
+        let copy_id = state.stack.back().unwrap().id;
+        resolve_top(&mut state, &mut events);
+
+        let copy = state.objects.get(&copy_id).expect("copy permanent");
+        assert_eq!(copy.zone, Zone::Battlefield);
+        assert!(
+            !copy.card_types.supertypes.contains(&Supertype::Legendary),
+            "Casualty copy must not be legendary"
+        );
+        assert_eq!(copy.loyalty, Some(4));
+        assert_eq!(
+            copy.counters.get(&CounterType::Loyalty).copied(),
+            Some(4),
+            "ETB must seed loyalty counters from the stamped entering face"
+        );
     }
 }

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -1,7 +1,8 @@
 use crate::types::ability::{
-    ControllerRef, CopyRetargetPermission, Effect, EffectError, EffectKind, ResolvedAbility,
-    TargetFilter, TargetRef,
+    ContinuousModification, ControllerRef, CopyRetargetPermission, Effect, EffectError, EffectKind,
+    ResolvedAbility, TargetFilter, TargetRef,
 };
+use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{CopyTargetSlot, GameState, StackEntry, StackEntryKind, WaitingFor};
 use crate::types::identifiers::ObjectId;
@@ -40,6 +41,19 @@ pub fn resolve(
     // `copier` override routes the copy to a player relative to the controller.
     let copy_controller = resolve_copy_controller(state, ability);
 
+    let (additional_modifications, starting_loyalty_from_casualty_sacrifice) = match &ability.effect
+    {
+        Effect::CopySpell {
+            additional_modifications,
+            starting_loyalty_from_casualty_sacrifice,
+            ..
+        } => (
+            additional_modifications.clone(),
+            *starting_loyalty_from_casualty_sacrifice,
+        ),
+        _ => (Vec::new(), false),
+    };
+
     // Allocate a new stack ID for the copy.
     let copy_id = ObjectId(state.next_object_id);
     state.next_object_id += 1;
@@ -61,6 +75,12 @@ pub fn resolve(
         // cast from a graveyard" riders (Sevinne's Reclamation, issue #3283)
         // re-fire when a flashback copy resolves.
         copy_obj.cast_from_zone = None;
+        apply_spell_copy_modifications(
+            &mut copy_obj,
+            &additional_modifications,
+            starting_loyalty_from_casualty_sacrifice,
+            top_entry.ability(),
+        );
         state.objects.insert(copy_id, copy_obj);
     }
 
@@ -191,6 +211,35 @@ pub fn resolve(
 
     drain_spell_copied_observer_triggers(state, events, copied_spell_card_id.is_some())?;
     Ok(())
+}
+
+/// CR 707.9 + CR 707.2: Stamp copy exceptions onto a spell copy's GameObject at
+/// creation (Ob Nixilis: "the copy isn't legendary and has starting loyalty X").
+fn apply_spell_copy_modifications(
+    copy_obj: &mut crate::game::game_object::GameObject,
+    modifications: &[ContinuousModification],
+    starting_loyalty_from_casualty_sacrifice: bool,
+    source_ability: Option<&ResolvedAbility>,
+) {
+    for modification in modifications {
+        if let ContinuousModification::RemoveSupertype { supertype } = modification {
+            copy_obj.card_types.supertypes.retain(|s| s != supertype);
+            copy_obj
+                .base_card_types
+                .supertypes
+                .retain(|s| s != supertype);
+        }
+    }
+    if starting_loyalty_from_casualty_sacrifice {
+        if let Some(power) = source_ability
+            .and_then(|a| a.cost_paid_object.as_ref())
+            .and_then(|snap| snap.lki.power)
+        {
+            copy_obj
+                .counters
+                .insert(CounterType::Loyalty, power.max(0) as u32);
+        }
+    }
 }
 
 /// CR 603.2 + CR 707.10: Drain `SpellCopied` observers collected when the copy
@@ -631,6 +680,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -711,6 +762,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: Some(ControllerRef::Opponent),
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -770,6 +823,8 @@ mod tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: Some(ControllerRef::Opponent),
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(10),
@@ -780,6 +835,8 @@ mod tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(10),
@@ -851,6 +908,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -895,6 +954,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: Some(ControllerRef::You),
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![TargetRef::Player(PlayerId(1))],
             ObjectId(20),
@@ -938,6 +999,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: Some(ControllerRef::You),
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -958,6 +1021,8 @@ mod tests {
             target: TargetFilter::Any,
             retarget: CopyRetargetPermission::KeepOriginalTargets,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         };
         let json_none = serde_json::to_string(&none).unwrap();
         assert!(
@@ -971,6 +1036,8 @@ mod tests {
             target: TargetFilter::Any,
             retarget: CopyRetargetPermission::MayChooseNewTargets,
             copier: Some(ControllerRef::Opponent),
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         };
         let json = serde_json::to_string(&with).unwrap();
         assert!(json.contains("copier"));
@@ -1019,6 +1086,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -1048,6 +1117,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -1089,6 +1160,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -1137,6 +1210,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -1192,6 +1267,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -1329,6 +1406,8 @@ mod tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(10), // source_id = original spell
@@ -1414,6 +1493,8 @@ mod tests {
                 target: TargetFilter::ParentTarget,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -1489,6 +1570,8 @@ mod tests {
                 target: TargetFilter::TriggeringSource,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(20),
@@ -1564,6 +1647,8 @@ mod tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![TargetRef::Player(PlayerId(1))],
             ObjectId(10),
@@ -1626,6 +1711,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![TargetRef::Object(ObjectId(10))],
             ObjectId(20),
@@ -1682,6 +1769,8 @@ mod tests {
                 target: TargetFilter::TriggeringSource,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             magus,
@@ -1749,6 +1838,8 @@ mod tests {
                 target: TargetFilter::TriggeringSource,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![TargetRef::Object(source_creature)],
             magus,
@@ -1781,6 +1872,8 @@ mod tests {
                 },
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             gogo_id,
@@ -1806,6 +1899,8 @@ mod tests {
                 },
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![TargetRef::Object(ObjectId(40))],
             other_id,
@@ -1898,6 +1993,8 @@ mod tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(10),
@@ -1992,6 +2089,8 @@ mod tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(10),
@@ -2115,6 +2214,8 @@ mod tests {
                 target: gogo_target_filter,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![TargetRef::Object(hope_trigger_entry)],
             gogo_id,
@@ -2190,6 +2291,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(800),
@@ -2393,6 +2496,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(70),
@@ -2470,6 +2575,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             vec![],
             ObjectId(70),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -17992,6 +17992,8 @@ mod tests {
             target: TargetFilter::Any,
             retarget: crate::types::ability::CopyRetargetPermission::MayChooseNewTargets,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         };
 
         // A copy was put on the stack → the effect was performed → the negated

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -993,6 +993,8 @@ mod auto_pass_decision_tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
             Vec::new(),
             copy_id,

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -2890,6 +2890,8 @@ mod tests {
                         target: TargetFilter::TriggeringSource,
                         retarget: CopyRetargetPermission::KeepOriginalTargets,
                         copier: None,
+                        additional_modifications: Vec::new(),
+                        starting_loyalty_from_casualty_sacrifice: false,
                     },
                 )),
                 uses_tracked_set: false,
@@ -2924,6 +2926,8 @@ mod tests {
                 target: TargetFilter::TriggeringSource,
                 retarget: CopyRetargetPermission::MayChooseNewTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
         );
         let delayed = AbilityDefinition::new(

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1781,6 +1781,8 @@ fn collect_pending_triggers(
                             target: TargetFilter::SelfRef,
                             retarget: CopyRetargetPermission::MayChooseNewTargets,
                             copier: None,
+                            additional_modifications: Vec::new(),
+                            starting_loyalty_from_casualty_sacrifice: false,
                         },
                         Vec::new(),
                         *cast_obj_id,

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3793,6 +3793,8 @@ pub(super) fn lower_utility_imperative_ast(ast: UtilityImperativeAst) -> Effect 
             target,
             retarget,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         },
         UtilityImperativeAst::Transform { target } => Effect::Transform { target },
         UtilityImperativeAst::Attach { attachment, target } => {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -5957,6 +5957,8 @@ mod tests {
             target: TargetFilter::SelfRef,
             retarget: CopyRetargetPermission::KeepOriginalTargets,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         };
         let result = parse_followup_continuation_ast(
             "may choose a new target for that copy",
@@ -5986,6 +5988,8 @@ mod tests {
                 target: TargetFilter::SelfRef,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
         )));
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7533,6 +7533,14 @@ pub enum Effect {
         /// sibling copy effect.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         copier: Option<ControllerRef>,
+        /// CR 707.9 + CR 707.2: Non-keyword copy exceptions stamped onto spell
+        /// copies at creation (Ob Nixilis: "except the copy isn't legendary").
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        additional_modifications: Vec<ContinuousModification>,
+        /// Ob Nixilis, the Adversary: "has starting loyalty X" where X is the
+        /// sacrificed creature's power when Casualty was paid.
+        #[serde(default)]
+        starting_loyalty_from_casualty_sacrifice: bool,
     },
     /// CR 702.50a + CR 707.10: Epic's recurring upkeep copy. Carries a snapshot
     /// of the Epic spell's resolved ability captured when the Epic spell

--- a/crates/phase-ai/src/features/spellslinger_prowess.rs
+++ b/crates/phase-ai/src/features/spellslinger_prowess.rs
@@ -448,6 +448,8 @@ mod tests {
             target: TargetFilter::Any,
             retarget: engine::types::ability::CopyRetargetPermission::KeepOriginalTargets,
             copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
         }
     }
 

--- a/crates/phase-ai/src/policies/spellslinger_casting.rs
+++ b/crates/phase-ai/src/policies/spellslinger_casting.rs
@@ -455,6 +455,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
         );
         let (context, config) = make_context(0.8);
@@ -510,6 +512,8 @@ mod tests {
                 target: TargetFilter::Any,
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
+                additional_modifications: Vec::new(),
+                starting_loyalty_from_casualty_sacrifice: false,
             },
         ));
         let (context, config) = make_context(0.8);


### PR DESCRIPTION
## Summary
- Parse Ob Nixilis-style Casualty rider text into `CopySpell` modifications
- Strip `Legendary` from the spell copy and set starting loyalty from the sacrificed creature's power

## Test plan
- [x] `cargo test -p engine --lib synthesize_casualty_ob_nixilis_rider_strips_legendary_and_sets_starting_loyalty`
- [x] `cargo clippy -p engine -- -D warnings`
- [x] `cargo fmt --all -- --check`

Fixes #3275

Made with [Cursor](https://cursor.com)