### PR TITLE
Fix #1323: conditional end-step token generation intervening-if

### DIFF
--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -658,7 +658,11 @@ pub(crate) fn resolve_quantity_for_trigger_check(
     // for hand-event triggers, etc. Without this binding, intervening-if
     // checks for `that player has X` silently resolve against the source's
     // controller and produce wrong results.
-    let resolution_event = state.current_trigger_event.as_ref().or(event);
+    // CR 603.4: The explicit `event` (stack entry / detection pass) wins over
+    // `current_trigger_event`, which may still hold a stale event from an
+    // unrelated in-flight resolution in the same step (Keeper of the Accord
+    // intervening-if at opponent end step — issue #1323).
+    let resolution_event = event.or(state.current_trigger_event.as_ref());
     let scoped_player =
         resolution_event.and_then(|e| crate::game::targeting::extract_player_from_event(e, state));
     let ctx = QuantityContext {
@@ -670,7 +674,8 @@ pub(crate) fn resolve_quantity_for_trigger_check(
 
     // Fast path: when current_trigger_event is already set (resolution-time
     // re-check in stack::resolve_top), the default resolver reads it directly.
-    if state.current_trigger_event.is_some() {
+    // Skip when an explicit override was supplied — that event is authoritative.
+    if event.is_none() && state.current_trigger_event.is_some() {
         return resolve_quantity_with_ctx(state, expr, controller, ctx);
     }
     if let Some(event) = event {

--- a/crates/engine/tests/integration/issue_1323_token_generation_conditions.rs
+++ b/crates/engine/tests/integration/issue_1323_token_generation_conditions.rs
@@ -1,0 +1,125 @@
+//! Regression for GitHub issue #1323: conditional end-step token generation must
+//! fire when intervening-if conditions are met (Keeper of the Accord) and when
+//! optional pay-life riders resolve (Elenda and Azor).
+//!
+//! https://github.com/phase-rs/phase/issues/1323
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+const KEEPER_ORACLE: &str = "At the beginning of each opponent's end step, if that player controls more creatures than you, create a 1/1 white Soldier creature token.\nAt the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.";
+
+const ELENDA_END_STEP: &str = "At the beginning of each end step, you may pay 4 life. If you do, create a number of 1/1 black Vampire Knight creature tokens with lifelink equal to the number of cards you've drawn this turn.";
+
+fn count_soldier_tokens(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|obj| {
+            obj.zone == engine::types::zones::Zone::Battlefield
+                && obj.is_token
+                && obj.controller == P0
+                && obj.name.eq_ignore_ascii_case("Soldier")
+        })
+        .count()
+}
+
+fn count_vampire_knight_tokens(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|obj| {
+            obj.zone == engine::types::zones::Zone::Battlefield
+                && obj.is_token
+                && obj.controller == P0
+                && obj.name.eq_ignore_ascii_case("Vampire Knight")
+        })
+        .count()
+}
+
+fn drive_end_step_stack(runner: &mut engine::game::scenario::GameRunner) {
+    for _ in 0..64 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declare attackers");
+            }
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept optional effect");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .ok();
+            }
+            WaitingFor::Priority { .. } if runner.state().phase == Phase::End => {
+                if runner.state().stack.is_empty() {
+                    return;
+                }
+                runner.act(GameAction::PassPriority).ok();
+            }
+            _ if runner.state().phase == Phase::End && runner.state().stack.is_empty() => return,
+            _ => runner.pass_both_players(),
+        }
+    }
+}
+
+#[test]
+fn issue_1323_keeper_creates_soldier_on_opponent_end_step_when_ahead_on_creatures() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Keeper of the Accord", 3, 4)
+        .from_oracle_text(KEEPER_ORACLE);
+    let _opp_a = scenario.add_creature(P1, "Opp A", 1, 1).id();
+    let _opp_b = scenario.add_creature(P1, "Opp B", 1, 1).id();
+    let _opp_c = scenario.add_creature(P1, "Opp C", 1, 1).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.advance_to_end_step();
+    drive_end_step_stack(&mut runner);
+
+    assert_eq!(
+        count_soldier_tokens(&runner),
+        1,
+        "Keeper must create a Soldier when opponent controls more creatures at their end step"
+    );
+}
+
+#[test]
+fn issue_1323_elenda_creates_vampire_knights_equal_to_cards_drawn_after_pay_life() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Elenda and Azor", 6, 6)
+        .from_oracle_text(ELENDA_END_STEP);
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].cards_drawn_this_turn = 3;
+    runner.state_mut().players[P0.0 as usize].life = 20;
+
+    runner.advance_to_end_step();
+    drive_end_step_stack(&mut runner);
+
+    assert_eq!(
+        count_vampire_knight_tokens(&runner),
+        3,
+        "Elenda must create one Vampire Knight per card drawn this turn after paying 4 life"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        16,
+        "accepting Elenda's end-step rider must pay 4 life"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -129,6 +129,7 @@ mod issue_1308_unstoppable_plan;
 mod issue_1312_prepared_spell_cast_triggers;
 mod issue_1318_throne_god_pharaoh;
 mod issue_1319_ninjutsu_dead_attacker;
+mod issue_1323_token_generation_conditions;
 mod issue_1325_ellie_brick_master;
 mod issue_1326_tabernacle_upkeep_destroy;
 mod issue_1327_zack_fair;


### PR DESCRIPTION
## Summary
- Prefer the explicit stack/detection trigger event over a stale `current_trigger_event` when resolving `QuantityComparison` intervening-if checks at trigger resolution.
- Add integration regressions for Keeper of the Accord (opponent end step creature count) and Elenda and Azor (optional pay 4 life, create tokens equal to cards drawn this turn).

## Test plan
- [x] `cargo test -p engine --test integration issue_1323`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #1323


Made with [Cursor](https://cursor.com)