### PR TITLE
fix(parser): keep token keyword when "named <X>" follows the clause

### DIFF
--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -1131,7 +1131,7 @@ fn strip_token_keyword_clause_suffixes(text: &str) -> &str {
     if let Ok((_, head)) = take_until::<_, _, nom::error::Error<&str>>("\"").parse(clause) {
         clause = head;
     }
-    for marker in [" where ", " equal to ", " attached "] {
+    for marker in [" where ", " equal to ", " attached ", " named "] {
         clause = truncate_token_keyword_clause_before(clause, marker);
     }
     clause
@@ -1668,6 +1668,44 @@ mod tests {
         let kws = parse_token_keyword_clause(
             "with flying equal to the number of card types among cards in your graveyard",
         );
+        assert_eq!(kws, vec![Keyword::Flying]);
+    }
+
+    /// "with <keyword> named <X>" (Crow Storm, The Hive, etc.): the trailing
+    /// "named …" token-name clause must be truncated before keyword parsing so
+    /// the keyword survives. Without the " named " marker this yields [].
+    #[test]
+    fn keyword_clause_with_named_suffix() {
+        let kws = parse_token_keyword_clause("with flying named storm crow");
+        assert_eq!(kws, vec![Keyword::Flying]);
+    }
+
+    /// Hornet Cannon: "with flying and haste named hornet" must keep BOTH.
+    #[test]
+    fn keyword_clause_multiple_with_named_suffix() {
+        let kws = parse_token_keyword_clause("with flying and haste named hornet");
+        assert!(kws.contains(&Keyword::Flying), "got {kws:?}");
+        assert!(kws.contains(&Keyword::Haste), "got {kws:?}");
+    }
+
+    /// Jungle Patrol / Wall of Kelp: "with defender named wall".
+    #[test]
+    fn keyword_clause_defender_with_named_suffix() {
+        let kws = parse_token_keyword_clause("with defender named wall");
+        assert_eq!(kws, vec![Keyword::Defender]);
+    }
+
+    /// Then Dreadmaws Ate Everyone: "with trample named dreadmaw".
+    #[test]
+    fn keyword_clause_trample_with_named_suffix() {
+        let kws = parse_token_keyword_clause("with trample named dreadmaw");
+        assert_eq!(kws, vec![Keyword::Trample]);
+    }
+
+    /// No-regression: the " attached " marker must still truncate.
+    #[test]
+    fn keyword_clause_with_attached_suffix() {
+        let kws = parse_token_keyword_clause("with flying attached to it");
         assert_eq!(kws, vec![Keyword::Flying]);
     }
 


### PR DESCRIPTION
Fixes #3697.

## Summary

When a created token's keyword clause is followed by "named `<Name>`", the keyword(s) were silently dropped:

- **Crow Storm** — "Create a 1/2 blue Bird creature token with flying named Storm Crow." → token had no Flying.
- **Hornet Cannon** — "…token with flying and haste named Hornet." → kept only Flying (Haste dropped).
- ~14 cards (The Hive, Jungle Patrol [defender], Then Dreadmaws Ate Everyone [trample], Tombstone Stairwell [haste], Wall of Kelp, …).

## Root cause

`strip_token_keyword_clause_suffixes` truncated the keyword clause before trailing modifiers (`" where "`, `" equal to "`, `" attached "`) but not before `" named "`, so "flying named storm crow" stayed glued, the keyword token failed to map, and it was dropped.

## Fix (parser-AST-only; no new engine variant, no runtime change)

Add `" named "` to the truncation-marker list so the token-name phrase is peeled before keyword mapping. The keyword(s) then map into the existing `Effect::Token` keywords vector, which the runtime already grants (sibling tokens without a trailing name parse correctly today — Lingering Souls → Flying, Oath of Eorl → Trample, Haste). The `take_until('"')` quoted-ability guard runs first, so quoted-ability tokens are unaffected; name-first tokens have their name stripped before this clause; no MTG keyword/type contains " named ", so there is no false truncation.

Capturing the token *name* ("Storm Crow") — currently defaulting to the subtype — is a separate pre-existing gap and is intentionally out of scope.

## Tests

- Keyword recovery (discriminating, revert-failing): Crow Storm → [Flying]; Hornet Cannon → [Flying, Haste]; a defender token → [Defender]; a trample token → [Trample].
- No-regression: "with flying" (no named) → [Flying]; the `" where "`/`" equal to "`/`" attached "` markers still truncate correctly; multi-keyword tokens without a name unchanged.

## Verification

Full `cargo +nightly test -p engine` (all targets): 0 failed (12449 lib + 1177 integration + standalone). `clippy -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean (reuses the existing `take_until` truncation idiom). No snapshot/fixture diff.
