### PR TITLE
fix: redact Hideaway/Foretell face-down exile from unauthorized viewers

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -810,6 +810,12 @@ export interface GameObject {
     color: ManaColor[];
     printed_ref?: PrintedRef | null;
   } | null;
+  /**
+   * CR 702.143c-d: Whether this card in exile is foretold. Its owner may look
+   * at it (and cast it on a later turn) even though `face_down` is true.
+   * Cleared when the card leaves exile (a zone change creates a new object).
+   */
+  foretold?: boolean;
 }
 
 export interface PrintedRef {
@@ -1866,6 +1872,23 @@ export interface EpicEffect {
 /** CR 731: the day/night designation, absent when neither is in effect. */
 export type DayNight = "Day" | "Night";
 
+/**
+ * Mirrors engine `ExileLinkKind` (`crates/engine/src/types/game_state.rs`).
+ * Unit variants serialize as bare strings; the two struct variants serialize
+ * as a single-key object under serde's default external tagging. Only
+ * `HideawayLookable` is currently read on the client (the exile-visibility
+ * gate in `viewmodel/gameStateView.ts`) — the rest are kept so `exile_links`
+ * round-trips the full wire shape rather than widening it to `unknown`.
+ */
+export type ExileLinkKind =
+  | "TrackedBySource"
+  | "Cipher"
+  | "Haunt"
+  | "HideawayLookable"
+  | "CraftMaterial"
+  | { UntilSourceLeaves: { return_zone: Zone } }
+  | { ParadigmSource: { player: PlayerId } };
+
 export interface GameState {
   turn_number: number;
   active_player: PlayerId;
@@ -1938,7 +1961,7 @@ export interface GameState {
   ring_level?: Record<string, number>;
   ring_bearer?: Record<string, ObjectId | null>;
   commander_damage?: CommanderDamageEntry[];
-  exile_links?: Array<{ exiled_id: ObjectId; source_id: ObjectId }>;
+  exile_links?: Array<{ exiled_id: ObjectId; source_id: ObjectId; kind?: ExileLinkKind }>;
   match_config?: MatchConfig;
   match_phase?: MatchPhase;
   match_score?: MatchScore;

--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -15,6 +15,7 @@ import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
 import {
   getPlayerZoneIds,
   getWaitingForObjectChoiceIds,
+  isFaceDownExileCardVisibleToViewer,
   isLibraryCardRevealedToViewer,
 } from "../../viewmodel/gameStateView.ts";
 import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
@@ -156,13 +157,26 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
                 ? playOrCastActionsForObject(legalActionsByObject, obj.id)
                 : [];
               const isValidTarget = currentLegalTargets.has(obj.id);
+              // CR 406.3 + CR 702.75a + CR 702.143e: a face-down card sitting
+              // in the shared exile pile (Hideaway, Foretell) carries its real
+              // name/printed_ref in the raw single-player state regardless of
+              // viewer — `isFaceDownExileCardVisibleToViewer` is the client
+              // half of the engine's look-permission gate, so an opponent's
+              // hidden exile renders as a face-down placeholder instead of
+              // leaking its identity.
+              const isHiddenFromViewer =
+                zone === "exile" && obj.face_down && !isFaceDownExileCardVisibleToViewer(gameState, obj, viewerId);
               return (
                 <ZoneCard
                   key={obj.id}
                   obj={obj}
                   isValidTarget={isValidTarget}
                   canCast={castActions.length > 0}
-                  castTitle={t("zone.castFromZone", { zone: zoneLabel, name: obj.name })}
+                  castTitle={t("zone.castFromZone", {
+                    zone: zoneLabel,
+                    name: isHiddenFromViewer ? t("card.faceDownName") : obj.name,
+                  })}
+                  hiddenFromViewer={isHiddenFromViewer}
                   onTarget={() => dispatchAction({ type: "ChooseTarget", data: { target: { Object: obj.id } } })}
                   onCast={() => handleCast(obj, castActions)}
                 />
@@ -180,6 +194,7 @@ function ZoneCard({
   isValidTarget,
   canCast,
   castTitle,
+  hiddenFromViewer,
   onTarget,
   onCast,
 }: {
@@ -187,6 +202,7 @@ function ZoneCard({
   isValidTarget: boolean;
   canCast: boolean;
   castTitle: string;
+  hiddenFromViewer: boolean;
   onTarget: () => void;
   onCast: () => void;
 }) {
@@ -230,8 +246,13 @@ function ZoneCard({
           DFC / transformed / back-face cards (e.g. a transformed planeswalker),
           which then falls back to the broken-image div. In the zone strip that
           fallback is sized up to ~560px, so a failed image rendered "huge" with
-          text instead of art. */}
-      <CardImage {...objectImageProps(obj)} size="normal" />
+          text instead of art. `faceDown` overrides all of that with the shared
+          card-back placeholder (CardImage.tsx) whenever this viewer has no
+          look-permission on a face-down exile (see `hiddenFromViewer` above) —
+          it must NOT be the raw `obj.face_down`, which is also true for the
+          legitimate Hideaway/Foretell controller who the engine intends to
+          let see the real card. */}
+      <CardImage {...objectImageProps(obj)} size="normal" faceDown={hiddenFromViewer} />
       {canCast && !isValidTarget && (
         <>
           {/* Arena-style purple "playable" affordance — same treatment as the

--- a/client/src/components/zone/__tests__/issue_2889_hideaway_exile_visibility.test.tsx
+++ b/client/src/components/zone/__tests__/issue_2889_hideaway_exile_visibility.test.tsx
@@ -1,10 +1,26 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GameObject, GameState } from "../../../adapter/types.ts";
 import { useGameStore } from "../../../stores/gameStore.ts";
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
 import { useUiStore } from "../../../stores/uiStore.ts";
+import { GameCardPreview } from "../../card/GameCardPreview.tsx";
 import { ZoneViewer } from "../ZoneViewer.tsx";
+
+// The hover/long-press preview (GameCardPreview -> CardPreview) reads the raw
+// object from the store independently of ZoneViewer's redacted strip — it has
+// its own `useCardImage`/engine-data fetches, mocked here the same way
+// GameCardPreview.test.tsx does, so the integration test below can render it
+// alongside ZoneViewer and simulate a real hover.
+vi.mock("../../../hooks/useCardImage.ts", () => ({
+  useCardImage: () => ({ src: "card.png", isLoading: false, isRotated: false, isFlip: false }),
+}));
+vi.mock("../../../hooks/useEngineCardData.ts", () => ({
+  useEngineCardData: () => null,
+  useCardParseDetails: () => null,
+  useCardRulings: () => [],
+}));
 
 // Issue #2889: a Hideaway permanent exiles a card face down (CR 702.75a). The
 // engine's per-viewer `filter_state_for_viewer` already redacts this card on
@@ -130,6 +146,19 @@ describe("ZoneViewer exile face-down visibility (issue #2889)", () => {
       pendingAbilityChoice: null,
       debugInteractionMode: false,
     });
+    // Desktop hover path: `useInspectHoverProps` gates onMouseEnter on
+    // `useCanHover` (any-hover media query) and `useIsMobile` (jsdom's default
+    // 1024px innerWidth already reads as non-mobile).
+    window.matchMedia = ((query: string) => ({
+      matches: query === "(any-hover: hover)",
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
   });
 
   afterEach(() => {
@@ -289,5 +318,69 @@ describe("ZoneViewer exile face-down visibility (issue #2889)", () => {
 
     expect(screen.getByTestId("card-image").getAttribute("data-face-down")).toBe("false");
     expect(screen.getByLabelText("Alrund's Epiphany")).toBeInTheDocument();
+  });
+
+  it("does not leak the real card via hover/long-press preview either", () => {
+    // The strip thumbnail is only half the surface: ZoneCard still wires
+    // `hoverProps(obj.id)` (mouseenter on desktop, long-press on touch) to
+    // `inspectObject`, and GameCardPreview resolves that id straight from the
+    // RAW, unredacted `gameState.objects` — independent of the redacted strip
+    // image above. It stays safe because `GameCardPreview` nulls the derived
+    // `cardName` whenever `obj.face_down` is true (regardless of viewer, the
+    // same fail-closed rule CR 708.5 already applies to a face-down battlefield
+    // permanent — see GameCardPreview.test.tsx's "never previews a face-down
+    // permanent" case), and `CardPreview` renders nothing at all when
+    // `cardName` is null. This test exercises that path end-to-end through a
+    // real hover instead of relying on the unit test alone.
+    const source = makeObject({
+      id: 1,
+      owner: 1,
+      controller: 1,
+      zone: "Battlefield",
+      name: "Windbrisk Heights",
+    });
+    const hidden = makeObject({
+      id: 2,
+      owner: 1,
+      controller: 1,
+      zone: "Exile",
+      name: "Ghalta, Primal Hunter",
+      face_down: true,
+      printed_ref: { oracle_id: "ghalta-oracle", face_name: "Ghalta, Primal Hunter" },
+    });
+    const gameState = makeState(
+      [source, hidden],
+      [{ exiled_id: 2, source_id: 1, kind: "HideawayLookable" }],
+    );
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [],
+      legalActionsByObject: {},
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+    usePreferencesStore.setState({ cardPreviewMode: "follow" });
+
+    render(
+      <>
+        <ZoneViewer zone="exile" playerId={1} onClose={vi.fn()} />
+        <GameCardPreview />
+      </>,
+    );
+
+    const cardImage = screen.getByTestId("card-image");
+    const hoverTarget = cardImage.parentElement as HTMLElement;
+    fireEvent.mouseEnter(hoverTarget);
+
+    // The hover did wire up — `inspectObject` ran — but the preview must
+    // render nothing for a face-down card with no look-permission.
+    expect(useUiStore.getState().inspectedObjectId).toBe(hidden.id);
+    expect(screen.queryByAltText("Ghalta, Primal Hunter")).not.toBeInTheDocument();
+    expect(document.querySelector("[data-card-preview]")).toBeNull();
+
+    fireEvent.mouseLeave(hoverTarget);
   });
 });

--- a/client/src/components/zone/__tests__/issue_2889_hideaway_exile_visibility.test.tsx
+++ b/client/src/components/zone/__tests__/issue_2889_hideaway_exile_visibility.test.tsx
@@ -1,0 +1,293 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameObject, GameState } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { ZoneViewer } from "../ZoneViewer.tsx";
+
+// Issue #2889: a Hideaway permanent exiles a card face down (CR 702.75a). The
+// engine's per-viewer `filter_state_for_viewer` already redacts this card on
+// the network path, but single-player renders the raw, unredacted state
+// directly — so the real `name`/`printed_ref` sit on the object regardless of
+// who's looking. Before this fix, `ZoneViewer`'s exile pile rendered that raw
+// object straight through `objectImageProps`, leaking an opponent's hidden
+// card's name and art the moment the Exile zone was opened. The mock below
+// surfaces the `faceDown` prop CardImage receives so these tests can assert
+// the placeholder path is taken instead of a real card-art lookup.
+vi.mock("../../card/CardImage.tsx", () => ({
+  // Mirrors the real CardImage.tsx: when `faceDown` is set, the card's own
+  // `cardName`/`oracleId` are ignored entirely in favor of the shared
+  // card-back placeholder — that's the behavior under test, so the mock must
+  // reproduce it rather than simply echoing whatever props it received.
+  CardImage: ({
+    cardName,
+    oracleId,
+    faceDown,
+  }: {
+    cardName: string;
+    oracleId?: string;
+    faceDown?: boolean;
+  }) => (
+    <div
+      aria-label={faceDown ? "Face-down card" : cardName}
+      data-testid="card-image"
+      data-oracle-id={faceDown ? "" : oracleId ?? ""}
+      data-face-down={String(!!faceDown)}
+    />
+  ),
+}));
+
+function makeObject(overrides: Partial<GameObject> = {}): GameObject {
+  return {
+    id: 7,
+    card_id: 700,
+    owner: 0,
+    controller: 0,
+    zone: "Exile",
+    tapped: false,
+    face_down: false,
+    flipped: false,
+    transformed: false,
+    damage_marked: 0,
+    dealt_deathtouch_damage: false,
+    attached_to: null,
+    attachments: [],
+    counters: {},
+    name: "Placeholder",
+    power: null,
+    toughness: null,
+    loyalty: null,
+    card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+    mana_cost: { type: "Cost", shards: [], generic: 0 },
+    keywords: [],
+    abilities: [],
+    trigger_definitions: [],
+    replacement_definitions: [],
+    static_definitions: [],
+    color: [],
+    base_power: null,
+    base_toughness: null,
+    base_keywords: [],
+    base_color: [],
+    timestamp: 1,
+    entered_battlefield_turn: null,
+    ...overrides,
+  };
+}
+
+function makeState(
+  objects: GameObject[],
+  exileLinks: NonNullable<GameState["exile_links"]> = [],
+): GameState {
+  return {
+    active_player: 0,
+    priority_player: 0,
+    players: [
+      {
+        id: 0,
+        life: 20,
+        poison_counters: 0,
+        mana_pool: { mana: [] },
+        library: [],
+        hand: [],
+        graveyard: [],
+        has_drawn_this_turn: false,
+        lands_played_this_turn: 0,
+        turns_taken: 0,
+      },
+      {
+        id: 1,
+        life: 20,
+        poison_counters: 0,
+        mana_pool: { mana: [] },
+        library: [],
+        hand: [],
+        graveyard: [],
+        has_drawn_this_turn: false,
+        lands_played_this_turn: 0,
+        turns_taken: 0,
+      },
+    ],
+    objects: Object.fromEntries(objects.map((o) => [o.id, o])),
+    battlefield: objects.filter((o) => o.zone === "Battlefield").map((o) => o.id),
+    exile: objects.filter((o) => o.zone === "Exile").map((o) => o.id),
+    stack: [],
+    combat: null,
+    exile_links: exileLinks,
+    waiting_for: { type: "Priority", data: { player: 0 } },
+  } as unknown as GameState;
+}
+
+describe("ZoneViewer exile face-down visibility (issue #2889)", () => {
+  const dispatch = vi.fn(async () => []);
+
+  beforeEach(() => {
+    dispatch.mockClear();
+    useUiStore.setState({
+      inspectedObjectId: null,
+      previewSticky: false,
+      pendingAbilityChoice: null,
+      debugInteractionMode: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("hides an opponent's Hideaway-exiled card from a viewer with no look-permission", () => {
+    // CR 702.75a: the permanent's controller (player 1) may look; the viewer
+    // (player 0, the default single-player viewer) is the opponent and must
+    // not see the real card.
+    const source = makeObject({
+      id: 1,
+      owner: 1,
+      controller: 1,
+      zone: "Battlefield",
+      name: "Windbrisk Heights",
+    });
+    const hidden = makeObject({
+      id: 2,
+      owner: 1,
+      controller: 1,
+      zone: "Exile",
+      name: "Ghalta, Primal Hunter",
+      face_down: true,
+      printed_ref: { oracle_id: "ghalta-oracle", face_name: "Ghalta, Primal Hunter" },
+    });
+    const gameState = makeState(
+      [source, hidden],
+      [{ exiled_id: 2, source_id: 1, kind: "HideawayLookable" }],
+    );
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [],
+      legalActionsByObject: {},
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="exile" playerId={1} onClose={vi.fn()} />);
+
+    const image = screen.getByTestId("card-image");
+    expect(image.getAttribute("data-face-down")).toBe("true");
+    expect(image.getAttribute("data-oracle-id")).toBe("");
+    expect(screen.queryByLabelText("Ghalta, Primal Hunter")).not.toBeInTheDocument();
+  });
+
+  it("reveals the real card to the controller of the Hideaway permanent that exiled it", () => {
+    const source = makeObject({
+      id: 1,
+      owner: 0,
+      controller: 0,
+      zone: "Battlefield",
+      name: "Windbrisk Heights",
+    });
+    const hidden = makeObject({
+      id: 2,
+      owner: 0,
+      controller: 0,
+      zone: "Exile",
+      name: "Ghalta, Primal Hunter",
+      face_down: true,
+      printed_ref: { oracle_id: "ghalta-oracle", face_name: "Ghalta, Primal Hunter" },
+    });
+    const gameState = makeState(
+      [source, hidden],
+      [{ exiled_id: 2, source_id: 1, kind: "HideawayLookable" }],
+    );
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [],
+      legalActionsByObject: {},
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="exile" playerId={0} onClose={vi.fn()} />);
+
+    const image = screen.getByTestId("card-image");
+    expect(image.getAttribute("data-face-down")).toBe("false");
+    expect(image.getAttribute("data-oracle-id")).toBe("ghalta-oracle");
+    expect(screen.getByLabelText("Ghalta, Primal Hunter")).toBeInTheDocument();
+  });
+
+  it("keeps a plain TrackedBySource face-down exile hidden even from the exiling permanent's controller", () => {
+    // Regression guard mirroring crates/engine/src/database/hideaway_tests.rs's
+    // `tracked_by_source_face_down_exile_stays_hidden_from_controller`: a
+    // Bomat-Courier-style link grants no look-permission, so even the
+    // exiling permanent's own controller must see a face-down placeholder.
+    const source = makeObject({
+      id: 1,
+      owner: 0,
+      controller: 0,
+      zone: "Battlefield",
+      name: "Bomat Courier",
+    });
+    const hidden = makeObject({
+      id: 2,
+      owner: 0,
+      controller: 0,
+      zone: "Exile",
+      name: "Secret Card",
+      face_down: true,
+    });
+    const gameState = makeState(
+      [source, hidden],
+      [{ exiled_id: 2, source_id: 1, kind: "TrackedBySource" }],
+    );
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [],
+      legalActionsByObject: {},
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="exile" playerId={0} onClose={vi.fn()} />);
+
+    const image = screen.getByTestId("card-image");
+    expect(image.getAttribute("data-face-down")).toBe("true");
+    expect(screen.queryByLabelText("Secret Card")).not.toBeInTheDocument();
+  });
+
+  it("reveals a foretold card to its owner but hides it from an opponent", () => {
+    // CR 702.143e: a foretold card's owner may look at it.
+    const ownForetold = makeObject({
+      id: 3,
+      owner: 0,
+      controller: 0,
+      zone: "Exile",
+      name: "Alrund's Epiphany",
+      face_down: true,
+      foretold: true,
+      printed_ref: { oracle_id: "epiphany-oracle", face_name: "Alrund's Epiphany" },
+    });
+    const gameState = makeState([ownForetold]);
+
+    useGameStore.setState({
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [],
+      legalActionsByObject: {},
+      spellCosts: {},
+      dispatch,
+      gameMode: "ai",
+    });
+
+    render(<ZoneViewer zone="exile" playerId={0} onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("card-image").getAttribute("data-face-down")).toBe("false");
+    expect(screen.getByLabelText("Alrund's Epiphany")).toBeInTheDocument();
+  });
+});

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -6,6 +6,7 @@ import {
   getOpponentIds,
   getSeatCount,
   getWaitingForObjectChoiceIds,
+  isFaceDownExileCardVisibleToViewer,
   isOneOnOne,
 } from "../gameStateView";
 
@@ -233,5 +234,101 @@ describe("getOpponentIds", () => {
     // guards against — `opponents[0]` is undefined here, and the layout
     // must not index `gameState.players[undefined]`.
     expect(getOpponentIds(makeState([0, 1], [1]), 0)).toEqual([]);
+  });
+});
+
+// Issue #2889: single-player renders the raw, unredacted state, so a
+// Hideaway/Foretell face-down exile's real `name`/`printed_ref` sit on the
+// object regardless of viewer. This helper is the client-side half of the
+// engine's `hidden_facedown_exile_ids` look-permission gate
+// (crates/engine/src/game/visibility.rs, CR 406.3 + CR 702.75a + CR 702.143e).
+describe("isFaceDownExileCardVisibleToViewer", () => {
+  function faceDownObject(overrides: Partial<GameObject> = {}): GameObject {
+    return {
+      id: 2,
+      card_id: 200,
+      owner: 1,
+      controller: 1,
+      zone: "Exile",
+      tapped: false,
+      face_down: true,
+      flipped: false,
+      transformed: false,
+      damage_marked: 0,
+      dealt_deathtouch_damage: false,
+      attached_to: null,
+      attachments: [],
+      counters: {},
+      name: "Ghalta, Primal Hunter",
+      power: null,
+      toughness: null,
+      loyalty: null,
+      card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+      mana_cost: { type: "Cost", shards: [], generic: 0 },
+      keywords: [],
+      abilities: [],
+      trigger_definitions: [],
+      replacement_definitions: [],
+      static_definitions: [],
+      color: [],
+      base_power: null,
+      base_toughness: null,
+      base_keywords: [],
+      base_color: [],
+      timestamp: 1,
+      entered_battlefield_turn: null,
+      ...overrides,
+    };
+  }
+
+  function stateWithSourceAndExiled(
+    source: GameObject,
+    exiled: GameObject,
+    kind: string,
+  ): GameState {
+    return {
+      objects: { [source.id]: source, [exiled.id]: exiled },
+      exile_links: [{ exiled_id: exiled.id, source_id: source.id, kind }],
+    } as unknown as GameState;
+  }
+
+  it("is false for a card that isn't face down", () => {
+    const obj = faceDownObject({ face_down: false });
+    expect(isFaceDownExileCardVisibleToViewer({ objects: {} } as GameState, obj, 1)).toBe(false);
+  });
+
+  it("is true for the controller of the Hideaway permanent that exiled it", () => {
+    const source: GameObject = { ...faceDownObject(), id: 1, zone: "Battlefield", face_down: false };
+    const exiled = faceDownObject();
+    const state = stateWithSourceAndExiled(source, exiled, "HideawayLookable");
+    expect(isFaceDownExileCardVisibleToViewer(state, exiled, 1)).toBe(true);
+  });
+
+  it("is false for an opponent of the Hideaway permanent's controller", () => {
+    const source: GameObject = { ...faceDownObject(), id: 1, zone: "Battlefield", face_down: false };
+    const exiled = faceDownObject();
+    const state = stateWithSourceAndExiled(source, exiled, "HideawayLookable");
+    expect(isFaceDownExileCardVisibleToViewer(state, exiled, 0)).toBe(false);
+  });
+
+  it("is false for a plain TrackedBySource link even for the source's controller", () => {
+    // Bomat Courier ("(You can't look at it.)") tracks its face-down exile by
+    // source for later retrieval but grants no look-permission.
+    const source: GameObject = { ...faceDownObject(), id: 1, zone: "Battlefield", face_down: false };
+    const exiled = faceDownObject();
+    const state = stateWithSourceAndExiled(source, exiled, "TrackedBySource");
+    expect(isFaceDownExileCardVisibleToViewer(state, exiled, 1)).toBe(false);
+  });
+
+  it("is true for the owner of a foretold card", () => {
+    const exiled = faceDownObject({ owner: 0, controller: 0, foretold: true });
+    const state = { objects: { [exiled.id]: exiled }, exile_links: [] } as unknown as GameState;
+    expect(isFaceDownExileCardVisibleToViewer(state, exiled, 0)).toBe(true);
+  });
+
+  it("is false for an opponent of a foretold card's owner", () => {
+    const exiled = faceDownObject({ owner: 0, controller: 0, foretold: true });
+    const state = { objects: { [exiled.id]: exiled }, exile_links: [] } as unknown as GameState;
+    expect(isFaceDownExileCardVisibleToViewer(state, exiled, 1)).toBe(false);
   });
 });

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -97,6 +97,39 @@ export function isLibraryCardRevealedToViewer(
   );
 }
 
+/**
+ * Whether a face-down card sitting in the shared Exile zone is visible to
+ * `viewerId`.
+ *
+ * Mirrors the engine's `hidden_facedown_exile_ids` gate
+ * (`crates/engine/src/game/visibility.rs`, CR 406.3 + CR 702.75a +
+ * CR 702.143e): a foretold card's owner may look at it, and the controller of
+ * the permanent that Hideaway-exiled a card may look at it. Every other
+ * face-down exile — including a plain `TrackedBySource` link that grants no
+ * look-permission (Bomat Courier, Necropotence, Asmodeus) — stays hidden.
+ *
+ * Like `isLibraryCardRevealedToViewer` above, this exists because single-player
+ * renders the raw, unredacted state: `obj.face_down` alone can't distinguish
+ * "hidden from this viewer" from "visible to this viewer", and the object's
+ * `name`/`printed_ref` carry the real identity regardless of viewer. Used by
+ * the exile `ZoneViewer` to keep an opponent's Hideaway-exiled card (or a
+ * non-owner's foretold exile) from leaking its name or image.
+ */
+export function isFaceDownExileCardVisibleToViewer(
+  gameState: GameState | null,
+  obj: GameObject,
+  viewerId: PlayerId,
+): boolean {
+  if (!gameState || !obj.face_down) return false;
+  if (obj.foretold && obj.owner === viewerId) return true;
+  return (gameState.exile_links ?? []).some(
+    (link) =>
+      link.exiled_id === obj.id &&
+      link.kind === "HideawayLookable" &&
+      gameState.objects[link.source_id]?.controller === viewerId,
+  );
+}
+
 export function getWaitingForObjectChoiceIds(
   waitingFor: WaitingFor | null | undefined,
 ): ObjectId[] {


### PR DESCRIPTION
## Summary
- `ZoneViewer`'s exile pile rendered every face-down exile's real name/art unconditionally, because single-player intentionally renders the raw, unredacted `GameState` (mirroring how the library viewer already needed `isLibraryCardRevealedToViewer`) — exile had no equivalent gate.
- Added `isFaceDownExileCardVisibleToViewer` (client-side mirror of the engine's `hidden_facedown_exile_ids` permission check in `visibility.rs`): visible to a foretold card's owner, visible to the controller of the Hideaway permanent that exiled it (`HideawayLookable` link), hidden for everything else (plain `TrackedBySource` links like Bomat Courier stay redacted even for the source's controller).
- Wired the check into `ZoneViewer.tsx` to gate `CardImage`'s `faceDown` prop and the cast tooltip per-viewer instead of on raw `obj.face_down` (which is also true for the legitimate controller).
- Plumbed the previously-missing wire fields the check needs: `kind` on `exile_links`, `foretold` on `GameObject`.

Closes #2889

## Test plan
- [x] New `issue_2889_hideaway_exile_visibility.test.tsx`: opponent sees a face-down placeholder, the Hideaway controller sees the real card, a `TrackedBySource`-only exile stays hidden from its own controller, a foretold card is visible only to its owner.
- [x] New unit tests for `isFaceDownExileCardVisibleToViewer` in `gameStateView.test.ts`.
- [x] Full frontend suite (`vitest`) green, `tsc --noEmit` clean, `eslint` clean on touched files.
- [ ] Manual: open the Exile zone as the non-controlling player in a local Hideaway game and confirm no card name/art leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
