### PR TITLE
fix: Ring-bearer badge hidden behind grouped Army tokens

### DIFF
--- a/client/src/viewmodel/__tests__/battlefieldGrouping.test.ts
+++ b/client/src/viewmodel/__tests__/battlefieldGrouping.test.ts
@@ -260,6 +260,23 @@ describe("groupByName", () => {
     expect(groups.find((g) => g.count === 1)?.ids).toEqual([3]);
   });
 
+  it("renders the ring-bearer solo even among identical same-named copies (issue #721)", () => {
+    const objects = [
+      makeGameObject({ id: 1, name: "Orc Army" }),
+      makeGameObject({ id: 2, name: "Orc Army" }),
+      makeGameObject({ id: 3, name: "Orc Army" }),
+    ];
+
+    const groups = groupByName(objects, new Set([2]));
+
+    // The ring-bearer (id 2) never gets hidden behind a non-bearer
+    // representative in a collapsed group — it always has its own entry so
+    // PermanentCard's ring-bearer badge is reachable.
+    expect(groups).toHaveLength(2);
+    expect(groups.find((g) => g.count === 2)?.ids).toEqual([1, 3]);
+    expect(groups.find((g) => g.count === 1)?.ids).toEqual([2]);
+  });
+
   it("separates copies with different counter amounts", () => {
     const objects = [
       makeGameObject({ id: 1, name: "Grizzly Bears", counters: { Plus1Plus1: 1 } }),

--- a/client/src/viewmodel/battlefieldProps.ts
+++ b/client/src/viewmodel/battlefieldProps.ts
@@ -2,8 +2,11 @@ import type { AttackerInfo, CombatState, GameObject, ObjectId, PlayerId } from "
 import { publicName, toCardProps } from "./cardProps";
 import type { CardViewProps } from "./cardProps";
 
-function canGroup(obj: GameObject): boolean {
-  return obj.attachments.length === 0;
+function canGroup(obj: GameObject, ringBearerIds: ReadonlySet<ObjectId>): boolean {
+  // Ring-bearers (CR 701.54) must never be hidden behind a same-named
+  // non-bearer representative in a collapsed/stacked group display — render
+  // them solo so the ring-bearer badge in PermanentCard is always visible.
+  return obj.attachments.length === 0 && !ringBearerIds.has(obj.id);
 }
 
 function groupKey(obj: GameObject): string {
@@ -82,12 +85,17 @@ export function partitionByType(objects: GameObject[]): BattlefieldPartition {
   return { creatures, lands, support, planeswalkers, other };
 }
 
-export function groupByName(objects: GameObject[]): GroupedPermanent[] {
+const NO_RING_BEARERS: ReadonlySet<ObjectId> = new Set();
+
+export function groupByName(
+  objects: GameObject[],
+  ringBearerIds: ReadonlySet<ObjectId> = NO_RING_BEARERS,
+): GroupedPermanent[] {
   const groups = new Map<string, GameObject[]>();
 
   for (const obj of objects) {
-    if (!canGroup(obj)) {
-      // Ungroupable objects (attachments, counters) get their own entry
+    if (!canGroup(obj, ringBearerIds)) {
+      // Ungroupable objects (attachments, ring-bearers) get their own entry
       groups.set(`__solo_${obj.id}`, [obj]);
       continue;
     }

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -195,11 +195,22 @@ export function buildPlayerBattlefieldView(
   const playerObjects = battlefieldObjects.filter(
     (object) => object.controller === playerId,
   );
-  return buildPlayerBattlefieldViewFromObjects(playerObjects);
+  // CR 701.54: the Ring-bearer must render as its own card even when a
+  // same-named, identically-statted permanent (e.g. another Army token)
+  // would otherwise collapse it into a shared group — otherwise the
+  // ring-bearer badge can land on the wrong representative or disappear
+  // entirely behind a stack badge.
+  const ringBearerIds = new Set(
+    Object.values(gameState.ring_bearer ?? {}).filter(
+      (id): id is ObjectId => id != null,
+    ),
+  );
+  return buildPlayerBattlefieldViewFromObjects(playerObjects, ringBearerIds);
 }
 
 export function buildPlayerBattlefieldViewFromObjects(
   playerObjects: GameObject[],
+  ringBearerIds: ReadonlySet<ObjectId> = new Set(),
 ): PlayerBattlefieldView {
   const partition = partitionByType(playerObjects);
   const objectMap = new Map(playerObjects.map((object) => [object.id, object]));
@@ -209,11 +220,11 @@ export function buildPlayerBattlefieldViewFromObjects(
       .filter(Boolean) as GameObject[];
 
   return {
-    creatures: groupByName(resolveObjects(partition.creatures)),
-    lands: groupByName(resolveObjects(partition.lands)),
-    support: groupByName(resolveObjects(partition.support)),
-    planeswalkers: groupByName(resolveObjects(partition.planeswalkers)),
-    other: groupByName(resolveObjects(partition.other)),
+    creatures: groupByName(resolveObjects(partition.creatures), ringBearerIds),
+    lands: groupByName(resolveObjects(partition.lands), ringBearerIds),
+    support: groupByName(resolveObjects(partition.support), ringBearerIds),
+    planeswalkers: groupByName(resolveObjects(partition.planeswalkers), ringBearerIds),
+    other: groupByName(resolveObjects(partition.other), ringBearerIds),
   };
 }
 


### PR DESCRIPTION
## Summary
- Root cause: `groupByName` collapses identical same-named permanents
  (e.g. Sauron, the Dark Lord's repeated `amass Orcs 1` tokens) into a
  single stacked group, and `GroupedPermanent` only renders
  `PermanentCard` for the group's representative id. If the
  Ring-bearer (CR 701.54) is assigned to a non-representative id in
  that group, its badge never renders even though engine state is
  correct.
- Fix: pass `gameState.ring_bearer` into `groupByName` and treat
  ring-bearer creatures as ungroupable (mirrors the existing
  attachment exception), so the Ring-bearer always gets its own card
  entry and badge.

Closes #721


## Test plan
- [x] `npx tsc -b --noEmit` (client) — clean
- [x] `battlefieldGrouping.test.ts` — added regression test for 3
      identical "Orc Army" tokens where one is the ring-bearer
- [x] `gameStateView.test.ts`, `RingBearerModal.test.tsx`,
      `PlayerHud.designations.test.tsx`,
      `OpponentHud.designations.test.tsx` — all passing
