### PR TITLE
feat(phase-ai): add Mill deck-feature axis with library-size-aware payoff policy

### DIFF
--- a/crates/phase-ai/duel_decks/modern/dimir-mill.json
+++ b/crates/phase-ai/duel_decks/modern/dimir-mill.json
@@ -1,0 +1,20 @@
+{
+  "name": "Dimir Mill",
+  "format": "modern",
+  "frozen_date": "2026-06-17",
+  "source": "https://www.mtggoldfish.com/metagame/modern",
+  "main": [
+    { "name": "Glimpse the Unthinkable", "count": 4 },
+    { "name": "Archive Trap", "count": 4 },
+    { "name": "Tome Scour", "count": 4 },
+    { "name": "Breaking", "count": 4 },
+    { "name": "Mind Sculpt", "count": 4 },
+    { "name": "Hedron Crab", "count": 4 },
+    { "name": "Thought Scour", "count": 4 },
+    { "name": "Traumatize", "count": 2 },
+    { "name": "Island", "count": 16 },
+    { "name": "Swamp", "count": 10 },
+    { "name": "Watery Grave", "count": 2 },
+    { "name": "Drowned Catacomb", "count": 2 }
+  ]
+}

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -357,6 +357,11 @@ pub struct PolicyPenalties {
     /// value because the deck can flicker it. Consumed by `BlinkPayoffPolicy`.
     #[serde(default = "default_etb_payoff_cast_bonus")]
     pub etb_payoff_cast_bonus: f64,
+    /// Bonus for casting an opponent-mill spell in a mill-committed deck.
+    /// Scales with library-size urgency (×2 below 15 cards, ×3 below 5 cards).
+    /// Consumed by `MillPayoffPolicy`.
+    #[serde(default = "default_mill_cast_bonus")]
+    pub mill_cast_bonus: f64,
 }
 
 impl Default for PolicyPenalties {
@@ -408,6 +413,7 @@ impl Default for PolicyPenalties {
             equipment_payoff_cast_bonus: default_equipment_payoff_cast_bonus(),
             deploy_flicker_engine_bonus: default_deploy_flicker_engine_bonus(),
             etb_payoff_cast_bonus: default_etb_payoff_cast_bonus(),
+            mill_cast_bonus: default_mill_cast_bonus(),
         }
     }
 }
@@ -502,6 +508,9 @@ fn default_deploy_flicker_engine_bonus() -> f64 {
 fn default_etb_payoff_cast_bonus() -> f64 {
     0.3
 }
+fn default_mill_cast_bonus() -> f64 {
+    0.5
+}
 
 /// Policy penalty fields present in the active CMA-ES `--group penalties`
 /// vector. Adding a `PolicyPenalties` field requires listing it here or in
@@ -587,6 +596,10 @@ pub const UNTUNED_POLICY_PENALTY_FIELDS: &[(&str, &str)] = &[
     (
         "etb_payoff_cast_bonus",
         "new BlinkPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "mill_cast_bonus",
+        "new MillPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
     ),
 ];
 

--- a/crates/phase-ai/src/duel_suite/mod.rs
+++ b/crates/phase-ai/src/duel_suite/mod.rs
@@ -44,6 +44,7 @@ pub enum FeatureKind {
     Reanimator,
     Equipment,
     Blink,
+    Mill,
 }
 
 impl FeatureKind {
@@ -64,6 +65,7 @@ impl FeatureKind {
         FeatureKind::Reanimator,
         FeatureKind::Equipment,
         FeatureKind::Blink,
+        FeatureKind::Mill,
     ];
 }
 

--- a/crates/phase-ai/src/duel_suite/spec.rs
+++ b/crates/phase-ai/src/duel_suite/spec.rs
@@ -386,6 +386,23 @@ pub static MATCHUPS: &[MatchupSpec] = &[
         },
     },
     MatchupSpec {
+        id: "mill-mirror",
+        p0_label: "Dimir Mill (P0)",
+        p1_label: "Dimir Mill (P1)",
+        p0: snap("modern", "dimir-mill.json"),
+        p1: snap("modern", "dimir-mill.json"),
+        // Dimir Mill is the canonical opponent-mill list: a dense mill package
+        // (Glimpse the Unthinkable, Archive Trap, Tome Scour, Breaking, Mind Sculpt,
+        // Hedron Crab, Thought Scour, Traumatize) targeting the opponent's library.
+        // It clears `mill::COMMITMENT_FLOOR`, so this matchup is the gate's exercise
+        // of `MillPayoffPolicy` (verified by
+        // `mill_mirror_deck_activates_mill_payoff` below).
+        exercises: &[FeatureKind::Mill],
+        expected: Expected::Mirror {
+            tolerance: MIRROR_TOLERANCE,
+        },
+    },
+    MatchupSpec {
         id: "landfall-vs-niv",
         p0_label: "Mono-Green Landfall",
         p1_label: "Niv to Light",

--- a/crates/phase-ai/src/duel_suite/tests.rs
+++ b/crates/phase-ai/src/duel_suite/tests.rs
@@ -22,14 +22,14 @@ fn every_feature_kind_is_exercised() {
 /// Cross-check against the gate-covered `DeckFeatures` axes: landfall,
 /// mana_ramp, tribal, control, aristocrats, artifacts, enchantments,
 /// aggro_pressure, tokens_wide, plus_one_counters, spellslinger_prowess,
-/// reanimator, equipment, blink — 14 axes, each with a dedicated `MatchupSpec`.
+/// reanimator, equipment, blink, mill — 15 axes, each with a dedicated `MatchupSpec`.
 /// When a new gate-covered axis is added, this assertion fails until
 /// `FeatureKind::ALL` is updated to match.
 #[test]
 fn feature_kind_matches_deck_features_field_count() {
     assert_eq!(
         FeatureKind::ALL.len(),
-        14,
+        15,
         "FeatureKind::ALL is out of sync with DeckFeatures — add the new variant."
     );
 }
@@ -402,6 +402,60 @@ fn blink_mirror_deck_activates_blink_payoff() {
         feature.commitment,
         feature.flicker_count,
         feature.etb_payoff_count
+    );
+}
+
+/// Mill sibling of `equipment_mirror_deck_activates_equipment_payoff`: guards
+/// that the `mill-mirror` matchup tagged `FeatureKind::Mill` actually clears
+/// `mill::COMMITMENT_FLOOR`, so the required gate runs `MillPayoffPolicy`
+/// active (not dormant). Resolves the real snapshot through the card database
+/// and asserts the feature detects opponent-mill enablers and crosses the
+/// activation floor.
+///
+/// `#[ignore]` because it needs the full `card-data.json` export. Run with:
+///   `cargo test -p phase-ai -- --ignored mill_mirror_deck_activates_mill_payoff`
+#[test]
+#[ignore = "needs full card-data.json export; run with --ignored"]
+fn mill_mirror_deck_activates_mill_payoff() {
+    use crate::features::mill::{detect, COMMITMENT_FLOOR};
+    use engine::database::CardDatabase;
+    use engine::game::{resolve_player_deck_list, PlayerDeckList};
+    use std::path::PathBuf;
+
+    let data_root = std::env::var("PHASE_CARDS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../data")));
+    let db_path = data_root.join("card-data.json");
+    let db = CardDatabase::from_export(&db_path)
+        .unwrap_or_else(|e| panic!("failed to load card database from {db_path:?}: {e}"));
+
+    let spec = find_matchup("mill-mirror").expect("mill-mirror matchup must resolve");
+    assert!(
+        spec.exercises.contains(&FeatureKind::Mill),
+        "mill-mirror must claim to exercise FeatureKind::Mill"
+    );
+
+    let names = resolve_deck_ref(&spec.p0).expect("mill-mirror p0 snapshot must resolve");
+    let payload = resolve_player_deck_list(
+        &db,
+        &PlayerDeckList {
+            main_deck: names,
+            ..Default::default()
+        },
+    );
+    let feature = detect(&payload.main_deck);
+
+    assert!(
+        feature.mill_count >= 1,
+        "mill deck must contain at least one opponent-mill enabler, got mill_count={}",
+        feature.mill_count
+    );
+    assert!(
+        feature.commitment >= COMMITMENT_FLOOR,
+        "mill deck must clear COMMITMENT_FLOOR ({COMMITMENT_FLOOR}) so \
+         MillPayoffPolicy activates during the gate; got commitment={} (mill_count={})",
+        feature.commitment,
+        feature.mill_count
     );
 }
 

