### PR TITLE
feat(phase-ai): add Energy-economy deck-feature axis with reserve-aware payoff policy

### DIFF
--- a/crates/phase-ai/duel_decks/modern/kaladesh-energy.json
+++ b/crates/phase-ai/duel_decks/modern/kaladesh-energy.json
@@ -1,0 +1,25 @@
+{
+  "name": "Kaladesh Energy",
+  "format": "modern",
+  "frozen_date": "2026-06-18",
+  "source": "constructed-energy-engine",
+  "main": [
+    { "name": "Attune with Aether", "count": 4 },
+    { "name": "Rogue Refiner", "count": 4 },
+    { "name": "Servant of the Conduit", "count": 4 },
+    { "name": "Longtusk Cub", "count": 4 },
+    { "name": "Bristling Hydra", "count": 4 },
+    { "name": "Whirler Virtuoso", "count": 4 },
+    { "name": "Harnessed Lightning", "count": 4 },
+    { "name": "Aether Meltdown", "count": 4 },
+    { "name": "Confiscation Coup", "count": 2 },
+    { "name": "Aetherworks Marvel", "count": 2 },
+    { "name": "Aether Hub", "count": 4 },
+    { "name": "Forest", "count": 6 },
+    { "name": "Island", "count": 4 },
+    { "name": "Mountain", "count": 4 },
+    { "name": "Botanical Sanctum", "count": 4 },
+    { "name": "Spirebluff Canal", "count": 4 },
+    { "name": "Sheltered Thicket", "count": 2 }
+  ]
+}

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -362,6 +362,12 @@ pub struct PolicyPenalties {
     /// Consumed by `MillPayoffPolicy`.
     #[serde(default = "default_mill_cast_bonus")]
     pub mill_cast_bonus: f64,
+    /// Bonus for casting an energy-relevant spell (producer or sink body) in an
+    /// energy-committed deck. Scales with the casting player's reserve momentum
+    /// (×2 at 2–4 {E}, ×3 at ≥5 {E}).
+    /// Consumed by `EnergyPayoffPolicy`.
+    #[serde(default = "default_energy_cast_bonus")]
+    pub energy_cast_bonus: f64,
 }
 
 impl Default for PolicyPenalties {
@@ -414,6 +420,7 @@ impl Default for PolicyPenalties {
             deploy_flicker_engine_bonus: default_deploy_flicker_engine_bonus(),
             etb_payoff_cast_bonus: default_etb_payoff_cast_bonus(),
             mill_cast_bonus: default_mill_cast_bonus(),
+            energy_cast_bonus: default_energy_cast_bonus(),
         }
     }
 }
@@ -511,6 +518,9 @@ fn default_etb_payoff_cast_bonus() -> f64 {
 fn default_mill_cast_bonus() -> f64 {
     0.5
 }
+fn default_energy_cast_bonus() -> f64 {
+    0.5
+}
 
 /// Policy penalty fields present in the active CMA-ES `--group penalties`
 /// vector. Adding a `PolicyPenalties` field requires listing it here or in
@@ -600,6 +610,10 @@ pub const UNTUNED_POLICY_PENALTY_FIELDS: &[(&str, &str)] = &[
     (
         "mill_cast_bonus",
         "new MillPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "energy_cast_bonus",
+        "new EnergyPayoffPolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
     ),
 ];
 

--- a/crates/phase-ai/src/duel_suite/mod.rs
+++ b/crates/phase-ai/src/duel_suite/mod.rs
@@ -45,6 +45,7 @@ pub enum FeatureKind {
     Equipment,
     Blink,
     Mill,
+    Energy,
 }
 
 impl FeatureKind {
@@ -66,6 +67,7 @@ impl FeatureKind {
         FeatureKind::Equipment,
         FeatureKind::Blink,
         FeatureKind::Mill,
+        FeatureKind::Energy,
     ];
 }
 

--- a/crates/phase-ai/src/duel_suite/spec.rs
+++ b/crates/phase-ai/src/duel_suite/spec.rs
@@ -403,6 +403,24 @@ pub static MATCHUPS: &[MatchupSpec] = &[
         },
     },
     MatchupSpec {
+        id: "kaladesh-energy-mirror",
+        p0_label: "Kaladesh Energy (P0)",
+        p1_label: "Kaladesh Energy (P1)",
+        p0: snap("modern", "kaladesh-energy.json"),
+        p1: snap("modern", "kaladesh-energy.json"),
+        // Kaladesh Energy is the canonical energy-engine list: a dense producer
+        // package (Attune with Aether, Rogue Refiner, Servant of the Conduit,
+        // Aether Meltdown, Aetherworks Marvel) feeding activated-ability sinks
+        // (Bristling Hydra, Longtusk Cub, Whirler Virtuoso, Confiscation Coup).
+        // It clears `energy::COMMITMENT_FLOOR`, so this matchup is the gate's
+        // exercise of `EnergyPayoffPolicy` (verified by
+        // `kaladesh_energy_deck_activates_energy_payoff` below).
+        exercises: &[FeatureKind::Energy],
+        expected: Expected::Mirror {
+            tolerance: MIRROR_TOLERANCE,
+        },
+    },
+    MatchupSpec {
         id: "landfall-vs-niv",
         p0_label: "Mono-Green Landfall",
         p1_label: "Niv to Light",

--- a/crates/phase-ai/src/duel_suite/tests.rs
+++ b/crates/phase-ai/src/duel_suite/tests.rs
@@ -22,14 +22,14 @@ fn every_feature_kind_is_exercised() {
 /// Cross-check against the gate-covered `DeckFeatures` axes: landfall,
 /// mana_ramp, tribal, control, aristocrats, artifacts, enchantments,
 /// aggro_pressure, tokens_wide, plus_one_counters, spellslinger_prowess,
-/// reanimator, equipment, blink, mill — 15 axes, each with a dedicated `MatchupSpec`.
+/// reanimator, equipment, blink, mill, energy — 16 axes, each with a dedicated `MatchupSpec`.
 /// When a new gate-covered axis is added, this assertion fails until
 /// `FeatureKind::ALL` is updated to match.
 #[test]
 fn feature_kind_matches_deck_features_field_count() {
     assert_eq!(
         FeatureKind::ALL.len(),
-        15,
+        16,
         "FeatureKind::ALL is out of sync with DeckFeatures — add the new variant."
     );
 }
@@ -456,6 +456,69 @@ fn mill_mirror_deck_activates_mill_payoff() {
          MillPayoffPolicy activates during the gate; got commitment={} (mill_count={})",
         feature.commitment,
         feature.mill_count
+    );
+}
+
+/// Energy sibling of `mill_mirror_deck_activates_mill_payoff`: guards that the
+/// `kaladesh-energy-mirror` matchup tagged `FeatureKind::Energy` actually clears
+/// `energy::COMMITMENT_FLOOR`, so the required gate runs `EnergyPayoffPolicy`
+/// active (not dormant). Resolves the real snapshot through the card database
+/// and asserts the feature detects both producers and sinks (the two-part
+/// energy economy) and crosses the activation floor.
+///
+/// `#[ignore]` because it needs the full `card-data.json` export. Run with:
+///   `cargo test -p phase-ai -- --ignored kaladesh_energy_deck_activates_energy_payoff`
+#[test]
+#[ignore = "needs full card-data.json export; run with --ignored"]
+fn kaladesh_energy_deck_activates_energy_payoff() {
+    use crate::features::energy::{detect, COMMITMENT_FLOOR};
+    use engine::database::CardDatabase;
+    use engine::game::{resolve_player_deck_list, PlayerDeckList};
+    use std::path::PathBuf;
+
+    let data_root = std::env::var("PHASE_CARDS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../data")));
+    let db_path = data_root.join("card-data.json");
+    let db = CardDatabase::from_export(&db_path)
+        .unwrap_or_else(|e| panic!("failed to load card database from {db_path:?}: {e}"));
+
+    let spec = find_matchup("kaladesh-energy-mirror")
+        .expect("kaladesh-energy-mirror matchup must resolve");
+    assert!(
+        spec.exercises.contains(&FeatureKind::Energy),
+        "kaladesh-energy-mirror must claim to exercise FeatureKind::Energy"
+    );
+
+    let names =
+        resolve_deck_ref(&spec.p0).expect("kaladesh-energy-mirror p0 snapshot must resolve");
+    let payload = resolve_player_deck_list(
+        &db,
+        &PlayerDeckList {
+            main_deck: names,
+            ..Default::default()
+        },
+    );
+    let feature = detect(&payload.main_deck);
+
+    assert!(
+        feature.producer_count >= 1,
+        "energy deck must contain at least one producer, got producer_count={}",
+        feature.producer_count
+    );
+    assert!(
+        feature.sink_count >= 1,
+        "energy deck must contain at least one sink, got sink_count={}",
+        feature.sink_count
+    );
+    assert!(
+        feature.commitment >= COMMITMENT_FLOOR,
+        "energy deck must clear COMMITMENT_FLOOR ({COMMITMENT_FLOOR}) so \
+         EnergyPayoffPolicy activates during the gate; got commitment={} \
+         (producer_count={}, sink_count={})",
+        feature.commitment,
+        feature.producer_count,
+        feature.sink_count
     );
 }
 

