### PR TITLE
fix(engine): Song of the Dryads strips host abilities (fixes #3279)

### DIFF
--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -302,6 +302,7 @@ pub fn attach_to(
     }
 
     crate::game::layers::mark_layers_full(state);
+    crate::game::layers::flush_layers(state);
     old_target
 }
 
@@ -522,6 +523,7 @@ pub fn attach_to_player(
     }
 
     crate::game::layers::mark_layers_full(state);
+    crate::game::layers::flush_layers(state);
     old_target
 }
 
@@ -545,6 +547,7 @@ pub(crate) fn unattach(state: &mut GameState, attachment_id: ObjectId) -> Option
         attachment.attached_to = None;
     }
     crate::game::layers::mark_layers_full(state);
+    crate::game::layers::flush_layers(state);
     Some(old_target)
 }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1947,6 +1947,27 @@ fn entered_object_blocks_incremental(
     false
 }
 
+/// Incremental layer re-derivation recipients: freshly-entered objects plus any
+/// host they are already attached to (Song of the Dryads class — the aura's
+/// continuous static applies to the enchanted permanent, not itself).
+fn incremental_recipient_ids(
+    state: &GameState,
+    entered_ids: &HashSet<ObjectId>,
+) -> HashSet<ObjectId> {
+    let mut recipients = entered_ids.clone();
+    for &id in entered_ids {
+        if let Some(host) = state
+            .objects
+            .get(&id)
+            .and_then(|obj| obj.attached_to.as_ref())
+            .and_then(|target| target.as_object())
+        {
+            recipients.insert(host);
+        }
+    }
+    recipients
+}
+
 /// Incremental layer re-derivation for a set of freshly-entered objects.
 ///
 /// Mirrors the PER-OBJECT subset of `evaluate_layers` for `entered_ids` only:
@@ -1963,8 +1984,9 @@ fn entered_object_blocks_incremental(
 /// effect's magnitude or affected set reads board population — so re-deriving
 /// just the entered objects yields a board identical to a full pass (CR 613.1).
 fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectId>) {
+    let recipient_ids = incremental_recipient_ids(state, entered_ids);
     // Step 1 (per-entered subset): reset computed characteristics to base.
-    for &id in entered_ids {
+    for &id in &recipient_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
             obj.sync_missing_base_characteristics();
             obj.name = obj.base_name.clone();
@@ -2001,14 +2023,14 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
         crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
     }
 
-    // Step 2: Copy effects first (Layer 1), restricted to entered objects.
+    // Step 2: Copy effects first (Layer 1), restricted to recipient objects.
     let copy_effects = gather_active_effects_for_layer(state, Layer::Copy);
     let ordered_copy = order_active_continuous_effects(Layer::Copy, &copy_effects, state);
     for effect in &ordered_copy {
-        apply_continuous_effect_to(state, effect, entered_ids);
+        apply_continuous_effect_to(state, effect, &recipient_ids);
     }
 
-    // Step 3-4: Remaining layers in order, restricted to entered objects.
+    // Step 3-4: Remaining layers in order, restricted to recipient objects.
     let effects_by_layer = gather_active_continuous_effects(state);
     for (layer, layer_bucket) in &effects_by_layer {
         if *layer == Layer::Copy {
@@ -2022,25 +2044,25 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
                 order_by_timestamp(&layer_effects)
             };
             for effect in &ordered {
-                apply_continuous_effect_to(state, effect, entered_ids);
+                apply_continuous_effect_to(state, effect, &recipient_ids);
             }
         }
         // CR 613.1f: mirror the full-pass end-of-Layer-6 denial hook for the
         // incremental path, restricted to the freshly-entered objects that were
         // reset and re-derived in this pass.
         if *layer == Layer::Ability {
-            apply_cant_have_keyword_denials(state, Some(entered_ids));
+            apply_cant_have_keyword_denials(state, Some(&recipient_ids));
         }
         // CR 613.4c: P/T counters modify power/toughness in layer 7c, before the
         // 7d switch (CR 613.4d). The CounterPT bucket carries no continuous
         // effects, so fold the on-object counters in here.
         if *layer == Layer::CounterPT {
-            apply_pt_counter_modifications(state, entered_ids.iter().copied());
+            apply_pt_counter_modifications(state, recipient_ids.iter().copied());
         }
         if *layer == Layer::Type {
-            apply_prototype_characteristics(state, entered_ids.iter().copied());
-            let entered_vec: Vec<ObjectId> = entered_ids.iter().copied().collect();
-            apply_intrinsic_basic_land_mana_abilities(state, &entered_vec);
+            apply_prototype_characteristics(state, recipient_ids.iter().copied());
+            let recipient_vec: Vec<ObjectId> = recipient_ids.iter().copied().collect();
+            apply_intrinsic_basic_land_mana_abilities(state, &recipient_vec);
         }
     }
 
