### PR TITLE
Fix #1321: Abigale removes Death's Shadow life-based CDA

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1,29 +1,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use std::cell::RefCell;
-
-thread_local! {
-    /// CR 613.1f: Objects that received `RemoveAllAbilities` during the
-    /// current layer pass must not apply their own printed static effects
-    /// (including CDAs) in later layers — issue #1321.
-    static ABILITIES_SUPPRESSED: RefCell<HashSet<ObjectId>> = RefCell::new(HashSet::new());
-}
-
-fn clear_abilities_suppressed() {
-    ABILITIES_SUPPRESSED.with(|slot| slot.borrow_mut().clear());
-}
-
-fn mark_abilities_suppressed(object_id: ObjectId) {
-    ABILITIES_SUPPRESSED.with(|slot| {
-        slot.borrow_mut().insert(object_id);
-    });
-}
-
-fn abilities_suppressed(object_id: ObjectId) -> bool {
-    ABILITIES_SUPPRESSED.with(|slot| slot.borrow().contains(&object_id))
-}
-
 use crate::database::synthesis::KeywordTriggerInstaller;
 use crate::game::arithmetic::saturating_pt_add;
 use crate::game::conditions::{
@@ -1292,7 +1269,7 @@ pub fn evaluate_layers(state: &mut GameState) {
     // taken by AI search or snapshot diffing retain their own roots, so this
     // does not break structural sharing across `GameState` clones.
     state.attribution.clear();
-    clear_abilities_suppressed();
+    let mut abilities_suppressed = HashSet::new();
     // CR 702.26b + CR 702.26e: Phased-out permanents are treated as though
     // they do not exist and are not included in continuous-effect affected
     // sets. Exclude them from the whole layer pass so the reset/apply invariant
@@ -1393,7 +1370,7 @@ pub fn evaluate_layers(state: &mut GameState) {
     let copy_effects = gather_active_effects_for_layer(state, Layer::Copy);
     let ordered_copy = order_active_continuous_effects(Layer::Copy, &copy_effects, state);
     for effect in &ordered_copy {
-        apply_continuous_effect(state, effect);
+        apply_continuous_effect(state, effect, &mut abilities_suppressed);
     }
 
     // Step 3: Gather active continuous effects after layer 1 is applied.
@@ -1416,7 +1393,7 @@ pub fn evaluate_layers(state: &mut GameState) {
             };
 
             for effect in &ordered {
-                apply_continuous_effect(state, effect);
+                apply_continuous_effect(state, effect, &mut abilities_suppressed);
             }
         }
 
@@ -2009,6 +1986,7 @@ fn incremental_recipient_ids(
 /// just the entered objects yields a board identical to a full pass (CR 613.1).
 fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectId>) {
     let recipient_ids = incremental_recipient_ids(state, entered_ids);
+    let mut abilities_suppressed = HashSet::new();
     // Step 1 (per-entered subset): reset computed characteristics to base.
     for &id in &recipient_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
@@ -2051,7 +2029,7 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
     let copy_effects = gather_active_effects_for_layer(state, Layer::Copy);
     let ordered_copy = order_active_continuous_effects(Layer::Copy, &copy_effects, state);
     for effect in &ordered_copy {
-        apply_continuous_effect_to(state, effect, &recipient_ids);
+        apply_continuous_effect_to(state, effect, &recipient_ids, &mut abilities_suppressed);
     }
 
     // Step 3-4: Remaining layers in order, restricted to recipient objects.
@@ -2068,7 +2046,12 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
                 order_by_timestamp(&layer_effects)
             };
             for effect in &ordered {
-                apply_continuous_effect_to(state, effect, &recipient_ids);
+                apply_continuous_effect_to(
+                    state,
+                    effect,
+                    &recipient_ids,
+                    &mut abilities_suppressed,
+                );
             }
         }
         // CR 613.1f: mirror the full-pass end-of-Layer-6 denial hook for the
@@ -3467,8 +3450,12 @@ fn modification_dynamic_quantity(m: &ContinuousModification) -> Option<&Quantity
     }
 }
 
