### PR TITLE
fix(parser): parse Iroh non-Lesson graveyard flashback static (#1163)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -741,13 +741,13 @@ fn try_parse_graveyard_keyword_static_with_continuation(line: &str) -> Option<St
     let lower = line.to_lowercase();
     let (prefix, continuation) = split_once_on_lower(line, &lower, ". ")?;
     let prefix_lower = prefix.to_lowercase();
-    let (grant_prefix, during_your_turn) = if let Some(suffix) = prefix_lower.strip_prefix("during your turn, ")
-    {
-        let start = prefix.len() - suffix.len();
-        (&prefix[start..], true)
-    } else {
-        (prefix, false)
-    };
+    let (grant_prefix, during_your_turn) =
+        if let Some(suffix) = prefix_lower.strip_prefix("during your turn, ") {
+            let start = prefix.len() - suffix.len();
+            (&prefix[start..], true)
+        } else {
+            (prefix, false)
+        };
     let (affected, kind) = try_parse_graveyard_keyword_grant_clause(grant_prefix)?;
     let keyword = parse_graveyard_keyword_continuation(continuation, kind)?;
     if !kind.matches_keyword(&keyword) {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -741,13 +741,10 @@ fn try_parse_graveyard_keyword_static_with_continuation(line: &str) -> Option<St
     let lower = line.to_lowercase();
     let (prefix, continuation) = split_once_on_lower(line, &lower, ". ")?;
     let prefix_lower = prefix.to_lowercase();
-    let (grant_prefix, during_your_turn) =
-        if let Some(suffix) = prefix_lower.strip_prefix("during your turn, ") {
-            let start = prefix.len() - suffix.len();
-            (&prefix[start..], true)
-        } else {
-            (prefix, false)
-        };
+    let (turn_condition, grant_prefix) = nom_on_lower(prefix, &prefix_lower, |input| {
+        value(StaticCondition::DuringYourTurn, tag("during your turn, ")).parse(input)
+    })
+    .map_or((None, prefix), |(condition, rest)| (Some(condition), rest));
     let (affected, kind) = try_parse_graveyard_keyword_grant_clause(grant_prefix)?;
     let keyword = parse_graveyard_keyword_continuation(continuation, kind)?;
     if !kind.matches_keyword(&keyword) {
@@ -757,8 +754,8 @@ fn try_parse_graveyard_keyword_static_with_continuation(line: &str) -> Option<St
         .affected(affected)
         .modifications(vec![ContinuousModification::AddKeyword { keyword }])
         .description(line.to_string());
-    if during_your_turn {
-        def = def.condition(StaticCondition::DuringYourTurn);
+    if let Some(condition) = turn_condition {
+        def = def.condition(condition);
     }
     Some(def)
 }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -740,14 +740,27 @@ fn parse_graveyard_keyword_continuation(
 fn try_parse_graveyard_keyword_static_with_continuation(line: &str) -> Option<StaticDefinition> {
     let lower = line.to_lowercase();
     let (prefix, continuation) = split_once_on_lower(line, &lower, ". ")?;
-    let (affected, kind) = try_parse_graveyard_keyword_grant_clause(prefix)?;
+    let prefix_lower = prefix.to_lowercase();
+    let (grant_prefix, during_your_turn) = if let Some(suffix) = prefix_lower.strip_prefix("during your turn, ")
+    {
+        let start = prefix.len() - suffix.len();
+        (&prefix[start..], true)
+    } else {
+        (prefix, false)
+    };
+    let (affected, kind) = try_parse_graveyard_keyword_grant_clause(grant_prefix)?;
     let keyword = parse_graveyard_keyword_continuation(continuation, kind)?;
-    kind.matches_keyword(&keyword).then_some(
-        StaticDefinition::continuous()
-            .affected(affected)
-            .modifications(vec![ContinuousModification::AddKeyword { keyword }])
-            .description(line.to_string()),
-    )
+    if !kind.matches_keyword(&keyword) {
+        return None;
+    }
+    let mut def = StaticDefinition::continuous()
+        .affected(affected)
+        .modifications(vec![ContinuousModification::AddKeyword { keyword }])
+        .description(line.to_string());
+    if during_your_turn {
+        def = def.condition(StaticCondition::DuringYourTurn);
+    }
+    Some(def)
 }
 
 /// Returns every `StaticDefinition` produced by `line`, with the

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -7436,6 +7436,41 @@ fn graveyard_keyword_grant_clause_escape() {
 }
 
 #[test]
+fn graveyard_keyword_grant_clause_non_lesson_instant_sorcery() {
+    let (filter, kind) = try_parse_graveyard_keyword_grant_clause(
+        "Each non-Lesson instant and sorcery card in your graveyard has flashback.",
+    )
+    .expect("non-Lesson instant/sorcery graveyard flashback");
+    assert_eq!(kind, GraveyardGrantedKeywordKind::Flashback);
+    let has_non_lesson = |tf: &TypedFilter| {
+        tf.type_filters.iter().any(|f| {
+            matches!(
+                f,
+                TypeFilter::Non(boxed) if matches!(**boxed, TypeFilter::Subtype(ref s) if s == "Lesson")
+            )
+        })
+    };
+    match filter {
+        TargetFilter::Or { ref filters } => {
+            assert_eq!(filters.len(), 2);
+            assert!(
+                filters.iter().all(|branch| {
+                    let TargetFilter::Typed(tf) = branch else {
+                        return false;
+                    };
+                    has_non_lesson(tf)
+                        && tf.properties.contains(&FilterProp::InZone {
+                            zone: Zone::Graveyard
+                        })
+                }),
+                "each branch should be non-Lesson instant/sorcery in graveyard: {filter:?}"
+            );
+        }
+        other => panic!("expected Or filter, got {other:?}"),
+    }
+}
+
+#[test]
 fn graveyard_keyword_grant_clause_rejects_non_you_scope() {
     let clause = try_parse_graveyard_keyword_grant_clause(
         "Each nonland card in their graveyard has escape.",
@@ -7444,6 +7479,63 @@ fn graveyard_keyword_grant_clause_rejects_non_you_scope() {
         clause.is_none(),
         "only your graveyard scope is currently supported"
     );
+}
+
+#[test]
+fn iroh_non_lesson_graveyard_flashback_self_mana_cost() {
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::keywords::{FlashbackCost, Keyword};
+
+    let parsed = parse_oracle_text(
+        "During your turn, each non-Lesson instant and sorcery card in your graveyard has flashback. The flashback cost is equal to that card's mana cost.",
+        "Iroh, Grand Lotus",
+        &[],
+        &["Creature".to_string(), "Planeswalker".to_string()],
+        &[],
+    );
+    let non_lesson = parsed
+        .statics
+        .iter()
+        .find(|def| {
+            def.description
+                .as_deref()
+                .is_some_and(|d| d.contains("non-Lesson"))
+        })
+        .expect("non-Lesson graveyard flashback static");
+    assert_eq!(
+        non_lesson.condition,
+        Some(StaticCondition::DuringYourTurn)
+    );
+    let TargetFilter::Or { filters } = non_lesson
+        .affected
+        .as_ref()
+        .expect("affected filter")
+    else {
+        panic!("expected Or filter for instant/sorcery");
+    };
+    assert_eq!(filters.len(), 2);
+    for branch in filters {
+        let TargetFilter::Typed(tf) = branch else {
+            panic!("expected typed branch");
+        };
+        assert!(
+            tf.type_filters.iter().any(|f| matches!(
+                f,
+                TypeFilter::Non(boxed) if matches!(**boxed, TypeFilter::Subtype(ref s) if s == "Lesson")
+            )),
+            "missing Non(Lesson): {:?}",
+            tf.type_filters
+        );
+        assert!(tf.properties.contains(&FilterProp::InZone {
+            zone: Zone::Graveyard
+        }));
+    }
+    match &non_lesson.modifications[0] {
+        ContinuousModification::AddKeyword {
+            keyword: Keyword::Flashback(FlashbackCost::Mana(ManaCost::SelfManaCost)),
+        } => {}
+        other => panic!("expected SelfManaCost flashback, got {other:?}"),
+    }
 }
 
 // --- Graveyard play permission tests (Crucible of Worlds / Icetill Explorer) ---

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -7460,7 +7460,7 @@ fn graveyard_keyword_grant_clause_non_lesson_instant_sorcery() {
                     };
                     has_non_lesson(tf)
                         && tf.properties.contains(&FilterProp::InZone {
-                            zone: Zone::Graveyard
+                            zone: Zone::Graveyard,
                         })
                 }),
                 "each branch should be non-Lesson instant/sorcery in graveyard: {filter:?}"
@@ -7502,14 +7502,8 @@ fn iroh_non_lesson_graveyard_flashback_self_mana_cost() {
                 .is_some_and(|d| d.contains("non-Lesson"))
         })
         .expect("non-Lesson graveyard flashback static");
-    assert_eq!(
-        non_lesson.condition,
-        Some(StaticCondition::DuringYourTurn)
-    );
-    let TargetFilter::Or { filters } = non_lesson
-        .affected
-        .as_ref()
-        .expect("affected filter")
+    assert_eq!(non_lesson.condition, Some(StaticCondition::DuringYourTurn));
+    let TargetFilter::Or { filters } = non_lesson.affected.as_ref().expect("affected filter")
     else {
         panic!("expected Or filter for instant/sorcery");
     };

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -7499,7 +7499,7 @@ fn iroh_non_lesson_graveyard_flashback_self_mana_cost() {
         .find(|def| {
             def.description
                 .as_deref()
-                .is_some_and(|d| d.contains("non-Lesson"))
+                == Some("During your turn, each non-Lesson instant and sorcery card in your graveyard has flashback.")
         })
         .expect("non-Lesson graveyard flashback static");
     assert_eq!(non_lesson.condition, Some(StaticCondition::DuringYourTurn));

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -7497,9 +7497,13 @@ fn iroh_non_lesson_graveyard_flashback_self_mana_cost() {
         .statics
         .iter()
         .find(|def| {
-            def.description
-                .as_deref()
-                == Some("During your turn, each non-Lesson instant and sorcery card in your graveyard has flashback.")
+            def.condition == Some(StaticCondition::DuringYourTurn)
+                && matches!(
+                    def.modifications.first(),
+                    Some(ContinuousModification::AddKeyword {
+                        keyword: Keyword::Flashback(FlashbackCost::Mana(ManaCost::SelfManaCost)),
+                    })
+                )
         })
         .expect("non-Lesson graveyard flashback static");
     assert_eq!(non_lesson.condition, Some(StaticCondition::DuringYourTurn));

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1962,6 +1962,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
                 let combined = distribute_shared_properties(combined, &properties);
                 let combined = distribute_controller_to_or(combined);
                 let combined = distribute_core_type_to_or(combined);
+                let combined = distribute_neg_type_filters_to_or(combined);
                 return (distribute_properties_to_or(combined), final_rest);
             }
         }
@@ -3037,6 +3038,44 @@ pub(crate) fn distribute_core_type_to_or(filter: TargetFilter) -> TargetFilter {
             }
         }
     }
