### PR TITLE
fix(engine): Consign to Memory counters triggered abilities only (fixes #3282)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17466,6 +17466,7 @@ mod tests {
                     target: TargetFilter::StackAbility {
                         controller: Some(ControllerRef::You),
                         tag: None,
+                    kind: None,
                     },
                     retarget: CopyRetargetPermission::MayChooseNewTargets,
                     copier: None,
@@ -20120,6 +20121,7 @@ mod tests {
                             TargetFilter::StackAbility {
                                 controller: None,
                                 tag: None,
+                            kind: None,
                             },
                         ],
                     },
@@ -20265,6 +20267,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
+                kind: None,
                 },
                 source_rider: None,
             },

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17466,7 +17466,7 @@ mod tests {
                     target: TargetFilter::StackAbility {
                         controller: Some(ControllerRef::You),
                         tag: None,
-                    kind: None,
+                        kind: None,
                     },
                     retarget: CopyRetargetPermission::MayChooseNewTargets,
                     copier: None,
@@ -20121,7 +20121,7 @@ mod tests {
                             TargetFilter::StackAbility {
                                 controller: None,
                                 tag: None,
-                            kind: None,
+                                kind: None,
                             },
                         ],
                     },
@@ -20267,7 +20267,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
                 source_rider: None,
             },

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -404,19 +404,41 @@ fn fmt_target(filter: &TargetFilter) -> String {
         TargetFilter::StackAbility {
             controller: None,
             tag: None,
+            kind: None,
         } => "ability on stack".into(),
+        TargetFilter::StackAbility {
+            controller: None,
+            tag: None,
+            kind: Some(crate::types::ability::StackAbilityKind::Triggered),
+        } => "triggered ability on stack".into(),
+        TargetFilter::StackAbility {
+            controller: None,
+            tag: None,
+            kind: Some(crate::types::ability::StackAbilityKind::Activated),
+        } => "activated ability on stack".into(),
         TargetFilter::StackAbility {
             controller: Some(ControllerRef::You),
             tag: None,
+            kind: None,
         } => "ability you control on stack".into(),
         TargetFilter::StackAbility {
             controller: Some(ControllerRef::Opponent),
             tag: None,
+            kind: None,
         } => "ability opponent controls on stack".into(),
         TargetFilter::StackAbility {
             controller: Some(controller),
             tag: None,
+            kind: None,
         } => format!("ability scoped to {controller:?} on stack"),
+        TargetFilter::StackAbility {
+            kind: Some(crate::types::ability::StackAbilityKind::Triggered),
+            ..
+        } => "triggered ability on stack".into(),
+        TargetFilter::StackAbility {
+            kind: Some(crate::types::ability::StackAbilityKind::Activated),
+            ..
+        } => "activated ability on stack".into(),
         TargetFilter::StackSpell => "spell on stack".into(),
         TargetFilter::AttachedTo => "attached permanent".into(),
         TargetFilter::LastCreated => "last created".into(),

--- a/crates/engine/src/game/effects/bounce.rs
+++ b/crates/engine/src/game/effects/bounce.rs
@@ -793,6 +793,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
+                kind: None,
                 },
                 destination: None,
                 selection: BounceSelection::Targeted,

--- a/crates/engine/src/game/effects/bounce.rs
+++ b/crates/engine/src/game/effects/bounce.rs
@@ -793,7 +793,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
                 destination: None,
                 selection: BounceSelection::Targeted,

--- a/crates/engine/src/game/effects/change_targets.rs
+++ b/crates/engine/src/game/effects/change_targets.rs
@@ -363,7 +363,7 @@ mod tests {
                         TargetFilter::StackAbility {
                             controller: None,
                             tag: None,
-                        kind: None,
+                            kind: None,
                         },
                         single,
                     ],

--- a/crates/engine/src/game/effects/change_targets.rs
+++ b/crates/engine/src/game/effects/change_targets.rs
@@ -363,6 +363,7 @@ mod tests {
                         TargetFilter::StackAbility {
                             controller: None,
                             tag: None,
+                        kind: None,
                         },
                         single,
                     ],

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -1778,6 +1778,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: Some(crate::types::ability::ControllerRef::You),
                     tag: None,
+                kind: None,
                 },
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
@@ -1803,6 +1804,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: Some(crate::types::ability::ControllerRef::You),
                     tag: None,
