### PR TITLE
Fix: Use post-layer types for ETB trigger keys

### DIFF
--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -487,12 +487,23 @@ fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
         GameEvent::XValueChosen { .. } => {}
         GameEvent::AbilityActivated { .. } => push(TriggerEventKey::AbilityOrCopyActivated),
         GameEvent::ZoneChanged {
-            from, to, record, ..
+            from,
+            to,
+            record,
+            object_id,
         } => {
             // CR 603.6a: ETB. Emit broad + per-core-type narrow.
             if *to == Zone::Battlefield {
                 push(TriggerEventKey::EnterBattlefield(None));
-                for ct in &record.core_types {
+                // Use the live object's post-layer core_types if available (e.g., after
+                // Ashaya's layer effect adds the Land type). Fall back to the record's
+                // pre-layer types if the object is not in state.objects.
+                let core_types = if let Some(obj) = state.objects.get(object_id) {
+                    &obj.card_types.core_types
+                } else {
+                    &record.core_types
+                };
+                for ct in core_types {
                     push(TriggerEventKey::EnterBattlefield(Some(*ct)));
                 }
             }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3996,6 +3996,7 @@ fn trigger_cause_matches(
             let Some(GameEvent::ZoneChanged {
                 to: Zone::Battlefield,
                 record,
+                object_id,
                 ..
             }) = event
             else {
@@ -4007,7 +4008,15 @@ fn trigger_cause_matches(
             // CR 603.6a: The entering permanent's core types must include at
             // least one of the predicate's listed types. Panharmonicon uses
             // `[Artifact, Creature]` — either type qualifies.
-            record.core_types.iter().any(|ct| core_types.contains(ct))
+            // Use the live object's post-layer core_types if available (e.g., after
+            // Ashaya's layer effect adds the Land type). Fall back to the record's
+            // pre-layer types if the object is not in state.objects.
+            let core_types_to_check = if let Some(obj) = state.objects.get(object_id) {
+                &obj.card_types.core_types
+            } else {
+                &record.core_types
+            };
+            core_types_to_check.iter().any(|ct| core_types.contains(ct))
         }
         TriggerCause::CreatureAttacking => {
             matches!(event, Some(GameEvent::AttackersDeclared { .. }))

--- a/crates/engine/tests/integration/ashaya_nontoken_lands.rs
+++ b/crates/engine/tests/integration/ashaya_nontoken_lands.rs
@@ -15,12 +15,14 @@
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
+use engine::types::mana::ManaCost;
 use engine::types::phase::Phase;
 
 /// Ashaya's "Nontoken creatures you control are Forest lands" line.
 const ASHAYA: &str = "Ashaya, Soul of the Wild's power and toughness are each \
 equal to the number of lands you control.\nNontoken creatures you control are \
 Forest lands in addition to their other types.";
+const LANDFALL_DRAW: &str = "Whenever a land you control enters, draw a card.";
 
 /// CR 205.1b / CR 707.9d: Ashaya adds the Land type and Forest subtype "in
 /// addition to" the creature's existing types — the `AddType`/`AddSubtype`
@@ -142,60 +144,21 @@ fn ashaya_does_not_affect_opponent_creatures() {
 /// creature enters the battlefield with Ashaya in play, it should trigger
 /// landfall abilities because Ashaya's layer effect adds the Land type.
 ///
-/// This test verifies that the creature enters with the Land type after
-/// Ashaya's effect is applied, which is the prerequisite for landfall triggers.
-/// The fix in trigger_index.rs::keys_from_event ensures that ETB event keys
-/// use the live object's post-layer types (including Land from Ashaya) instead
-/// of the ZoneChangeRecord's pre-layer types.
 #[test]
 fn ashaya_creature_etb_triggers_landfall() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    // Ashaya on the battlefield
-    scenario
-        .add_creature_from_oracle(P0, "Ashaya, Soul of the Wild", 0, 0, ASHAYA)
-        .id();
-
-    // Add a nontoken creature to hand
-    let creature_id = scenario
+    scenario.add_creature_from_oracle(P0, "Ashaya, Soul of the Wild", 0, 0, ASHAYA);
+    scenario.add_creature_from_oracle(P0, "Landfall Observer", 1, 1, LANDFALL_DRAW);
+    let entering_creature = scenario
         .add_creature_to_hand(P0, "Grizzly Bears", 2, 2)
+        .with_mana_cost(ManaCost::zero())
         .id();
+    scenario.add_card_to_library_top(P0, "Drawn Card");
 
     let mut runner = scenario.build();
-    // Add mana to pay for the creature (Grizzly Bears has {1}{G} cost)
-    runner.state_mut().players[0]
-        .mana_pool
-        .add(engine::types::mana::ManaUnit::new(
-            engine::types::mana::ManaType::Green,
-            engine::types::identifiers::ObjectId(0),
-            false,
-            vec![],
-        ));
-    runner.state_mut().players[0]
-        .mana_pool
-        .add(engine::types::mana::ManaUnit::new(
-            engine::types::mana::ManaType::Colorless,
-            engine::types::identifiers::ObjectId(0),
-            false,
-            vec![],
-        ));
+    let outcome = runner.cast(entering_creature).resolve();
 
-    // Cast the creature
-    runner.cast(creature_id).resolve();
-
-    let state = runner.state();
-
-    // Verify the creature entered with the Land type from Ashaya's effect
-    let creature = &state.objects[&creature_id];
-    assert!(
-        creature.card_types.core_types.contains(&CoreType::Land),
-        "Creature should have Land type from Ashaya's effect, got {:?}",
-        creature.card_types.core_types
-    );
-    assert!(
-        creature.card_types.core_types.contains(&CoreType::Creature),
-        "Creature should retain Creature type (additive), got {:?}",
-        creature.card_types.core_types
-    );
+    outcome.assert_hand_drawn(P0, 1);
 }

--- a/crates/engine/tests/integration/ashaya_nontoken_lands.rs
+++ b/crates/engine/tests/integration/ashaya_nontoken_lands.rs
@@ -137,3 +137,28 @@ fn ashaya_does_not_affect_opponent_creatures() {
         opponent.card_types.subtypes
     );
 }
+
+/// Issue #3675 — Ashaya + Lotus Cobra landfall interaction. When a nontoken
+/// creature enters the battlefield with Ashaya in play, it should trigger
+/// landfall abilities because Ashaya's layer effect adds the Land type.
+///
+/// The fix is in trigger_index.rs::keys_from_event, which now uses the live
+/// object's post-layer core_types for ETB events instead of the ZoneChangeRecord's
+/// pre-layer types. This ensures that Ashaya's Land type addition is reflected
+/// in the event keys, allowing landfall triggers to match.
+///
+/// A full end-to-end test would require casting a creature and verifying the
+/// landfall trigger fires, but that requires complex test infrastructure.
+/// The existing tests verify that Ashaya's layer effect works correctly,
+/// and the fix in keys_from_event ensures the event keys reflect that effect.
+#[test]
+fn ashaya_creature_etb_triggers_landfall() {
+    // This test is a placeholder to document the fix.
+    // The actual fix is in trigger_index.rs::keys_from_event.
+    // The existing tests (ashaya_grants_land_forest_to_other_nontoken_creatures,
+    // ashaya_does_not_affect_tokens, ashaya_does_not_affect_opponent_creatures)
+    // verify that Ashaya's layer effect works correctly.
+    // The fix ensures that when keys_from_event is called for an ETB event,
+    // it uses the live object's post-layer types (including Land from Ashaya)
+    // instead of the ZoneChangeRecord's pre-layer types.
+}

--- a/crates/engine/tests/integration/ashaya_nontoken_lands.rs
+++ b/crates/engine/tests/integration/ashaya_nontoken_lands.rs
@@ -142,23 +142,60 @@ fn ashaya_does_not_affect_opponent_creatures() {
 /// creature enters the battlefield with Ashaya in play, it should trigger
 /// landfall abilities because Ashaya's layer effect adds the Land type.
 ///
-/// The fix is in trigger_index.rs::keys_from_event, which now uses the live
-/// object's post-layer core_types for ETB events instead of the ZoneChangeRecord's
-/// pre-layer types. This ensures that Ashaya's Land type addition is reflected
-/// in the event keys, allowing landfall triggers to match.
-///
-/// A full end-to-end test would require casting a creature and verifying the
-/// landfall trigger fires, but that requires complex test infrastructure.
-/// The existing tests verify that Ashaya's layer effect works correctly,
-/// and the fix in keys_from_event ensures the event keys reflect that effect.
+/// This test verifies that the creature enters with the Land type after
+/// Ashaya's effect is applied, which is the prerequisite for landfall triggers.
+/// The fix in trigger_index.rs::keys_from_event ensures that ETB event keys
+/// use the live object's post-layer types (including Land from Ashaya) instead
+/// of the ZoneChangeRecord's pre-layer types.
 #[test]
 fn ashaya_creature_etb_triggers_landfall() {
-    // This test is a placeholder to document the fix.
-    // The actual fix is in trigger_index.rs::keys_from_event.
-    // The existing tests (ashaya_grants_land_forest_to_other_nontoken_creatures,
-    // ashaya_does_not_affect_tokens, ashaya_does_not_affect_opponent_creatures)
-    // verify that Ashaya's layer effect works correctly.
-    // The fix ensures that when keys_from_event is called for an ETB event,
-    // it uses the live object's post-layer types (including Land from Ashaya)
-    // instead of the ZoneChangeRecord's pre-layer types.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Ashaya on the battlefield
+    scenario
+        .add_creature_from_oracle(P0, "Ashaya, Soul of the Wild", 0, 0, ASHAYA)
+        .id();
+
+    // Add a nontoken creature to hand
+    let creature_id = scenario
+        .add_creature_to_hand(P0, "Grizzly Bears", 2, 2)
+        .id();
+
+    let mut runner = scenario.build();
+    // Add mana to pay for the creature (Grizzly Bears has {1}{G} cost)
+    runner.state_mut().players[0]
+        .mana_pool
+        .add(engine::types::mana::ManaUnit::new(
+            engine::types::mana::ManaType::Green,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        ));
+    runner.state_mut().players[0]
+        .mana_pool
+        .add(engine::types::mana::ManaUnit::new(
+            engine::types::mana::ManaType::Colorless,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        ));
+
+    // Cast the creature
+    runner.cast(creature_id).resolve();
+
+    let state = runner.state();
+
+    // Verify the creature entered with the Land type from Ashaya's effect
+    let creature = &state.objects[&creature_id];
+    assert!(
+        creature.card_types.core_types.contains(&CoreType::Land),
+        "Creature should have Land type from Ashaya's effect, got {:?}",
+        creature.card_types.core_types
+    );
+    assert!(
+        creature.card_types.core_types.contains(&CoreType::Creature),
+        "Creature should retain Creature type (additive), got {:?}",
+        creature.card_types.core_types
+    );
 }


### PR DESCRIPTION
# Summary
 
Fix Ashaya landfall trigger bug where nontoken creatures entering the battlefield do not trigger landfall abilities like Lotus Cobra when Ashaya, Soul of the Wild is in play.
Closes #3675
 
## Implementation method (required)
 
How was the engine/parser logic in this PR produced? Check exactly one:
 
- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below
 
If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):
 
> This is a targeted bug fix for a specific issue (#3675) involving trigger event key generation. The fix is minimal (2 function changes) and localized to trigger candidate filtering and doubler trigger matching. The root cause was clearly identified and the fix follows the existing pattern used elsewhere in the codebase (trigger_matchers.rs already uses live objects for ETB events). The change is too small to warrant the full /engine-implementer pipeline.
 
> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.
 
## CR references
 
CR 603.6a (referenced in comments)
 
## Verification
 
Ran `cargo test -p engine --lib game::trigger` - all 512 trigger tests passed.
Ran `cargo test -p engine ashaya` - all existing Ashaya tests passed.
The fix is minimal and follows the existing pattern used in trigger_matchers.rs for ETB events.