### PR TITLE
fix: Blood Scrivener: draw two cards + lose 1 life on empty hand draw

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4765,9 +4765,16 @@ fn extract_replacement_effect(text: &str) -> Option<String> {
         let effect = TextPair::new(effect, &lower)
             .trim_end()
             .trim_end_matches('.');
+        // Strip trailing "... instead" marker (e.g., "draw two cards instead.").
         let effect = effect
             .strip_suffix(" instead")
             .map_or(effect, |trimmed| trimmed.trim_end());
+        // Strip leading "instead ..." marker (e.g., "instead you draw two cards").
+        // This form appears when the subject follows the replacement word, as in
+        // Blood Scrivener: "..., instead you draw two cards and you lose 1 life."
+        let effect = effect
+            .strip_prefix("instead ")
+            .map_or(effect, |stripped| stripped.trim_start());
         if !effect.original.is_empty() {
             return Some(effect.original.to_string());
         }
@@ -11913,6 +11920,56 @@ mod tests {
                     qty: QuantityRef::EventContextAmount
                 }
             ) && *offset == 1
+        ));
+    }
+
+    #[test]
+    fn draw_replacement_leading_instead_prefix_blood_scrivener() {
+        // CR 614.1a: "instead you draw two cards" — leading "instead" form with
+        // subject prefix. The replacement must wire up Draw {count:2} as the
+        // execute effect and LoseLife as a sub_ability, gated on HandSize == 0.
+        // Regression test for issue #3305: "instead" was not stripped from the
+        // effect text, leaving the draw as Unimplemented and only the life loss
+        // fired.
+        let def = parse_replacement_line(
+            "If you would draw a card while you have no cards in hand, instead you draw two cards and you lose 1 life.",
+            "Blood Scrivener",
+        )
+        .unwrap();
+
+        assert_eq!(def.event, ReplacementEvent::Draw);
+        // Gate: HandSize EQ 0
+        assert!(matches!(
+            &def.condition,
+            Some(ReplacementCondition::OnlyIfQuantity {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: crate::types::ability::PlayerScope::Controller
+                    }
+                },
+                comparator: Comparator::EQ,
+                rhs: QuantityExpr::Fixed { value: 0 },
+                active_player_req: None,
+            })
+        ));
+        // Execute: Draw { count: 2 }
+        assert!(matches!(
+            def.execute.as_deref().map(|a| &*a.effect),
+            Some(Effect::Draw {
+                count: QuantityExpr::Fixed { value: 2 },
+                ..
+            })
+        ));
+        // Sub-ability: LoseLife { amount: 1 }
+        assert!(matches!(
+            def.execute
+                .as_deref()
+                .and_then(|a| a.sub_ability.as_deref())
+                .map(|a| &*a.effect),
+            Some(Effect::LoseLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                ..
+            })
         ));
     }
 

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4769,11 +4769,12 @@ fn extract_replacement_effect(text: &str) -> Option<String> {
         let effect = effect
             .strip_suffix(" instead")
             .map_or(effect, |trimmed| trimmed.trim_end());
-        // Strip leading "instead ..." marker (e.g., "instead you draw two cards").
-        // This form appears when the subject follows the replacement word, as in
-        // Blood Scrivener: "..., instead you draw two cards and you lose 1 life."
+        // CR 614.1a: Strip leading "instead ..." marker (e.g., "instead you
+        // draw two cards"). This form appears when the subject follows the
+        // replacement word, as in Blood Scrivener: "..., instead you draw two
+        // cards and you lose 1 life."
         let effect = effect
-            .strip_prefix("instead ")
+            .strip_prefix("instead ") // allow-noncombinator: TextPair structural cleanup on an already-extracted replacement effect fragment, mirroring the trailing "instead" strip above.
             .map_or(effect, |stripped| stripped.trim_start());
         if !effect.original.is_empty() {
             return Some(effect.original.to_string());


### PR DESCRIPTION
## Summary

**Bug:** When Blood Scrivener's controller drew a card with an empty hand, only the 1 life loss occurred — the draw of two cards was silently swallowed and never executed.

**Root cause:** `extract_replacement_effect` in `oracle_replacement.rs` normalizes the replacement effect text by stripping the semantically redundant `" instead"` marker. It correctly stripped a *trailing* form (`"draw two cards instead."` → `"draw two cards"`) but never stripped a *leading* form (`"instead you draw two cards"` → `"you draw two cards"`).

Blood Scrivener's Oracle text uses the leading form:

```
If you would draw a card while you have no cards in hand, instead you draw two cards and you lose 1 life.
```

So after `extract_replacement_effect`, the effect text handed to `parse_effect_chain` was:

```
instead you draw two cards and you lose 1 life
```

The imperative parser does not recognise `instead` as a verb, so it emitted:

```json
{ "type": "Unimplemented", "name": "instead", "description": "instead you draw two cards" }
```

as the `execute` effect. Only the chained `LoseLife` sub-ability (which was correctly attached as `sub_ability`) ever fired. The draw was a no-op.

## Fix

**One call added** to `extract_replacement_effect` — strip a leading `"instead "` prefix symmetrically with the existing trailing `" instead"` strip:

```rust
// Strip trailing "... instead" marker (e.g., "draw two cards instead.").
let effect = effect
    .strip_suffix(" instead")
    .map_or(effect, |trimmed| trimmed.trim_end());
// Strip leading "instead ..." marker (e.g., "instead you draw two cards").
let effect = effect
    .strip_prefix("instead ")
    .map_or(effect, |stripped| stripped.trim_start());
```

After the strip, `parse_effect_chain` receives `"you draw two cards and you lose 1 life"`. The sequence parser already recognises `"you draw "` as a clause start (sequence.rs), splits at `"and"`, and dispatches each clause:

- `"you draw two cards"` → `Effect::Draw { count: Fixed(2), target: Controller }`
- `"you lose 1 life"` → `Effect::LoseLife { amount: Fixed(1), target: Controller }`

These become the `execute` effect and its `sub_ability` respectively, exactly matching the Oracle text. The `while you have no cards in hand` gate (`HandSize EQ 0`) was already parsed correctly and is unchanged.

## Files changed

| File | Change |
|---|---|
| `crates/engine/src/parser/oracle_replacement.rs` | Add `strip_prefix("instead ")` to `extract_replacement_effect`; add regression test |

## Test

New unit test `draw_replacement_leading_instead_prefix_blood_scrivener` in `oracle_replacement.rs` asserts:

1. `event == ReplacementEvent::Draw`
2. `condition == OnlyIfQuantity { lhs: HandSize(Controller), EQ, 0 }`
3. `execute.effect == Effect::Draw { count: Fixed(2) }`
4. `execute.sub_ability.effect == Effect::LoseLife { amount: Fixed(1) }`

## Cards affected

All cards using the `"..., instead {subject} draw[s] N cards..."` form benefit from this fix. Known examples:

| Card | Oracle pattern |
|---|---|
| Blood Scrivener | `instead you draw two cards and you lose 1 life` |

Any future card using a leading `"instead "` subject-form draw replacement will also parse correctly without further changes.

## Verification checklist

- [x] `cargo fmt --all` — clean
- [x] Fix is a surgical addition to one helper function, no other call-sites changed
- [x] Existing trailing-`instead` tests (Alhammarret's Archive, Notion Thief, Hullbreacher, etc.) are unaffected — the `strip_prefix` path only fires when text actually starts with `"instead "`
- [x] Regression test added at the parser level (issue #3305)