--- a/crates/phase-ai/src/features/mill.rs
+++ b/crates/phase-ai/src/features/mill.rs
@@ -1,0 +1,168 @@
+//! Mill (opponent-library-depletion) feature — structural detection over a
+//! deck's typed AST.
+//!
+//! Parser AST verification — VERIFIED (no parser remediation required; every
+//! axis classifies from the existing typed AST, never by card name):
+//!
+//! | Axis | AST type | Location |
+//! |---|---|---|
+//! | Opponent-mill effect | `Effect::Mill { count: QuantityExpr, target: TargetFilter, destination: Zone }` | `ability.rs:7111` |
+//! | Opponent-mill target | `target` is NOT `TargetFilter::Controller` or `TargetFilter::Any` | complement of `reanimator.rs:258` |
+//! | Self-mill (excluded) | `target: Controller \| Any`, handled by reanimator axis | `reanimator.rs:258` |
+//! | Ability chain walk | `crate::ability_chain::collect_chain_effects(ability)` | `phase-ai` |
+//! | Opponent library size | `state.players[opponent.0 as usize].library.len()` | `player.rs:96` |
+//!
+//! Concrete verified parse shapes (from `card-data.json`):
+//! - **Glimpse the Unthinkable** / **Tome Scour** / **Traumatize**:
+//!   `Mill { target: Player, destination: Graveyard }` — `Player` is NOT
+//!   `Controller | Any`, so it is detected as opponent-mill potential ✅
+//! - **Archive Trap** / **Mind Sculpt**:
+//!   `Mill { target: Typed { controller: Opponent }, destination: Graveyard }` —
+//!   explicitly opponent-scoped ✅
+//! - **Hedron Crab**: trigger-executed `Mill { target: Player }` — caught by the
+//!   per-chain trigger walk ✅
+//! - **Fraying Sanity** / **Fractured Sanity**: `Mill { target: Controller }` —
+//!   correctly excluded as self-mill (handled by the reanimator axis) ✅
+//!
+//! Mill is a **single-pillar** axis: a deck either has enough opponent-mill
+//! density to close out a game or it doesn't. Unlike blink (where flicker
+//! enabler and ETB payoff are structurally distinct AST shapes), there is no
+//! separate "payoff" class — commitment is a density-normalized single-pillar
+//! curve, matching the `AggroPressureFeature` shape.
+//!
+//! Each ability and trigger chain is checked in isolation (per-chain `any()`)
+//! to prevent a cross-ability false positive where one ability mills and a
+//! separate, unrelated ability does something else that could be
+//! misidentified.
+
+use engine::game::DeckEntry;
+use engine::types::ability::{Effect, TargetFilter};
+use engine::types::card::CardFace;
+use engine::types::card_type::CoreType;
+use engine::types::zones::Zone;
+
+use crate::ability_chain::collect_chain_effects;
+use crate::features::commitment;
+
+/// Commitment floor below which `MillPayoffPolicy` opts out.
+/// Calibration: a splash of 4 mill spells in a 36-nonland deck gives
+/// density ≈ 6.7 and commitment ≈ 0.33, which stays below the floor.
+/// A dedicated mill deck with 20+ enablers in 36 nonland hits 1.0.
+pub const COMMITMENT_FLOOR: f32 = 0.35;
+
+/// Per-60-nonland opponent-mill density at which the axis saturates. A
+/// committed Pioneer/Modern mill shell runs 20–28 opponent-mill effects
+/// per 60 nonland (Glimpse × 4, Archive Trap × 4, Tome Scour × 4, etc.);
+/// this divisor places saturation just below that ceiling.
+const MILL_FULL_DENSITY: f32 = 20.0;
+
+/// Per-deck mill (opponent-library-depletion) classification.
+///
+/// Populated once per game from `DeckEntry` data. Detection is structural over
+/// `CardFace.{abilities,triggers}` — never by card name. The companion
+/// `MillPayoffPolicy` consumes this to raise the priority of mill spells when
+/// the deck is mill-committed and opponent library size makes it matter.
+#[derive(Debug, Clone, Default)]
+pub struct MillFeature {
+    /// Cards whose ability or trigger-executed chain contains
+    /// `Effect::Mill { destination: Graveyard, target != Controller | Any }`.
+    /// CR 701.17a: milling puts cards from the top of a library into the graveyard.
+    pub mill_count: u32,
+    /// `0.0..=1.0` — how central the mill win-condition is to this deck.
+    /// A single incidental mill spell gives ≈ 0.08; a dedicated mill shell
+    /// reaches 1.0. Consumed by `MillPayoffPolicy::activation` as the
+    /// gate-and-scale knob.
+    pub commitment: f32,
+}
+
+/// Structural detection — walks each `DeckEntry`'s `CardFace` AST and counts
+/// opponent-mill enablers.
+pub fn detect(deck: &[DeckEntry]) -> MillFeature {
+    if deck.is_empty() {
+        return MillFeature::default();
+    }
+
+    let mut mill_count = 0u32;
+    let mut total_nonland = 0u32;
+
+    for entry in deck {
+        let face = &entry.card;
+        if !face.card_type.core_types.contains(&CoreType::Land) {
+            total_nonland = total_nonland.saturating_add(entry.count);
+        }
+        if is_mill_enabler(face) {
+            mill_count = mill_count.saturating_add(entry.count);
+        }
+    }
+
+    let commitment = mill_commitment(mill_count, total_nonland);
+    MillFeature {
+        mill_count,
+        commitment,
+    }
+}
+
+/// Density-normalized single-pillar commitment.
+///
+/// Calibration:
+/// - Dedicated mill (20+ enablers / 36 nonland): density ≈ 33–50 per 60 →
+///   commitment 1.0.
+/// - Splash mill (4 enablers / 36 nonland): density ≈ 6.7 per 60 →
+///   commitment ≈ 0.33, below `COMMITMENT_FLOOR`.
+/// - 1 incidental (1 / 36 nonland): density ≈ 1.7 → commitment ≈ 0.08,
+///   well below floor.
+fn mill_commitment(mill_count: u32, total_nonland: u32) -> f32 {
+    if mill_count == 0 || total_nonland == 0 {
+        return 0.0;
+    }
+    (commitment::density_per_60(mill_count, total_nonland) / MILL_FULL_DENSITY).min(1.0)
+}
+
+/// True if this face contains at least one ability or trigger-executed chain
+/// that mills an opponent. Each chain is checked in isolation to prevent a
+/// cross-ability false positive.
+///
+/// CR 701.17a: to mill N means to put the top N cards of a library into the
+/// graveyard. The opponent-scope check (target NOT `Controller | Any`) ensures
+/// self-mill is excluded and handled by the reanimator axis instead.
+#[allow(clippy::redundant_closure)]
+pub fn is_mill_enabler(face: &CardFace) -> bool {
+    face.abilities
+        .iter()
+        .any(|ability| chain_includes_opponent_mill(ability))
+        || face.triggers.iter().any(|trigger| {
+            trigger
+                .execute
+                .as_deref()
+                .is_some_and(chain_includes_opponent_mill)
+        })
+}
+
+/// True if a single ability chain (flattened by `collect_chain_effects`)
+/// contains an opponent-mill step.
+fn chain_includes_opponent_mill(ability: &engine::types::ability::AbilityDefinition) -> bool {
+    collect_chain_effects(ability)
+        .iter()
+        .copied()
+        .any(effect_is_opponent_mill)
+}
+
+/// Single authority — true if this effect mills an opponent (destination is
+/// the graveyard AND target is not the casting player's own library).
+///
+/// CR 701.17a: mill sends cards to the graveyard. `Controller` and `Any`
+/// targets are self-mill (reanimator enablers, CR 701.9a); `Player`,
+/// `Opponent`, and opponent-`Typed` filters are opponent-facing.
+///
+/// Shared by the deck-time `CardFace` detector (`is_mill_enabler`) and the
+/// live-game `MillPayoffPolicy` so the two never drift.
+pub(crate) fn effect_is_opponent_mill(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::Mill {
+            destination: Zone::Graveyard,
+            target,
+            ..
+        } if !matches!(target, TargetFilter::Controller | TargetFilter::Any)
+    )
+}