+                kind: None,
                 },
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
@@ -2099,6 +2101,7 @@ mod tests {
         let gogo_target_filter = TargetFilter::StackAbility {
             controller: Some(crate::types::ability::ControllerRef::You),
             tag: None,
+        kind: None,
         };
         assert_eq!(
             crate::game::targeting::find_legal_targets(

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -1778,7 +1778,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: Some(crate::types::ability::ControllerRef::You),
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
@@ -1804,7 +1804,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: Some(crate::types::ability::ControllerRef::You),
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
                 retarget: CopyRetargetPermission::KeepOriginalTargets,
                 copier: None,
@@ -2101,7 +2101,7 @@ mod tests {
         let gogo_target_filter = TargetFilter::StackAbility {
             controller: Some(crate::types::ability::ControllerRef::You),
             tag: None,
-        kind: None,
+            kind: None,
         };
         assert_eq!(
             crate::game::targeting::find_legal_targets(

--- a/crates/engine/src/game/effects/counter.rs
+++ b/crates/engine/src/game/effects/counter.rs
@@ -710,7 +710,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
                 source_rider: Some(CounterSourceRider::LosesAbilities {
                     static_def: Box::new(source_static),
@@ -866,7 +866,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
                 source_rider: Some(CounterSourceRider::Destroy),
             },
@@ -1431,7 +1431,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
             },
             vec![],
@@ -1510,7 +1510,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: Some(ControllerRef::Opponent),
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
             },
             vec![],

--- a/crates/engine/src/game/effects/counter.rs
+++ b/crates/engine/src/game/effects/counter.rs
@@ -710,6 +710,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
+                kind: None,
                 },
                 source_rider: Some(CounterSourceRider::LosesAbilities {
                     static_def: Box::new(source_static),
@@ -865,6 +866,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
+                kind: None,
                 },
                 source_rider: Some(CounterSourceRider::Destroy),
             },
@@ -1333,7 +1335,7 @@ mod tests {
 
     /// CR 113.3 + CR 405.1: "Counter all abilities" — the resolver matches
     /// every activated/triggered ability on the stack, including keyword actions, via
-    /// `TargetFilter::StackAbility { controller: None, tag: None }` and removes the entry without moving any
+    /// `TargetFilter::StackAbility { controller: None, tag: None, kind: None }` and removes the entry without moving any
     /// card to a graveyard (abilities aren't cards).
     #[test]
     fn test_counter_all_abilities_removes_ability_entries() {
@@ -1429,6 +1431,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
+                kind: None,
                 },
             },
             vec![],
@@ -1507,6 +1510,7 @@ mod tests {
                 target: TargetFilter::StackAbility {
                     controller: Some(ControllerRef::Opponent),
                     tag: None,
+                kind: None,
                 },
             },
             vec![],

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -749,7 +749,11 @@ pub(crate) fn matches_stack_target_filter(
     match filter {
         TargetFilter::Any => true,
         TargetFilter::StackSpell => matches!(&entry.kind, StackEntryKind::Spell { .. }),
-        TargetFilter::StackAbility { controller, tag, kind } => {
+        TargetFilter::StackAbility {
+            controller,
+            tag,
+            kind,
+        } => {
             let ability_kind_ok = kind.as_ref().is_none_or(|kind| {
                 matches!(
                     (kind, &entry.kind),
@@ -4772,7 +4776,7 @@ mod tests {
         let ability_leg = TargetFilter::StackAbility {
             controller: None,
             tag: None,
-        kind: None,
+            kind: None,
         };
         assert!(
             matches_stack_target_filter(&state, ability_entry_id, &ability_leg, &ctx),

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -749,11 +749,24 @@ pub(crate) fn matches_stack_target_filter(
     match filter {
         TargetFilter::Any => true,
         TargetFilter::StackSpell => matches!(&entry.kind, StackEntryKind::Spell { .. }),
-        TargetFilter::StackAbility { controller, tag } => {
+        TargetFilter::StackAbility { controller, tag, kind } => {
+            let ability_kind_ok = kind.as_ref().is_none_or(|kind| {
+                matches!(
+                    (kind, &entry.kind),
+                    (
+                        crate::types::ability::StackAbilityKind::Activated,
+                        StackEntryKind::ActivatedAbility { .. }
+                    ) | (
+                        crate::types::ability::StackAbilityKind::Triggered,
+                        StackEntryKind::TriggeredAbility { .. }
+                    )
+                )
+            });
             matches!(
                 &entry.kind,
                 StackEntryKind::ActivatedAbility { .. } | StackEntryKind::TriggeredAbility { .. }
-            ) && stack_entry_controller_matches(state, controller.as_ref(), entry.controller, ctx)
+            ) && ability_kind_ok
+                && stack_entry_controller_matches(state, controller.as_ref(), entry.controller, ctx)
                 // CR 113.7a: keyword-origin tag (e.g. `AbilityTag::Backup`) must
                 // match the ability on the stack when the filter requires one.
                 && tag.as_ref().is_none_or(|tag| {
@@ -4759,6 +4772,7 @@ mod tests {
         let ability_leg = TargetFilter::StackAbility {
             controller: None,
             tag: None,
+        kind: None,
         };
         assert!(
             matches_stack_target_filter(&state, ability_entry_id, &ability_leg, &ctx),

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1188,7 +1188,11 @@ fn stack_ability_matches_filter(
     source_controller: PlayerId,
 ) -> bool {
     match filter {
-        TargetFilter::StackAbility { controller, tag, kind } => {
+        TargetFilter::StackAbility {
+            controller,
+            tag,
+            kind,
+        } => {
             if !matches!(
                 &entry.kind,
                 // CR 113.3b / CR 113.3c: Activated and triggered abilities are

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -1188,7 +1188,7 @@ fn stack_ability_matches_filter(
     source_controller: PlayerId,
 ) -> bool {
     match filter {
-        TargetFilter::StackAbility { controller, tag } => {
+        TargetFilter::StackAbility { controller, tag, kind } => {
             if !matches!(
                 &entry.kind,
                 // CR 113.3b / CR 113.3c: Activated and triggered abilities are
@@ -1199,6 +1199,21 @@ fn stack_ability_matches_filter(
                     | StackEntryKind::KeywordAction { .. }
             ) {
                 return false;
+            }
+            if let Some(kind) = kind {
+                let matches_kind = matches!(
+                    (kind, &entry.kind),
+                    (
+                        crate::types::ability::StackAbilityKind::Activated,
+                        StackEntryKind::ActivatedAbility { .. }
+                    ) | (
+                        crate::types::ability::StackAbilityKind::Triggered,
+                        StackEntryKind::TriggeredAbility { .. }
+                    )
+                );
+                if !matches_kind {
+                    return false;
+                }
             }
             // CR 113.7a + CR 115.1: when a keyword-origin `tag` is required (e.g.
             // `AbilityTag::Backup` for "becomes the target of a backup ability"),

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -9285,7 +9285,7 @@ mod tests {
                 TargetFilter::StackAbility {
                     controller: Some(controller),
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
             ],
         }
@@ -9427,7 +9427,7 @@ mod tests {
         trigger.valid_source = Some(TargetFilter::StackAbility {
             controller: None,
             tag: Some(AbilityTag::Backup),
-        kind: None,
+            kind: None,
         });
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),
@@ -9451,7 +9451,7 @@ mod tests {
         trigger.valid_source = Some(TargetFilter::StackAbility {
             controller: None,
             tag: Some(AbilityTag::Backup),
-        kind: None,
+            kind: None,
         });
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -9285,6 +9285,7 @@ mod tests {
                 TargetFilter::StackAbility {
                     controller: Some(controller),
                     tag: None,
+                kind: None,
                 },
             ],
         }
@@ -9426,6 +9427,7 @@ mod tests {
         trigger.valid_source = Some(TargetFilter::StackAbility {
             controller: None,
             tag: Some(AbilityTag::Backup),
+        kind: None,
         });
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),
@@ -9449,6 +9451,7 @@ mod tests {
         trigger.valid_source = Some(TargetFilter::StackAbility {
             controller: None,
             tag: Some(AbilityTag::Backup),
+        kind: None,
         });
         let event = GameEvent::BecomesTarget {
             target: TargetRef::Object(trigger_owner),

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -12588,6 +12588,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
+            kind: None,
             }
         ));
         assert!(

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -12588,7 +12588,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
-            kind: None,
+                kind: None,
             }
         ));
         assert!(

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3675,6 +3675,7 @@ fn parse_copy_stack_ability_target(input: &str) -> Option<(TargetFilter, &str)> 
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
+            kind: None,
             },
             rem,
         ));
@@ -3688,6 +3689,7 @@ fn parse_copy_stack_ability_target(input: &str) -> Option<(TargetFilter, &str)> 
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
+            kind: None,
             },
             input,
         ));
@@ -3709,6 +3711,7 @@ pub(super) fn stack_ability_filter_from_text(input: &str) -> TargetFilter {
     TargetFilter::StackAbility {
         controller,
         tag: None,
+    kind: None,
     }
 }
 
@@ -8942,7 +8945,8 @@ mod tests {
                 f,
                 TargetFilter::StackAbility {
                     controller: None,
-                    tag: None
+                    tag: None,
+                kind: None,
                 }
             )),
             "missing the activated/triggered ability disjunct: {target:?}"
@@ -8988,7 +8992,8 @@ mod tests {
                 f,
                 TargetFilter::StackAbility {
                     controller: None,
-                    tag: None
+                    tag: None,
+                kind: None,
                 }
             )),
             "missing the triggered-ability disjunct: {target:?}"
@@ -9040,7 +9045,8 @@ mod tests {
                 f,
                 TargetFilter::StackAbility {
                     controller: None,
-                    tag: None
+                    tag: None,
+                kind: None,
                 }
             )),
             "missing the activated/triggered ability disjunct: {target:?}"
@@ -12616,6 +12622,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
+            kind: None,
             }
         ));
 
@@ -12626,7 +12633,8 @@ mod tests {
             unscoped.0,
             TargetFilter::StackAbility {
                 controller: None,
-                tag: None
+                tag: None,
+            kind: None,
             }
         ));
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3675,7 +3675,7 @@ fn parse_copy_stack_ability_target(input: &str) -> Option<(TargetFilter, &str)> 
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
-            kind: None,
+                kind: None,
             },
             rem,
         ));
@@ -3689,7 +3689,7 @@ fn parse_copy_stack_ability_target(input: &str) -> Option<(TargetFilter, &str)> 
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
-            kind: None,
+                kind: None,
             },
             input,
         ));
@@ -3711,7 +3711,7 @@ pub(super) fn stack_ability_filter_from_text(input: &str) -> TargetFilter {
     TargetFilter::StackAbility {
         controller,
         tag: None,
-    kind: None,
+        kind: None,
     }
 }
 
@@ -8946,7 +8946,7 @@ mod tests {
                 TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: None,
                 }
             )),
             "missing the activated/triggered ability disjunct: {target:?}"
@@ -8993,7 +8993,7 @@ mod tests {
                 TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: Some(crate::types::ability::StackAbilityKind::Triggered),
                 }
             )),
             "missing the triggered-ability disjunct: {target:?}"
@@ -9046,7 +9046,7 @@ mod tests {
                 TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: None,
                 }
             )),
             "missing the activated/triggered ability disjunct: {target:?}"
@@ -12622,7 +12622,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
-            kind: None,
+                kind: None,
             }
         ));
 
