### PR TITLE
feat(multiplayer): add "request takeback" with unanimous human approval

### DIFF
--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -31,7 +31,7 @@ export interface DeckData {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  */
-export const PROTOCOL_VERSION = 7;
+export const PROTOCOL_VERSION = 8;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.
@@ -83,7 +83,9 @@ export type WsAdapterEvent =
   | { type: "stateChanged"; state: GameState; events: GameEvent[]; legalResult: LegalActionsResult }
   | { type: "emoteReceived"; fromPlayer: PlayerId; emote: string }
   | { type: "conceded"; player: PlayerId }
-  | { type: "timerUpdate"; player: PlayerId; remainingSeconds: number };
+  | { type: "timerUpdate"; player: PlayerId; remainingSeconds: number }
+  | { type: "takebackRequested"; requester: PlayerId; requesterName: string }
+  | { type: "takebackResolved"; approved: boolean; resolvedBy: PlayerId | null };
 
 type WsAdapterEventListener = (event: WsAdapterEvent) => void;
 
@@ -401,6 +403,22 @@ export class WebSocketAdapter implements EngineAdapter {
 
   sendEmote(emote: string): void {
     this.send({ type: "Emote", data: { emote } });
+  }
+
+  /** GH #1507: ask every other human player to approve rolling the game
+   * back to the state immediately before this player's last action. */
+  sendRequestTakeback(): void {
+    this.send({ type: "RequestTakeback" });
+  }
+
+  /** Approve or decline a pending takeback request. */
+  sendRespondTakeback(approve: boolean): void {
+    this.send({ type: "RespondTakeback", data: { approve } });
+  }
+
+  /** Withdraw a takeback request this player made themselves. */
+  sendCancelTakeback(): void {
+    this.send({ type: "CancelTakeback" });
   }
 
   sendReadyToggle(): void {
@@ -730,6 +748,26 @@ export class WebSocketAdapter implements EngineAdapter {
           type: "timerUpdate",
           player: data.player,
           remainingSeconds: data.remaining_seconds,
+        });
+        break;
+      }
+
+      case "TakebackRequested": {
+        const data = msg.data as { requester: PlayerId; requester_name: string };
+        this.emit({
+          type: "takebackRequested",
+          requester: data.requester,
+          requesterName: data.requester_name,
+        });
+        break;
+      }
+
+      case "TakebackResolved": {
+        const data = msg.data as { approved: boolean; resolved_by?: PlayerId | null };
+        this.emit({
+          type: "takebackResolved",
+          approved: data.approved,
+          resolvedBy: data.resolved_by ?? null,
         });
         break;
       }

--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -19,6 +19,9 @@ interface GameMenuProps {
   onSettingsClick: () => void;
   onHelpClick: () => void;
   onConcede?: () => void;
+  /** GH #1507: ask every other human player to approve rolling the game
+   * back to the state before this player's last action. Online-only. */
+  onRequestTakeback?: () => void;
   /** Show the always-visible Sandbox Tools button. Gated by the caller to
    *  game modes where debug actions actually work (vs-AI, local, or a
    *  multiplayer sandbox). */
@@ -35,6 +38,7 @@ export function GameMenu({
   onSettingsClick,
   onHelpClick,
   onConcede,
+  onRequestTakeback,
   showSandboxTools,
   onSandboxToolsClick,
 }: GameMenuProps) {
@@ -145,6 +149,15 @@ export function GameMenu({
               onClick={() => {
                 onToggleAiHand();
                 setOpen(false);
+              }}
+            />
+          )}
+          {isOnlineMode && onRequestTakeback && (
+            <MenuButton
+              label={t("gameMenu.requestTakeback")}
+              onClick={() => {
+                setOpen(false);
+                onRequestTakeback();
               }}
             />
           )}

--- a/client/src/components/multiplayer/TakebackRequestDialog.tsx
+++ b/client/src/components/multiplayer/TakebackRequestDialog.tsx
@@ -1,0 +1,93 @@
+import { motion, AnimatePresence } from "framer-motion";
+import { useTranslation } from "react-i18next";
+
+interface TakebackRequestDialogProps {
+  isOpen: boolean;
+  /** Display name of the player who requested the takeback. */
+  requesterName: string;
+  /** True when the local player is the one who made the request — shows a
+   * "waiting for approval" message with a cancel option instead of the
+   * approve/decline choice. */
+  isOwnRequest: boolean;
+  onApprove: () => void;
+  onDecline: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * GH #1507: shown to every seat while a "request takeback" is pending.
+ * The requester sees a waiting state with the option to withdraw; every
+ * other human seat sees an approve/decline choice. The dialog closes itself
+ * when the parent observes `TakebackResolved` and sets `isOpen` to false.
+ */
+export function TakebackRequestDialog({
+  isOpen,
+  requesterName,
+  isOwnRequest,
+  onApprove,
+  onDecline,
+  onCancel,
+}: TakebackRequestDialogProps) {
+  const { t } = useTranslation("multiplayer");
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <motion.div
+            className="absolute inset-0 bg-black/70"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          />
+          <motion.div
+            className="relative z-10 w-96 rounded-xl bg-gray-900 p-6 text-center shadow-2xl ring-1 ring-gray-700"
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+          >
+            {isOwnRequest ? (
+              <>
+                <h2 className="mb-2 text-xl font-bold text-white">
+                  {t("takebackDialog.ownTitle")}
+                </h2>
+                <p className="mb-6 text-sm text-gray-400">{t("takebackDialog.ownMessage")}</p>
+                <div className="flex justify-center gap-3">
+                  <button
+                    onClick={onCancel}
+                    className="rounded-lg bg-gray-700 px-5 py-2 text-sm font-semibold text-gray-200 transition hover:bg-gray-600"
+                  >
+                    {t("takebackDialog.cancel")}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h2 className="mb-2 text-xl font-bold text-white">
+                  {t("takebackDialog.requestedTitle", { name: requesterName })}
+                </h2>
+                <p className="mb-6 text-sm text-gray-400">
+                  {t("takebackDialog.requestedMessage")}
+                </p>
+                <div className="flex justify-center gap-3">
+                  <button
+                    onClick={onDecline}
+                    className="rounded-lg bg-gray-700 px-5 py-2 text-sm font-semibold text-gray-200 transition hover:bg-gray-600"
+                  >
+                    {t("takebackDialog.decline")}
+                  </button>
+                  <button
+                    onClick={onApprove}
+                    className="rounded-lg bg-emerald-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500"
+                  >
+                    {t("takebackDialog.approve")}
+                  </button>
+                </div>
+              </>
+            )}
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -37,6 +37,7 @@
     "helpShortcuts": "Hilfe & Tastenkürzel",
     "showAiHand": "KI-Hand anzeigen",
     "hideAiHand": "KI-Hand verbergen",
+    "requestTakeback": "Rücknahme beantragen",
     "concede": "Aufgeben",
     "backToDraft": "Zurück zum Draft",
     "mainMenu": "Hauptmenü",

--- a/client/src/i18n/locales/de/multiplayer.json
+++ b/client/src/i18n/locales/de/multiplayer.json
@@ -4,6 +4,16 @@
     "message": "Dein Gegner wird zum Sieger erklärt.",
     "concede": "Aufgeben"
   },
+  "takebackDialog": {
+    "requestedTitle": "{{name}} beantragt eine Rücknahme",
+    "requestedMessage": "Das Spiel auf den Moment direkt vor ihrer letzten Aktion zurücksetzen?",
+    "ownTitle": "Rücknahme beantragt",
+    "ownMessage": "Warten auf die Zustimmung der anderen Spieler, um auf den Zustand vor deiner letzten Aktion zurückzusetzen.",
+    "approve": "Zustimmen",
+    "decline": "Ablehnen",
+    "cancel": "Anfrage abbrechen",
+    "declinedToast": "Rücknahmeanfrage abgelehnt"
+  },
   "connectionDot": {
     "connected": "Verbunden",
     "connecting": "Verbinden...",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -37,6 +37,7 @@
     "helpShortcuts": "Help & Shortcuts",
     "showAiHand": "Show AI Hand",
     "hideAiHand": "Hide AI Hand",
+    "requestTakeback": "Request Takeback",
     "concede": "Concede",
     "backToDraft": "Back to Draft",
     "mainMenu": "Main Menu",

--- a/client/src/i18n/locales/en/multiplayer.json
+++ b/client/src/i18n/locales/en/multiplayer.json
@@ -4,6 +4,16 @@
     "message": "Your opponent will be declared the winner.",
     "concede": "Concede"
   },
+  "takebackDialog": {
+    "requestedTitle": "{{name}} requests a takeback",
+    "requestedMessage": "Roll the game back to the moment right before their last action?",
+    "ownTitle": "Takeback requested",
+    "ownMessage": "Waiting for the other players to approve rolling back to before your last action.",
+    "approve": "Approve",
+    "decline": "Decline",
+    "cancel": "Cancel request",
+    "declinedToast": "Takeback request declined"
+  },
   "connectionDot": {
     "connected": "Connected",
     "connecting": "Connecting...",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -37,6 +37,7 @@
     "helpShortcuts": "Ayuda y atajos",
     "showAiHand": "Mostrar la mano de la IA",
     "hideAiHand": "Ocultar la mano de la IA",
+    "requestTakeback": "Solicitar repetición",
     "concede": "Conceder",
     "backToDraft": "Volver al Draft",
     "mainMenu": "Menú principal",

--- a/client/src/i18n/locales/es/multiplayer.json
+++ b/client/src/i18n/locales/es/multiplayer.json
@@ -4,6 +4,16 @@
     "message": "Tu oponente será declarado ganador.",
     "concede": "Conceder"
   },
+  "takebackDialog": {
+    "requestedTitle": "{{name}} solicita una repetición",
+    "requestedMessage": "¿Volver al momento justo antes de su última acción?",
+    "ownTitle": "Repetición solicitada",
+    "ownMessage": "Esperando que los demás jugadores aprueben volver a antes de tu última acción.",
+    "approve": "Aprobar",
+    "decline": "Rechazar",
+    "cancel": "Cancelar solicitud",
+    "declinedToast": "Solicitud de repetición rechazada"
+  },
   "connectionDot": {
     "connected": "Conectado",
     "connecting": "Conectando...",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -37,6 +37,7 @@
     "helpShortcuts": "Aide et raccourcis",
     "showAiHand": "Afficher la main de l'IA",
     "hideAiHand": "Masquer la main de l'IA",
+    "requestTakeback": "Demander une reprise",
     "concede": "Concéder",
     "backToDraft": "Retour au Draft",
     "mainMenu": "Menu principal",

--- a/client/src/i18n/locales/fr/multiplayer.json
+++ b/client/src/i18n/locales/fr/multiplayer.json
@@ -4,6 +4,16 @@
     "message": "Votre adversaire sera déclaré vainqueur.",
     "concede": "Concéder"
   },
+  "takebackDialog": {
+    "requestedTitle": "{{name}} demande une reprise",
+    "requestedMessage": "Revenir au moment juste avant sa dernière action ?",
+    "ownTitle": "Reprise demandée",
+    "ownMessage": "En attente de l'approbation des autres joueurs pour revenir avant votre dernière action.",
+    "approve": "Approuver",
+    "decline": "Refuser",
+    "cancel": "Annuler la demande",
+    "declinedToast": "Demande de reprise refusée"
+  },
   "connectionDot": {
     "connected": "Connecté",
     "connecting": "Connexion...",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -37,6 +37,7 @@
     "helpShortcuts": "Aiuto e scorciatoie",
     "showAiHand": "Mostra mano IA",
     "hideAiHand": "Nascondi mano IA",
+    "requestTakeback": "Richiedi ripristino",
     "concede": "Concedi",
     "backToDraft": "Torna al Draft",
     "mainMenu": "Menu principale",

--- a/client/src/i18n/locales/it/multiplayer.json
+++ b/client/src/i18n/locales/it/multiplayer.json
@@ -4,6 +4,16 @@
     "message": "Il tuo avversario sarà dichiarato vincitore.",
     "concede": "Concedi"
   },
+  "takebackDialog": {
+    "requestedTitle": "{{name}} richiede un ripristino",
+    "requestedMessage": "Tornare al momento subito prima della sua ultima azione?",
+    "ownTitle": "Ripristino richiesto",
+    "ownMessage": "In attesa che gli altri giocatori approvino il ripristino a prima della tua ultima azione.",
+    "approve": "Approva",
+    "decline": "Rifiuta",
+    "cancel": "Annulla richiesta",
+    "declinedToast": "Richiesta di ripristino rifiutata"
+  },
   "connectionDot": {
     "connected": "Connesso",
     "connecting": "Connessione...",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -37,6 +37,7 @@
     "helpShortcuts": "Pomoc i skróty",
     "showAiHand": "Pokaż rękę AI",
     "hideAiHand": "Ukryj rękę AI",
+    "requestTakeback": "Poproś o wycofanie ruchu",
     "concede": "Poddaj się",
     "backToDraft": "Wróć do draftu",
     "mainMenu": "Menu główne",

--- a/client/src/i18n/locales/pl/multiplayer.json
+++ b/client/src/i18n/locales/pl/multiplayer.json
@@ -4,6 +4,16 @@
     "message": "Twój przeciwnik zostanie ogłoszony zwycięzcą.",
     "concede": "Poddaj się"
   },
+  "takebackDialog": {
+    "requestedTitle": "{{name}} prosi o wycofanie ruchu",
+    "requestedMessage": "Przywrócić stan gry z chwili przed jego ostatnią akcją?",
+    "ownTitle": "Poproszono o wycofanie ruchu",
+    "ownMessage": "Czekanie na zgodę innych graczy na przywrócenie stanu z przed twojej ostatniej akcji.",
+    "approve": "Zatwierdź",
+    "decline": "Odmów",
+    "cancel": "Anuluj prośbę",
+    "declinedToast": "Prośba o wycofanie ruchu odrzucona"
+  },
   "connectionDot": {
     "connected": "Połączono",
     "connecting": "Łączenie...",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -37,6 +37,7 @@
     "helpShortcuts": "Ajuda e Atalhos",
     "showAiHand": "Mostrar Mão da IA",
     "hideAiHand": "Ocultar Mão da IA",
+    "requestTakeback": "Solicitar retrocesso",
     "concede": "Conceder",
     "backToDraft": "Voltar ao Draft",
     "mainMenu": "Menu Principal",

--- a/client/src/i18n/locales/pt/multiplayer.json
+++ b/client/src/i18n/locales/pt/multiplayer.json
@@ -4,6 +4,16 @@
     "message": "Seu oponente será declarado o vencedor.",
     "concede": "Conceder"
   },
+  "takebackDialog": {
+    "requestedTitle": "{{name}} solicita um retrocesso",
+    "requestedMessage": "Voltar ao momento exatamente antes da última ação dele?",
+    "ownTitle": "Retrocesso solicitado",
+    "ownMessage": "Aguardando a aprovação dos outros jogadores para retroceder antes da sua última ação.",
+    "approve": "Aprovar",
+    "decline": "Recusar",
+    "cancel": "Cancelar solicitação",
+    "declinedToast": "Solicitação de retrocesso recusada"
+  },
   "connectionDot": {
     "connected": "Conectado",
     "connecting": "Conectando...",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -102,6 +102,7 @@ import {
 import { DebugPanel } from "../components/chrome/DebugPanel.tsx";
 import { GameMenu } from "../components/chrome/GameMenu.tsx";
 import { ConcedeDialog } from "../components/multiplayer/ConcedeDialog.tsx";
+import { TakebackRequestDialog } from "../components/multiplayer/TakebackRequestDialog.tsx";
 import { ConnectionToast } from "../components/multiplayer/ConnectionToast.tsx";
 import { EmoteOverlay } from "../components/multiplayer/EmoteOverlay.tsx";
 import { ResolutionProgressOverlay } from "../components/board/ResolutionProgressOverlay.tsx";
@@ -270,6 +271,10 @@ export function GamePage() {
   );
   const [gameStartedAt, setGameStartedAt] = useState<number | null>(null);
   const hasConcededRef = useRef(false);
+  // GH #1507: "request takeback" — the table-wide pending request, if any.
+  const [pendingTakeback, setPendingTakeback] = useState<
+    { requester: number; requesterName: string } | null
+  >(null);
 
   const handleWsEvent = useCallback((event: WsAdapterEvent) => {
     switch (event.type) {
@@ -354,6 +359,18 @@ export function GamePage() {
           ...prev,
           [event.player]: event.remainingSeconds,
         }));
+        break;
+      case "takebackRequested":
+        setPendingTakeback({
+          requester: event.requester,
+          requesterName: event.requesterName,
+        });
+        break;
+      case "takebackResolved":
+        setPendingTakeback(null);
+        if (!event.approved) {
+          useMultiplayerStore.getState().showToast(t("multiplayer:takebackDialog.declinedToast"));
+        }
         break;
       case "playerDisconnected":
         // Multiplayer (3+ players): a specific player disconnected
@@ -641,6 +658,8 @@ export function GamePage() {
         receivedEmote={receivedEmote}
         timerRemaining={timerRemaining}
         gameStartedAt={gameStartedAt}
+        pendingTakeback={pendingTakeback}
+        onCloseTakebackDialog={() => setPendingTakeback(null)}
         disconnectChoice={disconnectChoice}
         onDismissDisconnectChoice={() => setDisconnectChoice(null)}
         pauseReason={pauseReason}
@@ -676,6 +695,8 @@ interface GamePageContentProps {
   receivedEmote: string | null;
   timerRemaining: Record<number, number>;
   gameStartedAt: number | null;
+  pendingTakeback: { requester: number; requesterName: string } | null;
+  onCloseTakebackDialog: () => void;
   // 3-4p P2P additions
   disconnectChoice: { playerId: number; gracePeriodMs: number } | null;
   onDismissDisconnectChoice: () => void;
@@ -705,6 +726,8 @@ function GamePageContent({
   receivedEmote,
   timerRemaining,
   gameStartedAt,
+  pendingTakeback,
+  onCloseTakebackDialog,
   disconnectChoice,
   onDismissDisconnectChoice,
   pauseReason,
@@ -845,6 +868,31 @@ function GamePageContent({
     },
     [adapter],
   );
+
+  // GH #1507: "request takeback" — ask every other human player to approve
+  // rolling the game back to before this player's last action.
+  const handleRequestTakeback = useCallback(() => {
+    if (adapter && adapter instanceof WebSocketAdapter) {
+      adapter.sendRequestTakeback();
+    }
+  }, [adapter]);
+
+  const handleRespondTakeback = useCallback(
+    (approve: boolean) => {
+      if (adapter && adapter instanceof WebSocketAdapter) {
+        adapter.sendRespondTakeback(approve);
+      }
+      onCloseTakebackDialog();
+    },
+    [adapter, onCloseTakebackDialog],
+  );
+
+  const handleCancelTakeback = useCallback(() => {
+    if (adapter && adapter instanceof WebSocketAdapter) {
+      adapter.sendCancelTakeback();
+    }
+    onCloseTakebackDialog();
+  }, [adapter, onCloseTakebackDialog]);
 
   // Issue #311 safety net: when the engine emits a WaitingFor variant the
   // frontend has no UI for, this handler is the user's escape hatch.
@@ -1275,6 +1323,7 @@ function GamePageContent({
         onSettingsClick={() => setPreferencesOpen({})}
         onHelpClick={() => setHelpSheetOpen(true)}
         onConcede={onShowConcedeDialog}
+        onRequestTakeback={isOnlineMode ? handleRequestTakeback : undefined}
         showSandboxTools={mode === "ai" || mode === "local" || isSandboxGame}
         onSandboxToolsClick={() => useUiStore.getState().openSandboxTools()}
       />
@@ -1690,6 +1739,14 @@ function GamePageContent({
             isOpen={showConcedeDialog}
             onConfirm={handleConcede}
             onCancel={onHideConcedeDialog}
+          />
+          <TakebackRequestDialog
+            isOpen={pendingTakeback !== null}
+            requesterName={pendingTakeback?.requesterName ?? ""}
+            isOwnRequest={pendingTakeback?.requester === playerId}
+            onApprove={() => handleRespondTakeback(true)}
+            onDecline={() => handleRespondTakeback(false)}
+            onCancel={handleCancelTakeback}
           />
           {!isSpectatorMode && (
             <EmoteOverlay

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -630,7 +630,10 @@ fn reject_if_disabled(msg: &ClientMessage, mode: ServerMode) -> Option<&'static 
         | ClientMessage::SeatMutate { .. }
         | ClientMessage::Concede
         | ClientMessage::Emote { .. }
-        | ClientMessage::SpectatorJoin { .. } => match mode {
+        | ClientMessage::SpectatorJoin { .. }
+        | ClientMessage::RequestTakeback
+        | ClientMessage::RespondTakeback { .. }
+        | ClientMessage::CancelTakeback => match mode {
             ServerMode::Full => None,
             ServerMode::LobbyOnly => Some(LOBBY_ONLY_REJECTION),
         },
@@ -2503,6 +2506,72 @@ async fn draft_pack_generator_for_start(
     draft_pools
         .generator_for_set(&set_code)
         .ok_or_else(|| format!("No draft pool data for set: {set_code}"))
+}
+
+/// Broadcasts the result of an approved takeback (GH #1507): a `StateUpdate`
+/// carrying the rolled-back state to every seat, filtered per-player exactly
+/// like a normal action result, followed by `TakebackResolved { approved: true, .. }`.
+/// `resolved_by` is the player whose response concluded the request, or
+/// `None` when it resolved naturally (e.g. the requester was the sole human).
+async fn broadcast_takeback_approved(
+    connections: &SharedConnections,
+    game_code: &str,
+    player_count: u8,
+    snapshot: server_core::BroadcastSnapshot,
+    resolved_by: Option<PlayerId>,
+) {
+    let (raw_state, legal_actions, auto_pass, spell_costs, by_object) = snapshot;
+    let filtered_states: Vec<(PlayerId, GameState)> = (0..player_count)
+        .map(|i| {
+            let pid = PlayerId(i);
+            (pid, server_core::filter_state_for_player(&raw_state, pid))
+        })
+        .collect();
+
+    let conns = connections.lock().await;
+    if let Some(players) = conns.get(game_code) {
+        let actors = raw_state.waiting_for.acting_players();
+        for (pid, pstate) in &filtered_states {
+            if let Some(s) = players.get(pid) {
+                let is_actor = actors.contains(pid);
+                let player_legals = if is_actor {
+                    legal_actions.clone()
+                } else {
+                    vec![]
+                };
+                let p_auto_pass = if is_actor { auto_pass } else { false };
+                let p_spell_costs = if is_actor {
+                    spell_costs.clone()
+                } else {
+                    HashMap::new()
+                };
+                let p_by_object = if is_actor {
+                    by_object.clone()
+                } else {
+                    HashMap::new()
+                };
+                let _ = s.send(ServerMessage::StateUpdate {
+                    state: pstate.clone(),
+                    events: vec![],
+                    legal_actions: player_legals,
+                    auto_pass_recommended: p_auto_pass,
+                    eliminated_players: raw_state.eliminated_players.clone(),
+                    log_entries: vec![],
+                    spell_costs: p_spell_costs,
+                    legal_actions_by_object: p_by_object,
+                    derived: derive_views(pstate, Some(*pid)),
+                });
+            }
+        }
+
+        let resolved_msg = ServerMessage::TakebackResolved {
+            approved: true,
+            resolved_by,
+        };
+        for sender in players.values() {
+            let _ = sender.send(resolved_msg.clone());
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4422,6 +4491,185 @@ async fn handle_client_message(
             delete_session_async(game_db, &game_code);
         }
 
+        // GH #1507: multiplayer-safe "request takeback" — see
+        // `server_core::takeback` for the unanimous-approval rules this
+        // delegates to. None of these three arms touch `session.state`
+        // directly; they only call into `GameSession` methods that own the
+        // takeback/rollback invariants.
+        ClientMessage::RequestTakeback => {
+            let (game_code, player_id) = match (&identity.game_code, identity.player_id) {
+                (Some(c), Some(p)) => (c.clone(), p),
+                _ => {
+                    let msg = ServerMessage::Error {
+                        message: "Not in a game".to_string(),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                }
+            };
+
+            let mut mgr = state.lock().await;
+            let Some(session) = mgr.sessions.get_mut(&game_code) else {
+                drop(mgr);
+                return;
+            };
+            let outcome = session.request_takeback(player_id);
+            let requester_name = session
+                .display_names
+                .get(player_id.0 as usize)
+                .cloned()
+                .unwrap_or_default();
+            let player_count = session.player_count;
+            let approved_snapshot = matches!(outcome, Ok(server_core::TakebackOutcome::Approved))
+                .then(|| session.current_broadcast_snapshot());
+            drop(mgr);
+
+            match outcome {
+                Err(reason) => {
+                    let msg = ServerMessage::Error { message: reason };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                }
+                Ok(server_core::TakebackOutcome::Pending) => {
+                    info!(game = %game_code, player = ?player_id, "takeback requested");
+                    let conns = connections.lock().await;
+                    if let Some(players) = conns.get(&game_code) {
+                        let msg = ServerMessage::TakebackRequested {
+                            requester: player_id,
+                            requester_name,
+                        };
+                        for sender in players.values() {
+                            let _ = sender.send(msg.clone());
+                        }
+                    }
+                }
+                Ok(server_core::TakebackOutcome::Approved) => {
+                    info!(game = %game_code, player = ?player_id, "takeback auto-approved (sole human seat)");
+                    broadcast_takeback_approved(
+                        connections,
+                        &game_code,
+                        player_count,
+                        approved_snapshot.expect("Approved outcome always computes a snapshot"),
+                        None,
+                    )
+                    .await;
+                }
+                Ok(server_core::TakebackOutcome::Rejected) => {
+                    // request_takeback never returns Rejected — only respond_takeback does.
+                }
+            }
+        }
+
+        ClientMessage::RespondTakeback { approve } => {
+            let (game_code, player_id) = match (&identity.game_code, identity.player_id) {
+                (Some(c), Some(p)) => (c.clone(), p),
+                _ => {
+                    let msg = ServerMessage::Error {
+                        message: "Not in a game".to_string(),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                }
+            };
+
+            let mut mgr = state.lock().await;
+            let Some(session) = mgr.sessions.get_mut(&game_code) else {
+                drop(mgr);
+                return;
+            };
+            let outcome = session.respond_takeback(player_id, approve);
+            let player_count = session.player_count;
+            let approved_snapshot = matches!(outcome, Ok(server_core::TakebackOutcome::Approved))
+                .then(|| session.current_broadcast_snapshot());
+            drop(mgr);
+
+            match outcome {
+                Err(reason) => {
+                    let msg = ServerMessage::Error { message: reason };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                }
+                Ok(server_core::TakebackOutcome::Pending) => {
+                    info!(game = %game_code, player = ?player_id, approve, "takeback approval recorded");
+                }
+                Ok(server_core::TakebackOutcome::Approved) => {
+                    info!(game = %game_code, player = ?player_id, "takeback unanimously approved");
+                    broadcast_takeback_approved(
+                        connections,
+                        &game_code,
+                        player_count,
+                        approved_snapshot.expect("Approved outcome always computes a snapshot"),
+                        Some(player_id),
+                    )
+                    .await;
+                }
+                Ok(server_core::TakebackOutcome::Rejected) => {
+                    info!(game = %game_code, player = ?player_id, "takeback declined");
+                    let conns = connections.lock().await;
+                    if let Some(players) = conns.get(&game_code) {
+                        let msg = ServerMessage::TakebackResolved {
+                            approved: false,
+                            resolved_by: Some(player_id),
+                        };
+                        for sender in players.values() {
+                            let _ = sender.send(msg.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        ClientMessage::CancelTakeback => {
+            let (game_code, player_id) = match (&identity.game_code, identity.player_id) {
+                (Some(c), Some(p)) => (c.clone(), p),
+                _ => {
+                    let msg = ServerMessage::Error {
+                        message: "Not in a game".to_string(),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                }
+            };
+
+            let mut mgr = state.lock().await;
+            let Some(session) = mgr.sessions.get_mut(&game_code) else {
+                drop(mgr);
+                return;
+            };
+            let result = session.cancel_takeback(player_id);
+            drop(mgr);
+
+            match result {
+                Err(reason) => {
+                    let msg = ServerMessage::Error { message: reason };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                }
+                Ok(()) => {
+                    info!(game = %game_code, player = ?player_id, "takeback request cancelled");
+                    let conns = connections.lock().await;
+                    if let Some(players) = conns.get(&game_code) {
+                        let msg = ServerMessage::TakebackResolved {
+                            approved: false,
+                            resolved_by: Some(player_id),
+                        };
+                        for sender in players.values() {
+                            let _ = sender.send(msg.clone());
+                        }
+                    }
+                }
+            }
+        }
+
         ClientMessage::SpectatorJoin { game_code } => {
             if let Err(reason) = guard_spectator_join(&game_code) {
                 let msg = ServerMessage::Error { message: reason };
@@ -5739,6 +5987,9 @@ mod mode_gate_tests {
                 draft_code: "X".into(),
                 player_token: "t".into(),
             },
+            ClientMessage::RequestTakeback,
+            ClientMessage::RespondTakeback { approve: true },
+            ClientMessage::CancelTakeback,
         ];
         for msg in disabled {
             assert!(
@@ -5822,6 +6073,9 @@ mod mode_gate_tests {
                 draft_code: "X".into(),
                 action: draft_core::types::DraftAction::StartDraft,
             },
+            ClientMessage::RequestTakeback,
+            ClientMessage::RespondTakeback { approve: true },
+            ClientMessage::CancelTakeback,
         ];
         for m in msgs {
             assert!(reject_if_disabled(&m, ServerMode::Full).is_none());

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3179,6 +3179,10 @@ async fn handle_client_message(
                     player: PlayerId,
                     game_started_msg: Box<ServerMessage>,
                     ai_result: Option<Box<ActionResult>>,
+                    /// GH #1507: present when a takeback vote is in flight,
+                    /// so the reconnecting socket gets the same prompt it
+                    /// would have received had it stayed connected.
+                    pending_takeback_msg: Option<Box<ServerMessage>>,
                 },
                 Err(String),
             }
@@ -3227,10 +3231,13 @@ async fn handle_client_message(
                             // re-see the first-player roll).
                             let game_started_msg =
                                 build_game_started_message(session, player, None, Vec::new());
+                            let pending_takeback_msg =
+                                session.pending_takeback_message().map(Box::new);
                             ReconnectOutcome::InGame {
                                 player,
                                 game_started_msg: Box::new(game_started_msg),
                                 ai_result,
+                                pending_takeback_msg,
                             }
                         }
                         Err(e) => ReconnectOutcome::Err(e),
@@ -3269,6 +3276,7 @@ async fn handle_client_message(
                     player,
                     game_started_msg,
                     ai_result,
+                    pending_takeback_msg,
                 } => {
                     info!(game = %game_code, player = ?player, "reconnect succeeded");
                     identity.set_session(game_code.clone(), player, player_token);
@@ -3295,6 +3303,15 @@ async fn handle_client_message(
 
                     if let Ok(json) = serde_json::to_string(&game_started_msg) {
                         let _ = socket.send(Message::text(json)).await;
+                    }
+
+                    // GH #1507: replay the pending takeback prompt, if any,
+                    // so this socket isn't left with no way to approve or
+                    // decline a vote that started while it was disconnected.
+                    if let Some(msg) = pending_takeback_msg {
+                        if let Ok(json) = serde_json::to_string(&msg) {
+                            let _ = socket.send(Message::text(json)).await;
+                        }
                     }
 
                     if let Some(result) = ai_result {
@@ -4516,11 +4533,11 @@ async fn handle_client_message(
                 return;
             };
             let outcome = session.request_takeback(player_id);
-            let requester_name = session
-                .display_names
-                .get(player_id.0 as usize)
-                .cloned()
-                .unwrap_or_default();
+            // `pending_takeback_message` reads `session.pending_takeback`,
+            // which `request_takeback` already cleared on an Approved
+            // outcome — so this is `Some` exactly when we need it (the
+            // Pending arm below) and `None` otherwise.
+            let requested_msg = session.pending_takeback_message();
             let player_count = session.player_count;
             let approved_snapshot = matches!(outcome, Ok(server_core::TakebackOutcome::Approved))
                 .then(|| session.current_broadcast_snapshot());
@@ -4535,14 +4552,12 @@ async fn handle_client_message(
                 }
                 Ok(server_core::TakebackOutcome::Pending) => {
                     info!(game = %game_code, player = ?player_id, "takeback requested");
-                    let conns = connections.lock().await;
-                    if let Some(players) = conns.get(&game_code) {
-                        let msg = ServerMessage::TakebackRequested {
-                            requester: player_id,
-                            requester_name,
-                        };
-                        for sender in players.values() {
-                            let _ = sender.send(msg.clone());
+                    if let Some(msg) = requested_msg {
+                        let conns = connections.lock().await;
+                        if let Some(players) = conns.get(&game_code) {
+                            for sender in players.values() {
+                                let _ = sender.send(msg.clone());
+                            }
                         }
                     }
                 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -2515,6 +2515,7 @@ async fn draft_pack_generator_for_start(
 /// `None` when it resolved naturally (e.g. the requester was the sole human).
 async fn broadcast_takeback_approved(
     connections: &SharedConnections,
+    game_spectators: &SharedGameSpectators,
     game_code: &str,
     player_count: u8,
     snapshot: server_core::BroadcastSnapshot,
@@ -2570,6 +2571,22 @@ async fn broadcast_takeback_approved(
         };
         for sender in players.values() {
             let _ = sender.send(resolved_msg.clone());
+        }
+    }
+    drop(conns);
+
+    // Spectators are read-only viewers of `StateUpdate` only (mirroring the
+    // normal action-broadcast path) — they never receive player-facing
+    // notifications like `TakebackResolved`, just like they never receive
+    // `Conceded`/`GameOver`. Without this, a spectator would stay frozen on
+    // the pre-rollback state until some later action produced a new update.
+    if let Ok(spectator_msg) = build_spectator_state_update_message(&raw_state, &[], &[]) {
+        let mut specs = game_spectators.lock().await;
+        if let Some(spectators) = specs.get_mut(game_code) {
+            spectators.retain(|sender| sender.send(spectator_msg.clone()).is_ok());
+            if spectators.is_empty() {
+                specs.remove(game_code);
+            }
         }
     }
 }
@@ -4541,6 +4558,14 @@ async fn handle_client_message(
             let player_count = session.player_count;
             let approved_snapshot = matches!(outcome, Ok(server_core::TakebackOutcome::Approved))
                 .then(|| session.current_broadcast_snapshot());
+            // GH #1507: persist the rolled-back state immediately, in the
+            // same lock as the rollback itself — otherwise SQLite still
+            // holds the pre-rollback `GameState` until some later action
+            // happens to persist, and a crash/restart in that window
+            // resurrects the branch the table just agreed to undo.
+            if approved_snapshot.is_some() {
+                persist_session_async(game_db, &game_code, session);
+            }
             drop(mgr);
 
             match outcome {
@@ -4565,6 +4590,7 @@ async fn handle_client_message(
                     info!(game = %game_code, player = ?player_id, "takeback auto-approved (sole human seat)");
                     broadcast_takeback_approved(
                         connections,
+                        game_spectators,
                         &game_code,
                         player_count,
                         approved_snapshot.expect("Approved outcome always computes a snapshot"),
@@ -4601,6 +4627,11 @@ async fn handle_client_message(
             let player_count = session.player_count;
             let approved_snapshot = matches!(outcome, Ok(server_core::TakebackOutcome::Approved))
                 .then(|| session.current_broadcast_snapshot());
+            // GH #1507: persist the rolled-back state immediately — see the
+            // matching comment in the `RequestTakeback` arm above.
+            if approved_snapshot.is_some() {
+                persist_session_async(game_db, &game_code, session);
+            }
             drop(mgr);
 
             match outcome {
@@ -4617,6 +4648,7 @@ async fn handle_client_message(
                     info!(game = %game_code, player = ?player_id, "takeback unanimously approved");
                     broadcast_takeback_approved(
                         connections,
+                        game_spectators,
                         &game_code,
                         player_count,
                         approved_snapshot.expect("Approved outcome always computes a snapshot"),

--- a/crates/server-core/src/client_message_wire_guard.rs
+++ b/crates/server-core/src/client_message_wire_guard.rs
@@ -54,7 +54,10 @@ pub fn guard_client_message_before_dispatch(
         } => guard_game_reconnect(game_code, player_token),
         ClientMessage::SubscribeLobby
         | ClientMessage::UnsubscribeLobby
-        | ClientMessage::Concede => Ok(()),
+        | ClientMessage::Concede
+        | ClientMessage::RequestTakeback
+        | ClientMessage::RespondTakeback { .. }
+        | ClientMessage::CancelTakeback => Ok(()),
         ClientMessage::CreateGameWithSettings {
             deck,
             display_name,
@@ -234,7 +237,10 @@ pub fn guard_broker_projection_inbound(msg: &ClientMessage) -> Result<(), String
         | ClientMessage::JoinDraftWithPassword { .. }
         | ClientMessage::DraftAction { .. }
         | ClientMessage::ReconnectDraft { .. }
-        | ClientMessage::SpectateDraft { .. } => Ok(()),
+        | ClientMessage::SpectateDraft { .. }
+        | ClientMessage::RequestTakeback
+        | ClientMessage::RespondTakeback { .. }
+        | ClientMessage::CancelTakeback => Ok(()),
     }
 }
 

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod seat_mutation_wire_guard;
 pub mod session;
 pub mod spectator_wire_guard;
 pub mod starter_decks;
+pub mod takeback;
 
 pub use ai_seats_wire_guard::guard_create_ai_seats;
 pub use client_hello_guard::guard_client_hello;
@@ -59,9 +60,10 @@ pub use reconnect::ReconnectManager;
 pub use seat_mutation_wire_guard::guard_seat_mutation;
 pub use session::{
     acting_player, acting_players, generate_game_code, generate_player_token, is_acting,
-    SessionManager,
+    BroadcastSnapshot, SessionManager,
 };
 pub use spectator_wire_guard::{
     guard_draft_spectator_capacity, guard_game_spectator_capacity, guard_spectate_draft,
     guard_spectator_join, MAX_DRAFT_SPECTATORS_PER_DRAFT, MAX_GAME_SPECTATORS_PER_GAME,
 };
+pub use takeback::{PendingTakeback, TakebackOutcome, MAX_TAKEBACK_HISTORY};

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 /// (clients see "Invalid message: unknown variant") rather than at the
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
-pub const PROTOCOL_VERSION: u32 = 7;
+pub const PROTOCOL_VERSION: u32 = 8;
 
 /// Minimum protocol version the server will accept at the hello handshake.
 /// Clients on `MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION` are admitted to the
@@ -243,6 +243,18 @@ pub enum ClientMessage {
     SpectateDraft {
         draft_code: String,
     },
+    /// GH #1507: ask every other human player at the table to approve
+    /// rolling the game back to the state immediately before the requester's
+    /// most recent action. Auto-approves when the requester is the only
+    /// human seat (e.g. solo vs. AI).
+    RequestTakeback,
+    /// Approve or decline the table's pending takeback request. Any single
+    /// decline withdraws the request — rollback requires unanimous approval.
+    RespondTakeback {
+        approve: bool,
+    },
+    /// Withdraw a takeback request the caller themselves made.
+    CancelTakeback,
 }
 
 fn default_player_count() -> u8 {
@@ -466,6 +478,26 @@ pub enum ServerMessage {
     },
     DraftSpectatorView {
         view: draft_core::view::SpectatorDraftView,
+    },
+    /// GH #1507: a human player has requested a takeback. Sent to every
+    /// connected seat (including the requester) so the UI can prompt the
+    /// other human players for approval.
+    TakebackRequested {
+        requester: PlayerId,
+        requester_name: String,
+    },
+    /// The pending takeback request has been resolved, either by unanimous
+    /// approval, a decline, or the requester cancelling it. When
+    /// `approved` is true, a `StateUpdate` carrying the rolled-back state
+    /// is sent to every seat immediately before this message.
+    TakebackResolved {
+        approved: bool,
+        /// The player whose response concluded the request: the decliner,
+        /// or the requester on self-cancel. `None` when every human seat
+        /// approved without a final distinguished responder (e.g. the
+        /// requester was the sole human seat).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resolved_by: Option<PlayerId>,
     },
 }
 
@@ -1788,7 +1820,87 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_7() {
-        assert_eq!(PROTOCOL_VERSION, 7);
+    fn protocol_version_is_8() {
+        assert_eq!(PROTOCOL_VERSION, 8);
+    }
+
+    #[test]
+    fn client_message_request_takeback_roundtrips() {
+        let msg = ClientMessage::RequestTakeback;
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, ClientMessage::RequestTakeback));
+    }
+
+    #[test]
+    fn client_message_respond_takeback_roundtrips() {
+        let msg = ClientMessage::RespondTakeback { approve: false };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ClientMessage::RespondTakeback { approve } => assert!(!approve),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn client_message_cancel_takeback_roundtrips() {
+        let msg = ClientMessage::CancelTakeback;
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, ClientMessage::CancelTakeback));
+    }
+
+    #[test]
+    fn server_message_takeback_requested_roundtrips() {
+        let msg = ServerMessage::TakebackRequested {
+            requester: PlayerId(1),
+            requester_name: "Alice".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ServerMessage::TakebackRequested {
+                requester,
+                requester_name,
+            } => {
+                assert_eq!(requester, PlayerId(1));
+                assert_eq!(requester_name, "Alice");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn server_message_takeback_resolved_roundtrips() {
+        let msg = ServerMessage::TakebackResolved {
+            approved: true,
+            resolved_by: Some(PlayerId(0)),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ServerMessage::TakebackResolved {
+                approved,
+                resolved_by,
+            } => {
+                assert!(approved);
+                assert_eq!(resolved_by, Some(PlayerId(0)));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn server_message_takeback_resolved_omits_resolved_by_when_none() {
+        let msg = ServerMessage::TakebackResolved {
+            approved: false,
+            resolved_by: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(
+            !json.contains("resolved_by"),
+            "None must be omitted: {json}"
+        );
     }
 }

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -141,9 +141,12 @@ pub struct GameSession {
     /// A "request takeback" awaiting unanimous human approval, if any. See
     /// `crate::takeback` for the GH #1507 multiplayer-safe undo flow.
     pub pending_takeback: Option<PendingTakeback>,
-    /// Rolling buffer of authoritative states immediately preceding each
-    /// state-mutating action, used to restore on an approved takeback.
-    pub takeback_history: VecDeque<GameState>,
+    /// Rolling buffer of (actor, state) pairs — the authoritative state
+    /// immediately preceding each state-mutating action, tagged with which
+    /// player took that action. Tagged by actor so a takeback request can
+    /// find the requester's *own* last action even when other players have
+    /// acted since (see `crate::takeback::GameSession::request_takeback`).
+    pub takeback_history: VecDeque<(PlayerId, GameState)>,
 }
 
 impl GameSession {
@@ -1075,7 +1078,7 @@ impl SessionManager {
         // the rules; players may arrange them as they choose. Hand reordering
         // has no game-rules consequence.
         if matches!(action, GameAction::ReorderHand { .. }) {
-            session.push_takeback_snapshot();
+            session.push_takeback_snapshot(player);
             let result = apply(&mut session.state, player, action).map_err(|e| {
                 warn!(game = %game_code, player = ?player, error = %e, reason = "engine_error", "action rejected");
                 format!("Engine error: {}", e)
@@ -1105,7 +1108,7 @@ impl SessionManager {
                 | GameAction::GrantDebugPermission { .. }
                 | GameAction::RevokeDebugPermission { .. }
         ) {
-            session.push_takeback_snapshot();
+            session.push_takeback_snapshot(player);
             let result = apply(&mut session.state, player, action).map_err(|e| {
                 warn!(game = %game_code, player = ?player, error = %e, reason = "engine_error", "action rejected");
                 format!("Engine error: {}", e)
@@ -1190,7 +1193,7 @@ impl SessionManager {
         // `player == authorized_submitter(state)`, so a spoofed action at the
         // wire is rejected inside the engine as well as here.
         let action_type = action.variant_name();
-        session.push_takeback_snapshot();
+        session.push_takeback_snapshot(player);
         let result = apply(&mut session.state, player, action).map_err(|e| {
             warn!(game = %game_code, player = ?player, error = %e, reason = "engine_error", "action rejected");
             format!("Engine error: {}", e)
@@ -1802,6 +1805,69 @@ mod tests {
         assert!(session.pending_takeback.is_none());
     }
 
+    /// Player A acts, then player B acts. A's takeback request must restore
+    /// the state to right before A's *own* action — not merely undo B's more
+    /// recent action while leaving A's action intact. Regression test for a
+    /// bug where `takeback_history` ignored which player produced each
+    /// checkpoint and always restored the single most recent global entry.
+    #[test]
+    fn takeback_restores_requesters_own_action_not_latest_global_action() {
+        let (mut mgr, code, token0, token1) = setup_two_player_game();
+
+        let priority_player = match &mgr.sessions.get(&code).unwrap().state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {:?}", other),
+        };
+        let (player_a, token_a, player_b, token_b) = if priority_player == PlayerId(0) {
+            (PlayerId(0), token0.clone(), PlayerId(1), token1.clone())
+        } else {
+            (PlayerId(1), token1.clone(), PlayerId(0), token0.clone())
+        };
+
+        let state_before_a = mgr.sessions.get(&code).unwrap().state.clone();
+
+        let result = mgr.handle_action(&code, &token_a, GameAction::PassPriority);
+        assert!(
+            result.is_ok(),
+            "A's PassPriority should succeed: {:?}",
+            result.err()
+        );
+        let state_after_a = mgr.sessions.get(&code).unwrap().state.clone();
+        assert_ne!(
+            state_after_a.waiting_for, state_before_a.waiting_for,
+            "sanity: A's action should have changed turn state"
+        );
+
+        let result = mgr.handle_action(&code, &token_b, GameAction::PassPriority);
+        assert!(
+            result.is_ok(),
+            "B's PassPriority should succeed: {:?}",
+            result.err()
+        );
+        let state_after_b = mgr.sessions.get(&code).unwrap().state.clone();
+        assert_ne!(
+            state_after_b.waiting_for, state_after_a.waiting_for,
+            "sanity: B's action should have changed turn state further"
+        );
+
+        // A requests a takeback — must target the checkpoint before A's own
+        // action, not the checkpoint before B's (more recent) action.
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        let outcome = session.request_takeback(player_a).unwrap();
+        assert_eq!(outcome, TakebackOutcome::Pending);
+        let outcome = session.respond_takeback(player_b, true).unwrap();
+        assert_eq!(outcome, TakebackOutcome::Approved);
+
+        assert_eq!(
+            session.state.waiting_for, state_before_a.waiting_for,
+            "takeback must restore to before the REQUESTER's own action"
+        );
+        assert_ne!(
+            session.state.waiting_for, state_after_a.waiting_for,
+            "must not merely undo only the other player's later action"
+        );
+    }
+
     /// A single decline withdraws the request and leaves state untouched.
     #[test]
     fn takeback_decline_leaves_state_untouched() {
@@ -1912,9 +1978,81 @@ mod tests {
         let session = mgr.sessions.get_mut(&code).unwrap();
         // Force a known checkpoint to take back to, since the AI may have
         // already acted past mulligans by the time the game starts.
-        session.push_takeback_snapshot();
+        session.push_takeback_snapshot(PlayerId(0));
         let outcome = session.request_takeback(PlayerId(0)).unwrap();
         assert_eq!(outcome, TakebackOutcome::Approved);
+    }
+
+    /// `pending_takeback_message` is what a reconnecting socket replays to
+    /// learn about an in-flight vote — `None` when nothing is pending, and
+    /// the requester's identity once a request exists.
+    #[test]
+    fn pending_takeback_message_reflects_request_state() {
+        let (mut mgr, code, token0, token1) = setup_two_player_game();
+        let priority_player = match &mgr.sessions.get(&code).unwrap().state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {:?}", other),
+        };
+        let acting_token = if priority_player == PlayerId(0) {
+            &token0
+        } else {
+            &token1
+        };
+
+        assert!(mgr
+            .sessions
+            .get(&code)
+            .unwrap()
+            .pending_takeback_message()
+            .is_none());
+
+        let _ = mgr.handle_action(&code, acting_token, GameAction::PassPriority);
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.request_takeback(priority_player).unwrap();
+
+        match session.pending_takeback_message() {
+            Some(crate::protocol::ServerMessage::TakebackRequested { requester, .. }) => {
+                assert_eq!(requester, priority_player);
+            }
+            other => panic!("expected TakebackRequested, got {:?}", other),
+        }
+    }
+
+    /// GH #1507 regression guard: a pending takeback request must survive a
+    /// disconnect/reconnect cycle so the reconnecting socket can still be
+    /// told about it (see `pending_takeback_message` and the phase-server
+    /// Reconnect handler that replays it).
+    #[test]
+    fn pending_takeback_survives_disconnect_and_reconnect() {
+        let (mut mgr, code, token0, token1) = setup_two_player_game();
+        let priority_player = match &mgr.sessions.get(&code).unwrap().state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {:?}", other),
+        };
+        let (acting_token, approver, approver_token) = if priority_player == PlayerId(0) {
+            (token0.clone(), PlayerId(1), token1.clone())
+        } else {
+            (token1.clone(), PlayerId(0), token0.clone())
+        };
+
+        let _ = mgr.handle_action(&code, &acting_token, GameAction::PassPriority);
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.request_takeback(priority_player).unwrap();
+
+        mgr.handle_disconnect(&code, approver);
+        let reconnected_state = mgr.handle_reconnect(&code, &approver_token);
+        assert!(
+            reconnected_state.is_ok(),
+            "reconnect should succeed: {:?}",
+            reconnected_state.err()
+        );
+
+        let session = mgr.sessions.get(&code).unwrap();
+        assert!(
+            session.pending_takeback.is_some(),
+            "the pending takeback must still be there for the reconnecting socket to be told about"
+        );
+        assert!(session.pending_takeback_message().is_some());
     }
 
     // ── Sandbox capability tests ─────────────────────────────────────────

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -508,8 +508,16 @@ impl GameSession {
     /// Each entry contains: raw state snapshot, events, legal actions, and log entries.
     /// The caller is responsible for filtering the state per-player before sending.
     /// Returns an empty vec if the session has no AI seats.
+    ///
+    /// GH #1507: also a no-op while a takeback request is pending. AI moves
+    /// mutate `self.state` directly (not through `handle_action`'s pending-
+    /// takeback guard), so without this check an AI seat could advance the
+    /// authoritative state — e.g. via a reconnecting human's follow-up AI
+    /// turn — out from under the snapshot the table is voting to roll back
+    /// to. Every call site (join-fills-the-room, reconnect, fresh AI-game
+    /// creation) is gated here once rather than at each caller.
     pub fn run_ai(&mut self) -> Vec<ActionResult> {
-        if self.ai_seats.is_empty() {
+        if self.ai_seats.is_empty() || self.pending_takeback.is_some() {
             return vec![];
         }
 
@@ -2053,6 +2061,63 @@ mod tests {
             "the pending takeback must still be there for the reconnecting socket to be told about"
         );
         assert!(session.pending_takeback_message().is_some());
+    }
+
+    /// GH #1507 follow-up: `run_ai` must not advance the authoritative state
+    /// while a takeback vote is pending — AI moves bypass `handle_action`'s
+    /// pending-takeback guard entirely (they mutate `self.state` directly),
+    /// so without an explicit check here a reconnecting human's follow-up AI
+    /// turn (or any other `run_ai` call site) could move the state out from
+    /// under the snapshot the table is voting to roll back to.
+    #[test]
+    fn run_ai_is_noop_while_takeback_is_pending() {
+        let mut mgr = SessionManager::new();
+        let (code, _token0) = mgr.create_game_n_players(
+            make_deck(),
+            "Host".to_string(),
+            None,
+            3,
+            MatchConfig::default(),
+            None,
+        );
+        let (_token1, _) = mgr.join_game(&code, make_deck()).unwrap();
+        let (_token2, _) = mgr.join_game(&code, make_deck()).unwrap();
+
+        // Retroactively mark seat 2 as AI-controlled (server-side bookkeeping
+        // only — the engine state itself has no notion of AI seats), and
+        // hand it a known legal action: an undecided mulligan. This is
+        // exactly the kind of action `run_ai` would otherwise resolve.
+        let ai_pid = PlayerId(2);
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.ai_seats.insert(ai_pid);
+        session.ai_configs.insert(
+            ai_pid,
+            phase_ai::config::create_config_for_players(AiDifficulty::Easy, Platform::Native, 3),
+        );
+        session.state.waiting_for = WaitingFor::MulliganDecision {
+            pending: vec![engine::types::game_state::MulliganDecisionEntry {
+                player: ai_pid,
+                mulligan_count: 0,
+            }],
+            free_first_mulligan: true,
+        };
+
+        // Player 0 requests a takeback; with two human seats (0 and 1) it
+        // stays Pending until player 1 also approves.
+        session.push_takeback_snapshot(PlayerId(0));
+        let outcome = session.request_takeback(PlayerId(0)).unwrap();
+        assert_eq!(outcome, TakebackOutcome::Pending);
+
+        let state_before = session.state.clone();
+        let ai_results = session.run_ai();
+        assert!(
+            ai_results.is_empty(),
+            "run_ai must no-op while a takeback vote is pending, even though the AI seat has a legal action"
+        );
+        assert_eq!(
+            session.state.waiting_for, state_before.waiting_for,
+            "authoritative state must not move while a takeback vote is pending"
+        );
     }
 
     // ── Sandbox capability tests ─────────────────────────────────────────

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -28,6 +28,7 @@ use crate::filter::filter_state_for_player;
 use crate::persist::{PersistedLobbyMeta, PersistedSession};
 use crate::protocol::PlayerSlotInfo;
 use crate::reconnect::ReconnectManager;
+use crate::takeback::PendingTakeback;
 
 /// Result of handling a game action: raw state snapshot, events, legal actions, log entries,
 /// auto-pass flag, spell costs, and per-object action grouping.
@@ -42,6 +43,17 @@ pub type ActionResult = (
     // Per-object grouping of legal actions, keyed by `GameAction::source_object()`.
     // Required by the frontend's `collectObjectActions(...)` lookup for card clicks;
     // dropping this field leaves guests unable to play lands or cast spells.
+    HashMap<ObjectId, Vec<GameAction>>,
+);
+
+/// Broadcast-ready fields for a state snapshot taken outside the normal
+/// `handle_action` flow (e.g. an approved takeback rollback): the raw state,
+/// legal actions, auto-pass flag, spell costs, and per-object action grouping.
+pub type BroadcastSnapshot = (
+    GameState,
+    Vec<GameAction>,
+    bool,
+    HashMap<ObjectId, ManaCost>,
     HashMap<ObjectId, Vec<GameAction>>,
 );
 
@@ -126,6 +138,12 @@ pub struct GameSession {
     /// late joiners and reconnects do not re-receive the contest. Empty when the
     /// game has not started or the events have already been broadcast.
     pub start_events: Vec<GameEvent>,
+    /// A "request takeback" awaiting unanimous human approval, if any. See
+    /// `crate::takeback` for the GH #1507 multiplayer-safe undo flow.
+    pub pending_takeback: Option<PendingTakeback>,
+    /// Rolling buffer of authoritative states immediately preceding each
+    /// state-mutating action, used to restore on an approved takeback.
+    pub takeback_history: VecDeque<GameState>,
 }
 
 impl GameSession {
@@ -526,6 +544,23 @@ impl GameSession {
             .collect()
     }
 
+    /// Recomputes the broadcast-ready fields (legal actions, auto-pass,
+    /// spell costs, per-object grouping) for the session's *current* state.
+    /// Used after any out-of-band mutation that doesn't go through
+    /// `handle_action` — e.g. an approved takeback rollback — so the
+    /// resulting `StateUpdate` carries data consistent with a normal action.
+    pub fn current_broadcast_snapshot(&self) -> BroadcastSnapshot {
+        let (legal_actions, spell_costs, by_object) = engine_legal_actions_full(&self.state);
+        let auto_pass = auto_pass_recommended(&self.state, &legal_actions);
+        (
+            self.state.clone(),
+            legal_actions,
+            auto_pass,
+            spell_costs,
+            by_object,
+        )
+    }
+
     /// Create a serializable snapshot of this session for disk persistence.
     pub fn to_persisted(&self) -> PersistedSession {
         let ai_difficulties = self
@@ -613,6 +648,8 @@ impl GameSession {
             start_when_full: ps.start_when_full,
             ranked: ps.ranked,
             start_events: Vec::new(),
+            pending_takeback: None,
+            takeback_history: VecDeque::new(),
         }
     }
 }
@@ -722,6 +759,8 @@ impl SessionManager {
             start_when_full: true,
             ranked: false,
             start_events: Vec::new(),
+            pending_takeback: None,
+            takeback_history: VecDeque::new(),
         };
 
         self.token_to_game
@@ -933,6 +972,18 @@ impl SessionManager {
             .player_for_token(player_token)
             .ok_or_else(|| "Invalid player token".to_string())?;
 
+        // GH #1507: while a takeback request is awaiting approval, the
+        // authoritative state must not move out from under it — a new
+        // action here would either invalidate the snapshot the table is
+        // voting on or silently discard the action once the rollback lands.
+        // Require the table to resolve (approve/decline/cancel) first.
+        if session.pending_takeback.is_some() {
+            return Err(
+                "A takeback request is pending — resolve it before taking further actions"
+                    .to_string(),
+            );
+        }
+
         // Sandbox capability gate. A `Debug(_)` is accepted only when the
         // session was created in sandbox mode AND the submitting player is in
         // the `debug_permitted` set. The set is host-managed via
@@ -1024,6 +1075,7 @@ impl SessionManager {
         // the rules; players may arrange them as they choose. Hand reordering
         // has no game-rules consequence.
         if matches!(action, GameAction::ReorderHand { .. }) {
+            session.push_takeback_snapshot();
             let result = apply(&mut session.state, player, action).map_err(|e| {
                 warn!(game = %game_code, player = ?player, error = %e, reason = "engine_error", "action rejected");
                 format!("Engine error: {}", e)
@@ -1053,6 +1105,7 @@ impl SessionManager {
                 | GameAction::GrantDebugPermission { .. }
                 | GameAction::RevokeDebugPermission { .. }
         ) {
+            session.push_takeback_snapshot();
             let result = apply(&mut session.state, player, action).map_err(|e| {
                 warn!(game = %game_code, player = ?player, error = %e, reason = "engine_error", "action rejected");
                 format!("Engine error: {}", e)
@@ -1137,6 +1190,7 @@ impl SessionManager {
         // `player == authorized_submitter(state)`, so a spoofed action at the
         // wire is rejected inside the engine as well as here.
         let action_type = action.variant_name();
+        session.push_takeback_snapshot();
         let result = apply(&mut session.state, player, action).map_err(|e| {
             warn!(game = %game_code, player = ?player, error = %e, reason = "engine_error", "action rejected");
             format!("Engine error: {}", e)
@@ -1699,6 +1753,170 @@ mod tests {
         );
     }
 
+    // ── Takeback tests (GH #1507) ────────────────────────────────────────
+
+    use crate::takeback::TakebackOutcome;
+
+    /// Two human players: a request stays `Pending` until the other player
+    /// approves, then the rolled-back state matches the pre-action snapshot.
+    #[test]
+    fn takeback_requires_unanimous_human_approval() {
+        let (mut mgr, code, token0, token1) = setup_two_player_game();
+
+        let priority_player = match &mgr.sessions.get(&code).unwrap().state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {:?}", other),
+        };
+        let (acting_token, other_player) = if priority_player == PlayerId(0) {
+            (token0.clone(), PlayerId(1))
+        } else {
+            (token1.clone(), PlayerId(0))
+        };
+
+        let state_before = mgr.sessions.get(&code).unwrap().state.clone();
+        let result = mgr.handle_action(&code, &acting_token, GameAction::PassPriority);
+        assert!(
+            result.is_ok(),
+            "PassPriority should succeed: {:?}",
+            result.err()
+        );
+        assert_ne!(
+            mgr.sessions.get(&code).unwrap().state.waiting_for,
+            state_before.waiting_for,
+            "sanity: the action should have actually changed turn state"
+        );
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        let outcome = session.request_takeback(priority_player).unwrap();
+        assert_eq!(outcome, TakebackOutcome::Pending);
+
+        // A second concurrent request is rejected — only one in flight at a time.
+        assert!(session.request_takeback(other_player).is_err());
+
+        let outcome = session.respond_takeback(other_player, true).unwrap();
+        assert_eq!(outcome, TakebackOutcome::Approved);
+        assert_eq!(
+            session.state.waiting_for, state_before.waiting_for,
+            "approved takeback should restore the pre-action waiting_for"
+        );
+        assert!(session.pending_takeback.is_none());
+    }
+
+    /// A single decline withdraws the request and leaves state untouched.
+    #[test]
+    fn takeback_decline_leaves_state_untouched() {
+        let (mut mgr, code, token0, token1) = setup_two_player_game();
+        let priority_player = match &mgr.sessions.get(&code).unwrap().state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {:?}", other),
+        };
+        let (acting_token, other_player) = if priority_player == PlayerId(0) {
+            (token0.clone(), PlayerId(1))
+        } else {
+            (token1.clone(), PlayerId(0))
+        };
+
+        let _ = mgr.handle_action(&code, &acting_token, GameAction::PassPriority);
+        let state_after_pass = mgr.sessions.get(&code).unwrap().state.clone();
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.request_takeback(priority_player).unwrap();
+        let outcome = session.respond_takeback(other_player, false).unwrap();
+        assert_eq!(outcome, TakebackOutcome::Rejected);
+        assert!(session.pending_takeback.is_none());
+        assert_eq!(session.state.waiting_for, state_after_pass.waiting_for);
+    }
+
+    /// The requester can withdraw their own request before anyone responds;
+    /// nobody else may cancel it.
+    #[test]
+    fn takeback_cancel_is_requester_only() {
+        let (mut mgr, code, token0, token1) = setup_two_player_game();
+        let priority_player = match &mgr.sessions.get(&code).unwrap().state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {:?}", other),
+        };
+        let (acting_token, other_player) = if priority_player == PlayerId(0) {
+            (token0.clone(), PlayerId(1))
+        } else {
+            (token1.clone(), PlayerId(0))
+        };
+
+        let _ = mgr.handle_action(&code, &acting_token, GameAction::PassPriority);
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.request_takeback(priority_player).unwrap();
+
+        assert!(session.cancel_takeback(other_player).is_err());
+        assert!(session.pending_takeback.is_some());
+
+        assert!(session.cancel_takeback(priority_player).is_ok());
+        assert!(session.pending_takeback.is_none());
+    }
+
+    /// With no prior action, there is nothing to take back.
+    #[test]
+    fn takeback_with_no_history_is_rejected() {
+        let (mut mgr, code, token0, _token1) = setup_two_player_game();
+        let _ = token0;
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        let player = match &session.state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {:?}", other),
+        };
+        assert!(session.request_takeback(player).is_err());
+    }
+
+    /// While a takeback request is pending, new actions are rejected so the
+    /// table can't race the vote.
+    #[test]
+    fn action_rejected_while_takeback_pending() {
+        let (mut mgr, code, token0, token1) = setup_two_player_game();
+        let priority_player = match &mgr.sessions.get(&code).unwrap().state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {:?}", other),
+        };
+        let (acting_token, other_token) = if priority_player == PlayerId(0) {
+            (token0.clone(), token1.clone())
+        } else {
+            (token1.clone(), token0.clone())
+        };
+
+        let _ = mgr.handle_action(&code, &acting_token, GameAction::PassPriority);
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.request_takeback(priority_player).unwrap();
+
+        let result = mgr.handle_action(&code, &other_token, GameAction::PassPriority);
+        assert!(
+            result.is_err(),
+            "action should be rejected while a takeback is pending"
+        );
+    }
+
+    /// A solo human vs. AI seats auto-resolves their own takeback request —
+    /// there's nobody else at the table to ask.
+    #[test]
+    fn takeback_auto_approves_for_sole_human_seat() {
+        let mut mgr = SessionManager::new();
+        let db = engine::database::CardDatabase::default();
+        let (code, _token) = mgr.create_game_with_ai(
+            make_deck(),
+            "Host".to_string(),
+            None,
+            MatchConfig::default(),
+            vec![(1, AiDifficulty::Easy, make_deck())],
+            Vec::new(),
+            None,
+            &db,
+        );
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        // Force a known checkpoint to take back to, since the AI may have
+        // already acted past mulligans by the time the game starts.
+        session.push_takeback_snapshot();
+        let outcome = session.request_takeback(PlayerId(0)).unwrap();
+        assert_eq!(outcome, TakebackOutcome::Approved);
+    }
+
     // ── Sandbox capability tests ─────────────────────────────────────────
 
     fn create_sandbox_game(mgr: &mut SessionManager) -> (String, String) {
@@ -1993,6 +2211,8 @@ mod tests {
             start_when_full: true,
             ranked: false,
             start_events: Vec::new(),
+            pending_takeback: None,
+            takeback_history: VecDeque::new(),
         };
 
         let game_started_before = session.game_started;

--- a/crates/server-core/src/takeback.rs
+++ b/crates/server-core/src/takeback.rs
@@ -17,7 +17,7 @@
 //! told why it was handed an older `GameState`; it just continues from
 //! whatever state it's given, exactly as it does on reconnect/restore.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::HashSet;
 
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
@@ -60,13 +60,18 @@ pub enum TakebackOutcome {
 
 impl GameSession {
     /// Records the current authoritative state as a takeback checkpoint,
-    /// to be called immediately before a state-mutating action is applied.
-    /// Caps retention at [`MAX_TAKEBACK_HISTORY`] (oldest dropped first).
-    pub fn push_takeback_snapshot(&mut self) {
+    /// tagged with the player about to act — to be called immediately
+    /// before that player's action is applied. Caps retention at
+    /// [`MAX_TAKEBACK_HISTORY`] (oldest dropped first).
+    ///
+    /// Tagging by actor (rather than just "most recent action") is what lets
+    /// `request_takeback` find *this player's* last action even when other
+    /// players have acted since — see its doc comment.
+    pub fn push_takeback_snapshot(&mut self, actor: PlayerId) {
         if self.takeback_history.len() >= MAX_TAKEBACK_HISTORY {
             self.takeback_history.pop_front();
         }
-        self.takeback_history.push_back(self.state.clone());
+        self.takeback_history.push_back((actor, self.state.clone()));
     }
 
     /// Human (non-AI) seats in this session, in seat order. AI seats never
@@ -97,9 +102,15 @@ impl GameSession {
     }
 
     /// A human player requests rolling the game back to the state just
-    /// before their most recent action. Auto-resolves to `Approved`
-    /// immediately when the requester is the only human at the table
-    /// (e.g. solo vs. AI) since there is nobody else to ask.
+    /// before *their own* most recent action — not simply the most recent
+    /// action by anyone. Other players may have acted since; rolling back
+    /// to before the requester's action necessarily discards those later
+    /// actions too (there is no way to keep them while undoing an earlier
+    /// action they were built on), but it must never target a snapshot that
+    /// precedes a different player's action while leaving the requester's
+    /// own action untouched. Auto-resolves to `Approved` immediately when
+    /// the requester is the only human at the table (e.g. solo vs. AI)
+    /// since there is nobody else to ask.
     pub fn request_takeback(&mut self, player: PlayerId) -> Result<TakebackOutcome, String> {
         if self.pending_takeback.is_some() {
             return Err("A takeback request is already pending for this game".to_string());
@@ -109,9 +120,11 @@ impl GameSession {
         }
         let target_state = self
             .takeback_history
-            .back()
-            .cloned()
-            .ok_or_else(|| "There is no previous action to take back".to_string())?;
+            .iter()
+            .rev()
+            .find(|(actor, _)| *actor == player)
+            .map(|(_, state)| state.clone())
+            .ok_or_else(|| "There is no previous action of yours to take back".to_string())?;
 
         let mut approvals = HashSet::new();
         approvals.insert(player);
@@ -164,10 +177,23 @@ impl GameSession {
             None => Err("There is no pending takeback request".to_string()),
         }
     }
-}
 
-/// Empty history/no pending request — the value every freshly constructed
-/// `GameSession` starts with.
-pub fn fresh_takeback_state() -> (Option<PendingTakeback>, VecDeque<GameState>) {
-    (None, VecDeque::new())
+    /// The `TakebackRequested` notification for the current pending request,
+    /// if any. Used both for the original broadcast when a request goes out
+    /// and to replay the same prompt to a socket that (re)connects while the
+    /// vote is still in flight — otherwise a disconnected approver comes
+    /// back with no way to respond, and `handle_action` rejects all actions
+    /// while a request is pending, stalling the table.
+    pub fn pending_takeback_message(&self) -> Option<crate::protocol::ServerMessage> {
+        let pending = self.pending_takeback.as_ref()?;
+        let requester_name = self
+            .display_names
+            .get(pending.requested_by.0 as usize)
+            .cloned()
+            .unwrap_or_default();
+        Some(crate::protocol::ServerMessage::TakebackRequested {
+            requester: pending.requested_by,
+            requester_name,
+        })
+    }
 }

--- a/crates/server-core/src/takeback.rs
+++ b/crates/server-core/src/takeback.rs
@@ -1,0 +1,173 @@
+//! "Request takeback" — multiplayer-safe undo (GH #1507).
+//!
+//! Single-player/local undo (`engine-wasm::restore_game_state`) replaces the
+//! client's own state wholesale and is refused outright in multiplayer
+//! sessions, because no client may unilaterally rewrite the authoritative
+//! server state another player is relying on. This module gives multiplayer
+//! sessions an equivalent escape hatch for misclicks and UI confusion,
+//! without ever letting one player rewrite history unilaterally: a player
+//! may request to roll the *authoritative* session state back to the
+//! snapshot taken just before their most recent action, but the rollback
+//! only takes effect once every human seat at the table (the requester
+//! included) has approved it. Any single human decline cancels the request
+//! and the authoritative state is left untouched.
+//!
+//! This is intentionally a session/room-level concern, not an engine rule —
+//! there is no Comprehensive Rules concept of "undo." The engine is never
+//! told why it was handed an older `GameState`; it just continues from
+//! whatever state it's given, exactly as it does on reconnect/restore.
+
+use std::collections::{HashSet, VecDeque};
+
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use crate::session::GameSession;
+
+/// How many prior authoritative snapshots a session retains for takeback
+/// purposes. Bounded so a long game session can't accumulate unbounded
+/// memory — a takeback can only reach back to the most recent action, so
+/// anything beyond a handful of entries is never reachable anyway.
+pub const MAX_TAKEBACK_HISTORY: usize = 12;
+
+/// A takeback request awaiting unanimous human approval.
+#[derive(Debug, Clone)]
+pub struct PendingTakeback {
+    /// The player who asked for the takeback. Implicitly counted as having
+    /// approved their own request.
+    pub requested_by: PlayerId,
+    /// The authoritative state to restore if every human seat approves —
+    /// the snapshot taken immediately before the requester's last
+    /// state-mutating action.
+    pub target_state: GameState,
+    /// Human seats that have approved so far. The request resolves the
+    /// instant this set contains every human seat in the session.
+    pub approvals: HashSet<PlayerId>,
+}
+
+/// Outcome of requesting or responding to a takeback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TakebackOutcome {
+    /// Still waiting on one or more human players to respond.
+    Pending,
+    /// Every human seat approved — the session state has already been
+    /// rolled back to the target snapshot by the time this is returned.
+    Approved,
+    /// A human player declined — the request was withdrawn and the
+    /// authoritative state is unchanged.
+    Rejected,
+}
+
+impl GameSession {
+    /// Records the current authoritative state as a takeback checkpoint,
+    /// to be called immediately before a state-mutating action is applied.
+    /// Caps retention at [`MAX_TAKEBACK_HISTORY`] (oldest dropped first).
+    pub fn push_takeback_snapshot(&mut self) {
+        if self.takeback_history.len() >= MAX_TAKEBACK_HISTORY {
+            self.takeback_history.pop_front();
+        }
+        self.takeback_history.push_back(self.state.clone());
+    }
+
+    /// Human (non-AI) seats in this session, in seat order. AI seats never
+    /// request, approve, or block a takeback — they have no UI to misclick.
+    pub fn human_seats(&self) -> Vec<PlayerId> {
+        (0..self.player_count)
+            .map(PlayerId)
+            .filter(|p| !self.ai_seats.contains(p))
+            .collect()
+    }
+
+    /// Resolves the pending request if every human seat has now approved,
+    /// applying the rollback in place. Returns `None` if still pending.
+    fn try_resolve_pending_takeback(&mut self) -> Option<TakebackOutcome> {
+        let pending = self.pending_takeback.as_ref()?;
+        let humans = self.human_seats();
+        if !humans.iter().all(|p| pending.approvals.contains(p)) {
+            return None;
+        }
+        let pending = self.pending_takeback.take().expect("checked above");
+        self.state = pending.target_state;
+        // The rolled-back state is the new baseline; snapshots from the
+        // branch we just discarded no longer correspond to reachable
+        // history, and taking another takeback back through them would
+        // resurrect actions the table just agreed to undo.
+        self.takeback_history.clear();
+        Some(TakebackOutcome::Approved)
+    }
+
+    /// A human player requests rolling the game back to the state just
+    /// before their most recent action. Auto-resolves to `Approved`
+    /// immediately when the requester is the only human at the table
+    /// (e.g. solo vs. AI) since there is nobody else to ask.
+    pub fn request_takeback(&mut self, player: PlayerId) -> Result<TakebackOutcome, String> {
+        if self.pending_takeback.is_some() {
+            return Err("A takeback request is already pending for this game".to_string());
+        }
+        if !self.human_seats().contains(&player) {
+            return Err("Only human players may request a takeback".to_string());
+        }
+        let target_state = self
+            .takeback_history
+            .back()
+            .cloned()
+            .ok_or_else(|| "There is no previous action to take back".to_string())?;
+
+        let mut approvals = HashSet::new();
+        approvals.insert(player);
+        self.pending_takeback = Some(PendingTakeback {
+            requested_by: player,
+            target_state,
+            approvals,
+        });
+
+        Ok(self
+            .try_resolve_pending_takeback()
+            .unwrap_or(TakebackOutcome::Pending))
+    }
+
+    /// A human player approves or declines the pending takeback request.
+    /// A single decline withdraws the request outright (unanimity required).
+    pub fn respond_takeback(
+        &mut self,
+        player: PlayerId,
+        approve: bool,
+    ) -> Result<TakebackOutcome, String> {
+        if self.pending_takeback.is_none() {
+            return Err("There is no pending takeback request".to_string());
+        }
+        if !self.human_seats().contains(&player) {
+            return Err("Only human players may respond to a takeback request".to_string());
+        }
+
+        if !approve {
+            self.pending_takeback = None;
+            return Ok(TakebackOutcome::Rejected);
+        }
+
+        if let Some(pending) = self.pending_takeback.as_mut() {
+            pending.approvals.insert(player);
+        }
+        Ok(self
+            .try_resolve_pending_takeback()
+            .unwrap_or(TakebackOutcome::Pending))
+    }
+
+    /// The original requester withdraws their own pending takeback request.
+    pub fn cancel_takeback(&mut self, player: PlayerId) -> Result<(), String> {
+        match &self.pending_takeback {
+            Some(pending) if pending.requested_by == player => {
+                self.pending_takeback = None;
+                Ok(())
+            }
+            Some(_) => Err("Only the player who requested the takeback may cancel it".to_string()),
+            None => Err("There is no pending takeback request".to_string()),
+        }
+    }
+}
+
+/// Empty history/no pending request — the value every freshly constructed
+/// `GameSession` starts with.
+pub fn fresh_takeback_state() -> (Option<PendingTakeback>, VecDeque<GameState>) {
+    (None, VecDeque::new())
+}


### PR DESCRIPTION
## Summary
- Implements GH #1507: a "request takeback" flow for multiplayer games — a player can ask to roll the game back to right before their last action, but it only takes effect once every other human seat approves. A single decline cancels it; a solo human vs. AI auto-approves.
- Server-authoritative: rollback happens on the session's real `GameState`, not a client-side replace, so it stays correct across all connected seats (unlike the existing single-player undo, which is explicitly disabled in multiplayer).
- New protocol messages (`RequestTakeback` / `RespondTakeback` / `CancelTakeback` / `TakebackRequested` / `TakebackResolved`), protocol version bumped 7 → 8.
- Frontend: new `TakebackRequestDialog`, a "Request Takeback" menu entry (online games only), and adapter wiring in `ws-adapter.ts`.
Closes #1507 

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p server-core -p phase-server --all-targets -- -D warnings`
- [x] `cargo test -p server-core -p phase-server` (219 + 63 + protocol/contract tests, including 12 new takeback-specific tests)
- [x] `pnpm run type-check` / `eslint` on touched frontend files
- [x] `vitest run` (167 files / 1410 tests, including i18n locale-parity across all 7 locales)
- [ ] Manual multiplayer smoke test (2+ human browser sessions: request → approve/decline/cancel → verify rollback and resumed play)