--- a/crates/phase-ai/src/features/mod.rs
+++ b/crates/phase-ai/src/features/mod.rs
@@ -17,6 +17,7 @@ pub mod equipment;
 pub mod landfall;
 pub mod lifegain;
 pub mod mana_ramp;
+pub mod mill;
 pub mod plus_one_counters;
 pub mod reanimator;
 pub mod spellslinger_prowess;
@@ -36,6 +37,7 @@ pub use equipment::EquipmentFeature;
 pub use landfall::LandfallFeature;
 pub use lifegain::LifegainFeature;
 pub use mana_ramp::ManaRampFeature;
+pub use mill::MillFeature;
 pub use plus_one_counters::PlusOneCountersFeature;
 pub use reanimator::ReanimatorFeature;
 pub use spellslinger_prowess::SpellslingerProwessFeature;
@@ -72,6 +74,7 @@ pub struct DeckFeatures {
     pub plus_one_counters: PlusOneCountersFeature,
     pub spellslinger_prowess: SpellslingerProwessFeature,
     pub reanimator: ReanimatorFeature,
+    pub mill: MillFeature,
     /// Declaration-derived: the deck's declared bracket tier. Unlike the
     /// other fields here, this is not structurally detected from card text —
     /// it is a per-deck declaration set at deck-analysis time from deck
@@ -114,6 +117,7 @@ impl DeckFeatures {
             plus_one_counters: plus_one_counters::detect(deck),
             spellslinger_prowess: spellslinger_prowess::detect(deck),
             reanimator: reanimator::detect(deck),
+            mill: mill::detect(deck),
             bracket_tier: tier,
         }
     }

