### PR TITLE
Fix #1198: AI Mutate targets own creatures

### DIFF
--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -1045,7 +1045,9 @@ mod tests {
         ReplacementDefinition, ResolvedAbility, SacrificeCost, StaticDefinition, TargetFilter,
         TriggerDefinition, TypeFilter, TypedFilter,
     };
-    use engine::types::game_state::{GameState, PendingCast, TargetSelectionSlot, WaitingFor};
+    use engine::types::game_state::{
+        CastingVariant, GameState, PendingCast, TargetSelectionSlot, WaitingFor,
+    };
     use engine::types::identifiers::{CardId, ObjectId};
     use engine::types::keywords::Keyword;
     use engine::types::mana::ManaCost;
@@ -1126,6 +1128,25 @@ mod tests {
                 tactical_class: TacticalClass::Target,
             },
         };
+        (decision, candidate)
+    }
+
+    fn make_mutate_target_selection_ctx(
+        state: &GameState,
+        legal_targets: Vec<TargetRef>,
+        candidate_target: Option<TargetRef>,
+    ) -> (AiDecisionContext, CandidateAction) {
+        let (mut decision, candidate) = make_target_selection_ctx(
+            state,
+            Effect::TargetOnly {
+                target: TargetFilter::Any,
+            },
+            legal_targets,
+            candidate_target,
+        );
+        if let WaitingFor::TargetSelection { pending_cast, .. } = &mut decision.waiting_for {
+            pending_cast.casting_variant = CastingVariant::Mutate;
+        }
         (decision, candidate)
     }
 
@@ -1322,6 +1343,52 @@ mod tests {
         assert!(
             score_opp < 0.0,
             "Opponent creature score should be negative"
+        );
+    }
+
+    #[test]
+    fn mutate_target_prefers_own_creature() {
+        let mut state = make_state();
+        let own_id = add_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let opp_id = add_creature(&mut state, PlayerId(1), "Goblin", 2, 2);
+        let config = AiConfig::default();
+        let context = crate::context::AiContext::empty(&config.weights);
+
+        let (decision, candidate) = make_mutate_target_selection_ctx(
+            &state,
+            vec![TargetRef::Object(own_id), TargetRef::Object(opp_id)],
+            Some(TargetRef::Object(own_id)),
+        );
+        let ctx_own = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        let score_own = AntiSelfHarmPolicy.score(&ctx_own);
+
+        let (decision, candidate) = make_mutate_target_selection_ctx(
+            &state,
+            vec![TargetRef::Object(own_id), TargetRef::Object(opp_id)],
+            Some(TargetRef::Object(opp_id)),
+        );
+        let ctx_opp = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
+
+        assert!(
+            score_own > score_opp,
+            "Mutate should prefer own creature: own={score_own}, opp={score_opp}"
         );
     }
 

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -379,8 +379,9 @@ pub(crate) fn targets_creatures(effect: &Effect) -> bool {
 /// Defaults to false (assume harmful) when uncertain — safe fallback since most
 /// targeted spells in MTG are removal/damage.
 pub(crate) fn is_spell_beneficial(ctx: &PolicyContext<'_>) -> bool {
-    // CR 702.140a: Mutate merges onto a creature you control — treat as
-    // beneficial so targeting prefers your creatures over opponents'.
+    // CR 702.140a: Mutate targets a non-Human creature with the same owner as
+    // the spell — treat it as beneficial so targeting prefers our creatures over
+    // opponents' creatures when evaluating candidate targets.
     if let WaitingFor::TargetSelection { pending_cast, .. } = &ctx.decision.waiting_for {
         if pending_cast.casting_variant == CastingVariant::Mutate {
             return true;

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -5,7 +5,7 @@ use engine::types::ability::{
     TargetFilter, TypeFilter,
 };
 use engine::types::counter::CounterType;
-use engine::types::game_state::GameState;
+use engine::types::game_state::{CastingVariant, GameState, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
 use engine::types::player::PlayerId;
@@ -379,6 +379,14 @@ pub(crate) fn targets_creatures(effect: &Effect) -> bool {
 /// Defaults to false (assume harmful) when uncertain — safe fallback since most
 /// targeted spells in MTG are removal/damage.
 pub(crate) fn is_spell_beneficial(ctx: &PolicyContext<'_>) -> bool {
+    // CR 702.140a: Mutate merges onto a creature you control — treat as
+    // beneficial so targeting prefers your creatures over opponents'.
+    if let WaitingFor::TargetSelection { pending_cast, .. } = &ctx.decision.waiting_for {
+        if pending_cast.casting_variant == CastingVariant::Mutate {
+            return true;
+        }
+    }
+
     let player_impact = aggregate_player_impact(ctx);
     if player_impact > 0.25 {
         return true;


### PR DESCRIPTION
## Summary
- Treat `CastingVariant::Mutate` during target selection as beneficial in `is_spell_beneficial`
- Prevents the AI from merging mutate spells onto opponent creatures when effect polarity is ambiguous

## Test plan
- [ ] AI casts a mutate spell and selects one of its own non-Human creatures
- [ ] CI: `cargo test -p phase-ai --lib mutate_target_prefers_own_creature`

Fixes #1198

Made with [Cursor](https://cursor.com)