### PR TITLE
Fix #1322: Murktide Regent Delve payment and ETB counters

### DIFF
--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -19,7 +19,12 @@ import {
   isLibraryCardRevealedToViewer,
 } from "../../viewmodel/gameStateView.ts";
 import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
-import { playOrCastActionsForObject, resolveSingleActionDispatch } from "../../viewmodel/cardActionChoice.ts";
+import {
+  collectObjectActions,
+  isManaObjectAction,
+  playOrCastActionsForObject,
+  resolveSingleActionDispatch,
+} from "../../viewmodel/cardActionChoice.ts";
 
 interface ZoneViewerProps {
   zone: "graveyard" | "exile" | "library";
@@ -85,6 +90,13 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
   }, [objects, zoneIds, zone, gameState, viewerId, playerId]);
 
   const hasPriority = waitingFor?.type === "Priority" && canActForWaitingState;
+
+  const canDelveFromGraveyard =
+    zone === "graveyard"
+    && playerId === viewerId
+    && canActForWaitingState
+    && waitingFor?.type === "ManaPayment"
+    && waitingFor.data.convoke_mode === "Delve";
 
   const currentLegalTargets = useMemo(() => {
     const targets = new Set<number>();
@@ -156,6 +168,11 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
               const castActions = hasPriority
                 ? playOrCastActionsForObject(legalActionsByObject, obj.id)
                 : [];
+              const delveActions = canDelveFromGraveyard
+                ? collectObjectActions(legalActionsByObject, obj.id).filter((action) =>
+                    isManaObjectAction(action, obj),
+                  )
+                : [];
               const isValidTarget = currentLegalTargets.has(obj.id);
               // CR 406.3 + CR 702.75a + CR 702.143e: a face-down card sitting
               // in the shared exile pile (Hideaway, Foretell) carries its real
@@ -177,6 +194,15 @@ export function ZoneViewer({ zone, playerId, onClose }: ZoneViewerProps) {
                     name: isHiddenFromViewer ? t("card.faceDownName") : obj.name,
                   })}
                   hiddenFromViewer={isHiddenFromViewer}
+                  canDelve={delveActions.length > 0}
+                  onDelve={() => {
+                    const auto = resolveSingleActionDispatch(delveActions, obj);
+                    if (auto) {
+                      dispatchAction(auto);
+                    } else {
+                      setPendingAbilityChoice({ objectId: obj.id, actions: delveActions });
+                    }
+                  }}
                   onTarget={() => dispatchAction({ type: "ChooseTarget", data: { target: { Object: obj.id } } })}
                   onCast={() => handleCast(obj, castActions)}
                 />