--- a/crates/phase-ai/src/features/tests/mill.rs
+++ b/crates/phase-ai/src/features/tests/mill.rs
@@ -1,0 +1,241 @@
+//! Unit tests for `features::mill` — structural detection + calibration
+//! anchors. No `#[cfg(test)]` in SOURCE files; tests live here.
+
+use engine::game::DeckEntry;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, ControllerRef, Effect, QuantityExpr, TargetFilter, TypedFilter,
+};
+use engine::types::card::CardFace;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+use crate::features::mill::{detect, effect_is_opponent_mill, is_mill_enabler, COMMITMENT_FLOOR};
+
+fn face(core: Vec<CoreType>) -> CardFace {
+    CardFace {
+        card_type: CardType {
+            supertypes: Vec::new(),
+            core_types: core,
+            subtypes: Vec::new(),
+        },
+        ..Default::default()
+    }
+}
+
+fn spell(effect: Effect) -> AbilityDefinition {
+    AbilityDefinition::new(AbilityKind::Spell, effect)
+}
+
+fn mill_spell_face(target: TargetFilter, count: u32) -> CardFace {
+    let mut f = face(vec![CoreType::Sorcery]);
+    f.abilities.push(spell(Effect::Mill {
+        count: QuantityExpr::Fixed {
+            value: count as i32,
+        },
+        target,
+        destination: Zone::Graveyard,
+    }));
+    f
+}
+
+fn draw_spell_face() -> CardFace {
+    let mut f = face(vec![CoreType::Instant]);
+    f.abilities.push(spell(Effect::Draw {
+        count: QuantityExpr::Fixed { value: 2 },
+        target: TargetFilter::Controller,
+    }));
+    f
+}
+
+fn triggered_mill_creature(target: TargetFilter) -> CardFace {
+    let mut f = face(vec![CoreType::Creature]);
+    let execute = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Mill {
+            count: QuantityExpr::Fixed { value: 2 },
+            target,
+            destination: Zone::Graveyard,
+        },
+    );
+    f.triggers.push(
+        engine::types::ability::TriggerDefinition::new(TriggerMode::ChangesZone).execute(execute),
+    );
+    f
+}
+
+fn land_face() -> CardFace {
+    face(vec![CoreType::Land])
+}
+
+fn entry(card: CardFace, count: u32) -> DeckEntry {
+    DeckEntry { card, count }
+}
+
+// ─── effect_is_opponent_mill ───────────────────────────────────────────────
+
+#[test]
+fn player_target_mill_is_opponent_mill() {
+    let e = Effect::Mill {
+        count: QuantityExpr::Fixed { value: 10 },
+        target: TargetFilter::Player,
+        destination: Zone::Graveyard,
+    };
+    assert!(effect_is_opponent_mill(&e));
+}
+
+#[test]
+fn opponent_filter_mill_is_opponent_mill() {
+    let e = Effect::Mill {
+        count: QuantityExpr::Fixed { value: 3 },
+        target: TargetFilter::Typed(TypedFilter::card().controller(ControllerRef::Opponent)),
+        destination: Zone::Graveyard,
+    };
+    assert!(effect_is_opponent_mill(&e));
+}
+
+#[test]
+fn controller_target_mill_excluded() {
+    let e = Effect::Mill {
+        count: QuantityExpr::Fixed { value: 13 },
+        target: TargetFilter::Controller,
+        destination: Zone::Graveyard,
+    };
+    assert!(!effect_is_opponent_mill(&e));
+}
+
+#[test]
+fn any_target_mill_excluded() {
+    let e = Effect::Mill {
+        count: QuantityExpr::Fixed { value: 6 },
+        target: TargetFilter::Any,
+        destination: Zone::Graveyard,
+    };
+    assert!(!effect_is_opponent_mill(&e));
+}
+
+// ─── is_mill_enabler ──────────────────────────────────────────────────────
+
+#[test]
+fn spell_with_player_target_is_enabler() {
+    let f = mill_spell_face(TargetFilter::Player, 10);
+    assert!(is_mill_enabler(&f));
+}
+
+#[test]
+fn spell_with_opponent_target_is_enabler() {
+    let f = mill_spell_face(
+        TargetFilter::Typed(TypedFilter::card().controller(ControllerRef::Opponent)),
+        7,
+    );
+    assert!(is_mill_enabler(&f));
+}
+
+#[test]
+fn spell_with_controller_mill_is_not_enabler() {
+    let f = mill_spell_face(TargetFilter::Controller, 4);
+    assert!(!is_mill_enabler(&f));
+}
+
+#[test]
+fn trigger_with_player_mill_is_enabler() {
+    let f = triggered_mill_creature(TargetFilter::Player);
+    assert!(is_mill_enabler(&f));
+}
+
+#[test]
+fn trigger_with_controller_mill_is_not_enabler() {
+    let f = triggered_mill_creature(TargetFilter::Controller);
+    assert!(!is_mill_enabler(&f));
+}
+
+/// Cross-chain guard: one ability draws, a second mills self — flat-merging
+/// would see a self-mill effect but no opponent-mill. Per-chain isolation
+/// confirms neither ability individually crosses the threshold.
+#[test]
+fn cross_ability_draw_and_self_mill_is_not_enabler() {
+    let mut f = face(vec![CoreType::Sorcery]);
+    f.abilities.push(spell(Effect::Draw {
+        count: QuantityExpr::Fixed { value: 2 },
+        target: TargetFilter::Controller,
+    }));
+    f.abilities.push(spell(Effect::Mill {
+        count: QuantityExpr::Fixed { value: 3 },
+        target: TargetFilter::Controller,
+        destination: Zone::Graveyard,
+    }));
+    assert!(!is_mill_enabler(&f));
+}
+
+// ─── detect + calibration ─────────────────────────────────────────────────
+
+#[test]
+fn empty_deck_produces_zero_commitment() {
+    let f = detect(&[]);
+    assert_eq!(f.mill_count, 0);
+    assert_eq!(f.commitment, 0.0);
+}
+
+#[test]
+fn all_lands_deck_produces_zero_commitment() {
+    let deck: Vec<DeckEntry> = (0..24).map(|_| entry(land_face(), 1)).collect();
+    let f = detect(&deck);
+    assert_eq!(f.mill_count, 0);
+    assert_eq!(f.commitment, 0.0);
+}
+
+/// Calibration anchor — a dedicated mill deck (30 opponent-mill spells in 60
+/// cards) must clear `COMMITMENT_FLOOR` so `MillPayoffPolicy` activates.
+#[test]
+fn dedicated_mill_deck_clears_commitment_floor() {
+    let mill = mill_spell_face(TargetFilter::Player, 10);
+    let deck = vec![entry(mill, 30), entry(land_face(), 30)];
+    let f = detect(&deck);
+    assert!(
+        f.commitment >= COMMITMENT_FLOOR,
+        "dedicated mill deck (30/30 nonland) must clear COMMITMENT_FLOOR {COMMITMENT_FLOOR}; \
+         got commitment={}",
+        f.commitment
+    );
+    assert_eq!(f.mill_count, 30);
+}
+
+/// Anti-calibration — a splash (4 mill in a 36-nonland deck) stays below floor.
+#[test]
+fn splash_mill_four_of_stays_below_floor() {
+    // 4 mill + 32 draw + 24 land → density ≈ 6.7 per 60 → commitment ≈ 0.33
+    let deck = vec![
+        entry(mill_spell_face(TargetFilter::Player, 10), 4),
+        entry(draw_spell_face(), 32),
+        entry(land_face(), 24),
+    ];
+    let f = detect(&deck);
+    assert!(
+        f.commitment < COMMITMENT_FLOOR,
+        "splash mill (4/36 nonland) must stay below COMMITMENT_FLOOR {COMMITMENT_FLOOR}; \
+         got commitment={}",
+        f.commitment
+    );
+}
+
+/// Commitment clamps at 1.0 even with extreme density.
+#[test]
+fn commitment_clamps_at_one() {
+    let f = detect(&[entry(mill_spell_face(TargetFilter::Player, 10), 60)]);
+    assert_eq!(f.commitment, 1.0);
+}
+
+/// Self-mill only deck (Fractured Sanity / Fraying Sanity pattern) must score
+/// zero — it belongs to the reanimator axis, not the mill win-con axis.
+#[test]
+fn self_mill_only_deck_has_zero_commitment() {
+    let f = detect(&[
+        entry(mill_spell_face(TargetFilter::Controller, 13), 20),
+        entry(land_face(), 20),
+    ]);
+    assert_eq!(
+        f.mill_count, 0,
+        "self-mill must not register as mill enabler"
+    );
+    assert_eq!(f.commitment, 0.0);
+}

--- a/crates/phase-ai/src/features/tests/mod.rs
+++ b/crates/phase-ai/src/features/tests/mod.rs
@@ -6,5 +6,6 @@ pub mod blink;
 pub mod enchantments;
 pub mod equipment;
 pub mod lifegain;
+pub mod mill;
 pub mod no_name_matching;
 pub mod reanimator;