+    TargetFilter::Or { filters }
+}
+
+/// CR 205.4b: When a leading `non-` negation scopes a type disjunction
+/// ("non-Lesson instant and sorcery card"), the negated type must bind to
+/// every disjunct — not only the first leg parsed before the `and`/`or`
+/// connector. Without this, "non-Lesson instant and sorcery" would match
+/// any sorcery, including Lessons (issue #1163, Iroh, Grand Lotus).
+pub(crate) fn distribute_neg_type_filters_to_or(filter: TargetFilter) -> TargetFilter {
+    let TargetFilter::Or { mut filters } = filter else {
+        return filter;
+    };
+
+    let mut neg_filters: Vec<TypeFilter> = Vec::new();
+    for f in &filters {
+        if let TargetFilter::Typed(TypedFilter { type_filters, .. }) = f {
+            for tf in type_filters {
+                if matches!(tf, TypeFilter::Non(_)) && !neg_filters.contains(tf) {
+                    neg_filters.push(tf.clone());
+                }
+            }
+        }
+    }
+
+    if neg_filters.is_empty() {
+        return TargetFilter::Or { filters };
+    }
+
+    for f in &mut filters {
+        if let TargetFilter::Typed(ref mut typed) = f {
+            for neg in &neg_filters {
+                if !typed.type_filters.iter().any(|existing| existing == neg) {
+                    typed.type_filters.push(neg.clone());
+                }
+            }
+        }
+    }
+
     TargetFilter::Or { filters }
 }
 
