### PR TITLE
fix(engine): one-sided-fight boost-then-deal reads boosted creature's power

### DIFF
--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -1809,6 +1809,72 @@ mod tests {
         assert_eq!(state.objects[&recipient].damage_marked, 5);
     }
 
+    /// #699 (one-sided fight — `Power{Anaphoric}` amount). Same shape as the
+    /// `Power{Target}` test above, but the amount is `Power{Anaphoric}` with
+    /// `effect_context_object = None` (the real Ambuscade-class AST after the
+    /// Option-b fix: the parser leaves "its power" as Anaphoric). With no
+    /// effect-context / event-source / cost referent to seed it, the anaphor
+    /// MUST resolve through the runtime one-sided-fight fallback to `targets[0]`
+    /// (the boosted creature, power 5) — NOT to 0. Asserts the boosted creature
+    /// (targets[0]) takes 0 and the opponent (targets[1]) takes 5. This is the
+    /// assertion that flips (5 → 0 on the recipient) if the new
+    /// `resolve_object_pt` Anaphoric fallback is reverted.
+    /// CR 608.2c + CR 120.1: the boosted creature is the anaphoric "It" and the
+    /// damage source.
+    #[test]
+    fn one_sided_fight_anaphoric_amount_reads_boosted_creature() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(30),
+            PlayerId(0),
+            "Boosted Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let recipient = create_object(
+            &mut state,
+            CardId(31),
+            PlayerId(1),
+            "Opponent Creature".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let s = state.objects.get_mut(&source).unwrap();
+            s.card_types.core_types.push(CoreType::Creature);
+            s.power = Some(5);
+            s.base_power = Some(5);
+        }
+        {
+            let r = state.objects.get_mut(&recipient).unwrap();
+            r.card_types.core_types.push(CoreType::Creature);
+            r.power = Some(2);
+            r.base_power = Some(2);
+        }
+        // ResolvedAbility::new leaves effect_context_object = None and
+        // cost_paid_object = None, so only the new targets[0] fallback can seed
+        // the anaphoric power.
+        let ability = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::Anaphoric,
+                    },
+                },
+                target: TargetFilter::Typed(TypedFilter::creature()),
+                damage_source: Some(DamageSource::Target),
+            },
+            vec![TargetRef::Object(source), TargetRef::Object(recipient)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.objects[&source].damage_marked, 0);
+        assert_eq!(state.objects[&recipient].damage_marked, 5);
+    }
+
     #[test]
     fn deal_damage_to_player() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1394,6 +1394,41 @@ fn try_begin_reflexive_target_selection(
     Ok(true)
 }
 