@@ -12634,7 +12634,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
-            kind: None,
+                kind: None,
             }
         ));
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8974,17 +8974,26 @@ fn try_parse_verb_and_target<'a>(
     // CR 701.6: Counter a spell or ability on the stack.
     if let Some((_, rest)) = nom_on_lower(text, lower, |i| value((), tag("counter ")).parse(i)) {
         let rest_lower = &lower[lower.len() - rest.len()..];
+        let stack_phrase = rest
+            .strip_prefix("target ")
+            .or_else(|| rest.strip_prefix("Target "))
+            .unwrap_or(rest);
         let (parsed_target, rem) = parse_target_with_ctx(rest, ctx);
-        let target = if scan_contains_phrase(rest_lower, "activated or triggered ability") {
-            // CR 701.6: "activated or triggered ability" is a special-case target
-            // that maps to StackAbility. We still use parse_target's remainder to
-            // preserve the compound-detection contract.
-            imperative::stack_ability_filter_from_text(rest_lower)
-        } else if scan_contains_phrase(rest_lower, "spell") {
-            constrain_filter_to_stack(parsed_target)
-        } else {
-            parsed_target
-        };
+        let target =
+            if let Ok((_, stack_target)) =
+                crate::parser::oracle_nom::target::parse_stack_object_target(stack_phrase)
+            {
+                stack_target
+            } else if scan_contains_phrase(rest_lower, "activated or triggered ability") {
+                // CR 701.6: "activated or triggered ability" is a special-case target
+                // that maps to StackAbility. We still use parse_target's remainder to
+                // preserve the compound-detection contract.
+                imperative::stack_ability_filter_from_text(rest_lower)
+            } else if scan_contains_phrase(rest_lower, "spell") {
+                constrain_filter_to_stack(parsed_target)
+            } else {
+                parsed_target
+            };
         // CR 118.12: Parse "unless its controller pays {X}" for conditional counters
         let unless_pay = parse_unless_payment(rest_lower).map(counter_unless_pay_modifier);
         return Some((
@@ -20410,6 +20419,7 @@ fn try_parse_change_targets(lower: &str) -> Option<Effect> {
                 TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
+                kind: None,
                 },
             ],
         }
@@ -20419,6 +20429,7 @@ fn try_parse_change_targets(lower: &str) -> Option<Effect> {
         TargetFilter::StackAbility {
             controller: None,
             tag: None,
+        kind: None,
         }
     } else if scan_contains_phrase(spell_phrase_clean, "spell") {
         // Parse with parse_target for type-specific spells (e.g. "instant or sorcery spell")
@@ -26230,6 +26241,7 @@ mod tests {
                     target: TargetFilter::StackAbility {
                         controller: Some(ControllerRef::Opponent),
                         tag: None,
+                    kind: None,
                     },
                 }
             ),
@@ -26270,12 +26282,36 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::StackAbility {
                         controller: None,
-                        tag: None
+                        tag: None,
+                    kind: None,
                     },
                     ..
                 }
             ),
             "single-target ability counter must stay Counter {{ StackAbility }}, got {e:?}"
+        );
+    }
+
+    #[test]
+    fn effect_counter_consign_to_memory_disjunction() {
+        let e = parse_effect("Counter target triggered ability or colorless spell");
+        assert!(
+            matches!(
+                e,
+                Effect::Counter {
+                    target: TargetFilter::Or { ref filters },
+                    ..
+                } if filters.len() == 2
+                    && filters.iter().any(|f| matches!(
+                        f,
+                        TargetFilter::StackAbility {
+                            kind: Some(crate::types::ability::StackAbilityKind::Triggered),
+                            ..
+                        }
+                    ))
+                    && filters.iter().any(|f| matches!(f, TargetFilter::Typed(_)))
+            ),
+            "Consign to Memory must parse triggered-or-colorless disjunction, got {e:?}"
         );
     }
 
@@ -27107,6 +27143,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
+            kind: None,
             }
         ));
     }