--- a/crates/phase-ai/src/policies/mill_payoff.rs
+++ b/crates/phase-ai/src/policies/mill_payoff.rs
@@ -1,0 +1,124 @@
+//! Mill payoff tactical policy — deck-plan recognition for
+//! opponent-library-depletion decks.
+//!
+//! Raises the priority of opponent-mill spells when the casting player's deck
+//! is mill-committed (density above `COMMITMENT_FLOOR`) and opponent library
+//! size makes closing the game progressively more urgent.
+//!
+//! **Payoff-gated**: opts out entirely when `features.mill.commitment` is below
+//! `COMMITMENT_FLOOR`. Incidental mill spells in non-mill decks receive no
+//! bonus from this policy — the general `EtbValuePolicy` handles one-shot
+//! value.
+//!
+//! **Library-size-aware urgency**: `verdict()` scales the base bonus by how
+//! close the lowest-library opponent is to decking (CR 104.3c). Three tiers:
+//! - Normal  (≥ 15 cards): ×1.0
+//! - Elevated (< 15 cards): ×2.0
+//! - Urgent   (<  5 cards): ×3.0
+
+use engine::game::players;
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::ability_chain::collect_chain_effects;
+use crate::features::mill::{effect_is_opponent_mill, COMMITMENT_FLOOR};
+use crate::features::DeckFeatures;
+
+/// Library size below which mill urgency escalates to ×3.0. At this count the
+/// opponent is one moderate mill spell away from an empty library.
+pub(crate) const LIBRARY_THRESHOLD_URGENT: usize = 5;
+
+/// Library size below which mill urgency escalates to ×2.0. Fewer than 15
+/// cards puts the opponent within two-spell range.
+pub(crate) const LIBRARY_THRESHOLD_ELEVATED: usize = 15;
+
+pub(crate) const URGENCY_SCALE_HIGH: f64 = 3.0;
+pub(crate) const URGENCY_SCALE_MID: f64 = 2.0;
+pub(crate) const URGENCY_SCALE_NORMAL: f64 = 1.0;
+
+pub struct MillPayoffPolicy;
+
+impl TacticalPolicy for MillPayoffPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::MillPayoff
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::CastSpell]
+    }
+
+    fn activation(
+        &self,
+        features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        if features.mill.commitment < COMMITMENT_FLOOR {
+            None
+        } else {
+            Some(features.mill.commitment)
+        }
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let GameAction::CastSpell { object_id, .. } = &ctx.candidate.action else {
+            return PolicyVerdict::neutral(PolicyReason::new("mill_payoff_na"));
+        };
+        let Some(object) = ctx.state.objects.get(object_id) else {
+            return PolicyVerdict::neutral(PolicyReason::new("mill_payoff_na"));
+        };
+
+        // Re-classify the live object structurally and per-chain — identical
+        // isolation guard as BlinkPayoffPolicy. Two separate abilities where
+        // ability A exiles and ability B returns must NOT combine into a false-
+        // positive mill detection; checking each chain independently prevents this.
+        let casts_opponent_mill =
+            object.abilities.iter().any(|ability| {
+                collect_chain_effects(ability)
+                    .iter()
+                    .copied()
+                    .any(effect_is_opponent_mill)
+            }) || object.trigger_definitions.iter_unchecked().any(|trigger| {
+                trigger.execute.as_deref().is_some_and(|execute| {
+                    collect_chain_effects(execute)
+                        .iter()
+                        .copied()
+                        .any(effect_is_opponent_mill)
+                })
+            });
+
+        if !casts_opponent_mill {
+            return PolicyVerdict::neutral(PolicyReason::new("mill_payoff_inert"));
+        }
+
+        // Find the opponent with the fewest cards remaining — that opponent is
+        // the clock the deck is racing against.
+        // CR 104.3c: a player who draws from an empty library loses. Tracking the
+        // minimum-library opponent gives the most urgency-accurate scaling when
+        // there are multiple opponents.
+        let min_library = players::opponents(ctx.state, ctx.ai_player)
+            .iter()
+            .map(|&opp_id| ctx.state.players[opp_id.0 as usize].library.len())
+            .min()
+            .unwrap_or(60);
+
+        let urgency_scale = if min_library < LIBRARY_THRESHOLD_URGENT {
+            URGENCY_SCALE_HIGH
+        } else if min_library < LIBRARY_THRESHOLD_ELEVATED {
+            URGENCY_SCALE_MID
+        } else {
+            URGENCY_SCALE_NORMAL
+        };
+
+        let delta = ctx.penalties().mill_cast_bonus * urgency_scale;
+        PolicyVerdict::score(
+            delta,
+            PolicyReason::new("mill_cast")
+                .with_fact("library_remaining", min_library as i64)
+                .with_fact("urgency_x10", (urgency_scale * 10.0) as i64),
+        )
+    }
+}

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -35,6 +35,7 @@ mod lethality_awareness;
 mod life_total_resource;
 mod lifegain_payoff;
 mod mana_efficiency;
+mod mill_payoff;
 mod mill_targeting;
 pub mod mulligan;
 mod payment_selection;

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -25,6 +25,7 @@ use super::landfall_timing::LandfallTimingPolicy;
 use super::lethality_awareness::LethalityAwarenessPolicy;
 use super::life_total_resource::LifeTotalResourcePolicy;
 use super::lifegain_payoff::LifegainPayoffPolicy;
+use super::mill_payoff::MillPayoffPolicy;
 use super::payment_selection::PaymentSelectionPolicy;
 use super::plus_one_counters::PlusOneCountersPolicy;
 use super::ramp_timing::RampTimingPolicy;
@@ -118,6 +119,7 @@ pub enum PolicyId {
     XValue,
     LandAnimation,
     MillTargeting,
+    MillPayoff,
     ChaliceAvoidance,
     PaymentSelection,
     SeparatePilesTiming,
@@ -330,6 +332,7 @@ impl Default for PolicyRegistry {
             Box::new(super::control_change_awareness::ControlChangeAwarenessPolicy),
             Box::new(super::land_animation::LandAnimationPolicy),
             Box::new(super::mill_targeting::MillTargetingPolicy),
+            Box::new(MillPayoffPolicy),
             Box::new(ChaliceAvoidancePolicy),
             Box::new(PaymentSelectionPolicy),
             Box::new(SeparatePilesTimingPolicy),

--- a/crates/phase-ai/src/policies/tests/mill_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/mill_payoff.rs
@@ -1,0 +1,133 @@
+//! Tests for `MillPayoffPolicy` — activation gate + verdict branches including
+//! library-size urgency scaling. No `#[cfg(test)]` in SOURCE files; tests
+//! live here.
+
+use engine::types::ability::{AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter};
+use engine::types::zones::Zone;
+
+use crate::features::mill::COMMITMENT_FLOOR;
+use crate::features::DeckFeatures;
+use crate::policies::mill_payoff::MillPayoffPolicy;
+use crate::policies::registry::{DecisionKind, PolicyId, TacticalPolicy};
+
+fn policy() -> MillPayoffPolicy {
+    MillPayoffPolicy
+}
+
+// ─── id ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn identity_is_mill_payoff() {
+    assert_eq!(policy().id(), PolicyId::MillPayoff);
+}
+
+// ─── activation ──────────────────────────────────────────────────────────
+
+#[test]
+fn activation_below_floor_returns_none() {
+    use engine::types::game_state::GameState;
+    use engine::types::player::PlayerId;
+    let mut features = DeckFeatures::default();
+    features.mill.commitment = COMMITMENT_FLOOR - 0.01;
+    let state = GameState::default();
+    let result = policy().activation(&features, &state, PlayerId(0));
+    assert!(result.is_none(), "commitment below floor must return None");
+}
+
+#[test]
+fn activation_at_floor_returns_some() {
+    use engine::types::game_state::GameState;
+    use engine::types::player::PlayerId;
+    let mut features = DeckFeatures::default();
+    features.mill.commitment = COMMITMENT_FLOOR;
+    let state = GameState::default();
+    let result = policy().activation(&features, &state, PlayerId(0));
+    assert!(result.is_some(), "commitment at floor must return Some");
+    let v = result.unwrap();
+    assert!(
+        (v - COMMITMENT_FLOOR).abs() < 1e-6,
+        "activation should equal commitment; got {v}"
+    );
+}
+
+#[test]
+fn activation_above_floor_returns_commitment() {
+    use engine::types::game_state::GameState;
+    use engine::types::player::PlayerId;
+    let mut features = DeckFeatures::default();
+    features.mill.commitment = 0.9;
+    let state = GameState::default();
+    let result = policy().activation(&features, &state, PlayerId(0));
+    let v = result.expect("commitment 0.9 must activate");
+    assert!(
+        (v - 0.9).abs() < 1e-6,
+        "activation should equal commitment 0.9; got {v}"
+    );
+}
+
+// ─── verdict helpers ──────────────────────────────────────────────────────
+
+/// Build an `AbilityDefinition` with the given effect so it classifies as
+/// an opponent-mill ability during per-chain structural detection.
+#[allow(dead_code)]
+fn mill_ability(target: TargetFilter) -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Mill {
+            count: QuantityExpr::Fixed { value: 10 },
+            target,
+            destination: Zone::Graveyard,
+        },
+    )
+}
+
+
+// ─── verdict: inert spells ────────────────────────────────────────────────
+
+#[test]
+fn verdict_non_mill_spell_is_inert() {
+    use engine::types::game_state::GameState;
+
+    let state = GameState::default();
+    let features = {
+        let mut f = DeckFeatures::default();
+        f.mill.commitment = 1.0;
+        f
+    };
+
+    // Build a spell object that only draws — no mill
+    let object_id = engine::types::identifiers::ObjectId(0);
+    // We can't easily build a full PolicyContext here without a running game;
+    // test activation gate + structural re-classification separately.
+    // Activation gate is tested above; structural predicate tested in
+    // features/tests/mill.rs. The verdict path is validated by compile-time
+    // type safety — the policy can only return neutral/score/reject, and the
+    // score contract lint verifies no direct literal constructors are used.
+    let _ = (state, features, object_id);
+    // Confirm the policy registers for CastSpell only.
+    assert!(policy().decision_kinds().contains(&DecisionKind::CastSpell));
+    assert!(!policy().decision_kinds().contains(&DecisionKind::PlayLand));
+}
+
+// ─── verdict: urgency scaling ─────────────────────────────────────────────
+
+/// The urgency constants are compile-time validated:
+/// - URGENCY_SCALE_HIGH (3.0) > URGENCY_SCALE_MID (2.0) > URGENCY_SCALE_NORMAL (1.0)
+/// - LIBRARY_THRESHOLD_URGENT (5) < LIBRARY_THRESHOLD_ELEVATED (15) ≤ 5
+///
+/// These invariants hold by construction — the values are defined in
+/// `mill_payoff.rs` and clippy validates constant-value assertions at
+/// compile time.
+#[test]
+fn urgency_constants_are_ordered() {
+    use crate::policies::mill_payoff::{
+        LIBRARY_THRESHOLD_ELEVATED, LIBRARY_THRESHOLD_URGENT, URGENCY_SCALE_HIGH,
+        URGENCY_SCALE_MID, URGENCY_SCALE_NORMAL,
+    };
+    // Compile-time validation that thresholds are ordered correctly.
+    let _ = (
+        LIBRARY_THRESHOLD_URGENT < LIBRARY_THRESHOLD_ELEVATED,
+        URGENCY_SCALE_HIGH > URGENCY_SCALE_MID,
+        URGENCY_SCALE_MID > URGENCY_SCALE_NORMAL,
+    );
+}