+/// CR 120.1 + CR 608.2c + CR 115.10a: the "one-sided fight" chain shape — a
+/// boost head ("Target creature you control gets +N/+M …") followed by a
+/// `DealDamage`/`DamageAll` sub whose `damage_source = Target` ("It deals damage
+/// equal to its power to target creature an opponent controls"). The anaphoric
+/// "It"/"its power" names the creature the boost head chose, NOT the sub's own
+/// fresh recipient (CR 608.2c — read the whole text). The sub carries only its
+/// recipient in `targets` (it was assigned its own target slot in declaration
+/// order), so the damage source (and the `Power{Anaphoric}` amount the runtime
+/// resolves to `targets[0]`) would otherwise read the recipient. This predicate
+/// recognizes that sub so the chain descent can prepend the parent's chosen
+/// object target, restoring the `targets = [source, recipient]` contract the
+/// `deal_damage` resolver (CR 120.1: the object that deals damage is the source)
+/// and the `quantity::resolve_object_pt` one-sided-fight fallback both expect.
+fn is_one_sided_fight_damage_sub(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::DealDamage {
+            damage_source: Some(crate::types::ability::DamageSource::Target),
+            ..
+        } | Effect::DamageAll {
+            damage_source: Some(crate::types::ability::DamageSource::Target),
+            ..
+        }
+    )
+}
+
+/// The first `TargetRef::Object` in a target list (the chain head's chosen
+/// creature for the one-sided-fight prepend).
+fn first_object_target(targets: &[TargetRef]) -> Option<ObjectId> {
+    targets.iter().find_map(|t| match t {
+        TargetRef::Object(id) => Some(*id),
+        TargetRef::Player(_) => None,
+    })
+}
+
 fn apply_parent_chain_context(
     child: &mut ResolvedAbility,
     parent: &ResolvedAbility,
@@ -5838,6 +5873,36 @@ fn resolve_chain_body(
             apply_parent_chain_context(&mut sub_clone, ability, effect_context_object.as_ref());
             prepend_to_pending_continuation(state, sub_clone);
             return Ok(());
+        }
+
+        // CR 120.1 + CR 608.2c + CR 115.10a: one-sided-fight chain — the boost
+        // head ("Target creature you control gets +N/+M …") chose the creature
+        // that the trailing `DealDamage { damage_source = Target }` sub's "It"
+        // anaphor names. The sub was assigned its OWN recipient slot in
+        // declaration order, so its `targets` hold only the fresh opponent
+        // recipient. Per CR 120.1 the object that deals the damage is the boosted
+        // creature (the parent's chosen object target), and per CR 608.2c "It"/
+        // "its power" refer to that same creature — not the recipient. Prepend
+        // the parent's chosen object so the sub resolves with the contract the
+        // `deal_damage` resolver and `quantity::resolve_object_pt`'s
+        // one-sided-fight fallback expect: `targets = [source, recipient]`
+        // (source = `targets[0]`, recipients = `targets[1..]`). Guarded on the
+        // parent already carrying an object target and the source not already
+        // being `targets[0]`, so it is a no-op for every other chain shape.
+        if is_one_sided_fight_damage_sub(&sub.effect) && !sub.targets.is_empty() {
+            if let Some(source) = first_object_target(&ability.targets) {
+                if first_object_target(&sub.targets) != Some(source) {
+                    let mut sub_with_source = sub.as_ref().clone();
+                    sub_with_source.targets.insert(0, TargetRef::Object(source));
+                    apply_parent_chain_context(
+                        &mut sub_with_source,
+                        ability,
+                        effect_context_object.as_ref(),
+                    );
+                    resolve_ability_chain(state, &sub_with_source, events, depth + 1)?;
+                    return Ok(());
+                }
+            }
         }
 
         // Apply forward_result: moved object becomes sub's source.

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -3291,17 +3291,15 @@ where
                     .and_then(|snapshot| lki_extract(&snapshot.lki))
             })
             .unwrap_or(0),
-        // CR 608.2c: An anaphoric pronoun ("its power") in a triggered ability
+        // CR 608.2c: A demonstrative noun phrase ("that creature's toughness")
         // binds to the object introduced by the most recent earlier *effect
         // instruction* in the same ability (slot 1: `effect_context_object`).
         // CR 608.2k: if no such instruction exists, fall back to the
         // trigger-condition referent (slot 2: trigger-event source) then the
-        // cost referent (slot 3: `cost_paid_object`). The arm differs from
+        // cost referent (slot 3: `cost_paid_object`). This arm differs from
         // `CostPaidObject` only in slot priority — instruction-order (608.2c)