@@ -37160,7 +37197,8 @@ mod tests {
             filters[1],
             TargetFilter::StackAbility {
                 controller: None,
-                tag: None
+                tag: None,
+            kind: None,
             }
         ));
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8974,26 +8974,25 @@ fn try_parse_verb_and_target<'a>(
     // CR 701.6: Counter a spell or ability on the stack.
     if let Some((_, rest)) = nom_on_lower(text, lower, |i| value((), tag("counter ")).parse(i)) {
         let rest_lower = &lower[lower.len() - rest.len()..];
-        let stack_phrase = rest
-            .strip_prefix("target ")
-            .or_else(|| rest.strip_prefix("Target "))
-            .unwrap_or(rest);
+        let stack_phrase = tag::<_, _, OracleError<'_>>("target ")
+            .parse(rest_lower)
+            .map(|(phrase, _)| phrase)
+            .unwrap_or(rest_lower);
         let (parsed_target, rem) = parse_target_with_ctx(rest, ctx);
-        let target =
-            if let Ok((_, stack_target)) =
-                crate::parser::oracle_nom::target::parse_stack_object_target(stack_phrase)
-            {
-                stack_target
-            } else if scan_contains_phrase(rest_lower, "activated or triggered ability") {
-                // CR 701.6: "activated or triggered ability" is a special-case target
-                // that maps to StackAbility. We still use parse_target's remainder to
-                // preserve the compound-detection contract.
-                imperative::stack_ability_filter_from_text(rest_lower)
-            } else if scan_contains_phrase(rest_lower, "spell") {
-                constrain_filter_to_stack(parsed_target)
-            } else {
-                parsed_target
-            };
+        let target = if let Ok((_, stack_target)) =
+            crate::parser::oracle_nom::target::parse_stack_object_target(stack_phrase)
+        {
+            stack_target
+        } else if scan_contains_phrase(rest_lower, "activated or triggered ability") {
+            // CR 701.6: "activated or triggered ability" is a special-case target
+            // that maps to StackAbility. We still use parse_target's remainder to
+            // preserve the compound-detection contract.
+            imperative::stack_ability_filter_from_text(rest_lower)
+        } else if scan_contains_phrase(rest_lower, "spell") {
+            constrain_filter_to_stack(parsed_target)
+        } else {
+            parsed_target
+        };
         // CR 118.12: Parse "unless its controller pays {X}" for conditional counters
         let unless_pay = parse_unless_payment(rest_lower).map(counter_unless_pay_modifier);
         return Some((
@@ -20419,7 +20418,7 @@ fn try_parse_change_targets(lower: &str) -> Option<Effect> {
                 TargetFilter::StackAbility {
                     controller: None,
                     tag: None,
-                kind: None,
+                    kind: None,
                 },
             ],
         }
@@ -20429,7 +20428,7 @@ fn try_parse_change_targets(lower: &str) -> Option<Effect> {
         TargetFilter::StackAbility {
             controller: None,
             tag: None,
-        kind: None,
+            kind: None,
         }
     } else if scan_contains_phrase(spell_phrase_clean, "spell") {
         // Parse with parse_target for type-specific spells (e.g. "instant or sorcery spell")
@@ -26241,7 +26240,7 @@ mod tests {
                     target: TargetFilter::StackAbility {
                         controller: Some(ControllerRef::Opponent),
                         tag: None,
-                    kind: None,
+                        kind: None,
                     },
                 }
             ),
@@ -26283,7 +26282,7 @@ mod tests {
                     target: TargetFilter::StackAbility {
                         controller: None,
                         tag: None,
-                    kind: None,
+                        kind: None,
                     },
                     ..
                 }
@@ -27143,7 +27142,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
-            kind: None,
+                kind: None,
             }
         ));
     }
@@ -37198,7 +37197,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
-            kind: None,
+                kind: None,
             }
         ));
     }

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -13,7 +13,7 @@ use nom::Parser;
 use super::error::{oracle_err, OracleError, OracleResult};
 use super::primitives::parse_color;
 use crate::parser::oracle_util::{parse_subtype, OUTLAW_SUBTYPES};
-use crate::types::ability::{ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter};
+use crate::types::ability::{Comparator, ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter};
 use crate::types::card_type::Supertype;
 use crate::types::mana::ManaColor;
 use crate::types::zones::Zone;
@@ -30,8 +30,15 @@ pub fn parse_type_phrase(input: &str) -> OracleResult<'_, TargetFilter> {
     // Optional supertype prefix ("legendary", "basic", "snow")
     let (rest, supertype_opt) = opt(parse_supertype_prefix).parse(rest)?;
 
-    // Optional color prefix
-    let (rest, color_opt) = opt(parse_color_prefix).parse(rest)?;
+    // Optional color-quality prefix ("colorless ", "monocolored ", "multicolored ")
+    let (rest, color_quality_opt) = opt(parse_color_quality_prefix).parse(rest)?;
+
+    // Optional WUBRG color prefix (mutually exclusive with color-quality)
+    let (rest, color_opt) = if color_quality_opt.is_some() {
+        (rest, None)
+    } else {
+        opt(parse_color_prefix).parse(rest)?
+    };
 
     // Core type(s) joined by " or "
     let (rest, types) = parse_type_list(rest)?;
@@ -40,6 +47,12 @@ pub fn parse_type_phrase(input: &str) -> OracleResult<'_, TargetFilter> {
     let (rest, controller) = opt(preceded(space1, parse_controller_suffix)).parse(rest)?;
 
     let mut filter = build_type_filter(types, color_opt, supertype_opt, controller);
+
+    if let Some(prop) = color_quality_opt {
+        if let TargetFilter::Typed(ref mut tf) = filter {
+            tf.properties.push(prop);
+        }
+    }
 
     // Wrap in Non if "non" prefix was present
     if non_prefix.is_some() {
@@ -96,6 +109,35 @@ pub fn parse_supertype_prefix(input: &str) -> OracleResult<'_, Supertype> {
     let (rest, st) = parse_supertype_word(input)?;
     let (rest, _) = space1.parse(rest)?;
     Ok((rest, st))
+}
+
+/// Parse color-quality adjective prefixes: "colorless ", "monocolored ",
+/// "multicolored ".
+fn parse_color_quality_prefix(input: &str) -> OracleResult<'_, FilterProp> {
+    alt((
+        value(
+            FilterProp::ColorCount {
+                comparator: Comparator::EQ,
+                count: 0,
+            },
+            tag("colorless "),
+        ),
+        value(
+            FilterProp::ColorCount {
+                comparator: Comparator::EQ,
+                count: 1,
+            },
+            tag("monocolored "),
+        ),
+        value(
+            FilterProp::ColorCount {
+                comparator: Comparator::GE,
+                count: 2,
+            },
+            tag("multicolored "),
+        ),
+    ))
+    .parse(input)
 }
 
 /// Parse a color word followed by a space, consuming both.