--- a/crates/phase-ai/src/features/energy.rs
+++ b/crates/phase-ai/src/features/energy.rs
@@ -1,0 +1,229 @@
+//! Energy-economy feature — structural detection over a deck's typed AST.
+//!
+//! Recognizes a deck built around the energy reserve (CR 107.14 / CR 122.1):
+//! **producers** (`Effect::GainEnergy`) feeding **sinks/payoffs**
+//! (`AbilityCost::PayEnergy`). Energy is a two-part economy — a deck only
+//! "matters" on the energy axis when it can both generate *and* spend the
+//! reserve — so commitment is the geometric mean of producer and sink density,
+//! not a single-pillar count. This mirrors `AristocratsFeature`'s geometric-mean
+//! shape (enabler × payoff), not `MillFeature`'s single-pillar density.
+//!
+//! Parser AST verification — VERIFIED (no parser remediation required; every
+//! axis classifies from the existing typed AST, never by card name):
+//!
+//! | Axis | AST type | Location |
+//! |---|---|---|
+//! | Energy producer effect | `Effect::GainEnergy { amount: QuantityExpr }` | `ability.rs:8717` |
+//! | Energy sink cost | `AbilityCost::PayEnergy { amount }` via `cost_categories() → CostCategory::PaysEnergy` | `ability.rs:5888` |
+//! | Cost category (single authority) | `ability.cost_categories() -> Vec<CostCategory>` (never destructure `AbilityCost`) | `ability.rs` |
+//! | Ability chain walk | `crate::ability_chain::collect_chain_effects(ability)` | `phase-ai` |
+//! | Trigger-execute chain | `TriggerDefinition.execute: Option<Box<AbilityDefinition>>` | `ability.rs` |
+//! | Player energy reserve | `state.players[player.0 as usize].energy: u32` | `player.rs` |
+//!
+//! Concrete verified parse shapes (from `card-data.json`):
+//! - **Attune with Aether** / **Aetherworks Marvel**: spell/trigger `GainEnergy`
+//!   → detected as a producer ✅
+//! - **Rogue Refiner**: ETB trigger `execute = Draw`, `sub_ability = GainEnergy`
+//!   — only caught because `collect_chain_effects` walks the sub-ability chain
+//!   (a flat single-level walk misses it) ✅
+//! - **Bristling Hydra** / **Longtusk Cub** / **Whirler Virtuoso**: ability
+//!   `cost: PayEnergy` (sink) **and** a trigger `GainEnergy` (producer) →
+//!   detected as both, the true energy-engine cards ✅
+//! - **Aether Hub** (land): ETB `GainEnergy`, but lands are excluded from the
+//!   density denominator and from producer/sink counts (see `detect`) ✅
+//!
+//! Each ability/trigger chain is checked in isolation (per-chain `any()`) so a
+//! cross-ability false positive — one ability gains energy and a separate,
+//! unrelated ability does something else — cannot combine into a spurious
+//! producer hit.
+
+use engine::game::DeckEntry;
+use engine::types::ability::{AbilityDefinition, CostCategory, Effect};
+use engine::types::card::CardFace;
+use engine::types::card_type::CoreType;
+
+use crate::ability_chain::collect_chain_effects;
+use crate::features::commitment;
+
+/// Commitment floor below which `EnergyPayoffPolicy` opts out.
+/// Calibration: a dedicated energy-engine deck (≥~12 producers and ≥~8 sinks
+/// per 60 nonland) saturates to 1.0; a light splash (4 producers + 2 sinks /
+/// 36 nonland) gives ≈ 0.19; incidental-energy aggro with no activated sinks
+/// (e.g. Boros Energy: producers but `AbilityCost::PayEnergy` = 0) gives 0.0.
+pub const COMMITMENT_FLOOR: f32 = 0.35;
+
+/// Per-60-nonland producer density at which the producer side saturates. A
+/// committed energy shell runs ~24–30 producer cards per 60 nonland (Attune × 4,
+/// Rogue Refiner × 4, Servant × 4, Hydra/Cub/Virtuoso × 4 each, …); this divisor
+/// places saturation just below that ceiling.
+const PRODUCER_FULL_DENSITY: f32 = 30.0;
+
+/// Per-60-nonland sink density at which the sink side saturates. Energy decks
+/// run ~12–20 cards with an `AbilityCost::PayEnergy` activation (Hydra, Cub,
+/// Virtuoso, Servant, Marvel, Coup, …); this divisor places saturation around a
+/// dense engine.
+const SINK_FULL_DENSITY: f32 = 20.0;
+
+/// Per-deck energy-economy classification.
+///
+/// Populated once per game from `DeckEntry` data. Detection is structural over
+/// `CardFace.{abilities,triggers}` — never by card name. The companion
+/// `EnergyPayoffPolicy` consumes `commitment` to value energy-relevant casts
+/// when the deck is energy-committed and the live reserve makes it matter.
+#[derive(Debug, Clone, Default)]
+pub struct EnergyFeature {
+    /// Non-land cards whose ability or trigger-executed chain contains
+    /// `Effect::GainEnergy` (CR 107.14: the casting player gains energy).
+    pub producer_count: u32,
+    /// Non-land cards with at least one `AbilityCost::PayEnergy` activation
+    /// (CR 107.14: paying {E} removes one energy counter from the player).
+    pub sink_count: u32,
+    /// Non-land cards that are BOTH a producer and a sink — the true
+    /// energy-engine bodies (Bristling Hydra, Longtusk Cub, …). Diagnostic;
+    /// commitment is derived from producer × sink density, not this count.
+    pub payoff_count: u32,
+    /// `0.0..=1.0` — geometric mean of normalized producer and sink density.
+    /// High only when the deck can both generate *and* spend energy. Consumed
+    /// by `EnergyPayoffPolicy::activation` as the gate-and-scale knob.
+    pub commitment: f32,
+}
+
+/// Structural detection — walks each `DeckEntry`'s `CardFace` AST and counts
+/// energy producers and sinks among non-land cards.
+///
+/// Lands (including energy-fixing lands like Aether Hub) are excluded from both
+/// the counts and the density denominator: the energy archetype is defined by
+/// its non-land engine, and counting lands would inflate density for "free"
+/// producers. CR 107.14 / CR 122.1: energy is a player reserve built and spent
+/// by spells and activated abilities.
+pub fn detect(deck: &[DeckEntry]) -> EnergyFeature {
+    if deck.is_empty() {
+        return EnergyFeature::default();
+    }
+
+    let mut producer_count = 0u32;
+    let mut sink_count = 0u32;
+    let mut payoff_count = 0u32;
+    let mut total_nonland = 0u32;
+
+    for entry in deck {
+        let face = &entry.card;
+        if face.card_type.core_types.contains(&CoreType::Land) {
+            continue;
+        }
+        total_nonland = total_nonland.saturating_add(entry.count);
+
+        let is_producer = is_energy_producer(face);
+        let is_sink = is_energy_sink(face);
+        if is_producer {
+            producer_count = producer_count.saturating_add(entry.count);
+        }
+        if is_sink {
+            sink_count = sink_count.saturating_add(entry.count);
+        }
+        if is_producer && is_sink {
+            payoff_count = payoff_count.saturating_add(entry.count);
+        }
+    }
+
+    let commitment = energy_commitment(producer_count, sink_count, total_nonland);
+    EnergyFeature {
+        producer_count,
+        sink_count,
+        payoff_count,
+        commitment,
+    }
+}
+
+/// Geometric mean of normalized producer and sink density.
+///
+/// Energy is a two-part economy: the axis only matters when the deck can both
+/// build the reserve (producers) and drain it for value (sinks). The geometric
+/// mean is therefore limited by the scarcer side — a deck of pure producers
+/// (Attune for fixing, no sinks) or pure sinks scores 0, exactly matching the
+/// `AristocratsFeature` enabler × payoff shape.
+///
+/// Calibration:
+/// - Dedicated engine (36 prod / 12 sink / 36 nonland): density 60 / 20 → both
+///   sides saturate → commitment 1.0.
+/// - Splash (4 prod / 2 sink / 36 nonland): density 6.7 / 3.3 → normalized
+///   0.22 × 0.17 → commitment ≈ 0.19, below `COMMITMENT_FLOOR`.
+/// - Producers-only (Boros Energy, 0 activated sinks): commitment 0.0.
+fn energy_commitment(producer_count: u32, sink_count: u32, total_nonland: u32) -> f32 {
+    if producer_count == 0 || sink_count == 0 || total_nonland == 0 {
+        return 0.0;
+    }
+    let producer_norm = (commitment::density_per_60(producer_count, total_nonland)
+        / PRODUCER_FULL_DENSITY)
+        .min(1.0);
+    let sink_norm =
+        (commitment::density_per_60(sink_count, total_nonland) / SINK_FULL_DENSITY).min(1.0);
+    (producer_norm * sink_norm).sqrt().min(1.0)
+}
+
+/// True if this face contains at least one ability or trigger-executed chain
+/// that grants energy to its controller. Each chain is checked in isolation to
+/// prevent a cross-ability false positive.
+///
+/// CR 107.14: the {E} symbol represents one energy counter; `GainEnergy` adds
+/// counters to the resolving player's reserve (CR 122.1).
+pub fn is_energy_producer(face: &CardFace) -> bool {
+    face.abilities.iter().any(chain_includes_energy_gain)
+        || face.triggers.iter().any(|trigger| {
+            trigger
+                .execute
+                .as_deref()
+                .is_some_and(chain_includes_energy_gain)
+        })
+}
+
+/// True if this face contains at least one activated or spell ability whose
+/// cost pays energy, recursing through the ability tree (`sub_ability`,
+/// `else_ability`, `mode_abilities`) so energy payments nested in modal or
+/// chained abilities are caught.
+///
+/// CR 107.14: paying {E} removes one energy counter from the player. The single
+/// authority for cost classification is `AbilityDefinition::cost_categories()`
+/// (never destructure `AbilityCost`).
+pub fn is_energy_sink(face: &CardFace) -> bool {
+    face.abilities.iter().any(ability_tree_pays_energy)
+}
+
+/// True if a single ability chain (flattened by `collect_chain_effects`) grants
+/// energy.
+fn chain_includes_energy_gain(ability: &AbilityDefinition) -> bool {
+    collect_chain_effects(ability)
+        .iter()
+        .copied()
+        .any(effect_is_energy_gain)
+}
+
+/// True if this ability, or any ability nested under it
+/// (`sub_ability` / `else_ability` / `mode_abilities`), pays energy. The cost
+/// tree is walked explicitly because `cost_categories()` reports only the
+/// immediate ability's cost. Shared by the deck-time `CardFace` detector
+/// (`is_energy_sink`) and the live-game `EnergyPayoffPolicy`.
+pub(crate) fn ability_tree_pays_energy(ability: &AbilityDefinition) -> bool {
+    ability
+        .cost_categories()
+        .contains(&CostCategory::PaysEnergy)
+        || ability
+            .sub_ability
+            .as_deref()
+            .is_some_and(ability_tree_pays_energy)
+        || ability
+            .else_ability
+            .as_deref()
+            .is_some_and(ability_tree_pays_energy)
+        || ability.mode_abilities.iter().any(ability_tree_pays_energy)
+}
+
+/// Single authority — true if this effect grants energy to its controller.
+///
+/// CR 107.14 / CR 122.1: `GainEnergy` adds energy counters to the resolving
+/// player's reserve. Shared by the deck-time `CardFace` detector
+/// (`is_energy_producer`) and the live-game `EnergyPayoffPolicy` so the two
+/// never drift.
+pub(crate) fn effect_is_energy_gain(effect: &Effect) -> bool {
+    matches!(effect, Effect::GainEnergy { .. })
+}