--- a/crates/phase-ai/src/policies/tests/mill_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/mill_payoff.rs
@@ -1,49 +1,210 @@
 //! Tests for `MillPayoffPolicy` — activation gate + verdict branches including
 //! library-size urgency scaling. No `#[cfg(test)]` in SOURCE files; tests
 //! live here.
+//!
+//! The verdict path is exercised against a real `PolicyContext` built from a
+//! two-player `GameState` with a castable mill object and a controlled
+//! opponent library size, mirroring the `blink_payoff` policy-test shape.
 
+use std::sync::Arc;
+
+use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+use engine::game::zones::create_object;
 use engine::types::ability::{AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::game_state::{CastPaymentMode, GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
 
-use crate::features::mill::COMMITMENT_FLOOR;
+use crate::config::AiConfig;
+use crate::context::AiContext;
+use crate::features::mill::{MillFeature, COMMITMENT_FLOOR};
 use crate::features::DeckFeatures;
+use crate::policies::context::PolicyContext;
 use crate::policies::mill_payoff::MillPayoffPolicy;
-use crate::policies::registry::{DecisionKind, PolicyId, TacticalPolicy};
+use crate::policies::registry::{
+    DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy,
+};
+use crate::session::AiSession;
+
+const AI: PlayerId = PlayerId(0);
+const OPPONENT: PlayerId = PlayerId(1);
 
 fn policy() -> MillPayoffPolicy {
     MillPayoffPolicy
 }
 
-// ─── id ───────────────────────────────────────────────────────────────────
+// ─── fixtures ───────────────────────────────────────────────────────────────
+
+fn features(commitment: f32) -> DeckFeatures {
+    DeckFeatures {
+        mill: MillFeature {
+            mill_count: 20,
+            commitment,
+        },
+        ..DeckFeatures::default()
+    }
+}
+
+fn ai_context(commitment: f32) -> (AiContext, AiConfig) {
+    let config = AiConfig::default();
+    let mut session = AiSession::empty();
+    session.features.insert(AI, features(commitment));
+    let mut context = AiContext::empty(&config.weights);
+    context.session = Arc::new(session);
+    context.player = AI;
+    (context, config)
+}
+
+fn decision() -> AiDecisionContext {
+    AiDecisionContext {
+        waiting_for: WaitingFor::Priority { player: AI },
+        candidates: Vec::new(),
+    }
+}
+
+fn cast_candidate(object_id: ObjectId) -> CandidateAction {
+    CandidateAction {
+        action: GameAction::CastSpell {
+            object_id,
+            card_id: CardId(object_id.0),
+            targets: Vec::new(),
+            payment_mode: CastPaymentMode::default(),
+        },
+        metadata: ActionMetadata {
+            actor: Some(AI),
+            tactical_class: TacticalClass::Spell,
+        },
+    }
+}
+
+/// A non-cast (PlayLand) candidate — drives the `mill_payoff_na` branch,
+/// which short-circuits any candidate that is not a `CastSpell`.
+fn land_candidate(object_id: ObjectId) -> CandidateAction {
+    CandidateAction {
+        action: GameAction::PlayLand {
+            object_id,
+            card_id: CardId(object_id.0),
+        },
+        metadata: ActionMetadata {
+            actor: Some(AI),
+            tactical_class: TacticalClass::Land,
+        },
+    }
+}
+
+fn spell_object(state: &mut GameState, idx: u64, core: Vec<CoreType>) -> ObjectId {
+    let oid = create_object(state, CardId(idx), AI, format!("Spell {idx}"), Zone::Stack);
+    state.objects.get_mut(&oid).unwrap().card_types = CardType {
+        supertypes: Vec::new(),
+        core_types: core,
+        subtypes: Vec::new(),
+    };
+    oid
+}
+
+fn push_ability(state: &mut GameState, oid: ObjectId, ability: AbilityDefinition) {
+    Arc::make_mut(&mut state.objects.get_mut(&oid).unwrap().abilities).push(ability);
+}
+
+/// A Tome Scour-shape opponent-mill spell — classifies as opponent-mill under
+/// per-chain structural detection (`target: Player` ≠ `Controller | Any`).
+fn opponent_mill_ability() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Mill {
+            count: QuantityExpr::Fixed { value: 5 },
+            target: TargetFilter::Player,
+            destination: Zone::Graveyard,
+        },
+    )
+}
+
+/// A Divination-shape draw spell — no mill effect, so a cast is `mill_payoff_inert`.
+fn draw_ability() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 2 },
+            target: TargetFilter::Controller,
+        },
+    )
+}
+
+/// Set the opponent's library to `n` cards. Library size selects the urgency
+/// tier in `MillPayoffPolicy::verdict` (CR 104.3c).
+fn set_opponent_library(state: &mut GameState, n: usize) {
+    state.players[OPPONENT.0 as usize].library = (0..n).map(|i| ObjectId(i as u64)).collect();
+}
+
+fn ctx<'a>(
+    state: &'a GameState,
+    candidate: &'a CandidateAction,
+    decision: &'a AiDecisionContext,
+    context: &'a AiContext,
+    config: &'a AiConfig,
+) -> PolicyContext<'a> {
+    PolicyContext {
+        state,
+        decision,
+        candidate,
+        ai_player: AI,
+        config,
+        context,
+        cast_facts: None,
+    }
+}
+
+/// Unwrap a `Score` verdict into `(delta, reason)`; fail on `Reject`.
+fn score_of(verdict: PolicyVerdict) -> (f64, PolicyReason) {
+    match verdict {
+        PolicyVerdict::Score { delta, reason } => (delta, reason),
+        PolicyVerdict::Reject { reason } => panic!("unexpected Reject: {reason:?}"),
+    }
+}
+
+/// Look up a typed fact by key, panicking if it is absent.
+fn fact(reason: &PolicyReason, key: &str) -> i64 {
+    reason
+        .facts
+        .iter()
+        .find(|(k, _)| *k == key)
+        .map(|(_, v)| *v)
+        .unwrap_or_else(|| panic!("missing fact {key:?}; facts = {:?}", reason.facts))
+}
+
+// ─── identity ───────────────────────────────────────────────────────────────
 
 #[test]
 fn identity_is_mill_payoff() {
     assert_eq!(policy().id(), PolicyId::MillPayoff);
+    assert!(policy().decision_kinds().contains(&DecisionKind::CastSpell));
+    assert!(!policy().decision_kinds().contains(&DecisionKind::PlayLand));
 }
 
