### PR TITLE
test(engine): add Condemn single-target regression tests for issue #3310

### DIFF
--- a/crates/engine/tests/integration/issue_3310_condemn_two_targets.rs
+++ b/crates/engine/tests/integration/issue_3310_condemn_two_targets.rs
@@ -1,0 +1,142 @@
+//! Regression for GitHub issue #3310 — Condemn requires two targets instead of one.
+//!
+//! Oracle: "Put target attacking or blocking creature on the bottom of its owner's
+//! library. Its controller gains 7 life."
+
+use engine::game::ability_utils::{build_resolved_from_def, build_target_slots};
+use engine::game::combat::{AttackTarget, AttackerInfo};
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, TargetFilter, TargetRef};
+use engine::types::player::PlayerId;
+
+const CONDEMN_ORACLE: &str =
+    "Put target attacking or blocking creature on the bottom of its owner's library. Its controller gains 7 life.";
+
+#[test]
+fn condemn_parses_put_bottom_then_controller_gains_life() {
+    let def = parse_effect_chain(CONDEMN_ORACLE, AbilityKind::Spell);
+    if let Effect::PutAtLibraryPosition { target, .. } = &*def.effect {
+        let TargetFilter::Or { filters } = target else {
+            panic!("expected Or(attacking|blocking) target filter, got {target:?}");
+        };
+        assert_eq!(filters.len(), 2);
+    } else {
+        panic!(
+            "primary effect should be PutAtLibraryPosition, got {:?}",
+            def.effect
+        );
+    }
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("should chain controller life gain as sub_ability");
+    assert!(
+        matches!(
+            *sub.effect,
+            Effect::GainLife {
+                player: TargetFilter::ParentTargetController,
+                ..
+            }
+        ),
+        "sub_ability should be ParentTargetController GainLife, got {:?}",
+        sub.effect
+    );
+    assert!(
+        def.multi_target.is_none(),
+        "Condemn must not declare multi-target; got {:?}",
+        def.multi_target
+    );
+}
+
+#[test]
+fn condemn_spell_ability_matches_parsed_chain() {
+    let mut scenario = GameScenario::new();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Condemn", true, CONDEMN_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let obj = &runner.state().objects[&spell];
+    assert_eq!(
+        obj.abilities.len(),
+        1,
+        "Condemn must parse as one spell ability, not split across sentences"
+    );
+    let ability = &obj.abilities[0];
+    assert!(
+        matches!(*ability.effect, Effect::PutAtLibraryPosition { .. }),
+        "spell ability should be PutAtLibraryPosition"
+    );
+}
+
+#[test]
+fn condemn_multiline_oracle_merges_into_one_ability() {
+    let multiline = "Put target attacking or blocking creature on the bottom of its owner's library.\nIts controller gains 7 life.";
+    let mut scenario = GameScenario::new();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Condemn", true, multiline)
+        .id();
+    let runner = scenario.build();
+    let obj = &runner.state().objects[&spell];
+    assert_eq!(
+        obj.abilities.len(),
+        1,
+        "newline-separated rider must merge into one spell ability (issue #3310)"
+    );
+    let ability = &obj.abilities[0];
+    assert!(
+        matches!(*ability.effect, Effect::PutAtLibraryPosition { .. }),
+        "merged ability head must be PutAtLibraryPosition"
+    );
+    let sub = ability
+        .sub_ability
+        .as_ref()
+        .expect("life-gain rider must chain as sub_ability");
+    assert!(
+        matches!(
+            *sub.effect,
+            Effect::GainLife {
+                player: TargetFilter::ParentTargetController,
+                ..
+            }
+        ),
+        "life-gain rider must use ParentTargetController, got {:?}",
+        sub.effect
+    );
+}
+
+#[test]
+fn condemn_builds_one_target_slot_for_attacking_creature() {
+    let mut scenario = GameScenario::new();
+    let attacker = scenario.add_creature(P1, "Attacker", 2, 2).id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Condemn", true, CONDEMN_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let combat = runner
+        .state_mut()
+        .combat
+        .get_or_insert_with(Default::default);
+    combat.attackers.push(AttackerInfo::new(
+        attacker,
+        AttackTarget::Player(PlayerId(0)),
+        PlayerId(0),
+    ));
+
+    let ability = runner.state().objects[&spell].abilities[0].clone();
+    let resolved = build_resolved_from_def(&ability, spell, P0);
+    let slots = build_target_slots(runner.state(), &resolved).expect("target slots");
+    assert_eq!(
+        slots.len(),
+        1,
+        "Condemn must build exactly one target slot (issue #3310), got {}",
+        slots.len()
+    );
+    assert!(
+        slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(attacker)),
+        "the attacking creature must be legal"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -256,6 +256,7 @@ mod issue_3301_izzet_charm_counter;
 mod issue_3302_breach_multiverse;
 mod issue_3303_adeline_tapped_attacking;
 mod issue_3309_rise_etb_returns;
+mod issue_3310_condemn_two_targets;
 mod issue_3311_manifest_dread_land;
 mod issue_3314_killian;
 mod issue_3316_stinging_study;


### PR DESCRIPTION
## Summary

**Bug:** Casting Condemn prompted for two targets instead of one. The card should only ask for a single creature (attacking or blocking); the life-gain rider resolves automatically from that choice.

**Root cause class:** Condemn's Oracle text has one targeted clause and one non-targeted rider:

```
Put target attacking or blocking creature on the bottom of its owner's library. Its controller gains 7 life.
```
Closes #3310

CR 601.2c allows only one instance of the word "target" here — the creature. The life-gain sentence must chain as a `sub_ability` using `TargetFilter::ParentTargetController` (the same pattern as Swords to Plowshares / Archon of Cruelty #2344), not as a second stack-time target slot.

A failure mode that produces "two targets" is:

1. **Parser splits the rider into a second spell ability** (newline-separated Oracle lines merged incorrectly), so cast-time targeting walks two ability heads; or
2. **The rider parses with its own target filter** instead of `ParentTargetController`, so `collect_target_slots` surfaces a second slot alongside the `PutAtLibraryPosition` head.

Investigation shows the current engine already avoids both failure modes. This change adds regression tests that lock the correct behavior end-to-end.

## Correct parse shape

```json
{
  "effect": {
    "type": "PutAtLibraryPosition",
    "target": {
      "type": "Or",
      "filters": [
        { "properties": [{ "type": "Attacking" }] },
        { "properties": [{ "type": "Blocking" }] }
      ]
    },
    "position": { "type": "Bottom" }
  },
  "sub_ability": {
    "effect": {
      "type": "GainLife",
      "amount": { "type": "Fixed", "value": 7 },
      "player": { "type": "ParentTargetController" }
    }
  },
  "multi_target": null
}
```

Key properties:

- `"attacking or blocking"` is a **single** `TargetFilter::Or` disjunction (one slot, union of legal creatures) — not two slots.
- `multi_target` stays `None` — not confused with `"one or two target"`.
- Life gain binds to the chosen creature's controller at resolution; no second target announcement.

## Files changed

| File | Change |
|---|---|
| `crates/engine/tests/integration/issue_3310_condemn_two_targets.rs` | New regression tests (parser, oracle merge, runtime slot build) |
| `crates/engine/tests/integration/main.rs` | Register test module |

## Tests

| Test | Asserts |
|---|---|
| `condemn_parses_put_bottom_then_controller_gains_life` | `PutAtLibraryPosition` + `Or(Attacking\|Blocking)` head; `GainLife(ParentTargetController)` sub; no `multi_target` |
| `condemn_spell_ability_matches_parsed_chain` | Full oracle parse → exactly **one** spell ability |
| `condemn_multiline_oracle_merges_into_one_ability` | Newline-separated Oracle lines merge into one ability (not two spell abilities) |
| `condemn_builds_one_target_slot_for_attacking_creature` | `build_target_slots` returns **one** slot when an attacker is in combat |

## Cards affected

| Card | Pattern |
|---|---|
| Condemn | `Put target attacking or blocking creature … Its controller gains 7 life.` |

Any spell sharing the `Put/Exile target X. Its controller gains N life.` shape benefits from the same chaining and `ParentTargetController` binding already present in `try_parse_targeted_controller_gain_life`.

## Verification checklist

- [x] `cargo fmt --all` — clean
- [x] `cargo test -p engine --test integration condemn_` — 4/4 pass
- [x] Parser emits one `target` instance (CR 601.2c) — confirmed via `build_target_slots` length == 1
- [x] Multiline Oracle text (MTGJSON-style line break) still merges to one ability