--- a/crates/phase-ai/src/features/energy.rs
+++ b/crates/phase-ai/src/features/energy.rs
@@ -38,7 +38,7 @@
 //! producer hit.
 
 use engine::game::DeckEntry;
-use engine::types::ability::{AbilityDefinition, CostCategory, Effect};
+use engine::types::ability::{AbilityCost, AbilityDefinition, CostCategory, Effect};
 use engine::types::card::CardFace;
 use engine::types::card_type::CoreType;
 
@@ -177,21 +177,27 @@ pub fn is_energy_producer(face: &CardFace) -> bool {
         })
 }
 
-/// True if this face contains at least one activated or spell ability whose
-/// cost pays energy, recursing through the ability tree (`sub_ability`,
-/// `else_ability`, `mode_abilities`) so energy payments nested in modal or
-/// chained abilities are caught.
+/// True if this face contains at least one activated, spell, or trigger-executed
+/// ability whose cost pays energy, recursing through the ability tree
+/// (`sub_ability`, `else_ability`, `mode_abilities`) so energy payments nested
+/// in modal or chained abilities are caught.
 ///
 /// CR 107.14: paying {E} removes one energy counter from the player. The single
 /// authority for cost classification is `AbilityDefinition::cost_categories()`
 /// (never destructure `AbilityCost`).
 pub fn is_energy_sink(face: &CardFace) -> bool {
     face.abilities.iter().any(ability_tree_pays_energy)
+        || face.triggers.iter().any(|trigger| {
+            trigger
+                .execute
+                .as_deref()
+                .is_some_and(ability_tree_pays_energy)
+        })
 }
 
 /// True if a single ability chain (flattened by `collect_chain_effects`) grants
 /// energy.