@@ -371,6 +413,7 @@ pub fn parse_stack_object_target(input: &str) -> OracleResult<'_, TargetFilter> 
                     TargetFilter::StackAbility {
                         controller: None,
                         tag: None,
+                        kind: None,
                     },
                 ],
             },
@@ -390,28 +433,42 @@ pub fn parse_stack_object_target(input: &str) -> OracleResult<'_, TargetFilter> 
 
 /// Parse a single ability-kind leg of a stack-object phrase.
 ///
-/// CR 113.3b/113.3c: the only ability kinds that exist on the stack are
-/// activated and triggered abilities; both denote the same legal set (any
-/// ability on the stack), so every spelling maps to one
-/// `StackAbility { controller: None, tag: None }`. Longest-match-first so the
-/// comma/`or`-joined two-word forms are consumed whole before the shorter
-/// single-word alternates.
+/// CR 113.3b/113.3c: activated and triggered abilities are distinct stack
+/// objects; a lone "triggered ability" or "activated ability" leg narrows
+/// `kind`, while combined phrases accept both.
 fn parse_ability_kind_leg(input: &str) -> OracleResult<'_, TargetFilter> {
-    value(
-        TargetFilter::StackAbility {
-            controller: None,
-            tag: None,
-        },
-        alt((
-            tag("activated ability, triggered ability"),
-            tag("activated or triggered ability"),
-            tag("triggered or activated ability"),
-            tag("triggered ability or activated ability"),
-            tag("activated ability or triggered ability"),
+    alt((
+        map(
             tag("triggered ability"),
+            |_| TargetFilter::StackAbility {
+                controller: None,
+                tag: None,
+                kind: Some(crate::types::ability::StackAbilityKind::Triggered),
+            },
+        ),
+        map(
             tag("activated ability"),
-        )),
-    )
+            |_| TargetFilter::StackAbility {
+                controller: None,
+                tag: None,
+                kind: Some(crate::types::ability::StackAbilityKind::Activated),
+            },
+        ),
+        map(
+            alt((
+                tag("activated ability, triggered ability"),
+                tag("activated or triggered ability"),
+                tag("triggered or activated ability"),
+                tag("triggered ability or activated ability"),
+                tag("activated ability or triggered ability"),
+            )),
+            |_| TargetFilter::StackAbility {
+                controller: None,
+                tag: None,
+                kind: None,
+            },
+        ),
+    ))
     .parse(input)
 }
 
@@ -456,7 +513,7 @@ fn parse_ability_kind_leg(input: &str) -> OracleResult<'_, TargetFilter> {
 fn parse_ability_spell_disjunction(input: &str) -> OracleResult<'_, TargetFilter> {
     enum StackLeg {
         Spell(TargetFilter),
-        Ability,
+        Ability(TargetFilter),
     }
 
     fn parse_leg(input: &str) -> OracleResult<'_, StackLeg> {
@@ -465,25 +522,51 @@ fn parse_ability_spell_disjunction(input: &str) -> OracleResult<'_, TargetFilter
         // spell phrase, so the two leg kinds are disjoint and the order is for
         // determinism only.
         alt((
-            map(parse_ability_kind_leg, |_| StackLeg::Ability),
+            map(parse_ability_kind_leg, StackLeg::Ability),
             map(parse_restricted_spell, StackLeg::Spell),
         ))
         .parse(input)
     }
 
+    fn merge_ability_kind(
+        existing: Option<crate::types::ability::StackAbilityKind>,
+        incoming: Option<crate::types::ability::StackAbilityKind>,
+    ) -> Option<crate::types::ability::StackAbilityKind> {
+        match (existing, incoming) {
+            (None, k) | (k, None) => k,
+            (Some(a), Some(b)) if a == b => Some(a),
+            _ => None,
+        }
+    }
+
     // Source-encounter-ordered assembly. Ability legs fold into the first
     // ability slot: push a single `StackAbility` marker at the position it is