@@ -12820,5 +12859,29 @@ mod tests {
         };
         assert!(tf2.properties.contains(&FilterProp::Token));
         assert!(rest2.is_empty(), "expected empty remainder, got {rest2:?}");
+    }
+
+    #[test]
+    fn parse_non_lesson_instant_and_sorcery_distributes_negation() {
+        let (filter, rest) =
+            parse_type_phrase("non-Lesson instant and sorcery card in your graveyard");
+        assert!(rest.trim().is_empty(), "unexpected remainder: {rest:?}");
+        let TargetFilter::Or { filters } = filter else {
+            panic!("expected Or filter, got {filter:?}");
+        };
+        assert_eq!(filters.len(), 2);
+        for branch in filters {
+            let TargetFilter::Typed(tf) = branch else {
+                panic!("expected typed branch");
+            };
+            assert!(
+                tf.type_filters.iter().any(|f| matches!(
+                    f,
+                    TypeFilter::Non(boxed) if matches!(**boxed, TypeFilter::Subtype(ref s) if s == "Lesson")
+                )),
+                "each branch must exclude Lesson: {:?}",
+                tf.type_filters
+            );
+        }
     }
 }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -12890,4 +12890,40 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn parse_artifact_or_noncreature_permanent_keeps_negation_on_second_branch() {
+        let (filter, rest) = parse_type_phrase("artifact or noncreature permanent");
+        assert!(rest.trim().is_empty(), "unexpected remainder: {rest:?}");
+        let TargetFilter::Or { filters } = filter else {
+            panic!("expected Or filter, got {filter:?}");
+        };
+
+        let has_artifact = |filter: &TargetFilter| {
+            let TargetFilter::Typed(tf) = filter else {
+                return false;
+            };
+            tf.type_filters.contains(&TypeFilter::Artifact)
+        };
+        let has_noncreature = |filter: &TargetFilter| {
+            let TargetFilter::Typed(tf) = filter else {
+                return false;
+            };
+            tf.type_filters
+                .contains(&TypeFilter::Non(Box::new(TypeFilter::Creature)))
+        };
+
+        let artifact_branch = filters
+            .iter()
+            .find(|branch| has_artifact(branch))
+            .expect("artifact branch");
+        assert!(
+            !has_noncreature(artifact_branch),
+            "noncreature must not distribute back onto artifact branch: {artifact_branch:?}"
+        );
+        assert!(
+            filters.iter().any(has_noncreature),
+            "expected a noncreature branch in {filters:?}"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3051,22 +3051,28 @@ pub(crate) fn distribute_neg_type_filters_to_or(filter: TargetFilter) -> TargetF
         return filter;
     };
 
-    let mut neg_filters: Vec<TypeFilter> = Vec::new();
-    for f in &filters {
-        if let TargetFilter::Typed(TypedFilter { type_filters, .. }) = f {
-            for tf in type_filters {
-                if matches!(tf, TypeFilter::Non(_)) && !neg_filters.contains(tf) {
-                    neg_filters.push(tf.clone());
-                }
+    let neg_filters: Vec<TypeFilter> = filters
+        .first()
+        .and_then(|f| {
+            if let TargetFilter::Typed(TypedFilter { type_filters, .. }) = f {
+                Some(
+                    type_filters
+                        .iter()
+                        .filter(|tf| matches!(tf, TypeFilter::Non(_)))
+                        .cloned()
+                        .collect(),
+                )
+            } else {
+                None
             }
-        }
-    }
+        })
+        .unwrap_or_default();
 
     if neg_filters.is_empty() {
         return TargetFilter::Or { filters };
     }
 
-    for f in &mut filters {
+    for f in filters.iter_mut().skip(1) {
         if let TargetFilter::Typed(ref mut typed) = f {
             for neg in &neg_filters {
                 if !typed.type_filters.iter().any(|existing| existing == neg) {


### PR DESCRIPTION
## Summary
- Parse Iroh's "during your turn, each non-Lesson instant and sorcery … has flashback" static with a `DuringYourTurn` condition and `SelfManaCost` flashback cost.
- Distribute leading `non-` type negations across `and`/`or` type disjuncts so Lesson cards are excluded from both instant and sorcery branches.

## Test plan
- [x] `cargo test -p engine --lib non_lesson`
- [ ] Confirm Iroh no longer leaves the game waiting between phases when non-Lesson graveyard spells should have flashback


Fix #1163