-fn chain_includes_energy_gain(ability: &AbilityDefinition) -> bool {
+pub(crate) fn chain_includes_energy_gain(ability: &AbilityDefinition) -> bool {
     collect_chain_effects(ability)
         .iter()
         .copied()
@@ -207,6 +213,10 @@ pub(crate) fn ability_tree_pays_energy(ability: &AbilityDefinition) -> bool {
     ability
         .cost_categories()
         .contains(&CostCategory::PaysEnergy)
+        || collect_chain_effects(ability)
+            .iter()
+            .copied()
+            .any(effect_pays_energy)
         || ability
             .sub_ability
             .as_deref()
@@ -226,4 +236,14 @@ pub(crate) fn ability_tree_pays_energy(ability: &AbilityDefinition) -> bool {
 /// never drift.
 pub(crate) fn effect_is_energy_gain(effect: &Effect) -> bool {
     matches!(effect, Effect::GainEnergy { .. })
+}
+
+fn effect_pays_energy(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::PayCost {
+            cost: AbilityCost::PayEnergy { .. },
+            ..
+        }
+    )
 }

--- a/crates/phase-ai/src/features/mod.rs
+++ b/crates/phase-ai/src/features/mod.rs
@@ -13,6 +13,7 @@ pub mod blink;
 pub mod commitment;
 pub mod control;
 pub mod enchantments;
+pub mod energy;
 pub mod equipment;
 pub mod landfall;
 pub mod lifegain;
@@ -33,6 +34,7 @@ pub use artifacts::ArtifactsFeature;
 pub use blink::BlinkFeature;
 pub use control::ControlFeature;
 pub use enchantments::EnchantmentsFeature;
+pub use energy::EnergyFeature;
 pub use equipment::EquipmentFeature;
 pub use landfall::LandfallFeature;
 pub use lifegain::LifegainFeature;
@@ -75,6 +77,7 @@ pub struct DeckFeatures {
     pub spellslinger_prowess: SpellslingerProwessFeature,
     pub reanimator: ReanimatorFeature,
     pub mill: MillFeature,
+    pub energy: EnergyFeature,
     /// Declaration-derived: the deck's declared bracket tier. Unlike the
     /// other fields here, this is not structurally detected from card text —
     /// it is a per-deck declaration set at deck-analysis time from deck
@@ -118,6 +121,7 @@ impl DeckFeatures {
             spellslinger_prowess: spellslinger_prowess::detect(deck),
             reanimator: reanimator::detect(deck),
             mill: mill::detect(deck),
+            energy: energy::detect(deck),
             bracket_tier: tier,
         }
     }

--- a/crates/phase-ai/src/features/tests/energy.rs
+++ b/crates/phase-ai/src/features/tests/energy.rs
@@ -114,6 +114,45 @@ fn triggered_sub_chain_producer_face() -> CardFace {
     f
 }
 
+/// An Aether Chaser shape: the attack trigger's execute chain pays energy.
+fn triggered_energy_sink_face() -> CardFace {
+    let mut f = face(vec![CoreType::Creature]);
+    let execute = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PayCost {
+            cost: AbilityCost::PayEnergy {
+                amount: QuantityExpr::Fixed { value: 2 },
+            },
+            scale: None,
+            payer: TargetFilter::Controller,
+        },
+    );
+    f.triggers
+        .push(TriggerDefinition::new(TriggerMode::Attacks).execute(execute));
+    f
+}
+
+/// A Harnessed Lightning shape: the spell grants energy, then pays any amount
+/// of energy during resolution.
+fn spell_resolution_energy_sink_face() -> CardFace {
+    let mut f = producer_spell_face();
+    f.abilities[0].sub_ability = Some(Box::new(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PayCost {
+            cost: AbilityCost::PayEnergy {
+                amount: QuantityExpr::Ref {
+                    qty: engine::types::ability::QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+            },
+            scale: None,
+            payer: TargetFilter::Controller,
+        },
+    )));
+    f
+}
+
 fn entry(card: CardFace, count: u32) -> DeckEntry {
     DeckEntry { card, count }
 }
@@ -179,6 +218,18 @@ fn payoff_creature_is_both() {
 #[test]
 fn triggered_sub_chain_grants_energy_is_producer() {
     assert!(is_energy_producer(&triggered_sub_chain_producer_face()));
+}
+
+#[test]
+fn triggered_pay_energy_execute_is_sink() {
+    assert!(is_energy_sink(&triggered_energy_sink_face()));
+}
+
+#[test]
+fn spell_resolution_pay_energy_effect_is_sink() {
+    let f = spell_resolution_energy_sink_face();
+    assert!(is_energy_producer(&f));
+    assert!(is_energy_sink(&f));
 }
 
 #[test]

--- a/crates/phase-ai/src/features/tests/energy.rs
+++ b/crates/phase-ai/src/features/tests/energy.rs
@@ -1,0 +1,305 @@
+//! Unit tests for `features::energy` — structural detection + calibration
+//! anchors for the producer × sink energy economy. No `#[cfg(test)]` in SOURCE
+//! files; tests live here.
+
+use engine::game::DeckEntry;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter,
+    TriggerDefinition,
+};
+use engine::types::card::CardFace;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+use crate::features::energy::{
+    ability_tree_pays_energy, detect, effect_is_energy_gain, is_energy_producer, is_energy_sink,
+    COMMITMENT_FLOOR,
+};
+
+fn face(core: Vec<CoreType>) -> CardFace {
+    CardFace {
+        card_type: CardType {
+            supertypes: Vec::new(),
+            core_types: core,
+            subtypes: Vec::new(),
+        },
+        ..Default::default()
+    }
+}
+
+fn land_face() -> CardFace {
+    face(vec![CoreType::Land])
+}
+
+/// A sorcery that grants energy (Attune with Aether shape) — producer only.
+fn producer_spell_face() -> CardFace {
+    let mut f = face(vec![CoreType::Sorcery]);
+    f.abilities.push(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GainEnergy {
+            amount: QuantityExpr::Fixed { value: 1 },
+        },
+    ));
+    f
+}
+
+/// A creature whose activation pays energy (Bristling Hydra activation shape)
+/// — sink only. The effect is a non-energy effect so the face is not also a
+/// producer.
+fn sink_creature_face() -> CardFace {
+    let mut f = face(vec![CoreType::Creature]);
+    let mut ability = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    );
+    ability.cost = Some(AbilityCost::PayEnergy {
+        amount: QuantityExpr::Fixed { value: 1 },
+    });
+    f.abilities.push(ability);
+    f
+}
+
+/// A creature that both grants energy on a trigger and pays it on an activated
+/// ability (Longtusk Cub shape) — the true energy-engine payoff body.
+fn payoff_creature_face() -> CardFace {
+    let mut f = face(vec![CoreType::Creature]);
+    // Activated sink.
+    let mut sink = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    );
+    sink.cost = Some(AbilityCost::PayEnergy {
+        amount: QuantityExpr::Fixed { value: 2 },
+    });
+    f.abilities.push(sink);
+    // Triggered producer.
+    let producer = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GainEnergy {
+            amount: QuantityExpr::Fixed { value: 1 },
+        },
+    );
+    f.triggers
+        .push(TriggerDefinition::new(TriggerMode::ChangesZone).execute(producer));
+    f
+}
+
+/// A Rogue Refiner shape: the ETB trigger's execute chain grants energy only
+/// via a sub-ability (Draw → sub GainEnergy). A flat single-level walk misses
+/// this; `collect_chain_effects` must descend the sub-ability chain.
+fn triggered_sub_chain_producer_face() -> CardFace {
+    let mut f = face(vec![CoreType::Creature]);
+    let mut execute = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    );
+    execute.sub_ability = Some(Box::new(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GainEnergy {
+            amount: QuantityExpr::Fixed { value: 1 },
+        },
+    )));
+    f.triggers
+        .push(TriggerDefinition::new(TriggerMode::ChangesZone).execute(execute));
+    f
+}
+
+fn entry(card: CardFace, count: u32) -> DeckEntry {
+    DeckEntry { card, count }
+}
+
+/// A generic non-energy, non-land spell — dilutes the density denominator so a
+/// splash test reflects a realistic 36-nonland deck rather than a tiny all-energy
+/// list (which `density_per_60` would normalize to saturation).
+fn filler_face() -> CardFace {
+    let mut f = face(vec![CoreType::Sorcery]);
+    f.abilities.push(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    ));
+    f
+}
+
+// ─── effect_is_energy_gain ─────────────────────────────────────────────────
+
+#[test]
+fn gain_energy_effect_is_energy_gain() {
+    let e = Effect::GainEnergy {
+        amount: QuantityExpr::Fixed { value: 3 },
+    };
+    assert!(effect_is_energy_gain(&e));
+}
+
+#[test]
+fn mill_effect_is_not_energy_gain() {
+    let e = Effect::Mill {
+        count: QuantityExpr::Fixed { value: 3 },
+        target: TargetFilter::Player,
+        destination: Zone::Graveyard,
+    };
+    assert!(!effect_is_energy_gain(&e));
+}
+
+// ─── is_energy_producer / is_energy_sink ───────────────────────────────────
+
+#[test]
+fn gain_energy_spell_is_producer() {
+    assert!(is_energy_producer(&producer_spell_face()));
+    assert!(!is_energy_sink(&producer_spell_face()));
+}
+
+#[test]
+fn pay_energy_creature_is_sink() {
+    assert!(is_energy_sink(&sink_creature_face()));
+    assert!(!is_energy_producer(&sink_creature_face()));
+}
+
+#[test]
+fn payoff_creature_is_both() {
+    let f = payoff_creature_face();
+    assert!(is_energy_producer(&f));
+    assert!(is_energy_sink(&f));
+}
+
+/// The defining correctness case: energy granted only via a trigger's execute
+/// sub-ability must still register as a producer.
+#[test]
+fn triggered_sub_chain_grants_energy_is_producer() {
+    assert!(is_energy_producer(&triggered_sub_chain_producer_face()));
+}
+
+#[test]
+fn non_energy_spell_is_neither() {
+    let mut f = face(vec![CoreType::Instant]);
+    f.abilities.push(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 2 },
+            target: TargetFilter::Controller,
+        },
+    ));
+    assert!(!is_energy_producer(&f));
+    assert!(!is_energy_sink(&f));
+}
+
+#[test]
+fn ability_tree_pays_energy_detects_top_level_cost() {
+    let f = sink_creature_face();
+    assert!(f.abilities.iter().any(ability_tree_pays_energy));
+}
+
+// ─── detect + calibration ──────────────────────────────────────────────────
+
+#[test]
+fn empty_deck_produces_zero_commitment() {
+    let f = detect(&[]);
+    assert_eq!(f.producer_count, 0);
+    assert_eq!(f.sink_count, 0);
+    assert_eq!(f.commitment, 0.0);
+}
+
+#[test]
+fn all_lands_deck_produces_zero_commitment() {
+    let deck: Vec<DeckEntry> = (0..24).map(|_| entry(land_face(), 1)).collect();
+    let f = detect(&deck);
+    assert_eq!(f.commitment, 0.0);
+}
+
+/// Calibration anchor — a dedicated energy engine (producers + sinks in density)
+/// must clear `COMMITMENT_FLOOR` so `EnergyPayoffPolicy` activates.
+#[test]
+fn dedicated_energy_deck_clears_commitment_floor() {
+    let deck = vec![
+        entry(producer_spell_face(), 18),
+        entry(sink_creature_face(), 18),
+    ];
+    let f = detect(&deck);
+    assert!(
+        f.commitment >= COMMITMENT_FLOOR,
+        "dedicated energy deck must clear COMMITMENT_FLOOR {COMMITMENT_FLOOR}; got {}",
+        f.commitment
+    );
+    assert!(f.producer_count >= 1);
+    assert!(f.sink_count >= 1);
+}
+
+/// Anti-calibration — a producers-only deck (Attune-for-fixing with no sinks)
+/// scores zero: energy is a two-part economy, and the geometric mean collapses
+/// without the sink side.
+#[test]
+fn producers_only_deck_has_zero_commitment() {
+    let deck = vec![entry(producer_spell_face(), 24), entry(land_face(), 12)];
+    let f = detect(&deck);
+    assert!(f.producer_count > 0);
+    assert_eq!(f.sink_count, 0, "no sinks in a producers-only deck");
+    assert_eq!(
+        f.commitment, 0.0,
+        "producers-only must not register as energy-committed"
+    );
+}
+
+/// Anti-calibration — a sinks-only deck (nothing to spend) also scores zero.
+#[test]
+fn sinks_only_deck_has_zero_commitment() {
+    let deck = vec![entry(sink_creature_face(), 24), entry(land_face(), 12)];
+    let f = detect(&deck);
+    assert!(f.sink_count > 0);
+    assert_eq!(f.producer_count, 0);
+    assert_eq!(f.commitment, 0.0);
+}
+
+/// Anti-calibration — a light splash (4 producers + 2 sinks / 36 nonland)
+/// stays below the floor.
+#[test]
+fn splash_energy_stays_below_floor() {
+    // 4 producers + 2 sinks + 30 filler = 36 nonland → density 6.7 / 3.3 per 60
+    // → normalized 0.22 × 0.17 → commitment ≈ 0.19.
+    let deck = vec![
+        entry(producer_spell_face(), 4),
+        entry(sink_creature_face(), 2),
+        entry(filler_face(), 30),
+        entry(land_face(), 24),
+    ];
+    let f = detect(&deck);
+    assert!(
+        f.commitment < COMMITMENT_FLOOR,
+        "splash energy (4 prod / 2 sink / 36 nonland) must stay below \
+         COMMITMENT_FLOOR {COMMITMENT_FLOOR}; got {}",
+        f.commitment
+    );
+}
+
+/// Commitment clamps at 1.0 even with extreme producer × sink density.
+#[test]
+fn commitment_clamps_at_one() {
+    let deck = vec![entry(payoff_creature_face(), 36), entry(land_face(), 24)];
+    let f = detect(&deck);
+    assert_eq!(f.commitment, 1.0);
+}
+
+/// `payoff_count` counts faces that are both a producer and a sink.
+#[test]
+fn payoff_count_counts_both_faces() {
+    let deck = vec![
+        entry(payoff_creature_face(), 4),
+        entry(producer_spell_face(), 4),
+        entry(land_face(), 8),
+    ];
+    let f = detect(&deck);
+    assert_eq!(f.payoff_count, 4, "only the payoff creatures are both");
+    assert_eq!(f.producer_count, 8);
+    assert_eq!(f.sink_count, 4);
+}