-fn apply_continuous_effect(state: &mut GameState, effect: &ActiveContinuousEffect) {
-    apply_continuous_effect_filtered(state, effect, None);
+fn apply_continuous_effect(
+    state: &mut GameState,
+    effect: &ActiveContinuousEffect,
+    abilities_suppressed: &mut HashSet<ObjectId>,
+) {
+    apply_continuous_effect_filtered(state, effect, None, abilities_suppressed);
 }
 
 /// Apply a continuous effect's modification only to the subset of its affected
@@ -3483,19 +3470,21 @@ fn apply_continuous_effect_to(
     state: &mut GameState,
     effect: &ActiveContinuousEffect,
     restrict_to: &HashSet<ObjectId>,
+    abilities_suppressed: &mut HashSet<ObjectId>,
 ) {
-    apply_continuous_effect_filtered(state, effect, Some(restrict_to));
+    apply_continuous_effect_filtered(state, effect, Some(restrict_to), abilities_suppressed);
 }
 
 fn apply_continuous_effect_filtered(
     state: &mut GameState,
     effect: &ActiveContinuousEffect,
     restrict_to: Option<&HashSet<ObjectId>>,
+    abilities_suppressed: &mut HashSet<ObjectId>,
 ) {
     // CR 613.1f: A printed static on an object that lost all abilities this
     // pass must not re-apply in later layers (Death's Shadow CDA after
     // Abigale — issue #1321).
-    if effect.def_index.is_some() && abilities_suppressed(effect.source_id) {
+    if effect.def_index.is_some() && abilities_suppressed.contains(&effect.source_id) {
         return;
     }
 
@@ -3920,7 +3909,7 @@ fn apply_continuous_effect_filtered(
                 obj.replacement_definitions.clear();
                 obj.static_definitions.clear();
                 obj.keywords.clear();
-                mark_abilities_suppressed(id);
+                abilities_suppressed.insert(id);
             }
             ContinuousModification::AddType { core_type } => {
                 if !obj.card_types.core_types.contains(core_type) {
@@ -6824,6 +6813,55 @@ mod tests {
         assert!(obj.trigger_definitions.is_empty());
         assert!(obj.replacement_definitions.is_empty());
         assert!(obj.static_definitions.is_empty());
+    }
+
+    /// CR 613.1f (issue #1321): suppression state must be scoped to the current
+    /// layer pass — an incremental flush after a prior full pass that removed
+    /// abilities must not inherit stale suppression and skip self-sourced CDAs.
+    #[test]
+    fn incremental_layer_pass_does_not_inherit_remove_all_abilities_suppression() {
+        let mut state = setup();
+        let bear = make_creature(&mut state, "Bear", 2, 2, PlayerId(0));
+        {
+            let def = StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AddPower { value: 3 }]);
+            let bear_obj = state.objects.get_mut(&bear).unwrap();
+            bear_obj.static_definitions.push(def.clone());
+            Arc::make_mut(&mut bear_obj.base_static_definitions).push(def);
+        }
+
+        let suppressor = make_creature(&mut state, "Suppressor", 1, 1, PlayerId(0));
+        {
+            let def = StaticDefinition::continuous()
+                .affected(TargetFilter::SpecificObject { id: bear })
+                .modifications(vec![ContinuousModification::RemoveAllAbilities]);
+            state
+                .objects
+                .get_mut(&suppressor)
+                .unwrap()
+                .static_definitions
+                .push(def);
+        }
+
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&bear).unwrap().power,
+            Some(2),
+            "RemoveAllAbilities must suppress the CDA during the full pass"
+        );
+
+        // Suppressor leaves; only the bear is re-derived incrementally.
+        state.battlefield.retain(|&id| id != suppressor);
+        state.objects.remove(&suppressor);
+        state.layers_dirty = LayersDirty::EnteredObjects([bear].into());
+        flush_layers(&mut state);
+
+        assert_eq!(
+            state.objects.get(&bear).unwrap().power,
+            Some(5),
+            "incremental pass must rebuild suppression locally and re-apply the CDA"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1,6 +1,29 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use std::cell::RefCell;
+
+thread_local! {
+    /// CR 613.1f: Objects that received `RemoveAllAbilities` during the
+    /// current layer pass must not apply their own printed static effects
+    /// (including CDAs) in later layers — issue #1321.
+    static ABILITIES_SUPPRESSED: RefCell<HashSet<ObjectId>> = RefCell::new(HashSet::new());
+}
+
+fn clear_abilities_suppressed() {
+    ABILITIES_SUPPRESSED.with(|slot| slot.borrow_mut().clear());
+}
+
+fn mark_abilities_suppressed(object_id: ObjectId) {
+    ABILITIES_SUPPRESSED.with(|slot| {
+        slot.borrow_mut().insert(object_id);
+    });
+}
+
+fn abilities_suppressed(object_id: ObjectId) -> bool {
+    ABILITIES_SUPPRESSED.with(|slot| slot.borrow().contains(&object_id))
+}
+
 use crate::database::synthesis::KeywordTriggerInstaller;
 use crate::game::arithmetic::saturating_pt_add;
 use crate::game::conditions::{
@@ -1269,6 +1292,7 @@ pub fn evaluate_layers(state: &mut GameState) {
     // taken by AI search or snapshot diffing retain their own roots, so this
     // does not break structural sharing across `GameState` clones.
     state.attribution.clear();
+    clear_abilities_suppressed();
     // CR 702.26b + CR 702.26e: Phased-out permanents are treated as though
     // they do not exist and are not included in continuous-effect affected
     // sets. Exclude them from the whole layer pass so the reset/apply invariant
@@ -3468,6 +3492,13 @@ fn apply_continuous_effect_filtered(
     effect: &ActiveContinuousEffect,
     restrict_to: Option<&HashSet<ObjectId>>,
 ) {
+    // CR 613.1f: A printed static on an object that lost all abilities this
+    // pass must not re-apply in later layers (Death's Shadow CDA after
+    // Abigale — issue #1321).
+    if effect.def_index.is_some() && abilities_suppressed(effect.source_id) {
+        return;
+    }
+
     let scan_zone = effect
         .affected_filter
         .extract_in_zone()
@@ -3889,6 +3920,7 @@ fn apply_continuous_effect_filtered(
                 obj.replacement_definitions.clear();
                 obj.static_definitions.clear();
                 obj.keywords.clear();
+                mark_abilities_suppressed(id);
             }
             ContinuousModification::AddType { core_type } => {
                 if !obj.card_types.core_types.contains(core_type) {

--- a/crates/engine/tests/integration/abigale_integration.rs
+++ b/crates/engine/tests/integration/abigale_integration.rs
@@ -346,3 +346,47 @@ fn abigale_strips_non_keyword_abilities_from_target() {
         target.keywords,
     );
 }
+
+#[test]
+fn abigale_strips_death_shadow_life_based_cda() {
+    // CR 613.1f: "Loses all abilities" must suppress characteristic-defining
+    // statics sourced from the affected object itself, not just keywords and
+    // activated abilities (issue #1321).
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let abigale_oracle = "Flying, first strike, lifelink\n\
+        When Abigale enters, up to one other target creature loses all abilities. \
+        Put a flying counter, a first strike counter, and a lifelink counter on that creature.";
+    let abigale_builder =
+        scenario.add_creature_to_hand_from_oracle(P0, "Abigale", 1, 1, abigale_oracle);
+    let abigale_id = abigale_builder.id();
+
+    let death_shadow_oracle =
+        "This creature's power and toughness are each equal to 13 minus your life total.";
+    let death_shadow_id = scenario
+        .add_creature(P1, "Death's Shadow", 13, 13)
+        .from_oracle_text(death_shadow_oracle)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P1.0 as usize].life = 10;
+
+    let outcome = runner
+        .cast(abigale_id)
+        .target_object(death_shadow_id)
+        .resolve();
+
+    let shadow = outcome
+        .state()
+        .objects
+        .get(&death_shadow_id)
+        .expect("Death's Shadow present");
+    assert_eq!(
+        (shadow.power, shadow.toughness),
+        (Some(13), Some(13)),
+        "After losing all abilities, Death's Shadow must revert to printed 13/13, not 3/3 at 10 life; got {:?}/{:?}",
+        shadow.power,
+        shadow.toughness,
+    );
+}


### PR DESCRIPTION
## Summary
- When `RemoveAllAbilities` applies in layer 6, mark affected objects so their own printed static effects (including characteristic-defining abilities) do not re-apply in later layers during the same evaluation pass.
- Add integration regression: Abigale targeting Death's Shadow at 10 life must leave it 13/13, not 3/3.

## Test plan
- [x] `cargo test -p engine --test integration abigale_`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #1321


Made with [Cursor](https://cursor.com)