-    // first seen, and ignore later ability legs (they denote the same set).
-    fn push_leg(filters: &mut Vec<TargetFilter>, saw_ability: &mut bool, leg: StackLeg) {
+    // first seen, and merge later ability legs (widening `kind` when mixed).
+    fn push_leg(
+        filters: &mut Vec<TargetFilter>,
+        ability_slot: &mut Option<usize>,
+        ability_kind: &mut Option<crate::types::ability::StackAbilityKind>,
+        leg: StackLeg,
+    ) {
         match leg {
             StackLeg::Spell(f) => filters.push(f),
-            StackLeg::Ability => {
-                if !*saw_ability {
-                    *saw_ability = true;
-                    filters.push(TargetFilter::StackAbility {
-                        controller: None,
-                        tag: None,
-                    });
+            StackLeg::Ability(ability_filter) => {
+                let TargetFilter::StackAbility { kind, .. } = ability_filter else {
+                    return;
+                };
+                if let Some(slot) = ability_slot {
+                    *ability_kind = merge_ability_kind(*ability_kind, kind);
+                    if let TargetFilter::StackAbility {
+                        kind: slot_kind,
+                        ..
+                    } = &mut filters[*slot]
+                    {
+                        *slot_kind = *ability_kind;
+                    }
+                } else {
+                    *ability_slot = Some(filters.len());
+                    *ability_kind = kind;
+                    filters.push(ability_filter);
                 }
             }
         }
@@ -492,8 +575,9 @@ fn parse_ability_spell_disjunction(input: &str) -> OracleResult<'_, TargetFilter
     // First leg is mandatory.
     let (mut rest, first) = parse_leg(input)?;
     let mut filters: Vec<TargetFilter> = Vec::new();
-    let mut saw_ability = false;
-    push_leg(&mut filters, &mut saw_ability, first);
+    let mut ability_slot = None;
+    let mut ability_kind = None;
+    push_leg(&mut filters, &mut ability_slot, &mut ability_kind, first);
 
     // Subsequent legs joined by a list connector. Longest-match-first so
     // ", or " / ", and/or " win over the bare ", " separator.
@@ -508,7 +592,7 @@ fn parse_ability_spell_disjunction(input: &str) -> OracleResult<'_, TargetFilter
         match opt(preceded(connector, parse_leg)).parse(rest)? {
             (next, Some(leg)) => {
                 rest = next;
-                push_leg(&mut filters, &mut saw_ability, leg);
+                push_leg(&mut filters, &mut ability_slot, &mut ability_kind, leg);
             }
             (next, None) => {
                 rest = next;
@@ -519,7 +603,7 @@ fn parse_ability_spell_disjunction(input: &str) -> OracleResult<'_, TargetFilter
 
     // CONTRACT: an ability disjunct is required — pure-spell phrases go to
     // `parse_target` so the existing single-leg contracts hold.
-    if !saw_ability {
+    if ability_slot.is_none() {
         return Err(oracle_err(input));
     }
 
@@ -943,7 +1027,8 @@ mod tests {
                 filters: vec![
                     TargetFilter::StackAbility {
                         controller: None,
-                        tag: None
+                        tag: None,
+                        kind: None,
                     },
                     noncreature_spell_leg(),
                 ],
@@ -986,7 +1071,8 @@ mod tests {
             filter,
             TargetFilter::StackAbility {
                 controller: None,
-                tag: None
+                tag: None,
+            kind: None,
             }
         );
     }
@@ -999,9 +1085,45 @@ mod tests {
             filter,
             TargetFilter::StackAbility {
                 controller: None,
-                tag: None
+                tag: None,
+                kind: Some(crate::types::ability::StackAbilityKind::Activated),
             }
         );
+    }
+
+    #[test]
+    fn test_stack_object_triggered_ability_only() {
+        let (rest, filter) = parse_stack_object_target("triggered ability").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            filter,
+            TargetFilter::StackAbility {
+                controller: None,
+                tag: None,
+                kind: Some(crate::types::ability::StackAbilityKind::Triggered),
+            }
+        );
+    }
+
+    #[test]
+    fn test_stack_object_triggered_ability_or_colorless_spell() {
+        let (rest, filter) =
+            parse_stack_object_target("triggered ability or colorless spell").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(
+            filter,
+            TargetFilter::Or {
+                filters: legs
+            } if legs.len() == 2
+                && matches!(
+                    &legs[0],
+                    TargetFilter::StackAbility {
+                        kind: Some(crate::types::ability::StackAbilityKind::Triggered),
+                        ..
+                    }
+                )
+                && matches!(&legs[1], TargetFilter::Typed(_))
+        ));
     }
 
     #[test]
@@ -1018,7 +1140,8 @@ mod tests {
                     TargetFilter::StackSpell,
                     TargetFilter::StackAbility {
                         controller: None,
-                        tag: None
+                        tag: None,
+                        kind: None,
                     },
                 ],
             }
@@ -1072,6 +1195,7 @@ mod tests {
                     TargetFilter::StackAbility {
                         controller: None,
                         tag: None,
+                        kind: Some(crate::types::ability::StackAbilityKind::Triggered),
                     },
                 ],
             }

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -13,7 +13,9 @@ use nom::Parser;
 use super::error::{oracle_err, OracleError, OracleResult};
 use super::primitives::parse_color;
 use crate::parser::oracle_util::{parse_subtype, OUTLAW_SUBTYPES};
-use crate::types::ability::{Comparator, ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter};
+use crate::types::ability::{
+    Comparator, ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter,
+};
 use crate::types::card_type::Supertype;
 use crate::types::mana::ManaColor;
 use crate::types::zones::Zone;
@@ -438,22 +440,16 @@ pub fn parse_stack_object_target(input: &str) -> OracleResult<'_, TargetFilter> 
 /// `kind`, while combined phrases accept both.
 fn parse_ability_kind_leg(input: &str) -> OracleResult<'_, TargetFilter> {
     alt((
-        map(
-            tag("triggered ability"),
-            |_| TargetFilter::StackAbility {
-                controller: None,
-                tag: None,
-                kind: Some(crate::types::ability::StackAbilityKind::Triggered),
-            },
-        ),
-        map(
-            tag("activated ability"),
-            |_| TargetFilter::StackAbility {
-                controller: None,
-                tag: None,
-                kind: Some(crate::types::ability::StackAbilityKind::Activated),
-            },
-        ),
+        map(tag("triggered ability"), |_| TargetFilter::StackAbility {
+            controller: None,
+            tag: None,
+            kind: Some(crate::types::ability::StackAbilityKind::Triggered),
+        }),
+        map(tag("activated ability"), |_| TargetFilter::StackAbility {
+            controller: None,
+            tag: None,
+            kind: Some(crate::types::ability::StackAbilityKind::Activated),
+        }),
         map(
             alt((
                 tag("activated ability, triggered ability"),
@@ -557,8 +553,7 @@ fn parse_ability_spell_disjunction(input: &str) -> OracleResult<'_, TargetFilter
                 if let Some(slot) = ability_slot {
                     *ability_kind = merge_ability_kind(*ability_kind, kind);
                     if let TargetFilter::StackAbility {
-                        kind: slot_kind,
-                        ..
+                        kind: slot_kind, ..
                     } = &mut filters[*slot]
                     {
                         *slot_kind = *ability_kind;
@@ -1072,7 +1067,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
-            kind: None,
+                kind: None,
             }
         );
     }

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -773,6 +773,7 @@ fn parse_it_targets_that_targets_spell_filter(cond_text: &str) -> Option<TargetF
                     TargetFilter::StackAbility {
                         controller: None,
                         tag: None,
+                    kind: None,
                     },
                 ],
             },
@@ -786,6 +787,7 @@ fn parse_it_targets_that_targets_spell_filter(cond_text: &str) -> Option<TargetF
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
+            kind: None,
             },
             alt((
                 tag::<_, _, OracleError<'_>>("an activated or triggered ability"),

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -773,7 +773,7 @@ fn parse_it_targets_that_targets_spell_filter(cond_text: &str) -> Option<TargetF
                     TargetFilter::StackAbility {
                         controller: None,
                         tag: None,
-                    kind: None,
+                        kind: None,
                     },
                 ],
             },
@@ -787,7 +787,7 @@ fn parse_it_targets_that_targets_spell_filter(cond_text: &str) -> Option<TargetF
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
-            kind: None,
+                kind: None,
             },
             alt((
                 tag::<_, _, OracleError<'_>>("an activated or triggered ability"),

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2606,7 +2606,9 @@ fn static_this_spell_cost_less_if_it_targets_spell_or_ability_targeting_large_cr
             if filters.iter().any(|f| matches!(f, TargetFilter::StackSpell))
                 && filters
                     .iter()
-                    .any(|f| matches!(f, TargetFilter::StackAbility { controller: None, tag: None }))
+                    .any(|f| matches!(f, TargetFilter::StackAbility { controller: None, tag: None,
+        kind: None,
+        }))
     )));
     let stack_targets_filter = filters
         .iter()

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -177,6 +177,7 @@ fn becomes_target_source_filter(controller: ControllerRef) -> TargetFilter {
             TargetFilter::StackAbility {
                 controller: Some(controller),
                 tag: None,
+            kind: None,
             },
         ],
     }
