### PR TITLE
Fix #1191: Parse Tzaangor Shaman copy-next-spell delayed trigger

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -758,13 +758,66 @@ fn try_parse_when_next_event(tp: TextPair) -> Option<ParsedEffectClause> {
     })
 }
 
+/// CR 603.7: Parse "copy the next [type] spell you cast this turn when you cast it"
+/// — a one-shot delayed trigger that copies the next matching spell at cast time.
+/// Tzaangor Shaman (issue #1191) uses this wording instead of "when you next cast …".
+fn try_parse_copy_next_spell_when_cast(tp: TextPair) -> Option<ParsedEffectClause> {
+    use crate::types::ability::CopyRetargetPermission;
+    use crate::types::triggers::TriggerMode;
+
+    const PREFIX: &str = "copy the next ";
+    if !tp.lower.starts_with(PREFIX) {
+        return None;
+    }
+    const SUFFIX: &str = " you cast this turn when you cast it";
+    let rest = &tp.lower[PREFIX.len()..];
+    let spell_part_end = rest.find(SUFFIX)?;
+    let spell_part = rest[..spell_part_end].trim();
+    let combined_filter = extract_when_next_spell_filter(spell_part)?;
+
+    let after_suffix_idx = PREFIX.len() + spell_part_end + SUFFIX.len();
+    let remainder = tp.original.get(after_suffix_idx..).unwrap_or("").trim();
+    let remainder_for_retarget = remainder
+        .trim_start_matches(|c: char| c == '.' || c.is_whitespace())
+        .to_lowercase();
+    let retarget = if remainder_for_retarget.is_empty() {
+        CopyRetargetPermission::KeepOriginalTargets
+    } else if crate::parser::oracle_effect::sequence::recognize_copy_retarget_clause(
+        &remainder_for_retarget,
+    ) {
+        CopyRetargetPermission::MayChooseNewTargets
+    } else {
+        return None;
+    };
+
+    let inner = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::CopySpell {
+            target: TargetFilter::TriggeringSource,
+            retarget,
+            copier: None,
+            additional_modifications: Vec::new(),
+            starting_loyalty_from_casualty_sacrifice: false,
+        },
+    );
+
+    Some(build_when_next_delayed_trigger(
+        TriggerMode::SpellCast,
+        combined_filter,
+        inner,
+        None,
+    ))
+}
+
 pub(crate) fn try_parse_temporal_delayed_trigger_ability(
     text: &str,
     kind: AbilityKind,
 ) -> Option<AbilityDefinition> {
     let lower = text.to_lowercase();
     let tp = TextPair::new(text, &lower);
-    let clause = try_parse_whenever_this_turn(tp).or_else(|| try_parse_when_next_event(tp))?;
+    let clause = try_parse_whenever_this_turn(tp)
+        .or_else(|| try_parse_when_next_event(tp))
+        .or_else(|| try_parse_copy_next_spell_when_cast(tp))?;
     Some(ability_definition_from_clause(kind, clause))
 }
 
@@ -4694,6 +4747,11 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
 
     // CR 603.7: "When you next cast a [type] spell this turn, ..." — one-shot delayed trigger.
     if let Some(clause) = try_parse_when_next_event(tp) {
+        return clause;
+    }
+
+    // CR 603.7: "Copy the next [type] spell you cast this turn when you cast it."
+    if let Some(clause) = try_parse_copy_next_spell_when_cast(tp) {
         return clause;
     }
 
@@ -27734,6 +27792,42 @@ mod tests {
                 }
             ),
             "expected inner CopySpell with MayChooseNewTargets, got {:?}",
