### PR TITLE
Fix #1336: Ichormoon Gauntlet grants planeswalker loyalty abilities

### DIFF
--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1173,6 +1173,32 @@ pub(crate) fn parse_quoted_ability(text: &str) -> AbilityDefinition {
     }
 }
 
+/// True when `trimmed_prefix` is a bracketed planeswalker loyalty cost (`[+N]`,
+/// `[−N]`, `[0]`, `[-N]`) as printed in granted-ability text (Ichormoon Gauntlet).
+fn is_bracket_loyalty_cost_prefix(trimmed_prefix: &str) -> bool {
+    let Some(inner) = trimmed_prefix
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+    else {
+        return false;
+    };
+    if inner == "0" {
+        return true;
+    }
+    if inner.parse::<i32>().is_ok() {
+        return true;
+    }
+    let Some(rest) = inner
+        .strip_prefix('+')
+        .or_else(|| inner.strip_prefix('−'))
+        .or_else(|| inner.strip_prefix('–'))
+        .or_else(|| inner.strip_prefix('-'))
+    else {
+        return false;
+    };
+    rest.parse::<i32>().is_ok()
+}
+
 /// Find the position of the cost/effect separator colon in ability text.
 ///
 /// Looks for `: ` or `:\n` that appears after cost-like content (mana symbols,
@@ -1188,6 +1214,7 @@ pub(crate) fn find_cost_separator(text: &str) -> Option<usize> {
             let lower_prefix = trimmed_prefix.to_lowercase();
             let has_cost = prefix.contains('{')
                 || trimmed_prefix.parse::<i32>().is_ok()
+                || is_bracket_loyalty_cost_prefix(trimmed_prefix)
                 || trimmed_prefix.strip_prefix('+').is_some() // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
                 || trimmed_prefix.strip_prefix('\u{2212}').is_some() // minus sign for loyalty // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
                 // CR 118.12: Text-based costs — sacrifice, discard, pay life, tap/untap, exile, remove

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1179,10 +1179,12 @@ pub(crate) fn parse_quoted_ability(text: &str) -> AbilityDefinition {
 /// True when `trimmed_prefix` is a bracketed planeswalker loyalty cost (`[+N]`,
 /// `[−N]`, `[0]`, `[-N]`) as printed in granted-ability text (Ichormoon Gauntlet).
 fn is_bracket_loyalty_cost_prefix(trimmed_prefix: &str) -> bool {
+    parse_bracket_loyalty_cost_prefix(trimmed_prefix).is_ok()
+}
+
+fn parse_bracket_loyalty_cost_prefix(input: &str) -> nom::IResult<&str, &str, OracleError<'_>> {
     let loyalty_number = recognize(pair(opt(one_of("+−–-")), digit1));
-    all_consuming(delimited(tag("["), loyalty_number, tag("]")))
-        .parse(trimmed_prefix)
-        .is_ok()
+    all_consuming(delimited(tag("["), loyalty_number, tag("]"))).parse(input)
 }
 
 /// Find the position of the cost/effect separator colon in ability text.

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -6,6 +6,9 @@ use super::prelude::*;
 #[allow(unused_imports)]
 use super::support::*;
 use crate::types::ability::PlayerFilter;
+use nom::character::complete::{digit1, one_of};
+use nom::combinator::{all_consuming, opt, recognize};
+use nom::sequence::{delimited, pair};
 
 /// Lower a parsed rule-static predicate into the runtime static mode.
 pub(crate) fn lower_rule_static(
@@ -1176,27 +1179,10 @@ pub(crate) fn parse_quoted_ability(text: &str) -> AbilityDefinition {
 /// True when `trimmed_prefix` is a bracketed planeswalker loyalty cost (`[+N]`,
 /// `[−N]`, `[0]`, `[-N]`) as printed in granted-ability text (Ichormoon Gauntlet).
 fn is_bracket_loyalty_cost_prefix(trimmed_prefix: &str) -> bool {
-    let Some(inner) = trimmed_prefix
-        .strip_prefix('[')
-        .and_then(|s| s.strip_suffix(']'))
-    else {
-        return false;
-    };
-    if inner == "0" {
-        return true;
-    }
-    if inner.parse::<i32>().is_ok() {
-        return true;
-    }
-    let Some(rest) = inner
-        .strip_prefix('+')
-        .or_else(|| inner.strip_prefix('−'))
-        .or_else(|| inner.strip_prefix('–'))
-        .or_else(|| inner.strip_prefix('-'))
-    else {
-        return false;
-    };
-    rest.parse::<i32>().is_ok()
+    let loyalty_number = recognize(pair(opt(one_of("+−–-")), digit1));
+    all_consuming(delimited(tag("["), loyalty_number, tag("]")))
+        .parse(trimmed_prefix)
+        .is_ok()
 }
 
 /// Find the position of the cost/effect separator colon in ability text.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -18091,3 +18091,43 @@ fn granted_quoted_ability_with_internal_period_bypasses_split() {
         "expected a GrantAbility from the quoted ability, got {mods:?}"
     );
 }
+
+/// Issue #1336: Ichormoon Gauntlet grants bracket-loyalty planeswalker abilities.
+#[test]
+fn ichormoon_gauntlet_grants_loyalty_abilities_to_planeswalkers() {
+    let mods = parse_continuous_modifications(
+        "Planeswalkers you control have \"[0]: Proliferate\" and \"[−12]: Take an extra turn after this one.\"",
+    );
+    let grants: Vec<_> = mods
+        .iter()
+        .filter_map(|m| match m {
+            ContinuousModification::GrantAbility { definition } => Some(definition.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        grants.len(),
+        2,
+        "expected two GrantAbility mods, got {mods:?}"
+    );
+    assert!(
+        matches!(grants[0].cost, Some(AbilityCost::Loyalty { amount: 0 })),
+        "first grant should be [0] loyalty proliferate, got {:?}",
+        grants[0].cost
+    );
+    assert!(
+        matches!(*grants[0].effect, Effect::Proliferate),
+        "first grant effect should be Proliferate, got {:?}",
+        grants[0].effect
+    );
+    assert!(
+        matches!(grants[1].cost, Some(AbilityCost::Loyalty { amount: -12 })),
+        "second grant should be [−12] loyalty, got {:?}",
+        grants[1].cost
+    );
+    assert!(
+        matches!(*grants[1].effect, Effect::ExtraTurn { .. }),
+        "second grant effect should be ExtraTurn, got {:?}",
+        grants[1].effect
+    );
+}


### PR DESCRIPTION
## Summary
- Teach `find_cost_separator` to recognize bracketed loyalty costs (`[0]:`, `[−12]:`, etc.) inside quoted granted abilities.
- Ichormoon Gauntlet now parses its proliferate and extra-turn loyalty grants as real activated abilities instead of `Effect::Unimplemented`.

## Test plan
- [x] `cargo test -p engine --lib ichormoon_gauntlet`
- [x] `cargo clippy -p engine --lib -- -D warnings`

Fixes #1336

Made with [Cursor](https://cursor.com)