### PR TITLE
Fix #1218: ActionButton respects turn decision controller

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 
 import type { AttackTarget, ObjectId, WaitingFor } from "../../adapter/types.ts";
-import { usePlayerId } from "../../hooks/usePlayerId.ts";
+import { usePlayerId, useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { dispatchAction, dispatchResolveAll } from "../../game/dispatch.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { usePhaseInfo } from "../../hooks/usePhaseInfo.ts";
@@ -25,26 +25,17 @@ type ActionButtonMode =
 function getActionButtonMode(
   waitingFor: WaitingFor | null | undefined,
   stackLength: number,
-  currentPlayerId: number,
+  canAct: boolean,
 ): ActionButtonMode {
-  if (!waitingFor) return "hidden";
+  if (!waitingFor || !canAct) return "hidden";
 
-  if (
-    waitingFor.type === "DeclareAttackers" &&
-    waitingFor.data.player === currentPlayerId
-  ) {
+  if (waitingFor.type === "DeclareAttackers") {
     return "combat-attackers";
   }
-  if (
-    waitingFor.type === "DeclareBlockers" &&
-    waitingFor.data.player === currentPlayerId
-  ) {
+  if (waitingFor.type === "DeclareBlockers") {
     return "combat-blockers";
   }
-  if (
-    waitingFor.type === "Priority" &&
-    waitingFor.data.player === currentPlayerId
-  ) {
+  if (waitingFor.type === "Priority") {
     return stackLength > 0 ? "priority-stack" : "priority-empty";
   }
 
@@ -58,6 +49,7 @@ export function ActionButton() {
   const resolveAllTooltipId = useId();
   const passToEndTooltipId = useId();
   const playerId = usePlayerId();
+  const canActForWaitingState = useCanActForWaitingState();
   const gameState = useGameStore((s) => s.gameState);
   const waitingFor = useGameStore((s) => s.waitingFor);
   const stackLength = useGameStore((s) => s.gameState?.stack.length ?? 0);
@@ -94,7 +86,7 @@ export function ActionButton() {
 
   const { advanceLabel } = usePhaseInfo();
 
-  const mode = getActionButtonMode(waitingFor, stackLength, playerId);
+  const mode = getActionButtonMode(waitingFor, stackLength, canActForWaitingState);
 
   // Skip-confirm state for No Attacks / No Blocks
   const [skipArmed, setSkipArmed] = useState<"attackers" | "blockers" | null>(null);

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -139,7 +139,7 @@ describe("ActionButton", () => {
 
     render(<ActionButton />);
 
-    expect(screen.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Resolve Pass priority/ })).toBeInTheDocument();
   });
 
   it("shows blocker controls when turn decision controller differs from blocking player (issue #1199)", () => {

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -134,4 +134,27 @@ describe("ActionButton", () => {
 
     expect(screen.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
   });
+
+  it("shows blocker controls when turn decision controller differs from blocking player (issue #1199)", () => {
+    useGameStore.setState({
+      gameMode: "online",
+      gameState: createGameState(blockerPrompt()),
+      waitingFor: blockerPrompt(),
+      legalActions: [],
+    });
+    useGameStore.setState((state) => ({
+      gameState: state.gameState
+        ? {
+            ...state.gameState,
+            turn_decision_controller: 1,
+            active_player: 0,
+          }
+        : state.gameState,
+    }));
+    useMultiplayerStore.setState({ activePlayerId: 1, actionPending: false });
+
+    render(<ActionButton />);
+
+    expect(screen.getByRole("button", { name: "Block with None" })).toBeInTheDocument();
+  });
 });

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -123,7 +123,14 @@ describe("ActionButton", () => {
         }),
         turn_decision_controller: 1,
         active_player: 0,
-        stack: [{ object_id: 1, card_id: 1, controller: 0, owner: 0 }],
+        stack: [
+          {
+            id: 1,
+            source_id: 1,
+            controller: 0,
+            kind: { type: "Spell", data: { card_id: 1 } },
+          },
+        ],
       },
       waitingFor: { type: "Priority", data: { player: 0 } },
       legalActions: [],

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -112,4 +112,26 @@ describe("ActionButton", () => {
     expect(screen.getByRole("button", { name: "Block with None" })).toBeInTheDocument();
     expect(screen.queryByText("Auto-Passing to End Step...")).not.toBeInTheDocument();
   });
+
+  it("shows resolve when turn decision controller differs from priority player (issue #1218)", () => {
+    useGameStore.setState({
+      gameMode: "online",
+      gameState: {
+        ...createGameState({
+          type: "Priority",
+          data: { player: 0 },
+        }),
+        turn_decision_controller: 1,
+        active_player: 0,
+        stack: [{ object_id: 1, card_id: 1, controller: 0, owner: 0 }],
+      },
+      waitingFor: { type: "Priority", data: { player: 0 } },
+      legalActions: [],
+    });
+    useMultiplayerStore.setState({ activePlayerId: 1, actionPending: false });
+
+    render(<ActionButton />);
+
+    expect(screen.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Route ActionButton visibility through `useCanActForWaitingState` instead of comparing `waitingFor.data.player` to the local seat
- Fixes P2 (and other turn decision controllers) being unable to resolve the stack or confirm combat when acting for the active player
- Adds regression test for delegated resolve during online play

## Test plan
- [ ] Online 2P: player with turn decision control sees Resolve when stack is non-empty
- [ ] Blocker declaration still works while auto-pass-until-EOT is armed
- [ ] CI client tests pass

Fixes #1218

Made with [Cursor](https://cursor.com)