--- a/crates/phase-ai/src/features/tests/mod.rs
+++ b/crates/phase-ai/src/features/tests/mod.rs
@@ -4,6 +4,7 @@
 pub mod artifacts;
 pub mod blink;
 pub mod enchantments;
+pub mod energy;
 pub mod equipment;
 pub mod lifegain;
 pub mod mill;

--- a/crates/phase-ai/src/policies/energy_payoff.rs
+++ b/crates/phase-ai/src/policies/energy_payoff.rs
@@ -25,8 +25,9 @@ use engine::types::player::PlayerId;
 
 use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
-use crate::ability_chain::collect_chain_effects;
-use crate::features::energy::{ability_tree_pays_energy, effect_is_energy_gain, COMMITMENT_FLOOR};
+use crate::features::energy::{
+    ability_tree_pays_energy, chain_includes_energy_gain, COMMITMENT_FLOOR,
+};
 use crate::features::DeckFeatures;
 
 /// Energy reserve at or above which the momentum scale reaches ×3.0. Five
@@ -80,20 +81,20 @@ impl TacticalPolicy for EnergyPayoffPolicy {
         // ability tree pays energy (sink body like Bristling Hydra). Each chain
         // is checked in isolation so two unrelated abilities cannot combine into
         // a false positive.
-        let is_producer = object.abilities.iter().any(|ability| {
-            collect_chain_effects(ability)
-                .iter()
-                .copied()
-                .any(effect_is_energy_gain)
-        }) || object.trigger_definitions.iter_unchecked().any(|trigger| {
-            trigger.execute.as_deref().is_some_and(|execute| {
-                collect_chain_effects(execute)
-                    .iter()
-                    .copied()
-                    .any(effect_is_energy_gain)
-            })
-        });
-        let is_sink = object.abilities.iter().any(ability_tree_pays_energy);
+        let is_producer = object.abilities.iter().any(chain_includes_energy_gain)
+            || object.trigger_definitions.iter_unchecked().any(|trigger| {
+                trigger
+                    .execute
+                    .as_deref()
+                    .is_some_and(chain_includes_energy_gain)
+            });
+        let is_sink = object.abilities.iter().any(ability_tree_pays_energy)
+            || object.trigger_definitions.iter_unchecked().any(|trigger| {
+                trigger
+                    .execute
+                    .as_deref()
+                    .is_some_and(ability_tree_pays_energy)
+            });
 
         if !is_producer && !is_sink {
             return PolicyVerdict::neutral(PolicyReason::new("energy_payoff_inert"));

--- a/crates/phase-ai/src/policies/energy_payoff.rs
+++ b/crates/phase-ai/src/policies/energy_payoff.rs
@@ -1,0 +1,126 @@
+//! Energy payoff tactical policy — deck-plan recognition for energy-reserve
+//! decks (CR 107.14 / CR 122.1).
+//!
+//! Raises the priority of energy-relevant casts (producers that grant {E} and
+//! sink bodies that spend it) when the casting player's deck is
+//! energy-committed (producer × sink density above `COMMITMENT_FLOOR`) and the
+//! live reserve shows the engine has momentum.
+//!
+//! **Payoff-gated**: opts out entirely when `features.energy.commitment` is
+//! below `COMMITMENT_FLOOR`. Incidental energy cards in non-energy decks
+//! receive no bonus — the general `EtbValuePolicy` handles their one-shot value.
+//! This is what keeps the policy from perturbing the quick-filter baseline
+//! decks (red/affinity/enchantress), whose energy commitment is zero.
+//!
+//! **Reserve-aware momentum**: `verdict()` scales the base bonus by the casting
+//! player's banked energy reserve. Three tiers:
+//! - Building (0–1 {E}): ×1.0 — engine just starting, deploy normally.
+//! - Online   (2–4 {E}): ×2.0 — reserve building, prioritize engine pieces.
+//! - Humming  (≥ 5 {E}): ×3.0 — engine running, keep deploying energy-relevant
+//!   bodies before the opponent pressures the reserve out.
+
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use crate::ability_chain::collect_chain_effects;
+use crate::features::energy::{ability_tree_pays_energy, effect_is_energy_gain, COMMITMENT_FLOOR};
+use crate::features::DeckFeatures;
+
+/// Energy reserve at or above which the momentum scale reaches ×3.0. Five
+/// banked counters means the deck can threaten a major sink next turn.
+pub(crate) const RESERVE_THRESHOLD_HIGH: usize = 5;
+
+/// Energy reserve at or above which the momentum scale reaches ×2.0. Two
+/// counters means the engine is producing surplus beyond the first spend.
+pub(crate) const RESERVE_THRESHOLD_MID: usize = 2;
+
+pub(crate) const MOMENTUM_SCALE_HIGH: f64 = 3.0;
+pub(crate) const MOMENTUM_SCALE_MID: f64 = 2.0;
+pub(crate) const MOMENTUM_SCALE_NORMAL: f64 = 1.0;
+
+pub struct EnergyPayoffPolicy;
+
+impl TacticalPolicy for EnergyPayoffPolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::EnergyPayoff
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::CastSpell]
+    }
+
+    fn activation(
+        &self,
+        features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        if features.energy.commitment < COMMITMENT_FLOOR {
+            None
+        } else {
+            Some(features.energy.commitment)
+        }
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let GameAction::CastSpell { object_id, .. } = &ctx.candidate.action else {
+            return PolicyVerdict::neutral(PolicyReason::new("energy_payoff_na"));
+        };
+        let Some(object) = ctx.state.objects.get(object_id) else {
+            return PolicyVerdict::neutral(PolicyReason::new("energy_payoff_na"));
+        };
+
+        // Re-classify the live object structurally and per-chain — identical
+        // isolation guard as MillPayoffPolicy. An energy-relevant cast is one
+        // whose own ability chain grants energy (producer), whose trigger-execute
+        // chain grants energy (ETB producers like Rogue Refiner), or whose
+        // ability tree pays energy (sink body like Bristling Hydra). Each chain
+        // is checked in isolation so two unrelated abilities cannot combine into
+        // a false positive.
+        let is_producer = object.abilities.iter().any(|ability| {
+            collect_chain_effects(ability)
+                .iter()
+                .copied()
+                .any(effect_is_energy_gain)
+        }) || object.trigger_definitions.iter_unchecked().any(|trigger| {
+            trigger.execute.as_deref().is_some_and(|execute| {
+                collect_chain_effects(execute)
+                    .iter()
+                    .copied()
+                    .any(effect_is_energy_gain)
+            })
+        });
+        let is_sink = object.abilities.iter().any(ability_tree_pays_energy);
+
+        if !is_producer && !is_sink {
+            return PolicyVerdict::neutral(PolicyReason::new("energy_payoff_inert"));
+        }
+
+        // CR 122.1: energy counters are a player reserve. The casting player's
+        // banked reserve is the engine's momentum — more reserve means the deck
+        // is successfully executing its plan and should keep prioritizing
+        // energy-relevant casts.
+        let reserve = ctx.state.players[ctx.ai_player.0 as usize].energy as usize;
+
+        let momentum_scale = if reserve >= RESERVE_THRESHOLD_HIGH {
+            MOMENTUM_SCALE_HIGH
+        } else if reserve >= RESERVE_THRESHOLD_MID {
+            MOMENTUM_SCALE_MID
+        } else {
+            MOMENTUM_SCALE_NORMAL
+        };
+
+        let delta = ctx.penalties().energy_cast_bonus * momentum_scale;
+        PolicyVerdict::score(
+            delta,
+            PolicyReason::new("energy_cast")
+                .with_fact("energy_reserve", reserve as i64)
+                .with_fact("urgency_x10", (momentum_scale * 10.0) as i64)
+                .with_fact("is_producer", i64::from(is_producer))
+                .with_fact("is_sink", i64::from(is_sink)),
+        )
+    }
+}

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -19,6 +19,7 @@ mod downside_awareness;
 pub(crate) mod effect_classify;
 mod effect_timing;
 mod enchantments_payoff;