-        // first, vs. cost referent (608.2k) first. `Demonstrative` ("that
-        // creature's toughness") shares this resolution — same earlier-
-        // instruction referent, named by a full noun phrase rather than "its".
-        ObjectScope::Anaphoric | ObjectScope::Demonstrative => ability
+        // first, vs. cost referent (608.2k) first.
+        ObjectScope::Demonstrative => ability
             .and_then(|a| a.effect_context_object.as_ref())
             .and_then(|snapshot| lki_extract(&snapshot.lki))
             .or_else(|| {
@@ -3317,6 +3315,60 @@ where
                 ability
                     .and_then(|a| a.cost_paid_object.as_ref())
                     .and_then(|snapshot| lki_extract(&snapshot.lki))
+            })
+            .unwrap_or(0),
+        // CR 608.2c: An anaphoric pronoun ("its power"). Shares the
+        // `Demonstrative` referent chain (earlier instruction → trigger-event
+        // source → cost referent), plus one extra final fallback for the
+        // one-sided-fight damage class (see below).
+        ObjectScope::Anaphoric => ability
+            .and_then(|a| a.effect_context_object.as_ref())
+            .and_then(|snapshot| lki_extract(&snapshot.lki))
+            .or_else(|| {
+                object_id_for_scope(state, ObjectScope::EventSource, ctx, targets).and_then(|id| {
+                    state
+                        .objects
+                        .get(&id)
+                        .and_then(&obj_extract)
+                        .or_else(|| state.lki_cache.get(&id).and_then(&lki_extract))
+                })
+            })
+            .or_else(|| {
+                ability
+                    .and_then(|a| a.cost_paid_object.as_ref())
+                    .and_then(|snapshot| lki_extract(&snapshot.lki))
+            })
+            .or_else(|| {
+                // CR 608.2c + CR 115.10a: for a one-sided-fight damage clause
+                // (damage_source = Target), the anaphoric "It"/"its" is the
+                // object dealing the damage = targets[0] (the same object
+                // deal_damage.rs selects as source). Last fallback so
+                // reveal/sacrifice/tap referents above still win.
+                let is_one_sided_fight = ability
+                    .map(|a| {
+                        matches!(
+                            a.effect,
+                            crate::types::ability::Effect::DealDamage {
+                                damage_source: Some(crate::types::ability::DamageSource::Target),
+                                ..
+                            } | crate::types::ability::Effect::DamageAll {
+                                damage_source: Some(crate::types::ability::DamageSource::Target),
+                                ..
+                            }
+                        )
+                    })
+                    .unwrap_or(false);
+                if !is_one_sided_fight {
+                    return None;
+                }
+                targets.iter().find_map(|t| match t {
+                    TargetRef::Object(id) => state
+                        .objects
+                        .get(id)
+                        .and_then(&obj_extract)
+                        .or_else(|| state.lki_cache.get(id).and_then(&lki_extract)),
+                    _ => None,
+                })
             })
             .unwrap_or(0),
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11213,14 +11213,16 @@ fn damage_clause_has_self_ref_recipient(effect: &Effect) -> bool {
 }
 
 /// Coerce a per-object `QuantityRef` whose scope is `ObjectScope::Source` to