+            inner.effect
+        );
+    }
+
+    /// CR 603.7 (issue #1191): Tzaangor Shaman — "copy the next instant or
+    /// sorcery spell you cast this turn when you cast it" must install a
+    /// one-shot delayed trigger, not a combat-damage CopySpell.
+    #[test]
+    fn effect_tzaangor_copy_next_spell_when_cast() {
+        let def = parse_effect_chain(
+            "Copy the next instant or sorcery spell you cast this turn when you cast it. \
+             You may choose new targets for the copy.",
+            AbilityKind::Spell,
+        );
+        let Effect::CreateDelayedTrigger {
+            condition,
+            effect: inner,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected CreateDelayedTrigger, got {:?}", def.effect);
+        };
+        let DelayedTriggerCondition::WhenNextEvent { trigger, .. } = condition else {
+            panic!("expected WhenNextEvent, got {condition:?}");
+        };
+        assert_eq!(trigger.mode, crate::types::triggers::TriggerMode::SpellCast);
+        assert!(
+            matches!(
+                *inner.effect,
+                Effect::CopySpell {
+                    target: TargetFilter::TriggeringSource,
+                    retarget: CopyRetargetPermission::MayChooseNewTargets,
+                    ..
+                }
+            ),
+            "expected inner CopySpell on triggering spell, got {:?}",
             inner.effect
         );
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -56,15 +56,15 @@ pub(crate) use self::token::parse_token_description;
 
 use std::str::FromStr;
 
-use crate::parser::oracle_nom::error::OracleError;
+use crate::parser::oracle_nom::error::{oracle_err, OracleError};
 #[cfg(test)]
 use crate::parser::oracle_trigger::parse_trigger_line;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
-use nom::character::complete::{anychar, multispace1, space1};
+use nom::character::complete::{anychar, multispace0, multispace1, space1};
 use nom::combinator::{all_consuming, eof, map, not, opt, peek, recognize, rest, value};
 use nom::multi::{many1, separated_list1};
-use nom::sequence::{preceded, terminated};
+use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
 
 use super::oracle_nom::bridge::nom_on_lower;
@@ -91,8 +91,8 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction,
     BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
     ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard, ConjureSource,
-    ContinuousModification, ControllerRef, DamageModification, DamageSource,
-    DelayedTriggerCondition, DoubleTarget, Duration, Effect, EffectScope, FilterProp,
+    ContinuousModification, ControllerRef, CopyRetargetPermission, DamageModification,
+    DamageSource, DelayedTriggerCondition, DoubleTarget, Duration, Effect, EffectScope, FilterProp,
     GameRestriction, IntensityScope, IterationKindBinding, LibraryPosition, ManaProduction,
     ManaSpendPermission, MultiTargetSpec, ObjectProperty, ObjectScope, OriginConstraint,
     PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount, PreventionScope,
@@ -758,37 +758,46 @@ fn try_parse_when_next_event(tp: TextPair) -> Option<ParsedEffectClause> {
     })
 }
 