@@ -7389,6 +7390,7 @@ fn try_parse_event(
                 def.valid_source = Some(TargetFilter::StackAbility {
                     controller: None,
                     tag: Some(AbilityTag::Backup),
+                kind: None,
                 });
             }
             SimpleEvent::DealtCombatDamage => {
@@ -21701,6 +21703,7 @@ mod tests {
             Some(TargetFilter::StackAbility {
                 controller: None,
                 tag: Some(AbilityTag::Backup),
+            kind: None,
             })
         );
         // Subject: "another creature you control" → Typed creature / You / Another.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -177,7 +177,7 @@ fn becomes_target_source_filter(controller: ControllerRef) -> TargetFilter {
             TargetFilter::StackAbility {
                 controller: Some(controller),
                 tag: None,
-            kind: None,
+                kind: None,
             },
         ],
     }
@@ -7390,7 +7390,7 @@ fn try_parse_event(
                 def.valid_source = Some(TargetFilter::StackAbility {
                     controller: None,
                     tag: Some(AbilityTag::Backup),
-                kind: None,
+                    kind: None,
                 });
             }
             SimpleEvent::DealtCombatDamage => {
@@ -21703,7 +21703,7 @@ mod tests {
             Some(TargetFilter::StackAbility {
                 controller: None,
                 tag: Some(AbilityTag::Backup),
-            kind: None,
+                kind: None,
             })
         );
         // Subject: "another creature you control" → Typed creature / You / Another.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3033,6 +3033,14 @@ pub enum ThisWayCause {
     Bounced,
 }
 
+/// CR 113.3b / CR 113.3c: Which stack ability kinds a `StackAbility` filter accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum StackAbilityKind {
+    Activated,
+    Triggered,
+}
+
 /// Typed target filter replacing all Forge filter strings and TargetSpec.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -3060,11 +3068,15 @@ pub enum TargetFilter {
     /// CR 113.7a: once activated or triggered, an ability exists on the stack
     /// independently of its source — `tag` matches by keyword-origin marker
     /// (e.g. `AbilityTag::Backup` for "becomes the target of a backup ability").
+    /// `kind` narrows to one ability class when the Oracle text does (Consign to
+    /// Memory's "triggered ability" leg); `None` accepts both.
     StackAbility {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         controller: Option<ControllerRef>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tag: Option<AbilityTag>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        kind: Option<StackAbilityKind>,
     },
     /// Matches spells on the stack (not activated/triggered abilities).
     /// CR 115.1a: Used by "becomes the target of a spell" triggers to filter source type.