-// ─── activation ──────────────────────────────────────────────────────────
+// ─── activation gate ────────────────────────────────────────────────────────
 
 #[test]
 fn activation_below_floor_returns_none() {
-    use engine::types::game_state::GameState;
-    use engine::types::player::PlayerId;
     let mut features = DeckFeatures::default();
     features.mill.commitment = COMMITMENT_FLOOR - 0.01;
-    let state = GameState::default();
-    let result = policy().activation(&features, &state, PlayerId(0));
-    assert!(result.is_none(), "commitment below floor must return None");
+    let state = GameState::new_two_player(7);
+    assert!(
+        policy().activation(&features, &state, AI).is_none(),
+        "commitment below floor must return None"
+    );
 }
 
 #[test]
 fn activation_at_floor_returns_some() {
-    use engine::types::game_state::GameState;
-    use engine::types::player::PlayerId;
     let mut features = DeckFeatures::default();
     features.mill.commitment = COMMITMENT_FLOOR;
-    let state = GameState::default();
-    let result = policy().activation(&features, &state, PlayerId(0));
-    assert!(result.is_some(), "commitment at floor must return Some");
-    let v = result.unwrap();
+    let state = GameState::new_two_player(7);
+    let v = policy()
+        .activation(&features, &state, AI)
+        .expect("commitment at floor must activate");
     assert!(
         (v - COMMITMENT_FLOOR).abs() < 1e-6,
         "activation should equal commitment; got {v}"
@@ -52,82 +213,148 @@ fn activation_at_floor_returns_some() {
 
 #[test]
 fn activation_above_floor_returns_commitment() {
-    use engine::types::game_state::GameState;
-    use engine::types::player::PlayerId;
     let mut features = DeckFeatures::default();
     features.mill.commitment = 0.9;
-    let state = GameState::default();
-    let result = policy().activation(&features, &state, PlayerId(0));
-    let v = result.expect("commitment 0.9 must activate");
+    let state = GameState::new_two_player(7);
+    let v = policy()
+        .activation(&features, &state, AI)
+        .expect("commitment 0.9 must activate");
     assert!(
         (v - 0.9).abs() < 1e-6,
         "activation should equal commitment 0.9; got {v}"
     );
 }
 
-// ─── verdict helpers ──────────────────────────────────────────────────────
+// ─── verdict: non-cast → na ─────────────────────────────────────────────────
 
-/// Build an `AbilityDefinition` with the given effect so it classifies as
-/// an opponent-mill ability during per-chain structural detection.
-#[allow(dead_code)]
-fn mill_ability(target: TargetFilter) -> AbilityDefinition {
-    AbilityDefinition::new(
-        AbilityKind::Spell,
-        Effect::Mill {
-            count: QuantityExpr::Fixed { value: 10 },
-            target,
-            destination: Zone::Graveyard,
-        },
-    )
+#[test]
+fn verdict_non_cast_action_is_na() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 1, vec![CoreType::Land]);
+    push_ability(&mut state, oid, opponent_mill_ability());
+
+    // A mill-committed deck keeps the policy live, but a PlayLand candidate is
+    // not a cast — the verdict short-circuits to `mill_payoff_na` before any
+    // structural mill classification runs.
+    let candidate = land_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(1.0);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, reason) = score_of(policy().verdict(&ctx));
+    assert_eq!(reason.kind, "mill_payoff_na");
+    assert!(
+        delta.abs() < 1e-9,
+        "na must be neutral (delta 0), got {delta}"
+    );
 }
 
-
-// ─── verdict: inert spells ────────────────────────────────────────────────
+// ─── verdict: non-mill spell → inert ────────────────────────────────────────
 
 #[test]
 fn verdict_non_mill_spell_is_inert() {
-    use engine::types::game_state::GameState;
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 2, vec![CoreType::Sorcery]);
+    push_ability(&mut state, oid, draw_ability());
 
-    let state = GameState::default();
-    let features = {
-        let mut f = DeckFeatures::default();
-        f.mill.commitment = 1.0;
-        f
-    };
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(1.0);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
 
-    // Build a spell object that only draws — no mill
-    let object_id = engine::types::identifiers::ObjectId(0);
-    // We can't easily build a full PolicyContext here without a running game;
-    // test activation gate + structural re-classification separately.
-    // Activation gate is tested above; structural predicate tested in
-    // features/tests/mill.rs. The verdict path is validated by compile-time
-    // type safety — the policy can only return neutral/score/reject, and the
-    // score contract lint verifies no direct literal constructors are used.
-    let _ = (state, features, object_id);
-    // Confirm the policy registers for CastSpell only.
-    assert!(policy().decision_kinds().contains(&DecisionKind::CastSpell));
-    assert!(!policy().decision_kinds().contains(&DecisionKind::PlayLand));
+    let (delta, reason) = score_of(policy().verdict(&ctx));
+    assert_eq!(reason.kind, "mill_payoff_inert");
+    assert!(
+        delta.abs() < 1e-9,
+        "inert must be neutral (delta 0), got {delta}"
+    );
 }
 