@@ -193,18 +219,22 @@ function ZoneCard({
   obj,
   isValidTarget,
   canCast,
+  canDelve,
   castTitle,
   hiddenFromViewer,
   onTarget,
   onCast,
+  onDelve,
 }: {
   obj: GameObject;
   isValidTarget: boolean;
   canCast: boolean;
+  canDelve: boolean;
   castTitle: string;
   hiddenFromViewer: boolean;
   onTarget: () => void;
   onCast: () => void;
+  onDelve: () => void;
 }) {
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
@@ -224,14 +254,17 @@ function ZoneCard({
       return;
     }
     if (isValidTarget) { onTarget(); return; }
+    if (canDelve) { onDelve(); return; }
     if (canCast) onCast();
-  }, [obj.id, isValidTarget, canCast, onTarget, onCast, longPressFired]);
+  }, [obj.id, isValidTarget, canDelve, canCast, onTarget, onDelve, onCast, longPressFired]);
 
   return (
     <div
       className={`group relative inline-flex shrink-0 cursor-pointer rounded-lg transition-transform ${
         isValidTarget
           ? CASTABLE_AFFORDANCE_ACTIVE
+          : canDelve
+            ? "ring-2 ring-cyan-400 shadow-[0_0_14px_4px_rgba(34,211,238,0.55)]"
           : canCast
             ? "hover:scale-[1.03]"
             : "hover:ring-1 hover:ring-white/20"

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -24489,6 +24489,44 @@ mod tests {
     }
 
     #[test]
+    fn delve_records_exiled_with_casting_spell() {
+        use super::super::engine::apply_as_current;
+        let mut state = setup_game_at_main_phase();
+        let obj_id = make_delve_spell(&mut state);
+        let gy = create_object(
+            &mut state,
+            CardId(70),
+            PlayerId(0),
+            "Old Spell".to_string(),
+            Zone::Graveyard,
+        );
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 3);
+        add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
+
+        let result =
+            handle_cast_spell(&mut state, PlayerId(0), obj_id, CardId(22), &mut Vec::new())
+                .expect("delve spell should begin casting");
+        state.waiting_for = result;
+
+        apply_as_current(
+            &mut state,
+            crate::types::actions::GameAction::TapForConvoke {
+                object_id: gy,
+                mana_type: ManaType::Colorless,
+            },
+        )
+        .expect("delving a graveyard card is legal");
+
+        assert!(
+            state
+                .cards_exiled_with_source_this_turn
+                .get(&obj_id)
+                .is_some_and(|ids| ids.contains(&gy)),
+            "delved card must be tracked as exiled with the casting spell"
+        );
+    }
+
+    #[test]
     fn delve_makes_spell_castable_via_graveyard() {
         // CR 702.66a (#780): {3}{R} is castable with only {R} of mana when the
         // graveyard supplies the {3} generic via delve.

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3377,6 +3377,11 @@ fn apply_action(
                 ));
             }
             zones::move_to_zone(state, object_id, Zone::Exile, &mut events);
+            // CR 702.66a + CR 607.2a: Delved cards are exiled "with" the spell
+            // being cast (Murktide Regent ETB counters — issue #1322).
+            if let Some(spell_id) = state.pending_cast.as_ref().map(|p| p.object_id) {
+                crate::game::exile_links::push_tracked_by_source(state, object_id, spell_id);
+            }
             if let Some(p) = state.players.iter_mut().find(|p| p.id == player) {
                 p.mana_pool.add(crate::types::mana::ManaUnit::convoke_payment(
                     crate::types::mana::ManaType::Colorless,

--- a/crates/engine/tests/integration/issue_1322_murktide_delve.rs
+++ b/crates/engine/tests/integration/issue_1322_murktide_delve.rs
@@ -1,0 +1,111 @@
+//! Regression for GitHub issue #1322: Murktide Regent must accept Delve payment
+//! and enter with +1/+1 counters for instant/sorcery cards exiled with it.
+//!
+//! https://github.com/phase-rs/phase/issues/1322
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{CastPaymentMode, ConvokeMode, WaitingFor};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const MURKTIDE_ORACLE: &str =
+    "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n\
+Flying\n\
+This creature enters with a +1/+1 counter on it for each instant and sorcery card exiled with it.\n\
+Whenever an instant or sorcery card leaves your graveyard, put a +1/+1 counter on this creature.";
+
+#[test]
+fn issue_1322_murktide_enters_with_counters_for_instants_delved() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let murktide = scenario
+        .add_creature_to_hand_from_oracle(P0, "Murktide Regent", 3, 3, MURKTIDE_ORACLE)
+        .id();
+    let instant_a = scenario
+        .add_spell_to_graveyard(P0, "Lightning Bolt", true)
+        .id();
+    let instant_b = scenario.add_spell_to_graveyard(P0, "Shock", true).id();
+
+    let mut runner = scenario.build();
+    for _ in 0..5 {
+        runner.state_mut().players[P0.0 as usize]
+            .mana_pool
+            .add(ManaUnit::new(
+                ManaType::Blue,
+                engine::types::identifiers::ObjectId(0),
+                false,
+                vec![],
+            ));
+    }
+
+    let card_id = runner.state().objects[&murktide].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: murktide,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("begin casting Murktide");
+
+    for _ in 0..32 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ManaPayment {
+                convoke_mode: Some(ConvokeMode::Delve),
+                ..
+            } => {
+                for gy_id in [instant_a, instant_b] {
+                    if runner.state().objects[&gy_id].zone == Zone::Graveyard {
+                        runner
+                            .act(GameAction::TapForConvoke {
+                                object_id: gy_id,
+                                mana_type: ManaType::Colorless,
+                            })
+                            .expect("delve graveyard card");
+                    }
+                }
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("confirm mana payment");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    break;
+                }
+                runner.act(GameAction::PassPriority).ok();
+            }
+            _ => runner.pass_both_players(),
+        }
+        if runner
+            .state()
+            .objects
+            .get(&murktide)
+            .is_some_and(|o| o.zone == Zone::Battlefield)
+        {
+            break;
+        }
+    }
+
+    runner.advance_until_stack_empty();
+
+    let regent = runner
+        .state()
+        .objects
+        .get(&murktide)
+        .expect("Murktide should resolve to battlefield");
+    assert_eq!(regent.zone, Zone::Battlefield);
+    assert_eq!(
+        regent
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        2,
+        "Murktide must enter with a +1/+1 counter per instant/sorcery delved"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -129,6 +129,7 @@ mod issue_1308_unstoppable_plan;
 mod issue_1312_prepared_spell_cast_triggers;
 mod issue_1318_throne_god_pharaoh;
 mod issue_1319_ninjutsu_dead_attacker;
+mod issue_1322_murktide_delve;
 mod issue_1325_ellie_brick_master;
 mod issue_1326_tabernacle_upkeep_destroy;
 mod issue_1327_zack_fair;


### PR DESCRIPTION
## Summary
- When paying with Delve, exile-linked tracking records each delved card as exiled with the spell being cast so ETB replacement effects (Murktide Regent) count them.
- Graveyard zone viewer accepts `TapForConvoke` during Delve mana payment with convoke-style highlighting.
- Add unit and integration regressions for delve exile tracking and Murktide +1/+1 counters.

## Test plan
- [x] `cargo test -p engine --lib delve_records_exiled`
- [x] `cargo test -p engine --test integration issue_1322`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #1322


Made with [Cursor](https://cursor.com)