@@ -2069,7 +2091,7 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
     // CR 306.5c: loyalty re-derives from loyalty counters. Per-entered fixups
     // only. (P/T counters are applied in-loop at Layer::CounterPT above, in
     // layer 7c before the 7d switch — CR 613.4c/613.4d.)
-    for &id in entered_ids {
+    for &id in &recipient_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
             let granted: Vec<Keyword> = obj
                 .counters
@@ -2095,10 +2117,10 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
     // (which runs after the in-loop Layer 6 denial) so a counter can't add a
     // forbidden keyword. Restricted to the freshly-entered objects, mirroring the
     // incremental denial hook above.
-    apply_cant_have_keyword_denials(state, Some(entered_ids));
+    apply_cant_have_keyword_denials(state, Some(&recipient_ids));
 
-    // CR 613.11: Combat-assignment rule effects, restricted to entered objects.
-    apply_combat_assignment_rule_effects_filtered(state, Some(entered_ids));
+    // CR 613.11: Combat-assignment rule effects, restricted to recipient objects.
+    apply_combat_assignment_rule_effects_filtered(state, Some(&recipient_ids));
 
     // CR 603.6a + CR 611.2e: Rebuild the TriggerIndex so the next event scan
     // sees the entered objects' (and any granted) trigger sets.
@@ -9154,6 +9176,80 @@ mod tests {
             count_mana_abilities(creature, ManaColor::Green),
             1,
             "CR 305.7: Forest subtype should grant the intrinsic green mana ability"
+        );
+    }
+
+    #[test]
+    fn song_style_aura_applies_to_host_when_attached_via_attach_to() {
+        use crate::game::effects::attach::attach_to;
+
+        let mut state = setup();
+        let p0 = PlayerId(0);
+
+        let creature_id = create_object(
+            &mut state,
+            CardId(0),
+            p0,
+            "Test Creature".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let ts = state.next_timestamp();
+            let obj = state.objects.get_mut(&creature_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+            Arc::make_mut(&mut obj.base_abilities).push(AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            ));
+            obj.abilities = Arc::new((*obj.base_abilities).clone());
+        }
+
+        let aura_id = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "Song of the Dryads".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let ts = state.next_timestamp();
+            let obj = state.objects.get_mut(&aura_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::new(TypeFilter::Card)
+                            .properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                    .modifications(vec![
+                        ContinuousModification::SetCardTypes {
+                            core_types: vec![CoreType::Land],
+                        },
+                        ContinuousModification::SetBasicLandType {
+                            land_type: BasicLandType::Forest,
+                        },
+                    ]),
+            );
+        }
+
+        attach_to(&mut state, aura_id, creature_id);
+
+        let creature = state.objects.get(&creature_id).unwrap();
+        assert_eq!(creature.card_types.core_types, vec![CoreType::Land]);
+        assert!(creature.card_types.subtypes.contains(&"Forest".to_string()));
+        assert!(
+            !creature
+                .abilities
+                .iter()
+                .any(|ability| matches!(&*ability.effect, Effect::GainLife { .. })),
+            "CR 305.7: attach_to must flush layers so rules-text abilities are removed"
         );
     }
 


### PR DESCRIPTION
## Summary
- Flush layer evaluation immediately after `attach_to` / `attach_to_player` / `unattach` so aura statics (Song of the Dryads) apply to the host without waiting for a later flush.
- Expand incremental layer recipients to include attached hosts when an aura enters already attached.

## Root cause
Attachment updated the graph and marked layers dirty, but the enchanted permanent kept stale rules-text abilities until a separate full flush ran.

## Test plan
- [x] `cargo test -p engine --lib song_style_aura_applies_to_host`
- [x] `cargo clippy -p engine -- -D warnings`


Fixes #3278