### PR TITLE
Fix #1189: Stop AI loop when human controls AI seat via Mindslaver

### DIFF
--- a/crates/phase-ai/src/auto_play.rs
+++ b/crates/phase-ai/src/auto_play.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use engine::game::engine::apply;
+use engine::game::turn_control;
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
@@ -47,22 +48,19 @@ pub fn run_ai_actions(
     let mut results = Vec::new();
 
     for _ in 0..MAX_AI_ACTIONS_PER_SEQUENCE {
-        // CR 103.5: For simultaneous mulligan states, `acting_player()` returns
-        // None when multiple players are pending. Fall back to the first
-        // AI-controlled pending player so AI-vs-AI auto-play can advance
-        // through the mulligan phase one decision at a time.
-        let actor = match state.waiting_for.acting_player() {
-            Some(p) if ai_players.contains(&p) => p,
-            Some(_) => break, // Single human's turn
-            None => match state
-                .waiting_for
-                .acting_players()
-                .into_iter()
-                .find(|p| ai_players.contains(p))
-            {
-                Some(p) => p,
-                None => break, // No AI player is pending
-            },
+        // CR 723.5: Under turn control (Mindslaver, Emrakul), the authorized
+        // submitter is the controller — not the active player. Only run AI when
+        // that submitter is an AI seat; otherwise wait for the human controller
+        // (issue #1189).
+        let actor = state
+            .waiting_for
+            .acting_players()
+            .into_iter()
+            .map(|player| turn_control::authorized_submitter_for_player(state, player))
+            .find(|player| ai_players.contains(player));
+
+        let Some(actor) = actor else {
+            break;
         };
 
         let config = match ai_configs.get(&actor) {

--- a/crates/phase-ai/tests/scenarios.rs
+++ b/crates/phase-ai/tests/scenarios.rs
@@ -424,3 +424,73 @@ fn scenario_harvester_of_misery_cast_is_preferred_over_pass() {
         "AI should either cast Harvester or pass, got {action:?}"
     );
 }
+
+/// Regression (issue #1189): when a human controls an AI seat via Mindslaver,
+/// the server AI loop must not attempt to act for that seat — it would apply
+/// actions as the wrong player and hang or crash.
+#[test]
+fn mindslaver_human_control_stops_ai_loop() {
+    let mut runner = {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.add_land_to_hand(P1, "Forest");
+        scenario.build()
+    };
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.turn_decision_controller = Some(P0);
+        engine::game::public_state::sync_waiting_for(state, &WaitingFor::Priority { player: P1 });
+    }
+
+    let ai_players = HashSet::from([P1]);
+    let ai_configs = HashMap::from([(P1, create_config(AiDifficulty::VeryHard, Platform::Native))]);
+    let mut ai_rng = SmallRng::seed_from_u64(1189);
+    let ai_session = phase_ai::session::AiSession::arc_from_game(runner.state());
+    let results = run_ai_actions(
+        runner.state_mut(),
+        &ai_players,
+        &ai_configs,
+        &mut ai_rng,
+        &ai_session,
+    );
+
+    assert!(
+        results.is_empty(),
+        "AI must not act when a human controls the AI seat (Mindslaver)"
+    );
+}
+
+/// Under Emrakul-style control the AI controller must still act for the human seat.
+#[test]
+fn emrakul_ai_control_runs_for_controlled_human() {
+    let mut runner = {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.add_land_to_hand(P0, "Forest");
+        scenario.build()
+    };
+    {
+        let state = runner.state_mut();
+        state.active_player = P0;
+        state.turn_decision_controller = Some(P1);
+        engine::game::public_state::sync_waiting_for(state, &WaitingFor::Priority { player: P0 });
+    }
+
+    let ai_players = HashSet::from([P1]);
+    let ai_configs = HashMap::from([(P1, create_config(AiDifficulty::VeryHard, Platform::Native))]);
+    let mut ai_rng = SmallRng::seed_from_u64(2012);
+    let ai_session = phase_ai::session::AiSession::arc_from_game(runner.state());
+    let results = run_ai_actions(
+        runner.state_mut(),
+        &ai_players,
+        &ai_configs,
+        &mut ai_rng,
+        &ai_session,
+    );
+
+    assert!(
+        !results.is_empty(),
+        "AI controller must act during the controlled human turn"
+    );
+}


### PR DESCRIPTION
## Summary
- When turn decision control shifts to a human (Mindslaver on an AI opponent), the server `run_ai_actions` loop no longer tries to act for the AI seat.
- The loop now selects actors via `authorized_submitter_for_player`, matching CR 723.5 and preventing apply failures/hangs when the human must make all choices.

## Test plan
- [x] `cargo test -p phase-ai mindslaver_human_control`
- [x] `cargo test -p phase-ai emrakul_ai_control`
- [x] `cargo clippy -p phase-ai -- -D warnings`

Fixes #1189

Made with [Cursor](https://cursor.com)