-// ─── verdict: urgency scaling ─────────────────────────────────────────────
+// ─── verdict: urgency scaling (×1 / ×2 / ×3) ────────────────────────────────
 
-/// The urgency constants are compile-time validated:
-/// - URGENCY_SCALE_HIGH (3.0) > URGENCY_SCALE_MID (2.0) > URGENCY_SCALE_NORMAL (1.0)
-/// - LIBRARY_THRESHOLD_URGENT (5) < LIBRARY_THRESHOLD_ELEVATED (15) ≤ 5
-///
-/// These invariants hold by construction — the values are defined in
-/// `mill_payoff.rs` and clippy validates constant-value assertions at
-/// compile time.
+/// Cast a mill spell against a controlled opponent library size, returning the
+/// scored `(delta, reason)`. Commitment is pinned at 1.0 so the policy is
+/// active; the verdict's own scaling reads only the opponent's library.
+fn scored_mill_verdict(opponent_library: usize) -> (f64, PolicyReason) {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 3, vec![CoreType::Sorcery]);
+    push_ability(&mut state, oid, opponent_mill_ability());
+    set_opponent_library(&mut state, opponent_library);
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(1.0);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+    score_of(policy().verdict(&ctx))
+}
+
+#[test]
+fn verdict_normal_library_is_x1() {
+    // 20 cards (≥ ELEVATED threshold) → ×1.0.
+    let (delta, reason) = scored_mill_verdict(20);
+    let expected = AiConfig::default().policy_penalties.mill_cast_bonus * 1.0;
+    assert!(
+        (delta - expected).abs() < 1e-9,
+        "normal urgency (20 cards) must scale ×1 (expected {expected}); got {delta}"
+    );
+    assert_eq!(reason.kind, "mill_cast");
+    assert_eq!(fact(&reason, "library_remaining"), 20);
+    assert_eq!(fact(&reason, "urgency_x10"), 10);
+}
+
+#[test]
+fn verdict_elevated_library_is_x2() {
+    // 10 cards (< ELEVATED, ≥ URGENT) → ×2.0.
+    let (delta, reason) = scored_mill_verdict(10);
+    let expected = AiConfig::default().policy_penalties.mill_cast_bonus * 2.0;
+    assert!(
+        (delta - expected).abs() < 1e-9,
+        "elevated urgency (10 cards) must scale ×2 (expected {expected}); got {delta}"
+    );
+    assert_eq!(reason.kind, "mill_cast");
+    assert_eq!(fact(&reason, "library_remaining"), 10);
+    assert_eq!(fact(&reason, "urgency_x10"), 20);
+}
+
+#[test]
+fn verdict_urgent_library_is_x3() {
+    // 3 cards (< URGENT threshold) → ×3.0.
+    let (delta, reason) = scored_mill_verdict(3);
+    let expected = AiConfig::default().policy_penalties.mill_cast_bonus * 3.0;
+    assert!(
+        (delta - expected).abs() < 1e-9,
+        "urgent urgency (3 cards) must scale ×3 (expected {expected}); got {delta}"
+    );
+    assert_eq!(reason.kind, "mill_cast");
+    assert_eq!(fact(&reason, "library_remaining"), 3);
+    assert_eq!(fact(&reason, "urgency_x10"), 30);
+}
+
+// ─── urgency constants ──────────────────────────────────────────────────────
+
+/// Compile-time guard: the policy's library-size boundaries must be strictly
+/// ordered so the three tiers (normal / elevated / urgent) partition the space
+/// without overlap, and the scales must be strictly increasing. Each assert
+/// lives in a `const {}` block, so inverting any constant is a build error
+/// before the suite runs. Surfaced as a `#[test]` for discoverability.
 #[test]
 fn urgency_constants_are_ordered() {
     use crate::policies::mill_payoff::{
         LIBRARY_THRESHOLD_ELEVATED, LIBRARY_THRESHOLD_URGENT, URGENCY_SCALE_HIGH,
         URGENCY_SCALE_MID, URGENCY_SCALE_NORMAL,
     };
-    // Compile-time validation that thresholds are ordered correctly.
-    let _ = (
-        LIBRARY_THRESHOLD_URGENT < LIBRARY_THRESHOLD_ELEVATED,
-        URGENCY_SCALE_HIGH > URGENCY_SCALE_MID,
-        URGENCY_SCALE_MID > URGENCY_SCALE_NORMAL,
-    );
+    const {
+        assert!(
+            LIBRARY_THRESHOLD_URGENT < LIBRARY_THRESHOLD_ELEVATED,
+            "URGENT threshold must be strictly below ELEVATED"
+        );
+        assert!(
+            URGENCY_SCALE_HIGH > URGENCY_SCALE_MID,
+            "URGENCY_SCALE_HIGH must exceed URGENCY_SCALE_MID"
+        );
+        assert!(
+            URGENCY_SCALE_MID > URGENCY_SCALE_NORMAL,
+            "URGENCY_SCALE_MID must exceed URGENCY_SCALE_NORMAL"
+        );
+    }
 }

--- a/crates/phase-ai/src/policies/tests/mod.rs
+++ b/crates/phase-ai/src/policies/tests/mod.rs
@@ -6,6 +6,7 @@ pub mod blink_payoff;
 pub mod enchantments_payoff;
 pub mod equipment_payoff;
 pub mod lifegain_payoff;
+pub mod mill_payoff;
 pub mod mulligan_input_lint;
 pub mod reanimator_payoff;
 pub mod score_contract_lint;

--- a/crates/phase-ai/tests/duel_suite_attribution.rs
+++ b/crates/phase-ai/tests/duel_suite_attribution.rs
@@ -59,6 +59,7 @@ fn expected_policies(kind: FeatureKind) -> &'static [&'static str] {
         FeatureKind::Reanimator => &["ReanimatorPayoff"],
         FeatureKind::Equipment => &["EquipmentPayoff"],
         FeatureKind::Blink => &["BlinkPayoff"],
+        FeatureKind::Mill => &["MillPayoff"],
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #3722

Adds Mill deck-feature axis to `phase-ai` for opponent-library-depletion archetype recognition, with payoff-gated `MillPayoffPolicy` that scales casting priority based on opponent library size (×1.0 normal, ×2.0 below 15 cards, ×3.0 below 5 cards).

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

> This is a `phase-ai` feature addition (AI deck recognition + policy), not an engine rules change. The `Effect::Mill` type already exists in `cr/engine/` and is fully resolved. This work adds structural detection of opponent-mill density at deck-analysis time and a tactical policy that raises mill spell priority when the deck is mill-committed and the opponent's library is running low. No engine/parser logic was modified.

## CR references

- CR 701.17a — Mill sends cards from top of library to graveyard
- CR 104.3c — Player loses when drawing from empty library (urgency threshold rationale)

## Verification

### Built-in tests
```bash
# Feature detector tests (structural detection + calibration)
cargo test -p phase-ai features::tests::mill

# Policy tests (activation gate + verdict branches)
cargo test -p phase-ai policies::tests::mill_payoff

# Solar-system invariants
cargo test -p phase-ai duel_suite::tests::feature_kind_matches_deck_features_field_count  # asserts 15 axes
cargo test -p phase-ai duel_suite::tests::every_feature_kind_is_exercised                 # asserts Mill exercised
