### PR TITLE
Fix #1324: Commander opponent HUD with one rival left

### DIFF
--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -72,8 +72,11 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
   // those two derivations disagreeing after an elimination. The
   // `gameState != null` guard preserves the original null-state default
   // (treat as 1v1) so the pre-game placeholder renders the pill, not an
-  // empty rail.
-  const isMultiplayer = gameState != null && !isOneOnOne(gameState);
+  // empty rail. When only one opponent remains in a multi-seat game
+  // (Commander pod → last rival), collapse back to the single pill so
+  // eliminated tabs don't keep stealing focus/layout (#1324).
+  const isMultiplayer =
+    gameState != null && !isOneOnOne(gameState) && liveOpponents.length > 1;
 
   // The `OpponentTab` row renders with a default-focused opponent even when
   // `focusedOpponent` is null (it falls back to the first live opponent).
@@ -237,7 +240,8 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
   const connectionStatus = useMultiplayerStore((s) => s.connectionStatus);
   const isOnline = connectionStatus !== "disconnected";
 
-  const primaryOpponentId = allOpponents[0] ?? (playerId === 0 ? 1 : 0);
+  const primaryOpponentId =
+    liveOpponents[0] ?? allOpponents[0] ?? (playerId === 0 ? 1 : 0);
   const primaryOpponentAvatarUrl = useMultiplayerStore(
     (s) => s.playerAvatars.get(primaryOpponentId) ?? null,
   );

--- a/client/src/components/hud/__tests__/OpponentHud.test.tsx
+++ b/client/src/components/hud/__tests__/OpponentHud.test.tsx
@@ -480,4 +480,24 @@ describe("OpponentHud", () => {
 
     expect(screen.queryByLabelText(/Curse of Test/i)).toBeNull();
   });
+
+  it("uses the single opponent pill when a 4-player pod has one live rival (#1324)", () => {
+    act(() => {
+      useGameStore.setState({
+        gameState: createGameState({
+          eliminated_players: [1, 2],
+          active_player: 3,
+          priority_player: 3,
+          waiting_for: { type: "Priority", data: { player: 3 } },
+        }),
+      });
+      useUiStore.setState({ focusedOpponent: 1 });
+    });
+
+    render(<OpponentHud />);
+
+    expect(document.querySelector('[data-player-hud="3"]')).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Opp 2/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /OUT/i })).toBeNull();
+  });
 });

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1200,23 +1200,27 @@ function GamePageContent({
             className="flex shrink-0 items-start gap-1.5 px-1 py-1"
             style={playerZoneRailStyle}
           >
-            <ExilePile
-              playerId={activeOpponentId}
-              size={pileSize}
-              onClick={() => setViewingZone({ zone: "exile", playerId: activeOpponentId })}
-            />
-            <LibraryPile
-              playerId={activeOpponentId}
-              size={pileSize}
-              onView={() => setViewingZone({ zone: "library", playerId: activeOpponentId })}
-            />
-            <GraveyardPile
-              playerId={activeOpponentId}
-              size={pileSize}
-              onClick={() =>
-                setViewingZone({ zone: "graveyard", playerId: activeOpponentId })
-              }
-            />
+            {activeOpponentId != null ? (
+              <>
+                <ExilePile
+                  playerId={activeOpponentId}
+                  size={pileSize}
+                  onClick={() => setViewingZone({ zone: "exile", playerId: activeOpponentId })}
+                />
+                <LibraryPile
+                  playerId={activeOpponentId}
+                  size={pileSize}
+                  onView={() => setViewingZone({ zone: "library", playerId: activeOpponentId })}
+                />
+                <GraveyardPile
+                  playerId={activeOpponentId}
+                  size={pileSize}
+                  onClick={() =>
+                    setViewingZone({ zone: "graveyard", playerId: activeOpponentId })
+                  }
+                />
+              </>
+            ) : null}
           </DraggableWidget>
         </div>
 

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -812,8 +812,7 @@ function GamePageContent({
     return orderedPlayers.filter((id) => id !== perspectivePlayerId && !eliminated.has(id));
   }, [eliminatedPlayers, perspectivePlayerId, players, seatOrder]);
   const activeOpponentId =
-    resolveFocusedOpponent(focusedOpponent, opponents)
-    ?? (perspectivePlayerId === 0 ? 1 : 0);
+    resolveFocusedOpponent(focusedOpponent, opponents) ?? opponents[0] ?? null;
 
   // Memoize the HUD elements passed to GameBoard. GameBoard is wrapped in
   // React.memo, which shallow-compares props; without stable element


### PR DESCRIPTION
## Summary
- When a multi-seat Commander pod has only one live opponent left, show the single opponent pill instead of the multi-tab rail with eliminated seats.
- Resolve the live opponent from `liveOpponents` rather than the first seat in `seat_order`.
- Stop hardcoding P0→P1 fallback for focused opponent in `GamePage`.

## Test plan
- [x] Added `OpponentHud` regression test for 4-player pod with two eliminations
- [ ] `pnpm exec vitest run src/components/hud/__tests__/OpponentHud.test.tsx` (CI)

Fixes #1324

Made with [Cursor](https://cursor.com)