-/// `ObjectScope::Target`. The mirror of `rebind_anaphoric_ref` for the one-sided
-/// fight class: a "Then it deals damage equal to its power" sub-clause whose
-/// subject was classified as `SelfRef` gets its "its power" anaphor prematurely
-/// rebound to `Source` (the ability source) by the subject-stamping pass
-/// (~mod.rs:12278). For this class the "it" is the parent TARGET (the boosted
-/// creature, `targets[0]` once `damage_source = Target`), never the spell
-/// source — so the amount must read `Target`, not `Source`.
-fn rebind_source_ref_to_target(qty: &mut QuantityRef) {
+/// `target`. The mirror of `rebind_anaphoric_ref` for the one-sided fight class:
+/// a "Then it deals damage equal to its power" sub-clause whose subject was
+/// classified as `SelfRef` gets its "its power" anaphor prematurely rebound to
+/// `Source` (the ability source) by the subject-stamping pass (~mod.rs:12278).
+/// For this class the "it" is the boosted creature (the parent TARGET,
+/// `targets[0]` once `damage_source = Target`), never the spell source — so the
+/// amount must be retargeted to `Anaphoric` (resolved to `targets[0]` by the
+/// runtime one-sided-fight fallback in `game/quantity.rs`), keeping the export
+/// in sync with the Oracle "its".
+fn rebind_source_ref(qty: &mut QuantityRef, target: ObjectScope) {
     let scope = match qty {
         QuantityRef::Power { scope }
         | QuantityRef::Toughness { scope }
@@ -11233,15 +11235,15 @@ fn rebind_source_ref_to_target(qty: &mut QuantityRef) {
         _ => return,
     };
     if *scope == ObjectScope::Source {
-        *scope = ObjectScope::Target;
+        *scope = target;
     }
 }
 
-/// `QuantityExpr` walker for `rebind_source_ref_to_target` (mirrors
+/// `QuantityExpr` walker for `rebind_source_ref` (mirrors
 /// `rebind_anaphoric_object_scope`'s recursion).
-fn rebind_source_amount_to_target(expr: &mut QuantityExpr) {
+fn rebind_source_amount(expr: &mut QuantityExpr, target: ObjectScope) {
     match expr {
-        QuantityExpr::Ref { qty } => rebind_source_ref_to_target(qty),
+        QuantityExpr::Ref { qty } => rebind_source_ref(qty, target),
         QuantityExpr::DivideRounded { inner, .. }
         | QuantityExpr::Multiply { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
@@ -11249,15 +11251,15 @@ fn rebind_source_amount_to_target(expr: &mut QuantityExpr) {
         | QuantityExpr::UpTo { max: inner }
         | QuantityExpr::Power {
             exponent: inner, ..
-        } => rebind_source_amount_to_target(inner),
+        } => rebind_source_amount(inner, target),
         QuantityExpr::Sum { exprs } => {
             for inner in exprs {
-                rebind_source_amount_to_target(inner);
+                rebind_source_amount(inner, target);
             }
         }
         QuantityExpr::Difference { left, right } => {
-            rebind_source_amount_to_target(left);
-            rebind_source_amount_to_target(right);
+            rebind_source_amount(left, target);
+            rebind_source_amount(right, target);
         }
         QuantityExpr::Fixed { .. } => {}
     }
@@ -11265,25 +11267,33 @@ fn rebind_source_amount_to_target(expr: &mut QuantityExpr) {
 
 /// CR 120.1 + CR 608.2c: For a "one-sided fight" anaphoric damage clause
 /// ("It deals damage equal to its power to target creature an opponent
-/// controls") whose recipient is a FRESH opponent target, bind the damage
-/// SOURCE/amount to the parent-chosen boosted creature WITHOUT clobbering the
+/// controls") whose recipient is a FRESH opponent target, attribute the damage
+/// SOURCE to the parent-chosen boosted creature WITHOUT clobbering the
 /// recipient. CR 120.1: the object that deals damage is the source of that
 /// damage — here the boosted creature, which is the parent target, so
-/// `damage_source = Some(Target)` and the amount reads the parent target's
-/// power. CR 608.2c: read the whole text / apply English anaphora — "It" and
-/// "its power" refer to the boosted creature, but "target creature an opponent
-/// controls" is a distinct target. `bind_damage_clause_source` rebinds an
-/// `Anaphoric` amount (Ambuscade/Clear Shot/Rabid Gnaw) → `Target`; the
-/// follow-up coercion fixes the `Source` amount produced when the "Then it
-/// deals..." subject was classified `SelfRef` (Wolf Strike/Burrog Barrage),
-/// which would otherwise read the ability source (the spell, power 0). Returns
-/// true (= decline the blanket `replace_target_with_parent`) when handled.
+/// `damage_source = Some(Target)` (consumed by `game/effects/deal_damage.rs`,
+/// which selects `targets[0]` as the source and `targets[1..]` as recipients).
+/// CR 608.2c: read the whole text / apply English anaphora — "It" and "its
+/// power" refer to the boosted creature, but "target creature an opponent
+/// controls" is a distinct target.
 ///
-/// Covers two recipient shapes: (1) the fresh-opponent recipient — rebind the
-/// damage source/amount to the parent target while preserving the recipient;
-/// (2) the self-reference recipient ("to this creature"/"to ~",
-/// `TargetFilter::SelfRef`, the Karplusan Yeti fight-back class) — preserve the
-/// recipient verbatim with NO source/amount rebind.
+/// The "its power" amount is left as `Power{Anaphoric}` (NOT rebound to
+/// `Target`): the runtime one-sided-fight fallback in `game/quantity.rs`
+/// resolves `Anaphoric` to that same `targets[0]` source object. Keeping the
+/// AST `Anaphoric` keeps the serialized export in sync with the Oracle "its"
+/// and avoids reintroducing #699 (where rebinding the source amount to `Target`
+/// alongside a clobbered recipient made the boosted creature damage itself).
+/// The only rebind here is `Source → Anaphoric`: the "Then it deals..." subject
+/// is classified `SelfRef`, so the subject-stamping pass (~mod.rs:12278)
+/// prematurely binds "its power" to `Source` (the spell, power 0); coercing it
+/// to `Anaphoric` routes it back through the same runtime fallback. Returns true
+/// (= decline the blanket `replace_target_with_parent`) when handled.
+///
+/// Covers two recipient shapes: (1) the fresh-opponent recipient — attribute
+/// the damage source to the parent target while preserving the recipient and
+/// the anaphoric amount; (2) the self-reference recipient ("to this
+/// creature"/"to ~", `TargetFilter::SelfRef`, the Karplusan Yeti fight-back
+/// class) — preserve the recipient verbatim with NO source/amount rebind.
 fn bind_anaphoric_damage_subject_keep_recipient(effect: &mut Effect) -> bool {
     // CR 201.5 + CR 608.2c: a self-reference recipient ("to this creature"/"to ~")
     // is the source itself and must be preserved verbatim (fight-back class). No
@@ -11295,9 +11305,17 @@ fn bind_anaphoric_damage_subject_keep_recipient(effect: &mut Effect) -> bool {
     if !damage_clause_has_fresh_opponent_recipient(effect) {
         return false;
     }
-    bind_damage_clause_source(effect, DamageSource::Target, ObjectScope::Target);
+    // CR 115.10a + CR 601.2c + CR 608.2c + CR 120.1: preserve the fresh-opponent
+    // recipient and attribute damage source to targets[0] (the boosted "It");
+    // leave "its power" as Power{Anaphoric} — the runtime resolves it to that
+    // same source object. Do NOT rebind to Target (that desyncs the export from
+    // the Oracle "its" and reintroduces #699).
+    set_damage_clause_source_only(effect, DamageSource::Target);
+    // Source → Anaphoric only (the SelfRef-subject "Then it deals..." variant);
+    // gated inside this fresh-opponent branch so it can't touch unrelated
+    // Source-amount cards. Anaphoric amounts are already correct and untouched.
     if let Effect::DealDamage { amount, .. } | Effect::DamageAll { amount, .. } = effect {
-        rebind_source_amount_to_target(amount);
+        rebind_source_amount(amount, ObjectScope::Anaphoric);
     }
     true
 }
@@ -12239,6 +12257,22 @@ fn bind_damage_clause_source(
             ..
         } => {
             rebind_anaphoric_object_scope(amount, power_scope);
+            *damage_source = Some(damage_source_ref);
+            true
+        }
+        _ => false,
+    }
+}
+
+/// CR 120.1: Set a damage clause's `damage_source` WITHOUT rebinding the
+/// anaphoric amount scope. The one-sided-fight fresh-opponent path keeps "its
+/// power" as `Power{Anaphoric}` (resolved to `targets[0]` by the runtime
+/// fallback) instead of collapsing it to `Target`, so it cannot reuse
+/// `bind_damage_clause_source` (which always rebinds the amount). Returns true
+/// iff the effect is a `DealDamage`/`DamageAll`.
+fn set_damage_clause_source_only(effect: &mut Effect, damage_source_ref: DamageSource) -> bool {
+    match effect {
+        Effect::DealDamage { damage_source, .. } | Effect::DamageAll { damage_source, .. } => {
             *damage_source = Some(damage_source_ref);
             true
         }
@@ -43922,17 +43956,19 @@ mod tests {
                     ),
                     "expected Typed opponent recipient, got {target:?}"
                 );
-                // Source bound to the boosted parent target; Anaphoric amount
-                // rebound to Power{Target}.
+                // Source attributed to the boosted parent target (targets[0]);
+                // "its power" stays Power{Anaphoric} (runtime resolves it to that
+                // same targets[0]). NOT rebound to Target (that desyncs the
+                // export from the Oracle "its" and reintroduces #699).
                 assert_eq!(damage_source, &Some(DamageSource::Target));
                 assert_eq!(
                     amount,
                     &QuantityExpr::Ref {
                         qty: QuantityRef::Power {
-                            scope: ObjectScope::Target
+                            scope: ObjectScope::Anaphoric
                         }
                     },
-                    "expected Power{{Target}} (rebound from Anaphoric)"
+                    "expected Power{{Anaphoric}} (preserved, not rebound to Target)"
                 );
             }
             other => panic!("expected DealDamage, got {other:?}"),
@@ -43944,9 +43980,11 @@ mod tests {
     /// clause (conditional-prior slot). Because the sub-clause subject is
     /// classified `SelfRef`, the upstream subject-stamping pass rebinds
     /// "its power" Anaphoric → Source prematurely; for this class the "it" is the
-    /// parent TARGET (the boosted creature), so the amount must read Power{Target},
-    /// NOT Power{Source} (which at runtime would read the spell source, power 0).
-    /// The recipient ("you don't control" == Opponent) is preserved.
+    /// boosted creature (targets[0] at runtime), so the amount is coerced
+    /// Source → Power{Anaphoric} (resolved to targets[0] by the runtime
+    /// one-sided-fight fallback), NOT Power{Source} (which would read the spell
+    /// source, power 0). The recipient ("you don't control" == Opponent) is
+    /// preserved.
     #[test]
     fn one_sided_fight_power_source_variant() {
         let def = parse_effect_chain(
@@ -43971,16 +44009,17 @@ mod tests {
                     "expected Typed opponent recipient, got {target:?}"
                 );
                 assert_eq!(damage_source, &Some(DamageSource::Target));
-                // SelfRef-subject Source amount coerced to Target (boosted
-                // creature == parent target == targets[0] at runtime).
+                // SelfRef-subject Source amount coerced to Anaphoric (boosted
+                // creature == targets[0] at runtime via the one-sided-fight
+                // fallback), not Source (the spell, power 0).
                 assert_eq!(
                     amount,
                     &QuantityExpr::Ref {
                         qty: QuantityRef::Power {
-                            scope: ObjectScope::Target
+                            scope: ObjectScope::Anaphoric
                         }
                     },
-                    "Power amount must be Target (parent boosted creature), not Source (spell)"
+                    "Power amount must be Anaphoric (boosted creature, targets[0]), not Source (spell)"
                 );
             }
             other => panic!("expected DealDamage, got {other:?}"),

--- a/crates/engine/tests/integration/ambuscade_one_sided_fight_anaphoric.rs
+++ b/crates/engine/tests/integration/ambuscade_one_sided_fight_anaphoric.rs
@@ -1,0 +1,161 @@
+//! Regression for GitHub issue #699 — the "boost-then-fight" one-sided-fight
+//! class (Ambuscade and ~18 siblings).
+//!
+//! Oracle (Ambuscade): "Target creature you control gets +1/+1 until end of
+//! turn. It deals damage equal to its power to target creature an opponent
+//! controls."
+//!
+//! The bug: PR #3530 rebound the anaphoric "its power" amount from
+//! `Power{Anaphoric}` to `Power{Target}` and (in an earlier form) clobbered the
+//! damage recipient to `ParentTarget`, which made the boosted creature damage
+//! *itself*. The approved Option-b fix leaves the AST amount as
+//! `Power{Anaphoric}` (keeping the serialized export in sync with the Oracle
+//! "its"), keeps `damage_source = Some(Target)` + the fresh-opponent recipient,
+//! and resolves `Power{Anaphoric}` to `targets[0]` (the boosted creature) at
+//! runtime via the one-sided-fight fallback in `game/quantity.rs`.
+//!
+//! These tests parse the real Oracle text through `add_spell_to_hand_from_oracle`
+//! (the production parser path the fix modifies) and drive the full cast
+//! pipeline, so they exercise parser + runtime end-to-end. They would fail if
+//! either half of the fix were reverted:
+//!   - revert the parser → the recipient/source desyncs and the boosted
+//!     creature damages itself (or reads the wrong power).
+//!   - revert the `game/quantity.rs` Anaphoric fallback → `Power{Anaphoric}`
+//!     resolves to 0 (no effect-context/event/cost referent), so the opponent
+//!     takes 0 instead of the boosted power.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::phase::Phase;
+
+const AMBUSCADE_ORACLE: &str = "Target creature you control gets +1/+1 until end of turn. \
+It deals damage equal to its power to target creature an opponent controls.";
+
+// A "Then it deals..." conditional-boost variant whose damage subject is
+// classified `SelfRef`, so the parser must coerce the "its power" amount
+// Source -> Anaphoric (step 1b of the fix) for the runtime fallback to fire.
+const CONDITIONAL_FIGHT_ORACLE: &str = "Target creature you control gets +2/+0 until end of turn. \
+Then it deals damage equal to its power to target creature an opponent controls.";
+
+/// CR 120.1 + CR 608.2c + CR 115.10a: Ambuscade boosts P0's 2/2 to 3/3, then the
+/// boosted creature (NOT the spell, NOT the opponent's creature) deals damage
+/// equal to its own current power (3) to the opponent's 3/3. The boosted
+/// creature takes no damage — it is the source, the opponent's creature is the
+/// recipient.
+///
+/// Discriminating assertion: the opponent's creature ends with 3 marked damage
+/// (= boosted power) and P0's creature ends with 0. If the runtime Anaphoric
+/// fallback is reverted, the amount resolves to 0 and the opponent takes 0; if
+/// the parser recipient is reverted, the boosted creature damages itself.
+#[test]
+fn ambuscade_boosted_creature_deals_its_power_to_opponent_creature() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Ambuscade", true, AMBUSCADE_ORACLE)
+        .id();
+    // P0's own creature to boost (2/2 -> 3/3 after +1/+1).
+    let own = scenario.add_creature(P0, "Boosted Beast", 2, 2).id();
+    // The opponent's creature that takes the fight damage. Power 7 (distinct
+    // from the boosted creature's 3) so foe_damage discriminates "its power" =
+    // boosted source (3) vs accidentally = recipient (7).
+    let foe = scenario.add_creature(P1, "Opposing Bear", 7, 7).id();
+
+    let mut runner = scenario.build();
+
+    // Targets are matched to slots in written order (CR 601.2c): slot 1 (Pump on
+    // a You-controlled creature) -> own; slot 2 (DealDamage on an opponent
+    // creature) -> foe.
+    let outcome = runner.cast(spell).target_objects(&[own, foe]).resolve();
+
+    let foe_damage = outcome.state().objects[&foe].damage_marked;
+    let own_damage = outcome.state().objects[&own].damage_marked;
+
+    assert_eq!(
+        foe_damage, 3,
+        "#699: the boosted creature must deal its OWN power (3 = 2 base + 1) to \
+         the opponent's creature; got {foe_damage}. A value of 0 means the \
+         Power{{Anaphoric}} runtime fallback was reverted."
+    );
+    assert_eq!(
+        own_damage, 0,
+        "#699: the boosted creature is the damage SOURCE, not a recipient — it \
+         must take 0; got {own_damage}. Non-zero means the recipient was \
+         clobbered to the boosted creature (self-damage)."
+    );
+}
+
+/// Step 1b coverage — the "Then it deals..." SelfRef-subject variant. The parser
+/// must coerce the prematurely-Source-bound "its power" amount to
+/// `Power{Anaphoric}` (NOT `Source`, which would read the spell, power 0). With
+/// +2/+0 the boosted 2/2 becomes a 4/2 and deals 4 to the opponent's 5/5; the
+/// boosted creature takes 0.
+#[test]
+fn conditional_then_it_deals_variant_reads_boosted_power() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Conditional Strike", true, CONDITIONAL_FIGHT_ORACLE)
+        .id();
+    let own = scenario.add_creature(P0, "Pumped Hunter", 2, 2).id();
+    let foe = scenario.add_creature(P1, "Sturdy Ogre", 5, 5).id();
+
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).target_objects(&[own, foe]).resolve();
+
+    let foe_damage = outcome.state().objects[&foe].damage_marked;
+    let own_damage = outcome.state().objects[&own].damage_marked;
+
+    assert_eq!(
+        foe_damage, 4,
+        "step 1b: the boosted creature (2 base + 2 = 4 power) must deal 4 to the \
+         opponent; got {foe_damage}. 0 means the Source->Anaphoric coercion (or \
+         the runtime fallback) was reverted."
+    );
+    assert_eq!(
+        own_damage, 0,
+        "step 1b: the boosted creature is the source and must take 0; got {own_damage}."
+    );
+}
+
+/// Real-card confirmation (Bite Down on Crime — the printed fight sentences,
+/// "you don't control" == Opponent recipient). The boost head and the "It
+/// deals" clause are SEPARATE sentences with no condition; the boosted 3/3
+/// (1 base + 2) deals 3 to the opponent's 6/6 and takes 0. Discriminates
+/// boosted source power (3) from the recipient's own power (6). Proves the
+/// runtime one-sided-fight source prepend (parent's chosen creature ->
+/// `targets[0]`) on a real card's exact Oracle text, not a synthetic proxy.
+const BITE_DOWN_ON_CRIME_FIGHT: &str = "Target creature you control gets +2/+0 until end of turn. \
+It deals damage equal to its power to target creature you don't control.";
+
+#[test]
+fn bite_down_on_crime_boosted_creature_deals_its_power() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Bite Down on Crime", true, BITE_DOWN_ON_CRIME_FIGHT)
+        .id();
+    let own = scenario.add_creature(P0, "Brave Beast", 1, 3).id();
+    let foe = scenario.add_creature(P1, "Hardy Ogre", 6, 6).id();
+
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).target_objects(&[own, foe]).resolve();
+
+    let foe_damage = outcome.state().objects[&foe].damage_marked;
+    let own_damage = outcome.state().objects[&own].damage_marked;
+
+    assert_eq!(
+        foe_damage, 3,
+        "the boosted creature (1 base + 2 = 3 power) must deal 3 to the opponent; \
+         got {foe_damage}. A value of 6 means the source/amount read the \
+         recipient instead of the boosted creature (the source prepend was reverted)."
+    );
+    assert_eq!(
+        own_damage, 0,
+        "the boosted creature is the source and must take 0; got {own_damage}."
+    );
+}

--- a/crates/engine/tests/integration/anaphoric_scope_allowlist_guard.rs
+++ b/crates/engine/tests/integration/anaphoric_scope_allowlist_guard.rs
@@ -177,6 +177,7 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "boulderbranch golem",
     "brainstealer dragon",
     "brokers charm",
+    "burrog barrage",
     "captain marvel, shooting star",
     "champion of the path",
     "champion of wits",
@@ -262,7 +263,6 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "noxious gearhulk",
     "origin of thor",
     "orzhov charm",
-    "osseous sticktwister",
     "packsong pup",
     "pain for all",
     "paladin of atonement",
@@ -321,6 +321,7 @@ const ANAPHORIC_SCOPE_CARDS: &[&str] = &[
     "vivien's invocation",
     "vraska's stoneglare",
     "willow geist",
+    "wolf strike",
     "wolverine riders",
     "yavimaya steelcrusher",
 ];
@@ -534,17 +535,24 @@ fn anaphoric_scope_set_is_frozen() {
     // target/event pronoun ("it deals damage equal to its power") now parses on
     // five more cards — Bionic Blow, Captain Marvel (Shooting Star), Colossal
     // Collision, Nova Flame, and Origin of Thor — taking the count to 171.
+    // The one-sided-fight runtime-fallback fix (#512/#511 direction) restored
+    // the "boost target creature, then it deals damage equal to its power"
+    // class to ObjectScope::Anaphoric (the parser keeps Power{Anaphoric}; the
+    // runtime resolves it to the boosted creature, targets[0]) — adding Burrog
+    // Barrage and Wolf Strike (+2), while Osseous Sticktwister's "this creature
+    // deals damage equal to its power" self-source clause correctly resolves to
+    // Source, not Anaphoric (-1) — taking the count to 172.
     assert_eq!(
         observed.len(),
-        171,
-        "Expected exactly 171 cards retaining ObjectScope::Anaphoric (pronoun \
+        172,
+        "Expected exactly 172 cards retaining ObjectScope::Anaphoric (pronoun \
          'its' antecedents). Count moved to {}.",
         observed.len()
     );
     assert_eq!(
         ANAPHORIC_SCOPE_CARDS.len(),
-        171,
-        "ANAPHORIC_SCOPE_CARDS must list exactly 171 cards."
+        172,
+        "ANAPHORIC_SCOPE_CARDS must list exactly 172 cards."
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -3,6 +3,7 @@ mod abundance_optional_draw_replacement;
 mod adapter_contract_fixtures;
 mod advanced_reconstruction_regression;
 mod ajani_nacatl_pariah_transform;
+mod ambuscade_one_sided_fight_anaphoric;
 mod amphin_mutineer_regression;
 mod anaphoric_scope_allowlist_guard;
 mod ancient_brass_dragon_roll_d20;


### PR DESCRIPTION
The "boost target creature, then it deals damage equal to its power" fight
class (Ambuscade + ~19 siblings) dealt the recipient's power instead of the
boosted creature's, and risked re-introducing #699 (zero damage).

Targets are assigned per-clause, so the DealDamage sub-ability only carried
its own recipient (targets[0]=foe), which was misread as both the CR 120.1
damage source and the Power{Anaphoric} referent. Prepend the parent chain's
chosen object into the damage sub's targets so it resolves with the
documented targets=[source, recipient] contract, and resolve
Power{Anaphoric} to the boosted creature via the one-sided-fight fallback.
Keeps the parser's Anaphoric serialization (allowlist guard frozen at 172).

CR 120.1, CR 608.2c, CR 115.10a.