+/// CR 603.7: nom body for "copy the next [type] spell you cast this turn when
+/// you cast it[, optionally with copy retarget permission]".
+fn parse_copy_next_spell_when_cast_body(
+    input: &str,
+) -> OracleResult<'_, (TargetFilter, CopyRetargetPermission)> {
+    let (rest, spell_part) = preceded(
+        tag("copy the next "),
+        take_until(" you cast this turn when you cast it"),
+    )
+    .parse(input)?;
+    let (rest, _) = tag(" you cast this turn when you cast it").parse(rest)?;
+
+    let filter =
+        extract_when_next_spell_filter(spell_part.trim()).ok_or_else(|| oracle_err(spell_part))?;
+
+    let (rest, retarget) = alt((
+        map(
+            preceded(
+                pair(multispace0, opt(preceded(multispace0, tag(".")))),
+                all_consuming(sequence::parse_copy_retarget_clause),
+            ),
+            |_| CopyRetargetPermission::MayChooseNewTargets,
+        ),
+        value(
+            CopyRetargetPermission::KeepOriginalTargets,
+            all_consuming(eof),
+        ),
+    ))
+    .parse(rest)?;
+
+    Ok((rest, (filter, retarget)))
+}
+
 /// CR 603.7: Parse "copy the next [type] spell you cast this turn when you cast it"
 /// — a one-shot delayed trigger that copies the next matching spell at cast time.
 /// Tzaangor Shaman (issue #1191) uses this wording instead of "when you next cast …".
 fn try_parse_copy_next_spell_when_cast(tp: TextPair) -> Option<ParsedEffectClause> {
-    use crate::types::ability::CopyRetargetPermission;
-    use crate::types::triggers::TriggerMode;
-
-    const PREFIX: &str = "copy the next ";
-    if !tp.lower.starts_with(PREFIX) {
-        return None;
-    }
-    const SUFFIX: &str = " you cast this turn when you cast it";
-    let rest = &tp.lower[PREFIX.len()..];
-    let spell_part_end = rest.find(SUFFIX)?;
-    let spell_part = rest[..spell_part_end].trim();
-    let combined_filter = extract_when_next_spell_filter(spell_part)?;
-
-    let after_suffix_idx = PREFIX.len() + spell_part_end + SUFFIX.len();
-    let remainder = tp.original.get(after_suffix_idx..).unwrap_or("").trim();
-    let remainder_for_retarget = remainder
-        .trim_start_matches(|c: char| c == '.' || c.is_whitespace())
-        .to_lowercase();
-    let retarget = if remainder_for_retarget.is_empty() {
-        CopyRetargetPermission::KeepOriginalTargets
-    } else if crate::parser::oracle_effect::sequence::recognize_copy_retarget_clause(
-        &remainder_for_retarget,
-    ) {
-        CopyRetargetPermission::MayChooseNewTargets
-    } else {
-        return None;
-    };
+    let (_, (combined_filter, retarget)) = all_consuming(parse_copy_next_spell_when_cast_body)
+        .parse(tp.lower)
+        .ok()?;
 
     let inner = AbilityDefinition::new(
         AbilityKind::Spell,

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1,7 +1,7 @@
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, tag_no_case, take_until};
-use nom::character::complete::{multispace0, multispace1};
+use nom::character::complete::multispace1;
 use nom::combinator::{all_consuming, eof, opt, value};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
@@ -2108,8 +2108,24 @@ fn recognize_counter_destroy_rider(lower: &str) -> bool {
     .is_ok()
 }
 
-/// CR 707.10c: nom recognizer for the "[you] may choose [a] new target[s] for
+/// CR 707.10c: nom parser for the "[you] may choose [a] new target[s] for
 /// {the,that} copy/copies" continuation clause that grants copy retargeting.
+pub(super) fn parse_copy_retarget_clause(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        (
+            opt(alt((tag(", and "), tag("and ")))),
+            opt(tag("you ")),
+            tag("may choose "),
+            alt((tag("a new target "), tag("new targets "))),
+            tag("for "),
+            alt((tag("the copies"), tag("the copy"), tag("that copy"))),
+            opt(alt((tag("."), tag(",")))),
+        ),
+    )
+    .parse(input)
+}
+
 /// Operates on lowercased text; tolerates a trailing period/whitespace.
 ///
 /// The clause is composed from independent axes rather than enumerated as full