+mod energy_payoff;
 mod equipment_payoff;
 mod equipment_priority;
 mod etb_value;

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -13,6 +13,7 @@ use super::context::PolicyContext;
 use super::copy_value::CopyValuePolicy;
 use super::effect_timing::EffectTimingPolicy;
 use super::enchantments_payoff::EnchantmentsPayoffPolicy;
+use super::energy_payoff::EnergyPayoffPolicy;
 use super::equipment_payoff::EquipmentPayoffPolicy;
 use super::etb_value::EtbValuePolicy;
 use super::evasion_removal_priority::EvasionRemovalPriorityPolicy;
@@ -120,6 +121,7 @@ pub enum PolicyId {
     LandAnimation,
     MillTargeting,
     MillPayoff,
+    EnergyPayoff,
     ChaliceAvoidance,
     PaymentSelection,
     SeparatePilesTiming,
@@ -333,6 +335,7 @@ impl Default for PolicyRegistry {
             Box::new(super::land_animation::LandAnimationPolicy),
             Box::new(super::mill_targeting::MillTargetingPolicy),
             Box::new(MillPayoffPolicy),
+            Box::new(EnergyPayoffPolicy),
             Box::new(ChaliceAvoidancePolicy),
             Box::new(PaymentSelectionPolicy),
             Box::new(SeparatePilesTimingPolicy),

--- a/crates/phase-ai/src/policies/tests/energy_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/energy_payoff.rs
@@ -12,12 +12,14 @@ use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, Tac
 use engine::game::zones::create_object;
 use engine::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter,
+    TriggerDefinition,
 };
 use engine::types::actions::GameAction;
 use engine::types::card_type::{CardType, CoreType};
 use engine::types::game_state::{CastPaymentMode, GameState, WaitingFor};
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::player::PlayerId;
+use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
 
 use crate::config::AiConfig;
@@ -112,6 +114,15 @@ fn push_ability(state: &mut GameState, oid: ObjectId, ability: AbilityDefinition
     Arc::make_mut(&mut state.objects.get_mut(&oid).unwrap().abilities).push(ability);
 }
 
+fn push_trigger(state: &mut GameState, oid: ObjectId, trigger: TriggerDefinition) {
+    state
+        .objects
+        .get_mut(&oid)
+        .unwrap()
+        .trigger_definitions
+        .push(trigger);
+}
+
 /// An Attune with Aether shape producer — grants energy. `is_producer = true`.
 fn producer_ability() -> AbilityDefinition {
     AbilityDefinition::new(
@@ -136,6 +147,19 @@ fn sink_ability() -> AbilityDefinition {
         amount: QuantityExpr::Fixed { value: 1 },
     });
     ability
+}
+
+fn trigger_energy_sink() -> TriggerDefinition {
+    TriggerDefinition::new(TriggerMode::Attacks).execute(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PayCost {
+            cost: AbilityCost::PayEnergy {
+                amount: QuantityExpr::Fixed { value: 2 },
+            },
+            scale: None,
+            payer: TargetFilter::Controller,
+        },
+    ))
 }
 
 /// A Divination shape draw spell — no energy interaction. Drives `energy_payoff_inert`.
@@ -366,6 +390,29 @@ fn verdict_sink_body_is_scored() {
     assert!(
         (delta - expected).abs() < 1e-9,
         "sink body at 4 reserve must scale ×2 (expected {expected}); got {delta}"
+    );
+    assert_eq!(reason.kind, "energy_cast");
+    assert_eq!(fact(&reason, "is_producer"), 0);
+    assert_eq!(fact(&reason, "is_sink"), 1);
+}
+
+#[test]
+fn verdict_trigger_energy_sink_body_is_scored() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 5, vec![CoreType::Creature]);
+    push_trigger(&mut state, oid, trigger_energy_sink());
+    set_reserve(&mut state, 4);
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(1.0);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, reason) = score_of(policy().verdict(&ctx));
+    let expected = AiConfig::default().policy_penalties.energy_cast_bonus * 2.0;
+    assert!(
+        (delta - expected).abs() < 1e-9,
+        "trigger energy sink at 4 reserve must scale ×2 (expected {expected}); got {delta}"
     );
     assert_eq!(reason.kind, "energy_cast");
     assert_eq!(fact(&reason, "is_producer"), 0);

