### PR TITLE
fix(parser): bind ETB token-copier "exile it" anaphor to the created token

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1463,7 +1463,21 @@ pub(super) fn rewrite_parent_target_to_last_created(effect: &mut Effect) {
         | Effect::Pump { target, .. }
         | Effect::Attach { target, .. }
         | Effect::ChangeZone { target, .. } => {
-            if matches!(target, TargetFilter::ParentTarget) {
+            // CR 603.7c + CR 608.2c: inside an ETB-triggered token-copier (e.g.
+            // Flameshadow Conjuring / Inalla: "create a token that's a copy of
+            // that creature. … Exile it at the beginning of the next end step"),
+            // the trigger sets the effect's subject to the *entering* creature,
+            // so the bare-"it" pronoun lowers to `TriggeringSource` rather than
+            // `ParentTarget`. In this gated post-token scope the antecedent of
+            // "it"/"that token" is the newly created token, so both fallback
+            // anaphors rewrite to `LastCreated`. (The `CopyTokenOf` copy source
+            // is structurally absent from these arms, so it stays
+            // `TriggeringSource` — the token is still a copy of the entering
+            // creature.)
+            if matches!(
+                target,
+                TargetFilter::ParentTarget | TargetFilter::TriggeringSource
+            ) {
                 *target = TargetFilter::LastCreated;
             }
         }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -16513,6 +16513,109 @@ mod tests {
     }
 
     #[test]
+    fn etb_token_copier_exile_anaphor_binds_created_token() {
+        // CR 603.7c + CR 608.2c: in an ETB-triggered token-copier, the trigger
+        // sets the effect subject to the *entering* creature, so the bare-"it"
+        // pronoun in "Exile it at the beginning of the next end step" lowers to
+        // `TriggeringSource`. But the antecedent is the newly created TOKEN, so
+        // the delayed-exile must bind `LastCreated`. The `CopyTokenOf` copy
+        // source stays `TriggeringSource` (the token IS a copy of the entering
+        // creature — locked by `necroduality_copies_entering_zombie_not_source`).
+        fn collect<'a>(def: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+            out.push(&def.effect);
+            if let Effect::CreateDelayedTrigger { effect: inner, .. } = &*def.effect {
+                collect(inner, out);
+            }
+            if let Some(sub) = def.sub_ability.as_deref() {
+                collect(sub, out);
+            }
+            if let Some(els) = def.else_ability.as_deref() {
+                collect(els, out);
+            }
+        }
+        fn copy_source(effs: &[&Effect]) -> Option<TargetFilter> {
+            effs.iter().find_map(|e| match e {
+                Effect::CopyTokenOf { target, .. } => Some(target.clone()),
+                _ => None,
+            })
+        }
+        fn exile_target(effs: &[&Effect]) -> Option<TargetFilter> {
+            effs.iter().find_map(|e| match e {
+                Effect::ChangeZone {
+                    destination: Zone::Exile,
+                    target,
+                    ..
+                } => Some(target.clone()),
+                _ => None,
+            })
+        }
+
+        for (name, text) in [
+            (
+                "Flameshadow Conjuring",
+                "Whenever a nontoken creature you control enters, you may pay {R}. If you do, create a token that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step.",
+            ),
+            (
+                "Inalla, Archmage Ritualist",
+                "Whenever another nontoken Wizard you control enters, you may pay {1}. If you do, create a token that's a copy of that Wizard. The token gains haste. Exile it at the beginning of the next end step.",
+            ),
+        ] {
+            let def = parse_trigger_line(text, name);
+            let exec = def.execute.as_ref().expect("execute must be Some");
+            let mut effs = Vec::new();
+            collect(exec, &mut effs);
+            assert_eq!(
+                copy_source(&effs),
+                Some(TargetFilter::TriggeringSource),
+                "{name}: CopyTokenOf source must stay TriggeringSource (copy the entering creature)"
+            );
+            assert_eq!(
+                exile_target(&effs),
+                Some(TargetFilter::LastCreated),
+                "{name}: delayed exile must bind the created token (LastCreated), not the entering creature"
+            );
+        }
+    }
+
+    #[test]
+    fn non_token_enters_exile_it_stays_triggering_source() {
+        // No-regression: a non-token ETB trigger "exile it" has NO token creator
+        // in the chain, so the populate-anaphor repair pass is never entered and
+        // "it" correctly stays `TriggeringSource` (the entering creature).
+        let def = parse_trigger_line(
+            "Whenever a creature you control enters, exile it at the beginning of the next end step.",
+            "Test Nontoken Exiler",
+        );
+        let exec = def.execute.as_ref().expect("execute must be Some");
+        fn find_exile(def: &AbilityDefinition) -> Option<TargetFilter> {
+            if let Effect::CreateDelayedTrigger { effect: inner, .. } = &*def.effect {
+                if let Effect::ChangeZone {
+                    destination: Zone::Exile,
+                    target,
+                    ..
+                } = &*inner.effect
+                {
+                    return Some(target.clone());
+                }
+            }
+            if let Effect::ChangeZone {
+                destination: Zone::Exile,
+                target,
+                ..
+            } = &*def.effect
+            {
+                return Some(target.clone());
+            }
+            def.sub_ability.as_deref().and_then(find_exile)
+        }
+        assert_eq!(
+            find_exile(exec),
+            Some(TargetFilter::TriggeringSource),
+            "non-token 'exile it' must stay TriggeringSource (no token creator → pass not entered)"
+        );
+    }
+
+    #[test]
     fn flicker_enters_trigger_keeps_chosen_target_anaphor() {
         // CR 608.2c: "When ~ enters, you may exile another target permanent you
         // control, then return that card …" — "that card" refers to the CHOSEN


### PR DESCRIPTION
Fixes #3759.

## Summary

An ETB-triggered token-copier that says "create a token that's a copy of that creature. … **Exile it** at the beginning of the next end step" exiled the **entering creature** instead of the created token:

- **Inalla, Archmage Ritualist** — "…create a token that's a copy of that Wizard. The token gains haste. Exile it at the beginning of the next end step." → delayed exile hit the original Wizard.
- **Flameshadow Conjuring** — same "Exile it" bug.

The ETB trigger sets the effect subject to the entering creature, so the bare-"it" pronoun lowers to `TriggeringSource`. The post-token anaphor-repair pass (`rewrite_parent_target_to_last_created`) only rewrote `ParentTarget`/`SelfRef`, so `TriggeringSource` escaped and `ChangeZone { destination: Exile, target: TriggeringSource }` bound the entering creature.

## Fix (parser-AST-only; no new engine variant, no runtime change)

Widen the **gated post-token-creator** repair pass `rewrite_parent_target_to_last_created` so its target-bearing effect arms (Sacrifice/Destroy/Bounce/SetTapState/Pump/Attach/ChangeZone) also rewrite `TriggeringSource → LastCreated`, not just `ParentTarget`. This pass only runs when a token-creating effect is present in the chain, so a normal "whenever X enters, do Y to it" trigger is untouched. The `CopyTokenOf` copy source is structurally absent from those arms, so it stays `TriggeringSource` (the token remains a copy of the entering creature — locked by the existing Necroduality test).

`LastCreated` is already runtime-handled — sibling **Felhide Spiritbinder** (copy of a *target* creature) parses its "Exile it" to `LastCreated` today. CR 603.7c (delayed triggered ability refers to a specific object), CR 608.2c (anaphora).

## Scope

Fully fixes Inalla and Flameshadow Conjuring's exile. Flameshadow's separate "That token gains haste" grant (`affected: ParentTarget`, `target: TriggeringSource`) has a related but distinct mis-binding whose fix would risk the Fractal Harness / Emperor of Bones `forward_result` class — left as a documented follow-up, out of scope here.

## Tests

- Discriminating (real `parse_trigger_line` pipeline): Flameshadow + Inalla → `CopyTokenOf` source stays `TriggeringSource`, delayed exile `ChangeZone.target == LastCreated`. Revert-failing.
- No-regression: a non-token "whenever a creature you control enters, exile it" → exile stays `TriggeringSource` (no token creator → repair pass not entered); the existing Necroduality copy-source test stays green.

## Verification

`cargo +nightly test -p engine` (all targets): 12544 passed; the only failure is the pre-existing flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (a global perf-counter race under parallel execution — passes in isolation, unrelated to this parser-only change). `clippy -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean (exit 0) for this diff.