@@ -2121,23 +2137,9 @@ fn recognize_counter_destroy_rider(lower: &str) -> bool {
 ///   - determiner ("the copy/copies" — Fork/Twincast; "that copy" — the Chain
 ///     cycle's "a new target for that copy").
 pub(super) fn recognize_copy_retarget_clause(lower: &str) -> bool {
-    value(
-        (),
-        (
-            multispace0,
-            opt(alt((tag::<_, _, OracleError<'_>>(", and "), tag("and ")))),
-            opt(tag("you ")),
-            tag("may choose "),
-            alt((tag("a new target "), tag("new targets "))),
-            tag("for "),
-            alt((tag("the copies"), tag("the copy"), tag("that copy"))),
-            opt(alt((tag("."), tag(",")))),
-            multispace0,
-            eof,
-        ),
-    )
-    .parse(lower.trim())
-    .is_ok()
+    all_consuming(parse_copy_retarget_clause)
+        .parse(lower.trim())
+        .is_ok()
 }
 
 /// CR 707.10c: Set `retarget` on the (possibly delayed-trigger-wrapped)

--- a/crates/engine/tests/integration/issue_1191_tzaangor_shaman.rs
+++ b/crates/engine/tests/integration/issue_1191_tzaangor_shaman.rs
@@ -1,0 +1,138 @@
+//! Regression for GitHub issue #1191 — Tzaangor Shaman delayed copy trigger.
+//!
+//! Oracle: "Whenever this creature deals combat damage to a player, copy the next
+//! instant or sorcery spell you cast this turn when you cast it."
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    CopyRetargetPermission, DelayedTriggerCondition, Effect, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+
+use super::rules::AttackTarget;
+
+const TZAANGOR_ORACLE: &str = "Flying\n\
+Whenever this creature deals combat damage to a player, copy the next instant or sorcery spell you cast this turn when you cast it. \
+You may choose new targets for the copy.";
+
+#[test]
+fn tzaangor_combat_damage_installs_when_next_copy_delayed_trigger() {
+    let parsed = parse_oracle_text(
+        TZAANGOR_ORACLE,
+        "Tzaangor Shaman",
+        &["Flying".to_string()],
+        &["Creature".to_string()],
+        &["Mutant".to_string(), "Shaman".to_string()],
+    );
+    assert_eq!(parsed.triggers.len(), 1, "expected one triggered ability");
+    let trigger = &parsed.triggers[0];
+    assert_eq!(trigger.mode, TriggerMode::DamageDone);
+
+    let execute = trigger
+        .execute
+        .as_deref()
+        .expect("combat damage trigger must have execute body");
+    let Effect::CreateDelayedTrigger {
+        condition,
+        effect: inner,
+        ..
+    } = execute.effect.as_ref()
+    else {
+        panic!(
+            "expected CreateDelayedTrigger on combat damage, got {:?}",
+            execute.effect
+        );
+    };
+    let DelayedTriggerCondition::WhenNextEvent {
+        trigger: spell_trigger,
+        ..
+    } = condition
+    else {
+        panic!("expected WhenNextEvent delayed trigger, got {condition:?}");
+    };
+    assert_eq!(spell_trigger.mode, TriggerMode::SpellCast);
+    assert!(
+        matches!(
+            *inner.effect,
+            Effect::CopySpell {
+                target: TargetFilter::TriggeringSource,
+                retarget: CopyRetargetPermission::MayChooseNewTargets,
+                ..
+            }
+        ),
+        "inner effect must copy the triggering spell, got {:?}",
+        inner.effect
+    );
+}
+
+#[test]
+fn tzaangor_delayed_trigger_copies_next_instant_on_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let shaman = scenario
+        .add_creature_from_oracle(P0, "Tzaangor Shaman", 3, 3, TZAANGOR_ORACLE)
+        .with_subtypes(vec!["Mutant", "Shaman"])
+        .id();
+    let bolt = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Lightning Bolt",
+            true,
+            "Lightning Bolt deals 3 damage to any target.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(shaman, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("declare attack");
+
+    for _ in 0..40 {
+        match &runner.state().waiting_for {
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("no blocks");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .ok();
+            }
+            _ if runner.state().phase == Phase::PostCombatMain => break,
+            _ => runner.pass_both_players(),
+        }
+    }
+
+    assert!(
+        runner.state().delayed_triggers.iter().any(|dt| {
+            matches!(dt.condition, DelayedTriggerCondition::WhenNextEvent { .. })
+                && matches!(dt.ability.effect, Effect::CopySpell { .. })
+                && dt.source_id == shaman
+        }),
+        "combat damage must install a WhenNextEvent CopySpell delayed trigger; got {:?}",
+        runner.state().delayed_triggers
+    );
+
+    let stack_before = runner.state().stack.len();
+    runner.cast(bolt).target_player(P1).commit();
+    let stack_after = runner.state().stack.len();
+    assert!(
+        stack_after > stack_before,
+        "Lightning Bolt must be on the stack (before={stack_before}, after={stack_after})"
+    );
+    assert!(
+        stack_after >= stack_before + 2,
+        "Tzaangor delayed trigger should put a copy on the stack alongside Bolt (stack {stack_before}→{stack_after})"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -118,6 +118,7 @@ mod issue_1022_savai_triome_cycling;
 mod issue_1023_oversold_cemetery;
 mod issue_1025_rishkars_expertise;
 mod issue_1156_coin_of_mastery;
+mod issue_1191_tzaangor_shaman;
 mod issue_1202_prepared_spell_cast_timing;
 mod issue_1206_shelob_spider_death_tokens;
 mod issue_1297_venture_initiative_triggers;


### PR DESCRIPTION
## Summary
- Add parser support for "copy the next [instant or sorcery] spell you cast this turn when you cast it", which Tzaangor Shaman uses on its combat-damage trigger.
- Previously this lowered to an immediate `CopySpell` with a fallback target, firing at the wrong time; it now installs a one-shot `WhenNextEvent` delayed trigger that copies the spell as it is cast.

## Test plan
- [x] `cargo test -p engine --lib effect_tzaangor_copy_next_spell_when_cast`
- [x] `cargo test -p engine --test integration issue_1191`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #1191

Made with [Cursor](https://cursor.com)