--- a/crates/phase-ai/src/policies/tests/energy_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/energy_payoff.rs
@@ -1,0 +1,401 @@
+//! Tests for `EnergyPayoffPolicy` — activation gate + verdict branches
+//! including reserve-momentum scaling. No `#[cfg(test)]` in SOURCE files;
+//! tests live here.
+//!
+//! The verdict path is exercised against a real `PolicyContext` built from a
+//! two-player `GameState` with a castable energy object and a controlled
+//! casting-player reserve, mirroring the `mill_payoff` policy-test shape.
+
+use std::sync::Arc;
+
+use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::game_state::{CastPaymentMode, GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+use crate::config::AiConfig;
+use crate::context::AiContext;
+use crate::features::energy::{EnergyFeature, COMMITMENT_FLOOR};
+use crate::features::DeckFeatures;
+use crate::policies::context::PolicyContext;
+use crate::policies::energy_payoff::EnergyPayoffPolicy;
+use crate::policies::registry::{
+    DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy,
+};
+use crate::session::AiSession;
+
+const AI: PlayerId = PlayerId(0);
+
+fn policy() -> EnergyPayoffPolicy {
+    EnergyPayoffPolicy
+}
+
+// ─── fixtures ───────────────────────────────────────────────────────────────
+
+fn features(commitment: f32) -> DeckFeatures {
+    DeckFeatures {
+        energy: EnergyFeature {
+            producer_count: 20,
+            sink_count: 12,
+            payoff_count: 8,
+            commitment,
+        },
+        ..DeckFeatures::default()
+    }
+}
+
+fn ai_context(commitment: f32) -> (AiContext, AiConfig) {
+    let config = AiConfig::default();
+    let mut session = AiSession::empty();
+    session.features.insert(AI, features(commitment));
+    let mut context = AiContext::empty(&config.weights);
+    context.session = Arc::new(session);
+    context.player = AI;
+    (context, config)
+}
+
+fn decision() -> AiDecisionContext {
+    AiDecisionContext {
+        waiting_for: WaitingFor::Priority { player: AI },
+        candidates: Vec::new(),
+    }
+}
+
+fn cast_candidate(object_id: ObjectId) -> CandidateAction {
+    CandidateAction {
+        action: GameAction::CastSpell {
+            object_id,
+            card_id: CardId(object_id.0),
+            targets: Vec::new(),
+            payment_mode: CastPaymentMode::default(),
+        },
+        metadata: ActionMetadata {
+            actor: Some(AI),
+            tactical_class: TacticalClass::Spell,
+        },
+    }
+}
+
+/// A non-cast (PlayLand) candidate — drives the `energy_payoff_na` branch,
+/// which short-circuits any candidate that is not a `CastSpell`.
+fn land_candidate(object_id: ObjectId) -> CandidateAction {
+    CandidateAction {
+        action: GameAction::PlayLand {
+            object_id,
+            card_id: CardId(object_id.0),
+        },
+        metadata: ActionMetadata {
+            actor: Some(AI),
+            tactical_class: TacticalClass::Land,
+        },
+    }
+}
+
+fn spell_object(state: &mut GameState, idx: u64, core: Vec<CoreType>) -> ObjectId {
+    let oid = create_object(state, CardId(idx), AI, format!("Spell {idx}"), Zone::Stack);
+    state.objects.get_mut(&oid).unwrap().card_types = CardType {
+        supertypes: Vec::new(),
+        core_types: core,
+        subtypes: Vec::new(),
+    };
+    oid
+}
+
+fn push_ability(state: &mut GameState, oid: ObjectId, ability: AbilityDefinition) {
+    Arc::make_mut(&mut state.objects.get_mut(&oid).unwrap().abilities).push(ability);
+}
+
+/// An Attune with Aether shape producer — grants energy. `is_producer = true`.
+fn producer_ability() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GainEnergy {
+            amount: QuantityExpr::Fixed { value: 1 },
+        },
+    )
+}
+
+/// A Bristling Hydra activation shape sink — pays energy for a non-energy
+/// effect. `is_sink = true`, `is_producer = false`.
+fn sink_ability() -> AbilityDefinition {
+    let mut ability = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    );
+    ability.cost = Some(AbilityCost::PayEnergy {
+        amount: QuantityExpr::Fixed { value: 1 },
+    });
+    ability
+}
+
+/// A Divination shape draw spell — no energy interaction. Drives `energy_payoff_inert`.
+fn draw_ability() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 2 },
+            target: TargetFilter::Controller,
+        },
+    )
+}
+
+/// Set the casting player's banked energy reserve — the momentum knob.
+fn set_reserve(state: &mut GameState, reserve: u32) {
+    state.players[AI.0 as usize].energy = reserve;
+}
+
+fn ctx<'a>(
+    state: &'a GameState,
+    candidate: &'a CandidateAction,
+    decision: &'a AiDecisionContext,
+    context: &'a AiContext,
+    config: &'a AiConfig,
+) -> PolicyContext<'a> {
+    PolicyContext {
+        state,
+        decision,
+        candidate,
+        ai_player: AI,
+        config,
+        context,
+        cast_facts: None,
+    }
+}
+
+/// Unwrap a `Score` verdict into `(delta, reason)`; fail on `Reject`.
+fn score_of(verdict: PolicyVerdict) -> (f64, PolicyReason) {
+    match verdict {
+        PolicyVerdict::Score { delta, reason } => (delta, reason),
+        PolicyVerdict::Reject { reason } => panic!("unexpected Reject: {reason:?}"),
+    }
+}
+
+/// Look up a typed fact by key, panicking if it is absent.
+fn fact(reason: &PolicyReason, key: &str) -> i64 {
+    reason
+        .facts
+        .iter()
+        .find(|(k, _)| *k == key)
+        .map(|(_, v)| *v)
+        .unwrap_or_else(|| panic!("missing fact {key:?}; facts = {:?}", reason.facts))
+}
+
+// ─── identity ───────────────────────────────────────────────────────────────
+
+#[test]
+fn identity_is_energy_payoff() {
+    assert_eq!(policy().id(), PolicyId::EnergyPayoff);
+    assert!(policy().decision_kinds().contains(&DecisionKind::CastSpell));
+    assert!(!policy().decision_kinds().contains(&DecisionKind::PlayLand));
+}
+
+// ─── activation gate ────────────────────────────────────────────────────────
+
+#[test]
+fn activation_below_floor_returns_none() {
+    let mut features = DeckFeatures::default();
+    features.energy.commitment = COMMITMENT_FLOOR - 0.01;
+    let state = GameState::new_two_player(7);
+    assert!(
+        policy().activation(&features, &state, AI).is_none(),
+        "commitment below floor must return None"
+    );
+}
+
+#[test]
+fn activation_at_floor_returns_some() {
+    let mut features = DeckFeatures::default();
+    features.energy.commitment = COMMITMENT_FLOOR;
+    let state = GameState::new_two_player(7);
+    let v = policy()
+        .activation(&features, &state, AI)
+        .expect("commitment at floor must activate");
+    assert!(
+        (v - COMMITMENT_FLOOR).abs() < 1e-6,
+        "activation should equal commitment; got {v}"
+    );
+}
+
+#[test]
+fn activation_above_floor_returns_commitment() {
+    let mut features = DeckFeatures::default();
+    features.energy.commitment = 0.9;
+    let state = GameState::new_two_player(7);
+    let v = policy()
+        .activation(&features, &state, AI)
+        .expect("commitment 0.9 must activate");
+    assert!(
+        (v - 0.9).abs() < 1e-6,
+        "activation should equal commitment 0.9; got {v}"
+    );
+}
+
+// ─── verdict: non-cast → na ─────────────────────────────────────────────────
+
+#[test]
+fn verdict_non_cast_action_is_na() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 1, vec![CoreType::Land]);
+    push_ability(&mut state, oid, producer_ability());
+
+    // An energy-committed deck keeps the policy live, but a PlayLand candidate
+    // is not a cast — the verdict short-circuits to `energy_payoff_na` before
+    // any structural energy classification runs.
+    let candidate = land_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(1.0);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, reason) = score_of(policy().verdict(&ctx));
+    assert_eq!(reason.kind, "energy_payoff_na");
+    assert!(
+        delta.abs() < 1e-9,
+        "na must be neutral (delta 0), got {delta}"
+    );
+}
+
+// ─── verdict: non-energy spell → inert ──────────────────────────────────────
+
+#[test]
+fn verdict_non_energy_spell_is_inert() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 2, vec![CoreType::Sorcery]);
+    push_ability(&mut state, oid, draw_ability());
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(1.0);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, reason) = score_of(policy().verdict(&ctx));
+    assert_eq!(reason.kind, "energy_payoff_inert");
+    assert!(
+        delta.abs() < 1e-9,
+        "inert must be neutral (delta 0), got {delta}"
+    );
+}
+
+// ─── verdict: reserve-momentum scaling (×1 / ×2 / ×3) ───────────────────────
+
+/// Cast a producer spell against a controlled reserve, returning the scored
+/// `(delta, reason)`. Commitment is pinned at 1.0 so the policy is active.
+fn scored_producer_verdict(reserve: u32) -> (f64, PolicyReason) {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 3, vec![CoreType::Sorcery]);
+    push_ability(&mut state, oid, producer_ability());
+    set_reserve(&mut state, reserve);
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(1.0);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+    score_of(policy().verdict(&ctx))
+}
+
+#[test]
+fn verdict_building_reserve_is_x1() {
+    // 0 reserve (< MID threshold) → ×1.0.
+    let (delta, reason) = scored_producer_verdict(0);
+    let expected = AiConfig::default().policy_penalties.energy_cast_bonus * 1.0;
+    assert!(
+        (delta - expected).abs() < 1e-9,
+        "building momentum (0 reserve) must scale ×1 (expected {expected}); got {delta}"
+    );
+    assert_eq!(reason.kind, "energy_cast");
+    assert_eq!(fact(&reason, "energy_reserve"), 0);
+    assert_eq!(fact(&reason, "urgency_x10"), 10);
+    assert_eq!(fact(&reason, "is_producer"), 1);
+    assert_eq!(fact(&reason, "is_sink"), 0);
+}
+
+#[test]
+fn verdict_online_reserve_is_x2() {
+    // 3 reserve (≥ MID, < HIGH) → ×2.0.
+    let (delta, reason) = scored_producer_verdict(3);
+    let expected = AiConfig::default().policy_penalties.energy_cast_bonus * 2.0;
+    assert!(
+        (delta - expected).abs() < 1e-9,
+        "online momentum (3 reserve) must scale ×2 (expected {expected}); got {delta}"
+    );
+    assert_eq!(reason.kind, "energy_cast");
+    assert_eq!(fact(&reason, "energy_reserve"), 3);
+    assert_eq!(fact(&reason, "urgency_x10"), 20);
+}
+
+#[test]
+fn verdict_humming_reserve_is_x3() {
+    // 6 reserve (≥ HIGH) → ×3.0.
+    let (delta, reason) = scored_producer_verdict(6);
+    let expected = AiConfig::default().policy_penalties.energy_cast_bonus * 3.0;
+    assert!(
+        (delta - expected).abs() < 1e-9,
+        "humming momentum (6 reserve) must scale ×3 (expected {expected}); got {delta}"
+    );
+    assert_eq!(reason.kind, "energy_cast");
+    assert_eq!(fact(&reason, "energy_reserve"), 6);
+    assert_eq!(fact(&reason, "urgency_x10"), 30);
+}
+
+// ─── verdict: sink body ─────────────────────────────────────────────────────
+
+#[test]
+fn verdict_sink_body_is_scored() {
+    let mut state = GameState::new_two_player(7);
+    let oid = spell_object(&mut state, 4, vec![CoreType::Creature]);
+    push_ability(&mut state, oid, sink_ability());
+    set_reserve(&mut state, 4);
+
+    let candidate = cast_candidate(oid);
+    let decision = decision();
+    let (context, config) = ai_context(1.0);
+    let ctx = ctx(&state, &candidate, &decision, &context, &config);
+
+    let (delta, reason) = score_of(policy().verdict(&ctx));
+    // 4 reserve → ×2.0.
+    let expected = AiConfig::default().policy_penalties.energy_cast_bonus * 2.0;
+    assert!(
+        (delta - expected).abs() < 1e-9,
+        "sink body at 4 reserve must scale ×2 (expected {expected}); got {delta}"
+    );
+    assert_eq!(reason.kind, "energy_cast");
+    assert_eq!(fact(&reason, "is_producer"), 0);
+    assert_eq!(fact(&reason, "is_sink"), 1);
+}
+
+// ─── momentum constants ─────────────────────────────────────────────────────
+
+/// Compile-time guard: the reserve boundaries must be strictly ordered so the
+/// three tiers (building / online / humming) partition the reserve space, and
+/// the scales must be strictly increasing. Inverting any constant is a build
+/// error. Surfaced as a `#[test]` for discoverability.
+#[test]
+fn momentum_constants_are_ordered() {
+    use crate::policies::energy_payoff::{
+        MOMENTUM_SCALE_HIGH, MOMENTUM_SCALE_MID, MOMENTUM_SCALE_NORMAL, RESERVE_THRESHOLD_HIGH,
+        RESERVE_THRESHOLD_MID,
+    };
+    const {
+        assert!(
+            RESERVE_THRESHOLD_MID < RESERVE_THRESHOLD_HIGH,
+            "MID threshold must be strictly below HIGH"
+        );
+        assert!(
+            MOMENTUM_SCALE_HIGH > MOMENTUM_SCALE_MID,
+            "MOMENTUM_SCALE_HIGH must exceed MOMENTUM_SCALE_MID"
+        );
+        assert!(
+            MOMENTUM_SCALE_MID > MOMENTUM_SCALE_NORMAL,
+            "MOMENTUM_SCALE_MID must exceed MOMENTUM_SCALE_NORMAL"
+        );
+    }
+}

