### PR TITLE
Fix #3659: Gix draw goes to creature controller

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -4599,9 +4599,8 @@ fn resolve_player_anaphor_damage_recipient(
     }
     match ctx.relative_player_scope {
         Some(ControllerRef::ScopedPlayer) => Some(TargetFilter::ScopedPlayer),
-        Some(ControllerRef::ParentTargetController) => {
-            Some(TargetFilter::ParentTargetController)
-        }
+        Some(ControllerRef::ParentTargetController) => Some(TargetFilter::ParentTargetController),
+        Some(ControllerRef::ParentTargetOwner) => Some(TargetFilter::ParentTargetOwner),
         Some(ControllerRef::TriggeringPlayer) | Some(ControllerRef::TargetPlayer) => {
             Some(TargetFilter::TriggeringPlayer)
         }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -4587,6 +4587,9 @@ fn resolve_player_anaphor_damage_recipient(
     }
     match ctx.relative_player_scope {
         Some(ControllerRef::ScopedPlayer) => Some(TargetFilter::ScopedPlayer),
+        Some(ControllerRef::ParentTargetController) => {
+            Some(TargetFilter::ParentTargetController)
+        }
         Some(ControllerRef::TriggeringPlayer) | Some(ControllerRef::TargetPlayer) => {
             Some(TargetFilter::TriggeringPlayer)
         }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -18131,7 +18131,14 @@ pub(crate) fn parse_effect_chain_ir(
         // chunk (both higher-precedence rungs are None). Independent of the
         // lazy `.or_else` chain — pure Option inspection.
         let seeded_parent_target_controller_this_chunk = chain_chosen_player_scope.is_none()
-            && ctx.relative_player_scope.is_none()
+            && matches!(
+                chain_chosen_player_scope
+                    .clone()
+                    .or_else(|| chain_parent_target_controller_scope.clone())
+                    .or_else(|| ctx.relative_player_scope.clone())
+                    .as_ref(),
+                Some(ControllerRef::ParentTargetController)
+            )
             && chain_parent_target_controller_scope.is_some();
         let mut chunk_ctx = ParseContext {
             subject: chunk_subject,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -18150,16 +18150,13 @@ pub(crate) fn parse_effect_chain_ir(
             // player controls" anaphor binds to the most recent choice.
             relative_player_scope: chain_chosen_player_scope
                 .clone()
-                .or_else(|| ctx.relative_player_scope.clone())
                 // CR 608.2c (issue #1670): body "its controller may" antecedent
-                // (Star Athlete). Placed BELOW ctx.relative_player_scope so a
-                // trigger-CONDITION-derived scope keeps precedence — conservative
-                // non-regressive ordering. No card today has BOTH a
-                // condition-scoped player AND an independent body "its controller"
-                // antecedent; this only supplies a scope when the condition set
-                // none (e.g. "Whenever ~ attacks", where ctx.relative_player_scope
-                // is None).
+                // (Star Athlete; issue #3659 Gix — "its controller may pay … if
+                // they do, they draw" must bind "they" to the creature's
+                // controller, not the damaged player from the trigger
+                // condition's TriggeringPlayer scope).
                 .or_else(|| chain_parent_target_controller_scope.clone())
+                .or_else(|| ctx.relative_player_scope.clone())
                 .or_else(|| {
                     player_scope
                         .is_some()

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1740,6 +1740,12 @@ fn resolve_they_pronoun(ctx: &mut ParseContext) -> TargetFilter {
     ) {
         return TargetFilter::ParentTargetController;
     }
+    if matches!(
+        ctx.relative_player_scope,
+        Some(ControllerRef::ParentTargetOwner)
+    ) {
+        return TargetFilter::ParentTargetOwner;
+    }
     // CR 603.7c + CR 120.3 + CR 506.2: A "deals [combat] damage to a player" or
     // "attacks a player" trigger introduces the damaged/attacked player as the
     // event referent (the parser stamps `relative_player_scope = TargetPlayer`).

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1731,6 +1731,15 @@ fn resolve_they_pronoun(ctx: &mut ParseContext) -> TargetFilter {
     if matches!(ctx.relative_player_scope, Some(ControllerRef::ScopedPlayer)) {
         return TargetFilter::ScopedPlayer;
     }
+    // CR 608.2c + CR 109.4 (issue #1670, #3659): "they" after body "its
+    // controller may … if they do, they draw" refers to that creature's
+    // controller, not the damaged opponent from the trigger condition.
+    if matches!(
+        ctx.relative_player_scope,
+        Some(ControllerRef::ParentTargetController)
+    ) {
+        return TargetFilter::ParentTargetController;
+    }
     // CR 603.7c + CR 120.3 + CR 506.2: A "deals [combat] damage to a player" or
     // "attacks a player" trigger introduces the damaged/attacked player as the
     // event referent (the parser stamps `relative_player_scope = TargetPlayer`).

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -29797,6 +29797,41 @@ mod tests {
         out
     }
 
+    /// Issue #3659 — Gix, Yawgmoth Praetor: damage trigger with "its controller may
+    /// pay … if they do, they draw" must route the draw to the creature's
+    /// controller (ParentTargetController), not the damaged opponent
+    /// (TriggeringPlayer from the damage condition scope).
+    #[test]
+    fn gix_optional_draw_binds_creature_controller_not_damaged_player() {
+        let def = parse_trigger_line(
+            "Whenever a creature deals combat damage to one of your opponents, its controller may pay 1 life. If they do, they draw a card.",
+            "Gix, Yawgmoth Praetor",
+        );
+        assert_eq!(def.mode, TriggerMode::DamageDone);
+        let execute = def.execute.as_ref().expect("trigger should have execute");
+        let chain = ability_chain(execute);
+        let draw_node = chain
+            .iter()
+            .find(|d| matches!(d.effect.as_ref(), Effect::Draw { .. }))
+            .expect("chain must contain a Draw node");
+        match draw_node.effect.as_ref() {
+            Effect::Draw { target, count, .. } => {
+                assert_eq!(
+                    *target,
+                    TargetFilter::ParentTargetController,
+                    "Gix draw must go to the creature's controller who paid, not the damaged opponent"
+                );
+                assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+            }
+            other => panic!("expected Draw, got {other:?}"),
+        }
+        assert_eq!(
+            draw_node.condition,
+            Some(AbilityCondition::effect_performed()),
+            "draw must be gated on optional cost payment"
+        );
+    }
+
     /// Issue #1670 — Star Athlete: "Whenever this creature attacks, choose up to
     /// one target nonland permanent. Its controller may sacrifice it. If they
     /// don't, this creature deals 5 damage to that player." The "that player"

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -29832,6 +29832,34 @@ mod tests {
         );
     }
 
+    /// Issue #3659 (leak guard) — Gix's "its controller may pay … if they do,
+    /// they draw" antecedent must not leak into a later independent "that
+    /// player" clause, which must bind to the damaged opponent (TriggeringPlayer).
+    #[test]
+    fn gix_its_controller_antecedent_does_not_leak_to_later_that_player() {
+        let def = parse_trigger_line(
+            "Whenever a creature deals combat damage to one of your opponents, \
+             its controller may pay 1 life. If they do, they draw a card. That player discards a card.",
+            "Gix, Yawgmoth Praetor",
+        );
+        let execute = def.execute.as_ref().expect("trigger should have execute");
+        let chain = ability_chain(execute);
+        let discard_node = chain
+            .iter()
+            .find(|d| matches!(d.effect.as_ref(), Effect::Discard { .. }))
+            .expect("chain must contain a Discard node");
+        match discard_node.effect.as_ref() {
+            Effect::Discard { target, .. } => {
+                assert_eq!(
+                    *target,
+                    TargetFilter::TriggeringPlayer,
+                    "later 'that player' must be the damaged opponent, not the creature's controller"
+                );
+            }
+            other => panic!("expected Discard, got {other:?}"),
+        }
+    }
+
     /// Issue #1670 — Star Athlete: "Whenever this creature attacks, choose up to
     /// one target nonland permanent. Its controller may sacrifice it. If they
     /// don't, this creature deals 5 damage to that player." The "that player"


### PR DESCRIPTION
## Summary
- Reorder effect-chain player scope so body "its controller may … if they do, they draw" binds to the creature's controller, not the damaged opponent
- Extend pronoun lowering for `ParentTargetController` in damage-recipient and subject resolution

## Test plan
- [x] `cargo test -p engine --lib gix_optional_draw`

Fixes #3659

Made with [Cursor](https://cursor.com)