@@ -16235,7 +16247,8 @@ mod tests {
             filter,
             TargetFilter::StackAbility {
                 controller: None,
-                tag: None
+                tag: None,
+            kind: None,
             }
         );
         assert_eq!(
@@ -16252,7 +16265,8 @@ mod tests {
             filter,
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
-                tag: None
+                tag: None,
+            kind: None,
             }
         );
         assert_eq!(

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -16248,7 +16248,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
-            kind: None,
+                kind: None,
             }
         );
         assert_eq!(
@@ -16266,7 +16266,7 @@ mod tests {
             TargetFilter::StackAbility {
                 controller: Some(ControllerRef::You),
                 tag: None,
-            kind: None,
+                kind: None,
             }
         );
         assert_eq!(

--- a/crates/engine/tests/integration/backup_becomes_target_trigger.rs
+++ b/crates/engine/tests/integration/backup_becomes_target_trigger.rs
@@ -7,7 +7,7 @@
 //!
 //! The synthesized Backup ETB ability (`synthesize_backup`) is stamped with
 //! `AbilityTag::Backup`; the trigger's `valid_source` is
-//! `TargetFilter::StackAbility { tag: Some(AbilityTag::Backup) }`, honored at
+//! `TargetFilter::StackAbility { tag: Some(AbilityTag::Backup), kind: None }`, honored at
 //! runtime by `stack_ability_matches_filter` (CR 113.7a — the ability exists on
 //! the stack independently of its source, so the tag is read off the resolved
 //! ability). The backup ETB targets `target creature` (CR 115.1d), so locking

--- a/crates/engine/tests/integration/issue_3282_consign_to_memory_counter.rs
+++ b/crates/engine/tests/integration/issue_3282_consign_to_memory_counter.rs
@@ -1,0 +1,194 @@
+//! Issue #3282 — Consign to Memory counter target.
+//!
+//! Oracle: "Counter target triggered ability or colorless spell."
+//! Before the fix, the parser produced bare `StackAbility` (any ability) and
+//! dropped the colorless-spell disjunct, so activated abilities were wrongly
+//! legal and colorless spells were not.
+
+use engine::game::targeting::find_legal_targets;
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect;
+use engine::types::ability::{
+    Effect, ResolvedAbility, StackAbilityKind, TargetFilter, TargetRef,
+};
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::game_state::{CastingVariant, GameState, StackEntry, StackEntryKind};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::zones::Zone;
+use engine::types::PlayerId;
+
+fn consign_counter_target() -> TargetFilter {
+    match parse_effect("Counter target triggered ability or colorless spell") {
+        Effect::Counter { target, .. } => target,
+        other => panic!("expected Counter effect, got {other:?}"),
+    }
+}
+
+#[test]
+fn consign_to_memory_parses_triggered_or_colorless_disjunction() {
+    let target = consign_counter_target();
+
+    let TargetFilter::Or { filters } = &target else {
+        panic!("expected Or disjunction, got {target:?}");
+    };
+    assert_eq!(filters.len(), 2, "must have triggered-ability + spell legs");
+
+    assert!(
+        filters.iter().any(|f| matches!(
+            f,
+            TargetFilter::StackAbility {
+                kind: Some(StackAbilityKind::Triggered),
+                ..
+            }
+        )),
+        "ability leg must narrow to triggered only: {target:?}"
+    );
+
+    assert!(
+        filters.iter().any(|f| matches!(f, TargetFilter::Typed(_))),
+        "spell leg must be a stack-pinned typed filter: {target:?}"
+    );
+}
+
+fn stack_with_counter_targets() -> (GameState, ObjectId, ObjectId, ObjectId, ObjectId) {
+    let mut state = GameState::new_two_player(42);
+
+    let perm = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(1),
+        "Ability Source".to_string(),
+        Zone::Battlefield,
+    );
+
+    let activated = ObjectId(901);
+    let triggered = ObjectId(902);
+    state.stack.push_back(StackEntry {
+        id: activated,
+        source_id: perm,
+        controller: PlayerId(1),
+        kind: StackEntryKind::ActivatedAbility {
+            source_id: perm,
+            ability: ResolvedAbility::new(
+                Effect::Unimplemented {
+                    name: "Act".to_string(),
+                    description: None,
+                },
+                vec![],
+                perm,
+                PlayerId(1),
+            ),
+        },
+    });
+    state.stack.push_back(StackEntry {
+        id: triggered,
+        source_id: perm,
+        controller: PlayerId(1),
+        kind: StackEntryKind::TriggeredAbility {
+            source_id: perm,
+            ability: Box::new(ResolvedAbility::new(
+                Effect::Unimplemented {
+                    name: "Trig".to_string(),
+                    description: None,
+                },
+                vec![],
+                perm,
+                PlayerId(1),
+            )),
+            condition: None,
+            trigger_event: None,
+            description: None,
+            source_name: String::new(),
+            subject_match_count: None,
+            die_result: None,
+        },
+    });
+
+    // Colorless spell on the stack.
+    let colorless_spell = create_object(
+        &mut state,
+        CardId(10),
+        PlayerId(1),
+        "Colorless Spell".to_string(),
+        Zone::Stack,
+    );
+    {
+        let artifact = CardType {
+            core_types: vec![CoreType::Artifact],
+            ..Default::default()
+        };
+        let obj = state.objects.get_mut(&colorless_spell).unwrap();
+        obj.card_types = artifact.clone();
+        obj.base_card_types = artifact;
+        obj.color.clear();
+    }
+
+    // Colored spell on the stack.
+    let colored_spell = create_object(
+        &mut state,
+        CardId(11),
+        PlayerId(1),
+        "Colored Spell".to_string(),
+        Zone::Stack,
+    );
+    {
+        let instant = CardType {
+            core_types: vec![CoreType::Instant],
+            ..Default::default()
+        };
+        let obj = state.objects.get_mut(&colored_spell).unwrap();
+        obj.card_types = instant.clone();
+        obj.base_card_types = instant;
+        obj.color = vec![engine::types::mana::ManaColor::Red];
+    }
+
+    for (id, card_id) in [(colorless_spell, CardId(10)), (colored_spell, CardId(11))] {
+        state.stack.push_back(StackEntry {
+            id,
+            source_id: id,
+            controller: PlayerId(1),
+            kind: StackEntryKind::Spell {
+                card_id,
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+    }
+
+    (
+        state,
+        activated,
+        triggered,
+        colorless_spell,
+        colored_spell,
+    )
+}
+
+#[test]
+fn consign_to_memory_counter_target_legality() {
+    let filter = consign_counter_target();
+    let (state, activated, triggered, colorless_spell, colored_spell) =
+        stack_with_counter_targets();
+
+    let source = ObjectId(1000);
+    let legal = find_legal_targets(&state, &filter, PlayerId(0), source);
+    let is_legal = |id: ObjectId| legal.contains(&TargetRef::Object(id));
+
+    assert!(
+        !is_legal(activated),
+        "activated abilities must NOT be legal targets"
+    );
+    assert!(
+        is_legal(triggered),
+        "triggered abilities must be legal targets"
+    );
+    assert!(
+        is_legal(colorless_spell),
+        "colorless spells must be legal targets"
+    );
+    assert!(
+        !is_legal(colored_spell),
+        "colored spells must NOT be legal targets"
+    );
+}

--- a/crates/engine/tests/integration/issue_3282_consign_to_memory_counter.rs
+++ b/crates/engine/tests/integration/issue_3282_consign_to_memory_counter.rs
@@ -8,9 +8,7 @@
 use engine::game::targeting::find_legal_targets;
 use engine::game::zones::create_object;
 use engine::parser::oracle_effect::parse_effect;
-use engine::types::ability::{
-    Effect, ResolvedAbility, StackAbilityKind, TargetFilter, TargetRef,
-};
+use engine::types::ability::{Effect, ResolvedAbility, StackAbilityKind, TargetFilter, TargetRef};
 use engine::types::card_type::{CardType, CoreType};
 use engine::types::game_state::{CastingVariant, GameState, StackEntry, StackEntryKind};
 use engine::types::identifiers::{CardId, ObjectId};
@@ -156,13 +154,7 @@ fn stack_with_counter_targets() -> (GameState, ObjectId, ObjectId, ObjectId, Obj
         });
     }
 
-    (
-        state,
-        activated,
-        triggered,
-        colorless_spell,
-        colored_spell,
-    )
+    (state, activated, triggered, colorless_spell, colored_spell)
 }
 
 #[test]

--- a/crates/engine/tests/integration/louisoix_sacrifice_counter.rs
+++ b/crates/engine/tests/integration/louisoix_sacrifice_counter.rs
@@ -83,7 +83,7 @@ fn louisoix_sacrifice_parses_disjunctive_counter_target() {
             TargetFilter::StackAbility {
                 controller: None,
                 tag: None,
-            kind: None,
+                kind: None,
             }
         )),
         "missing the activated/triggered ability disjunct: {target:?}"

--- a/crates/engine/tests/integration/louisoix_sacrifice_counter.rs
+++ b/crates/engine/tests/integration/louisoix_sacrifice_counter.rs
@@ -82,7 +82,8 @@ fn louisoix_sacrifice_parses_disjunctive_counter_target() {
             f,
             TargetFilter::StackAbility {
                 controller: None,
-                tag: None
+                tag: None,
+            kind: None,
             }
         )),
         "missing the activated/triggered ability disjunct: {target:?}"

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -235,6 +235,7 @@ mod issue_2943_kayas_wrath;
 mod issue_3127_reveal_otherwise_graveyard;
 mod issue_3245_abhorrent_oculus_manifest_dread;
 mod issue_3260_phantasmal_image_persist;
+mod issue_3282_consign_to_memory_counter;
 mod issue_3283_sevinne_reclamation_copy_no_self_copy;
 mod issue_3285_face_down_public_zone;
 mod issue_3288_electrolyze_second_target;


### PR DESCRIPTION
## Summary
- Add `StackAbilityKind` to `TargetFilter::StackAbility` so filters can accept only triggered or only activated stack abilities.
- Route counter-effect parsing through `parse_stack_object_target` for ability-or-spell disjunctions (e.g. Consign to Memory's "triggered ability or colorless spell").
- Teach `oracle_nom` stack-object spell legs to parse color-quality prefixes like "colorless spell".

## Test plan
- [x] `cargo test -p engine test_stack_object --lib`
- [x] `cargo test -p engine effect_counter_consign --lib`
- [x] `cargo test -p engine --test integration issue_3282`
- [x] `cargo clippy -p engine --lib --tests -- -D warnings`


Fix #3282