--- a/crates/phase-ai/src/policies/tests/mod.rs
+++ b/crates/phase-ai/src/policies/tests/mod.rs
@@ -4,6 +4,7 @@ pub mod activation_marker_lint;
 pub mod artifact_synergy;
 pub mod blink_payoff;
 pub mod enchantments_payoff;
+pub mod energy_payoff;
 pub mod equipment_payoff;
 pub mod lifegain_payoff;
 pub mod mill_payoff;

--- a/crates/phase-ai/tests/duel_suite_attribution.rs
+++ b/crates/phase-ai/tests/duel_suite_attribution.rs
@@ -60,6 +60,7 @@ fn expected_policies(kind: FeatureKind) -> &'static [&'static str] {
         FeatureKind::Equipment => &["EquipmentPayoff"],
         FeatureKind::Blink => &["BlinkPayoff"],
         FeatureKind::Mill => &["MillPayoff"],
+        FeatureKind::Energy => &["EnergyPayoff"],
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #3728 

Adds an **Energy-economy deck-feature axis** (`EnergyFeature`) and a payoff-gated, reserve-aware `EnergyPayoffPolicy` to `phase-ai`. The AI previously valued energy only as a flat `energy * 0.1` reserve (`eval.rs:402`); it could not recognize a deck built around energy **producers** feeding **sinks**, so it never valued building the reserve toward a payoff. Detection is fully structural (producer = `Effect::GainEnergy`, sink = `AbilityCost::PayEnergy`), commitment is the geometric mean of producer × sink density, and the policy scales by the casting player's banked reserve (×1 / ×2 / ×3) while staying inert below a `COMMITMENT_FLOOR` so it doesn't perturb non-energy decks.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> This PR touches only `crates/phase-ai/` — a new deck-feature detector (`features/energy.rs`) and tactical policy (`policies/energy_payoff.rs`) in the AI layer. It does **not** change `crates/engine/` game logic (no parser, effect, resolver, targeting, or rules-behavior changes). It was produced following the `add-ai-feature-policy` skill checklist (the authoritative pipeline for `DeckFeatures` axes + companion policies), mirroring the existing `mill`/`blink`/`equipment` axis pattern.

## CR references

- **CR 107.14** — the energy symbol `{E}` / energy reserve (gain and pay). Grep-verified: `grep -n "^107.14" docs/MagicCompRules.txt`.
- **CR 122.1** — energy counters as a player resource. Grep-verified: `grep -n "^122.1" docs/MagicCompRules.txt`.

Annotated in `features/energy.rs` (producer/sink detection + `EnergyFeature` fields) and `policies/energy_payoff.rs` (reserve-aware verdict). No 701.x/702.x keyword applies (energy is a reserve resource, not a keyword ability).

## Verification

Tilt was down, so cargo was run directly:

- `cargo fmt --all -- --check` → exit 0 ✅
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0 ✅
- `cargo test -p phase-ai` → **1114 passed, 0 failed** (1081 lib + `ai_quality` 14 + `cedh_integration` 4 + `decision_trace` 2 + `scenarios` 12 + `duel_suite_attribution` 1). The lone `community_scenarios` failure is a pre-existing local-env issue (missing `unzip` binary); unrelated to this change and green in CI.
- `cargo test -p phase-ai --lib kaladesh_energy_deck_activates_energy_payoff -- --ignored` → passes (13.9s): the `kaladesh-energy.json` anchor is confirmed to clear `COMMITMENT_FLOOR` against real `card-data.json`.

Calibration verified: Kaladesh Energy (anchor) → commitment 1.0 ✅; incidental-energy Boros (0 activated sinks) → 0.0 ✅; light splash (4 prod / 2 sink / 36 nonland) → ~0.19 ✅.
