### PR TITLE
fix(engine): honor copy starting loyalty

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3011,6 +3011,9 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
                 None => format!("enter with {count_str} {} counter", counter_type.as_str()),
             }
         }
+        ContinuousModification::SetStartingLoyalty { value } => {
+            format!("starting loyalty {value}")
+        }
         ContinuousModification::RemoveManaCost => "no mana cost".to_string(),
     }
 }

--- a/crates/engine/src/game/effects/become_copy.rs
+++ b/crates/engine/src/game/effects/become_copy.rs
@@ -78,19 +78,29 @@ pub fn resolve(
     {
         values.mana_cost = crate::types::mana::ManaCost::NoCost;
     }
+    if let Some(loyalty) = additional_modifications.iter().rev().find_map(|m| {
+        if let ContinuousModification::SetStartingLoyalty { value } = m {
+            Some(*value)
+        } else {
+            None
+        }
+    }) {
+        values.loyalty = Some(loyalty);
+    }
 
-    // CR 122.1 + CR 614.1c + CR 202.1b: `AddCounterOnEnter` (counter placement)
-    // and `RemoveManaCost` (consumed above) are resolution-time exceptions, not
-    // layered modifications — partition them out so the layer pipeline only sees
-    // the layered variants. The counter-on-enter variants are applied via the
-    // counter primitive after layer evaluation; RemoveManaCost is already
-    // consumed into `values`, so it is dropped here.
+    // CR 122.1 + CR 614.1c + CR 202.1b + CR 707.9b: `AddCounterOnEnter`
+    // (counter placement), `RemoveManaCost`, and `SetStartingLoyalty` are
+    // resolution-time exceptions, not layered modifications — partition them
+    // out so the layer pipeline only sees layered variants. Counter-on-enter is
+    // applied via the counter primitive after layer evaluation; the mana-cost
+    // and starting-loyalty exceptions were already consumed into `values`.
     let (resolution_mods, layered_mods): (Vec<_>, Vec<_>) =
         additional_modifications.into_iter().partition(|m| {
             matches!(
                 m,
                 ContinuousModification::AddCounterOnEnter { .. }
                     | ContinuousModification::RemoveManaCost
+                    | ContinuousModification::SetStartingLoyalty { .. }
             )
         });
 

--- a/crates/engine/src/game/effects/become_copy.rs
+++ b/crates/engine/src/game/effects/become_copy.rs
@@ -78,13 +78,9 @@ pub fn resolve(
     {
         values.mana_cost = crate::types::mana::ManaCost::NoCost;
     }
-    if let Some(loyalty) = additional_modifications.iter().rev().find_map(|m| {
-        if let ContinuousModification::SetStartingLoyalty { value } = m {
-            Some(*value)
-        } else {
-            None
-        }
-    }) {
+    if let Some(loyalty) =
+        super::token_copy::copy_starting_loyalty_override(&additional_modifications)
+    {
         values.loyalty = Some(loyalty);
     }
 

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -423,14 +423,17 @@ pub(crate) fn apply_copy_token_after_replacement(
     } = copy;
     let name = values.name.clone();
     let mut created_ids = Vec::with_capacity(final_count as usize);
+    let copied_loyalty =
+        copy_starting_loyalty_override(&additional_modifications).or(values.loyalty);
 
-    // CR 306.5b + CR 707.2: A token that's a copy of a planeswalker enters with
-    // loyalty counters equal to the copied permanent's loyalty — CR 306.5c makes
-    // the counter map the single source of truth for loyalty. The copy path
-    // builds the object directly (not through the ZoneChange ETB-counter seeding
-    // used by cast/play/effect entries), so seed the intrinsic loyalty counters
-    // here, ahead of any explicit `enter_with_counters`, routing them through
-    // `add_counter_with_replacement` below so Doubling Season etc. apply
+    // CR 306.5b + CR 707.2 + CR 707.9b: A token that's a copy of a planeswalker
+    // enters with loyalty counters equal to the copied loyalty, except a copy
+    // exception may set that starting loyalty to a different value. CR 306.5c
+    // makes the counter map the single source of truth for loyalty. The copy
+    // path builds the object directly (not through the ZoneChange ETB-counter
+    // seeding used by cast/play/effect entries), so seed the intrinsic loyalty
+    // counters here, ahead of any explicit `enter_with_counters`, routing them
+    // through `add_counter_with_replacement` below so Doubling Season etc. apply
     // (CR 614.1a). Without this a copied planeswalker enters with 0 loyalty
     // counters and dies immediately to CR 704.5i. Copies don't track battle
     // defense (`CopiableValues` has no defense field), so only loyalty is seeded.
@@ -441,7 +444,7 @@ pub(crate) fn apply_copy_token_after_replacement(
     // intrinsic "enters with counters" replacement is seeded here from its
     // copiable replacement set rather than firing during entry.
     let etb_counters: Vec<(crate::types::counter::CounterType, u32)> =
-        crate::game::printed_cards::intrinsic_face_counters(values.loyalty, None)
+        crate::game::printed_cards::intrinsic_face_counters(copied_loyalty, None)
             .into_iter()
             .chain(crate::game::printed_cards::self_etb_counter_replacements(
                 &values.replacement_definitions,
@@ -478,8 +481,8 @@ pub(crate) fn apply_copy_token_after_replacement(
         token.power = values.power;
         token.base_toughness = values.toughness;
         token.toughness = values.toughness;
-        token.base_loyalty = values.loyalty;
-        token.loyalty = values.loyalty;
+        token.base_loyalty = copied_loyalty;
+        token.loyalty = copied_loyalty;
         token.base_keywords = values.keywords.clone();
         token.keywords = values.keywords.clone();
         // All four ability sets are Arc-shared — refcount bumps, no deep copy.
@@ -1059,6 +1062,16 @@ fn apply_token_modifications(
                     token.toughness = Some(val);
                 }
             }
+            // CR 707.9b + CR 306.5b/c: Starting-loyalty exceptions are already
+            // consumed before loyalty counters are seeded, but apply the live
+            // fields idempotently so a paused/resumed modification sequence
+            // keeps the stamped token coherent.
+            ContinuousModification::SetStartingLoyalty { value } => {
+                if let Some(token) = state.objects.get_mut(&token_id) {
+                    token.base_loyalty = Some(*value);
+                    token.loyalty = Some(*value);
+                }
+            }
             // CR 707.2 + CR 702 keyword grants flow through `extra_keywords`,
             // not here. Other layered-only modifications (CopyValues,
             // ChangeController, etc.) are intentionally skipped — their
@@ -1069,6 +1082,16 @@ fn apply_token_modifications(
         }
     }
     true
+}
+
+fn copy_starting_loyalty_override(modifications: &[ContinuousModification]) -> Option<u32> {
+    modifications.iter().rev().find_map(|modification| {
+        if let ContinuousModification::SetStartingLoyalty { value } = modification {
+            Some(*value)
+        } else {
+            None
+        }
+    })
 }
 
 /// CR 205.1a + CR 613.1d: remove every subtype belonging to the given
@@ -2965,6 +2988,77 @@ mod tests {
             Some(5),
             "copied planeswalker loyalty must derive from its seeded counters",
         );
+    }
+
+    /// CR 707.9b + CR 306.5b/c: Jace, Mirror Mage's token-copy exception sets
+    /// the copy's starting loyalty to 1. This is not an extra loyalty counter;
+    /// it replaces the loyalty value used for intrinsic planeswalker counter
+    /// seeding, so the token must enter with one loyalty counter even if the
+    /// copied source has a different loyalty value.
+    #[test]
+    fn copy_token_starting_loyalty_exception_overrides_seeded_loyalty() {
+        use crate::game::layers::evaluate_layers;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Jace, Mirror Mage".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.base_loyalty = Some(5);
+            source.loyalty = Some(5);
+            source.base_card_types = CardType {
+                supertypes: vec![crate::types::card_type::Supertype::Legendary],
+                core_types: vec![CoreType::Planeswalker],
+                subtypes: vec!["Jace".to_string()],
+            };
+            source.card_types = source.base_card_types.clone();
+        }
+
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::Any,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![
+                    ContinuousModification::RemoveSupertype {
+                        supertype: crate::types::card_type::Supertype::Legendary,
+                    },
+                    ContinuousModification::SetStartingLoyalty { value: 1 },
+                ],
+            },
+            vec![TargetRef::Object(source_id)],
+            source_id,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let token_id = ObjectId(state.next_object_id - 1);
+        let token = &state.objects[&token_id];
+        assert_eq!(token.base_loyalty, Some(1));
+        assert_eq!(
+            token.counters.get(&CounterType::Loyalty).copied(),
+            Some(1),
+            "starting-loyalty exception must seed one loyalty counter"
+        );
+        assert!(!token
+            .card_types
+            .supertypes
+            .contains(&crate::types::card_type::Supertype::Legendary));
+
+        evaluate_layers(&mut state);
+        let token = &state.objects[&token_id];
+        assert_eq!(token.zone, Zone::Battlefield);
+        assert_eq!(token.loyalty, Some(1));
     }
 
     /// Regression: Helm of the Host (DOM, MH3, BLC) — pin the already-shipped

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1084,7 +1084,9 @@ fn apply_token_modifications(
     true
 }
 
-fn copy_starting_loyalty_override(modifications: &[ContinuousModification]) -> Option<u32> {
+pub(crate) fn copy_starting_loyalty_override(
+    modifications: &[ContinuousModification],
+) -> Option<u32> {
     modifications.iter().rev().find_map(|modification| {
         if let ContinuousModification::SetStartingLoyalty { value } = modification {
             Some(*value)

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3394,7 +3394,8 @@ fn modification_dynamic_quantity(m: &ContinuousModification) -> Option<&Quantity
         | ContinuousModification::AddDynamicToughness { value }
         | ContinuousModification::AddDynamicKeyword { value, .. } => Some(value),
         // Resolution-time-consumed; never an active continuous effect.
-        ContinuousModification::AddCounterOnEnter { .. } => None,
+        ContinuousModification::AddCounterOnEnter { .. }
+        | ContinuousModification::SetStartingLoyalty { .. } => None,
         // Non-dynamic modifications carry plain i32 / enum payloads, no dynamic
         // magnitude. Enumerated explicitly (no wildcard) so a future
         // QuantityExpr-carrying variant forces a decision here.
@@ -3969,6 +3970,17 @@ fn apply_continuous_effect_filtered(
                      not via apply_continuous_effect"
                 );
             }
+            // CR 707.9b + CR 306.5b/c: Starting-loyalty exceptions are folded
+            // into copied values at copy resolution, before loyalty counters
+            // are seeded. Reaching the layer system means a resolver forgot to
+            // consume this one-shot copy exception.
+            ContinuousModification::SetStartingLoyalty { .. } => {
+                debug_assert!(
+                    false,
+                    "SetStartingLoyalty must be consumed at copy resolution time, \
+                     not via apply_continuous_effect"
+                );
+            }
             // CR 707.9 + CR 202.1b: the "has no mana cost" copy exception is
             // consumed at copy resolution (token_copy.rs bakes it into the token;
             // become_copy.rs strips it from the copied values), never via a
@@ -4346,6 +4358,12 @@ pub(crate) fn compute_current_copiable_values(
             // source's name.
             ContinuousModification::SetName { name } => {
                 values.name = name.clone();
+            }
+            // CR 707.9b + CR 306.5b: Starting loyalty is a copy-effect
+            // characteristic exception. A later copy of this copy must see
+            // the overridden loyalty value.
+            ContinuousModification::SetStartingLoyalty { value } => {
+                values.loyalty = Some(*value);
             }
             // CR 707.9a: A copy effect that grants/retains an ability ("…
             // and it has this ability") makes that ability part of the

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -701,6 +701,7 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }
         | ContinuousModification::AddCounterOnEnter { .. }
+        | ContinuousModification::SetStartingLoyalty { .. }
         | ContinuousModification::RemoveManaCost => {}
     }
 }

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -73,6 +73,7 @@ use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::char;
 use nom::combinator::{opt, value};
+use nom::sequence::preceded;
 use nom::Parser;
 
 use super::super::oracle_keyword::parse_keyword_from_oracle;
@@ -968,14 +969,17 @@ fn parse_additional_count(input: &str) -> Option<(&str, i32)> {
 /// is shared with BecomeCopy exceptions so future planeswalker-copy effects use
 /// the same resolution-time override.
 fn parse_starting_loyalty_override(input: &str) -> Option<(&str, ContinuousModification)> {
-    let (rest, _) = alt((
-        tag::<_, _, OracleError<'_>>("its starting loyalty is "),
-        tag("his starting loyalty is "),
-        tag("her starting loyalty is "),
-        tag("their starting loyalty is "),
-        tag("it's starting loyalty is "),
-        tag("it\u{2019}s starting loyalty is "),
-    ))
+    let (rest, _) = preceded(
+        alt((
+            tag::<_, _, OracleError<'_>>("its"),
+            tag("his"),
+            tag("her"),
+            tag("their"),
+            tag("it's"),
+            tag("it\u{2019}s"),
+        )),
+        tag(" starting loyalty is "),
+    )
     .parse(input)
     .ok()?;
     let (rest, value) = nom_primitives::parse_number(rest).ok()?;

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -46,6 +46,9 @@
 //!   pronoun accepts `he`/`she`/`it` so cards from any gender print route
 //!   through the same arm. When neither index is set, the arm declines (no
 //!   modification produced) so the rest of the except clause still parses.
+//! - `<possessive> starting loyalty is N`
+//!   → [`ContinuousModification::SetStartingLoyalty`] so planeswalker-copy
+//!   exceptions seed loyalty counters from the overridden value.
 //!
 //! # Fail-soft semantics
 //!
@@ -161,6 +164,7 @@ pub(crate) fn parse_except_clause<'a>(
 ///   - `it's a(n) {subtype} in addition to its other types`    → AddSubtype
 ///   - `is a(n) {core_type|subtype} in addition to its other types`
 ///     (elided-subject form for non-leading bodies)            → AddType/AddSubtype
+///   - `<possessive> starting loyalty is N`                    → SetStartingLoyalty
 ///   - `it has "<triggered/activated/static ability>"`         → GrantTrigger/GrantAbility/etc.
 ///   - `it has {keyword[, keyword, ...]}`                      → AddKeyword per kw
 pub(crate) fn parse_except_body<'a>(
@@ -190,6 +194,9 @@ pub(crate) fn parse_except_body<'a>(
         return Some((rest, vec![modification]));
     }
     if let Some((rest, modification)) = parse_enters_with_additional_counter(input) {
+        return Some((rest, vec![modification]));
+    }
+    if let Some((rest, modification)) = parse_starting_loyalty_override(input) {
         return Some((rest, vec![modification]));
     }
     // CR 707.9d: the replacement form ("… and loses all other card types")
@@ -954,6 +961,25 @@ fn parse_additional_count(input: &str) -> Option<(&str, i32)> {
         return Some((rest, count));
     }
     Some((rest, 1))
+}
+
+/// CR 707.9b + CR 306.5b/c: Match "`its/their starting loyalty is N`" copy
+/// exceptions. Jace, Mirror Mage is the canonical token-copy form; the grammar
+/// is shared with BecomeCopy exceptions so future planeswalker-copy effects use
+/// the same resolution-time override.
+fn parse_starting_loyalty_override(input: &str) -> Option<(&str, ContinuousModification)> {
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("its starting loyalty is "),
+        tag("his starting loyalty is "),
+        tag("her starting loyalty is "),
+        tag("their starting loyalty is "),
+        tag("it's starting loyalty is "),
+        tag("it\u{2019}s starting loyalty is "),
+    ))
+    .parse(input)
+    .ok()?;
+    let (rest, value) = nom_primitives::parse_number(rest).ok()?;
+    Some((rest, ContinuousModification::SetStartingLoyalty { value }))
 }
 
 /// Parse the optional `" if it's a <core_type>"` tail trailing a counter
@@ -1976,6 +2002,27 @@ mod tests {
             }
             other => panic!("expected AddCounterOnEnter, got {other:?}"),
         }
+    }
+
+    /// CR 707.9b + CR 306.5b/c: Jace, Mirror Mage's token-copy exception
+    /// changes the copy's starting loyalty instead of merely adding counters.
+    #[test]
+    fn starting_loyalty_exception_emits_override() {
+        let (_, mods) = parse_except_clause(
+            ", except it's not legendary and its starting loyalty is 1",
+            "Jace, Mirror Mage",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert!(mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::RemoveSupertype {
+                supertype: Supertype::Legendary
+            }
+        )));
+        assert!(mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetStartingLoyalty { value: 1 })));
     }
 
     /// CR 122.1 + CR 614.1c: Spark Double's three-clause body — bare comma

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5447,7 +5447,8 @@ fn apply_where_x_continuous_modification(
         }
         // Resolution-time-consumed; where-X counter quantities are applied by
         // the counter/enter-with parser paths before this continuous grant pass.
-        ContinuousModification::AddCounterOnEnter { .. } => {}
+        ContinuousModification::AddCounterOnEnter { .. }
+        | ContinuousModification::SetStartingLoyalty { .. } => {}
         // Non-dynamic modifications carry fixed integers, enum payloads, or
         // nested definitions that are already parsed/lowered independently.
         // Keep this wildcard-free so a future QuantityExpr-carrying variant
@@ -5544,7 +5545,8 @@ fn rebind_target_anaphor_continuous_modification(modification: &mut ContinuousMo
         | ContinuousModification::AddDynamicKeyword { value, .. } => {
             rebind_cost_paid_object_pt_to_target(value);
         }
-        ContinuousModification::AddCounterOnEnter { .. } => {}
+        ContinuousModification::AddCounterOnEnter { .. }
+        | ContinuousModification::SetStartingLoyalty { .. } => {}
         ContinuousModification::CopyValues { .. }
         | ContinuousModification::SetName { .. }
         | ContinuousModification::AddPower { .. }

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -1423,6 +1423,37 @@ mod tests {
         );
     }
 
+    /// Issue #823 — Jace, Mirror Mage: the copy token exception includes both
+    /// "not legendary" and a starting-loyalty override. Both are non-keyword
+    /// copy exceptions and must reach `CopyTokenOf.additional_modifications`.
+    #[test]
+    fn jace_copy_token_routes_starting_loyalty_override() {
+        let effect = try_parse_token(
+            "create a token that's a copy of ~, except it's not legendary and its starting loyalty is 1",
+            "create a token that's a copy of ~, except it's not legendary and its starting loyalty is 1",
+            &mut ParseContext::default(),
+        )
+        .expect("expected CopyTokenOf");
+        let Effect::CopyTokenOf {
+            target,
+            additional_modifications,
+            ..
+        } = effect
+        else {
+            panic!("expected CopyTokenOf, got {effect:?}");
+        };
+        assert_eq!(target, TargetFilter::SelfRef);
+        assert!(additional_modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::RemoveSupertype {
+                supertype: Supertype::Legendary
+            }
+        )));
+        assert!(additional_modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetStartingLoyalty { value: 1 })));
+    }
+
     /// Issue #1696 — Myrkul, Lord of Bones: "create a token that's a copy of
     /// that card, except it's an enchantment and loses all other card types."
     /// CR 205.1a + CR 707.9d: the "loses all other card types" suffix is the

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -15001,6 +15001,14 @@ pub enum ContinuousModification {
         /// characteristics").
         if_type: Option<CoreType>,
     },
+    /// CR 707.9b + CR 306.5b/c: Override the starting loyalty declared by a
+    /// copy exception ("its starting loyalty is N"). Like `AddCounterOnEnter`,
+    /// this is consumed at copy resolution: token-copy uses the value before
+    /// seeding intrinsic loyalty counters, and BecomeCopy folds it into the
+    /// copied values before installing the layer-1 copy effect.
+    SetStartingLoyalty {
+        value: u32,
+    },
     /// CR 707.9 + CR 202.1b: Strip a copy's mana cost — the "has no mana cost"
     /// copy exception used by Embalm (CR 702.128a) and Eternalize
     /// (CR 702.129a). Like `AddCounterOnEnter`, this is consumed at copy
@@ -16665,6 +16673,7 @@ mod tests {
             ContinuousModification::AddColor {
                 color: ManaColor::Red,
             },
+            ContinuousModification::SetStartingLoyalty { value: 1 },
         ];
         let json = serde_json::to_string(&mods).unwrap();
         let deserialized: Vec<ContinuousModification> = serde_json::from_str(&json).unwrap();

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -124,6 +124,14 @@ impl ContinuousModification {
                 "AddCounterOnEnter is consumed at resolution; never layered. \
                  Verify resolver dispatch in token_copy.rs / become_copy.rs."
             ),
+            // CR 707.9b + CR 306.5b/c: Starting loyalty exceptions are folded
+            // into copied values before a copy is installed or a copy token's
+            // loyalty counters are seeded, so they never become standalone
+            // continuous-effect layer entries.
+            ContinuousModification::SetStartingLoyalty { .. } => unreachable!(
+                "SetStartingLoyalty is consumed at copy resolution; never layered. \
+                 Verify resolver dispatch in token_copy.rs / become_copy.rs."
+            ),
             // CR 707.9 + CR 202.1b: The "has no mana cost" copy exception is
             // consumed at copy resolution (token_copy.rs bakes it into the token;
             // become_copy.rs strips it from the copied values), exactly like

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -25,8 +25,8 @@
     "crates/engine/src/types/statics.rs",
     "crates/engine/src/types/card.rs"
   ],
-  "enum_count": 296,
-  "variant_count": 3133,
+  "enum_count": 297,
+  "variant_count": 3168,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -362,10 +362,32 @@
     {
       "enum_name": "QuantityRef",
       "cluster": {
+        "shared_root": "ObjectManaValue",
+        "members": [
+          "ObjectManaValue",
+          "TargetObjectManaValue"
+        ],
+        "smell_score": "LOW"
+      }
+    },
+    {
+      "enum_name": "QuantityRef",
+      "cluster": {
         "shared_root": "ZoneCardCount",
         "members": [
           "TargetZoneCardCount",
           "ZoneCardCount"
+        ],
+        "smell_score": "LOW"
+      }
+    },
+    {
+      "enum_name": "StaticCondition",
+      "cluster": {
+        "shared_root": "IsTapped",
+        "members": [
+          "IsTapped",
+          "SourceIsTapped"
         ],
         "smell_score": "LOW"
       }
@@ -501,15 +523,16 @@
     },
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12014,
+      "line": 12311,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 12032,
+          "line": 12329,
           "kind": "struct",
           "field_names": [
+            "subject",
             "source",
             "origin",
             "origin_ordinal",
@@ -527,7 +550,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 12052,
+          "line": 12360,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -538,7 +561,7 @@
         },
         {
           "name": "AlternativeManaCostPaid",
-          "line": 12056,
+          "line": 12364,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9 + CR 608.2c: \"If the {COST} cost was paid\" on spells with an alternative *mana* cost (e.g. Baleful Mastery). Evaluates against `SpellContext.alternative_mana_cost_paid`, not `additional_cost_paid`.",
@@ -549,7 +572,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 12061,
+          "line": 12369,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -563,7 +586,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 12066,
+          "line": 12374,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -573,7 +596,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 12074,
+          "line": 12382,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -583,7 +606,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 12077,
+          "line": 12385,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -595,7 +618,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 12081,
+          "line": 12389,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -608,7 +631,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 12084,
+          "line": 12392,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -621,7 +644,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 12087,
+          "line": 12395,
           "kind": "struct",
           "field_names": [
             "color",
@@ -635,7 +658,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 12097,
+          "line": 12405,
           "kind": "struct",
           "field_names": [
             "card_types",
@@ -649,7 +672,7 @@
         },
         {
           "name": "ObjectsShareQuality",
-          "line": 12119,
+          "line": 12427,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -664,7 +687,7 @@
         },
         {
           "name": "TargetSharesNameWithOtherExiledThisWay",
-          "line": 12127,
+          "line": 12435,
           "kind": "struct",
           "field_names": [
             "target"
@@ -677,7 +700,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 12131,
+          "line": 12439,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -688,7 +711,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 12134,
+          "line": 12442,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -701,7 +724,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 12139,
+          "line": 12447,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -715,7 +738,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 12143,
+          "line": 12451,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -729,7 +752,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 12152,
+          "line": 12460,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -743,7 +766,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 12157,
+          "line": 12465,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -753,7 +776,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 12159,
+          "line": 12467,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -763,7 +786,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 12162,
+          "line": 12470,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: \"if you have the initiative\" is true when the ability controller has the initiative designation.",
@@ -773,7 +796,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 12165,
+          "line": 12473,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -783,7 +806,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 12169,
+          "line": 12477,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -795,7 +818,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 12174,
+          "line": 12482,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -809,7 +832,7 @@
         },
         {
           "name": "TriggeringSpellTargetsFilter",
-          "line": 12186,
+          "line": 12494,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -822,7 +845,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 12190,
+          "line": 12498,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -834,7 +857,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 12195,
+          "line": 12503,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -850,7 +873,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 12207,
+          "line": 12515,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -863,7 +886,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 12211,
+          "line": 12519,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -876,7 +899,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 12215,
+          "line": 12523,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -886,7 +909,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 12223,
+          "line": 12531,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -899,7 +922,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 12228,
+          "line": 12536,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -912,7 +935,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 12233,
+          "line": 12541,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -924,7 +947,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 12239,
+          "line": 12547,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -936,7 +959,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 12243,
+          "line": 12551,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -950,7 +973,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 12246,
+          "line": 12554,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -959,8 +982,19 @@
           ]
         },
         {
+          "name": "SourceAttachedToCreature",
+          "line": 12562,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 301.5 + CR 303.4: \"if this permanent is attached to a creature you control\" — checks whether the source Aura/Equipment is currently attached to a creature controlled by the ability's controller. Used at the effect-resolution seam by optional bestow-trigger branches like Springheart Nantuko's landfall pay (the trigger itself fires regardless; only the optional payment / copy-token sub-ability is gated on attachment so the fallback Insect token branch can still resolve when the Aura is unattached).",
+          "cr_refs": [
+            "CR 301.5",
+            "CR 303.4"
+          ]
+        },
+        {
           "name": "ConditionInstead",
-          "line": 12255,
+          "line": 12571,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -973,7 +1007,7 @@
         },
         {
           "name": "And",
-          "line": 12260,
+          "line": 12576,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -985,7 +1019,7 @@
         },
         {
           "name": "Or",
-          "line": 12265,
+          "line": 12581,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -997,7 +1031,7 @@
         },
         {
           "name": "Not",
-          "line": 12273,
+          "line": 12589,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1009,7 +1043,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 12277,
+          "line": 12593,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -1019,7 +1053,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 12279,
+          "line": 12595,
           "kind": "struct",
           "field_names": [
             "state"
@@ -1031,7 +1065,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 12289,
+          "line": 12605,
           "kind": "struct",
           "field_names": [
             "n"
@@ -1043,7 +1077,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 12292,
+          "line": 12608,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -1055,7 +1089,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 12312,
+          "line": 12628,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -1081,13 +1115,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5642,
+      "line": 5808,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 5643,
+          "line": 5809,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1097,7 +1131,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 5652,
+          "line": 5818,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -1110,7 +1144,7 @@
         },
         {
           "name": "Tap",
-          "line": 5655,
+          "line": 5821,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1118,7 +1152,7 @@
         },
         {
           "name": "Untap",
-          "line": 5656,
+          "line": 5822,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1126,7 +1160,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 5657,
+          "line": 5823,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1136,7 +1170,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5660,
+          "line": 5826,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -1144,7 +1178,7 @@
         },
         {
           "name": "PayLife",
-          "line": 5666,
+          "line": 5832,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1156,7 +1190,7 @@
         },
         {
           "name": "Discard",
-          "line": 5669,
+          "line": 5835,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1169,7 +1203,7 @@
         },
         {
           "name": "Exile",
-          "line": 5680,
+          "line": 5846,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1181,7 +1215,7 @@
         },
         {
           "name": "ExileMaterials",
-          "line": 5694,
+          "line": 5860,
           "kind": "struct",
           "field_names": [
             "materials",
@@ -1194,7 +1228,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 5701,
+          "line": 5867,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1207,7 +1241,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 5704,
+          "line": 5870,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1218,7 +1252,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 5714,
+          "line": 5880,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1234,7 +1268,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 5722,
+          "line": 5888,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1244,7 +1278,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 5726,
+          "line": 5892,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1257,7 +1291,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 5734,
+          "line": 5900,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1271,7 +1305,7 @@
         },
         {
           "name": "Unattach",
-          "line": 5743,
+          "line": 5909,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1281,7 +1315,7 @@
         },
         {
           "name": "Mill",
-          "line": 5744,
+          "line": 5910,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1291,7 +1325,7 @@
         },
         {
           "name": "Exert",
-          "line": 5747,
+          "line": 5913,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1299,7 +1333,7 @@
         },
         {
           "name": "Blight",
-          "line": 5750,
+          "line": 5916,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1309,7 +1343,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5753,
+          "line": 5919,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1320,7 +1354,7 @@
         },
         {
           "name": "Behold",
-          "line": 5761,
+          "line": 5927,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1332,7 +1366,7 @@
         },
         {
           "name": "Composite",
-          "line": 5767,
+          "line": 5933,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1342,7 +1376,7 @@
         },
         {
           "name": "OneOf",
-          "line": 5784,
+          "line": 5950,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1355,7 +1389,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 5788,
+          "line": 5954,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1365,7 +1399,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 5793,
+          "line": 5959,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1378,7 +1412,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 5800,
+          "line": 5966,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1390,7 +1424,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 5816,
+          "line": 5982,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1404,7 +1438,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 5821,
+          "line": 5987,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1417,13 +1451,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10988,
+      "line": 11261,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 10990,
+          "line": 11263,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1431,7 +1465,7 @@
         },
         {
           "name": "Activated",
-          "line": 10991,
+          "line": 11264,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1439,7 +1473,7 @@
         },
         {
           "name": "Database",
-          "line": 10992,
+          "line": 11265,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1447,7 +1481,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 10995,
+          "line": 11268,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1455,7 +1489,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 11001,
+          "line": 11274,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1468,7 +1502,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11154,
+      "line": 11439,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1476,7 +1510,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 11156,
+          "line": 11441,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1486,7 +1520,7 @@
         },
         {
           "name": "Evolve",
-          "line": 11158,
+          "line": 11443,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1496,7 +1530,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 11160,
+          "line": 11445,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1506,7 +1540,7 @@
         },
         {
           "name": "Outlast",
-          "line": 11162,
+          "line": 11447,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1516,7 +1550,7 @@
         },
         {
           "name": "Cycling",
-          "line": 11167,
+          "line": 11452,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29a + CR 702.29e: This ability originated from a Cycling (or Typecycling) keyword definition. Used so the activation pipeline can emit a `GameEvent::Cycled` (CR 702.29c) that \"When you cycle this card\" triggers match.",
@@ -1528,7 +1562,7 @@
         },
         {
           "name": "Backup",
-          "line": 11169,
+          "line": 11454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.165a: ability originated from a Backup keyword definition.",
@@ -1570,13 +1604,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11177,
+      "line": 11462,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 11178,
+          "line": 11463,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1584,7 +1618,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 11179,
+          "line": 11464,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1592,7 +1626,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 11180,
+          "line": 11465,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1600,7 +1634,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 11181,
+          "line": 11466,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1608,7 +1642,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 11182,
+          "line": 11467,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1616,7 +1650,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 11183,
+          "line": 11468,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1624,7 +1658,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 11184,
+          "line": 11469,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1632,7 +1666,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 11185,
+          "line": 11470,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1640,7 +1674,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 11186,
+          "line": 11471,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1648,7 +1682,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 11187,
+          "line": 11472,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1658,7 +1692,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 11190,
+          "line": 11475,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1668,7 +1702,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 11194,
+          "line": 11479,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1678,7 +1712,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 11196,
+          "line": 11481,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1690,7 +1724,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 11201,
+          "line": 11486,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1704,7 +1738,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 11212,
+          "line": 11497,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1718,7 +1752,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 11225,
+          "line": 11510,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1731,13 +1765,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6046,
+      "line": 6212,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 6052,
+          "line": 6218,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1748,7 +1782,7 @@
         },
         {
           "name": "Kicker",
-          "line": 6067,
+          "line": 6233,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1764,7 +1798,7 @@
         },
         {
           "name": "Choice",
-          "line": 6079,
+          "line": 6245,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1772,7 +1806,7 @@
         },
         {
           "name": "Required",
-          "line": 6081,
+          "line": 6247,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1783,7 +1817,7 @@
     },
     "AdditionalCostOrigin": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6089,
+      "line": 6255,
       "doc": "CR 113.2c + CR 601.2b/f: Linked identity for one independently functioning additional-cost keyword instance. Cast-time copy triggers read their own Casualty/Replicate payments via CR 702.153b / CR 702.56b; ETB-linked Squad/Offspring triggers read their own payments via CR 607.2g.",
       "cr_refs": [
         "CR 113.2c",
@@ -1795,7 +1829,7 @@
       "variants": [
         {
           "name": "Kicker",
-          "line": 6090,
+          "line": 6256,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1803,7 +1837,7 @@
         },
         {
           "name": "Casualty",
-          "line": 6091,
+          "line": 6257,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1811,7 +1845,7 @@
         },
         {
           "name": "Offspring",
-          "line": 6092,
+          "line": 6258,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1819,7 +1853,7 @@
         },
         {
           "name": "Squad",
-          "line": 6093,
+          "line": 6259,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1827,7 +1861,7 @@
         },
         {
           "name": "Replicate",
-          "line": 6094,
+          "line": 6260,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1835,7 +1869,7 @@
         },
         {
           "name": "Other",
-          "line": 6096,
+          "line": 6262,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1846,7 +1880,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6201,
+      "line": 6367,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1854,7 +1888,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 6203,
+          "line": 6369,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1862,7 +1896,7 @@
         },
         {
           "name": "Kicker",
-          "line": 6204,
+          "line": 6370,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1870,7 +1904,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 6205,
+          "line": 6371,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1881,13 +1915,13 @@
     },
     "AdditionalCostRepeatability": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2844,
+      "line": 2906,
       "doc": "Whether an optional or kicker additional cost may be paid multiple times.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Once",
-          "line": 2847,
+          "line": 2909,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay at most once (ordinary kicker / optional cost).",
@@ -1895,7 +1929,7 @@
         },
         {
           "name": "Repeatable",
-          "line": 2849,
+          "line": 2911,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay any number of times (multikicker, replicate).",
@@ -1925,7 +1959,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3998,
+      "line": 4129,
       "doc": "Reduction applied when collapsing a set of per-object values (CR 208.1 power/ toughness, CR 202.3 mana value) into a single number. The Comprehensive Rules define no standalone \"aggregate function\" rule; this enum names the reduction kind used by the various property-aggregate `QuantityRef` variants.",
       "cr_refs": [
         "CR 202.3",
@@ -1934,7 +1968,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 3999,
+          "line": 4130,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1942,7 +1976,7 @@
         },
         {
           "name": "Min",
-          "line": 4000,
+          "line": 4131,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1950,7 +1984,7 @@
         },
         {
           "name": "Sum",
-          "line": 4001,
+          "line": 4132,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1995,7 +2029,7 @@
     },
     "AlternativeCastKeyword": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2293,
+      "line": 2362,
       "doc": "CR 118.9: Identifies which keyword ability granted an alternative casting cost so the `WaitingFor::AlternativeCastChoice` dispatcher can route to the keyword-specific post-payment handler. The four keywords share a single player decision shape (printed cost vs. alternative cost) but diverge in post-payment semantics — this enum keeps the prompt unified while preserving CR fidelity at resolution.  Adding a new alternative-cost keyword (e.g., Madness CR 702.35a, Spectacle CR 702.137a) is a compile error at every dispatch site until handled.",
       "cr_refs": [
         "CR 118.9",
@@ -2005,7 +2039,7 @@
       "variants": [
         {
           "name": "Warp",
-          "line": 2295,
+          "line": 2364,
           "kind": "unit",
           "field_names": [],
           "doc": "Custom Warp keyword — exile-at-end-step rider; no CR section.",
@@ -2013,7 +2047,7 @@
         },
         {
           "name": "Evoke",
-          "line": 2298,
+          "line": 2367,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: ETB + sacrifice trigger fires when the resolving permanent was cast for its evoke cost (CR 702.74b).",
@@ -2024,7 +2058,7 @@
         },
         {
           "name": "Emerge",
-          "line": 2301,
+          "line": 2370,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.119a-c: Emerge alternative cost requires sacrificing a creature while casting and reduces the emerge cost by that creature's mana value.",
@@ -2034,7 +2068,7 @@
         },
         {
           "name": "Dash",
-          "line": 2304,
+          "line": 2373,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.109a: Cast for the dash cost — the resolving permanent gains haste and is returned to its owner's hand at the next end step.",
@@ -2044,7 +2078,7 @@
         },
         {
           "name": "Blitz",
-          "line": 2307,
+          "line": 2376,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.152a: Cast for the blitz cost — the resolving permanent gains haste and a dies-draw trigger, and is sacrificed at the next end step.",
@@ -2054,7 +2088,7 @@
         },
         {
           "name": "Overload",
-          "line": 2309,
+          "line": 2378,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a: Spell's text changes \"target\" to \"each\" (CR 702.96b-c).",
@@ -2065,7 +2099,7 @@
         },
         {
           "name": "Bestow",
-          "line": 2311,
+          "line": 2380,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a: Spell becomes an Aura with enchant creature (CR 702.103b).",
@@ -2076,7 +2110,7 @@
         },
         {
           "name": "Awaken",
-          "line": 2316,
+          "line": 2385,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: \"If this spell's awaken cost was paid, put N +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.\" Paying the awaken cost adds the land target (CR 702.113b); casting normally adds no target and no rider.",
@@ -2087,7 +2121,7 @@
         },
         {
           "name": "Cleave",
-          "line": 2319,
+          "line": 2388,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Paying the cleave cost removes every square-bracketed span from the spell's text (a text-changing effect).",
@@ -2098,7 +2132,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 2321,
+          "line": 2390,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.162a: Cast converted (back face up, CR 712.14a) for the MTMTE cost.",
@@ -2109,7 +2143,7 @@
         },
         {
           "name": "Impending",
-          "line": 2325,
+          "line": 2394,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: Impending alternative cost paid from hand. On resolution the permanent enters with N time counters and isn't a creature until the last is removed. An end-step trigger removes one counter per turn.",
@@ -2119,7 +2153,7 @@
         },
         {
           "name": "Prototype",
-          "line": 2329,
+          "line": 2398,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.160a: Prototype alternative cost paid from hand. The resulting spell/permanent uses the secondary power, toughness, and mana cost characteristics while it is a creature.",
@@ -2129,7 +2163,7 @@
         },
         {
           "name": "Mutate",
-          "line": 2334,
+          "line": 2403,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.140a: Mutate alternative cost paid from hand. The spell becomes a mutating creature spell targeting a non-Human creature the caster owns (CR 702.140a); on resolution it merges with that creature (CR 730) rather than entering the battlefield, unless the target is illegal (CR 702.140b).",
@@ -2141,7 +2175,7 @@
         },
         {
           "name": "Spectacle",
-          "line": 2338,
+          "line": 2407,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.137a: Spectacle alternative cost paid from hand, available only if an opponent lost life this turn. A pure cost substitution — the spell resolves normally (no riders); spectacle changes only how the cost is paid.",
@@ -2192,7 +2226,7 @@
     },
     "AttachmentKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2144,
+      "line": 2161,
       "doc": "CR 301 / CR 303: Kinds of attachments to permanents. Used by `FilterProp::HasAttachment` and `QuantityRef::AttachmentsOnLeavingObject` to parameterize attachment-predicate checks.",
       "cr_refs": [
         "CR 301",
@@ -2201,7 +2235,7 @@
       "variants": [
         {
           "name": "Aura",
-          "line": 2146,
+          "line": 2163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4: Aura — enchantment subtype that attaches via Enchant ability.",
@@ -2211,7 +2245,7 @@
         },
         {
           "name": "Equipment",
-          "line": 2148,
+          "line": 2165,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5: Equipment — artifact subtype that attaches via Equip ability.",
@@ -2224,7 +2258,7 @@
     },
     "AttackScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4107,
+      "line": 4238,
       "doc": "CR 508.6: The time window over which \"attacked [a player]\" is measured.",
       "cr_refs": [
         "CR 508.6"
@@ -2232,7 +2266,7 @@
       "variants": [
         {
           "name": "ThisTurn",
-          "line": 4109,
+          "line": 4240,
           "kind": "unit",
           "field_names": [],
           "doc": "Across the whole turn, accumulated over every combat (CR 508.5).",
@@ -2242,7 +2276,7 @@
         },
         {
           "name": "ThisCombat",
-          "line": 4111,
+          "line": 4242,
           "kind": "unit",
           "field_names": [],
           "doc": "Within the current combat only (CR 702.121a Melee).",
@@ -2255,7 +2289,7 @@
     },
     "AttackSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4098,
+      "line": 4229,
       "doc": "CR 506.2 + CR 508.1b: Whose attacks the \"opponents attacked\" player set is measured over.",
       "cr_refs": [
         "CR 506.2",
@@ -2264,7 +2298,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 4100,
+          "line": 4231,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's controller — \"opponents you attacked\".",
@@ -2272,7 +2306,7 @@
         },
         {
           "name": "Source",
-          "line": 4102,
+          "line": 4233,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source creature — \"opponents this creature attacked\".",
@@ -2348,7 +2382,7 @@
     },
     "AttackersDeclaredCountSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4641,
+      "line": 4772,
       "doc": "CR 508.1 / CR 508.1b: Subject axis for counting members of a triggering `AttackersDeclared` event.",
       "cr_refs": [
         "CR 508.1",
@@ -2357,7 +2391,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 4649,
+          "line": 4780,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -2370,7 +2404,7 @@
         },
         {
           "name": "AttackTarget",
-          "line": 4656,
+          "line": 4787,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -2384,13 +2418,13 @@
     },
     "AutoMayChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 543,
+      "line": 568,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Accept",
-          "line": 544,
+          "line": 569,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2398,7 +2432,7 @@
         },
         {
           "name": "Decline",
-          "line": 545,
+          "line": 570,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2409,13 +2443,13 @@
     },
     "AutoPassMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4524,
+      "line": 4611,
       "doc": "What the engine stores for auto-pass (includes captured state).",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 4527,
+          "line": 4614,
           "kind": "struct",
           "field_names": [
             "initial_stack_len"
@@ -2425,7 +2459,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 4531,
+          "line": 4618,
           "kind": "unit",
           "field_names": [],
           "doc": "Auto-pass through priority/combat stops until the flagged player's next turn starts. Interrupted by opponent stack activity (MTGA-style) or when the current phase matches the player's entry in `GameState::phase_stops`.",
@@ -2436,13 +2470,13 @@
     },
     "AutoPassRequest": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4516,
+      "line": 4603,
       "doc": "What the frontend requests for auto-pass (no internal state).  Phase stops that should interrupt `UntilEndOfTurn` are a separate per-player preference on `GameState::phase_stops`, managed via `GameAction::SetPhaseStops`. Keeping them out of the request preserves a single source of truth and lets the preference change mid-session without requiring a new auto-pass request.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 4517,
+          "line": 4604,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2450,7 +2484,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 4518,
+          "line": 4605,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2461,7 +2495,7 @@
     },
     "BasicLandType": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 420,
+      "line": 427,
       "doc": "The five basic land types (CR 305.6).",
       "cr_refs": [
         "CR 305.6"
@@ -2469,7 +2503,7 @@
       "variants": [
         {
           "name": "Plains",
-          "line": 421,
+          "line": 428,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2477,7 +2511,7 @@
         },
         {
           "name": "Island",
-          "line": 422,
+          "line": 429,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2485,7 +2519,7 @@
         },
         {
           "name": "Swamp",
-          "line": 423,
+          "line": 430,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2493,7 +2527,7 @@
         },
         {
           "name": "Mountain",
-          "line": 424,
+          "line": 431,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2501,7 +2535,7 @@
         },
         {
           "name": "Forest",
-          "line": 425,
+          "line": 432,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2512,7 +2546,7 @@
     },
     "BatchCompletion": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1149,
+      "line": 1207,
       "doc": "CR 701.25a / manifest dread: the post-loop cleanup a rest-pile batch must run once its graveyard pile has been delivered. These flows partition a looked-at pile into a graveyard \"rest\" pile (delivered through the simultaneous-move batch so per-card `Moved` redirects fire — Rest in Peace / Leyline of the Void class) and a \"kept\" remainder whose placement/marker cleanup happens after the whole pile lands. Because a per-card redirect can pause the batch (two simultaneous redirects on one card need a CR 616.1 ordering choice), the cleanup cannot run inline at the end of the loop — it would run before the paused tail finished, then never again. Stashing it as typed data on [`PendingBatchDeliveries`] (not a closure) lets the drain run it exactly once on true completion, mirroring the `PendingCounterPostAction` continuation pattern.",
       "cr_refs": [
         "CR 616.1",
@@ -2521,7 +2555,7 @@
       "variants": [
         {
           "name": "SurveilKeepOnTop",
-          "line": 1153,
+          "line": 1211,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2534,7 +2568,7 @@
         },
         {
           "name": "ManifestDreadCleanup",
-          "line": 1159,
+          "line": 1217,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2545,7 +2579,7 @@
         },
         {
           "name": "RevealRestPile",
-          "line": 1169,
+          "line": 1227,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2564,7 +2598,7 @@
         },
         {
           "name": "RemoveExileLinks",
-          "line": 1199,
+          "line": 1257,
           "kind": "struct",
           "field_names": [
             "returned_ids"
@@ -2577,7 +2611,7 @@
         },
         {
           "name": "NinjutsuPlacement",
-          "line": 1213,
+          "line": 1271,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2596,7 +2630,7 @@
         },
         {
           "name": "AttractionOpenRemainder",
-          "line": 1227,
+          "line": 1285,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2614,13 +2648,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5392,
+      "line": 5558,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 5393,
+          "line": 5559,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2628,7 +2662,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 5394,
+          "line": 5560,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2768,7 +2802,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6632,
+      "line": 6798,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2776,7 +2810,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 6635,
+          "line": 6801,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2784,7 +2818,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 6637,
+          "line": 6803,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2915,7 +2949,7 @@
     },
     "CardPlayMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 592,
+      "line": 599,
       "doc": "CR 601.2 vs CR 305.1: Distinguishes \"cast\" (spells only) from \"play\" (spells + lands).",
       "cr_refs": [
         "CR 305.1",
@@ -2924,7 +2958,7 @@
       "variants": [
         {
           "name": "Cast",
-          "line": 595,
+          "line": 602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2: Cast a spell (cannot play lands this way).",
@@ -2934,7 +2968,7 @@
         },
         {
           "name": "Play",
-          "line": 597,
+          "line": 604,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1: Play a card — cast if it's a spell, play as a land if it's a land.",
@@ -2947,7 +2981,7 @@
     },
     "CardSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2756,
+      "line": 2818,
       "doc": "CR 701.9a: How cards are selected from a zone during an effect or cost.  Analogous to `TargetSelectionMode` but for cards from a player's hand (or other non-target zones) rather than spell/ability targets.",
       "cr_refs": [
         "CR 701.9a"
@@ -2955,7 +2989,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2759,
+          "line": 2821,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d: The affected player or controller chooses the card(s).",
@@ -2965,7 +2999,7 @@
         },
         {
           "name": "Random",
-          "line": 2761,
+          "line": 2823,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9a: The game selects card(s) uniformly at random.",
@@ -2978,13 +3012,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3380,
+      "line": 3462,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 3382,
+          "line": 3464,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -2998,7 +3032,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 3384,
+          "line": 3466,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -3009,7 +3043,7 @@
         },
         {
           "name": "Objects",
-          "line": 3386,
+          "line": 3468,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -3017,6 +3051,19 @@
           "doc": "CR 109.2: Objects matching a battlefield-style filter.",
           "cr_refs": [
             "CR 109.2"
+          ]
+        },
+        {
+          "name": "TrackedSet",
+          "line": 3474,
+          "kind": "struct",
+          "field_names": [
+            "caused_by"
+          ],
+          "doc": "CR 608.2c + CR 205.2a: distinct card types among the current chain tracked set, optionally restricted to members produced by `caused_by`. Mirrors `QuantityRef::FilteredTrackedSetSize { caused_by }`: a merged Draw->Discard set is disambiguated by CAUSE (drawn members are unstamped), so Some(Discarded) counts only discarded members. None counts all.",
+          "cr_refs": [
+            "CR 205.2a",
+            "CR 608.2c"
           ]
         }
       ],
@@ -3129,7 +3176,7 @@
     },
     "CastFromZoneDriver": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 627,
+      "line": 634,
       "doc": "CR 608.2g vs CR 118.9: Which casting *mechanism* an `Effect::CastFromZone` drives — i.e. *when* relative to the granting ability's resolution the card is cast. This is orthogonal to `duration` (CR 611.2a permission-expiry), `mode` (CR 601.2 cast vs CR 305.1 play), and `alt_ability_cost` (CR 118.9 cost-substitution); none of those describe the casting mechanism, so the router must read this field rather than inferring the mechanism from them.",
       "cr_refs": [
         "CR 118.9",
@@ -3141,7 +3188,7 @@
       "variants": [
         {
           "name": "LingeringPermission",
-          "line": 636,
+          "line": 643,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9: Grant a lingering `CastingPermission` on the target card(s) and return — the controller casts the card later, during the granting effect's own (or a future) priority window. The default for every permission-granting cast-from-zone effect: Discover/Nashi/Jeleva-style \"you may cast those exiled cards\" and Rebound's next-upkeep recast offer (CR 702.88a), whose `duration: Some(UntilEndOfTurn)` then prunes the unused permission.",
@@ -3152,7 +3199,7 @@
         },
         {
           "name": "DuringResolution",
-          "line": 643,
+          "line": 650,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2g: Cast the card *as the granting ability resolves* — the card goes onto the stack immediately via `initiate_cast_during_resolution`, and the CR 608.2g timing bypass (sorcery-speed / empty-stack / active-player gates do not apply) is armed. Set by Suspend's last-time-counter trigger (CR 702.62a) so a suspended sorcery recast at upkeep is not blocked by the sorcery-speed gate (issue #1520).",
@@ -3166,7 +3213,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3391,
+      "line": 3482,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -3174,7 +3221,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 3393,
+          "line": 3484,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -3182,18 +3229,29 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 3395,
+          "line": 3486,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
           "cr_refs": []
+        },
+        {
+          "name": "AbilityTarget",
+          "line": 3490,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 115.1 + CR 601.2h: The first object target of the resolving ability — \"it\"/\"that spell\" when the condition gates on the targeted spell (Nix: \"Counter target spell if no mana was spent to cast it\").",
+          "cr_refs": [
+            "CR 115.1",
+            "CR 601.2h"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3401,
+      "line": 3496,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -3202,7 +3260,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 3403,
+          "line": 3498,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -3210,7 +3268,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 3405,
+          "line": 3500,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -3218,7 +3276,7 @@
         },
         {
           "name": "FromSource",
-          "line": 3407,
+          "line": 3502,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -3231,13 +3289,13 @@
     },
     "CastOfferKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2438,
+      "line": 2507,
       "doc": "The specific kind of cast offer being presented to the player. Parameterizes `WaitingFor::CastOffer` — all variants share `player: PlayerId` at the outer level; the kind-specific payload lives here.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Adventure",
-          "line": 2440,
+          "line": 2509,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -3251,7 +3309,7 @@
         },
         {
           "name": "Miracle",
-          "line": 2447,
+          "line": 2516,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -3264,7 +3322,7 @@
         },
         {
           "name": "Madness",
-          "line": 2452,
+          "line": 2521,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -3277,7 +3335,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 2457,
+          "line": 2526,
           "kind": "struct",
           "field_names": [
             "offers"
@@ -3289,7 +3347,7 @@
         },
         {
           "name": "Cascade",
-          "line": 2459,
+          "line": 2528,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -3303,7 +3361,7 @@
         },
         {
           "name": "Discover",
-          "line": 2465,
+          "line": 2534,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -3317,7 +3375,7 @@
         },
         {
           "name": "Ripple",
-          "line": 2480,
+          "line": 2549,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -3331,7 +3389,7 @@
         },
         {
           "name": "FreeCastWindow",
-          "line": 2492,
+          "line": 2561,
           "kind": "struct",
           "field_names": [
             "candidates",
@@ -3353,7 +3411,7 @@
     },
     "CastPaymentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1517,
+      "line": 1586,
       "doc": "CR 601.2g-h: Whether the engine may auto-pay an unambiguous spell mana cost or must pause after announcement so the player can activate mana abilities manually before committing payment.",
       "cr_refs": [
         "CR 601.2g"
@@ -3361,7 +3419,7 @@
       "variants": [
         {
           "name": "Auto",
-          "line": 1519,
+          "line": 1588,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3369,7 +3427,7 @@
         },
         {
           "name": "Manual",
-          "line": 1520,
+          "line": 1589,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3380,7 +3438,7 @@
     },
     "CastPermissionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1827,
+      "line": 1834,
       "doc": "CR 702.85a: Typed cast-time predicates attached to an `ExileWithAltCost` permission. Extend this enum when future mechanics need cast-time gating that cannot be evaluated at permission-grant time (e.g., X-cost spells whose mana value is only known after the caster chooses X).",
       "cr_refs": [
         "CR 702.85a"
@@ -3388,7 +3446,7 @@
       "variants": [
         {
           "name": "ManaValue",
-          "line": 1830,
+          "line": 1837,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -3405,7 +3463,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5362,
+      "line": 5528,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -3414,7 +3472,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 5365,
+          "line": 5531,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -3422,7 +3480,7 @@
         },
         {
           "name": "Offering",
-          "line": 5369,
+          "line": 5535,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.48a: The spell was cast at instant speed by paying an Offering additional cost. When this permission is set, the Offering sacrifice is required (the player used the offering to unlock instant-speed timing).",
@@ -3435,7 +3493,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5311,
+      "line": 5477,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -3446,7 +3504,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 5313,
+          "line": 5479,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -3457,7 +3515,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 5316,
+          "line": 5482,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -3467,7 +3525,7 @@
         },
         {
           "name": "Sneak",
-          "line": 5318,
+          "line": 5484,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -3477,7 +3535,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 5320,
+          "line": 5486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -3487,7 +3545,7 @@
         },
         {
           "name": "Evoke",
-          "line": 5323,
+          "line": 5489,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -3497,7 +3555,7 @@
         },
         {
           "name": "Suspend",
-          "line": 5329,
+          "line": 5495,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -3507,7 +3565,7 @@
         },
         {
           "name": "Escape",
-          "line": 5334,
+          "line": 5500,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -3518,7 +3576,7 @@
         },
         {
           "name": "Foretell",
-          "line": 5337,
+          "line": 5503,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -3528,7 +3586,7 @@
         },
         {
           "name": "Bestow",
-          "line": 5342,
+          "line": 5508,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -3539,7 +3597,7 @@
         },
         {
           "name": "Impending",
-          "line": 5347,
+          "line": 5513,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: The spell was cast for its impending alternative cost. The permanent entered with N time counters and is not a creature while any remain. Read by the end-step counter-removal trigger and the \"not a creature\" layer fixup.",
@@ -3549,7 +3607,7 @@
         },
         {
           "name": "Surge",
-          "line": 5351,
+          "line": 5517,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.117a: Surge alternative cast cost was paid from hand. Read by the \"if its surge cost was paid\" intervening-if (Reckless Bushwhacker, Tyrant of Valakut).",
@@ -3559,7 +3617,7 @@
         },
         {
           "name": "Spectacle",
-          "line": 5355,
+          "line": 5521,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.137a: Spectacle alternative cast cost was paid from hand. Read by the \"if its spectacle cost was paid\" intervening-if (Rafter Demon) and the \"...if its spectacle cost was paid, instead\" clause (Rix Maadi Reveler).",
@@ -3572,13 +3630,13 @@
     },
     "CastingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1605,
+      "line": 1612,
       "doc": "A permission granted to a `GameObject` allowing it to be cast under specific conditions. Stored in `GameObject::casting_permissions`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdventureCreature",
-          "line": 1607,
+          "line": 1614,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.5: After Adventure resolves to exile, creature face castable from exile.",
@@ -3588,7 +3646,7 @@
         },
         {
           "name": "ExileWithAltCost",
-          "line": 1612,
+          "line": 1619,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -3607,7 +3665,7 @@
         },
         {
           "name": "PlayFromExile",
-          "line": 1677,
+          "line": 1684,
           "kind": "struct",
           "field_names": [
             "duration",
@@ -3629,7 +3687,7 @@
         },
         {
           "name": "ExileWithEnergyCost",
-          "line": 1734,
+          "line": 1741,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.3: Cast from exile by paying {E} equal to the card's mana value. Building block for Amped Raptor and similar energy-based casting mechanics.",
@@ -3639,7 +3697,7 @@
         },
         {
           "name": "ExileWithAltAbilityCost",
-          "line": 1743,
+          "line": 1750,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -3654,7 +3712,7 @@
         },
         {
           "name": "WarpExile",
-          "line": 1761,
+          "line": 1768,
           "kind": "struct",
           "field_names": [
             "castable_after_turn"
@@ -3666,7 +3724,7 @@
         },
         {
           "name": "Plotted",
-          "line": 1771,
+          "line": 1778,
           "kind": "struct",
           "field_names": [
             "turn_plotted"
@@ -3679,7 +3737,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1777,
+          "line": 1784,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -3758,13 +3816,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11233,
+      "line": 11518,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 11234,
+          "line": 11519,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3772,7 +3830,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 11235,
+          "line": 11520,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3780,7 +3838,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 11236,
+          "line": 11521,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3788,7 +3846,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 11237,
+          "line": 11522,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3796,7 +3854,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 11238,
+          "line": 11523,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3804,7 +3862,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 11239,
+          "line": 11524,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3812,7 +3870,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 11240,
+          "line": 11525,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3820,7 +3878,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 11241,
+          "line": 11526,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3828,7 +3886,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 11242,
+          "line": 11527,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3836,7 +3894,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 11243,
+          "line": 11528,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3844,7 +3902,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 11244,
+          "line": 11529,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3852,7 +3910,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 11245,
+          "line": 11530,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3860,7 +3918,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 11246,
+          "line": 11531,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3868,7 +3926,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 11247,
+          "line": 11532,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3876,7 +3934,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 11248,
+          "line": 11533,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3884,7 +3942,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 11249,
+          "line": 11534,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3897,13 +3955,13 @@
     },
     "CastingVariant": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4609,
+      "line": 4696,
       "doc": "How a spell was cast — determines zone routing and post-resolution behavior. Replaces individual boolean flags (cast_as_adventure, cast_as_warp) with a single enum that captures the casting context.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Normal",
-          "line": 4612,
+          "line": 4699,
           "kind": "unit",
           "field_names": [],
           "doc": "Normal spell cast — no special resolution behavior.",
@@ -3911,7 +3969,7 @@
         },
         {
           "name": "Adventure",
-          "line": 4615,
+          "line": 4702,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.4: Cast as the Adventure half. On resolution, exiled with AdventureCreature permission and creature face restored.",
@@ -3921,7 +3979,7 @@
         },
         {
           "name": "Omen",
-          "line": 4618,
+          "line": 4705,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 720.3d / CR 720.4: Cast as the Omen half. On resolution, shuffled into its owner's library with normal characteristics restored.",
@@ -3932,7 +3990,7 @@
         },
         {
           "name": "Warp",
-          "line": 4621,
+          "line": 4708,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.185a: Cast via Warp alternative cost from hand. On resolution, creates a delayed trigger to exile at end step with WarpExile permission.",
@@ -3942,7 +4000,7 @@
         },
         {
           "name": "Escape",
-          "line": 4624,
+          "line": 4711,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138: Cast from graveyard via Escape. On resolution, goes to appropriate zone normally (unlike Flashback which exiles).",
@@ -3952,7 +4010,7 @@
         },
         {
           "name": "Retrace",
-          "line": 4627,
+          "line": 4714,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.81a: Cast from graveyard via Retrace by discarding a land card as an additional cost. Resolution uses normal spell routing.",
@@ -3962,7 +4020,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 4630,
+          "line": 4717,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled instead of going anywhere else (unlike Escape which returns to graveyard).",
@@ -3972,7 +4030,7 @@
         },
         {
           "name": "Mayhem",
-          "line": 4635,
+          "line": 4722,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.187b: Cast from graveyard for mayhem cost (allowed only while the card was discarded this turn). Unlike Flashback/Harmonize, the spell is NOT exiled — it resolves normally (like Escape), so it can be discarded and recast again on a later turn.",
@@ -3982,7 +4040,7 @@
         },
         {
           "name": "Flashback",
-          "line": 4638,
+          "line": 4725,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34a: Cast from graveyard for flashback cost. On resolution (or whenever leaving the stack for any reason), exiled instead of going anywhere else.",
@@ -3992,7 +4050,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 4641,
+          "line": 4728,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Cast an aftermath half of a split card from a graveyard. If it was cast from a graveyard, exile it any time it leaves the stack.",
@@ -4002,7 +4060,7 @@
         },
         {
           "name": "Disturb",
-          "line": 4645,
+          "line": 4732,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.146a-b + CR 712.8c: Cast transformed from graveyard for disturb cost. The stack spell uses its back-face characteristics and the permanent enters the battlefield back face up on resolution.",
@@ -4013,7 +4071,7 @@
         },
         {
           "name": "GraveyardPermission",
-          "line": 4649,
+          "line": 4736,
           "kind": "struct",
           "field_names": [
             "source",
@@ -4029,7 +4087,7 @@
         },
         {
           "name": "HandPermission",
-          "line": 4675,
+          "line": 4762,
           "kind": "struct",
           "field_names": [
             "source",
@@ -4044,7 +4102,7 @@
         },
         {
           "name": "ExilePermission",
-          "line": 4691,
+          "line": 4778,
           "kind": "struct",
           "field_names": [
             "source",
@@ -4060,7 +4118,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4708,
+          "line": 4795,
           "kind": "struct",
           "field_names": [
             "returned_creature",
@@ -4074,7 +4132,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4717,
+          "line": 4804,
           "kind": "struct",
           "field_names": [
             "returned_creature"
@@ -4086,7 +4144,7 @@
         },
         {
           "name": "Miracle",
-          "line": 4724,
+          "line": 4811,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94a: Cast from hand via Miracle's alternative cost after revealing the card as the first card drawn this turn. The granting keyword carries the miracle mana cost, which `prepare_spell_cast_with_variant_override` substitutes for the printed mana cost. The keyword's `ManaCost` payload is read at preparation time rather than stored here because `prepare_spell_cast` already reads `obj.keywords` for analogous paths.",
@@ -4096,7 +4154,7 @@
         },
         {
           "name": "Madness",
-          "line": 4727,
+          "line": 4814,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.35a: Cast from exile via Madness after the discard replacement exiled the card and its madness triggered ability resolved.",
@@ -4106,7 +4164,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4731,
+          "line": 4818,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Cast from hand via Evoke's alternative cost. On resolution, the permanent enters tagged with `CastVariantPaid::Evoke`, which fires the synthesized intervening-if ETB sacrifice trigger.",
@@ -4116,7 +4174,7 @@
         },
         {
           "name": "Emerge",
-          "line": 4737,
+          "line": 4824,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.119a-c: Cast from hand via Emerge's alternative cost. The printed mana cost is replaced by `Keyword::Emerge(cost)` at cast preparation; casting requires sacrificing a creature, then reduces that emerge cost by the sacrificed creature's mana value. Resolution routing matches a normal cast; Emerge has no resolution rider.",
@@ -4126,7 +4184,7 @@
         },
         {
           "name": "Dash",
-          "line": 4741,
+          "line": 4828,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.109a: Cast from hand via Dash's alternative cost. On resolution, `dash::install_dash_riders` grants the permanent haste and schedules a next-end-step return to its owner's hand.",
@@ -4136,7 +4194,7 @@
         },
         {
           "name": "Blitz",
-          "line": 4745,
+          "line": 4832,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.152a: Cast from hand via Blitz's alternative cost. On resolution, `blitz::install_blitz_riders` grants the permanent haste and a dies-draw trigger and schedules a next-end-step sacrifice.",
@@ -4146,7 +4204,7 @@
         },
         {
           "name": "Spectacle",
-          "line": 4749,
+          "line": 4836,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.137a: Cast from hand via Spectacle's alternative cost, available only if an opponent lost life this turn. A pure cost substitution — the spell resolves normally with no resolution riders.",
@@ -4156,7 +4214,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4756,
+          "line": 4843,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast from exile via Suspend's \"play it without paying its mana cost\" trigger after the last time counter was removed. On resolution of the resulting permanent, the stack handler tags `CastVariantPaid::Suspend` and — for creature spells — installs a transient continuous \"has haste\" effect that lasts as long as the resolution-time controller still controls the permanent.",
@@ -4166,7 +4224,7 @@
         },
         {
           "name": "Plot",
-          "line": 4763,
+          "line": 4850,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.170d: Cast from exile via the Plot \"cast without paying its mana cost\" permission during the owner's main phase on a turn after the card was plotted. Detected at cast preparation when the exile-zone source has a `CastingPermission::Plotted { turn_plotted }` and the current turn is strictly greater than `turn_plotted`. Zeroes the mana cost and routes through the normal cast pipeline; no special resolution-time behavior.",
@@ -4176,7 +4234,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4770,
+          "line": 4857,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a-c: Cast from exile via a foretold card's foretell cost on a turn after it was foretold. Detected at cast preparation when the exile-zone source has a `CastingPermission::Foretold { .. }`. The permission supplies the alternative mana cost; stack finalization tags the source with `CastVariantPaid::Foretell` so \"if this spell was foretold\" clauses can evaluate while the spell resolves.",
@@ -4186,7 +4244,7 @@
         },
         {
           "name": "Overload",
-          "line": 4780,
+          "line": 4867,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a-c: Cast from hand via Overload's alternative cost. The printed mana cost is replaced by `Keyword::Overload(cost)` at cast preparation (mirrors `Evoke`/`Warp`). Per CR 702.96b, every \"target\" in the spell's text is replaced by \"each\" — applied as a cast-time transformation of the spell's ability tree (`Destroy`→`DestroyAll`, `Pump`→`PumpAll`, `DealDamage`→`DamageAll`, `Tap`→`TapAll`, `Bounce`→`ChangeZoneAll`). Per CR 702.96c, the resulting spell has no targets, so target selection is naturally skipped because the transformed effects carry no `TargetRef` slots.",
@@ -4198,7 +4256,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4795,
+          "line": 4882,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a-b: Cast from hand via Bestow's alternative cost. The printed mana cost is replaced by `Keyword::Bestow(cost)` at cast preparation; the spell becomes an Aura with `enchant creature` while on the stack and as the resulting permanent (until it becomes unattached, per CR 702.103f). The type-changing mutation is applied directly to the stack object (mirroring `swap_to_alternative_spell_face` for Adventure/Omen) — Layers cannot be used here because they only apply to battlefield/hand objects, not stack objects.  Per CR 702.103e: if the target is illegal at resolution, the type-changing effect ends and the spell resolves as a creature spell. Per CR 702.103f: when a bestowed Aura becomes unattached on the battlefield, the type-changing effect ends — it remains as an enchantment creature (overrides CR 704.5m for bestow Auras).",
@@ -4211,7 +4269,7 @@
         },
         {
           "name": "Awaken",
-          "line": 4806,
+          "line": 4893,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: Cast from hand via Awaken's alternative cost. The printed mana cost is replaced by `Keyword::Awaken { cost }` at cast preparation (mirrors `Overload`). A resolution rider is appended to the tail of the spell's ability tree (`effects::awaken::append_awaken_rider`): the printed effect resolves first, then \"put N +1/+1 counters on target land you control; that land becomes a 0/0 Elemental creature with haste; it's still a land.\" Per CR 702.113b, the land target only exists on the awaken variant — a normal cast appends no rider and requests no land target. CR 702.113a: the spell goes to the graveyard normally, so this variant is deliberately absent from `exiles_when_leaving_stack_for_any_reason`.",
@@ -4222,7 +4280,7 @@
         },
         {
           "name": "Cleave",
-          "line": 4817,
+          "line": 4904,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Cast from hand via Cleave's alternative cost (CR 118.9). The printed mana cost is replaced by `Keyword::Cleave(cost)` at cast preparation (mirrors `Evoke`/`Overload`). Per CR 702.148a, paying the cleave cost is a text-changing effect (CR 612) that removes every square-bracketed span from the spell's rules text. The bracket-removed ability set is parsed at build time into `CardFace::cleave_variant` and swapped onto the stack object before preparation (mirroring the Bestow object-mutation-before-prepare seam). Resolution routing matches a normal spell — there is no on-resolve special behavior, so the spell goes to its owner's graveyard like any instant/sorcery.",
@@ -4234,7 +4292,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 4824,
+          "line": 4911,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.162a + CR 712.14a: Cast from any castable zone via the More Than Meets the Eye alternative cost. The printed mana cost is replaced by the `Keyword::MoreThanMeetsTheEye(cost)` payload at cast preparation (mirrors Overload). On resolution the spell is cast CONVERTED — the resulting permanent enters the battlefield transformed (back face up) via the existing `enter_transformed` ZoneChange seed. CR 701.28 (Convert).",
@@ -4246,7 +4304,7 @@
         },
         {
           "name": "Impending",
-          "line": 4830,
+          "line": 4917,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: Cast from hand via Impending's alternative cost. The printed mana cost is replaced by `Keyword::Impending { cost, .. }` at cast preparation (mirrors Overload/Evoke). On resolution the permanent enters with N time counters (from the keyword) and is not a creature while any remain. At the beginning of your end step one time counter is removed.",
@@ -4256,7 +4314,7 @@
         },
         {
           "name": "Prototype",
-          "line": 4835,
+          "line": 4922,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.160a: Cast from hand prototyped. The printed mana cost is replaced by the prototype cost during cast preparation, and the object is tagged so stack display plus layer evaluation use the secondary mana cost and P/T while it is a creature.",
@@ -4266,7 +4324,7 @@
         },
         {
           "name": "Mutate",
-          "line": 4848,
+          "line": 4935,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.140a-c: Cast from hand via Mutate's alternative cost. The printed mana cost is replaced by `Keyword::Mutate(cost)` at cast preparation (mirrors Bestow). The spell gains a single target — a non-Human creature the caster owns (CR 702.140a) — attached Bestow-style before preparation. On resolution (`stack::resolve_top`): if the target is illegal (CR 702.140b) the spell reverts to a plain creature spell and enters the battlefield normally; if legal (CR 702.140c) it does NOT enter — instead it merges with the target creature (CR 730) and the controller chooses top/bottom. Unlike Bestow this variant neither exiles on leaving the stack nor restores a front face, so it is intentionally absent from `exiles_when_leaving_stack_for_any_reason` and `restores_front_face_after_stack_exit`.",
@@ -4279,7 +4337,7 @@
         },
         {
           "name": "Freerunning",
-          "line": 4856,
+          "line": 4943,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.173a: Cast from hand via Freerunning's alternative cost. Legal only when a player was dealt combat damage this turn by an Assassin creature or a commander under the caster's control. The printed mana cost is replaced by the `Keyword::Freerunning(cost)` payload at cast preparation (mirrors `Overload` / `Foretell`). Resolution routing matches a normal cast — no on-resolve special behavior — so this is a casting-context tag, not a resolution-affecting variant.",
@@ -4289,7 +4347,7 @@
         },
         {
           "name": "Prowl",
-          "line": 4864,
+          "line": 4951,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.76a: Cast from hand via Prowl's alternative cost. Legal only when a player was dealt combat damage this turn by a source under the caster's control that, at damage time, had any of this spell's creature types. The printed mana cost is replaced by the `Keyword::Prowl(cost)` payload at cast preparation (mirrors `Freerunning`/`Overload`). Resolution routing matches a normal cast — no on-resolve special behavior — so this is a casting-context tag, not a resolution-affecting variant.",
@@ -4299,7 +4357,7 @@
         },
         {
           "name": "JumpStart",
-          "line": 4872,
+          "line": 4959,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.133a: Cast from a graveyard via Jump-start. The card is cast for its normal mana cost plus an additional cost of discarding a card (CR 601.2b/601.2f–h) — so, like `Retrace`/`Aftermath`, this is an additional cost, not an alternative cost, and is absent from `uses_alternative_cost`. Like `Flashback`, a spell cast this way is exiled instead of going anywhere else any time it would leave the stack (see `exiles_when_leaving_stack_for_any_reason`).",
@@ -4310,7 +4368,7 @@
         },
         {
           "name": "Fuse",
-          "line": 4878,
+          "line": 4965,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.102a-d: Both halves of a split card cast from hand as a fused split spell. The mana cost is the combined cost of both halves (CR 702.102c). On resolution, the left half's instructions are followed first, then the right half's (CR 702.102d). Not an alternative cost (CR 118.9a) — the player pays the full combined printed mana cost.",
@@ -4323,7 +4381,7 @@
         },
         {
           "name": "Surge",
-          "line": 4882,
+          "line": 4969,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.117a: Cast from hand for the surge alternative cost, legal only if the caster has cast another spell this turn. Resolution is normal (no exile/restore), so it appears only in `uses_alternative_cost`.",
@@ -4336,7 +4394,7 @@
     },
     "CategoryChooserScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 66,
+      "line": 73,
       "doc": "CR 101.4: Who selects permanents in a multi-player category choice effect (e.g., Cataclysm, Tragic Arrogance). Determines whether each player independently chooses which of their permanents to keep, or the spell's controller decides for everyone.",
       "cr_refs": [
         "CR 101.4"
@@ -4344,7 +4402,7 @@
       "variants": [
         {
           "name": "EachPlayerSelf",
-          "line": 69,
+          "line": 76,
           "kind": "unit",
           "field_names": [],
           "doc": "Each player chooses their own permanents in APNAP order (Cataclysm, Cataclysmic Gearhulk).",
@@ -4352,7 +4410,7 @@
         },
         {
           "name": "ControllerForAll",
-          "line": 71,
+          "line": 78,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the spell/ability chooses for all players (Tragic Arrogance).",
@@ -4363,13 +4421,13 @@
     },
     "ChoiceType": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 185,
+      "line": 192,
       "doc": "What kind of named choice the player must make at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CreatureType",
-          "line": 186,
+          "line": 193,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4377,7 +4435,7 @@
         },
         {
           "name": "Color",
-          "line": 187,
+          "line": 194,
           "kind": "struct",
           "field_names": [
             "excluded"
@@ -4387,7 +4445,7 @@
         },
         {
           "name": "OddOrEven",
-          "line": 194,
+          "line": 201,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4395,7 +4453,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 195,
+          "line": 202,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4403,7 +4461,7 @@
         },
         {
           "name": "CardType",
-          "line": 196,
+          "line": 203,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4411,7 +4469,7 @@
         },
         {
           "name": "CardName",
-          "line": 197,
+          "line": 204,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4419,7 +4477,7 @@
         },
         {
           "name": "NumberRange",
-          "line": 199,
+          "line": 206,
           "kind": "struct",
           "field_names": [
             "min",
@@ -4430,7 +4488,7 @@
         },
         {
           "name": "Labeled",
-          "line": 204,
+          "line": 211,
           "kind": "struct",
           "field_names": [
             "options"
@@ -4440,7 +4498,7 @@
         },
         {
           "name": "LandType",
-          "line": 208,
+          "line": 215,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a land type\" — includes basic + common nonbasic land types.",
@@ -4448,7 +4506,7 @@
         },
         {
           "name": "Opponent",
-          "line": 219,
+          "line": 226,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -4461,7 +4519,7 @@
         },
         {
           "name": "Player",
-          "line": 223,
+          "line": 230,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a player\" — selects any player in the game.",
@@ -4469,7 +4527,7 @@
         },
         {
           "name": "TwoColors",
-          "line": 225,
+          "line": 232,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose two colors\" — selects two distinct mana colors.",
@@ -4477,7 +4535,7 @@
         },
         {
           "name": "Word",
-          "line": 227,
+          "line": 234,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a word\" — names any English word (Un-set and silver-border cards).",
@@ -4485,7 +4543,7 @@
         },
         {
           "name": "Artist",
-          "line": 229,
+          "line": 236,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose an artist\" — selects a Magic card artist name.",
@@ -4493,7 +4551,7 @@
         },
         {
           "name": "Keyword",
-          "line": 237,
+          "line": 244,
           "kind": "struct",
           "field_names": [
             "options"
@@ -4508,68 +4566,12 @@
     },
     "ChoiceValue": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 775,
+      "line": 782,
       "doc": "A typed value chosen at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Color",
-          "line": 776,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreatureType",
-          "line": 777,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BasicLandType",
-          "line": 778,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CardType",
-          "line": 779,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "OddOrEven",
-          "line": 780,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CardName",
-          "line": 781,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Number",
-          "line": 782,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Label",
           "line": 783,
           "kind": "tuple",
           "field_names": [],
@@ -4577,7 +4579,7 @@
           "cr_refs": []
         },
         {
-          "name": "LandType",
+          "name": "CreatureType",
           "line": 784,
           "kind": "tuple",
           "field_names": [],
@@ -4585,7 +4587,7 @@
           "cr_refs": []
         },
         {
-          "name": "Player",
+          "name": "BasicLandType",
           "line": 785,
           "kind": "tuple",
           "field_names": [],
@@ -4593,7 +4595,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoColors",
+          "name": "CardType",
           "line": 786,
           "kind": "tuple",
           "field_names": [],
@@ -4601,8 +4603,64 @@
           "cr_refs": []
         },
         {
-          "name": "Keyword",
+          "name": "OddOrEven",
+          "line": 787,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CardName",
+          "line": 788,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Number",
+          "line": 789,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Label",
+          "line": 790,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "LandType",
           "line": 791,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Player",
+          "line": 792,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "TwoColors",
+          "line": 793,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Keyword",
+          "line": 798,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2d: typed-keyword choice from a `ChoiceType::Keyword` option list (Urborg / Walking Sponge). Persisted into the source's `chosen_attributes` as `ChosenAttribute::Keyword` for later `RemoveChosenKeyword` resolution.",
@@ -4615,13 +4673,13 @@
     },
     "ChooseFromZoneConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 84,
+      "line": 91,
       "doc": "Additional selection constraints for tracked-set card picks during resolution.  Internally tagged (`{ \"type\": \"DistinctCardTypes\", \"categories\": [...] }`) to match the sibling [`SearchSelectionConstraint`] convention and the frontend's `ChooseFromZoneConstraint` type, which discriminates on the `type` field. The `CardChoiceModal` confirm gate reads `constraint.type`; without the tag the default external representation (`{ \"DistinctCardTypes\": {...} }`) leaves `type` undefined and the modal can never validate a selection.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DistinctCardTypes",
-          "line": 87,
+          "line": 94,
           "kind": "struct",
           "field_names": [
             "categories"
@@ -4663,13 +4721,13 @@
     },
     "ChosenAttribute": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 678,
+      "line": 685,
       "doc": "A typed choice stored on a permanent (e.g., \"choose a color\" → Color(Red)). The variant discriminant serves as the category key.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Color",
-          "line": 679,
+          "line": 686,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4677,7 +4735,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 680,
+          "line": 687,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4685,7 +4743,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 681,
+          "line": 688,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4693,7 +4751,7 @@
         },
         {
           "name": "CardType",
-          "line": 682,
+          "line": 689,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4701,7 +4759,7 @@
         },
         {
           "name": "OddOrEven",
-          "line": 683,
+          "line": 690,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4709,7 +4767,7 @@
         },
         {
           "name": "CardName",
-          "line": 684,
+          "line": 691,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4717,7 +4775,7 @@
         },
         {
           "name": "Number",
-          "line": 686,
+          "line": 693,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores a chosen number (e.g., \"choose a number\" for Talion).",
@@ -4725,7 +4783,7 @@
         },
         {
           "name": "Player",
-          "line": 688,
+          "line": 695,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores the chosen opponent/player ID (CR 800.4a).",
@@ -4735,7 +4793,7 @@
         },
         {
           "name": "TwoColors",
-          "line": 690,
+          "line": 697,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores two chosen colors as a pair.",
@@ -4743,7 +4801,7 @@
         },
         {
           "name": "TributeOutcome",
-          "line": 694,
+          "line": 701,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.104a + CR 702.104b: Records whether the opponent chosen for the Tribute ETB replacement paid tribute or declined. Read by the companion `TriggerCondition::TributeNotPaid` evaluator.",
@@ -4754,7 +4812,7 @@
         },
         {
           "name": "Keyword",
-          "line": 699,
+          "line": 706,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2d: Records the typed keyword chosen from a `ChoiceType::Keyword` option list (Urborg / Walking Sponge \"choose an ability the target has, remove it\"). Read by `ContinuousModification::RemoveChosenKeyword` at Layer 6 evaluation to strip the chosen keyword from the recipient.",
@@ -4764,7 +4822,7 @@
         },
         {
           "name": "Label",
-          "line": 708,
+          "line": 715,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 614.12c: Records the anchor-word label chosen as the permanent entered the battlefield (e.g. Frostcliff Siege \"Jeskai\" / \"Temur\", Khans of Tarkir Sieges \"Khans\" / \"Dragons\"). Read by `StaticCondition::ChosenLabelIs` and `TriggerCondition::ChosenLabelIs` to gate which of the two anchor-word-marked abilities (CR 607: linked abilities) functions while the permanent is on the battlefield. The label is stored case-canonicalised to match `ChoiceType::Labeled`'s capitalised option list.",
@@ -4778,13 +4836,13 @@
     },
     "ChosenSubtypeKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 843,
+      "line": 850,
       "doc": "How to specify a damage amount -- either a fixed integer or a variable reference. Which category of chosen attribute to read as a subtype. Used by `ContinuousModification::AddChosenSubtype` in layer evaluation.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CreatureType",
-          "line": 844,
+          "line": 851,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4792,7 +4850,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 845,
+          "line": 852,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4838,7 +4896,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13305,
+      "line": 13720,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -4846,7 +4904,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 13306,
+          "line": 13721,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4854,7 +4912,7 @@
         },
         {
           "name": "Lost",
-          "line": 13307,
+          "line": 13722,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4865,13 +4923,13 @@
     },
     "CollectEvidenceResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1707,
+      "line": 1776,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Casting",
-          "line": 1708,
+          "line": 1777,
           "kind": "struct",
           "field_names": [
             "pending_cast"
@@ -4881,7 +4939,7 @@
         },
         {
           "name": "Effect",
-          "line": 1711,
+          "line": 1780,
           "kind": "struct",
           "field_names": [
             "pending_ability"
@@ -4944,7 +5002,7 @@
     },
     "CombatDamageAssignmentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4013,
+      "line": 4100,
       "doc": "CR 510.1c: Optional combat-damage assignment mode for attackers with text like \"you may have this creature assign its combat damage as though it weren't blocked.\"",
       "cr_refs": [
         "CR 510.1c"
@@ -4952,7 +5010,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 4015,
+          "line": 4102,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4960,7 +5018,7 @@
         },
         {
           "name": "AsThoughUnblocked",
-          "line": 4016,
+          "line": 4103,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4971,7 +5029,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13844,
+      "line": 14261,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -4979,7 +5037,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 13845,
+          "line": 14262,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4987,7 +5045,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 13846,
+          "line": 14263,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4998,13 +5056,13 @@
     },
     "CombatRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2186,
+      "line": 2203,
       "doc": "Combat relationship required by `FilterProp::CombatRelation`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "BlockingOrBlockedBy",
-          "line": 2188,
+          "line": 2205,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g/509.1h: Candidate is blocking the subject or is blocked by it.",
@@ -5017,13 +5075,13 @@
     },
     "CombatRelationSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2193,
+      "line": 2210,
       "doc": "Context object for a combat relationship filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2195,
+          "line": 2212,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object of the resolving spell or ability.",
@@ -5031,7 +5089,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2197,
+          "line": 2214,
           "kind": "unit",
           "field_names": [],
           "doc": "The first selected object target of the resolving spell or ability.",
@@ -5042,7 +5100,7 @@
     },
     "CombatTaxContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1996,
+      "line": 2065,
       "doc": "CR 508.1d + CR 509.1c: Which combat step a `WaitingFor::CombatTaxPayment` belongs to.  Drives the resume branch after the tax decision — on accept, the engine submits the stored attacker / blocker declaration; on decline, the engine filters the taxed creatures out of that declaration and submits the remainder.",
       "cr_refs": [
         "CR 508.1d",
@@ -5051,7 +5109,7 @@
       "variants": [
         {
           "name": "Attacking",
-          "line": 1997,
+          "line": 2066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5059,7 +5117,7 @@
         },
         {
           "name": "Blocking",
-          "line": 1998,
+          "line": 2067,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5070,7 +5128,7 @@
     },
     "CombatTaxPending": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2006,
+      "line": 2075,
       "doc": "CR 508.1d + CR 509.1c: The declaration that is paused awaiting a combat-tax decision. Keyed by `CombatTaxContext` — the engine resumes the matching variant on `GameAction::PayCombatTax`.",
       "cr_refs": [
         "CR 508.1d",
@@ -5079,7 +5137,7 @@
       "variants": [
         {
           "name": "Attack",
-          "line": 2007,
+          "line": 2076,
           "kind": "struct",
           "field_names": [
             "attacks",
@@ -5090,7 +5148,7 @@
         },
         {
           "name": "Block",
-          "line": 2015,
+          "line": 2084,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -5103,7 +5161,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4762,
+      "line": 4893,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -5111,7 +5169,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 4765,
+          "line": 4896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -5122,7 +5180,7 @@
         },
         {
           "name": "Any",
-          "line": 4769,
+          "line": 4900,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -5226,13 +5284,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4602,
+      "line": 4733,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 4603,
+          "line": 4734,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5240,7 +5298,7 @@
         },
         {
           "name": "LT",
-          "line": 4604,
+          "line": 4735,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5248,7 +5306,7 @@
         },
         {
           "name": "GE",
-          "line": 4605,
+          "line": 4736,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5256,7 +5314,7 @@
         },
         {
           "name": "LE",
-          "line": 4606,
+          "line": 4737,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5264,7 +5322,7 @@
         },
         {
           "name": "EQ",
-          "line": 4607,
+          "line": 4738,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5272,7 +5330,7 @@
         },
         {
           "name": "NE",
-          "line": 4608,
+          "line": 4739,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5283,7 +5341,7 @@
     },
     "ConjureSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6539,
+      "line": 6705,
       "doc": "CR 707.2: Where a conjured card's identity is taken from. Untagged so the legacy named form (`{\"name\": \"X\"}`) and the duplicate form (`{\"duplicate_of\": <filter>}`) are distinguished by their disjoint keys.",
       "cr_refs": [
         "CR 707.2"
@@ -5291,7 +5349,7 @@
       "variants": [
         {
           "name": "Named",
-          "line": 6541,
+          "line": 6707,
           "kind": "struct",
           "field_names": [
             "name"
@@ -5301,7 +5359,7 @@
         },
         {
           "name": "Duplicate",
-          "line": 6545,
+          "line": 6711,
           "kind": "struct",
           "field_names": [
             "duplicate_of"
@@ -5316,13 +5374,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14297,
+      "line": 14714,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 14298,
+          "line": 14715,
           "kind": "struct",
           "field_names": [
             "values",
@@ -5335,7 +5393,7 @@
         },
         {
           "name": "SetName",
-          "line": 14330,
+          "line": 14747,
           "kind": "struct",
           "field_names": [
             "name"
@@ -5349,7 +5407,7 @@
         },
         {
           "name": "AddPower",
-          "line": 14333,
+          "line": 14750,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5359,7 +5417,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 14336,
+          "line": 14753,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5369,7 +5427,7 @@
         },
         {
           "name": "SetPower",
-          "line": 14339,
+          "line": 14756,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5379,7 +5437,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 14342,
+          "line": 14759,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5389,7 +5447,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 14345,
+          "line": 14762,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -5399,7 +5457,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 14348,
+          "line": 14765,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -5409,7 +5467,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 14351,
+          "line": 14768,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -5419,7 +5477,7 @@
         },
         {
           "name": "GrantAllActivatedAbilitiesOf",
-          "line": 14363,
+          "line": 14780,
           "kind": "struct",
           "field_names": [
             "source"
@@ -5432,7 +5490,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 14370,
+          "line": 14787,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -5444,7 +5502,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 14373,
+          "line": 14790,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5452,7 +5510,7 @@
         },
         {
           "name": "AddType",
-          "line": 14374,
+          "line": 14791,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -5462,7 +5520,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 14377,
+          "line": 14794,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -5472,7 +5530,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 14380,
+          "line": 14797,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -5482,7 +5540,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 14383,
+          "line": 14800,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -5492,7 +5550,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 14390,
+          "line": 14807,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -5505,7 +5563,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 14396,
+          "line": 14813,
           "kind": "struct",
           "field_names": [
             "set"
@@ -5518,7 +5576,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 14400,
+          "line": 14817,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5528,7 +5586,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 14404,
+          "line": 14821,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5538,7 +5596,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 14411,
+          "line": 14828,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5550,7 +5608,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 14416,
+          "line": 14833,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5562,7 +5620,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 14420,
+          "line": 14837,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5574,7 +5632,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 14424,
+          "line": 14841,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5586,7 +5644,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 14429,
+          "line": 14846,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -5599,7 +5657,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 14435,
+          "line": 14852,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -5607,7 +5665,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 14438,
+          "line": 14855,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -5618,7 +5676,7 @@
         },
         {
           "name": "AddAllLandTypes",
-          "line": 14442,
+          "line": 14859,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and their mana abilities, additive. Distinct from AddAllBasicLandTypes (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.",
@@ -5630,7 +5688,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 14445,
+          "line": 14862,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -5640,7 +5698,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 14450,
+          "line": 14867,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -5650,7 +5708,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 14457,
+          "line": 14874,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -5660,8 +5718,19 @@
           ]
         },
         {
+          "name": "AddChosenKeyword",
+          "line": 14884,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 608.2d + CR 613.1f: Grant the chosen keyword (read from the granting source's `chosen_attributes`) to the affected object. The additive counterpart of `RemoveChosenKeyword`, mirroring the `AddChosenColor` / `AddChosenSubtype` chosen-attribute family. Used by the \"choose [keyword], …; creatures you control gain that ability until end of turn\" class (Angelic Skirmisher, Linvala, Shield of Sea Gate): a preceding `Effect::Choose { ChoiceType::Keyword, persist }` stores the selection as `ChosenAttribute::Keyword`, which this modification reads at Layer 6 evaluation to install on every recipient.",
+          "cr_refs": [
+            "CR 608.2d",
+            "CR 613.1f"
+          ]
+        },
+        {
           "name": "SetColor",
-          "line": 14458,
+          "line": 14885,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -5671,7 +5740,7 @@
         },
         {
           "name": "AddColor",
-          "line": 14461,
+          "line": 14888,
           "kind": "struct",
           "field_names": [
             "color"
@@ -5681,7 +5750,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 14466,
+          "line": 14893,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -5691,7 +5760,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 14481,
+          "line": 14908,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -5706,7 +5775,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 14485,
+          "line": 14912,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -5716,7 +5785,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 14488,
+          "line": 14915,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -5726,7 +5795,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 14490,
+          "line": 14917,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -5736,7 +5805,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 14492,
+          "line": 14919,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -5746,7 +5815,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 14495,
+          "line": 14922,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -5756,7 +5825,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 14498,
+          "line": 14925,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -5768,7 +5837,7 @@
         },
         {
           "name": "SetChosenBasicLandType",
-          "line": 14512,
+          "line": 14939,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.7 + CR 305.6: Sets a land's subtype to the basic land type CHOSEN by the granting source (e.g. Phantasmal Terrain, Convincing Mirage: \"As this Aura enters, choose a basic land type.\" + \"Enchanted land is the chosen type.\"). Mirrors `SetBasicLandType`'s replacement semantics — removes the land's old land subtypes and clears the abilities generated from its rules text — but reads the concrete subtype from the source object's `chosen_attributes` (`ChosenSubtypeKind::BasicLandType`) at layer evaluation time rather than carrying a fixed type. Unit variant: the kind is implicitly `BasicLandType`. The intrinsic mana ability for the new type is derived from the subtype in `mana_sources.rs` (CR 305.6), so no explicit mana grant is needed here.",
@@ -5779,7 +5848,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 14524,
+          "line": 14951,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -5791,7 +5860,7 @@
         },
         {
           "name": "RetainPrintedAbilityFromSource",
-          "line": 14537,
+          "line": 14964,
           "kind": "struct",
           "field_names": [
             "source_ability_index"
@@ -5803,7 +5872,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 14545,
+          "line": 14972,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -5818,7 +5887,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 14554,
+          "line": 14981,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -5833,7 +5902,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 14568,
+          "line": 14995,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -5847,8 +5916,21 @@
           ]
         },
         {
+          "name": "SetStartingLoyalty",
+          "line": 15009,
+          "kind": "struct",
+          "field_names": [
+            "value"
+          ],
+          "doc": "CR 707.9b + CR 306.5b/c: Override the starting loyalty declared by a copy exception (\"its starting loyalty is N\"). Like `AddCounterOnEnter`, this is consumed at copy resolution: token-copy uses the value before seeding intrinsic loyalty counters, and BecomeCopy folds it into the copied values before installing the layer-1 copy effect.",
+          "cr_refs": [
+            "CR 306.5b",
+            "CR 707.9b"
+          ]
+        },
+        {
           "name": "RemoveManaCost",
-          "line": 14584,
+          "line": 15019,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.9 + CR 202.1b: Strip a copy's mana cost — the \"has no mana cost\" copy exception used by Embalm (CR 702.128a) and Eternalize (CR 702.129a). Like `AddCounterOnEnter`, this is consumed at copy resolution, never evaluated through the layer system, so `ContinuousModification::layer()` treats it as unreachable: `token_copy.rs` bakes it into the new token's base mana cost, and `become_copy.rs` strips it from the copied values so the continuous copy carries mana value 0.",
@@ -5864,13 +5946,13 @@
     },
     "ControllerRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2086,
+      "line": 2100,
       "doc": "Controller reference for filter matching.",
       "cr_refs": [],
       "variants": [
         {
           "name": "You",
-          "line": 2087,
+          "line": 2101,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5878,7 +5960,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2088,
+          "line": 2102,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5886,7 +5968,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2091,
+          "line": 2105,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: Filter controller is the current player being affected by an \"each player/opponent\" instruction during resolution.",
@@ -5897,7 +5979,7 @@
         },
         {
           "name": "TargetPlayer",
-          "line": 2098,
+          "line": 2112,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 115.1: Filter controller is the player chosen as a target of the enclosing ability (e.g., \"each creature target player controls\"). At resolution time, `filter_inner` reads the first `TargetRef::Player` from `ability.targets`. At target-selection time, `collect_target_slots` surfaces a companion `TargetFilter::Player` slot so the player is chosen as part of CR 601.2c / CR 603.3d target declaration.",
@@ -5910,7 +5992,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2102,
+          "line": 2116,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 109.4: Filter controller is the controller of the parent object target inherited by this chained effect (\"that permanent's controller may sacrifice a land\").",
@@ -5920,8 +6002,19 @@
           ]
         },
         {
+          "name": "ParentTargetOwner",
+          "line": 2119,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 608.2c + CR 108.3: Filter owner is the owner of the parent object target inherited by this chained effect (\"its owner's graveyard\").",
+          "cr_refs": [
+            "CR 108.3",
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "DefendingPlayer",
-          "line": 2107,
+          "line": 2124,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Filter controller is the defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by intervening-if quantity checks such as \"defending player controls more lands than you.\"",
@@ -5932,7 +6025,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 2118,
+          "line": 2135,
           "kind": "struct",
           "field_names": [
             "index"
@@ -5945,7 +6038,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 2130,
+          "line": 2147,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.1 + CR 109.4: Filter controller is the player PERSISTED on the source via `ChosenAttribute::Player` — the player chosen by an \"as ~ enters the battlefield, choose a player\" replacement. Read at filter / layer-evaluation time from the source's `chosen_attributes` (mirrors `GameObject::protector`). Distinct from `ChosenPlayer { index }`, which is resolution-scoped (valid only mid-resolution); this is a durable characteristic readable continuously, as a CDA requires. Powers \"~'s power and toughness are each equal to the number of <X> the chosen player controls\" (Skyshroud War Beast, Lost Order of Jarkeld).",
@@ -5956,7 +6049,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2137,
+          "line": 2154,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 109.4: Filter controller is the player identified by the triggering event (the drawer, life-gainer, attacker, etc.). Resolved against `state.current_trigger_event` via `extract_player_from_event`. Mirrors `PlayerFilter::TriggeringPlayer` and `TargetFilter::TriggeringPlayer`. Used by control-relative trigger restrictions (\"an opponent who controls F draws a card\").",
@@ -6037,7 +6130,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14655,
+      "line": 15090,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -6047,7 +6140,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 14658,
+          "line": 15093,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -6055,7 +6148,7 @@
         },
         {
           "name": "Finalized",
-          "line": 14660,
+          "line": 15095,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -6066,13 +6159,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6576,
+      "line": 6742,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 6577,
+          "line": 6743,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6083,7 +6176,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9138,
+      "line": 9397,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -6092,7 +6185,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 9140,
+          "line": 9399,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -6100,7 +6193,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 9142,
+          "line": 9401,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -6271,7 +6364,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5835,
+      "line": 6001,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice(_)` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -6279,7 +6372,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 5836,
+          "line": 6002,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6287,7 +6380,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 5837,
+          "line": 6003,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6295,7 +6388,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 5838,
+          "line": 6004,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6303,7 +6396,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 5839,
+          "line": 6005,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6311,7 +6404,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 5840,
+          "line": 6006,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6319,7 +6412,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 5841,
+          "line": 6007,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6327,7 +6420,7 @@
         },
         {
           "name": "Discards",
-          "line": 5842,
+          "line": 6008,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6335,7 +6428,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 5843,
+          "line": 6009,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6343,7 +6436,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 5844,
+          "line": 6010,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6351,7 +6444,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 5845,
+          "line": 6011,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6359,7 +6452,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 5846,
+          "line": 6012,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6367,7 +6460,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 5847,
+          "line": 6013,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6375,7 +6468,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 5848,
+          "line": 6014,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6383,7 +6476,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 5849,
+          "line": 6015,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6391,7 +6484,7 @@
         },
         {
           "name": "Mills",
-          "line": 5850,
+          "line": 6016,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6399,7 +6492,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 5851,
+          "line": 6017,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6407,7 +6500,7 @@
         },
         {
           "name": "Reveals",
-          "line": 5852,
+          "line": 6018,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6415,7 +6508,7 @@
         },
         {
           "name": "Exerts",
-          "line": 5853,
+          "line": 6019,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6423,7 +6516,7 @@
         },
         {
           "name": "KeywordCost",
-          "line": 5854,
+          "line": 6020,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6471,7 +6564,7 @@
     },
     "CostObjectCount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5401,
+      "line": 5567,
       "doc": "CR 702.167a: Object-count requirement for costs whose text may ask for an exact number (\"two creatures\") or a minimum (\"one or more creatures\").",
       "cr_refs": [
         "CR 702.167a"
@@ -6479,7 +6572,7 @@
       "variants": [
         {
           "name": "Exactly",
-          "line": 5402,
+          "line": 5568,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6489,7 +6582,7 @@
         },
         {
           "name": "AtLeast",
-          "line": 5403,
+          "line": 5569,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6534,7 +6627,7 @@
     },
     "CostResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2405,
+      "line": 2474,
       "doc": "CR 601.2b + CR 605.3b: Resumption context after a PayCost choice completes. Determines whether the engine re-enters the spell-casting pipeline or the mana-ability pipeline.",
       "cr_refs": [
         "CR 601.2b",
@@ -6543,7 +6636,7 @@
       "variants": [
         {
           "name": "Spell",
-          "line": 2406,
+          "line": 2475,
           "kind": "struct",
           "field_names": [
             "spell"
@@ -6553,7 +6646,7 @@
         },
         {
           "name": "SpellCost",
-          "line": 2410,
+          "line": 2479,
           "kind": "struct",
           "field_names": [
             "spell",
@@ -6565,7 +6658,7 @@
         },
         {
           "name": "ManaAbility",
-          "line": 2416,
+          "line": 2485,
           "kind": "struct",
           "field_names": [
             "mana_ability"
@@ -6578,7 +6671,7 @@
     },
     "CountScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 859,
+      "line": 866,
       "doc": "Which players' zones to count across for zone-based quantity references.  CR 608.2 + CR 109.5: `Controller` and `ScopedPlayer` are distinct axes during `player_scope` iteration. `Controller` always means the printed ability's controller (the \"you\" axis from CR 109.5). `ScopedPlayer` means the player whose iteration copy is currently running (e.g., each opponent in \"Each opponent mills half of *their* library, rounded up.\" — Maddening Cacophony's kicker mode). Outside iteration, `ScopedPlayer` falls back to `Controller`. Mirrors the `ControllerRef::You` vs `ControllerRef::ScopedPlayer` split.",
       "cr_refs": [
         "CR 109.5",
@@ -6587,7 +6680,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 861,
+          "line": 868,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5: The printed ability's controller — \"you\" / \"your\" semantics.",
@@ -6597,7 +6690,7 @@
         },
         {
           "name": "Owner",
-          "line": 864,
+          "line": 871,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 404.2: The printed ability controller as owner for player-scoped queries over non-battlefield zones.",
@@ -6608,7 +6701,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 870,
+          "line": 877,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2 + CR 109.5: The currently iterated player during a `player_scope` resolution — \"they\" / \"their\" semantics relative to the iteration. Issue #310: distinguishes \"their library\" (per-iteration) from \"your library\" (always caster). Falls back to `Controller` outside iteration.",
@@ -6619,7 +6712,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 874,
+          "line": 881,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 608.2c: The source's linked persisted chosen player — \"the chosen player's <zone>\" on cards whose source stored `ChosenAttribute::Player`.",
@@ -6630,7 +6723,7 @@
         },
         {
           "name": "All",
-          "line": 875,
+          "line": 882,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6638,7 +6731,7 @@
         },
         {
           "name": "Opponents",
-          "line": 876,
+          "line": 883,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6649,13 +6742,13 @@
     },
     "CounterCostSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5497,
+      "line": 5663,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "SingleObject",
-          "line": 5499,
+          "line": 5665,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6663,7 +6756,7 @@
         },
         {
           "name": "AmongObjects",
-          "line": 5500,
+          "line": 5666,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6701,13 +6794,13 @@
     },
     "CounterMoveSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 927,
+      "line": 934,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "StackTarget",
-          "line": 929,
+          "line": 936,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6715,7 +6808,7 @@
         },
         {
           "name": "StackTargetAnyNumber",
-          "line": 930,
+          "line": 937,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6723,7 +6816,7 @@
         },
         {
           "name": "ResolutionDistributionAnyNumber",
-          "line": 931,
+          "line": 938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6803,7 +6896,7 @@
     },
     "CounterSourceRider": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 950,
+      "line": 957,
       "doc": "CR 701.6 + CR 608.2c: A follow-up instruction carried by `Effect::Counter` that acts on the *source permanent* of an ability countered by the effect.  The rider only fires when the countered object was an activated or triggered ability — per CR 701.8a / CR 110.1 a spell is not a permanent, so when a spell is countered there is no permanent for the rider to act on and it is skipped (the conditional \"if a permanent's ability is countered this way\" is encoded structurally by this spell-vs-ability gate, not by a separate `AbilityCondition`).  Both variants share one categorical axis — \"an effect applied to the countered ability's source permanent\" — so they live on a single enum rather than as sibling `Option` fields on `Effect::Counter` (parameterize, don't proliferate).",
       "cr_refs": [
         "CR 110.1",
@@ -6814,7 +6907,7 @@
       "variants": [
         {
           "name": "LosesAbilities",
-          "line": 954,
+          "line": 961,
           "kind": "struct",
           "field_names": [
             "static_def"
@@ -6826,7 +6919,7 @@
         },
         {
           "name": "Destroy",
-          "line": 957,
+          "line": 964,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8: \"destroy that permanent\" — destroys the countered ability's source permanent (Teferi's Response, Green Slime).",
@@ -6839,7 +6932,7 @@
     },
     "CounterTransferMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 919,
+      "line": 926,
       "doc": "CR 122.5 / CR 122.8: Whether a counter-transfer effect actually moves counters off the source or only puts matching counters on the destination.",
       "cr_refs": [
         "CR 122.5",
@@ -6848,7 +6941,7 @@
       "variants": [
         {
           "name": "Move",
-          "line": 921,
+          "line": 928,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.5: Remove counters from the source and put them on the target.",
@@ -6858,7 +6951,7 @@
         },
         {
           "name": "Put",
-          "line": 923,
+          "line": 930,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.8: Put matching counters on the target using source/LKI state.",
@@ -7104,7 +7197,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4010,
+      "line": 4141,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -7112,7 +7205,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 4013,
+          "line": 4144,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -7125,7 +7218,7 @@
     },
     "DamageKindFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2074,
+      "line": 2088,
       "doc": "Filter for damage type on trigger definitions. CR 120.3: Combat damage is dealt during the combat damage step; all other damage is noncombat.",
       "cr_refs": [
         "CR 120.3"
@@ -7133,7 +7226,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 2077,
+          "line": 2091,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches both combat and noncombat damage.",
@@ -7141,7 +7234,7 @@
         },
         {
           "name": "CombatOnly",
-          "line": 2079,
+          "line": 2093,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2a: Only combat damage (dealt as a result of combat).",
@@ -7151,7 +7244,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 2081,
+          "line": 2095,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2b: Only noncombat damage (dealt as an effect of a spell or ability).",
@@ -7164,7 +7257,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13717,
+      "line": 14132,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -7172,7 +7265,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 13719,
+          "line": 14134,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -7180,7 +7273,7 @@
         },
         {
           "name": "Triple",
-          "line": 13721,
+          "line": 14136,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -7188,7 +7281,7 @@
         },
         {
           "name": "Plus",
-          "line": 13723,
+          "line": 14138,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7198,7 +7291,7 @@
         },
         {
           "name": "Minus",
-          "line": 13730,
+          "line": 14145,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7211,7 +7304,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 13734,
+          "line": 14149,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -7221,7 +7314,7 @@
         },
         {
           "name": "SetTo",
-          "line": 13740,
+          "line": 14155,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7233,7 +7326,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 13746,
+          "line": 14161,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -7248,7 +7341,7 @@
     },
     "DamageRedirectTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 542,
+      "line": 549,
       "doc": "CR 614.9: Recipient of a one-shot damage-redirection effect — the battle/creature/planeswalker/player the replaced damage is dealt to instead. Resolved to a concrete object/player at effect-resolution time (see `effects::create_damage_replacement::resolve`).",
       "cr_refs": [
         "CR 614.9"
@@ -7256,7 +7349,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 545,
+          "line": 552,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to you instead\" — the replacement source's controller (Jade Monolith, Goblin Psychopath).",
@@ -7264,7 +7357,7 @@
         },
         {
           "name": "SourceObject",
-          "line": 548,
+          "line": 555,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to ~ instead\" / \"...dealt to this creature instead\" — the replacement source object itself (Beacon of Destiny).",
@@ -7272,7 +7365,7 @@
         },
         {
           "name": "ChosenObjectTarget",
-          "line": 551,
+          "line": 558,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to target creature instead\" — an object chosen as a target of the creating ability (Soltari Guerrillas).",
@@ -7283,7 +7376,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6511,
+      "line": 6677,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -7291,7 +7384,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 6513,
+          "line": 6679,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -7299,7 +7392,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 6516,
+          "line": 6682,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -7313,7 +7406,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13832,
+      "line": 14249,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -7321,7 +7414,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 13834,
+          "line": 14251,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -7329,7 +7422,7 @@
         },
         {
           "name": "Player",
-          "line": 13836,
+          "line": 14253,
           "kind": "struct",
           "field_names": [
             "player"
@@ -7339,7 +7432,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 13839,
+          "line": 14256,
           "kind": "struct",
           "field_names": [
             "player"
@@ -7352,7 +7445,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13816,
+      "line": 14233,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -7360,7 +7453,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 13817,
+          "line": 14234,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7368,7 +7461,7 @@
         },
         {
           "name": "Opponent",
-          "line": 13818,
+          "line": 14235,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7376,7 +7469,7 @@
         },
         {
           "name": "Controller",
-          "line": 13821,
+          "line": 14238,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -7384,7 +7477,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 13825,
+          "line": 14242,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 614.1a: Damage recipient is the player chosen for the replacement source by a linked persisted choice, or a permanent that player controls for `PlayerOrPermanentsControlledBy`.",
@@ -7395,7 +7488,7 @@
         },
         {
           "name": "Specific",
-          "line": 13826,
+          "line": 14243,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -7848,7 +7941,7 @@
     },
     "DelayedTriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1909,
+      "line": 1916,
       "doc": "When a delayed triggered ability fires (CR 603.7).",
       "cr_refs": [
         "CR 603.7"
@@ -7856,7 +7949,7 @@
       "variants": [
         {
           "name": "AtNextPhase",
-          "line": 1912,
+          "line": 1919,
           "kind": "struct",
           "field_names": [
             "phase"
@@ -7868,7 +7961,7 @@
         },
         {
           "name": "AtNextPhaseForPlayer",
-          "line": 1915,
+          "line": 1922,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -7879,7 +7972,7 @@
         },
         {
           "name": "WhenLeavesPlay",
-          "line": 1917,
+          "line": 1924,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -7889,7 +7982,7 @@
         },
         {
           "name": "WhenDies",
-          "line": 1923,
+          "line": 1930,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7901,7 +7994,7 @@
         },
         {
           "name": "WhenLeavesPlayFiltered",
-          "line": 1926,
+          "line": 1933,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7913,7 +8006,7 @@
         },
         {
           "name": "WhenEntersBattlefield",
-          "line": 1929,
+          "line": 1936,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7925,7 +8018,7 @@
         },
         {
           "name": "WhenDiesOrExiled",
-          "line": 1932,
+          "line": 1939,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7935,7 +8028,7 @@
         },
         {
           "name": "WheneverEvent",
-          "line": 1937,
+          "line": 1944,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -7947,10 +8040,11 @@
         },
         {
           "name": "WhenNextEvent",
-          "line": 1941,
+          "line": 1948,
           "kind": "struct",
           "field_names": [
-            "trigger"
+            "trigger",
+            "or_trigger"
           ],
           "doc": "CR 603.7: \"When you next [event] this turn\" — fires once on the next matching event, then is removed. One-shot variant of `WheneverEvent`. Uses existing trigger matching infrastructure to detect the event.",
           "cr_refs": [
@@ -7962,7 +8056,7 @@
     },
     "DevotionColors": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1038,
+      "line": 1045,
       "doc": "CR 700.5: Which color set a devotion quantity counts.",
       "cr_refs": [
         "CR 700.5"
@@ -7970,7 +8064,7 @@
       "variants": [
         {
           "name": "Fixed",
-          "line": 1040,
+          "line": 1047,
           "kind": "tuple",
           "field_names": [],
           "doc": "Count devotion to one or more fixed colors.",
@@ -7978,7 +8072,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 1043,
+          "line": 1050,
           "kind": "unit",
           "field_names": [],
           "doc": "Count devotion to the color chosen by the source's current choice effect or persisted chosen-color attribute.",
@@ -7989,7 +8083,7 @@
     },
     "DieRollModifier": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 499,
+      "line": 506,
       "doc": "CR 706.2: Modifier applied to a die roll's natural result before the effect's result table is consulted. \"Roll a d20 and add the number of cards in your hand\" → `Add(QuantityExpr::Ref(HandSize { player: Controller }))`. \"Roll a d20 and subtract the number of cards in your hand\" → `Subtract(...)`.",
       "cr_refs": [
         "CR 706.2"
@@ -7997,7 +8091,7 @@
       "variants": [
         {
           "name": "Add",
-          "line": 501,
+          "line": 508,
           "kind": "struct",
           "field_names": [
             "value"
@@ -8007,7 +8101,7 @@
         },
         {
           "name": "Subtract",
-          "line": 503,
+          "line": 510,
           "kind": "struct",
           "field_names": [
             "value"
@@ -8020,13 +8114,13 @@
     },
     "DiscardSelfScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2800,
+      "line": 2862,
       "doc": "Whether a discard cost discards the ability source itself or cards from hand.",
       "cr_refs": [],
       "variants": [
         {
           "name": "FromHand",
-          "line": 2803,
+          "line": 2865,
           "kind": "unit",
           "field_names": [],
           "doc": "Discard from hand per `filter` / `count` (the default).",
@@ -8034,7 +8128,7 @@
         },
         {
           "name": "SourceCard",
-          "line": 2805,
+          "line": 2867,
           "kind": "unit",
           "field_names": [],
           "doc": "Discard the source card itself (Channel's \"Discard this card\").",
@@ -8045,7 +8139,7 @@
     },
     "DistributionUnit": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4032,
+      "line": 4119,
       "doc": "CR 601.2d: What is being distributed (damage, counters, life).",
       "cr_refs": [
         "CR 601.2d"
@@ -8053,7 +8147,7 @@
       "variants": [
         {
           "name": "Damage",
-          "line": 4033,
+          "line": 4120,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8061,7 +8155,7 @@
         },
         {
           "name": "EvenSplitDamage",
-          "line": 4036,
+          "line": 4123,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down). No player choice needed; bypasses `WaitingFor::DistributeAmong`.",
@@ -8071,7 +8165,7 @@
         },
         {
           "name": "Counters",
-          "line": 4037,
+          "line": 4124,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8079,7 +8173,7 @@
         },
         {
           "name": "Life",
-          "line": 4038,
+          "line": 4125,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8090,7 +8184,7 @@
     },
     "DoublePTMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 910,
+      "line": 917,
       "doc": "CR 701.10a: Which P/T characteristics to double.",
       "cr_refs": [
         "CR 701.10a"
@@ -8098,7 +8192,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 911,
+          "line": 918,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8106,7 +8200,7 @@
         },
         {
           "name": "Toughness",
-          "line": 912,
+          "line": 919,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8114,7 +8208,7 @@
         },
         {
           "name": "PowerAndToughness",
-          "line": 913,
+          "line": 920,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8125,7 +8219,7 @@
     },
     "DoubleTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 897,
+      "line": 904,
       "doc": "CR 701.10d-f: What aspect to double (counters, life total, or mana pool). Used by `Effect::Double` per locked decision D-05. DoublePT/DoublePTAll handle CR 701.10a-c (power/toughness) separately.",
       "cr_refs": [
         "CR 701.10a",
@@ -8134,7 +8228,7 @@
       "variants": [
         {
           "name": "Counters",
-          "line": 900,
+          "line": 907,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -8146,7 +8240,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 902,
+          "line": 909,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.10d: Double a player's life total.",
@@ -8156,7 +8250,7 @@
         },
         {
           "name": "ManaPool",
-          "line": 905,
+          "line": 912,
           "kind": "struct",
           "field_names": [
             "color"
@@ -8171,13 +8265,13 @@
     },
     "Duration": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1480,
+      "line": 1487,
       "doc": "Duration for temporary effects.  Player-axis variants are parameterized by `PlayerScope` per the workspace \"Parameterize, don't proliferate\" principle. `PlayerScope::Controller` recovers the legacy \"until your next turn\" / \"controller's next step\" semantics; future `Target` / `Opponent` / `AllPlayers` readings unblock cards whose duration is bound to a non-controller player.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilEndOfTurn",
-          "line": 1482,
+          "line": 1489,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of turn (cleanup step).",
@@ -8187,7 +8281,7 @@
         },
         {
           "name": "UntilEndOfCombat",
-          "line": 1484,
+          "line": 1491,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of combat phase.",
@@ -8197,7 +8291,7 @@
         },
         {
           "name": "UntilNextTurnOf",
-          "line": 1488,
+          "line": 1495,
           "kind": "struct",
           "field_names": [
             "player"
@@ -8210,7 +8304,7 @@
         },
         {
           "name": "UntilEndOfNextTurnOf",
-          "line": 1498,
+          "line": 1505,
           "kind": "struct",
           "field_names": [
             "player"
@@ -8222,7 +8316,7 @@
         },
         {
           "name": "UntilHostLeavesPlay",
-          "line": 1503,
+          "line": 1510,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a: Effect expires when the source object leaves the battlefield.",
@@ -8232,7 +8326,7 @@
         },
         {
           "name": "UntilNextStepOf",
-          "line": 1509,
+          "line": 1516,
           "kind": "struct",
           "field_names": [
             "step",
@@ -8248,7 +8342,7 @@
         },
         {
           "name": "ForAsLongAs",
-          "line": 1515,
+          "line": 1522,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -8260,7 +8354,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1518,
+          "line": 1525,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8323,13 +8417,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6756,
+      "line": 6922,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 6758,
+          "line": 6924,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -8341,7 +8435,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 6764,
+          "line": 6930,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -8356,7 +8450,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 6775,
+          "line": 6941,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8368,7 +8462,7 @@
         },
         {
           "name": "Draw",
-          "line": 6795,
+          "line": 6961,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8384,7 +8478,7 @@
         },
         {
           "name": "Pump",
-          "line": 6801,
+          "line": 6967,
           "kind": "struct",
           "field_names": [
             "power",
@@ -8396,7 +8490,7 @@
         },
         {
           "name": "PairWith",
-          "line": 6812,
+          "line": 6978,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8409,7 +8503,7 @@
         },
         {
           "name": "Destroy",
-          "line": 6815,
+          "line": 6981,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8420,7 +8514,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 6823,
+          "line": 6989,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8432,7 +8526,7 @@
         },
         {
           "name": "Counter",
-          "line": 6827,
+          "line": 6993,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8443,7 +8537,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 6848,
+          "line": 7014,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8457,7 +8551,7 @@
         },
         {
           "name": "Token",
-          "line": 6852,
+          "line": 7018,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8480,7 +8574,7 @@
         },
         {
           "name": "GainLife",
-          "line": 6890,
+          "line": 7056,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8491,7 +8585,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 6901,
+          "line": 7067,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8502,7 +8596,7 @@
         },
         {
           "name": "SetTapState",
-          "line": 6919,
+          "line": 7085,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8517,7 +8611,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 6930,
+          "line": 7096,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8529,7 +8623,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 6945,
+          "line": 7111,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8541,7 +8635,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 6966,
+          "line": 7132,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8552,7 +8646,7 @@
         },
         {
           "name": "Mill",
-          "line": 6972,
+          "line": 7138,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8564,7 +8658,7 @@
         },
         {
           "name": "Scry",
-          "line": 6989,
+          "line": 7155,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8579,7 +8673,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 6995,
+          "line": 7161,
           "kind": "struct",
           "field_names": [
             "power",
@@ -8591,7 +8685,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 7009,
+          "line": 7175,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8608,7 +8702,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 7033,
+          "line": 7199,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8621,7 +8715,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 7037,
+          "line": 7203,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8632,7 +8726,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 7044,
+          "line": 7210,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -8652,7 +8746,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 7089,
+          "line": 7255,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -8670,7 +8764,7 @@
         },
         {
           "name": "Dig",
-          "line": 7134,
+          "line": 7300,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8691,7 +8785,7 @@
         },
         {
           "name": "GainControl",
-          "line": 7167,
+          "line": 7333,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8701,7 +8795,7 @@
         },
         {
           "name": "GainControlAll",
-          "line": 7179,
+          "line": 7345,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8713,7 +8807,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 7183,
+          "line": 7349,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8724,7 +8818,7 @@
         },
         {
           "name": "Attach",
-          "line": 7189,
+          "line": 7355,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -8735,7 +8829,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 7201,
+          "line": 7367,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -8748,7 +8842,7 @@
         },
         {
           "name": "Surveil",
-          "line": 7213,
+          "line": 7379,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8763,7 +8857,7 @@
         },
         {
           "name": "Fight",
-          "line": 7219,
+          "line": 7385,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8774,7 +8868,7 @@
         },
         {
           "name": "Bounce",
-          "line": 7227,
+          "line": 7393,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8786,7 +8880,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 7246,
+          "line": 7412,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8801,7 +8895,7 @@
         },
         {
           "name": "Explore",
-          "line": 7254,
+          "line": 7420,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8809,7 +8903,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 7258,
+          "line": 7424,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8821,7 +8915,7 @@
         },
         {
           "name": "Investigate",
-          "line": 7263,
+          "line": 7429,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Investigate — create a Clue token.",
@@ -8831,7 +8925,7 @@
         },
         {
           "name": "Tribute",
-          "line": 7270,
+          "line": 7436,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8844,7 +8938,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 7276,
+          "line": 7442,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -8854,7 +8948,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 7278,
+          "line": 7444,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -8864,7 +8958,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 7279,
+          "line": 7445,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8872,7 +8966,7 @@
         },
         {
           "name": "ProliferateTarget",
-          "line": 7286,
+          "line": 7452,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8885,7 +8979,7 @@
         },
         {
           "name": "Populate",
-          "line": 7291,
+          "line": 7457,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -8895,7 +8989,7 @@
         },
         {
           "name": "Clash",
-          "line": 7293,
+          "line": 7459,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -8905,7 +8999,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 7298,
+          "line": 7464,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.1: End the turn. Exile every object on the stack, check state-based actions, remove everything from combat, then skip straight to the cleanup step. Time Stop, Sundial of the Infinite, Obeka, Glorious End, Discontinuity, Day's Undoing.",
@@ -8915,7 +9009,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 7303,
+          "line": 7469,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase. Exile every object on the stack, check state-based actions, remove everything from combat, expire \"until end of combat\" effects, and skip straight to the postcombat main phase. Does nothing outside a combat phase (CR 724.2g). Mandate of Peace.",
@@ -8926,7 +9020,7 @@
         },
         {
           "name": "Vote",
-          "line": 7318,
+          "line": 7484,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -8942,7 +9036,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7362,
+          "line": 7528,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -8962,7 +9056,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7381,
+          "line": 7547,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8974,19 +9068,21 @@
         },
         {
           "name": "CopySpell",
-          "line": 7385,
+          "line": 7551,
           "kind": "struct",
           "field_names": [
             "target",
             "retarget",
-            "copier"
+            "copier",
+            "additional_modifications",
+            "starting_loyalty_from_casualty_sacrifice"
           ],
           "doc": "",
           "cr_refs": []
         },
         {
           "name": "EpicCopy",
-          "line": 7410,
+          "line": 7584,
           "kind": "struct",
           "field_names": [
             "spell"
@@ -8999,7 +9095,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 7415,
+          "line": 7589,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9012,7 +9108,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 7426,
+          "line": 7600,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9032,7 +9128,7 @@
         },
         {
           "name": "CreateTokenCopyFromPool",
-          "line": 7481,
+          "line": 7655,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -9053,7 +9149,7 @@
         },
         {
           "name": "Myriad",
-          "line": 7512,
+          "line": 7686,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -9063,7 +9159,7 @@
         },
         {
           "name": "Encore",
-          "line": 7519,
+          "line": 7693,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.141a: Encore — for each opponent, create a token that's a copy of the (exiled) source card that must attack that opponent this turn if able. The tokens gain haste and are sacrificed at the beginning of the next end step. Resolver: `game/effects/encore.rs`. No player-selectable target (opponents and per-opponent attack binding are chosen by the effect, like `Myriad`).",
@@ -9073,7 +9169,7 @@
         },
         {
           "name": "Meld",
-          "line": 7527,
+          "line": 7701,
           "kind": "struct",
           "field_names": [
             "source",
@@ -9088,7 +9184,7 @@
         },
         {
           "name": "ExileHaunting",
-          "line": 7537,
+          "line": 7711,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9100,7 +9196,7 @@
         },
         {
           "name": "HideawayConceal",
-          "line": 7546,
+          "line": 7720,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9112,7 +9208,7 @@
         },
         {
           "name": "CopyTokenBlockingAttacker",
-          "line": 7558,
+          "line": 7732,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -9127,7 +9223,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 7570,
+          "line": 7744,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9143,7 +9239,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 7580,
+          "line": 7754,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -9154,7 +9250,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 7594,
+          "line": 7768,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9168,7 +9264,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 7602,
+          "line": 7776,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9182,7 +9278,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 7609,
+          "line": 7783,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9194,7 +9290,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 7617,
+          "line": 7791,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -9207,7 +9303,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 7623,
+          "line": 7797,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -9220,7 +9316,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 7631,
+          "line": 7805,
           "kind": "struct",
           "field_names": [
             "source",
@@ -9238,7 +9334,7 @@
         },
         {
           "name": "Animate",
-          "line": 7651,
+          "line": 7825,
           "kind": "struct",
           "field_names": [
             "power",
@@ -9253,7 +9349,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 7689,
+          "line": 7863,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -9277,7 +9373,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 7705,
+          "line": 7879,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -9287,7 +9383,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 7709,
+          "line": 7883,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -9299,7 +9395,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 7717,
+          "line": 7891,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -9316,7 +9412,7 @@
         },
         {
           "name": "Mana",
-          "line": 7735,
+          "line": 7909,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -9330,7 +9426,7 @@
         },
         {
           "name": "Discard",
-          "line": 7758,
+          "line": 7932,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9344,7 +9440,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 7785,
+          "line": 7959,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9354,7 +9450,7 @@
         },
         {
           "name": "Transform",
-          "line": 7789,
+          "line": 7963,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9364,7 +9460,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 7795,
+          "line": 7969,
           "kind": "struct",
           "field_names": [
             "source_zones",
@@ -9380,7 +9476,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 7852,
+          "line": 8026,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9398,7 +9494,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 7863,
+          "line": 8037,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9412,7 +9508,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 7892,
+          "line": 8066,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9425,7 +9521,7 @@
         },
         {
           "name": "Reveal",
-          "line": 7903,
+          "line": 8077,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9438,7 +9534,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 7908,
+          "line": 8082,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9451,7 +9547,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 7917,
+          "line": 8091,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9463,7 +9559,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 7940,
+          "line": 8114,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9473,18 +9569,19 @@
         },
         {
           "name": "Choose",
-          "line": 7946,
+          "line": 8120,
           "kind": "struct",
           "field_names": [
             "choice_type",
-            "persist"
+            "persist",
+            "selection"
           ],
           "doc": "Resolution-time named choice: \"choose a creature type\", \"choose a color\", etc. Sets WaitingFor::NamedChoice and stores the result in GameState::last_named_choice.",
           "cr_refs": []
         },
         {
           "name": "ChooseDamageSource",
-          "line": 7957,
+          "line": 8138,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -9497,7 +9594,7 @@
         },
         {
           "name": "Suspect",
-          "line": 7962,
+          "line": 8143,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9509,7 +9606,7 @@
         },
         {
           "name": "Connive",
-          "line": 7972,
+          "line": 8153,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9523,7 +9620,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 7980,
+          "line": 8161,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9535,7 +9632,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 7987,
+          "line": 8168,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9547,7 +9644,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 7992,
+          "line": 8173,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9559,7 +9656,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 7997,
+          "line": 8178,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9573,7 +9670,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 8006,
+          "line": 8187,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -9583,7 +9680,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 8013,
+          "line": 8194,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9595,7 +9692,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 8020,
+          "line": 8201,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9607,7 +9704,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 8025,
+          "line": 8206,
           "kind": "struct",
           "field_names": [
             "level"
@@ -9619,7 +9716,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 8030,
+          "line": 8211,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -9633,7 +9730,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 8060,
+          "line": 8241,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -9647,7 +9744,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 8066,
+          "line": 8247,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -9659,7 +9756,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 8071,
+          "line": 8252,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9672,10 +9769,11 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 8078,
+          "line": 8259,
           "kind": "struct",
           "field_names": [
             "modifier",
+            "player",
             "spell_filter"
           ],
           "doc": "CR 601.2f: \"The next [type] spell you cast this turn [has keyword/can't be countered/etc.].\" Creates a one-shot modifier applied when the player casts their next qualifying spell.",
@@ -9685,7 +9783,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 8087,
+          "line": 8274,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9698,7 +9796,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 8095,
+          "line": 8282,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -9712,7 +9810,7 @@
         },
         {
           "name": "PayCost",
-          "line": 8110,
+          "line": 8297,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -9726,7 +9824,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 8128,
+          "line": 8315,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9746,7 +9844,7 @@
         },
         {
           "name": "FreeCastFromZones",
-          "line": 8196,
+          "line": 8383,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9766,7 +9864,7 @@
         },
         {
           "name": "ExileResolvingSpellInsteadOfGraveyard",
-          "line": 8231,
+          "line": 8418,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 608.2n + CR 607.2b: \"Exile it instead of putting it into a graveyard as it resolves\" — the self-replacement rider applied by a `WhenAPlayerCasts` trigger to the *triggering spell* (Rod of Absorption).  At resolution this effect does NOT move the spell (it is still on the stack); it stamps the per-object linked-source marker so the stack-resolution router sends the spell to exile (CR 614.1a replaces the normal CR 608.2n graveyard destination) when it finishes resolving. When the spell reaches exile, it is recorded as \"exiled with\" the trigger source so a linked ability (CR 607.2b — \"cards exiled with this artifact\") can later refer to the accumulating set.  Distinct from `ChangeZone { destination: Exile }` (which moves a card that is already in a zone) and from `FreeCastFromZones { exile_instead… }` (which stamps the same rider on a spell *cast during resolution*, with no linked-exile payoff). This effect is the trigger-driven, link-establishing form for the resolving spell itself.",
@@ -9778,7 +9876,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 8233,
+          "line": 8420,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9795,7 +9893,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 8278,
+          "line": 8465,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -9817,7 +9915,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 8319,
+          "line": 8506,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9829,7 +9927,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 8328,
+          "line": 8515,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9841,7 +9939,7 @@
         },
         {
           "name": "RollDie",
-          "line": 8341,
+          "line": 8528,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9859,34 +9957,39 @@
         },
         {
           "name": "FlipCoin",
-          "line": 8351,
+          "line": 8553,
           "kind": "struct",
           "field_names": [
             "win_effect",
-            "lose_effect"
+            "lose_effect",
+            "flipper"
           ],
-          "doc": "CR 705: Flip a coin. Optionally execute different effects on win/lose.",
+          "doc": "CR 705: Flip a coin. Optionally execute different effects on win/lose.  CR 705.2: \"only the player who flips a coin wins or loses the flip.\" The `flipper` selects WHICH player flips (and therefore whose win/lose result drives the branches and whose `CoinFlipped` is recorded). It is the same player-reference type every other player-acting effect carries (`LoseLife.target`, `Draw.target`, `GainLife.player`) and is resolved by the single-authority `resolve_player_for_context_ref`, so \"that player flips a coin\" (Mirrored Depths, Planar Chaos) flips for the triggering player rather than the source's controller. Defaults to `Controller` for the bare \"flip a coin\" / \"you flip a coin\" case (CR 705.2) and for back-compat with serialized data written before this field existed. \"each player flips a coin\" is NOT expressed here — it rides the surrounding `AbilityDefinition.player_scope` iteration (CR 101.4 APNAP), which rebinds the acting controller per player so `flipper = Controller` flips once for each player.",
           "cr_refs": [
-            "CR 705"
+            "CR 101.4",
+            "CR 705",
+            "CR 705.2"
           ]
         },
         {
           "name": "FlipCoins",
-          "line": 8363,
+          "line": 8573,
           "kind": "struct",
           "field_names": [
             "count",
             "win_effect",
-            "lose_effect"
+            "lose_effect",
+            "flipper"
           ],
-          "doc": "CR 705: Flip N coins. `win_effect` runs once per heads (win), `lose_effect` runs once per tails (loss). Generalization of `FlipCoin` for \"flip N coins, for each heads …\" patterns (Ral Zarek, Guest Lecturer). The one-flip degenerate case stays as `FlipCoin` — this variant is only emitted when `count > 1` or when the Oracle text explicitly binds a count.",
+          "doc": "CR 705: Flip N coins. `win_effect` runs once per heads (win), `lose_effect` runs once per tails (loss). Generalization of `FlipCoin` for \"flip N coins, for each heads …\" patterns (Ral Zarek, Guest Lecturer). The one-flip degenerate case stays as `FlipCoin` — this variant is only emitted when `count > 1` or when the Oracle text explicitly binds a count.  CR 705.2: `flipper` selects which player flips all `count` coins (see `FlipCoin::flipper`). Defaults to `Controller`.",
           "cr_refs": [
-            "CR 705"
+            "CR 705",
+            "CR 705.2"
           ]
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 8372,
+          "line": 8587,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -9898,7 +10001,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 8377,
+          "line": 8592,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -9908,7 +10011,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 8380,
+          "line": 8595,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -9918,7 +10021,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 8382,
+          "line": 8597,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -9930,7 +10033,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 8387,
+          "line": 8602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -9941,7 +10044,7 @@
         },
         {
           "name": "Planeswalk",
-          "line": 8392,
+          "line": 8607,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 901.8 / CR 901.9c: The synthetic \"planeswalking ability.\" When a player rolls the Planeswalker symbol on the planar die, this ability triggers and is put on the stack; on resolution its controller (the roller, CR 901.8) planeswalks (CR 701.31).",
@@ -9953,7 +10056,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 8395,
+          "line": 8610,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9965,7 +10068,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 8399,
+          "line": 8614,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.52: Roll to visit your Attractions.",
@@ -9975,7 +10078,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 8402,
+          "line": 8617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -9985,7 +10088,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 8405,
+          "line": 8620,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -9997,7 +10100,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 8422,
+          "line": 8637,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10007,6 +10110,7 @@
             "filter",
             "chooser",
             "up_to",
+            "selection",
             "constraint"
           ],
           "doc": "Choose card(s) from a zone (typically exiled cards from a prior effect). Building block for impulse draw, cascade, hideaway, and similar exile-then-select patterns. The selection is from the tracked set of the parent effect's result, falling back to direct zone contents for wordings like \"choose a card in your hand.\" CR 700.2: The `chooser` field determines who makes the selection.",
@@ -10016,7 +10120,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 8455,
+          "line": 8684,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -10031,7 +10135,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 8468,
+          "line": 8697,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -10047,7 +10151,7 @@
         },
         {
           "name": "Exploit",
-          "line": 8483,
+          "line": 8712,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10059,7 +10163,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 8488,
+          "line": 8717,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10071,7 +10175,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 8493,
+          "line": 8722,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -10086,7 +10190,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 8505,
+          "line": 8734,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10098,7 +10202,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 8517,
+          "line": 8746,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10114,7 +10218,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 8528,
+          "line": 8757,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10132,7 +10236,7 @@
         },
         {
           "name": "Discover",
-          "line": 8566,
+          "line": 8795,
           "kind": "struct",
           "field_names": [
             "mana_value_limit"
@@ -10144,7 +10248,7 @@
         },
         {
           "name": "Cascade",
-          "line": 8578,
+          "line": 8807,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -10154,7 +10258,7 @@
         },
         {
           "name": "Ripple",
-          "line": 8583,
+          "line": 8812,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10166,7 +10270,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 8589,
+          "line": 8818,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -10178,7 +10282,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 8594,
+          "line": 8823,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -10190,7 +10294,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 8607,
+          "line": 8836,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10202,7 +10306,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 8616,
+          "line": 8845,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10214,7 +10318,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 8625,
+          "line": 8854,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10224,7 +10328,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 8630,
+          "line": 8859,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -10234,7 +10338,7 @@
         },
         {
           "name": "Goad",
-          "line": 8636,
+          "line": 8865,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10246,7 +10350,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 8643,
+          "line": 8872,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10258,7 +10362,7 @@
         },
         {
           "name": "Detain",
-          "line": 8650,
+          "line": 8879,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10270,7 +10374,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 8661,
+          "line": 8890,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -10284,7 +10388,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 8672,
+          "line": 8901,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10298,11 +10402,13 @@
         },
         {
           "name": "Manifest",
-          "line": 8687,
+          "line": 8916,
           "kind": "struct",
           "field_names": [
             "target",
-            "count"
+            "count",
+            "profile",
+            "enters_under"
           ],
           "doc": "CR 701.40a: Manifest — put the top card of a player's library onto the battlefield face down as a 2/2 creature with no text, no name, no subtypes, and no mana cost. `target` selects whose library is manifested from: `Controller` for \"you manifest...\" (Whisperwood Elemental, Qarsi High Priest), `ParentTargetController` for \"its controller manifests...\" (Reality Shift), and `TriggeringPlayer` for \"that player's library\" trigger bodies (Orochi Soul-Reaver). `count` determines how many cards to manifest.",
           "cr_refs": [
@@ -10311,7 +10417,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 8693,
+          "line": 8936,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -10321,7 +10427,7 @@
         },
         {
           "name": "Cloak",
-          "line": 8700,
+          "line": 8943,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10335,7 +10441,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 8712,
+          "line": 8955,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10348,7 +10454,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 8719,
+          "line": 8962,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10360,7 +10466,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 8733,
+          "line": 8976,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -10373,7 +10479,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 8744,
+          "line": 8987,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10386,7 +10492,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 8754,
+          "line": 8997,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10400,7 +10506,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 8770,
+          "line": 9013,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10417,7 +10523,7 @@
         },
         {
           "name": "Double",
-          "line": 8783,
+          "line": 9026,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -10431,7 +10537,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 8791,
+          "line": 9034,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -10443,7 +10549,7 @@
         },
         {
           "name": "Incubate",
-          "line": 8797,
+          "line": 9040,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10455,7 +10561,7 @@
         },
         {
           "name": "Amass",
-          "line": 8805,
+          "line": 9048,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -10468,7 +10574,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 8813,
+          "line": 9056,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10480,7 +10586,7 @@
         },
         {
           "name": "Specialize",
-          "line": 8819,
+          "line": 9062,
           "kind": "unit",
           "field_names": [],
           "doc": "Digital-only Specialize: permanently become a color-specific face after paying the synthesized activation cost (mana + discard). Not in CR text.",
@@ -10488,7 +10594,7 @@
         },
         {
           "name": "Renown",
-          "line": 8822,
+          "line": 9065,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10500,7 +10606,7 @@
         },
         {
           "name": "Bolster",
-          "line": 8828,
+          "line": 9071,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10512,7 +10618,7 @@
         },
         {
           "name": "Adapt",
-          "line": 8834,
+          "line": 9077,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10524,7 +10630,7 @@
         },
         {
           "name": "Learn",
-          "line": 8840,
+          "line": 9083,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -10534,7 +10640,7 @@
         },
         {
           "name": "Forage",
-          "line": 8842,
+          "line": 9085,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.61a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -10544,7 +10650,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 8844,
+          "line": 9087,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10556,7 +10662,7 @@
         },
         {
           "name": "Endure",
-          "line": 8851,
+          "line": 9094,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10569,7 +10675,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 8856,
+          "line": 9099,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10581,7 +10687,7 @@
         },
         {
           "name": "Seek",
-          "line": 8861,
+          "line": 9104,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -10595,7 +10701,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 8878,
+          "line": 9121,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10608,7 +10714,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 8893,
+          "line": 9136,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10623,8 +10729,21 @@
           ]
         },
         {
+          "name": "ExchangeLifeTotals",
+          "line": 9144,
+          "kind": "struct",
+          "field_names": [
+            "player_a",
+            "player_b"
+          ],
+          "doc": "CR 701.12a: Two players exchange life totals. player_a/player_b each select a player (Controller for \"you\", Opponent filter for \"target opponent\", Player for \"target player\"). Both swap simultaneously, all-or-nothing.",
+          "cr_refs": [
+            "CR 701.12a"
+          ]
+        },
+        {
           "name": "SetDayNight",
-          "line": 8900,
+          "line": 9152,
           "kind": "struct",
           "field_names": [
             "to"
@@ -10636,7 +10755,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 8905,
+          "line": 9157,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10649,7 +10768,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 8914,
+          "line": 9166,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10661,7 +10780,7 @@
         },
         {
           "name": "Conjure",
-          "line": 8921,
+          "line": 9173,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -10673,7 +10792,7 @@
         },
         {
           "name": "Intensify",
-          "line": 8933,
+          "line": 9185,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -10684,7 +10803,7 @@
         },
         {
           "name": "DraftFromSpellbook",
-          "line": 8947,
+          "line": 9199,
           "kind": "struct",
           "field_names": [
             "destination",
@@ -10695,7 +10814,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 8966,
+          "line": 9218,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -10709,7 +10828,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 8977,
+          "line": 9229,
           "kind": "struct",
           "field_names": [
             "name",
@@ -10812,13 +10931,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15131,
+      "line": 15566,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 15133,
+          "line": 15568,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10826,7 +10945,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 15135,
+          "line": 15570,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10834,7 +10953,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 15137,
+          "line": 15572,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10842,7 +10961,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 15139,
+          "line": 15574,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10850,7 +10969,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 15141,
+          "line": 15576,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10858,7 +10977,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 15143,
+          "line": 15578,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10869,13 +10988,13 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10578,
+      "line": 10849,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 10579,
+          "line": 10850,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10883,7 +11002,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 10580,
+          "line": 10851,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10891,7 +11010,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 10581,
+          "line": 10852,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10899,7 +11018,7 @@
         },
         {
           "name": "Draw",
-          "line": 10582,
+          "line": 10853,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10907,7 +11026,7 @@
         },
         {
           "name": "Pump",
-          "line": 10583,
+          "line": 10854,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10915,7 +11034,7 @@
         },
         {
           "name": "PairWith",
-          "line": 10584,
+          "line": 10855,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10923,7 +11042,7 @@
         },
         {
           "name": "Destroy",
-          "line": 10585,
+          "line": 10856,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10931,7 +11050,7 @@
         },
         {
           "name": "Counter",
-          "line": 10586,
+          "line": 10857,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10939,7 +11058,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 10587,
+          "line": 10858,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10947,7 +11066,7 @@
         },
         {
           "name": "Token",
-          "line": 10588,
+          "line": 10859,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10955,7 +11074,7 @@
         },
         {
           "name": "GainLife",
-          "line": 10589,
+          "line": 10860,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10963,7 +11082,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 10590,
+          "line": 10861,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10971,7 +11090,7 @@
         },
         {
           "name": "Tap",
-          "line": 10591,
+          "line": 10862,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10979,7 +11098,7 @@
         },
         {
           "name": "Untap",
-          "line": 10592,
+          "line": 10863,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10987,7 +11106,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 10593,
+          "line": 10864,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10995,7 +11114,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 10594,
+          "line": 10865,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11003,7 +11122,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 10595,
+          "line": 10866,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11011,7 +11130,7 @@
         },
         {
           "name": "Mill",
-          "line": 10596,
+          "line": 10867,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11019,7 +11138,7 @@
         },
         {
           "name": "Scry",
-          "line": 10597,
+          "line": 10868,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11027,7 +11146,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 10598,
+          "line": 10869,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11035,7 +11154,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 10599,
+          "line": 10870,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11043,7 +11162,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 10600,
+          "line": 10871,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11051,7 +11170,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 10601,
+          "line": 10872,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11059,7 +11178,7 @@
         },
         {
           "name": "TapAll",
-          "line": 10602,
+          "line": 10873,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11067,7 +11186,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 10603,
+          "line": 10874,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11075,7 +11194,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 10604,
+          "line": 10875,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11083,7 +11202,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 10605,
+          "line": 10876,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11091,7 +11210,7 @@
         },
         {
           "name": "Dig",
-          "line": 10606,
+          "line": 10877,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11099,7 +11218,7 @@
         },
         {
           "name": "GainControl",
-          "line": 10607,
+          "line": 10878,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11107,7 +11226,7 @@
         },
         {
           "name": "GainControlAll",
-          "line": 10608,
+          "line": 10879,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11115,7 +11234,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 10609,
+          "line": 10880,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11123,7 +11242,7 @@
         },
         {
           "name": "Attach",
-          "line": 10610,
+          "line": 10881,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11131,7 +11250,7 @@
         },
         {
           "name": "AttachAll",
-          "line": 10611,
+          "line": 10882,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11139,7 +11258,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 10612,
+          "line": 10883,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11147,7 +11266,7 @@
         },
         {
           "name": "Surveil",
-          "line": 10613,
+          "line": 10884,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11155,7 +11274,7 @@
         },
         {
           "name": "Fight",
-          "line": 10614,
+          "line": 10885,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11163,7 +11282,7 @@
         },
         {
           "name": "Bounce",
-          "line": 10615,
+          "line": 10886,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11171,7 +11290,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 10616,
+          "line": 10887,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11179,7 +11298,7 @@
         },
         {
           "name": "Explore",
-          "line": 10617,
+          "line": 10888,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11187,7 +11306,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 10618,
+          "line": 10889,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11195,7 +11314,7 @@
         },
         {
           "name": "Investigate",
-          "line": 10619,
+          "line": 10890,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11203,7 +11322,7 @@
         },
         {
           "name": "Tribute",
-          "line": 10620,
+          "line": 10891,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11211,7 +11330,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 10621,
+          "line": 10892,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11219,7 +11338,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 10622,
+          "line": 10893,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11227,7 +11346,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 10623,
+          "line": 10894,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11235,7 +11354,7 @@
         },
         {
           "name": "ProliferateTarget",
-          "line": 10624,
+          "line": 10895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11243,7 +11362,7 @@
         },
         {
           "name": "Populate",
-          "line": 10625,
+          "line": 10896,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11251,7 +11370,7 @@
         },
         {
           "name": "Clash",
-          "line": 10626,
+          "line": 10897,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11259,7 +11378,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 10627,
+          "line": 10898,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11267,7 +11386,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 10629,
+          "line": 10900,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase — skip to the postcombat main phase.",
@@ -11277,7 +11396,7 @@
         },
         {
           "name": "Vote",
-          "line": 10631,
+          "line": 10902,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -11287,7 +11406,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 10633,
+          "line": 10904,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -11297,7 +11416,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 10634,
+          "line": 10905,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11305,7 +11424,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 10635,
+          "line": 10906,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11313,7 +11432,7 @@
         },
         {
           "name": "EpicCopy",
-          "line": 10636,
+          "line": 10907,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11321,7 +11440,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 10637,
+          "line": 10908,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11329,7 +11448,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 10638,
+          "line": 10909,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11337,7 +11456,7 @@
         },
         {
           "name": "CreateTokenCopyFromPool",
-          "line": 10639,
+          "line": 10910,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11345,7 +11464,7 @@
         },
         {
           "name": "Myriad",
-          "line": 10640,
+          "line": 10911,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11353,7 +11472,7 @@
         },
         {
           "name": "Encore",
-          "line": 10641,
+          "line": 10912,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11361,7 +11480,7 @@
         },
         {
           "name": "Meld",
-          "line": 10642,
+          "line": 10913,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11369,7 +11488,7 @@
         },
         {
           "name": "ExileHaunting",
-          "line": 10643,
+          "line": 10914,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11377,7 +11496,7 @@
         },
         {
           "name": "HideawayConceal",
-          "line": 10644,
+          "line": 10915,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11385,7 +11504,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 10645,
+          "line": 10916,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11393,7 +11512,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 10646,
+          "line": 10917,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11401,7 +11520,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 10647,
+          "line": 10918,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11409,7 +11528,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 10648,
+          "line": 10919,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11417,7 +11536,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 10649,
+          "line": 10920,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11425,7 +11544,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 10650,
+          "line": 10921,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11433,7 +11552,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 10651,
+          "line": 10922,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11441,7 +11560,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 10652,
+          "line": 10923,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11449,7 +11568,7 @@
         },
         {
           "name": "Animate",
-          "line": 10653,
+          "line": 10924,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11457,7 +11576,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 10654,
+          "line": 10925,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11465,7 +11584,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 10655,
+          "line": 10926,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11473,7 +11592,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 10656,
+          "line": 10927,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11481,7 +11600,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 10657,
+          "line": 10928,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11489,7 +11608,7 @@
         },
         {
           "name": "Mana",
-          "line": 10658,
+          "line": 10929,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11497,7 +11616,7 @@
         },
         {
           "name": "Discard",
-          "line": 10659,
+          "line": 10930,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11505,7 +11624,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 10660,
+          "line": 10931,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11513,7 +11632,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 10661,
+          "line": 10932,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11521,7 +11640,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 10662,
+          "line": 10933,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11529,7 +11648,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 10663,
+          "line": 10934,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11537,7 +11656,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 10664,
+          "line": 10935,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11545,7 +11664,7 @@
         },
         {
           "name": "Choose",
-          "line": 10665,
+          "line": 10936,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11553,7 +11672,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 10666,
+          "line": 10937,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11561,7 +11680,7 @@
         },
         {
           "name": "Suspect",
-          "line": 10667,
+          "line": 10938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11569,7 +11688,7 @@
         },
         {
           "name": "Connive",
-          "line": 10668,
+          "line": 10939,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11577,7 +11696,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 10669,
+          "line": 10940,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11585,7 +11704,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 10670,
+          "line": 10941,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11593,7 +11712,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 10671,
+          "line": 10942,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11601,7 +11720,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 10672,
+          "line": 10943,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11609,7 +11728,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 10673,
+          "line": 10944,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11617,7 +11736,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 10675,
+          "line": 10946,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -11627,7 +11746,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 10677,
+          "line": 10948,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -11637,7 +11756,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 10678,
+          "line": 10949,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11645,7 +11764,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 10679,
+          "line": 10950,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11653,7 +11772,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 10680,
+          "line": 10951,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11661,7 +11780,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 10681,
+          "line": 10952,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11669,7 +11788,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 10682,
+          "line": 10953,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11677,7 +11796,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 10683,
+          "line": 10954,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11685,7 +11804,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 10684,
+          "line": 10955,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11693,7 +11812,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 10685,
+          "line": 10956,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11701,7 +11820,7 @@
         },
         {
           "name": "PayCost",
-          "line": 10686,
+          "line": 10957,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11709,7 +11828,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 10687,
+          "line": 10958,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11717,7 +11836,7 @@
         },
         {
           "name": "FreeCastFromZones",
-          "line": 10688,
+          "line": 10959,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11725,7 +11844,7 @@
         },
         {
           "name": "ExileResolvingSpellInsteadOfGraveyard",
-          "line": 10689,
+          "line": 10960,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11733,7 +11852,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 10690,
+          "line": 10961,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11741,7 +11860,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 10691,
+          "line": 10962,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11749,7 +11868,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 10692,
+          "line": 10963,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11757,7 +11876,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 10693,
+          "line": 10964,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11765,7 +11884,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 10694,
+          "line": 10965,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11773,7 +11892,7 @@
         },
         {
           "name": "RollDie",
-          "line": 10695,
+          "line": 10966,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11781,7 +11900,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 10696,
+          "line": 10967,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11789,7 +11908,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 10697,
+          "line": 10968,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11797,7 +11916,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 10698,
+          "line": 10969,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11805,7 +11924,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 10699,
+          "line": 10970,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11813,7 +11932,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 10700,
+          "line": 10971,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11821,7 +11940,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 10701,
+          "line": 10972,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11829,7 +11948,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 10702,
+          "line": 10973,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11837,7 +11956,7 @@
         },
         {
           "name": "Planeswalk",
-          "line": 10703,
+          "line": 10974,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11845,7 +11964,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 10704,
+          "line": 10975,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11853,7 +11972,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 10705,
+          "line": 10976,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11861,7 +11980,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 10706,
+          "line": 10977,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11869,7 +11988,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 10707,
+          "line": 10978,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11877,7 +11996,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 10708,
+          "line": 10979,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11885,7 +12004,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 10709,
+          "line": 10980,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11893,7 +12012,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 10710,
+          "line": 10981,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11901,7 +12020,7 @@
         },
         {
           "name": "Exploit",
-          "line": 10711,
+          "line": 10982,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11909,7 +12028,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 10712,
+          "line": 10983,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11917,7 +12036,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 10713,
+          "line": 10984,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11925,7 +12044,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 10714,
+          "line": 10985,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11933,7 +12052,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 10715,
+          "line": 10986,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11941,7 +12060,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 10716,
+          "line": 10987,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11949,7 +12068,7 @@
         },
         {
           "name": "Discover",
-          "line": 10717,
+          "line": 10988,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11957,7 +12076,7 @@
         },
         {
           "name": "Cascade",
-          "line": 10718,
+          "line": 10989,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11965,7 +12084,7 @@
         },
         {
           "name": "Ripple",
-          "line": 10719,
+          "line": 10990,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11973,7 +12092,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 10720,
+          "line": 10991,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11981,7 +12100,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 10721,
+          "line": 10992,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11989,7 +12108,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 10722,
+          "line": 10993,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11997,7 +12116,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 10723,
+          "line": 10994,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12005,7 +12124,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 10724,
+          "line": 10995,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12013,7 +12132,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 10725,
+          "line": 10996,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12021,7 +12140,7 @@
         },
         {
           "name": "Goad",
-          "line": 10726,
+          "line": 10997,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12029,7 +12148,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 10727,
+          "line": 10998,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12037,7 +12156,7 @@
         },
         {
           "name": "Detain",
-          "line": 10728,
+          "line": 10999,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12045,7 +12164,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 10729,
+          "line": 11000,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12053,7 +12172,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 10730,
+          "line": 11001,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12061,7 +12180,7 @@
         },
         {
           "name": "Incubate",
-          "line": 10731,
+          "line": 11002,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12069,7 +12188,7 @@
         },
         {
           "name": "Amass",
-          "line": 10732,
+          "line": 11003,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12077,7 +12196,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 10733,
+          "line": 11004,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12085,7 +12204,7 @@
         },
         {
           "name": "Specialize",
-          "line": 10734,
+          "line": 11005,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12093,7 +12212,7 @@
         },
         {
           "name": "Renown",
-          "line": 10735,
+          "line": 11006,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12101,7 +12220,7 @@
         },
         {
           "name": "Bolster",
-          "line": 10736,
+          "line": 11007,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12109,7 +12228,7 @@
         },
         {
           "name": "Adapt",
-          "line": 10737,
+          "line": 11008,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12117,7 +12236,7 @@
         },
         {
           "name": "Manifest",
-          "line": 10738,
+          "line": 11009,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12125,7 +12244,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 10739,
+          "line": 11010,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12133,7 +12252,7 @@
         },
         {
           "name": "Cloak",
-          "line": 10741,
+          "line": 11012,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.58a: Cloak (face-down 2/2 with ward {2}).",
@@ -12143,7 +12262,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 10742,
+          "line": 11013,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12151,7 +12270,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 10743,
+          "line": 11014,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12159,7 +12278,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 10744,
+          "line": 11015,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12167,7 +12286,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 10745,
+          "line": 11016,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12175,7 +12294,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 10746,
+          "line": 11017,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12183,7 +12302,7 @@
         },
         {
           "name": "Double",
-          "line": 10747,
+          "line": 11018,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12191,7 +12310,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 10748,
+          "line": 11019,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12199,7 +12318,7 @@
         },
         {
           "name": "Learn",
-          "line": 10749,
+          "line": 11020,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12207,7 +12326,7 @@
         },
         {
           "name": "Forage",
-          "line": 10750,
+          "line": 11021,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12215,7 +12334,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 10751,
+          "line": 11022,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12223,7 +12342,7 @@
         },
         {
           "name": "Endure",
-          "line": 10752,
+          "line": 11023,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12231,7 +12350,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 10753,
+          "line": 11024,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12239,7 +12358,7 @@
         },
         {
           "name": "Seek",
-          "line": 10754,
+          "line": 11025,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12247,7 +12366,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 10755,
+          "line": 11026,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12255,7 +12374,15 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 10756,
+          "line": 11027,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ExchangeLifeTotals",
+          "line": 11028,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12263,7 +12390,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 10757,
+          "line": 11029,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12271,7 +12398,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 10758,
+          "line": 11030,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12279,7 +12406,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 10759,
+          "line": 11031,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12287,7 +12414,7 @@
         },
         {
           "name": "Conjure",
-          "line": 10760,
+          "line": 11032,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12295,7 +12422,7 @@
         },
         {
           "name": "Intensify",
-          "line": 10761,
+          "line": 11033,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12303,7 +12430,7 @@
         },
         {
           "name": "DraftFromSpellbook",
-          "line": 10762,
+          "line": 11034,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12311,7 +12438,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 10763,
+          "line": 11035,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12319,7 +12446,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 10764,
+          "line": 11036,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12327,7 +12454,7 @@
         },
         {
           "name": "Equip",
-          "line": 10766,
+          "line": 11038,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -12335,7 +12462,7 @@
         },
         {
           "name": "Crew",
-          "line": 10768,
+          "line": 11040,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -12345,7 +12472,7 @@
         },
         {
           "name": "Station",
-          "line": 10770,
+          "line": 11042,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -12355,7 +12482,7 @@
         },
         {
           "name": "Saddle",
-          "line": 10772,
+          "line": 11044,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -12365,7 +12492,7 @@
         },
         {
           "name": "Reveal",
-          "line": 10774,
+          "line": 11046,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -12373,7 +12500,7 @@
         },
         {
           "name": "Transform",
-          "line": 10775,
+          "line": 11047,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12381,7 +12508,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 10776,
+          "line": 11048,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12389,7 +12516,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 10777,
+          "line": 11049,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12505,13 +12632,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11998,
+      "line": 12295,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 12002,
+          "line": 12299,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -12522,7 +12649,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 12005,
+          "line": 12302,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -12572,7 +12699,7 @@
     },
     "EffectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3214,
+      "line": 3296,
       "doc": "CR 701.26a / CR 701.26b: Selection scope for `Effect::SetTapState`. Picks whether the tap/untap targets a single chosen/source permanent (the legacy `Tap` / `Untap`) or every permanent matching the filter (the legacy `TapAll` / `UntapAll`). Parameterizes the structural \"single vs mass\" axis instead of proliferating sibling effect variants.",
       "cr_refs": [
         "CR 701.26a",
@@ -12581,7 +12708,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 3217,
+          "line": 3299,
           "kind": "unit",
           "field_names": [],
           "doc": "One permanent — `target` is a selectable target filter (legacy `Effect::Tap` / `Effect::Untap`). `target_filter()` exposes it.",
@@ -12589,7 +12716,7 @@
         },
         {
           "name": "All",
-          "line": 3220,
+          "line": 3302,
           "kind": "unit",
           "field_names": [],
           "doc": "Every permanent matching the filter — `target` is a non-targeting population filter (legacy `Effect::TapAll` / `Effect::UntapAll`).",
@@ -12872,7 +12999,7 @@
     },
     "ExileLinkKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 698,
+      "line": 723,
       "doc": "CR 607.2a + CR 406.6: Tracks the link between an exiling source and the exiled card. When the source leaves the battlefield, the exiled card returns (CR 610.3a).",
       "cr_refs": [
         "CR 406.6",
@@ -12882,7 +13009,7 @@
       "variants": [
         {
           "name": "UntilSourceLeaves",
-          "line": 700,
+          "line": 725,
           "kind": "struct",
           "field_names": [
             "return_zone"
@@ -12894,7 +13021,7 @@
         },
         {
           "name": "TrackedBySource",
-          "line": 702,
+          "line": 727,
           "kind": "unit",
           "field_names": [],
           "doc": "Track cards \"exiled with\" a source without creating an automatic return.",
@@ -12902,7 +13029,7 @@
         },
         {
           "name": "ParadigmSource",
-          "line": 711,
+          "line": 736,
           "kind": "struct",
           "field_names": [
             "player"
@@ -12917,7 +13044,7 @@
         },
         {
           "name": "Cipher",
-          "line": 720,
+          "line": 745,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99b: Cipher — the exiled card (`exiled_id`) is *encoded* on the creature (`source_id`). While the card stays in exile and the creature stays on the battlefield, the creature has \"Whenever this creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost\" (CR 702.99c). The link is pruned automatically when the card leaves exile (`zones.rs` exile-exit) or the creature leaves the battlefield (`zones.rs` battlefield-exit, since this is not an `UntilSourceLeaves` link) — exactly CR 702.99c's lifetime.",
@@ -12928,7 +13055,7 @@
         },
         {
           "name": "Haunt",
-          "line": 731,
+          "line": 756,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.55b: Haunt — the exiled card (`exiled_id`) \"haunts\" the creature (`source_id`) targeted by its haunt ability. The link drives the card's haunt-payoff trigger, which fires from the exile zone when the haunted creature dies (CR 702.55c). Unlike `Cipher`, this link is **preserved** when the haunted creature leaves the battlefield (`zones.rs` battlefield exit) — the haunted creature's death is exactly when the payoff must read the link. The card \"haunts the creature it haunts regardless of whether or not that object is still a creature\" (CR 702.55b), so the link is pruned only when the haunting card itself leaves exile (`zones.rs` exile-exit), not when the creature changes or dies.",
@@ -12939,7 +13066,7 @@
         },
         {
           "name": "HideawayLookable",
-          "line": 743,
+          "line": 768,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.75a: Hideaway — the card (`exiled_id`) was exiled face down by the permanent (`source_id`). Like `TrackedBySource` it tracks the card so the companion \"you may play the exiled card\" ability (`TargetFilter:: ExiledBySource`, which is kind-agnostic) can later find it — but it additionally grants a *look-permission*: the player who controls the exiling permanent \"may look at this card in the exile zone\". Visibility keys the controller's face-down look-through on this kind specifically, so plain `TrackedBySource` face-down exiles that grant no such permission (Bomat Courier's \"(You can't look at it.)\", Necropotence, Asmodeus) stay redacted. Pruned on exile-exit / source-exit like `Cipher` (not an `UntilSourceLeaves` link, so no automatic return).",
@@ -12949,7 +13076,7 @@
         },
         {
           "name": "CraftMaterial",
-          "line": 755,
+          "line": 780,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.167c: Craft material — the card (`exiled_id`) was exiled to pay the craft activation cost of the permanent (`source_id`) that returns to the battlefield transformed. \"An ability of a permanent may refer to the exiled cards used to craft it.\" Unlike `TrackedBySource`, this link is **preserved** when the craft source leaves the battlefield — the source self-exiles mid-activation (CR 702.167a) and returns with the SAME ObjectId, so the link must survive its battlefield exit for the returned permanent to read it. Unlike `UntilSourceLeaves` it triggers NO automatic return (the materials stay in exile). Read by the kind-agnostic `ExiledBySource` / `CardsExiledBySource` consumers; pruned only when a material itself leaves exile (`zones.rs` exile-exit).",
@@ -12963,7 +13090,7 @@
     },
     "FaceDownBody": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6657,
+      "line": 6823,
       "doc": "CR 708.2a: Whether a face-down permanent is a creature or a non-creature.  CR 708.2a sentence 1 gives the manifest/morph default: a face-down permanent is a 2/2 *creature*. Sentence 2 (\"...unless otherwise specified by the effect that put it onto the battlefield face down\") lets an effect specify a non-creature body instead — e.g. Yedora, Grave Gardener's \"It's a Forest land.\" (It has no other types or abilities.)\". This typed discriminant replaces an implicit \"Creature is always present\" assumption so the same face-down machinery covers both classes without a raw bool.",
       "cr_refs": [
         "CR 708.2a"
@@ -12971,7 +13098,7 @@
       "variants": [
         {
           "name": "Creature",
-          "line": 6663,
+          "line": 6829,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2a (sentence 1): the morph/manifest default — the face-down permanent has the Creature core type (always present) and defaults to 2/2 power/toughness. Any `extra_core_types` are layered on top of Creature (e.g. \"artifact creatures\").",
@@ -12981,7 +13108,7 @@
         },
         {
           "name": "Noncreature",
-          "line": 6668,
+          "line": 6834,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2a (sentence 2): the effect fully specifies the core types and the permanent is NOT a creature — so it has no power/toughness (CR 208.1) and gains no implicit Creature type. Used for \"It's a Forest land.\" The profile's `extra_core_types` are the complete core-type set.",
@@ -12995,13 +13122,13 @@
     },
     "FilterProp": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2203,
+      "line": 2220,
       "doc": "Individual filter properties that can be combined in a Typed filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Token",
-          "line": 2205,
+          "line": 2222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are tokens.",
@@ -13011,7 +13138,7 @@
         },
         {
           "name": "NonToken",
-          "line": 2207,
+          "line": 2224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are not tokens.",
@@ -13020,8 +13147,19 @@
           ]
         },
         {
+          "name": "WasPlayed",
+          "line": 2228,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 305.1 + CR 601.2a: Matches objects entering from being played (land play) or cast (spell), excluding tokens put directly onto the battlefield without a prior zone.",
+          "cr_refs": [
+            "CR 305.1",
+            "CR 601.2a"
+          ]
+        },
+        {
           "name": "Attacking",
-          "line": 2210,
+          "line": 2231,
           "kind": "struct",
           "field_names": [
             "defender"
@@ -13033,7 +13171,7 @@
         },
         {
           "name": "Blocking",
-          "line": 2215,
+          "line": 2236,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Matches creatures that are blocking.",
@@ -13043,7 +13181,7 @@
         },
         {
           "name": "BlockingSource",
-          "line": 2218,
+          "line": 2239,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g: Matches creatures currently blocking the filter source. Used for \"creature(s) blocking it\" source-relative quantities and filters.",
@@ -13053,7 +13191,7 @@
         },
         {
           "name": "CombatRelation",
-          "line": 2221,
+          "line": 2242,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -13066,7 +13204,7 @@
         },
         {
           "name": "Unblocked",
-          "line": 2226,
+          "line": 2247,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Matches attacking creatures with no blockers assigned.",
@@ -13075,8 +13213,28 @@
           ]
         },
         {
+          "name": "AttackingAlone",
+          "line": 2252,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 506.5: Matches a creature that is (or, via the zone-change look-back snapshot, was) the sole attacker — \"attacking alone\". Live evaluation reads combat; look-back evaluation reads `ZoneChangeCombatStatus::attacking_alone`.",
+          "cr_refs": [
+            "CR 506.5"
+          ]
+        },
+        {
+          "name": "BlockingAlone",
+          "line": 2256,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 506.5: Matches a creature that is (or was) the sole blocker — \"blocking alone\". Look-back evaluation reads `ZoneChangeCombatStatus::blocking_alone`.",
+          "cr_refs": [
+            "CR 506.5"
+          ]
+        },
+        {
           "name": "Tapped",
-          "line": 2227,
+          "line": 2257,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13084,7 +13242,7 @@
         },
         {
           "name": "Untapped",
-          "line": 2229,
+          "line": 2259,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 / CR 110.5: Untapped status as targeting qualifier.",
@@ -13095,7 +13253,7 @@
         },
         {
           "name": "IsSaddled",
-          "line": 2231,
+          "line": 2261,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: Matches permanents with the saddled designation.",
@@ -13104,8 +13262,21 @@
           ]
         },
         {
+          "name": "ProtectorMatches",
+          "line": 2264,
+          "kind": "struct",
+          "field_names": [
+            "controller"
+          ],
+          "doc": "CR 310.8a + CR 310.8e: Matches battles whose protector satisfies `controller` relative to the ability source (\"each battle they protect\").",
+          "cr_refs": [
+            "CR 310.8a",
+            "CR 310.8e"
+          ]
+        },
+        {
           "name": "HasHasteOrControlledSinceTurnBegan",
-          "line": 2235,
+          "line": 2270,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 + CR 702.10b + CR 702.154a: Matches creatures that either have haste or have been under their controller's control continuously since that player's most recent turn began. Used by Enlist's tap eligibility.",
@@ -13117,7 +13288,7 @@
         },
         {
           "name": "WithKeyword",
-          "line": 2236,
+          "line": 2271,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13127,7 +13298,7 @@
         },
         {
           "name": "HasKeywordKind",
-          "line": 2239,
+          "line": 2274,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13137,7 +13308,7 @@
         },
         {
           "name": "WithoutKeyword",
-          "line": 2244,
+          "line": 2279,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13149,7 +13320,7 @@
         },
         {
           "name": "WithoutKeywordKind",
-          "line": 2247,
+          "line": 2282,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13159,7 +13330,7 @@
         },
         {
           "name": "CanEnchant",
-          "line": 2255,
+          "line": 2290,
           "kind": "struct",
           "field_names": [
             "target"
@@ -13172,7 +13343,7 @@
         },
         {
           "name": "Counters",
-          "line": 2265,
+          "line": 2300,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -13186,7 +13357,7 @@
         },
         {
           "name": "Cmc",
-          "line": 2275,
+          "line": 2310,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -13199,7 +13370,7 @@
         },
         {
           "name": "ManaCostIn",
-          "line": 2282,
+          "line": 2317,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -13212,7 +13383,7 @@
         },
         {
           "name": "InZone",
-          "line": 2285,
+          "line": 2320,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -13222,7 +13393,7 @@
         },
         {
           "name": "Owned",
-          "line": 2288,
+          "line": 2323,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -13232,7 +13403,7 @@
         },
         {
           "name": "Foretold",
-          "line": 2294,
+          "line": 2329,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c-d: Matches cards in exile that have the foretold designation. This is a status of the exiled card, not equivalent to having the Foretell keyword or a generic exile casting permission.",
@@ -13242,7 +13413,7 @@
         },
         {
           "name": "EnchantedBy",
-          "line": 2295,
+          "line": 2330,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13250,7 +13421,7 @@
         },
         {
           "name": "EquippedBy",
-          "line": 2296,
+          "line": 2331,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13258,7 +13429,7 @@
         },
         {
           "name": "AttachedToSource",
-          "line": 2302,
+          "line": 2337,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the matched object's `attached_to` field equals the filter source's object ID. Inverse of `EnchantedBy`/`EquippedBy`, which check whether the source has an attachment. Used for \"Aura and Equipment attached to ~\" quantity clauses (Kellan, the Fae-Blooded) and for any compound filter whose subject is \"attached to <self>\".",
@@ -13269,7 +13440,7 @@
         },
         {
           "name": "AttachedToRecipient",
-          "line": 2316,
+          "line": 2351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4 + CR 613.4c: True when the matched object's `attached_to` field equals the *recipient* of the resolving effect (the per-object `id` in a layer's affected list). Distinct from `AttachedToSource` — for an Aura/Equipment static \"Enchanted/Equipped creature gets +N/+M for each X attached to it\", the pronoun \"it\" refers to the affected creature, not to the static's source object. The recipient is supplied through `FilterContext::recipient_id`; when recipient is unknown (no per-recipient context), this prop evaluates to false. Covers ~25 cards: Strong Back, Mantle of the Ancients, Auramancer's Guise, Champion of the Flame, Bruenor Battlehammer's \"Each creature you control gets +2/+0 for each Equipment attached to it\", and the broader \"<subject> gets +N/+M for each Aura/Equipment attached to it\" family.",
@@ -13281,7 +13452,7 @@
         },
         {
           "name": "HasAttachment",
-          "line": 2331,
+          "line": 2366,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -13296,7 +13467,7 @@
         },
         {
           "name": "HasAnyAttachmentOf",
-          "line": 2348,
+          "line": 2383,
           "kind": "struct",
           "field_names": [
             "kinds",
@@ -13310,7 +13481,7 @@
         },
         {
           "name": "Another",
-          "line": 2354,
+          "line": 2389,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches any object that is NOT the trigger source (for \"another creature\" triggers).",
@@ -13318,7 +13489,7 @@
         },
         {
           "name": "Unpaired",
-          "line": 2356,
+          "line": 2391,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Matches objects that are not paired with another creature.",
@@ -13328,7 +13499,7 @@
         },
         {
           "name": "OtherThanTriggerObject",
-          "line": 2365,
+          "line": 2400,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 109.3: Matches any object that is NOT the object that caused the currently-evaluating trigger to fire (the \"triggering object\"). Distinct from `Another`, which excludes the *ability source*. Used for intervening-if count predicates like Valakut, the Molten Pinnacle's \"if you control at least five other Mountains\" — here \"other\" means \"other than the newly- entered Mountain,\" not \"other than Valakut.\" Resolves against `FilterContext::triggering_object_id`, populated at trigger-condition evaluation from the current `GameEvent`.",
@@ -13339,7 +13510,7 @@
         },
         {
           "name": "HasColor",
-          "line": 2367,
+          "line": 2402,
           "kind": "struct",
           "field_names": [
             "color"
@@ -13349,7 +13520,7 @@
         },
         {
           "name": "PtComparison",
-          "line": 2394,
+          "line": 2429,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -13367,7 +13538,7 @@
         },
         {
           "name": "PowerGTSource",
-          "line": 2403,
+          "line": 2438,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: Matches objects whose power is strictly greater than the source object's power. Used for \"creatures with greater power\" blocking restrictions (relative comparison).",
@@ -13377,7 +13548,7 @@
         },
         {
           "name": "ColorCount",
-          "line": 2407,
+          "line": 2442,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -13390,7 +13561,7 @@
         },
         {
           "name": "HasSupertype",
-          "line": 2412,
+          "line": 2447,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13400,7 +13571,7 @@
         },
         {
           "name": "IsChosenCreatureType",
-          "line": 2417,
+          "line": 2452,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose subtypes include the source object's chosen creature type. Used for \"of the chosen type\" patterns (Cavern of Souls, Metallic Mimic).",
@@ -13408,7 +13579,7 @@
         },
         {
           "name": "MostPrevalentCreatureTypeIn",
-          "line": 2430,
+          "line": 2465,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -13422,7 +13593,7 @@
         },
         {
           "name": "IsChosenColor",
-          "line": 2439,
+          "line": 2474,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose colors include the source object's chosen color. Used for \"of the chosen color\" patterns (Hall of Triumph, Runed Stalactite). Reads `ChosenAttribute::Color` from the source permanent.",
@@ -13430,7 +13601,7 @@
         },
         {
           "name": "IsChosenCardType",
-          "line": 2443,
+          "line": 2478,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose core type includes the source object's chosen card type. Used for \"spells of the chosen type\" patterns (Archon of Valor's Reach). Reads `ChosenAttribute::CardType` from the source permanent.",
@@ -13438,7 +13609,7 @@
         },
         {
           "name": "IsChosenLandOrNonlandKind",
-          "line": 2448,
+          "line": 2483,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.2 + CR 608.2c: Matches objects by the transient \"land or nonland\" choice made earlier in the same resolving instruction sequence. Used by \"of the chosen kind\" library filters, where \"Land\" means cards with the land card type and \"Nonland\" means cards without it.",
@@ -13449,7 +13620,7 @@
         },
         {
           "name": "HasSingleTarget",
-          "line": 2451,
+          "line": 2486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.7: Matches stack entries that have exactly one target. Used for \"with a single target\" qualifiers on retarget effects.",
@@ -13459,7 +13630,7 @@
         },
         {
           "name": "NotColor",
-          "line": 2454,
+          "line": 2489,
           "kind": "struct",
           "field_names": [
             "color"
@@ -13471,7 +13642,7 @@
         },
         {
           "name": "NotSupertype",
-          "line": 2459,
+          "line": 2494,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13483,7 +13654,7 @@
         },
         {
           "name": "Suspected",
-          "line": 2463,
+          "line": 2498,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.60b: Matches suspected creatures.",
@@ -13493,7 +13664,7 @@
         },
         {
           "name": "Renowned",
-          "line": 2465,
+          "line": 2500,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112b: Matches permanents with the renowned designation.",
@@ -13503,7 +13674,7 @@
         },
         {
           "name": "ToughnessGTPower",
-          "line": 2467,
+          "line": 2502,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: Matches creatures whose toughness is greater than their power.",
@@ -13513,7 +13684,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2474,
+          "line": 2509,
           "kind": "struct",
           "field_names": [
             "props"
@@ -13522,8 +13693,20 @@
           "cr_refs": []
         },
         {
+          "name": "Not",
+          "line": 2520,
+          "kind": "struct",
+          "field_names": [
+            "prop"
+          ],
+          "doc": "CR 608.2c: Logical negation of a filter property — matches objects for which the inner property does NOT hold (\"apply the rules of English\"). General recursive combinator mirroring `TargetFilter::Not`, `StaticCondition::Not`, `AbilityCondition::Not`, and `TriggerCondition::Not`. Composes with the AND-combined `properties` vector, so a negated-verb relative clause like \"that didn't attack or enter this turn\" decomposes (De Morgan) into `Not(AttackedThisTurn)` AND `Not(EnteredThisTurn)` rather than a bespoke `NotAttacked`/`NotEntered` sibling cluster. Boxed for recursion.",
+          "cr_refs": [
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "Modified",
-          "line": 2486,
+          "line": 2532,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.9: A permanent is modified if it has one or more counters on it (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura that is controlled by that permanent's controller (CR 303.4).  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.9 names \"modified\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Modified` for \"modified creature(s)\" subjects, analogous to how `FilterProp::Suspected` models CR 701.60b's \"suspected\" status.",
@@ -13537,7 +13720,7 @@
         },
         {
           "name": "Historic",
-          "line": 2496,
+          "line": 2542,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: An object is historic if it has the legendary supertype, the artifact card type, or the Saga subtype.  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.6 names \"historic\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Historic` for \"historic permanent\" / \"historic spell\" / \"historic card\" subjects, mirroring `FilterProp::Modified` for CR 700.9's \"modified\" predicate.",
@@ -13548,7 +13731,7 @@
         },
         {
           "name": "NotHistoric",
-          "line": 2500,
+          "line": 2546,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: Matches objects that are not historic (negation of `Historic`). Used for \"nonhistoric\" / \"not historic\" in compound type phrases such as Desynchronization's \"nonland, nonhistoric permanent\".",
@@ -13558,7 +13741,7 @@
         },
         {
           "name": "DifferentNameFrom",
-          "line": 2504,
+          "line": 2550,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -13568,7 +13751,7 @@
         },
         {
           "name": "InAnyZone",
-          "line": 2509,
+          "line": 2555,
           "kind": "struct",
           "field_names": [
             "zones"
@@ -13580,7 +13763,7 @@
         },
         {
           "name": "SharesQuality",
-          "line": 2515,
+          "line": 2561,
           "kind": "struct",
           "field_names": [
             "quality",
@@ -13592,7 +13775,7 @@
         },
         {
           "name": "WasDealtDamageThisTurn",
-          "line": 2524,
+          "line": 2570,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1: Object was dealt damage during this turn. Checks `damage_marked > 0` (damage persists until cleanup step).",
@@ -13602,7 +13785,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2527,
+          "line": 2573,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: Object entered the battlefield during this turn. Checks `entered_battlefield_turn == Some(current_turn)`.",
@@ -13612,7 +13795,7 @@
         },
         {
           "name": "ZoneChangedThisTurn",
-          "line": 2532,
+          "line": 2578,
           "kind": "struct",
           "field_names": [
             "from",
@@ -13626,7 +13809,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 2540,
+          "line": 2586,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Creature was declared as an attacker this turn. Checks `creatures_attacked_this_turn` tracking set on GameState.",
@@ -13636,7 +13819,7 @@
         },
         {
           "name": "BlockedThisTurn",
-          "line": 2543,
+          "line": 2589,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Creature was declared as a blocker this turn. Checks `creatures_blocked_this_turn` tracking set on GameState.",
@@ -13646,7 +13829,7 @@
         },
         {
           "name": "AttackedOrBlockedThisTurn",
-          "line": 2546,
+          "line": 2592,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a + CR 509.1a: Creature attacked or blocked this turn. Compound check used by \"that attacked or blocked this turn\" Oracle text.",
@@ -13657,7 +13840,7 @@
         },
         {
           "name": "FaceDown",
-          "line": 2549,
+          "line": 2595,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.2: Matches face-down objects on the battlefield. Used for \"face-down creature\" trigger subjects.",
@@ -13667,7 +13850,7 @@
         },
         {
           "name": "TargetsOnly",
-          "line": 2554,
+          "line": 2600,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -13679,7 +13862,7 @@
         },
         {
           "name": "Targets",
-          "line": 2560,
+          "line": 2606,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -13692,7 +13875,7 @@
         },
         {
           "name": "HasXInManaCost",
-          "line": 2569,
+          "line": 2615,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains an `{X}` shard. Used for \"spell with {X} in its mana cost\" qualifier on spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin Spiralmancer, Brass Infiniscope, Elementalist's Palette). Evaluated against `SpellCastRecord.has_x_in_cost` in the spell-history filter path and against `cost_has_x(&obj.mana_cost)` for live objects.",
@@ -13702,8 +13885,29 @@
           ]
         },
         {
+          "name": "HasXInActivationCost",
+          "line": 2619,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 107.3 + CR 602.1: Matches activated abilities whose activation cost contains an `{X}` shard. Used for \"activate an ability with {X} in its activation cost\" on `AbilityActivated` delayed triggers (Magus Lucea Kane).",
+          "cr_refs": [
+            "CR 107.3",
+            "CR 602.1"
+          ]
+        },
+        {
+          "name": "WasKicked",
+          "line": 2624,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.33d: Matches spells whose kicker additional cost was paid for this cast. Used for \"the first kicked spell you cast each turn\" cost reducers (Vine Gecko). Live evaluation reads `pending_cast` / `GameObject.kickers_paid`; turn-history evaluation reads `SpellCastRecord.was_kicked`.",
+          "cr_refs": [
+            "CR 702.33d"
+          ]
+        },
+        {
           "name": "HasManaAbility",
-          "line": 2573,
+          "line": 2628,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1: Matches objects that have at least one ability classified as a mana ability by the engine's authoritative mana-ability classifier. Used for library filters such as \"artifact card with a mana ability\".",
@@ -13713,7 +13917,7 @@
         },
         {
           "name": "HasNoAbilities",
-          "line": 2577,
+          "line": 2632,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.1 + CR 113.3: Matches objects that currently have no abilities: no keyword, activated, triggered, replacement, or static abilities. Used for library filters such as \"creature card with no abilities\".",
@@ -13724,7 +13928,7 @@
         },
         {
           "name": "Named",
-          "line": 2581,
+          "line": 2636,
           "kind": "struct",
           "field_names": [
             "name"
@@ -13737,7 +13941,7 @@
         },
         {
           "name": "SameName",
-          "line": 2586,
+          "line": 2641,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects with the same name as a previously-referenced card. Used for \"search your library for a card with that name\" patterns.",
@@ -13745,7 +13949,7 @@
         },
         {
           "name": "SameNameAsParentTarget",
-          "line": 2599,
+          "line": 2654,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: Matches objects whose name equals the name of the resolving ability's first object target. Used by chained sub-abilities where a prior step targeted/exiled a card and the next step references \"cards with that name\" — e.g., Deadly Cover-Up's \"search ... for any number of cards with that name and exile them\" (the \"that name\" is the name of the card exiled by the immediately preceding effect, which is inherited as the first target via `TargetFilter::ParentTarget`).  Differs from `SameName` (which reads the source object's name): this reads from `ability.targets[0]` when that target is `TargetRef::Object`, looking up the name from `state.objects` (or `lki_cache` if the target has already left its zone).",
@@ -13755,7 +13959,7 @@
         },
         {
           "name": "NameMatchesAnyPermanent",
-          "line": 2606,
+          "line": 2661,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -13768,7 +13972,7 @@
         },
         {
           "name": "IsCommander",
-          "line": 2615,
+          "line": 2670,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 903.3d: Matches permanents on the battlefield that are a commander. Reads `GameObject::is_commander`, set during deck construction per CR 903.3 (the legendary card designated as that deck's commander). Used for \"commander(s) you control\", \"your commander\" subject phrases and for \"target commander\" in commander-format effects (Codsworth, Falthis, Anara, Champions of Archery, etc.).",
@@ -13779,7 +13983,7 @@
         },
         {
           "name": "Other",
-          "line": 2616,
+          "line": 2671,
           "kind": "struct",
           "field_names": [
             "value"
@@ -16720,13 +16924,13 @@
     },
     "GameRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1529,
+      "line": 1536,
       "doc": "A game-level restriction that modifies how rules are applied. Stored in `GameState::restrictions` and evaluated by relevant game systems.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DamagePreventionDisabled",
-          "line": 1531,
+          "line": 1538,
           "kind": "struct",
           "field_names": [
             "source",
@@ -16740,7 +16944,7 @@
         },
         {
           "name": "ProhibitActivity",
-          "line": 1539,
+          "line": 1546,
           "kind": "struct",
           "field_names": [
             "source",
@@ -16883,13 +17087,13 @@
     },
     "IntensityScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6563,
+      "line": 6729,
       "doc": "Digital-only Alchemy: which cards an `Effect::Intensify` applies to. Every scope resolves across ALL zones (a card's intensity follows it everywhere).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 6566,
+          "line": 6732,
           "kind": "unit",
           "field_names": [],
           "doc": "\"this creature/artifact/… intensifies\" — the source object only.",
@@ -16897,7 +17101,7 @@
         },
         {
           "name": "OwnedSameName",
-          "line": 6569,
+          "line": 6735,
           "kind": "unit",
           "field_names": [],
           "doc": "\"cards you own named [this card] intensify\" — every card the source's controller owns with the source's name.",
@@ -16905,7 +17109,7 @@
         },
         {
           "name": "OwnedSubtype",
-          "line": 6572,
+          "line": 6738,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -16918,7 +17122,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11784,
+      "line": 12080,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -16927,7 +17131,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 11787,
+          "line": 12083,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -18389,17 +18593,18 @@
         },
         {
           "name": "Squad",
-          "line": 822,
+          "line": 828,
           "kind": "tuple",
           "field_names": [],
-          "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (variable additional cost + ETB token-per-payment not wired). CR 702.157: Squad {cost} — as an additional cost to cast, you may pay {cost} any number of times; ETB creates that many tokens.",
+          "doc": "CR 702.157a: Squad {cost} — \"As an additional cost to cast this spell, you may pay {cost} any number of times.\" \"When this creature enters, if its squad cost was paid, create a token that's a copy of it for each time its squad cost was paid.\" (CR 702.157b: each instance triggers separately.)  Runtime: `database::synthesis::synthesize_squad` builds a `AdditionalCost::Optional { repeatability: Repeatable }` additional-cost instance (origin: `AdditionalCostOrigin::Squad`) and an ETB copy trigger keyed on `QuantityRef::AdditionalCostPaymentCountFor { origin: Squad }`. `casting_costs::effective_squad_additional_cost_instances` surfaces the per-instance additional costs during casting. Fully wired.",
           "cr_refs": [
-            "CR 702.157"
+            "CR 702.157a",
+            "CR 702.157b"
           ]
         },
         {
           "name": "Typecycling",
-          "line": 826,
+          "line": 832,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -18412,7 +18617,7 @@
         },
         {
           "name": "Firebending",
-          "line": 832,
+          "line": 838,
           "kind": "tuple",
           "field_names": [],
           "doc": "Firebending N — produces N {R} when this creature attacks (Avatar crossover).",
@@ -18420,7 +18625,7 @@
         },
         {
           "name": "Splice",
-          "line": 837,
+          "line": 843,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -18433,7 +18638,7 @@
         },
         {
           "name": "Bargain",
-          "line": 843,
+          "line": 849,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Bargain — you may sacrifice an artifact, enchantment, or token as an additional cost to cast this spell.",
@@ -18443,7 +18648,7 @@
         },
         {
           "name": "Sunburst",
-          "line": 850,
+          "line": 856,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.44a: Sunburst — as an object enters the battlefield as a resolving spell, it enters with a +1/+1 counter (if entering as a creature) or a charge counter (otherwise) for each color of mana spent to cast it. Wired at runtime by `synthesize_sunburst` as an ETB-counter replacement whose count is the distinct-colors-spent metric. Per CR 702.44d each instance works separately.",
@@ -18454,7 +18659,7 @@
         },
         {
           "name": "Champion",
-          "line": 855,
+          "line": 861,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.72a: Champion a [type] — exile another object of the specified type you control or sacrifice this permanent when it enters; return the exiled card when this leaves. Wired at build time by `synthesize_champion`; CR 702.72b makes the two abilities linked.",
@@ -18465,7 +18670,7 @@
         },
         {
           "name": "Training",
-          "line": 858,
+          "line": 864,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.149a: Training — whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.",
@@ -18475,7 +18680,7 @@
         },
         {
           "name": "Assist",
-          "line": 860,
+          "line": 866,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.132a: Assist — another player can help pay the generic mana cost of this spell.",
@@ -18485,7 +18690,7 @@
         },
         {
           "name": "Augment",
-          "line": 864,
+          "line": 870,
           "kind": "unit",
           "field_names": [],
           "doc": "Acorn/Un-set keyword: Augment. Runtime host-combine semantics are not implemented; the keyword identity is used for characteristic filters such as \"a card with augment\".",
@@ -18493,7 +18698,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 868,
+          "line": 874,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Aftermath allows casting this half of a split card only from a graveyard, and exiles the spell any time it leaves the stack if it was cast from a graveyard.",
@@ -18503,7 +18708,7 @@
         },
         {
           "name": "JumpStart",
-          "line": 870,
+          "line": 876,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.133a: Jump-start — cast from graveyard by discarding a card, then exile.",
@@ -18513,7 +18718,7 @@
         },
         {
           "name": "Cipher",
-          "line": 873,
+          "line": 879,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99a: Cipher — exile this spell encoded on a creature you control; whenever that creature deals combat damage to a player, cast a copy.",
@@ -18523,7 +18728,7 @@
         },
         {
           "name": "Transmute",
-          "line": 878,
+          "line": 884,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.53a: Transmute {cost} — \"[Cost], Discard this card: Search your library for a card with the same mana value as the discarded card, reveal it, put it into your hand, then shuffle. Activate only as a sorcery.\" Runtime: `synthesize_transmute` (database/synthesis.rs).",
@@ -18533,7 +18738,7 @@
         },
         {
           "name": "Transfigure",
-          "line": 883,
+          "line": 889,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.71a: Transfigure {cost} — \"[Cost], Sacrifice this permanent: Search your library for a creature card with the same mana value as this permanent and put it onto the battlefield. Then shuffle your library. Activate only as a sorcery.\" Runtime: `synthesize_transfigure` (database/synthesis.rs).",
@@ -18543,7 +18748,7 @@
         },
         {
           "name": "Escalate",
-          "line": 886,
+          "line": 892,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.120a: Escalate [cost] — additional cost for each mode chosen beyond the first on a modal spell.",
@@ -18553,7 +18758,7 @@
         },
         {
           "name": "Recover",
-          "line": 890,
+          "line": 896,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.59a: Recover {cost} — triggered ability: when a creature is put into your graveyard from the battlefield, you may pay {cost} to return this card from your graveyard to your hand; otherwise exile it.",
@@ -18563,7 +18768,7 @@
         },
         {
           "name": "Cleave",
-          "line": 892,
+          "line": 898,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.148a: Cleave — alternative cost that removes bracketed text from Oracle text.",
@@ -18573,7 +18778,7 @@
         },
         {
           "name": "Undaunted",
-          "line": 894,
+          "line": 900,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.125a: Undaunted — costs {1} less for each opponent.",
@@ -18583,7 +18788,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 902,
+          "line": 908,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — a keyword on instants/sorceries. Reminder: \"Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases.\" Runtime hooks in `stack.rs` (first-resolution arming) and `turns.rs` (first-main-phase offer) carry the semantics. Assign when WotC publishes SOS CR update.",
@@ -18593,7 +18798,7 @@
         },
         {
           "name": "Station",
-          "line": 910,
+          "line": 916,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Station — \"Tap another untapped creature you control: Put a number of charge counters on this permanent equal to the tapped creature's power. Activate only as a sorcery.\" The keyword is fixed (no parameter) — the full semantics come from the rule text. Runtime activation is handled via `GameAction::ActivateStation`, not through the generic activated-ability dispatch.",
@@ -18603,7 +18808,7 @@
         },
         {
           "name": "Replicate",
-          "line": 924,
+          "line": 930,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: `database::synthesis::synthesize_replicate` — repeatable optional additional cost (`AdditionalCost::Optional { repeatability: Repeatable }`) plus a `SpellCast` trigger whose execute is `replicate_copy_ability_definition()` (a `CopySpell` with `repeat_for = AdditionalCostPaymentCount`). CR 702.56a: Replicate {cost} — additional-cost-on-cast copy mechanic. \"As an additional cost to cast this spell, you may pay [cost] any number of times\" + \"When you cast this spell, if a replicate cost was paid for it, copy it for each time its replicate cost was paid. If the spell has any targets, you may choose new targets for any of the copies.\" Carries the per-copy mana cost.",
@@ -18613,20 +18818,23 @@
         },
         {
           "name": "Awaken",
-          "line": 931,
+          "line": 943,
           "kind": "struct",
           "field_names": [
             "count",
             "cost"
           ],
-          "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cast hook + awaken-paid branch not wired). CR 702.113a: Awaken N—{cost} — alternative cost that also puts N +1/+1 counters on target land, animating it as a 0/0 Elemental creature with haste.",
+          "doc": "CR 702.113a: Awaken N—{cost} — alternative cost that also puts N +1/+1 counters on target land you control, animating it as a 0/0 Elemental creature with haste (it's still a land). Casting with awaken follows CR 601.2b and CR 601.2f–h. CR 702.113b: the land target exists only when the awaken cost was paid.  Runtime: `CastingVariant::Awaken` + `casting::handle_awaken_cost_choice` substitutes the awaken mana cost for the printed cost and calls `effects::awaken::append_awaken_rider` to append the resolution rider (`PutCounter{N, land you control}` → `Animate{0/0 Elemental, Haste, Permanent}`) at the tail of the spell's ability tree. Fully wired.",
           "cr_refs": [
-            "CR 702.113a"
+            "CR 601.2b",
+            "CR 601.2f",
+            "CR 702.113a",
+            "CR 702.113b"
           ]
         },
         {
           "name": "ForMirrodin",
-          "line": 940,
+          "line": 952,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.163a: For Mirrodin! — Equipment-only triggered ability. \"When this Equipment enters, create a 2/2 red Rebel creature token, then attach this Equipment to it.\" Bare keyword; ETB trigger semantics are synthesized in `database::synthesis`.",
@@ -18636,27 +18844,34 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 948,
+          "line": 967,
           "kind": "tuple",
           "field_names": [],
-          "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cost cast hook not wired). CR 702.162a: More Than Meets the Eye {cost} — alternative cost (Transformers crossover). \"You may cast this card converted by paying [cost] rather than its mana cost.\" Stores the alt mana cost; the runtime alt-cost cast hook is not yet wired.",
+          "doc": "CR 702.162a: More Than Meets the Eye {cost} — alternative cost (Transformers crossover). \"You may cast this card converted by paying [cost] rather than its mana cost.\" Follows CR 701.28 (Convert) — the permanent enters the battlefield transformed (back face up). Alternative cost rules: CR 601.2b, CR 601.2f–h, CR 118.9.  Runtime: `CastingVariant::MoreThanMeetsTheEye` + `casting::handle_mtmte_cost_choice` substitutes the MTMTE mana cost for the printed cost and routes through `continue_cast_with_alternative_spell_face`, which sets the stack spell to use back-face characteristics. On resolution, `enter_transformed` ZoneChange seed ensures the permanent enters back face up. `CastingVariant::restores_front_face_after_stack_exit` handles cleanup if the spell leaves the stack without resolving. Fully wired.",
           "cr_refs": [
+            "CR 118.9",
+            "CR 601.2b",
+            "CR 601.2f",
+            "CR 701.28",
             "CR 702.162a"
           ]
         },
         {
           "name": "Freerunning",
-          "line": 959,
+          "line": 983,
           "kind": "tuple",
           "field_names": [],
-          "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (alt-cast hook + combat-damage-this-turn predicate not wired). CR 702.173a: Freerunning {cost} — alternative cost. \"You may pay [cost] rather than pay this spell's mana cost if a player was dealt combat damage this turn by a creature that, at the time it dealt that damage, was an Assassin creature or a commander under your control.\" Stores the alt mana cost; runtime alt-cast hook (combat-damage-this-turn predicate) is not yet wired.",
+          "doc": "CR 702.173a: Freerunning {cost} — alternative cost. \"You may pay [cost] rather than pay this spell's mana cost if a player was dealt combat damage this turn by a creature that, at the time it dealt that damage, was an Assassin creature or a commander under your control.\" Follows CR 601.2b and CR 601.2f–h. A pure cost substitution — no resolution rider.  Runtime: The eligibility predicate is tracked in `GameState::assassin_or_commander_dealt_combat_damage_this_turn` (a `HashSet<PlayerId>` seeded by `triggers::collect_pending_triggers` when an Assassin or commander deals combat damage, per CR 702.173a). The ledger is cleared at cleanup (CR 514) by `turns::run_cleanup`. `casting::casting_variant_candidates` checks the ledger to surface `CastingVariant::Freerunning`; `casting_costs` substitutes the Freerunning cost for the printed cost. Fully wired.",
           "cr_refs": [
+            "CR 514",
+            "CR 601.2b",
+            "CR 601.2f",
             "CR 702.173a"
           ]
         },
         {
           "name": "Increment",
-          "line": 963,
+          "line": 987,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.191a: Increment — spell-cast trigger synthesized in `database::synthesis::synthesize_increment`.",
@@ -18666,15 +18881,15 @@
         },
         {
           "name": "Specialize",
-          "line": 976,
+          "line": 1005,
           "kind": "tuple",
           "field_names": [],
-          "doc": "RUNTIME: TODO — converter accepts this keyword but engine has no behavioral handler (choose-color + transform hooks not wired). CR ???: Specialize {cost} — not in CR text (needs manual verification). Strixhaven student-into-mage transformation: activated alt-cast that turns the source into a colour-specific version. Stores the activation mana cost; the choose-color and transform hooks are not yet wired. mtgish encodes activation timing modifiers and from-graveyard variants separately; this keyword carries only the cost (the engine drops the activation modifier and the from-graveyard hint, mirroring how `LevelUp` drops its `Vec<Level>` payload).",
+          "doc": "Digital-only Specialize (Alchemy Horizons: Baldur's Gate) — not in the Comprehensive Rules; behavior follows MTG Arena. \"{cost}, Discard a colored card or a card with a basic land subtype: This permanent becomes the matching color-specialized face permanently.\" Activated ability, sorcery speed. The keyword carries only the activation mana cost; the discard filter and color selection are built at synthesis time.  Runtime: `database::synthesis::synthesize_specialize` builds a sorcery- speed `AbilityKind::Activated` with `Effect::Specialize` and `AbilityCost::Composite { Mana + Discard { filter: specialize_discard_filter } }`. `effects::specialize::resolve` reads the discarded card's LKI snapshot to determine eligible colors via `game::specialize::eligible_specialize_colors`, then either calls `specialize_permanent` directly (one option) or sets `WaitingFor::SpecializeColor` for the player to choose. `engine_resolution_choices` dispatches `GameAction::ChooseSpecializeColor` to complete the transformation. Fully wired.",
           "cr_refs": []
         },
         {
           "name": "Offering",
-          "line": 985,
+          "line": 1014,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.48a: \"[Quality] offering\" — as an additional cost to cast this spell, you may sacrifice a [Quality] permanent. If you do, this spell's total cost is reduced by the sacrificed permanent's mana cost (CR 702.48c), and you may cast this spell any time you could cast an instant. Carries the canonical subtype string (e.g. \"Spirit\", \"Dragon\"). Runtime behavior is fully wired: timing unlock, sacrifice selection, and cost reduction in `casting_costs.rs`.",
@@ -18685,7 +18900,7 @@
         },
         {
           "name": "Unknown",
-          "line": 988,
+          "line": 1017,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized keywords.",
@@ -18696,7 +18911,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14611,
+      "line": 15046,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -18705,7 +18920,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 14613,
+          "line": 15048,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -18718,7 +18933,7 @@
         },
         {
           "name": "Crew",
-          "line": 14619,
+          "line": 15054,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -18731,7 +18946,7 @@
         },
         {
           "name": "Saddle",
-          "line": 14625,
+          "line": 15060,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -18744,7 +18959,7 @@
         },
         {
           "name": "Station",
-          "line": 14633,
+          "line": 15068,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -19911,7 +20126,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12439,
+      "line": 12786,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -19921,7 +20136,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 12441,
+          "line": 12788,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -19931,7 +20146,7 @@
         },
         {
           "name": "Second",
-          "line": 12444,
+          "line": 12791,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -20066,7 +20281,7 @@
     },
     "LayersDirty": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1886,
+      "line": 1955,
       "doc": "Lattice tracking which battlefield objects need layer (continuous-effect) re-evaluation. Replaces the old `bool` flag so that a token / conjure / copy entry can request an INCREMENTAL re-derive of only the entering object(s) instead of a full battlefield reset+reapply.  CR 613.1: continuous effects are evaluated in layer order over the whole board. A full evaluation is always correct; the incremental path is a performance optimization that `flush_layers` only takes when it can prove (per-entered preconditions + a board-wide escalation scan) that re-deriving just the entered objects produces a board state identical to a full pass. `mark_full()` is the conservative escalation any non-entry mutation uses.",
       "cr_refs": [
         "CR 613.1"
@@ -20074,7 +20289,7 @@
       "variants": [
         {
           "name": "Clean",
-          "line": 1889,
+          "line": 1958,
           "kind": "unit",
           "field_names": [],
           "doc": "Layers are up to date; nothing to flush.",
@@ -20082,7 +20297,7 @@
         },
         {
           "name": "EnteredObjects",
-          "line": 1893,
+          "line": 1962,
           "kind": "tuple",
           "field_names": [],
           "doc": "Only these objects entered the battlefield since the last flush and no other layer-affecting mutation occurred. Candidate for the incremental fast path.",
@@ -20090,7 +20305,7 @@
         },
         {
           "name": "Full",
-          "line": 1895,
+          "line": 1964,
           "kind": "unit",
           "field_names": [],
           "doc": "A full battlefield re-evaluation is required.",
@@ -20215,13 +20430,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6497,
+      "line": 6663,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 6498,
+          "line": 6664,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20229,7 +20444,7 @@
         },
         {
           "name": "Bottom",
-          "line": 6499,
+          "line": 6665,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20237,7 +20452,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 6501,
+          "line": 6667,
           "kind": "struct",
           "field_names": [
             "n"
@@ -20250,7 +20465,7 @@
     },
     "LinkedExileScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1235,
+      "line": 1242,
       "doc": "CR 607.2a + CR 406.6 + CR 610.3: Which exile-link relation a mana ability reads when computing legal colors. Typed enum — never a bool — so future extensions (e.g. links to a different host than `~` itself) slot in cleanly.",
       "cr_refs": [
         "CR 406.6",
@@ -20260,7 +20475,7 @@
       "variants": [
         {
           "name": "ThisObject",
-          "line": 1239,
+          "line": 1246,
           "kind": "unit",
           "field_names": [],
           "doc": "Read `state.exile_links` keyed to this ability's source object (the activating permanent).",
@@ -20447,13 +20662,13 @@
     },
     "ManaAbilityResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1717,
+      "line": 1786,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1718,
+          "line": 1787,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20461,7 +20676,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1719,
+          "line": 1788,
           "kind": "struct",
           "field_names": [
             "convoke_mode"
@@ -20471,7 +20686,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 1723,
+          "line": 1792,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -20488,7 +20703,7 @@
     },
     "ManaChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1789,
+      "line": 1858,
       "doc": "CR 608.2d + CR 605.3b: Player's answer to a `ManaChoicePrompt`, carried by `GameAction::ChooseManaColor`. Shape mirrors the prompt variant.",
       "cr_refs": [
         "CR 605.3b",
@@ -20497,7 +20712,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1790,
+          "line": 1859,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20505,7 +20720,7 @@
         },
         {
           "name": "Combination",
-          "line": 1791,
+          "line": 1860,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20516,7 +20731,7 @@
     },
     "ManaChoiceContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1799,
+      "line": 1868,
       "doc": "CR 106.3 + CR 608.2d + CR 605.3b: What resumes after a mana-color choice. Mana abilities and resolving spell/ability effects share the same prompt and response action, but resume through different rules paths.",
       "cr_refs": [
         "CR 106.3",
@@ -20526,7 +20741,7 @@
       "variants": [
         {
           "name": "ManaAbility",
-          "line": 1800,
+          "line": 1869,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20534,7 +20749,7 @@
         },
         {
           "name": "ResolvingEffect",
-          "line": 1801,
+          "line": 1870,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20545,7 +20760,7 @@
     },
     "ManaChoicePrompt": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1772,
+      "line": 1841,
       "doc": "CR 608.2d + CR 605.3b: The shape of the prompt surfaced via `WaitingFor::ChooseManaColor`. Typed enum rather than a bool discriminator: the continuation logic is identical (validate choice → produce mana → resume), only the option set differs.",
       "cr_refs": [
         "CR 605.3b",
@@ -20554,7 +20769,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1775,
+          "line": 1844,
           "kind": "struct",
           "field_names": [
             "options"
@@ -20564,7 +20779,7 @@
         },
         {
           "name": "Combination",
-          "line": 1777,
+          "line": 1846,
           "kind": "struct",
           "field_names": [
             "options"
@@ -20574,7 +20789,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1779,
+          "line": 1848,
           "kind": "struct",
           "field_names": [
             "count",
@@ -20637,7 +20852,7 @@
     },
     "ManaContribution": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1018,
+      "line": 1025,
       "doc": "CR 605.1a + CR 107.4a: Whether a mana-production effect is the *base* mana addition (e.g. a basic Forest tapping for `{G}`) or an *additional* mana addition that piggy-backs on another mana event (e.g. Fertile Ground's \"adds an additional one mana\"). Typed enum — never a bool — so the parser and resolver can dispatch on the contribution role without conflating it with other dimensions of mana production.",
       "cr_refs": [
         "CR 107.4a",
@@ -20646,7 +20861,7 @@
       "variants": [
         {
           "name": "Base",
-          "line": 1021,
+          "line": 1028,
           "kind": "unit",
           "field_names": [],
           "doc": "The mana addition stands on its own (most mana abilities).",
@@ -20654,7 +20869,7 @@
         },
         {
           "name": "Additional",
-          "line": 1024,
+          "line": 1031,
           "kind": "unit",
           "field_names": [],
           "doc": "The mana addition is additive — it augments another mana event (Utopia Sprawl, Fertile Ground, Wild Growth, Carpet of Flowers).",
@@ -20665,13 +20880,13 @@
     },
     "ManaCost": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 855,
+      "line": 878,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "NoCost",
-          "line": 856,
+          "line": 879,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20679,7 +20894,7 @@
         },
         {
           "name": "Cost",
-          "line": 857,
+          "line": 880,
           "kind": "struct",
           "field_names": [
             "shards",
@@ -20690,7 +20905,7 @@
         },
         {
           "name": "SelfManaCost",
-          "line": 862,
+          "line": 885,
           "kind": "unit",
           "field_names": [],
           "doc": "The card's own mana cost (used for \"the flashback cost is equal to its mana cost\").",
@@ -20701,164 +20916,12 @@
     },
     "ManaCostShard": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 620,
+      "line": 643,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "White",
-          "line": 622,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Blue",
-          "line": 623,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Black",
-          "line": 624,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Red",
-          "line": 625,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Green",
-          "line": 626,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Colorless",
-          "line": 628,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Snow",
-          "line": 629,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "X",
-          "line": 630,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TwoOrMoreColorSource",
-          "line": 632,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "`{Z}`: one mana from a source that could produce two or more colors.",
-          "cr_refs": []
-        },
-        {
-          "name": "WhiteBlue",
-          "line": 634,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "WhiteBlack",
-          "line": 635,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BlueBlack",
-          "line": 636,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BlueRed",
-          "line": 637,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BlackRed",
-          "line": 638,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BlackGreen",
-          "line": 639,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RedWhite",
-          "line": 640,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RedGreen",
-          "line": 641,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GreenWhite",
-          "line": 642,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GreenBlue",
-          "line": 643,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TwoWhite",
           "line": 645,
           "kind": "unit",
           "field_names": [],
@@ -20866,7 +20929,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoBlue",
+          "name": "Blue",
           "line": 646,
           "kind": "unit",
           "field_names": [],
@@ -20874,7 +20937,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoBlack",
+          "name": "Black",
           "line": 647,
           "kind": "unit",
           "field_names": [],
@@ -20882,7 +20945,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoRed",
+          "name": "Red",
           "line": 648,
           "kind": "unit",
           "field_names": [],
@@ -20890,7 +20953,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoGreen",
+          "name": "Green",
           "line": 649,
           "kind": "unit",
           "field_names": [],
@@ -20898,7 +20961,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhite",
+          "name": "Colorless",
           "line": 651,
           "kind": "unit",
           "field_names": [],
@@ -20906,7 +20969,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlue",
+          "name": "Snow",
           "line": 652,
           "kind": "unit",
           "field_names": [],
@@ -20914,7 +20977,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlack",
+          "name": "X",
           "line": 653,
           "kind": "unit",
           "field_names": [],
@@ -20922,23 +20985,15 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianRed",
-          "line": 654,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PhyrexianGreen",
+          "name": "TwoOrMoreColorSource",
           "line": 655,
           "kind": "unit",
           "field_names": [],
-          "doc": "",
+          "doc": "`{Z}`: one mana from a source that could produce two or more colors.",
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhiteBlue",
+          "name": "WhiteBlue",
           "line": 657,
           "kind": "unit",
           "field_names": [],
@@ -20946,7 +21001,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhiteBlack",
+          "name": "WhiteBlack",
           "line": 658,
           "kind": "unit",
           "field_names": [],
@@ -20954,7 +21009,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlueBlack",
+          "name": "BlueBlack",
           "line": 659,
           "kind": "unit",
           "field_names": [],
@@ -20962,7 +21017,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlueRed",
+          "name": "BlueRed",
           "line": 660,
           "kind": "unit",
           "field_names": [],
@@ -20970,7 +21025,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlackRed",
+          "name": "BlackRed",
           "line": 661,
           "kind": "unit",
           "field_names": [],
@@ -20978,7 +21033,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlackGreen",
+          "name": "BlackGreen",
           "line": 662,
           "kind": "unit",
           "field_names": [],
@@ -20986,7 +21041,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianRedWhite",
+          "name": "RedWhite",
           "line": 663,
           "kind": "unit",
           "field_names": [],
@@ -20994,7 +21049,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianRedGreen",
+          "name": "RedGreen",
           "line": 664,
           "kind": "unit",
           "field_names": [],
@@ -21002,7 +21057,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianGreenWhite",
+          "name": "GreenWhite",
           "line": 665,
           "kind": "unit",
           "field_names": [],
@@ -21010,7 +21065,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianGreenBlue",
+          "name": "GreenBlue",
           "line": 666,
           "kind": "unit",
           "field_names": [],
@@ -21018,7 +21073,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessWhite",
+          "name": "TwoWhite",
           "line": 668,
           "kind": "unit",
           "field_names": [],
@@ -21026,7 +21081,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessBlue",
+          "name": "TwoBlue",
           "line": 669,
           "kind": "unit",
           "field_names": [],
@@ -21034,7 +21089,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessBlack",
+          "name": "TwoBlack",
           "line": 670,
           "kind": "unit",
           "field_names": [],
@@ -21042,7 +21097,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessRed",
+          "name": "TwoRed",
           "line": 671,
           "kind": "unit",
           "field_names": [],
@@ -21050,8 +21105,168 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessGreen",
+          "name": "TwoGreen",
           "line": 672,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianWhite",
+          "line": 674,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlue",
+          "line": 675,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlack",
+          "line": 676,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianRed",
+          "line": 677,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianGreen",
+          "line": 678,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianWhiteBlue",
+          "line": 680,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianWhiteBlack",
+          "line": 681,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlueBlack",
+          "line": 682,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlueRed",
+          "line": 683,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlackRed",
+          "line": 684,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlackGreen",
+          "line": 685,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianRedWhite",
+          "line": 686,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianRedGreen",
+          "line": 687,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianGreenWhite",
+          "line": 688,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianGreenBlue",
+          "line": 689,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessWhite",
+          "line": 691,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessBlue",
+          "line": 692,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessBlack",
+          "line": 693,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessRed",
+          "line": 694,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessGreen",
+          "line": 695,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21062,7 +21277,7 @@
     },
     "ManaExpiry": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 517,
+      "line": 540,
       "doc": "When mana expires — controls lifecycle beyond the normal CR 106.4 step/phase drain.",
       "cr_refs": [
         "CR 106.4"
@@ -21070,7 +21285,7 @@
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 520,
+          "line": 543,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana persists through normal step/phase drains until the turn reaches cleanup. Used by \"Until end of turn, you don't lose this mana as steps and phases end.\"",
@@ -21078,7 +21293,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 523,
+          "line": 546,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana persists through combat steps but drains at EndCombat → PostCombatMain. Used by Firebending and similar \"mana lasts within combat\" mechanics.",
@@ -21089,7 +21304,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13787,
+      "line": 14204,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -21098,7 +21313,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 13790,
+          "line": 14207,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -21110,7 +21325,7 @@
         },
         {
           "name": "Multiply",
-          "line": 13793,
+          "line": 14210,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -21185,13 +21400,13 @@
     },
     "ManaProduction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1085,
+      "line": 1092,
       "doc": "Mana production descriptor for `Effect::Mana`.  Custom Deserialize: accepts both the tagged format `{\"type\":\"Fixed\",\"colors\":[\"White\"]}` (new) and a plain array of `ManaColor` like `[\"White\",\"Green\"]` (legacy, pre-ManaProduction refactor).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Fixed",
-          "line": 1087,
+          "line": 1094,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -21202,7 +21417,7 @@
         },
         {
           "name": "Colorless",
-          "line": 1098,
+          "line": 1105,
           "kind": "struct",
           "field_names": [
             "count"
@@ -21212,7 +21427,7 @@
         },
         {
           "name": "Mixed",
-          "line": 1103,
+          "line": 1110,
           "kind": "struct",
           "field_names": [
             "colorless_count",
@@ -21223,7 +21438,7 @@
         },
         {
           "name": "AnyOneColor",
-          "line": 1108,
+          "line": 1115,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21235,7 +21450,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1121,
+          "line": 1128,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21246,7 +21461,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 1128,
+          "line": 1135,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21258,7 +21473,7 @@
         },
         {
           "name": "OpponentLandColors",
-          "line": 1145,
+          "line": 1152,
           "kind": "struct",
           "field_names": [
             "count"
@@ -21270,7 +21485,7 @@
         },
         {
           "name": "AnyTypeProduceableBy",
-          "line": 1159,
+          "line": 1166,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21285,7 +21500,7 @@
         },
         {
           "name": "ChoiceAmongExiledColors",
-          "line": 1169,
+          "line": 1176,
           "kind": "struct",
           "field_names": [
             "source"
@@ -21299,7 +21514,7 @@
         },
         {
           "name": "ChoiceAmongCombinations",
-          "line": 1179,
+          "line": 1186,
           "kind": "struct",
           "field_names": [
             "options"
@@ -21312,7 +21527,7 @@
         },
         {
           "name": "AnyInCommandersColorIdentity",
-          "line": 1189,
+          "line": 1196,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21327,7 +21542,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 1205,
+          "line": 1212,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21341,7 +21556,7 @@
         },
         {
           "name": "AnyOneColorAmongPermanents",
-          "line": 1211,
+          "line": 1218,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21357,7 +21572,7 @@
         },
         {
           "name": "TriggerEventManaType",
-          "line": 1227,
+          "line": 1234,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c + CR 106.3: Produce one mana of the same type as the mana produced by the triggering `ManaAdded` event. Used by `TapsForMana` triggers of the form \"add one mana of any type that land produced\" (Vorinclex, Voice of Hunger; Dictate of Karametra). Resolves from `state.current_trigger_event` at resolution time; emits no mana if the current trigger event is absent or not a `ManaAdded` event (CR 106.5).",
@@ -21372,7 +21587,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13799,
+      "line": 14216,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -21381,7 +21596,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 13802,
+          "line": 14219,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -21389,7 +21604,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 13804,
+          "line": 14221,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -21429,8 +21644,20 @@
           "cr_refs": []
         },
         {
+          "name": "SharesCreatureTypeWithCommander",
+          "line": 316,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 106.6 + CR 205.3m + CR 903.3: \"a creature spell that shares a creature type with your commander\" — relational spend filter for Path of Ancestry. This is a distinct *relational-to-commander* axis, not a fixed-subtype parameterization of `OnlyForCreatureType`: the matching subtype set is computed from live commander state per spend, so it cannot be evaluated from `SpellMeta` alone. `allows_spell` returns `false` (no commander context here); the real relational evaluation happens at the `apply_mana_spell_grants` spend-check site, which has game-state access — mirroring how `OnlyForXCosts` defers full detection to its call site.",
+          "cr_refs": [
+            "CR 106.6",
+            "CR 205.3m",
+            "CR 903.3"
+          ]
+        },
+        {
           "name": "OnlyForTypeSpellsOrAbilities",
-          "line": 312,
+          "line": 322,
           "kind": "struct",
           "field_names": [
             "spell_type",
@@ -21443,7 +21670,7 @@
         },
         {
           "name": "OnlyForActivation",
-          "line": 318,
+          "line": 328,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to activate abilities.\" Cannot be used for casting spells — activation-only.",
@@ -21451,7 +21678,7 @@
         },
         {
           "name": "OnlyForXCosts",
-          "line": 321,
+          "line": 331,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only on costs that include {X}.\" Only permits spending on spells or abilities with {X} in their cost.",
@@ -21459,7 +21686,7 @@
         },
         {
           "name": "OnlyForSpellWithKeywordKind",
-          "line": 323,
+          "line": 333,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback.\"",
@@ -21467,7 +21694,7 @@
         },
         {
           "name": "OnlyForSpellWithKeywordKindFromZone",
-          "line": 325,
+          "line": 335,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback from a graveyard.\"",
@@ -21475,7 +21702,7 @@
         },
         {
           "name": "OnlyForSpellWithManaValue",
-          "line": 329,
+          "line": 339,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -21488,7 +21715,7 @@
         },
         {
           "name": "OnlyForSpellWithColorCount",
-          "line": 333,
+          "line": 343,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -21502,7 +21729,7 @@
         },
         {
           "name": "OnlyForSpellFromZone",
-          "line": 338,
+          "line": 348,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.6 + CR 400.7: \"Spend this mana only to cast spells from your graveyard\" / \"from exile\". Gates on the spell's cast-from zone, consulting `SpellMeta.cast_from_zone`. A distinct axis from `OnlyForSpellWithKeywordKindFromZone` (which also requires a keyword).",
@@ -21513,7 +21740,7 @@
         },
         {
           "name": "ConvokePayment",
-          "line": 342,
+          "line": 352,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51a: Internal marker for a convoke tap that substitutes for paying mana. The payment algorithm may consume it for the current spell, but cast-spent metrics and mana-added triggers must ignore it.",
@@ -21526,7 +21753,7 @@
     },
     "ManaSpellGrant": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 492,
+      "line": 515,
       "doc": "CR 106.6: Additional effect that the mana confers upon the spell it is spent on. E.g., \"that spell can't be countered\" (Cavern of Souls, Delighted Halfling).",
       "cr_refs": [
         "CR 106.6"
@@ -21534,7 +21761,7 @@
       "variants": [
         {
           "name": "CantBeCountered",
-          "line": 494,
+          "line": 517,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell cast with this mana can't be countered.",
@@ -21542,7 +21769,7 @@
         },
         {
           "name": "AddKeywordUntilEndOfTurn",
-          "line": 497,
+          "line": 520,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -21556,7 +21783,7 @@
         },
         {
           "name": "TriggerOnSpend",
-          "line": 508,
+          "line": 531,
           "kind": "struct",
           "field_names": [
             "restriction",
@@ -21573,7 +21800,7 @@
     },
     "ManaSpendPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1782,
+      "line": 1789,
       "doc": "CR 609.4b: Permission modifying how mana may be spent to pay a cost.",
       "cr_refs": [
         "CR 609.4b"
@@ -21581,7 +21808,7 @@
       "variants": [
         {
           "name": "AnyTypeOrColor",
-          "line": 1786,
+          "line": 1793,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana may be spent as though it were mana of any type or color for this payment. This preserves the Oracle distinction without changing the actual mana spent.",
@@ -21592,13 +21819,13 @@
     },
     "ManaSpendRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1428,
+      "line": 1435,
       "doc": "Parse-time template for mana spend restrictions.  Unlike [`ManaRestriction`](super::mana::ManaRestriction) which carries concrete values on a `ManaUnit`, this enum is stored on `Effect::Mana` and resolved at production time by reading runtime state (e.g., chosen creature type from the source object).",
       "cr_refs": [],
       "variants": [
         {
           "name": "SpellOnly",
-          "line": 1430,
+          "line": 1437,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells.\"",
@@ -21606,7 +21833,7 @@
         },
         {
           "name": "SpellType",
-          "line": 1432,
+          "line": 1439,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast creature spells.\"",
@@ -21614,7 +21841,7 @@
         },
         {
           "name": "ChosenCreatureType",
-          "line": 1435,
+          "line": 1442,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast a creature spell of the chosen type.\" Resolved at runtime from the source's `chosen_creature_type()`.",
@@ -21622,7 +21849,7 @@
         },
         {
           "name": "SpellTypeOrAbilityActivation",
-          "line": 1440,
+          "line": 1447,
           "kind": "struct",
           "field_names": [
             "spell_type",
@@ -21635,7 +21862,7 @@
         },
         {
           "name": "ActivateOnly",
-          "line": 1446,
+          "line": 1453,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to activate abilities.\" Cannot be used to cast spells; only for ability activation costs.",
@@ -21643,7 +21870,7 @@
         },
         {
           "name": "XCostOnly",
-          "line": 1449,
+          "line": 1456,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only on costs that include {X}.\" Only permits spending on spells or abilities with {X} in their cost.",
@@ -21651,7 +21878,7 @@
         },
         {
           "name": "SpellWithKeywordKind",
-          "line": 1451,
+          "line": 1458,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback.\"",
@@ -21659,7 +21886,7 @@
         },
         {
           "name": "SpellWithKeywordKindFromZone",
-          "line": 1453,
+          "line": 1460,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -21670,7 +21897,7 @@
         },
         {
           "name": "SpellWithManaValue",
-          "line": 1460,
+          "line": 1467,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -21683,7 +21910,7 @@
         },
         {
           "name": "SpellWithColorCount",
-          "line": 1464,
+          "line": 1471,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -21697,7 +21924,7 @@
         },
         {
           "name": "SpellFromZone",
-          "line": 1469,
+          "line": 1476,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.6 + CR 400.7: \"Spend this mana only to cast spells from your graveyard\" / \"from exile\". Gates spending on the spell's cast-from zone alone — a distinct axis from [`ManaSpendRestriction::SpellWithKeywordKindFromZone`], which additionally requires a keyword. Resolved against `SpellMeta.cast_from_zone`.",
@@ -21711,7 +21938,7 @@
     },
     "ManaSupertype": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 528,
+      "line": 551,
       "doc": "CR 205.4g: Supertype carried by produced mana (Snow today; extensible).",
       "cr_refs": [
         "CR 205.4g"
@@ -21719,7 +21946,7 @@
       "variants": [
         {
           "name": "Snow",
-          "line": 529,
+          "line": 552,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21886,13 +22113,13 @@
     },
     "MayTriggerOrigin": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 550,
+      "line": 575,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Printed",
-          "line": 551,
+          "line": 576,
           "kind": "struct",
           "field_names": [
             "trigger_index"
@@ -21902,7 +22129,7 @@
         },
         {
           "name": "Keyword",
-          "line": 552,
+          "line": 577,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -21915,13 +22142,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11067,
+      "line": 11352,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 11069,
+          "line": 11354,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -21933,7 +22160,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 11072,
+          "line": 11357,
           "kind": "struct",
           "field_names": [
             "source",
@@ -21954,13 +22181,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11047,
+      "line": 11332,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 11048,
+          "line": 11333,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21968,7 +22195,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 11051,
+          "line": 11336,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -21983,7 +22210,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 11058,
+          "line": 11343,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -21993,7 +22220,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 11061,
+          "line": 11346,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -22046,7 +22273,7 @@
     },
     "NextSpellModifier": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 337,
+      "line": 342,
       "doc": "CR 601.2f: The kind of modification to apply to the next qualifying spell.",
       "cr_refs": [
         "CR 601.2f"
@@ -22054,7 +22281,7 @@
       "variants": [
         {
           "name": "CantBeCountered",
-          "line": 339,
+          "line": 344,
           "kind": "unit",
           "field_names": [],
           "doc": "\"The next spell you cast this turn can't be countered.\"",
@@ -22062,7 +22289,7 @@
         },
         {
           "name": "HasKeyword",
-          "line": 341,
+          "line": 346,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -22072,7 +22299,7 @@
         },
         {
           "name": "CastAsThoughFlash",
-          "line": 343,
+          "line": 348,
           "kind": "unit",
           "field_names": [],
           "doc": "\"The next spell you cast this turn can be cast as though it had flash.\"",
@@ -22080,7 +22307,7 @@
         },
         {
           "name": "WithoutPayingManaCost",
-          "line": 346,
+          "line": 351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9a: \"The next [filter] spell you cast this turn can be cast without paying its mana cost.\" Additional costs still apply (CR 118.8).",
@@ -22094,7 +22321,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5293,
+      "line": 5459,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -22104,7 +22331,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 5295,
+          "line": 5461,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -22114,7 +22341,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 5297,
+          "line": 5463,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -22127,13 +22354,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4018,
+      "line": 4149,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 4019,
+          "line": 4150,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22141,7 +22368,7 @@
         },
         {
           "name": "Toughness",
-          "line": 4020,
+          "line": 4151,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22149,7 +22376,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 4021,
+          "line": 4152,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22160,13 +22387,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3308,
+      "line": 3390,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 3314,
+          "line": 3396,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -22177,7 +22404,7 @@
         },
         {
           "name": "Target",
-          "line": 3317,
+          "line": 3399,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -22187,7 +22414,7 @@
         },
         {
           "name": "Recipient",
-          "line": 3323,
+          "line": 3405,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -22198,7 +22425,7 @@
         },
         {
           "name": "EventSource",
-          "line": 3325,
+          "line": 3407,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -22208,7 +22435,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 3332,
+          "line": 3414,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -22221,7 +22448,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 3348,
+          "line": 3430,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric **pronoun** (\"it\" / \"its\") whose object referent is bound at parse time. The parser rebinds this to a concrete scope wherever the enclosing clause establishes the antecedent — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\", `EventSource` when the subject is the triggering object. The rebind ([`rebind_anaphoric_object_scope`] in `parser/oracle_effect/mod.rs`) covers every per-object characteristic (power, toughness, mana value, …) — not just power — because the pronoun refers to one object and the rebind only retargets *which* object, never *which* characteristic. When no clause subject applies (triggered-ability anaphora) `Anaphoric` survives to runtime, where it resolves identically to a demonstrative (effect-context referent first; see [`ObjectScope::Demonstrative`]). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work.",
@@ -22231,7 +22458,7 @@
         },
         {
           "name": "Demonstrative",
-          "line": 3365,
+          "line": 3447,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: A **demonstrative / definite** possessive back-reference (\"that creature's\", \"that card's\", \"that spell's\", \"the creature's\") whose antecedent is a full noun phrase naming an object introduced by an earlier instruction in the same ability — *not* the grammatical subject of the clause it appears in. Unlike [`ObjectScope::Anaphoric`] (the pronoun \"its\"), the subject-injection rewrite MUST NOT rebind this — its antecedent is fixed by the Oracle text. Steadfast Armasaur (\"its toughness\", `Anaphoric` → rebound to `Source`) and Creature Bond (\"that creature's toughness\", `Demonstrative` → never rebound) parse to the same `QuantityRef` property and differ only by this scope: collapsing them caused the LKI-toughness bug. At runtime `Demonstrative` resolves identically to `Anaphoric` — `effect_context_object` (CR 608.2c instruction-order referent) first, then the trigger source (CR 608.2k), then the cost-paid object. This is the Yuriko / Dark Confidant / Mana Drain class (issue #511): a reveal/counter/reanimate earlier in the same ability binds \"that <type>'s\" to the referenced object.",
@@ -22242,7 +22469,7 @@
         },
         {
           "name": "EventTarget",
-          "line": 3374,
+          "line": 3456,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 120.1: The object that **received** the damage referenced by the current trigger event — the recipient counterpart to [`ObjectScope::EventSource`]. This is \"that creature\" in \"deals noncombat damage to a creature equal to that creature's toughness\": the antecedent is the damaged object carried by the `DamageDealt` event, not the ability source or a target. Resolved at both trigger detection and resolution (CR 603.4 intervening-if) via `extract_target_object_from_event`.",
@@ -22266,7 +22493,7 @@
     },
     "OpeningHandBottomReason": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2174,
+      "line": 2243,
       "doc": "CR 103.5 / TL:R 906.6a: Why a player is bottoming cards from an opening hand before the normal mulligan-decision step.",
       "cr_refs": [
         "CR 103.5"
@@ -22274,7 +22501,7 @@
       "variants": [
         {
           "name": "TinyLeadersMultiCommander",
-          "line": 2175,
+          "line": 2244,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22285,7 +22512,7 @@
     },
     "OpponentMayScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 176,
+      "line": 183,
       "doc": "CR 608.2d: Who may choose to perform an optional effect during resolution. Used with `AbilityDefinition::optional_for` to route the \"you may\" prompt to opponents.",
       "cr_refs": [
         "CR 608.2d"
@@ -22293,7 +22520,7 @@
       "variants": [
         {
           "name": "AnyOpponent",
-          "line": 178,
+          "line": 185,
           "kind": "unit",
           "field_names": [],
           "doc": "\"any opponent may\" — each opponent in APNAP order gets the chance; first accept wins.",
@@ -22301,7 +22528,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 180,
+          "line": 187,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 101.4: \"any player may\" — every player INCLUDING the controller is offered in APNAP order; first accept wins (distinct from AnyOpponent which excludes the controller).",
@@ -22315,7 +22542,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13237,
+      "line": 13637,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -22325,7 +22552,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 13239,
+          "line": 13639,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -22333,7 +22560,7 @@
         },
         {
           "name": "Equals",
-          "line": 13241,
+          "line": 13641,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -22341,7 +22568,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 13244,
+          "line": 13644,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -22349,7 +22576,7 @@
         },
         {
           "name": "OneOf",
-          "line": 13246,
+          "line": 13646,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -22360,7 +22587,7 @@
     },
     "OutsideGameChoiceSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2124,
+      "line": 2193,
       "doc": "CR 400.11 + CR 406.3: A discriminated source for one outside-game selection. Sideboard entries (the wishboard pool) and face-up exile cards (the Karn / Coax wishboard return pool) are surfaced through one choice list so the caster picks across both pools in a single decision.  The size delta between the two variants (`Sideboard` carries a full `CardFace` so the UI can render the wishboard card without a sideboard lookup; `FaceUpExile` holds only an `ObjectId`) is intentional — `OutsideGameChoiceEntry` lists are short-lived (one entry per offered candidate while a single `WaitingFor::OutsideGameChoice` is active) and never collected by the million, so the asymmetry doesn't warrant boxing every CardFace through a heap indirection.",
       "cr_refs": [
         "CR 400.11",
@@ -22369,7 +22596,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 2126,
+          "line": 2195,
           "kind": "struct",
           "field_names": [
             "sideboard_index",
@@ -22382,7 +22609,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 2131,
+          "line": 2200,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -22433,7 +22660,7 @@
     },
     "OutsideGameSourcePool": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 132,
+      "line": 139,
       "doc": "CR 400.11 + CR 406.3: Candidate pool for outside-game searches. The baseline pool is the player's sideboard; Karn/Coax-class text widens that pool to include owned face-up exile cards that match the same filter.",
       "cr_refs": [
         "CR 400.11",
@@ -22442,7 +22669,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 135,
+          "line": 142,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.11a: Tournament sideboard / casual outside-the-game collection.",
@@ -22452,7 +22679,7 @@
         },
         {
           "name": "SideboardAndFaceUpExile",
-          "line": 137,
+          "line": 144,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.11a + CR 406.3: Sideboard plus matching owned face-up exile.",
@@ -22466,13 +22693,13 @@
     },
     "Parity": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 479,
+      "line": 486,
       "doc": "Odd or even — used by cards like \"choose odd or even.\"",
       "cr_refs": [],
       "variants": [
         {
           "name": "Odd",
-          "line": 480,
+          "line": 487,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22480,7 +22707,7 @@
         },
         {
           "name": "Even",
-          "line": 481,
+          "line": 488,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22491,7 +22718,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5057,
+      "line": 5223,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -22500,7 +22727,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 5058,
+          "line": 5224,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22510,7 +22737,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 5062,
+          "line": 5228,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -22520,7 +22747,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 5063,
+          "line": 5229,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22528,7 +22755,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 5065,
+          "line": 5231,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -22538,7 +22765,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 5066,
+          "line": 5232,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -22548,7 +22775,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 5069,
+          "line": 5235,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -22559,7 +22786,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 5073,
+          "line": 5239,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -22569,7 +22796,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 5077,
+          "line": 5243,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -22579,7 +22806,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 5079,
+          "line": 5245,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -22589,7 +22816,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 5080,
+          "line": 5246,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22597,7 +22824,7 @@
         },
         {
           "name": "SourceAttachedTo",
-          "line": 5084,
+          "line": 5250,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -22610,7 +22837,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 5087,
+          "line": 5253,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -22620,7 +22847,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 5090,
+          "line": 5256,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -22630,7 +22857,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 5093,
+          "line": 5259,
           "kind": "struct",
           "field_names": [
             "color"
@@ -22640,7 +22867,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 5096,
+          "line": 5262,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22648,7 +22875,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 5097,
+          "line": 5263,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22656,7 +22883,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 5098,
+          "line": 5264,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22664,7 +22891,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 5099,
+          "line": 5265,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22675,7 +22902,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 5103,
+          "line": 5269,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22686,7 +22913,7 @@
         },
         {
           "name": "ZoneCoreTypeCardCountAtLeast",
-          "line": 5107,
+          "line": 5273,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22698,7 +22925,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 5112,
+          "line": 5278,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22710,7 +22937,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 5117,
+          "line": 5283,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22720,7 +22947,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 5120,
+          "line": 5286,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22730,7 +22957,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 5123,
+          "line": 5289,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -22740,7 +22967,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 5128,
+          "line": 5294,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22752,7 +22979,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 5137,
+          "line": 5303,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22767,7 +22994,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 5142,
+          "line": 5308,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -22777,7 +23004,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 5145,
+          "line": 5311,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -22787,7 +23014,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 5148,
+          "line": 5314,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -22798,7 +23025,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 5152,
+          "line": 5318,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -22809,7 +23036,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 5156,
+          "line": 5322,
           "kind": "struct",
           "field_names": [
             "color",
@@ -22820,7 +23047,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 5160,
+          "line": 5326,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -22830,7 +23057,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 5163,
+          "line": 5329,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22838,7 +23065,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 5164,
+          "line": 5330,
           "kind": "struct",
           "field_names": [
             "name"
@@ -22848,7 +23075,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 5171,
+          "line": 5337,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -22861,7 +23088,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 5175,
+          "line": 5341,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -22871,7 +23098,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 5178,
+          "line": 5344,
           "kind": "struct",
           "field_names": [
             "power",
@@ -22882,7 +23109,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 5182,
+          "line": 5348,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22890,7 +23117,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 5183,
+          "line": 5349,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22900,7 +23127,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 5186,
+          "line": 5352,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22910,7 +23137,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 5189,
+          "line": 5355,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22920,7 +23147,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 5192,
+          "line": 5358,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22928,7 +23155,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 5193,
+          "line": 5359,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22936,7 +23163,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 5194,
+          "line": 5360,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22946,7 +23173,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 5200,
+          "line": 5366,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -22954,7 +23181,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 5203,
+          "line": 5369,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -22967,7 +23194,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 5207,
+          "line": 5373,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22975,7 +23202,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 5208,
+          "line": 5374,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22985,7 +23212,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 5211,
+          "line": 5377,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22993,7 +23220,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 5212,
+          "line": 5378,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23001,7 +23228,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 5213,
+          "line": 5379,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23009,7 +23236,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 5214,
+          "line": 5380,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23017,7 +23244,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 5216,
+          "line": 5382,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -23027,7 +23254,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 5217,
+          "line": 5383,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23035,7 +23262,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 5218,
+          "line": 5384,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23043,7 +23270,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 5219,
+          "line": 5385,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23051,7 +23278,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 5220,
+          "line": 5386,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -23062,7 +23289,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 5224,
+          "line": 5390,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23072,7 +23299,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 5229,
+          "line": 5395,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -23085,7 +23312,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 5234,
+          "line": 5400,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -23095,7 +23322,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 5242,
+          "line": 5408,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -23105,7 +23332,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 5255,
+          "line": 5421,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23119,7 +23346,7 @@
         },
         {
           "name": "And",
-          "line": 5263,
+          "line": 5429,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23132,7 +23359,7 @@
         },
         {
           "name": "Or",
-          "line": 5269,
+          "line": 5435,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23145,7 +23372,7 @@
         },
         {
           "name": "Not",
-          "line": 5276,
+          "line": 5442,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -23232,7 +23459,7 @@
     },
     "PayCostKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2354,
+      "line": 2423,
       "doc": "CR 118.3 + CR 601.2b + CR 605.3b: Identifies the specific action to take on the objects a player selects while paying a cost.",
       "cr_refs": [
         "CR 118.3",
@@ -23242,7 +23469,7 @@
       "variants": [
         {
           "name": "Discard",
-          "line": 2355,
+          "line": 2424,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23250,7 +23477,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 2356,
+          "line": 2425,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23258,7 +23485,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 2357,
+          "line": 2426,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23266,7 +23493,7 @@
         },
         {
           "name": "ExileFromZone",
-          "line": 2359,
+          "line": 2428,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23276,7 +23503,7 @@
         },
         {
           "name": "ExileMaterials",
-          "line": 2366,
+          "line": 2435,
           "kind": "struct",
           "field_names": [
             "materials"
@@ -23288,7 +23515,7 @@
         },
         {
           "name": "ExilePermanent",
-          "line": 2377,
+          "line": 2446,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23302,7 +23529,7 @@
         },
         {
           "name": "ExileFromManaZone",
-          "line": 2381,
+          "line": 2450,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23312,7 +23539,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 2384,
+          "line": 2453,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -23324,7 +23551,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 2394,
+          "line": 2463,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23332,7 +23559,7 @@
         },
         {
           "name": "Behold",
-          "line": 2395,
+          "line": 2464,
           "kind": "struct",
           "field_names": [
             "action"
@@ -23345,7 +23572,7 @@
     },
     "PayableResource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4046,
+      "line": 4133,
       "doc": "CR 107.14 + CR 118.8: Resource that can be paid in a \"pay any amount of X\" prompt. Typed so the same `WaitingFor::PayAmountChoice` variant generalizes to future classes (energy, life, mana) without re-introducing boolean flags.",
       "cr_refs": [
         "CR 107.14",
@@ -23354,7 +23581,7 @@
       "variants": [
         {
           "name": "Energy",
-          "line": 4048,
+          "line": 4135,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.",
@@ -23364,7 +23591,7 @@
         },
         {
           "name": "ManaGeneric",
-          "line": 4050,
+          "line": 4137,
           "kind": "struct",
           "field_names": [
             "per_x"
@@ -23377,7 +23604,7 @@
         },
         {
           "name": "Counters",
-          "line": 4055,
+          "line": 4142,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c + CR 122.1: Choose how many counters to remove.",
@@ -23429,7 +23656,7 @@
     },
     "PendingCoinFlipKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 884,
+      "line": 909,
       "doc": "CR 705.1 + CR 614.1a: Discriminates which multi-flip resolver paused for a Krark's Thumb keep-1 choice, carrying the loop position needed to re-enter.",
       "cr_refs": [
         "CR 614.1a",
@@ -23438,7 +23665,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 886,
+          "line": 911,
           "kind": "unit",
           "field_names": [],
           "doc": "`Effect::FlipCoin` — a single logical flip.",
@@ -23446,7 +23673,7 @@
         },
         {
           "name": "FlipN",
-          "line": 889,
+          "line": 914,
           "kind": "struct",
           "field_names": [
             "remaining"
@@ -23456,7 +23683,7 @@
         },
         {
           "name": "UntilLose",
-          "line": 892,
+          "line": 917,
           "kind": "struct",
           "field_names": [
             "wins_so_far"
@@ -23469,13 +23696,13 @@
     },
     "PendingCounterAddition": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1445,
+      "line": 1503,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 1446,
+          "line": 1504,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -23488,7 +23715,7 @@
         },
         {
           "name": "Player",
-          "line": 1452,
+          "line": 1510,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -23501,7 +23728,7 @@
         },
         {
           "name": "Energy",
-          "line": 1458,
+          "line": 1516,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -23516,13 +23743,13 @@
     },
     "PendingCounterPostAction": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1315,
+      "line": 1373,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "EmitEffectResolved",
-          "line": 1316,
+          "line": 1374,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -23533,7 +23760,7 @@
         },
         {
           "name": "RecordPlayerAction",
-          "line": 1320,
+          "line": 1378,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -23544,7 +23771,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 1324,
+          "line": 1382,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23555,7 +23782,7 @@
         },
         {
           "name": "InjectPredefinedTokenAbilities",
-          "line": 1328,
+          "line": 1386,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -23565,7 +23792,7 @@
         },
         {
           "name": "FinalizeTokenEntry",
-          "line": 1331,
+          "line": 1389,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23580,7 +23807,7 @@
         },
         {
           "name": "ContinueTokenCreation",
-          "line": 1339,
+          "line": 1397,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -23593,7 +23820,7 @@
         },
         {
           "name": "FinalizeCopyTokenEntry",
-          "line": 1345,
+          "line": 1403,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23607,7 +23834,7 @@
         },
         {
           "name": "ContinueCopyTokenCreation",
-          "line": 1352,
+          "line": 1410,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -23621,7 +23848,7 @@
         },
         {
           "name": "ApplyCopyTokenModificationsAndFinalize",
-          "line": 1359,
+          "line": 1417,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23636,7 +23863,7 @@
         },
         {
           "name": "ClearPendingEtbCounters",
-          "line": 1367,
+          "line": 1425,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -23646,7 +23873,7 @@
         },
         {
           "name": "ContinueZoneDeliveryTail",
-          "line": 1370,
+          "line": 1428,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23663,7 +23890,7 @@
         },
         {
           "name": "RecordStationed",
-          "line": 1384,
+          "line": 1442,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -23675,7 +23902,7 @@
         },
         {
           "name": "MarkMonstrous",
-          "line": 1389,
+          "line": 1447,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -23685,7 +23912,7 @@
         },
         {
           "name": "MarkRenowned",
-          "line": 1392,
+          "line": 1450,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -23698,13 +23925,13 @@
     },
     "PendingEffectResolutionEvent": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1302,
+      "line": 1360,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Emit",
-          "line": 1304,
+          "line": 1362,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23712,7 +23939,7 @@
         },
         {
           "name": "Suppress",
-          "line": 1305,
+          "line": 1363,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23723,7 +23950,7 @@
     },
     "PermissionGrantee": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1805,
+      "line": 1812,
       "doc": "CR 611.2a + CR 108.3: Identifies which player a `CastingPermission` is granted to at resolution time. Resolved to a concrete `PlayerId` by `grant_permission::resolve` before the permission is written to the target `GameObject`. Drives both `granted_to` binding and, for durations scoped to that player (e.g., `UntilNextTurnOf`), the prune step in `layers.rs`.  Default is `AbilityController` for all pre-existing parser call sites. Additional variants support compound-exile patterns where multiple objects are granted distinct permissions tied to different players: - `ObjectOwner` — Suspend Aggression: \"its owner may play it\". Each object   in the tracked set is granted to its own owner (CR 108.3). - `ParentTargetController` — Expedited Inheritance: \"its controller may   exile [N] ... They may play those cards\". The grant is tied to the   parent effect's player target rather than the triggered-ability controller.",
       "cr_refs": [
         "CR 108.3",
@@ -23732,7 +23959,7 @@
       "variants": [
         {
           "name": "AbilityController",
-          "line": 1808,
+          "line": 1815,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a default — the controller of the effect that created the grant.",
@@ -23742,7 +23969,7 @@
         },
         {
           "name": "ObjectOwner",
-          "line": 1810,
+          "line": 1817,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 — each iterated object's owner (per-object binding).",
@@ -23752,7 +23979,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1812,
+          "line": 1819,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 — the player target of the parent effect in the chain.",
@@ -23902,7 +24129,7 @@
     },
     "PileSide": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2261,
+      "line": 2330,
       "doc": "CR 700.3: Identifies one of the two piles produced by a `SeparateIntoPiles` partition. Typed rather than `bool` so the `GameAction::ChoosePile` payload and the engine handler share a self-documenting domain and the parser/AI cannot accidentally swap pile semantics. Pile A is the partitioner's chosen subset; pile B is `eligible \\ pile_a`.",
       "cr_refs": [
         "CR 700.3"
@@ -23910,7 +24137,7 @@
       "variants": [
         {
           "name": "A",
-          "line": 2262,
+          "line": 2331,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23918,7 +24145,7 @@
         },
         {
           "name": "B",
-          "line": 2263,
+          "line": 2332,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24044,13 +24271,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4117,
+      "line": 4248,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 4121,
+          "line": 4252,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -24060,7 +24287,7 @@
         },
         {
           "name": "Opponent",
-          "line": 4123,
+          "line": 4254,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -24068,7 +24295,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 4125,
+          "line": 4256,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -24078,7 +24305,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 4127,
+          "line": 4258,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -24086,7 +24313,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 4129,
+          "line": 4260,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -24094,7 +24321,7 @@
         },
         {
           "name": "HasLostTheGame",
-          "line": 4134,
+          "line": 4265,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3 + CR 104.5: Each player who has lost the game (`is_eliminated`). Quantity-only: players who lost have left the game, so this is not a live effect recipient filter. Rampant Frogantua class: \"+10/+10 for each player who has lost the game\".",
@@ -24105,7 +24332,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 4144,
+          "line": 4275,
           "kind": "struct",
           "field_names": [
             "source"
@@ -24120,7 +24347,7 @@
         },
         {
           "name": "OpponentAttacked",
-          "line": 4158,
+          "line": 4289,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -24136,7 +24363,7 @@
         },
         {
           "name": "All",
-          "line": 4163,
+          "line": 4294,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -24144,7 +24371,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 4165,
+          "line": 4296,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -24154,7 +24381,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 4168,
+          "line": 4299,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -24162,7 +24389,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 4172,
+          "line": 4303,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24176,7 +24403,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 4178,
+          "line": 4309,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -24184,7 +24411,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 4182,
+          "line": 4313,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -24195,7 +24422,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 4191,
+          "line": 4322,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -24206,7 +24433,7 @@
         },
         {
           "name": "OpponentOfTriggeringPlayerNotAttacked",
-          "line": 4197,
+          "line": 4328,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 508.6 + CR 603.4: Each opponent of the *triggering/attacking* player (resolved from the active AttackersDeclared trigger event) who is NOT in that player's attacked-this-combat set. Models \"that player has another opponent who isn't being attacked\" (Suppressor Skyguard); counted via QuantityRef::PlayerCount, gated as count >= 1.",
@@ -24218,7 +24445,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 4208,
+          "line": 4339,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -24231,7 +24458,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 4220,
+          "line": 4351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -24242,7 +24469,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 4242,
+          "line": 4373,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24258,7 +24485,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 4268,
+          "line": 4399,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24276,7 +24503,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 4284,
+          "line": 4415,
           "kind": "struct",
           "field_names": [
             "index"
@@ -24289,7 +24516,7 @@
         },
         {
           "name": "ParentObjectTargetOwner",
-          "line": 4294,
+          "line": 4425,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 109.4: The owner of the first object target of the resolving ability. The owner-axis sibling of `ParentObjectTargetController`, completing the owner/controller pair that `PlayerScope` (`ParentObjectTargetController`) and `TargetFilter` (`ParentTargetOwner` / `ParentTargetController`) already carry. Resolved via `ability_utils::parent_target_owner`. Powers the \"[target's owner] …, then faces a villainous choice — …\" class (This Is How It Ends) where the player facing the choice is the owner of the targeted permanent named in the prior clause, not the ability controller.",
@@ -24312,7 +24539,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4086,
+      "line": 4217,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -24322,7 +24549,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 4088,
+          "line": 4219,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -24330,7 +24557,7 @@
         },
         {
           "name": "Opponent",
-          "line": 4090,
+          "line": 4221,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -24338,7 +24565,7 @@
         },
         {
           "name": "All",
-          "line": 4092,
+          "line": 4223,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -24349,7 +24576,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3249,
+      "line": 3331,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -24359,7 +24586,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3251,
+          "line": 3333,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -24370,7 +24597,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 3255,
+          "line": 3337,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -24381,7 +24608,7 @@
         },
         {
           "name": "Target",
-          "line": 3258,
+          "line": 3340,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -24393,7 +24620,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3262,
+          "line": 3344,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -24406,7 +24633,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 3267,
+          "line": 3349,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -24419,7 +24646,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 3281,
+          "line": 3363,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -24430,7 +24657,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3287,
+          "line": 3369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -24441,7 +24668,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3293,
+          "line": 3375,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -24452,7 +24679,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 3300,
+          "line": 3382,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.1 + CR 109.4: The player PERSISTED on the source via `ChosenAttribute::Player` (an \"as ~ enters the battlefield, choose a player\" replacement). The player-scalar-axis analogue of `ControllerRef::SourceChosenPlayer`, read continuously from the source's `chosen_attributes` so a CDA P/T can track e.g. the chosen player's hand or graveyard size (Entropic Specter, Sewer Nemesis).",
@@ -24493,7 +24720,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13907,
+      "line": 14324,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -24502,7 +24729,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 13908,
+          "line": 14325,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24510,7 +24737,7 @@
         },
         {
           "name": "Resolved",
-          "line": 13909,
+          "line": 14326,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24521,13 +24748,13 @@
     },
     "PostReplacementDrainOwner": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1430,
+      "line": 1488,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DeliveryTail",
-          "line": 1435,
+          "line": 1493,
           "kind": "unit",
           "field_names": [],
           "doc": "The shared delivery tail (`apply_zone_delivery_tail`) drains the continuation ctx-less — every direct pipeline delivery (effect moves, stack resolution, land play, destroy/sacrifice lowering).",
@@ -24535,7 +24762,7 @@
         },
         {
           "name": "CallerEpilogue",
-          "line": 1441,
+          "line": 1499,
           "kind": "unit",
           "field_names": [],
           "doc": "The caller's epilogue owns the drain; the tail skips it. Used by `engine_replacement::handle_replacement_choice`, whose post-`Execute` epilogue drains with the spell-resolution ctx and clears `post_replacement_source` for zone changes (CR 614.12a ordering: `apply_pending_spell_resolution` runs before the drain there).",
@@ -24548,7 +24775,7 @@
     },
     "PreventionAmount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 529,
+      "line": 536,
       "doc": "CR 615: How much damage to prevent.",
       "cr_refs": [
         "CR 615"
@@ -24556,7 +24783,7 @@
       "variants": [
         {
           "name": "Next",
-          "line": 531,
+          "line": 538,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Prevent the next N damage\"",
@@ -24564,7 +24791,7 @@
         },
         {
           "name": "All",
-          "line": 533,
+          "line": 540,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Prevent all damage\"",
@@ -24575,7 +24802,7 @@
     },
     "PreventionScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 519,
+      "line": 526,
       "doc": "CR 615: Damage prevention scope.",
       "cr_refs": [
         "CR 615"
@@ -24583,7 +24810,7 @@
       "variants": [
         {
           "name": "AllDamage",
-          "line": 522,
+          "line": 529,
           "kind": "unit",
           "field_names": [],
           "doc": "Prevent all damage (combat + noncombat).",
@@ -24591,7 +24818,7 @@
         },
         {
           "name": "CombatDamage",
-          "line": 524,
+          "line": 531,
           "kind": "unit",
           "field_names": [],
           "doc": "Prevent only combat damage.",
@@ -24602,7 +24829,7 @@
     },
     "ProductionOverride": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1755,
+      "line": 1824,
       "doc": "CR 605.3b + CR 106.1a: A pre-resolved choice that short-circuits the normal `ChooseManaColor` prompt. Auto-tap sets this when the cost-payment planner has already determined the exact mana to produce; manual activation leaves it `None` so the player is prompted.  Typed enum (never a bool): `SingleColor` covers the one-color-repeated variants (`AnyOneColor`, `ChoiceAmongExiledColors`), while `Combination` carries the full pre-chosen multi-mana sequence for fixed combinations (`ChoiceAmongCombinations`) and free per-slot choices (`AnyCombination`).",
       "cr_refs": [
         "CR 106.1a",
@@ -24611,7 +24838,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1759,
+          "line": 1828,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked a single color; every unit of mana the ability produces becomes this color (mirrors the pre-widening `Option<ManaType>` semantics).",
@@ -24619,7 +24846,7 @@
         },
         {
           "name": "Combination",
-          "line": 1762,
+          "line": 1831,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked one complete mana sequence; the ability produces exactly these mana types in order.",
@@ -24630,13 +24857,13 @@
     },
     "ProhibitedActivity": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1549,
+      "line": 1556,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "CastOnlyFromZones",
-          "line": 1551,
+          "line": 1558,
           "kind": "struct",
           "field_names": [
             "allowed_zones"
@@ -24649,7 +24876,7 @@
         },
         {
           "name": "CastSpells",
-          "line": 1553,
+          "line": 1560,
           "kind": "struct",
           "field_names": [
             "spell_filter"
@@ -24661,7 +24888,7 @@
         },
         {
           "name": "ActivateAbilities",
-          "line": 1559,
+          "line": 1566,
           "kind": "struct",
           "field_names": [
             "exemption"
@@ -24821,8 +25048,37 @@
           ]
         },
         {
+          "name": "Explore",
+          "line": 258,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "applied"
+          ],
+          "doc": "CR 701.37a + CR 614.1a: A creature is about to explore. Replacement effects can modify the explore action (e.g., add a scry prelude).",
+          "cr_refs": [
+            "CR 614.1a",
+            "CR 701.37a"
+          ]
+        },
+        {
+          "name": "Proliferate",
+          "line": 265,
+          "kind": "struct",
+          "field_names": [
+            "player_id",
+            "count",
+            "applied"
+          ],
+          "doc": "CR 701.34a + CR 614.1a: A player is about to proliferate. Replacement effects can modify how many times the proliferate action is performed (Tekuthal, Inquiry Dominus — \"proliferate twice instead\").",
+          "cr_refs": [
+            "CR 614.1a",
+            "CR 701.34a"
+          ]
+        },
+        {
           "name": "LifeGain",
-          "line": 256,
+          "line": 270,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -24834,7 +25090,7 @@
         },
         {
           "name": "LifeLoss",
-          "line": 261,
+          "line": 275,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -24846,7 +25102,7 @@
         },
         {
           "name": "AddCounter",
-          "line": 266,
+          "line": 280,
           "kind": "struct",
           "field_names": [
             "placement",
@@ -24858,7 +25114,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 275,
+          "line": 289,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -24871,7 +25127,7 @@
         },
         {
           "name": "MoveCounter",
-          "line": 284,
+          "line": 298,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -24890,7 +25146,7 @@
         },
         {
           "name": "CreateToken",
-          "line": 304,
+          "line": 318,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -24908,7 +25164,7 @@
         },
         {
           "name": "Discard",
-          "line": 323,
+          "line": 337,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -24922,7 +25178,7 @@
         },
         {
           "name": "Tap",
-          "line": 335,
+          "line": 349,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -24933,7 +25189,7 @@
         },
         {
           "name": "Untap",
-          "line": 339,
+          "line": 353,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -24944,7 +25200,7 @@
         },
         {
           "name": "Destroy",
-          "line": 343,
+          "line": 357,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -24957,7 +25213,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 350,
+          "line": 364,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -24969,7 +25225,7 @@
         },
         {
           "name": "BeginTurn",
-          "line": 361,
+          "line": 375,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -24986,7 +25242,7 @@
         },
         {
           "name": "BeginPhase",
-          "line": 371,
+          "line": 385,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -25001,7 +25257,7 @@
         },
         {
           "name": "ProduceMana",
-          "line": 380,
+          "line": 394,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -25019,7 +25275,7 @@
         },
         {
           "name": "EmptyManaPool",
-          "line": 409,
+          "line": 423,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -25134,7 +25390,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4667,
+      "line": 4798,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -25142,7 +25398,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 4669,
+          "line": 4800,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -25152,7 +25408,7 @@
         },
         {
           "name": "Toughness",
-          "line": 4671,
+          "line": 4802,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -25162,7 +25418,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 4673,
+          "line": 4804,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -25175,13 +25431,13 @@
     },
     "PtValue": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 966,
+      "line": 973,
       "doc": "Power/toughness value -- either a fixed integer or a variable reference (e.g. \"*\", \"X\").  Custom Deserialize: accepts both the tagged format `{\"type\":\"Fixed\",\"value\":2}` (new) and plain strings like `\"2\"` or `\"*\"` (legacy card-data.json).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Fixed",
-          "line": 967,
+          "line": 974,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25189,7 +25445,7 @@
         },
         {
           "name": "Variable",
-          "line": 968,
+          "line": 975,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25197,7 +25453,7 @@
         },
         {
           "name": "Quantity",
-          "line": 969,
+          "line": 976,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25208,7 +25464,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4682,
+      "line": 4813,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -25217,7 +25473,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 4685,
+          "line": 4816,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -25227,7 +25483,7 @@
         },
         {
           "name": "Base",
-          "line": 4688,
+          "line": 4819,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -25240,7 +25496,7 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4306,
+      "line": 4437,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.  CR 107: `Deserialize` is hand-written below (NOT derived) so it ALSO accepts the legacy bare-integer form (`2`, `-1`) that pre-`QuantityExpr` card-data and committed game-state snapshots stored. `Serialize` stays derived, so the canonical on-disk form remains the tagged `{\"type\":\"Fixed\",\"value\":2}`.",
       "cr_refs": [
         "CR 107"
@@ -25248,7 +25504,7 @@
       "variants": [
         {
           "name": "Ref",
-          "line": 4308,
+          "line": 4439,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -25258,7 +25514,7 @@
         },
         {
           "name": "Fixed",
-          "line": 4310,
+          "line": 4441,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25268,7 +25524,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 4314,
+          "line": 4445,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25282,7 +25538,7 @@
         },
         {
           "name": "Offset",
-          "line": 4321,
+          "line": 4452,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25295,7 +25551,7 @@
         },
         {
           "name": "ClampMin",
-          "line": 4330,
+          "line": 4461,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25308,7 +25564,7 @@
         },
         {
           "name": "Multiply",
-          "line": 4335,
+          "line": 4466,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -25319,7 +25575,7 @@
         },
         {
           "name": "Sum",
-          "line": 4344,
+          "line": 4475,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -25329,7 +25585,7 @@
         },
         {
           "name": "UpTo",
-          "line": 4369,
+          "line": 4500,
           "kind": "struct",
           "field_names": [
             "max"
@@ -25342,7 +25598,7 @@
         },
         {
           "name": "Power",
-          "line": 4375,
+          "line": 4506,
           "kind": "struct",
           "field_names": [
             "base",
@@ -25355,7 +25611,7 @@
         },
         {
           "name": "Difference",
-          "line": 4390,
+          "line": 4521,
           "kind": "struct",
           "field_names": [
             "left",
@@ -25371,7 +25627,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13753,
+      "line": 14168,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -25379,15 +25635,23 @@
       "variants": [
         {
           "name": "Double",
-          "line": 13755,
+          "line": 14170,
           "kind": "unit",
           "field_names": [],
           "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
           "cr_refs": []
         },
         {
+          "name": "Half",
+          "line": 14172,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "count / 2 rounded down — Halving Season",
+          "cr_refs": []
+        },
+        {
           "name": "Plus",
-          "line": 13757,
+          "line": 14174,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25397,7 +25661,7 @@
         },
         {
           "name": "Minus",
-          "line": 13759,
+          "line": 14176,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25407,7 +25671,7 @@
         },
         {
           "name": "Prevent",
-          "line": 13779,
+          "line": 14196,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -25424,13 +25688,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3413,
+      "line": 3508,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 3417,
+          "line": 3512,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25442,7 +25706,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 3420,
+          "line": 3515,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25454,7 +25718,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 3426,
+          "line": 3521,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25466,7 +25730,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 3429,
+          "line": 3524,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -25474,7 +25738,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 3431,
+          "line": 3526,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -25484,7 +25748,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 3434,
+          "line": 3529,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25494,7 +25758,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 3451,
+          "line": 3546,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25508,7 +25772,7 @@
         },
         {
           "name": "ObjectCountBySharedQuality",
-          "line": 3461,
+          "line": 3556,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25523,7 +25787,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 3468,
+          "line": 3563,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25533,7 +25797,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 3489,
+          "line": 3584,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25546,7 +25810,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 3498,
+          "line": 3593,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -25559,7 +25823,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 3517,
+          "line": 3612,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -25576,7 +25840,7 @@
         },
         {
           "name": "Variable",
-          "line": 3522,
+          "line": 3617,
           "kind": "struct",
           "field_names": [
             "name"
@@ -25586,7 +25850,7 @@
         },
         {
           "name": "Power",
-          "line": 3529,
+          "line": 3624,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25600,7 +25864,7 @@
         },
         {
           "name": "Intensity",
-          "line": 3533,
+          "line": 3628,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25610,7 +25874,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3538,
+          "line": 3633,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25624,7 +25888,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 3544,
+          "line": 3639,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25636,8 +25900,21 @@
           ]
         },
         {
+          "name": "TargetObjectManaValue",
+          "line": 3645,
+          "kind": "struct",
+          "field_names": [
+            "filter"
+          ],
+          "doc": "CR 202.3 + CR 115.1: Mana value of the object chosen for a count-derived target slot whose legal candidates are `filter` (e.g. \"target artifact or creature you control\"). Distinct from `ObjectManaValue { scope: Target }` (a possessive \"that creature's mana value\", filterless); this variant owns its own target slot, surfaced via `quantity_ref_target_slot_spec`.",
+          "cr_refs": [
+            "CR 115.1",
+            "CR 202.3"
+          ]
+        },
+        {
           "name": "ObjectColorCount",
-          "line": 3550,
+          "line": 3651,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25650,7 +25927,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 3555,
+          "line": 3656,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25663,7 +25940,7 @@
         },
         {
           "name": "ObjectTypelineComponentCount",
-          "line": 3559,
+          "line": 3660,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25677,7 +25954,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 3566,
+          "line": 3667,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25691,7 +25968,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 3578,
+          "line": 3679,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -25703,7 +25980,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 3580,
+          "line": 3681,
           "kind": "struct",
           "field_names": [
             "function",
@@ -25717,7 +25994,7 @@
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 3597,
+          "line": 3698,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25731,7 +26008,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 3604,
+          "line": 3705,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -25741,7 +26018,7 @@
         },
         {
           "name": "Devotion",
-          "line": 3606,
+          "line": 3707,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -25753,7 +26030,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 3610,
+          "line": 3711,
           "kind": "struct",
           "field_names": [
             "source"
@@ -25765,7 +26042,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 3615,
+          "line": 3716,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -25775,8 +26052,20 @@
           ]
         },
         {
+          "name": "ExiledCardPower",
+          "line": 3719,
+          "kind": "struct",
+          "field_names": [
+            "index"
+          ],
+          "doc": "CR 607.2b: The power of a specific card exiled by the source, indexed by order. Used by The Mimeoplasm to read the second exiled card's power for counter placement.",
+          "cr_refs": [
+            "CR 607.2b"
+          ]
+        },
+        {
           "name": "ZoneCardCount",
-          "line": 3619,
+          "line": 3723,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -25791,7 +26080,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 3628,
+          "line": 3732,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -25803,7 +26092,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 3632,
+          "line": 3736,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -25813,7 +26102,7 @@
         },
         {
           "name": "FilteredTrackedSetSize",
-          "line": 3647,
+          "line": 3751,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25827,8 +26116,24 @@
           ]
         },
         {
+          "name": "TrackedSetAggregate",
+          "line": 3765,
+          "kind": "struct",
+          "field_names": [
+            "function",
+            "property"
+          ],
+          "doc": "CR 608.2c + CR 609.3 + CR 107.3e + CR 202.3: Reduce a numeric property over the most recent chain tracked set (sum/max/min), reading the same set as [`QuantityRef::FilteredTrackedSetSize`] but aggregating a per-member value instead of counting members. The set is selected by highest id (the set the immediately-preceding chain effect published) and is zone-independent — its members are addressed by identity, so cards the producer moved to exile are read in place. Used by \"deals damage equal to the total mana value of those exiled cards\" (Ensnared by the Mara — `Sum` over `ManaValue` of the set the preceding `ExileTop` published).",
+          "cr_refs": [
+            "CR 107.3e",
+            "CR 202.3",
+            "CR 608.2c",
+            "CR 609.3"
+          ]
+        },
+        {
           "name": "ExiledFromHandThisResolution",
-          "line": 3657,
+          "line": 3774,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -25839,7 +26144,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 3661,
+          "line": 3778,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -25849,7 +26154,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 3676,
+          "line": 3793,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25862,7 +26167,7 @@
         },
         {
           "name": "PartySize",
-          "line": 3685,
+          "line": 3802,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25875,7 +26180,7 @@
         },
         {
           "name": "UnspentMana",
-          "line": 3694,
+          "line": 3811,
           "kind": "struct",
           "field_names": [
             "color"
@@ -25887,7 +26192,7 @@
         },
         {
           "name": "Speed",
-          "line": 3701,
+          "line": 3818,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25899,7 +26204,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 3704,
+          "line": 3821,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -25909,7 +26214,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 3712,
+          "line": 3829,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -25923,7 +26228,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 3724,
+          "line": 3841,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -25935,7 +26240,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 3727,
+          "line": 3844,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25948,7 +26253,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 3734,
+          "line": 3851,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25958,7 +26263,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 3740,
+          "line": 3857,
           "kind": "struct",
           "field_names": [
             "player",
@@ -25971,7 +26276,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 3745,
+          "line": 3862,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -25981,7 +26286,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 3751,
+          "line": 3868,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25993,7 +26298,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 3756,
+          "line": 3873,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26004,8 +26309,22 @@
           ]
         },
         {
+          "name": "BattlefieldEntriesThisTurn",
+          "line": 3879,
+          "kind": "struct",
+          "field_names": [
+            "player",
+            "filter"
+          ],
+          "doc": "CR 403.3 + CR 608.2h: Count of battlefield entries this turn by the scoped player matching `filter`, using `battlefield_entries_this_turn` snapshots (lands that entered and later left still count). Smuggler's Share class: \"for each opponent who had two or more lands enter the battlefield under their control this turn.\"",
+          "cr_refs": [
+            "CR 403.3",
+            "CR 608.2h"
+          ]
+        },
+        {
           "name": "LandsPlayedThisTurn",
-          "line": 3761,
+          "line": 3887,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26019,7 +26338,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 3768,
+          "line": 3894,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -26029,7 +26348,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 3772,
+          "line": 3898,
           "kind": "struct",
           "field_names": [
             "from",
@@ -26044,7 +26363,7 @@
         },
         {
           "name": "ZoneChangeAggregateThisTurn",
-          "line": 3790,
+          "line": 3916,
           "kind": "struct",
           "field_names": [
             "from",
@@ -26065,7 +26384,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 3812,
+          "line": 3938,
           "kind": "struct",
           "field_names": [
             "source",
@@ -26083,7 +26402,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 3831,
+          "line": 3957,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -26091,7 +26410,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 3841,
+          "line": 3967,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26104,7 +26423,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 3848,
+          "line": 3974,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -26114,7 +26433,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 3856,
+          "line": 3982,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26128,7 +26447,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 3859,
+          "line": 3985,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -26138,7 +26457,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 3873,
+          "line": 3999,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26152,7 +26471,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 3884,
+          "line": 4010,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -26167,7 +26486,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 3893,
+          "line": 4019,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26180,7 +26499,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 3898,
+          "line": 4024,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26194,7 +26513,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 3906,
+          "line": 4032,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26208,7 +26527,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 3911,
+          "line": 4037,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -26218,7 +26537,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 3918,
+          "line": 4044,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -26228,7 +26547,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 3921,
+          "line": 4047,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -26239,7 +26558,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 3925,
+          "line": 4051,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -26251,7 +26570,7 @@
         },
         {
           "name": "AdditionalCostPaymentCountFor",
-          "line": 3929,
+          "line": 4055,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -26265,7 +26584,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 3937,
+          "line": 4063,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -26275,7 +26594,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 3942,
+          "line": 4068,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26289,7 +26608,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 3953,
+          "line": 4079,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -26300,7 +26619,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 3958,
+          "line": 4084,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -26309,8 +26628,20 @@
           ]
         },
         {
+          "name": "CommanderManaValue",
+          "line": 4089,
+          "kind": "struct",
+          "field_names": [
+            "owner"
+          ],
+          "doc": "CR 903.3d: Mana value of a commander you own on the battlefield or in the command zone. Used by Stinging Study's \"X is the mana value of a commander you own on the battlefield or in the command zone\" pattern. The resolver selects the first matching commander (any one if multiple exist) and returns its mana value.",
+          "cr_refs": [
+            "CR 903.3d"
+          ]
+        },
+        {
           "name": "DistinctColorsAmongPermanents",
-          "line": 3965,
+          "line": 4096,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26324,7 +26655,7 @@
         },
         {
           "name": "DistinctCounterKindsAmong",
-          "line": 3974,
+          "line": 4105,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26338,7 +26669,7 @@
         },
         {
           "name": "VoteCount",
-          "line": 3981,
+          "line": 4112,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -26352,6 +26683,14 @@
         }
       ],
       "sibling_clusters": [
+        {
+          "shared_root": "ObjectManaValue",
+          "members": [
+            "ObjectManaValue",
+            "TargetObjectManaValue"
+          ],
+          "smell_score": "LOW"
+        },
         {
           "shared_root": "ZoneCardCount",
           "members": [
@@ -26421,7 +26760,7 @@
     },
     "RenownSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12632,
+      "line": 12979,
       "doc": "CR 702.112: Which creature's renowned designation an `IsRenowned` condition reads.  Renowned (CR 702.112b) is a per-permanent designation other spells and abilities can identify, so a condition may reference either the ability's own permanent or a different (event-subject) creature.   - `Source` — the ability's own permanent (\"~\"), as in Renown's own     intervening-if (CR 702.112a, \"if it isn't renowned\" where \"it\" == this creature).   - `EventSubject` — the creature named by the triggering event (\"it\"), a creature     other than the source (CR 702.112b).",
       "cr_refs": [
         "CR 702.112",
@@ -26431,7 +26770,7 @@
       "variants": [
         {
           "name": "Source",
-          "line": 12633,
+          "line": 12980,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26439,7 +26778,7 @@
         },
         {
           "name": "EventSubject",
-          "line": 12634,
+          "line": 12981,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26450,7 +26789,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11760,
+      "line": 12056,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
       "cr_refs": [
         "CR 107.1c",
@@ -26459,7 +26798,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 11764,
+          "line": 12060,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -26469,7 +26808,7 @@
         },
         {
           "name": "UntilStopConditions",
-          "line": 11770,
+          "line": 12066,
           "kind": "struct",
           "field_names": [
             "stop_on_put_to_hand",
@@ -26486,13 +26825,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13009,
+      "line": 13370,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 13012,
+          "line": 13373,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -26504,7 +26843,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 13018,
+          "line": 13379,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -26514,7 +26853,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 13025,
+          "line": 13386,
           "kind": "struct",
           "field_names": [
             "count",
@@ -26527,7 +26866,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 13030,
+          "line": 13391,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26539,7 +26878,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 13035,
+          "line": 13396,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26552,7 +26891,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 13038,
+          "line": 13399,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -26564,7 +26903,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 13041,
+          "line": 13402,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -26574,7 +26913,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 13044,
+          "line": 13405,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -26585,7 +26924,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 13052,
+          "line": 13413,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26598,7 +26937,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 13066,
+          "line": 13427,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26611,7 +26950,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 13075,
+          "line": 13436,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -26622,7 +26961,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 13078,
+          "line": 13439,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -26632,7 +26971,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 13084,
+          "line": 13445,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26644,7 +26983,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 13089,
+          "line": 13450,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -26655,8 +26994,22 @@
           ]
         },
         {
+          "name": "EnteredFromZone",
+          "line": 13471,
+          "kind": "struct",
+          "field_names": [
+            "origin_constraint",
+            "cast_origin"
+          ],
+          "doc": "CR 614.1d + CR 601: Gates a replacement on how the *entering* object (the event's `affected_object_id`) arrived — NOT the replacement source. Both halves reference the entering object, which distinguishes this from `CastFromZone` (which reads the replacement's `source_id`; for a global floating install that source is the sentinel `ObjectId(0)`, so `CastFromZone` cannot express entering-object origin).  `origin_constraint` reuses the engine's canonical from-zone primitive (`OriginConstraint`) to test the event's `from` field — the \"would enter from <zone>\" half (CR 614.1d). Because `ProposedEvent::ZoneChange.from` is a non-optional `Zone`, the evaluator wraps it as `Some(from)` before delegating to `OriginConstraint::matches_from`.  `cast_origin`, when `Some(zone)`, additionally matches when the entering object was cast from `zone` (`GameObject.cast_from_zone == Some(zone)`) and thus physically enters from the Stack — the \"or after being cast from <zone>\" half (CR 601) that `OriginConstraint` cannot express because it only inspects `from`, never `cast_from_zone`. The two halves are OR-combined. Covers Don't Blink's \"if one or more creatures would enter from exile or after being cast from exile\" in a single leaf.",
+          "cr_refs": [
+            "CR 601",
+            "CR 614.1d"
+          ]
+        },
+        {
           "name": "YouAttackedThisTurn",
-          "line": 13094,
+          "line": 13486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -26667,7 +27020,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 13103,
+          "line": 13495,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -26679,7 +27032,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 13110,
+          "line": 13502,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -26693,7 +27046,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 13118,
+          "line": 13510,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -26703,7 +27056,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 13123,
+          "line": 13515,
           "kind": "struct",
           "field_names": [
             "source"
@@ -26717,7 +27070,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 13127,
+          "line": 13519,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26730,7 +27083,7 @@
         },
         {
           "name": "EffectCausedDiscard",
-          "line": 13132,
+          "line": 13524,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 701.9a: Replacement applies only when the discard was caused by resolving a spell or ability effect, not by paying a cost or by a turn-based action (cleanup hand-size discard). Used by Library of Leng (\"If an effect causes you to discard a card...\").",
@@ -26741,7 +27094,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 13137,
+          "line": 13529,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -26752,7 +27105,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 13148,
+          "line": 13540,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -26765,7 +27118,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 13159,
+          "line": 13551,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -26777,7 +27130,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 13167,
+          "line": 13559,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26790,7 +27143,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 13177,
+          "line": 13569,
           "kind": "struct",
           "field_names": [
             "level"
@@ -26801,8 +27154,19 @@
           ]
         },
         {
+          "name": "DuringUntapStep",
+          "line": 13577,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 502.3 + CR 502.4: True only during the untap step. Permanents untap as a turn-based action during the untap step (502.3) and no player receives priority then (502.4), so the only `ProposedEvent::Untap` raised during this phase is the turn-based untap. Gates an untap replacement (\"if [X] would untap during [its controller's / your] untap step, [effect] instead\" — Freyalise's Winds, Edge of Malacol) so it does NOT apply to effect-untaps (\"untap target creature\") at other times.",
+          "cr_refs": [
+            "CR 502.3",
+            "CR 502.4"
+          ]
+        },
+        {
           "name": "Unrecognized",
-          "line": 13182,
+          "line": 13582,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27199,15 +27563,18 @@
         },
         {
           "name": "Proliferate",
-          "line": 98,
+          "line": 100,
           "kind": "unit",
           "field_names": [],
-          "doc": "",
-          "cr_refs": []
+          "doc": "CR 701.34a + CR 614.1a: Replaces a proliferate action (count-modifying \"proliferate twice instead\" effects such as Tekuthal, Inquiry Dominus).",
+          "cr_refs": [
+            "CR 614.1a",
+            "CR 701.34a"
+          ]
         },
         {
           "name": "Other",
-          "line": 101,
+          "line": 103,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for truly unknown event strings.",
@@ -27218,13 +27585,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13873,
+      "line": 14290,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 13876,
+          "line": 14293,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -27232,7 +27599,7 @@
         },
         {
           "name": "Optional",
-          "line": 13878,
+          "line": 14295,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -27242,7 +27609,7 @@
         },
         {
           "name": "MayCost",
-          "line": 13885,
+          "line": 14302,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -27259,7 +27626,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13861,
+      "line": 14278,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source player. For permanents/spells this is the source's controller; for cards outside the battlefield/stack, CR 109.4 + CR 108.4a make this the owner. `valid_player: None` keeps the source-player default; `Some(You)` is the explicit source-player scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 108.4a",
@@ -27269,7 +27636,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 13863,
+          "line": 14280,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source player.",
@@ -27277,7 +27644,7 @@
         },
         {
           "name": "Opponent",
-          "line": 13865,
+          "line": 14282,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source player.",
@@ -27285,7 +27652,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 13867,
+          "line": 14284,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -27296,7 +27663,7 @@
     },
     "ResolutionCastSuccessAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1879,
+      "line": 1886,
       "doc": "CR 608.2g: Follow-up after a during-resolution cast succeeds.",
       "cr_refs": [
         "CR 608.2g"
@@ -27304,7 +27671,7 @@
       "variants": [
         {
           "name": "BottomMisses",
-          "line": 1882,
+          "line": 1889,
           "kind": "unit",
           "field_names": [],
           "doc": "Cascade/Discover: cast hit is gone, so bottom the dig misses now.",
@@ -27312,7 +27679,7 @@
         },
         {
           "name": "RippleOfferRemaining",
-          "line": 1885,
+          "line": 1892,
           "kind": "struct",
           "field_names": [
             "remaining_hits"
@@ -27324,7 +27691,7 @@
         },
         {
           "name": "FreeCastOfferRemaining",
-          "line": 1894,
+          "line": 1901,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -27346,7 +27713,7 @@
     },
     "ResolutionMvRejectAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1864,
+      "line": 1871,
       "doc": "CR 608.2g: Disposition of a during-resolution card that is not cast.",
       "cr_refs": [
         "CR 608.2g"
@@ -27354,7 +27721,7 @@
       "variants": [
         {
           "name": "BottomWithMisses",
-          "line": 1866,
+          "line": 1873,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: cascade — hit joins misses on the bottom in random order.",
@@ -27364,7 +27731,7 @@
         },
         {
           "name": "ToHand",
-          "line": 1868,
+          "line": 1875,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.57a: discover — hit goes to its owner's hand; misses to bottom.",
@@ -27374,7 +27741,7 @@
         },
         {
           "name": "RemainExiled",
-          "line": 1873,
+          "line": 1880,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Suspend's last-counter free cast — the card has no dig misses and no resulting-MV gate, so this reject disposition is only reached if a future during-resolution free cast adds a constraint. \"If you don't [cast it], it remains exiled\" — the card stays in exile.",
@@ -27387,13 +27754,13 @@
     },
     "RestrictionExpiry": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1565,
+      "line": 1572,
       "doc": "When a game restriction expires.",
       "cr_refs": [],
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 1566,
+          "line": 1573,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27401,7 +27768,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 1567,
+          "line": 1574,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27409,7 +27776,7 @@
         },
         {
           "name": "UntilPlayerNextTurn",
-          "line": 1568,
+          "line": 1575,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27422,13 +27789,13 @@
     },
     "RestrictionPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1583,
+      "line": 1590,
       "doc": "Identifies which players are affected by a temporary game restriction.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 1584,
+          "line": 1591,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27436,7 +27803,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 1585,
+          "line": 1592,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27444,7 +27811,7 @@
         },
         {
           "name": "TargetedPlayer",
-          "line": 1588,
+          "line": 1595,
           "kind": "unit",
           "field_names": [],
           "doc": "Placeholder used by parser lowering for effects that target a player. Resolved to `SpecificPlayer` by `add_restriction` at resolution time.",
@@ -27452,7 +27819,7 @@
         },
         {
           "name": "ParentTargetedPlayer",
-          "line": 1593,
+          "line": 1600,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Anaphoric \"that player\" in a sub-ability reuses a player target already chosen for an earlier instruction in the same chain. Resolved to `SpecificPlayer` by `add_restriction` after parent target propagation, without declaring a second target slot.",
@@ -27462,7 +27829,7 @@
         },
         {
           "name": "OpponentsOfSourceController",
-          "line": 1594,
+          "line": 1601,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27473,13 +27840,13 @@
     },
     "RestrictionScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1574,
+      "line": 1581,
       "doc": "Limits the scope of a game restriction to specific sources or targets.",
       "cr_refs": [],
       "variants": [
         {
           "name": "SourcesControlledBy",
-          "line": 1575,
+          "line": 1582,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27487,7 +27854,7 @@
         },
         {
           "name": "SpecificSource",
-          "line": 1576,
+          "line": 1583,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27495,7 +27862,7 @@
         },
         {
           "name": "DamageToTarget",
-          "line": 1577,
+          "line": 1584,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27506,7 +27873,7 @@
     },
     "RetargetScope": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4065,
+      "line": 4152,
       "doc": "CR 115.7: Scope of retargeting — single target, all targets, or forced.",
       "cr_refs": [
         "CR 115.7"
@@ -27514,7 +27881,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 4066,
+          "line": 4153,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27522,7 +27889,7 @@
         },
         {
           "name": "All",
-          "line": 4067,
+          "line": 4154,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27530,7 +27897,7 @@
         },
         {
           "name": "ForcedTo",
-          "line": 4068,
+          "line": 4155,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27541,7 +27908,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3988,
+      "line": 4119,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -27549,7 +27916,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 3989,
+          "line": 4120,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27557,7 +27924,7 @@
         },
         {
           "name": "Down",
-          "line": 3990,
+          "line": 4121,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27568,7 +27935,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5386,
+      "line": 5552,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -27576,7 +27943,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 5388,
+          "line": 5554,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -27587,7 +27954,7 @@
     },
     "SacrificeAggregateStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5505,
+      "line": 5671,
       "doc": "CR 701.21: Aggregate statistic for a sacrifice-cost selection constraint.",
       "cr_refs": [
         "CR 701.21"
@@ -27595,7 +27962,7 @@
       "variants": [
         {
           "name": "TotalPower",
-          "line": 5506,
+          "line": 5672,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27606,7 +27973,7 @@
     },
     "SacrificeRequirement": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5512,
+      "line": 5678,
       "doc": "CR 701.21: How many permanents must be sacrificed, or what aggregate constraint the chosen set must satisfy (Phyrexian Dreadnought).",
       "cr_refs": [
         "CR 701.21"
@@ -27614,7 +27981,7 @@
       "variants": [
         {
           "name": "Count",
-          "line": 5514,
+          "line": 5680,
           "kind": "struct",
           "field_names": [
             "count"
@@ -27624,7 +27991,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 5518,
+          "line": 5684,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -27639,13 +28006,13 @@
     },
     "SearchSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 96,
+      "line": 103,
       "doc": "Selection constraint applied to multi-card library searches at the `WaitingFor::SearchChoice` step. Lives one abstraction up from `count` / `up_to` so the engine can reject illegal combinations and the AI can prune its candidate space without bespoke per-card knowledge.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 99,
+          "line": 106,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: No restriction beyond `count` (and `up_to`).",
@@ -27655,7 +28022,7 @@
         },
         {
           "name": "DistinctQualities",
-          "line": 104,
+          "line": 111,
           "kind": "struct",
           "field_names": [
             "qualities"
@@ -27667,7 +28034,7 @@
         },
         {
           "name": "TotalManaValue",
-          "line": 109,
+          "line": 116,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -27681,7 +28048,7 @@
         },
         {
           "name": "MatchEachFilter",
-          "line": 114,
+          "line": 121,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -27697,7 +28064,7 @@
     },
     "SeatDirection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4073,
+      "line": 4204,
       "doc": "CR 102.1 + CR 103.1: Seating direction relative to a player. The game's default turn order proceeds clockwise (CR 103.1); the next player in turn order is seated to the active player's left (CR 101.4). Thus walking forward through `seat_order` is `Left`, and walking backward is `Right`.",
       "cr_refs": [
         "CR 101.4",
@@ -27707,7 +28074,7 @@
       "variants": [
         {
           "name": "Left",
-          "line": 4076,
+          "line": 4207,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's left — the next player in turn order (CR 101.4). Forward through `seat_order`.",
@@ -27717,7 +28084,7 @@
         },
         {
           "name": "Right",
-          "line": 4079,
+          "line": 4210,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's right — the previous player in turn order. Backward through `seat_order`.",
@@ -27728,7 +28095,7 @@
     },
     "ShardChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2044,
+      "line": 2113,
       "doc": "CR 107.4f + CR 601.2f: The caster's resolved choice for one Phyrexian shard.",
       "cr_refs": [
         "CR 107.4f",
@@ -27737,7 +28104,7 @@
       "variants": [
         {
           "name": "PayMana",
-          "line": 2046,
+          "line": 2115,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay one mana of the shard's color (or either component color for hybrid-Phyrexian).",
@@ -27745,7 +28112,7 @@
         },
         {
           "name": "PayLife",
-          "line": 2048,
+          "line": 2117,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay 2 life.",
@@ -27756,7 +28123,7 @@
     },
     "ShardOptions": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2032,
+      "line": 2101,
       "doc": "CR 107.4f + CR 601.2h: Which legal payments a single Phyrexian shard offers to the caster. Computed from the mana pool state (Phyrexian color availability) combined with the caster's life total and CantLoseLife status (CR 118.3 + CR 119.8).  The engine pauses at `WaitingFor::PhyrexianPayment` whenever any shard would deduct life — both `ManaOrLife` (player explicitly picks mana vs life) and `LifeOnly` (life is the only remaining payment route; player confirms or cancels via `CancelCast`). Only `ManaOnly` shards auto-resolve without surfacing the prompt, since they have no life consequence (issue #704: silent life deduction violated CR 601.2h's right to refuse the cast).",
       "cr_refs": [
         "CR 107.4f",
@@ -27767,7 +28134,7 @@
       "variants": [
         {
           "name": "ManaOrLife",
-          "line": 2034,
+          "line": 2103,
           "kind": "unit",
           "field_names": [],
           "doc": "Both mana and 2 life are legal payments; player must choose.",
@@ -27775,7 +28142,7 @@
         },
         {
           "name": "ManaOnly",
-          "line": 2036,
+          "line": 2105,
           "kind": "unit",
           "field_names": [],
           "doc": "Only mana is legal (insufficient life or CR 119.8 CantLoseLife lock).",
@@ -27785,7 +28152,7 @@
         },
         {
           "name": "LifeOnly",
-          "line": 2038,
+          "line": 2107,
           "kind": "unit",
           "field_names": [],
           "doc": "Only 2 life is legal (no mana of the shard's color available, given restrictions).",
@@ -27796,13 +28163,13 @@
     },
     "SharedQuality": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2154,
+      "line": 2171,
       "doc": "Qualities that can be shared across multi-target selections. Used by `FilterProp::SharesQuality` for group constraint validation at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Name",
-          "line": 2156,
+          "line": 2173,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: object names compared by shared name.",
@@ -27812,7 +28179,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 2158,
+          "line": 2175,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: mana value.",
@@ -27822,7 +28189,7 @@
         },
         {
           "name": "Power",
-          "line": 2160,
+          "line": 2177,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: power.",
@@ -27832,7 +28199,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2162,
+          "line": 2179,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: toughness.",
@@ -27842,7 +28209,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 2164,
+          "line": 2181,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: sum of power and toughness.",
@@ -27852,7 +28219,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 2165,
+          "line": 2182,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27860,7 +28227,7 @@
         },
         {
           "name": "Color",
-          "line": 2166,
+          "line": 2183,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27868,7 +28235,7 @@
         },
         {
           "name": "CardType",
-          "line": 2167,
+          "line": 2184,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27876,7 +28243,7 @@
         },
         {
           "name": "LandType",
-          "line": 2169,
+          "line": 2186,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.6: land subtypes, including the five basic land types.",
@@ -27890,13 +28257,13 @@
     },
     "SharedQualityRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2174,
+      "line": 2191,
       "doc": "Relationship required by `FilterProp::SharesQuality`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Shares",
-          "line": 2176,
+          "line": 2193,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27904,7 +28271,7 @@
         },
         {
           "name": "DoesNotShare",
-          "line": 2177,
+          "line": 2194,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27915,13 +28282,13 @@
     },
     "ShieldKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 556,
+      "line": 563,
       "doc": "Shield type for one-shot replacement effects that expire at cleanup.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 558,
+          "line": 565,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27929,7 +28296,7 @@
         },
         {
           "name": "Regeneration",
-          "line": 560,
+          "line": 567,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.19a: Regeneration shield — consumed on use, expires at cleanup.",
@@ -27939,7 +28306,7 @@
         },
         {
           "name": "Prevention",
-          "line": 562,
+          "line": 569,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -27951,7 +28318,7 @@
         },
         {
           "name": "DamageReplacementOneShot",
-          "line": 569,
+          "line": 576,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.5 + CR 614.1a: One-shot damage-amount replacement created by an effect (\"the next time ... would deal damage this turn, it deals double that damage instead\" — Desperate Gambit). Gets one opportunity to affect a damage event, is consumed on use, and expires at cleanup. Distinct from a continuous static `damage_modification` (Furnace of Rath), which keeps `ShieldKind::None` and re-applies to every damage event.",
@@ -27962,7 +28329,7 @@
         },
         {
           "name": "Redirection",
-          "line": 574,
+          "line": 581,
           "kind": "struct",
           "field_names": [
             "recipient",
@@ -28014,7 +28381,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4695,
+      "line": 4826,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -28023,7 +28390,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 4697,
+          "line": 4828,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -28035,7 +28402,7 @@
         },
         {
           "name": "Condition",
-          "line": 4707,
+          "line": 4838,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -28047,7 +28414,7 @@
         },
         {
           "name": "Text",
-          "line": 4709,
+          "line": 4840,
           "kind": "struct",
           "field_names": [
             "description"
@@ -28060,13 +28427,13 @@
     },
     "SourceExclusion": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2888,
+      "line": 2950,
       "doc": "Whether a filter predicate includes or excludes the ability source object.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Include",
-          "line": 2891,
+          "line": 2953,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object may satisfy the predicate.",
@@ -28074,7 +28441,7 @@
         },
         {
           "name": "Exclude",
-          "line": 2893,
+          "line": 2955,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object is excluded (\"another Aura/Equipment\" semantics).",
@@ -28085,7 +28452,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6584,
+      "line": 6750,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -28093,7 +28460,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 6586,
+          "line": 6752,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -28103,7 +28470,7 @@
         },
         {
           "name": "Decrease",
-          "line": 6588,
+          "line": 6754,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -28116,13 +28483,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6264,
+      "line": 6430,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 6265,
+          "line": 6431,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28130,7 +28497,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 6266,
+          "line": 6432,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28138,7 +28505,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 6267,
+          "line": 6433,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28146,7 +28513,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 6269,
+          "line": 6435,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -28159,7 +28526,7 @@
     },
     "SpellCostSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2426,
+      "line": 2495,
       "doc": "CR 601.2h + CR 702.48c: Identifies which spell-cost component a `WaitingFor::PayCost` choice is paying when the same `AbilityCost` shape can come from different rules.",
       "cr_refs": [
         "CR 601.2h",
@@ -28168,7 +28535,7 @@
       "variants": [
         {
           "name": "Other",
-          "line": 2428,
+          "line": 2497,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28176,7 +28543,7 @@
         },
         {
           "name": "Offering",
-          "line": 2429,
+          "line": 2498,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28184,7 +28551,35 @@
         },
         {
           "name": "Emerge",
-          "line": 2430,
+          "line": 2499,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "StackAbilityKind": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 3039,
+      "doc": "CR 113.3b / CR 113.3c: Which stack ability kinds a `StackAbility` filter accepts.",
+      "cr_refs": [
+        "CR 113.3b",
+        "CR 113.3c"
+      ],
+      "variants": [
+        {
+          "name": "Activated",
+          "line": 3040,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Triggered",
+          "line": 3041,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28195,13 +28590,13 @@
     },
     "StackEntryKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4989,
+      "line": 5076,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 4990,
+          "line": 5077,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -28214,7 +28609,7 @@
         },
         {
           "name": "ActivatedAbility",
-          "line": 5004,
+          "line": 5091,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -28225,7 +28620,7 @@
         },
         {
           "name": "TriggeredAbility",
-          "line": 5008,
+          "line": 5095,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -28242,7 +28637,7 @@
         },
         {
           "name": "KeywordAction",
-          "line": 5051,
+          "line": 5138,
           "kind": "struct",
           "field_names": [
             "action"
@@ -28258,13 +28653,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4775,
+      "line": 4906,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 4776,
+          "line": 4907,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -28275,7 +28670,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 4780,
+          "line": 4911,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28285,7 +28680,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 4786,
+          "line": 4917,
           "kind": "struct",
           "field_names": [
             "color"
@@ -28295,7 +28690,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 4795,
+          "line": 4926,
           "kind": "struct",
           "field_names": [
             "label"
@@ -28308,7 +28703,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4801,
+          "line": 4932,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -28320,7 +28715,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 4807,
+          "line": 4938,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -28330,7 +28725,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 4809,
+          "line": 4940,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -28343,7 +28738,7 @@
         },
         {
           "name": "And",
-          "line": 4813,
+          "line": 4944,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -28353,7 +28748,7 @@
         },
         {
           "name": "Or",
-          "line": 4817,
+          "line": 4948,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -28363,7 +28758,7 @@
         },
         {
           "name": "Not",
-          "line": 4823,
+          "line": 4954,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -28373,7 +28768,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 4827,
+          "line": 4958,
           "kind": "struct",
           "field_names": [
             "state"
@@ -28385,7 +28780,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 4836,
+          "line": 4967,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -28401,7 +28796,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 4846,
+          "line": 4977,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28414,7 +28809,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 4854,
+          "line": 4985,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -28429,7 +28824,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 4862,
+          "line": 4993,
           "kind": "struct",
           "field_names": [
             "level"
@@ -28441,7 +28836,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 4869,
+          "line": 5000,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28453,7 +28848,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 4873,
+          "line": 5004,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -28463,7 +28858,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 4877,
+          "line": 5008,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -28474,7 +28869,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 4881,
+          "line": 5012,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -28485,7 +28880,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 4885,
+          "line": 5016,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -28495,7 +28890,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 4887,
+          "line": 5018,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -28505,7 +28900,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 4889,
+          "line": 5020,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: True when the controller has the initiative.",
@@ -28515,7 +28910,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 4892,
+          "line": 5023,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -28525,7 +28920,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 4894,
+          "line": 5025,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -28535,7 +28930,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 4897,
+          "line": 5028,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -28545,7 +28940,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 4903,
+          "line": 5034,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -28557,7 +28952,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 4911,
+          "line": 5042,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28569,7 +28964,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 4915,
+          "line": 5046,
           "kind": "struct",
           "field_names": [
             "count"
@@ -28581,7 +28976,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 4940,
+          "line": 5071,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -28599,7 +28994,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 4949,
+          "line": 5080,
           "kind": "struct",
           "field_names": [
             "text"
@@ -28609,7 +29004,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 4952,
+          "line": 5083,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28617,7 +29012,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 4955,
+          "line": 5086,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -28627,7 +29022,7 @@
         },
         {
           "name": "SourceHasDealtDamage",
-          "line": 4964,
+          "line": 5095,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.1 + CR 120.3/120.6 + CR 702.11b + CR 613.1f: True once the source permanent has actually dealt damage (combat or noncombat) since it entered the battlefield. Sticky per-object flag (set on the first nonzero amount of damage actually dealt per CR 120.3/120.6, not the would-be amount of CR 120.1a; reset when the object leaves the battlefield). Used as a Layer 6 (CR 613.1f) ability-adding gate for \"has hexproof if it hasn't dealt damage yet\" (Palladia-Mors, the Ruiner; Karakyk Guardian). The \"hasn't\" negation wraps this in `StaticCondition::Not`.",
@@ -28641,7 +29036,7 @@
         },
         {
           "name": "WasCast",
-          "line": 4969,
+          "line": 5100,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -28654,7 +29049,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 4974,
+          "line": 5105,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -28664,7 +29059,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 4976,
+          "line": 5107,
           "kind": "struct",
           "field_names": [
             "level"
@@ -28676,7 +29071,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 4982,
+          "line": 5113,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -28690,7 +29085,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 4987,
+          "line": 5118,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -28699,8 +29094,22 @@
           ]
         },
         {
+          "name": "IsTapped",
+          "line": 5135,
+          "kind": "struct",
+          "field_names": [
+            "scope"
+          ],
+          "doc": "CR 110.5b + CR 110.5d: True when a scope-resolved object is on the battlefield AND tapped. Scope-parameterized sibling of `SourceIsTapped`.  `SourceIsTapped` is intentionally retained as the canonical `scope: Source` spelling: it lives on three enums (`StaticCondition`, `AbilityCondition`, `TriggerCondition`) plus `TriggerCondition::ZoneChangeObjectIsTapped`, so a full collapse into `IsTapped { scope: Source }` would be a cross-enum rename. This asymmetry (source = `SourceIsTapped`, non-source = `IsTapped { scope }`) mirrors the `QuantityRef::Power { scope }` precedent: tap status is a single CR 110.5 status category, so the scope axis lies wholly within one rule section (no categorical-boundary violation).  The parser emits this only for demonstrative subjects (\"for as long as THAT creature remains tapped\" — Zygon Infiltrator's copy duration, where the tracked object is the copy *target*, not the source). Negation is `Not { Box::new(IsTapped { scope }) }`.",
+          "cr_refs": [
+            "CR 110.5",
+            "CR 110.5b",
+            "CR 110.5d"
+          ]
+        },
+        {
           "name": "SourceIsSaddled",
-          "line": 4989,
+          "line": 5139,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: True when the source permanent is saddled. Negation via Not { SourceIsSaddled }.",
@@ -28710,7 +29119,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 4996,
+          "line": 5146,
           "kind": "struct",
           "field_names": [
             "player"
@@ -28723,7 +29132,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 5001,
+          "line": 5151,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -28733,7 +29142,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 5005,
+          "line": 5155,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -28743,7 +29152,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 5009,
+          "line": 5159,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -28754,7 +29163,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 5013,
+          "line": 5163,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28766,7 +29175,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 5025,
+          "line": 5175,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28777,8 +29186,23 @@
           ]
         },
         {
+          "name": "RecipientAttackingOwnerTarget",
+          "line": 5191,
+          "kind": "struct",
+          "field_names": [
+            "target"
+          ],
+          "doc": "CR 509.1b + CR 506.2 + CR 108.3: True when the recipient creature (the per-object subject of the continuous effect — i.e. the attacking creature this static is gating) is currently attacking a target permitted by `target`, evaluated relative to the recipient's OWNER (CR 108.3), not its controller. Used to express \"can't be blocked unless it's attacking its owner or a permanent its owner controls\" by wrapping this in `StaticCondition::Not` (the \"unless\"): the creature is unblockable except when attacking its owner or a permanent its owner controls. Recipient-scoped (mirrors `RecipientMatchesFilter`/`RecipientHasCounters`); the affected (attacking) creature is supplied as the recipient by the block-restriction gate in `combat.rs`. `target` reuses `AttackTargetFilter` — the same owner-relative axis as the attack-side \"can't attack its owner …\" restriction (CR 506.2 / CR 508.1).",
+          "cr_refs": [
+            "CR 108.3",
+            "CR 506.2",
+            "CR 508.1",
+            "CR 509.1b"
+          ]
+        },
+        {
           "name": "SourceIsPaired",
-          "line": 5029,
+          "line": 5195,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -28788,7 +29212,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 5032,
+          "line": 5198,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -28800,7 +29224,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 5038,
+          "line": 5204,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -28811,7 +29235,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 5043,
+          "line": 5209,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ModifyCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -28822,14 +29246,23 @@
         },
         {
           "name": "None",
-          "line": 5044,
+          "line": 5210,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         }
       ],
-      "sibling_clusters": []
+      "sibling_clusters": [
+        {
+          "shared_root": "IsTapped",
+          "members": [
+            "IsTapped",
+            "SourceIsTapped"
+          ],
+          "smell_score": "LOW"
+        }
+      ]
     },
     "StaticMode": {
       "file": "crates/engine/src/types/statics.rs",
@@ -28974,8 +29407,22 @@
           ]
         },
         {
+          "name": "GrantsExtraVillainousChoice",
+          "line": 707,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.55c: A replacement effect causes an opponent who would face a villainous choice to face that choice some number of additional times (The Valeyard — \"If an opponent would face a villainous choice, they face that choice an additional time.\"). Each active source controlled by an opponent of the facing player adds +1 additional villainous-choice instance for that player; the whole CR 701.55a process is then performed that many additional times, one at a time (CR 701.55c). Parallel to `GrantsExtraVote` (CR 701.38d), but counts a different keyword action read by a different resolver (`choose_one_of`), so the two are not unifiable (categorical-boundary rule: CR 701.55 vs CR 701.38 are separate sections). Like `GrantsExtraVote`, it does not feed into layer 7 — there is no continuous P/T or keyword grant.",
+          "cr_refs": [
+            "CR 701.38",
+            "CR 701.38d",
+            "CR 701.55",
+            "CR 701.55a",
+            "CR 701.55c"
+          ]
+        },
+        {
           "name": "CastWithKeyword",
-          "line": 698,
+          "line": 711,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -28987,7 +29434,7 @@
         },
         {
           "name": "CastWithAlternativeCost",
-          "line": 711,
+          "line": 724,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -29002,7 +29449,7 @@
         },
         {
           "name": "AlternativeKeywordCost",
-          "line": 726,
+          "line": 739,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -29018,7 +29465,7 @@
         },
         {
           "name": "ModifyCost",
-          "line": 736,
+          "line": 749,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -29033,7 +29480,7 @@
         },
         {
           "name": "ImposeAdditionalCost",
-          "line": 750,
+          "line": 763,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -29048,7 +29495,7 @@
         },
         {
           "name": "ReduceAbilityCost",
-          "line": 759,
+          "line": 772,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -29063,7 +29510,7 @@
         },
         {
           "name": "ModifyActivationLimit",
-          "line": 774,
+          "line": 787,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -29076,7 +29523,7 @@
         },
         {
           "name": "ActivateAsInstant",
-          "line": 784,
+          "line": 797,
           "kind": "struct",
           "field_names": [
             "cost_category"
@@ -29089,7 +29536,7 @@
         },
         {
           "name": "CantPayCost",
-          "line": 794,
+          "line": 807,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29104,7 +29551,7 @@
         },
         {
           "name": "CantGainLife",
-          "line": 798,
+          "line": 811,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29112,7 +29559,7 @@
         },
         {
           "name": "CantLoseLife",
-          "line": 799,
+          "line": 812,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29120,7 +29567,7 @@
         },
         {
           "name": "PlayerProtection",
-          "line": 808,
+          "line": 821,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.16: The scoped player(s) have protection from a quality — e.g. Serra's Emissary's \"You ... have protection from the chosen card type.\" Player scope rides on `StaticDefinition::affected` (identical to `CantGainLife`); `ProtectionTarget` is the canonical protection-quality axis. Data-carrying variant — not registry-registered (see `coverage::is_data_carrying_static`); consumed by direct pattern-match in `player_protection_from`. Only the `ChosenCardType` arm is runtime-implemented; other arms are inert.",
@@ -29130,7 +29577,7 @@
         },
         {
           "name": "MustAttack",
-          "line": 809,
+          "line": 822,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29138,7 +29585,7 @@
         },
         {
           "name": "MustAttackPlayer",
-          "line": 817,
+          "line": 830,
           "kind": "struct",
           "field_names": [
             "player"
@@ -29150,7 +29597,7 @@
         },
         {
           "name": "MustBlock",
-          "line": 820,
+          "line": 833,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29158,7 +29605,7 @@
         },
         {
           "name": "MustBlockAttacker",
-          "line": 828,
+          "line": 841,
           "kind": "struct",
           "field_names": [
             "attacker"
@@ -29171,7 +29618,7 @@
         },
         {
           "name": "CantDraw",
-          "line": 831,
+          "line": 844,
           "kind": "struct",
           "field_names": [
             "who"
@@ -29181,7 +29628,7 @@
         },
         {
           "name": "DoubleTriggers",
-          "line": 838,
+          "line": 851,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -29193,7 +29640,7 @@
         },
         {
           "name": "IgnoreHexproof",
-          "line": 841,
+          "line": 854,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29201,7 +29648,7 @@
         },
         {
           "name": "ExtraBlockers",
-          "line": 844,
+          "line": 857,
           "kind": "struct",
           "field_names": [
             "count"
@@ -29214,7 +29661,7 @@
         },
         {
           "name": "RevealTopOfLibrary",
-          "line": 849,
+          "line": 862,
           "kind": "struct",
           "field_names": [
             "all_players"
@@ -29226,7 +29673,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 854,
+          "line": 867,
           "kind": "struct",
           "field_names": [
             "who"
@@ -29239,7 +29686,7 @@
         },
         {
           "name": "GraveyardCastPermission",
-          "line": 859,
+          "line": 872,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -29254,7 +29701,7 @@
         },
         {
           "name": "TopOfLibraryCastPermission",
-          "line": 889,
+          "line": 902,
           "kind": "struct",
           "field_names": [
             "play_mode",
@@ -29269,7 +29716,7 @@
         },
         {
           "name": "CastFromHandFree",
-          "line": 906,
+          "line": 919,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -29283,7 +29730,7 @@
         },
         {
           "name": "ExileCastPermission",
-          "line": 937,
+          "line": 950,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -29301,7 +29748,7 @@
         },
         {
           "name": "LinkedCollectionCounterPlayPermission",
-          "line": 990,
+          "line": 1003,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6 + CR 601.2a: Marker static identifying a source whose linked \"play a card from exile with a collection counter on it\" permission is live (Evelyn, the Covetous). Per CR 113.6, that play permission is a static ability of the source and functions only while the source is on the battlefield under the player's control; this marker is what `casting.rs::source_has_collection_counter_play_permission` consults so the per-card `CastingPermission::PlayFromExile` (collection-counter + controller provenance) is honored only while a live source remains. CR 601.2a: the permission authorizes moving a matching exiled card to the stack / battlefield (playing it).  Distinct from `ExileCastPermission`: that static is self-contained and grants the cast itself, keyed on a source-identity exile pool. This is a nullary marker; the actual permission lives on each exiled card as a `CastingPermission::PlayFromExile`, linked by the collection counter (not source identity), so the authority winks out if every source leaves but the counter persists.  RUNTIME: handled by direct match in `casting.rs::source_has_collection_counter_play_permission`; coverage support is via `is_data_carrying_static()` (mirrors the cast-permission cluster, which is also runtime-by-direct-match, not registry-keyed).",
@@ -29311,8 +29758,21 @@
           ]
         },
         {
+          "name": "CountersPersistAcrossZones",
+          "line": 1020,
+          "kind": "struct",
+          "field_names": [
+            "excluded_zones"
+          ],
+          "doc": "CR 122.2 + CR 113.6b: Override the default rule that counters cease to exist when an object changes zones. This source's counters *remain* as it moves to any zone NOT listed in `excluded_zones`; moves into an excluded zone follow the normal CR 122.2 clear.  Class members (verbatim \"Counters remain on [self] as it moves to any zone other than a player's hand or library\"): Me, the Immortal and Skullbriar, the Walking Grave. Both encode `excluded_zones = [Hand, Library]` — counters persist into the battlefield, graveyard, exile, and command zone, but are cleared into a hand or library (CR 122.2 still applies there).  CR 113.6b: This ability states the zones it functions from implicitly — per Me's official ruling (\"only works if it has that ability in the zone it's moving from\"), the persistence is read from the object's state in the *from*-zone at the moment of the move, not the destination.",
+          "cr_refs": [
+            "CR 113.6b",
+            "CR 122.2"
+          ]
+        },
+        {
           "name": "CantBeCountered",
-          "line": 992,
+          "line": 1028,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2: This spell/permanent can't be countered.",
@@ -29322,7 +29782,7 @@
         },
         {
           "name": "CantBeCopied",
-          "line": 995,
+          "line": 1031,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2 + CR 707.10: This spell can't be copied by spells or abilities. Enforced in `copy_spell::resolve` when selecting the spell to copy.",
@@ -29333,7 +29793,7 @@
         },
         {
           "name": "CantEnterBattlefieldFrom",
-          "line": 997,
+          "line": 1033,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 604.3: Cards in specified zones can't enter the battlefield.",
@@ -29343,7 +29803,7 @@
         },
         {
           "name": "CantCastFrom",
-          "line": 1017,
+          "line": 1053,
           "kind": "struct",
           "field_names": [
             "who"
@@ -29357,7 +29817,7 @@
         },
         {
           "name": "CantCastDuring",
-          "line": 1023,
+          "line": 1059,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29370,7 +29830,7 @@
         },
         {
           "name": "CantActivateDuring",
-          "line": 1050,
+          "line": 1086,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29388,7 +29848,7 @@
         },
         {
           "name": "PerTurnCastLimit",
-          "line": 1060,
+          "line": 1096,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29403,7 +29863,7 @@
         },
         {
           "name": "PerTurnDrawLimit",
-          "line": 1068,
+          "line": 1104,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29416,7 +29876,7 @@
         },
         {
           "name": "SuppressTriggers",
-          "line": 1095,
+          "line": 1131,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -29431,7 +29891,7 @@
         },
         {
           "name": "CantBeBlocked",
-          "line": 1102,
+          "line": 1138,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: This creature can't be blocked.",
@@ -29441,7 +29901,7 @@
         },
         {
           "name": "CantBeBlockedExceptBy",
-          "line": 1104,
+          "line": 1140,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -29453,7 +29913,7 @@
         },
         {
           "name": "CantBeBlockedBy",
-          "line": 1109,
+          "line": 1145,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29465,7 +29925,7 @@
         },
         {
           "name": "CantBeBlockedByMoreThan",
-          "line": 1117,
+          "line": 1153,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29477,7 +29937,7 @@
         },
         {
           "name": "AttachmentRestriction",
-          "line": 1137,
+          "line": 1173,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29493,7 +29953,7 @@
         },
         {
           "name": "Protection",
-          "line": 1141,
+          "line": 1177,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16: Protection prevents targeting, blocking, damage, and attachment.",
@@ -29503,7 +29963,7 @@
         },
         {
           "name": "Indestructible",
-          "line": 1143,
+          "line": 1179,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.12: Indestructible — prevents destruction by lethal damage and destroy effects.",
@@ -29513,7 +29973,7 @@
         },
         {
           "name": "CantBeDestroyed",
-          "line": 1145,
+          "line": 1181,
           "kind": "unit",
           "field_names": [],
           "doc": "Permanent cannot be destroyed (distinct from Indestructible).",
@@ -29521,7 +29981,7 @@
         },
         {
           "name": "CantBeRegenerated",
-          "line": 1157,
+          "line": 1193,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.19c: \"[Permanent] can't be regenerated [this turn].\" This does not stop regeneration abilities from being activated or shields from being created; rather, it causes regeneration shields to not be applied the next time the affected permanent would be destroyed. The per-target `StaticDefinition::affected` filter carries which permanent is marked; runtime enforcement bypasses the regen shield in `replacement.rs::destroy_applier` (CR 701.19). Distinct from `CantBeDestroyed` (which prevents destruction outright) and the inline `Effect::Destroy { cant_regenerate }` (the \"Destroy X. It can't be regenerated.\" one-shot) — this is the standalone, until-end-of-turn form (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort).",
@@ -29532,7 +29992,7 @@
         },
         {
           "name": "FlashBack",
-          "line": 1159,
+          "line": 1195,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34: Flashback — allows casting from graveyard, exiled after resolution.",
@@ -29542,7 +30002,7 @@
         },
         {
           "name": "Shroud",
-          "line": 1161,
+          "line": 1197,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.18: Shroud — permanent cannot be the target of spells or abilities.",
@@ -29552,7 +30012,7 @@
         },
         {
           "name": "Hexproof",
-          "line": 1166,
+          "line": 1202,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.11: Hexproof — affected player/permanent cannot be the target of spells or abilities an opponent controls. Applied at the player scope (\"You have hexproof.\") mirroring `Shroud`; permanent-scope hexproof grants flow through `ContinuousModification::AddKeyword` instead.",
@@ -29562,7 +30022,7 @@
         },
         {
           "name": "Vigilance",
-          "line": 1168,
+          "line": 1204,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.20: Vigilance — attacking doesn't cause this creature to tap.",
@@ -29572,7 +30032,7 @@
         },
         {
           "name": "Menace",
-          "line": 1170,
+          "line": 1206,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.111: Menace — can't be blocked except by two or more creatures.",
@@ -29582,7 +30042,7 @@
         },
         {
           "name": "Reach",
-          "line": 1172,
+          "line": 1208,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.17: Reach — can block creatures with flying.",
@@ -29592,7 +30052,7 @@
         },
         {
           "name": "Flying",
-          "line": 1174,
+          "line": 1210,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.9: Flying — can't be blocked except by creatures with flying or reach.",
@@ -29602,7 +30062,7 @@
         },
         {
           "name": "Trample",
-          "line": 1176,
+          "line": 1212,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.19: Trample — excess combat damage is assigned to the defending player.",
@@ -29612,7 +30072,7 @@
         },
         {
           "name": "Deathtouch",
-          "line": 1178,
+          "line": 1214,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.2: Deathtouch — any amount of damage dealt is lethal.",
@@ -29622,7 +30082,7 @@
         },
         {
           "name": "Lifelink",
-          "line": 1180,
+          "line": 1216,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.15: Lifelink — damage dealt also causes controller to gain that much life.",
@@ -29632,7 +30092,7 @@
         },
         {
           "name": "CantTap",
-          "line": 1183,
+          "line": 1219,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29640,7 +30100,7 @@
         },
         {
           "name": "CantUntap",
-          "line": 1184,
+          "line": 1220,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29648,7 +30108,7 @@
         },
         {
           "name": "MustBeBlocked",
-          "line": 1187,
+          "line": 1223,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: This creature must be blocked if able — the defending player must assign at least one legal blocker to it.",
@@ -29658,7 +30118,7 @@
         },
         {
           "name": "MustBeBlockedByAll",
-          "line": 1193,
+          "line": 1229,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: \"All creatures able to block this creature do so\" (Lure, Prized Unicorn, Breaker of Armies, …). Unlike [`MustBeBlocked`], this places a block requirement on *every* creature able to block it: each such untapped defender must be declared as a blocker of this attacker, not merely one.",
@@ -29668,7 +30128,7 @@
         },
         {
           "name": "Goaded",
-          "line": 1197,
+          "line": 1233,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.15b: This creature is goaded for as long as the static applies. The source controller is the goading player for the \"attack another player if able\" requirement.",
@@ -29678,7 +30138,7 @@
         },
         {
           "name": "CombatAlone",
-          "line": 1205,
+          "line": 1241,
           "kind": "struct",
           "field_names": [
             "action",
@@ -29693,7 +30153,7 @@
         },
         {
           "name": "CantCrew",
-          "line": 1210,
+          "line": 1246,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122c: This creature can't crew Vehicles.",
@@ -29703,7 +30163,7 @@
         },
         {
           "name": "CrewContribution",
-          "line": 1216,
+          "line": 1252,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -29718,7 +30178,7 @@
         },
         {
           "name": "MayLookAtTopOfLibrary",
-          "line": 1220,
+          "line": 1256,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29726,7 +30186,7 @@
         },
         {
           "name": "MayChooseNotToUntap",
-          "line": 1224,
+          "line": 1260,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3: You may choose not to untap this permanent during your untap step.",
@@ -29736,7 +30196,7 @@
         },
         {
           "name": "AdditionalLandDrop",
-          "line": 1227,
+          "line": 1263,
           "kind": "struct",
           "field_names": [
             "count"
@@ -29748,7 +30208,7 @@
         },
         {
           "name": "EmblemStatic",
-          "line": 1230,
+          "line": 1266,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29756,7 +30216,7 @@
         },
         {
           "name": "BlockRestriction",
-          "line": 1233,
+          "line": 1269,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29768,7 +30228,7 @@
         },
         {
           "name": "NoMaximumHandSize",
-          "line": 1237,
+          "line": 1273,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 402.2: No maximum hand size.",
@@ -29778,7 +30238,7 @@
         },
         {
           "name": "MaximumHandSize",
-          "line": 1240,
+          "line": 1276,
           "kind": "struct",
           "field_names": [
             "modification"
@@ -29791,7 +30251,7 @@
         },
         {
           "name": "MayPlayAdditionalLand",
-          "line": 1243,
+          "line": 1279,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29799,7 +30259,7 @@
         },
         {
           "name": "CantHaveKeyword",
-          "line": 1247,
+          "line": 1283,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -29811,7 +30271,7 @@
         },
         {
           "name": "CantWinTheGame",
-          "line": 1252,
+          "line": 1288,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: This player can't win the game (Platinum Angel effect).",
@@ -29821,7 +30281,7 @@
         },
         {
           "name": "CantLoseTheGame",
-          "line": 1254,
+          "line": 1290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3b: This player can't lose the game (Platinum Angel effect).",
@@ -29831,7 +30291,7 @@
         },
         {
           "name": "LegendRuleDoesntApply",
-          "line": 1263,
+          "line": 1299,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 704.5j: The \"legend rule\" doesn't apply to the affected permanents, so they are excluded from the same-name legendary grouping in the legend-rule SBA. Scope rides on `StaticDefinition::affected`: `None` = global (Mirror Gallery, \"the legend rule doesn't apply\"); a controller-scoped filter = \"doesn't apply to [permanents/tokens/Slivers/commanders] you control\" (Sakashima of a Thousand Faces, Mirror Box, Cadric, Sliver Gravemother, Try-My-Deck Elemental, ...). Enforced per-permanent in `sba.rs` via `check_static_ability` with the candidate as the target object.",
@@ -29841,7 +30301,7 @@
         },
         {
           "name": "SpeedCanIncreaseBeyondFour",
-          "line": 1265,
+          "line": 1301,
           "kind": "unit",
           "field_names": [],
           "doc": "Speed may increase beyond 4, and 4+ still counts as max speed for that player.",
@@ -29849,7 +30309,7 @@
         },
         {
           "name": "DefilerCostReduction",
-          "line": 1269,
+          "line": 1305,
           "kind": "struct",
           "field_names": [
             "color",
@@ -29863,7 +30323,7 @@
         },
         {
           "name": "SkipStep",
-          "line": 1279,
+          "line": 1315,
           "kind": "struct",
           "field_names": [
             "step"
@@ -29876,7 +30336,7 @@
         },
         {
           "name": "SpendManaAsAnyColor",
-          "line": 1284,
+          "line": 1320,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.4b: \"You may spend mana as though it were mana of any color.\" Allows the controller to pay colored mana costs with mana of any color.",
@@ -29886,7 +30346,7 @@
         },
         {
           "name": "PayLifeAsColoredMana",
-          "line": 1296,
+          "line": 1332,
           "kind": "struct",
           "field_names": [
             "color"
@@ -29898,7 +30358,7 @@
         },
         {
           "name": "StepEndUnspentMana",
-          "line": 1310,
+          "line": 1346,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -29914,7 +30374,7 @@
         },
         {
           "name": "CanAttackWithDefender",
-          "line": 1316,
+          "line": 1352,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.3b: Allows creatures with defender to attack despite having the keyword. \"can attack as though it didn't have defender\" overrides the defender restriction.",
@@ -29924,7 +30384,7 @@
         },
         {
           "name": "IgnoreLandwalkForBlocking",
-          "line": 1333,
+          "line": 1369,
           "kind": "struct",
           "field_names": [
             "qualifier"
@@ -29939,7 +30399,7 @@
         },
         {
           "name": "CanActivateAbilitiesAsThoughHaste",
-          "line": 1341,
+          "line": 1377,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.5a: Bypasses the summoning-sickness gate on a creature's `{T}`/`{Q}` activated abilities — \"You may activate abilities of creatures you control as though those creatures had haste.\" This is NOT `AddKeyword(Haste)`: only the CR 602.5a activation restriction is lifted, combat attacker validation (CR 508.1a) is untouched. Canonical card: Tyvar, Jubilant Brawler.",
@@ -29950,7 +30410,7 @@
         },
         {
           "name": "CanBlockShadow",
-          "line": 1356,
+          "line": 1392,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b + CR 609.4 + CR 702.28b: Per-source block permission that lifts the shadow blocker-side restriction for the affected creature only — it may block creatures with shadow despite not having shadow itself. Shadow is the unique evasion keyword (CR 702.28b) with a symmetric \"without-shadow can't block with-shadow\" pairing, so this is keyword-specific (mirrors `CanAttackWithDefender`) rather than a generic keyword-parameterized form, which would cross keyword CR sections with distinct runtime resolvers.  Captures both printed phrasings of the same CR 509.1b outcome: \"can block creatures with shadow as though they didn't have shadow\" (Heartwood Dryad) and \"can block creatures with shadow as though it had shadow\" (Wall of Diffusion). `affected: SelfRef` (per-source, not the global rule modification `IgnoreLandwalkForBlocking` uses). Enforced inside the shadow block-legality seam in `combat.rs`, not as a layer-6 keyword grant.",
@@ -29962,7 +30422,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 1360,
+          "line": 1396,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage. Used for creatures like Ornithopter of Paradise and various Walls that can attack/block but deal 0 combat damage.",
@@ -29972,7 +30432,7 @@
         },
         {
           "name": "UntapsDuringEachOtherPlayersUntapStep",
-          "line": 1369,
+          "line": 1405,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3 + CR 113.6: Continuous static that grants a second untap pass during each OTHER player's untap step. The source's controller untaps the permanents matching `StaticDefinition.affected` — NOT the active player's permanents. Canonical card: Seedborn Muse (\"Untap all permanents you control during each other player's untap step.\"). Runtime: `turns::execute_untap` runs a second pass after the active player's normal untap, scanning the battlefield for this variant on permanents whose controller != active_player.",
@@ -29983,7 +30443,7 @@
         },
         {
           "name": "MaxUntapPerType",
-          "line": 1390,
+          "line": 1426,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -29996,7 +30456,7 @@
         },
         {
           "name": "EntersWithAdditionalCounters",
-          "line": 1413,
+          "line": 1449,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -30010,7 +30470,7 @@
         },
         {
           "name": "Other",
-          "line": 1418,
+          "line": 1454,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized static mode strings.",
@@ -30052,7 +30512,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6596,
+      "line": 6762,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -30061,7 +30521,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 6597,
+          "line": 6763,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30069,7 +30529,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 6598,
+          "line": 6764,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30080,7 +30540,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11725,
+      "line": 12021,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -30088,7 +30548,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 11733,
+          "line": 12029,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -30096,7 +30556,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 11738,
+          "line": 12034,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -30275,7 +30735,7 @@
     },
     "TapStateChange": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3228,
+      "line": 3310,
       "doc": "CR 701.26a (tap) / CR 701.26b (untap): Direction of an `Effect::SetTapState`. Parameterizes the tap/untap axis so a single effect variant covers both keyword actions.",
       "cr_refs": [
         "CR 701.26a",
@@ -30284,7 +30744,7 @@
       "variants": [
         {
           "name": "Tap",
-          "line": 3230,
+          "line": 3312,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26a: Turn the permanent sideways (tap it).",
@@ -30294,7 +30754,7 @@
         },
         {
           "name": "Untap",
-          "line": 3232,
+          "line": 3314,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26b: Rotate the permanent upright (untap it).",
@@ -30307,7 +30767,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11277,
+      "line": 11562,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -30317,7 +30777,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 11279,
+          "line": 11564,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30325,7 +30785,7 @@
         },
         {
           "name": "Resolution",
-          "line": 11280,
+          "line": 11565,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30336,13 +30796,13 @@
     },
     "TargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2977,
+      "line": 3047,
       "doc": "Typed target filter replacing all Forge filter strings and TargetSpec.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 2978,
+          "line": 3048,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30350,7 +30810,7 @@
         },
         {
           "name": "Any",
-          "line": 2979,
+          "line": 3049,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30358,7 +30818,7 @@
         },
         {
           "name": "Player",
-          "line": 2980,
+          "line": 3050,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30366,7 +30826,7 @@
         },
         {
           "name": "Controller",
-          "line": 2981,
+          "line": 3051,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30374,7 +30834,7 @@
         },
         {
           "name": "SelfRef",
-          "line": 2982,
+          "line": 3052,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30382,7 +30842,7 @@
         },
         {
           "name": "SourceOrPaired",
-          "line": 2985,
+          "line": 3055,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Resolves to the source object and the creature it is paired with. If the source is not paired, this matches no objects.",
@@ -30392,7 +30852,7 @@
         },
         {
           "name": "Typed",
-          "line": 2986,
+          "line": 3056,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30400,7 +30860,7 @@
         },
         {
           "name": "Not",
-          "line": 2987,
+          "line": 3057,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30410,7 +30870,7 @@
         },
         {
           "name": "Or",
-          "line": 2990,
+          "line": 3060,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -30420,7 +30880,7 @@
         },
         {
           "name": "And",
-          "line": 2993,
+          "line": 3063,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -30430,20 +30890,21 @@
         },
         {
           "name": "StackAbility",
-          "line": 3001,
+          "line": 3073,
           "kind": "struct",
           "field_names": [
             "controller",
-            "tag"
+            "tag",
+            "kind"
           ],
-          "doc": "Matches non-mana activated or triggered abilities on the stack. Used by \"counter target activated or triggered ability\" effects. CR 113.7a: once activated or triggered, an ability exists on the stack independently of its source — `tag` matches by keyword-origin marker (e.g. `AbilityTag::Backup` for \"becomes the target of a backup ability\").",
+          "doc": "Matches non-mana activated or triggered abilities on the stack. Used by \"counter target activated or triggered ability\" effects. CR 113.7a: once activated or triggered, an ability exists on the stack independently of its source — `tag` matches by keyword-origin marker (e.g. `AbilityTag::Backup` for \"becomes the target of a backup ability\"). `kind` narrows to one ability class when the Oracle text does (Consign to Memory's \"triggered ability\" leg); `None` accepts both.",
           "cr_refs": [
             "CR 113.7a"
           ]
         },
         {
           "name": "StackSpell",
-          "line": 3009,
+          "line": 3083,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches spells on the stack (not activated/triggered abilities). CR 115.1a: Used by \"becomes the target of a spell\" triggers to filter source type.",
@@ -30453,7 +30914,7 @@
         },
         {
           "name": "SpecificObject",
-          "line": 3013,
+          "line": 3087,
           "kind": "struct",
           "field_names": [
             "id"
@@ -30463,7 +30924,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 3021,
+          "line": 3095,
           "kind": "struct",
           "field_names": [
             "id"
@@ -30476,7 +30937,7 @@
         },
         {
           "name": "Neighbor",
-          "line": 3029,
+          "line": 3103,
           "kind": "struct",
           "field_names": [
             "direction"
@@ -30489,7 +30950,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 3035,
+          "line": 3109,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -30500,7 +30961,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 3038,
+          "line": 3112,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -30508,7 +30969,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 3041,
+          "line": 3115,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -30516,7 +30977,7 @@
         },
         {
           "name": "LastRevealed",
-          "line": 3048,
+          "line": 3122,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.20e + CR 608.2c: Resolves to the most recently looked-at or revealed card(s) from a `Dig`/`RevealTop` effect in the current resolution (`state.last_revealed_ids`). Used by anaphoric \"it\" / \"that card\" references after \"look at the top card of your library\" (Amareth, the Lustrous) and by `AbilityCondition::ObjectsShareQuality` subject slots.",
@@ -30527,7 +30988,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 3052,
+          "line": 3126,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -30538,7 +30999,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 3055,
+          "line": 3129,
           "kind": "struct",
           "field_names": [
             "id"
@@ -30550,7 +31011,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 3082,
+          "line": 3156,
           "kind": "struct",
           "field_names": [
             "id",
@@ -30567,17 +31028,29 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 3090,
+          "line": 3164,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 610.3: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
+          "doc": "CR 607.2a: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
           "cr_refs": [
-            "CR 610.3"
+            "CR 607.2a"
+          ]
+        },
+        {
+          "name": "ExiledCardByIndex",
+          "line": 3170,
+          "kind": "struct",
+          "field_names": [
+            "index"
+          ],
+          "doc": "CR 607.2b: References a specific card exiled by the source, indexed by order. Used by The Mimeoplasm to distinguish \"the first card exiled this way\" from \"the second card exiled this way\". The index is 0-based and corresponds to the order in `state.cards_exiled_with_source_this_turn[source_id]`. ENGINE INVARIANT: The ordering is guaranteed by Vec::push in push_exiled_with_source_this_turn.",
+          "cr_refs": [
+            "CR 607.2b"
           ]
         },
         {
           "name": "TriggeringSpellController",
-          "line": 3092,
+          "line": 3174,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -30587,7 +31060,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 3094,
+          "line": 3176,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -30597,7 +31070,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3096,
+          "line": 3178,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -30607,7 +31080,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 3098,
+          "line": 3180,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -30617,7 +31090,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 3103,
+          "line": 3185,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -30625,7 +31098,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 3108,
+          "line": 3190,
           "kind": "struct",
           "field_names": [
             "index"
@@ -30637,7 +31110,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 3114,
+          "line": 3196,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -30647,7 +31120,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 3125,
+          "line": 3207,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -30659,7 +31132,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 3130,
+          "line": 3212,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 608.2c: Resolves to the player chosen for the source by a linked persisted choice (\"the chosen player\"). This is not a target slot and is distinct from `ControllerRef::ChosenPlayer`, which is resolution-scoped to the current ability chain.",
@@ -30670,7 +31143,7 @@
         },
         {
           "name": "OriginalController",
-          "line": 3151,
+          "line": 3233,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -30682,7 +31155,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 3170,
+          "line": 3252,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -30693,7 +31166,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 3175,
+          "line": 3257,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -30703,7 +31176,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3179,
+          "line": 3261,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -30714,7 +31187,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 3182,
+          "line": 3264,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -30722,7 +31195,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 3186,
+          "line": 3268,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -30732,7 +31205,7 @@
         },
         {
           "name": "Named",
-          "line": 3189,
+          "line": 3271,
           "kind": "struct",
           "field_names": [
             "name"
@@ -30742,7 +31215,7 @@
         },
         {
           "name": "Owner",
-          "line": 3197,
+          "line": 3279,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -30752,7 +31225,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 3204,
+          "line": 3286,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -30783,13 +31256,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14593,
+      "line": 15028,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 14594,
+          "line": 15029,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30797,7 +31270,7 @@
         },
         {
           "name": "Player",
-          "line": 14595,
+          "line": 15030,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30808,13 +31281,13 @@
     },
     "TargetSelectionConstraint": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1972,
+      "line": 2041,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 1973,
+          "line": 2042,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30822,7 +31295,7 @@
         },
         {
           "name": "DifferentObjectControllers",
-          "line": 1975,
+          "line": 2044,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2c: Object targets must be controlled by different players.",
@@ -30833,7 +31306,7 @@
         },
         {
           "name": "TotalManaValue",
-          "line": 1983,
+          "line": 2052,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -30852,7 +31325,7 @@
     },
     "TargetSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2733,
+      "line": 2788,
       "doc": "CR 115.1 + CR 701.9b: How a target slot's referent is selected.  CR 115.1: Default — the spell/ability's controller chooses each target. CR 701.9b: Some effects override the controller-choice default by requiring the game to make the selection (analogous to \"random discard\" — the affected player does not choose). Magic Oracle text expresses this with the modifier \"random target [predicate]\" appearing immediately before the target word (Mana Clash, Goblin Lyre, Pixie Queen, Vexing Sphinx, Maddening Hex, etc.).  Categorical-boundary check (per CLAUDE.md \"Parameterize, don't proliferate\"): this enum is the *selection-mode* axis — one level above the predicate (`TargetFilter`) and orthogonal to slot count (`MultiTargetSpec`). It does not belong on `TargetFilter` (which captures *what* matches), nor on `MultiTargetSpec` (which captures *how many*). It captures *who selects*.",
       "cr_refs": [
         "CR 115.1",
@@ -30861,7 +31334,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2736,
+          "line": 2791,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The spell or ability's controller chooses each target.",
@@ -30871,7 +31344,7 @@
         },
         {
           "name": "Random",
-          "line": 2739,
+          "line": 2794,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9b (analogous): The game selects each target uniformly at random from the legal-target set. The controller does not choose.",
@@ -30884,7 +31357,7 @@
     },
     "ThisWayCause": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2953,
+      "line": 3015,
       "doc": "CR 608.2c: Producer-action provenance for a tracked-set member — the keyword action (or one-shot zone change) that made the object part of a \"this way\" set. This is the IDENTITY of a \"<verb>ed this way\" relationship: it is the ACTION performed on the member, NOT the zone the member finally landed in.  Binding \"this way\" consumers to the action rather than the destination zone is required for two reasons (issue #2932):    1. CR 608.2c ordering — multiple distinct producer actions share the same      destination. Sacrifice (CR 701.21a), destroy (CR 701.8a), mill      (CR 701.17a), and discard (CR 701.9a) all land in the graveyard, so a      chain that mills AND sacrifices before a later \"sacrificed this way\"      consumer cannot be disambiguated by zone alone.   2. CR 614.1 / CR 614.6 replacement redirection — a replacement effect can      change a member's destination. With a Rest-in-Peace-style replacement a      sacrificed or discarded object lands in Exile, but it was still      *sacrificed / discarded this way*. The cause is the action, so it      survives the redirect; a zone binding would miss it.  Each variant cites the keyword action that produces it. `Returned` / `Bounced` are plain zone changes governed by CR 400.7 (no dedicated keyword action), distinguished by destination (battlefield vs. hand).",
       "cr_refs": [
         "CR 400.7",
@@ -30899,7 +31372,7 @@
       "variants": [
         {
           "name": "Exiled",
-          "line": 2955,
+          "line": 3017,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.13a: the member was exiled this way.",
@@ -30909,7 +31382,7 @@
         },
         {
           "name": "Sacrificed",
-          "line": 2958,
+          "line": 3020,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.21a: the member was sacrificed this way (cause survives a replacement that redirects the sacrifice to another zone — CR 614.6).",
@@ -30920,7 +31393,7 @@
         },
         {
           "name": "Destroyed",
-          "line": 2960,
+          "line": 3022,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8a: the member was destroyed this way.",
@@ -30930,7 +31403,7 @@
         },
         {
           "name": "Milled",
-          "line": 2962,
+          "line": 3024,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.17a: the member was milled this way.",
@@ -30940,7 +31413,7 @@
         },
         {
           "name": "Discarded",
-          "line": 2965,
+          "line": 3027,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9a: the member was discarded this way (cause survives a replacement that redirects the discard to another zone — CR 614.6).",
@@ -30951,7 +31424,7 @@
         },
         {
           "name": "Returned",
-          "line": 2968,
+          "line": 3030,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 400.7: the member was returned (put onto the battlefield) this way by a one-shot put-onto-battlefield instruction.",
@@ -30962,7 +31435,7 @@
         },
         {
           "name": "Bounced",
-          "line": 2971,
+          "line": 3033,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 400.7: the member was bounced (returned to its owner's hand) this way by a mass-bounce instruction.",
@@ -30976,7 +31449,7 @@
     },
     "TimeTravelPhase": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2520,
+      "line": 2589,
       "doc": "CR 701.56a: Which half of a time-travel choice is currently being presented. Typed instead of boolean so serialized engine state says whether the player is adding or removing counters.",
       "cr_refs": [
         "CR 701.56a"
@@ -30984,7 +31457,7 @@
       "variants": [
         {
           "name": "Remove",
-          "line": 2521,
+          "line": 2590,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30992,7 +31465,7 @@
         },
         {
           "name": "Add",
-          "line": 2522,
+          "line": 2591,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31003,7 +31476,7 @@
     },
     "TributeOutcome": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 667,
+      "line": 674,
       "doc": "CR 702.104a + CR 702.104b: The outcome of the Tribute choice the chosen opponent made as the creature entered the battlefield. Persisted as a `ChosenAttribute` on the Tribute creature so the companion \"if tribute wasn't paid\" trigger (CR 702.104b) can read the decision. A typed enum rather than a `bool` so the absence of any `TributeOutcome` remains distinguishable from an explicit `Declined`.",
       "cr_refs": [
         "CR 702.104a",
@@ -31012,7 +31485,7 @@
       "variants": [
         {
           "name": "Paid",
-          "line": 669,
+          "line": 676,
           "kind": "unit",
           "field_names": [],
           "doc": "The chosen opponent placed the Tribute +1/+1 counters (CR 702.104a).",
@@ -31022,7 +31495,7 @@
         },
         {
           "name": "Declined",
-          "line": 671,
+          "line": 678,
           "kind": "unit",
           "field_names": [],
           "doc": "The chosen opponent declined (CR 702.104b: \"if tribute wasn't paid\").",
@@ -31099,13 +31572,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12651,
+      "line": 12998,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 12654,
+          "line": 13001,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -31115,7 +31588,7 @@
         },
         {
           "name": "LostLife",
-          "line": 12656,
+          "line": 13003,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -31123,7 +31596,7 @@
         },
         {
           "name": "Descended",
-          "line": 12658,
+          "line": 13005,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -31131,7 +31604,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 12660,
+          "line": 13007,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31141,7 +31614,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 12662,
+          "line": 13009,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -31151,7 +31624,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 12664,
+          "line": 13011,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -31161,7 +31634,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 12674,
+          "line": 13021,
           "kind": "struct",
           "field_names": [
             "player"
@@ -31174,7 +31647,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 12677,
+          "line": 13024,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -31185,7 +31658,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 12680,
+          "line": 13027,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -31195,7 +31668,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 12693,
+          "line": 13040,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -31209,7 +31682,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 12700,
+          "line": 13047,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -31219,7 +31692,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 12703,
+          "line": 13050,
           "kind": "struct",
           "field_names": [
             "level"
@@ -31231,7 +31704,7 @@
         },
         {
           "name": "AttractionVisitRoll",
-          "line": 12706,
+          "line": 13053,
           "kind": "struct",
           "field_names": [
             "min",
@@ -31245,7 +31718,7 @@
         },
         {
           "name": "WasCast",
-          "line": 12709,
+          "line": 13056,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -31259,7 +31732,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 12718,
+          "line": 13065,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -31270,7 +31743,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 12723,
+          "line": 13070,
           "kind": "struct",
           "field_names": [
             "source",
@@ -31288,7 +31761,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 12743,
+          "line": 13090,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -31298,7 +31771,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 12749,
+          "line": 13096,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -31313,7 +31786,7 @@
         },
         {
           "name": "CastVariantPaidPersistent",
-          "line": 12754,
+          "line": 13101,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -31326,7 +31799,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 12758,
+          "line": 13105,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -31337,7 +31810,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 12762,
+          "line": 13109,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -31348,7 +31821,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 12767,
+          "line": 13114,
           "kind": "struct",
           "field_names": [
             "source"
@@ -31362,7 +31835,7 @@
         },
         {
           "name": "WasType",
-          "line": 12772,
+          "line": 13119,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -31375,7 +31848,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 12775,
+          "line": 13122,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -31387,7 +31860,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 12779,
+          "line": 13126,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -31400,7 +31873,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 12783,
+          "line": 13130,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31412,7 +31885,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 12787,
+          "line": 13134,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -31422,7 +31895,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 12790,
+          "line": 13137,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -31434,7 +31907,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 12794,
+          "line": 13141,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31446,7 +31919,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 12797,
+          "line": 13144,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -31458,7 +31931,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 12803,
+          "line": 13150,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -31468,7 +31941,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 12806,
+          "line": 13153,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -31478,7 +31951,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 12809,
+          "line": 13156,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: \"if you have the initiative\" is true when the controller has the initiative designation.",
@@ -31488,7 +31961,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 12812,
+          "line": 13159,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -31498,7 +31971,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 12819,
+          "line": 13166,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -31510,7 +31983,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 12824,
+          "line": 13171,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -31522,7 +31995,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 12828,
+          "line": 13175,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -31532,7 +32005,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 12833,
+          "line": 13180,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -31544,7 +32017,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 12839,
+          "line": 13186,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -31554,7 +32027,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 12844,
+          "line": 13191,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -31564,7 +32037,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 12847,
+          "line": 13194,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -31574,7 +32047,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 12850,
+          "line": 13197,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -31584,7 +32057,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 12852,
+          "line": 13199,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -31596,7 +32069,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 12855,
+          "line": 13202,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -31606,7 +32079,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 12859,
+          "line": 13206,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -31616,7 +32089,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 12863,
+          "line": 13210,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31629,7 +32102,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 12866,
+          "line": 13213,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -31639,7 +32112,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 12870,
+          "line": 13217,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -31652,7 +32125,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 12873,
+          "line": 13220,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -31665,7 +32138,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 12875,
+          "line": 13222,
           "kind": "struct",
           "field_names": [
             "color",
@@ -31678,7 +32151,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 12877,
+          "line": 13224,
           "kind": "struct",
           "field_names": [
             "text"
@@ -31690,7 +32163,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 12879,
+          "line": 13226,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -31702,7 +32175,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 12883,
+          "line": 13230,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -31716,7 +32189,7 @@
         },
         {
           "name": "IsRenowned",
-          "line": 12890,
+          "line": 13237,
           "kind": "struct",
           "field_names": [
             "subject"
@@ -31730,7 +32203,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 12895,
+          "line": 13242,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -31745,7 +32218,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 12906,
+          "line": 13253,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -31761,7 +32234,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 12921,
+          "line": 13268,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -31773,7 +32246,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 12924,
+          "line": 13271,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31786,7 +32259,7 @@
         },
         {
           "name": "EventDamageSourceMatchesFilter",
-          "line": 12937,
+          "line": 13284,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31798,8 +32271,20 @@
           ]
         },
         {
+          "name": "DamagedPlayerIsEventSourceOwner",
+          "line": 13298,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 120.1 + CR 108.3 + CR 603.4: Intervening-if predicate that holds when the player dealt the triggering damage is the OWNER of the object that dealt it (\"deals combat damage to its owner\"). Reads the triggering `GameEvent::DamageDealt`: true when `target == Player(p)` and the damage source object's `owner == p` (CR 120.1: the object that deals damage is the source of that damage). Distinct from `EventDamageSourceMatchesFilter` (which filters the damage *source* by a TargetFilter) and from `DealtDamageBySourceThisTurn` (which gates a dying creature against this-turn damage records) — this gates the recipient↔source-owner relation, which no static `TargetFilter` can express. Evaluated at both fire-time and resolution-time per CR 603.4, and per synthetic per-source event on the aggregate combat-damage path. The Beast, Deathless Prince.",
+          "cr_refs": [
+            "CR 108.3",
+            "CR 120.1",
+            "CR 603.4"
+          ]
+        },
+        {
           "name": "ChosenLabelIs",
-          "line": 12947,
+          "line": 13308,
           "kind": "struct",
           "field_names": [
             "label"
@@ -31813,7 +32298,7 @@
         },
         {
           "name": "AttackersDeclaredCount",
-          "line": 12961,
+          "line": 13322,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -31830,7 +32315,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 12975,
+          "line": 13336,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -31842,7 +32327,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 12986,
+          "line": 13347,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -31854,7 +32339,7 @@
         },
         {
           "name": "And",
-          "line": 12990,
+          "line": 13351,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -31864,7 +32349,7 @@
         },
         {
           "name": "Or",
-          "line": 12992,
+          "line": 13353,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -31874,7 +32359,7 @@
         },
         {
           "name": "Not",
-          "line": 13002,
+          "line": 13363,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -31890,13 +32375,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13188,
+      "line": 13588,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 13190,
+          "line": 13590,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -31904,7 +32389,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 13192,
+          "line": 13592,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -31912,7 +32397,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 13194,
+          "line": 13594,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -31920,7 +32405,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 13199,
+          "line": 13599,
           "kind": "struct",
           "field_names": [
             "n",
@@ -31931,7 +32416,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 13206,
+          "line": 13606,
           "kind": "struct",
           "field_names": [
             "n"
@@ -31941,7 +32426,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 13208,
+          "line": 13608,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -31949,7 +32434,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 13212,
+          "line": 13612,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -31959,7 +32444,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 13214,
+          "line": 13614,
           "kind": "struct",
           "field_names": [
             "level"
@@ -31971,7 +32456,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 13217,
+          "line": 13617,
           "kind": "struct",
           "field_names": [
             "max"
@@ -31983,7 +32468,7 @@
         },
         {
           "name": "OncePerOpponentPerTurn",
-          "line": 13221,
+          "line": 13621,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: \"for the first time during each of their turns\" — fires once per opponent per turn. Used by Valgavoth, Harrower of Souls: \"Whenever an opponent loses life for the first time during each of their turns, ...\"",
@@ -31993,7 +32478,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 13228,
+          "line": 13628,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -34173,13 +34658,13 @@
     },
     "TypeFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2047,
+      "line": 2061,
       "doc": "Type filter for card type matching in filters.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Creature",
-          "line": 2048,
+          "line": 2062,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34187,7 +34672,7 @@
         },
         {
           "name": "Land",
-          "line": 2049,
+          "line": 2063,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34195,7 +34680,7 @@
         },
         {
           "name": "Artifact",
-          "line": 2050,
+          "line": 2064,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34203,7 +34688,7 @@
         },
         {
           "name": "Enchantment",
-          "line": 2051,
+          "line": 2065,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34211,7 +34696,7 @@
         },
         {
           "name": "Instant",
-          "line": 2052,
+          "line": 2066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34219,7 +34704,7 @@
         },
         {
           "name": "Sorcery",
-          "line": 2053,
+          "line": 2067,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34227,7 +34712,7 @@
         },
         {
           "name": "Planeswalker",
-          "line": 2054,
+          "line": 2068,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34235,7 +34720,7 @@
         },
         {
           "name": "Battle",
-          "line": 2056,
+          "line": 2070,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 310: Battle — a permanent type introduced in March of the Machine.",
@@ -34245,7 +34730,7 @@
         },
         {
           "name": "Permanent",
-          "line": 2057,
+          "line": 2071,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34253,7 +34738,7 @@
         },
         {
           "name": "Card",
-          "line": 2058,
+          "line": 2072,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34261,7 +34746,7 @@
         },
         {
           "name": "Any",
-          "line": 2059,
+          "line": 2073,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34269,7 +34754,7 @@
         },
         {
           "name": "Non",
-          "line": 2062,
+          "line": 2076,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.4b: Negation — matches objects whose type does NOT match the inner filter. \"noncreature\" → `Non(Box::new(Creature))`, \"non-Human\" → `Non(Box::new(Subtype(\"Human\")))`",
@@ -34279,7 +34764,7 @@
         },
         {
           "name": "Subtype",
-          "line": 2065,
+          "line": 2079,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.3: Matches objects with a specific subtype (creature type, land type, etc.). String because MTG has 250+ creature subtypes (CR 205.3m) with new ones each set.",
@@ -34290,7 +34775,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2068,
+          "line": 2082,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2b: Disjunction — matches if ANY inner filter matches. \"creature or enchantment\" → `AnyOf(vec![Creature, Enchantment])`",
@@ -34369,7 +34854,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4728,
+      "line": 4859,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -34378,7 +34863,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 4730,
+          "line": 4861,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34386,7 +34871,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 4731,
+          "line": 4862,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34394,7 +34879,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 4732,
+          "line": 4863,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34404,7 +34889,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 4735,
+          "line": 4866,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34414,7 +34899,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 4747,
+          "line": 4878,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34430,7 +34915,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4043,
+      "line": 4174,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -34443,7 +34928,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 4047,
+          "line": 4178,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -34456,7 +34941,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 4051,
+          "line": 4182,
           "kind": "struct",
           "field_names": [
             "property",
@@ -34474,7 +34959,7 @@
     },
     "VoteActor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2236,
+      "line": 2305,
       "doc": "CR 101.4 + CR 608.2 (Battlebond friend-or-foe keyword action — no explicit CR section): The \"who acts\" semantic for a `WaitingFor::VoteChoice` step.  * `SubjectActs` — the player named by `player` casts the vote for   themselves. Classic Council's-dilemma (CR 701.38) is exclusively this   case: each voter acts on their own behalf and APNAP iteration changes   both subject and actor together. * `Delegated(actor)` — a fixed `actor` casts every vote on behalf of the   cycling subjects. The Battlebond friend-or-foe spell controller pins   themselves here so `player` cycles through every player in APNAP order   while authorization stays with the controller.  Stored on `WaitingFor::VoteChoice` instead of `Option<PlayerId>` so the \"is this delegated?\" discriminator is a named sum type with a meaningful pair of variant names, not a boolean-flavored optional. Callers route through [`VoteActor::resolve`] to get the authorized submitter without branching at every call site.",
       "cr_refs": [
         "CR 101.4",
@@ -34484,7 +34969,7 @@
       "variants": [
         {
           "name": "SubjectActs",
-          "line": 2237,
+          "line": 2306,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34492,7 +34977,7 @@
         },
         {
           "name": "Delegated",
-          "line": 2238,
+          "line": 2307,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -34503,7 +34988,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9373,
+      "line": 9635,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -34512,7 +34997,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 9376,
+          "line": 9638,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -34522,7 +35007,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 9380,
+          "line": 9642,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -34532,7 +35017,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 9388,
+          "line": 9650,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -34546,13 +35031,13 @@
     },
     "WaitingFor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2527,
+      "line": 2596,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 2528,
+          "line": 2597,
           "kind": "struct",
           "field_names": [
             "player"
@@ -34562,7 +35047,7 @@
         },
         {
           "name": "MulliganDecision",
-          "line": 2544,
+          "line": 2613,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -34577,7 +35062,7 @@
         },
         {
           "name": "MulliganBottomCards",
-          "line": 2557,
+          "line": 2626,
           "kind": "struct",
           "field_names": [
             "pending"
@@ -34589,7 +35074,7 @@
         },
         {
           "name": "OpeningHandBottomCards",
-          "line": 2563,
+          "line": 2632,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -34600,7 +35085,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 2567,
+          "line": 2636,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34611,7 +35096,7 @@
         },
         {
           "name": "AssistChoosePlayer",
-          "line": 2581,
+          "line": 2650,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34626,7 +35111,7 @@
         },
         {
           "name": "AssistPayment",
-          "line": 2595,
+          "line": 2664,
           "kind": "struct",
           "field_names": [
             "caster",
@@ -34641,16 +35126,17 @@
         },
         {
           "name": "ChooseXValue",
-          "line": 2613,
+          "line": 2686,
           "kind": "struct",
           "field_names": [
             "player",
             "min",
             "max",
             "pending_cast",
-            "convoke_mode"
+            "convoke_mode",
+            "x_cost_previews"
           ],
-          "doc": "CR 107.1b + CR 601.2f: Caster chooses the value of X for a pending cast whose cost contains `ManaCostShard::X`. Usually fires after target selection and before `ManaPayment`; fires before target selection when a selected mode's target legality depends on X. `max` is the engine-computed upper bound for UI display and AI enumeration (see `casting_costs::max_x_value`). `min` defaults to zero and is raised by parser-stamped restrictions such as \"X can't be 0.\" `convoke_mode` passes through to the subsequent `ManaPayment` step. `pending_cast` is embedded so filtered state snapshots (multiplayer) still carry enough context for the UI to render the spell name/cost.",
+          "doc": "CR 107.1b + CR 601.2f: Caster chooses the value of X for a pending cast whose cost contains `ManaCostShard::X`. Usually fires after target selection and before `ManaPayment`; fires before target selection when a selected mode's target legality depends on X. `max` is the engine-computed upper bound for UI display and AI enumeration (see `casting_costs::max_x_value`). `min` defaults to zero and is raised by parser-stamped restrictions such as \"X can't be 0.\" `convoke_mode` passes through to the subsequent `ManaPayment` step. `pending_cast` is embedded so filtered state snapshots (multiplayer) still carry enough context for the UI to render the spell name/cost. `x_cost_previews` maps each legal X in `[min, max]` to the engine- authoritative total mana cost after concretizing X and applying cost modifiers (Affinity, reductions, floors). Display-only for the Choose-X UI — omitted when the range is empty or unreasonably large.",
           "cr_refs": [
             "CR 107.1b",
             "CR 601.2f"
@@ -34658,7 +35144,7 @@
         },
         {
           "name": "TargetSelection",
-          "line": 2622,
+          "line": 2697,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34672,7 +35158,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 2638,
+          "line": 2713,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34684,7 +35170,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 2644,
+          "line": 2719,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34697,7 +35183,7 @@
         },
         {
           "name": "UntapChoice",
-          "line": 2660,
+          "line": 2735,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34711,7 +35197,7 @@
         },
         {
           "name": "ChooseUntapSubset",
-          "line": 2679,
+          "line": 2754,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34725,7 +35211,7 @@
         },
         {
           "name": "ExertChoice",
-          "line": 2694,
+          "line": 2769,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34740,7 +35226,7 @@
         },
         {
           "name": "EnlistChoice",
-          "line": 2705,
+          "line": 2780,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34756,7 +35242,7 @@
         },
         {
           "name": "GameOver",
-          "line": 2712,
+          "line": 2787,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -34766,7 +35252,7 @@
         },
         {
           "name": "ReplacementChoice",
-          "line": 2715,
+          "line": 2790,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34778,7 +35264,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 2728,
+          "line": 2803,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34793,7 +35279,7 @@
         },
         {
           "name": "CopyTargetChoice",
-          "line": 2734,
+          "line": 2809,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34808,7 +35294,7 @@
         },
         {
           "name": "ExploreChoice",
-          "line": 2744,
+          "line": 2819,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34824,7 +35310,7 @@
         },
         {
           "name": "ReturnAsAuraTarget",
-          "line": 2766,
+          "line": 2841,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34847,7 +35333,7 @@
         },
         {
           "name": "EquipTarget",
-          "line": 2783,
+          "line": 2858,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34859,7 +35345,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 2789,
+          "line": 2864,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34874,7 +35360,7 @@
         },
         {
           "name": "StationTarget",
-          "line": 2800,
+          "line": 2875,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34888,7 +35374,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 2808,
+          "line": 2883,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34903,7 +35389,7 @@
         },
         {
           "name": "ScryChoice",
-          "line": 2816,
+          "line": 2891,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34914,7 +35400,7 @@
         },
         {
           "name": "CoinFlipKeepChoice",
-          "line": 2823,
+          "line": 2898,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34930,7 +35416,7 @@
         },
         {
           "name": "DigChoice",
-          "line": 2829,
+          "line": 2904,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34951,7 +35437,7 @@
         },
         {
           "name": "SurveilChoice",
-          "line": 2858,
+          "line": 2933,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34962,7 +35448,7 @@
         },
         {
           "name": "RevealChoice",
-          "line": 2862,
+          "line": 2937,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34976,7 +35462,7 @@
         },
         {
           "name": "SearchChoice",
-          "line": 2881,
+          "line": 2956,
           "kind": "struct",
           "field_names": [
             "player",
@@ -34992,7 +35478,7 @@
         },
         {
           "name": "SearchPartitionChoice",
-          "line": 2915,
+          "line": 2990,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35011,7 +35497,7 @@
         },
         {
           "name": "OutsideGameChoice",
-          "line": 2928,
+          "line": 3003,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35030,7 +35516,7 @@
         },
         {
           "name": "ChooseFromZoneChoice",
-          "line": 2942,
+          "line": 3017,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35047,7 +35533,7 @@
         },
         {
           "name": "ChooseOneOfBranch",
-          "line": 2954,
+          "line": 3029,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35066,7 +35552,7 @@
         },
         {
           "name": "ConniveDiscard",
-          "line": 2972,
+          "line": 3047,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35082,7 +35568,7 @@
         },
         {
           "name": "DiscardChoice",
-          "line": 2981,
+          "line": 3056,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35100,7 +35586,7 @@
         },
         {
           "name": "EffectZoneChoice",
-          "line": 2997,
+          "line": 3072,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35119,7 +35605,8 @@
             "owner_library",
             "track_exiled_by_source",
             "face_down_profile",
-            "count_param"
+            "count_param",
+            "is_cost_payment"
           ],
           "doc": "CR 608.2d: Player chooses object(s) from a zone during effect resolution. Generalizes the DiscardChoice pattern to sacrifice-from-battlefield and hand-to-battlefield.",
           "cr_refs": [
@@ -35128,7 +35615,7 @@
         },
         {
           "name": "DrawnThisTurnTopdeckChoice",
-          "line": 3050,
+          "line": 3130,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35143,7 +35630,7 @@
         },
         {
           "name": "LearnChoice",
-          "line": 3060,
+          "line": 3140,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35156,11 +35643,12 @@
         },
         {
           "name": "ManifestDreadChoice",
-          "line": 3066,
+          "line": 3146,
           "kind": "struct",
           "field_names": [
             "player",
-            "cards"
+            "cards",
+            "source_id"
           ],
           "doc": "CR 701.62a: Player chooses one of the top 2 revealed cards to manifest face-down. The unchosen card goes to graveyard. Cards are visible only to the manifesting player.",
           "cr_refs": [
@@ -35169,7 +35657,7 @@
         },
         {
           "name": "TriggerTargetSelection",
-          "line": 3070,
+          "line": 3153,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35185,7 +35673,7 @@
         },
         {
           "name": "BetweenGamesSideboard",
-          "line": 3090,
+          "line": 3173,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35197,7 +35685,7 @@
         },
         {
           "name": "BetweenGamesChoosePlayDraw",
-          "line": 3095,
+          "line": 3178,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35209,7 +35697,7 @@
         },
         {
           "name": "NamedChoice",
-          "line": 3101,
+          "line": 3184,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35222,7 +35710,7 @@
         },
         {
           "name": "SpellbookDraft",
-          "line": 3112,
+          "line": 3195,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35236,7 +35724,7 @@
         },
         {
           "name": "DamageSourceChoice",
-          "line": 3122,
+          "line": 3205,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35250,19 +35738,20 @@
         },
         {
           "name": "ModeChoice",
-          "line": 3128,
+          "line": 3211,
           "kind": "struct",
           "field_names": [
             "player",
             "modal",
-            "pending_cast"
+            "pending_cast",
+            "unavailable_modes"
           ],
           "doc": "Player must choose modes for a modal spell (e.g. \"Choose one —\").",
           "cr_refs": []
         },
         {
           "name": "DiscardToHandSize",
-          "line": 3134,
+          "line": 3221,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35274,7 +35763,7 @@
         },
         {
           "name": "OptionalCostChoice",
-          "line": 3142,
+          "line": 3229,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35287,7 +35776,7 @@
         },
         {
           "name": "SpliceOffer",
-          "line": 3158,
+          "line": 3245,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35301,7 +35790,7 @@
         },
         {
           "name": "DefilerPayment",
-          "line": 3165,
+          "line": 3252,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35316,7 +35805,7 @@
         },
         {
           "name": "CastOffer",
-          "line": 3175,
+          "line": 3262,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35334,7 +35823,7 @@
         },
         {
           "name": "ModalFaceChoice",
-          "line": 3189,
+          "line": 3276,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35350,7 +35839,7 @@
         },
         {
           "name": "AlternativeCastChoice",
-          "line": 3212,
+          "line": 3299,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35376,7 +35865,7 @@
         },
         {
           "name": "MutateMergeChoice",
-          "line": 3251,
+          "line": 3338,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35393,7 +35882,7 @@
         },
         {
           "name": "CipherEncodeChoice",
-          "line": 3261,
+          "line": 3348,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35407,7 +35896,7 @@
         },
         {
           "name": "CastingVariantChoice",
-          "line": 3268,
+          "line": 3355,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35423,7 +35912,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 3280,
+          "line": 3367,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35440,7 +35929,7 @@
         },
         {
           "name": "MultiTargetSelection",
-          "line": 3291,
+          "line": 3378,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35456,7 +35945,7 @@
         },
         {
           "name": "AbilityModeChoice",
-          "line": 3302,
+          "line": 3389,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35473,7 +35962,7 @@
         },
         {
           "name": "OptionalEffectChoice",
-          "line": 3325,
+          "line": 3412,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35488,7 +35977,7 @@
         },
         {
           "name": "PairChoice",
-          "line": 3336,
+          "line": 3423,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35503,7 +35992,7 @@
         },
         {
           "name": "TributeChoice",
-          "line": 3347,
+          "line": 3434,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35518,7 +36007,7 @@
         },
         {
           "name": "MiracleReveal",
-          "line": 3359,
+          "line": 3446,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35533,7 +36022,7 @@
         },
         {
           "name": "OpponentMayChoice",
-          "line": 3366,
+          "line": 3453,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35549,7 +36038,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 3379,
+          "line": 3466,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35567,7 +36056,7 @@
         },
         {
           "name": "UnlessPaymentChooseCost",
-          "line": 3413,
+          "line": 3500,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35585,7 +36074,7 @@
         },
         {
           "name": "WardDiscardChoice",
-          "line": 3443,
+          "line": 3530,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35601,7 +36090,7 @@
         },
         {
           "name": "WardSacrificeChoice",
-          "line": 3459,
+          "line": 3546,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35617,7 +36106,7 @@
         },
         {
           "name": "UnlessBounceChoice",
-          "line": 3475,
+          "line": 3562,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35632,7 +36121,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 3483,
+          "line": 3570,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35645,7 +36134,7 @@
         },
         {
           "name": "ChooseDungeon",
-          "line": 3488,
+          "line": 3575,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35658,7 +36147,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 3493,
+          "line": 3580,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35673,7 +36162,7 @@
         },
         {
           "name": "SpecializeColor",
-          "line": 3500,
+          "line": 3587,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35685,7 +36174,7 @@
         },
         {
           "name": "PayCost",
-          "line": 3511,
+          "line": 3598,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35704,7 +36193,7 @@
         },
         {
           "name": "ActivationCostOneOfChoice",
-          "line": 3525,
+          "line": 3612,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35718,7 +36207,7 @@
         },
         {
           "name": "BlightChoice",
-          "line": 3531,
+          "line": 3618,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35731,7 +36220,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 3549,
+          "line": 3636,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35747,7 +36236,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 3559,
+          "line": 3646,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35763,7 +36252,7 @@
         },
         {
           "name": "CollectEvidenceChoice",
-          "line": 3566,
+          "line": 3653,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35779,7 +36268,7 @@
         },
         {
           "name": "HarmonizeTapChoice",
-          "line": 3575,
+          "line": 3662,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35796,7 +36285,7 @@
         },
         {
           "name": "RevealUntilKeptChoice",
-          "line": 3587,
+          "line": 3674,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35817,7 +36306,7 @@
         },
         {
           "name": "RepeatDecision",
-          "line": 3608,
+          "line": 3695,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35831,7 +36320,7 @@
         },
         {
           "name": "TopOrBottomChoice",
-          "line": 3615,
+          "line": 3702,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35844,7 +36333,7 @@
         },
         {
           "name": "PopulateChoice",
-          "line": 3620,
+          "line": 3707,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35858,7 +36347,7 @@
         },
         {
           "name": "ClashChooseOpponent",
-          "line": 3630,
+          "line": 3717,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35872,7 +36361,7 @@
         },
         {
           "name": "ClashCardPlacement",
-          "line": 3638,
+          "line": 3725,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35886,7 +36375,7 @@
         },
         {
           "name": "VoteChoice",
-          "line": 3649,
+          "line": 3736,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35908,7 +36397,7 @@
         },
         {
           "name": "SeparatePilesPartition",
-          "line": 3708,
+          "line": 3795,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35929,7 +36418,7 @@
         },
         {
           "name": "SeparatePilesChoice",
-          "line": 3738,
+          "line": 3825,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35946,7 +36435,7 @@
         },
         {
           "name": "CompanionReveal",
-          "line": 3753,
+          "line": 3840,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35959,7 +36448,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 3760,
+          "line": 3847,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35973,7 +36462,7 @@
         },
         {
           "name": "CommanderZoneChoice",
-          "line": 3769,
+          "line": 3856,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35987,7 +36476,7 @@
         },
         {
           "name": "BattleProtectorChoice",
-          "line": 3780,
+          "line": 3867,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36003,7 +36492,7 @@
         },
         {
           "name": "ProliferateChoice",
-          "line": 3787,
+          "line": 3874,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36016,7 +36505,7 @@
         },
         {
           "name": "TimeTravelChoice",
-          "line": 3800,
+          "line": 3887,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36030,7 +36519,7 @@
         },
         {
           "name": "ChooseObjectsSelection",
-          "line": 3810,
+          "line": 3897,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36044,7 +36533,7 @@
         },
         {
           "name": "CategoryChoice",
-          "line": 3823,
+          "line": 3910,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36068,7 +36557,7 @@
         },
         {
           "name": "CopyRetarget",
-          "line": 3860,
+          "line": 3947,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36085,7 +36574,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 3875,
+          "line": 3962,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36107,7 +36596,7 @@
         },
         {
           "name": "AssignBlockerDamage",
-          "line": 3902,
+          "line": 3989,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36123,7 +36612,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 3912,
+          "line": 3999,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36138,7 +36627,7 @@
         },
         {
           "name": "MoveCountersDistribution",
-          "line": 3920,
+          "line": 4007,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36156,7 +36645,7 @@
         },
         {
           "name": "PayAmountChoice",
-          "line": 3934,
+          "line": 4021,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36175,7 +36664,7 @@
         },
         {
           "name": "RetargetChoice",
-          "line": 3949,
+          "line": 4036,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36191,7 +36680,7 @@
         },
         {
           "name": "CombatTaxPayment",
-          "line": 3971,
+          "line": 4058,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36211,7 +36700,7 @@
         },
         {
           "name": "PhyrexianPayment",
-          "line": 3989,
+          "line": 4076,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36374,13 +36863,13 @@
     },
     "ZoneDeliveryExileTracking": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1398,
+      "line": 1456,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 1400,
+          "line": 1458,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36388,7 +36877,7 @@
         },
         {
           "name": "TrackBySource",
-          "line": 1401,
+          "line": 1459,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36439,19 +36928,30 @@
           "cr_refs": [
             "CR 701.38d"
           ]
+        },
+        {
+          "name": "EachPlayer",
+          "line": 66,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 101.4 + CR 608.2c: Every player owns a referenced zone, iterated in APNAP order. A `ChooseFromZone { zone_owner: EachPlayer }` parks one choice per player, drawing candidates from THAT player's zone, and accumulates each pick into the resolution chain's tracked object set. Building block for Breach the Multiverse (\"For each player, choose a creature or planeswalker card in that player's graveyard\").",
+          "cr_refs": [
+            "CR 101.4",
+            "CR 608.2c"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "ZoneRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 885,
+      "line": 892,
       "doc": "Which zone to count cards in (for `QuantityRef::ZoneCardCount`).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Graveyard",
-          "line": 886,
+          "line": 893,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36459,7 +36959,7 @@
         },
         {
           "name": "Exile",
-          "line": 887,
+          "line": 894,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36467,7 +36967,7 @@
         },
         {
           "name": "Library",
-          "line": 888,
+          "line": 895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36475,7 +36975,7 @@
         },
         {
           "name": "Hand",
-          "line": 889,
+          "line": 896,
           "kind": "unit",
           "field_names": [],
           "doc": "",


### PR DESCRIPTION
## Summary

Fixes #823 by parsing copy exceptions that set starting loyalty and consuming that exception at copy resolution, so Jace, Mirror Mage's kicked copy token enters with the correct loyalty counters instead of dying immediately.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> The pipeline runner was unavailable in this environment during implementation. I followed the engine/parser checklist locally, and completed workspace-level verification.

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

- `CR 707.9b`: copy effects may include exceptions to copied characteristics.
- `CR 306.5b` / `CR 306.5c`: planeswalkers enter with loyalty counters and the counter map is the loyalty source of truth.
- `CR 614.1c`: enters-with-counter replacement handling.
- `CR 122.1`: counter handling for the seeded loyalty counters.

## Verification

- `cargo fmt --all` passed.
- `cargo fmt --all -- --check` passed.
- `cargo check --workspace --all-targets` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` passed.
- `./scripts/check-parser-combinators.sh` passed.
- `./scripts/check-engine-authorities.sh upstream/main` passed.
- `git diff --check` passed.
- `cargo test -p engine starting_loyalty -- --nocapture` passed.
- `cargo test -p engine --lib --quiet -- --test-threads=1` passed.
- `cargo test -p phase-ai --lib --quiet` passed.
- `cargo test -p mtgish-import --lib --quiet` passed.
- `cargo nextest` is not installed locally; CI covers the nextest runner.
