### PR TITLE
Fix Tempt with Bunnies optional offer rewards

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1605,6 +1605,9 @@ pub(super) fn resolve_optional_effect_decision(
     match choice {
         AutoMayChoice::Accept => {
             ability.context.optional_effect_performed = true;
+            state
+                .player_actions_this_way
+                .insert((ability.controller, PlayerActionKind::AcceptedOptionalEffect));
             resolve_ability_chain(state, &ability, events, depth)?;
             // CR 608.2c: When an optional effect's prompt suspended the parent
             // chain, the "If you do" sibling continuation was stashed BEFORE the
@@ -2024,8 +2027,14 @@ fn detach_after_player_scope_local_chain(
     if next_is_co_scoped_anaphoric_consumer {
         next.player_scope = None;
     }
+    // "Each opponent may X and Y" makes the whole same-sentence X/Y clause
+    // optional for that opponent. Keep the continuation inside the scoped
+    // template so accepting the offer performs both instructions.
+    let next_is_optional_clause_continuation =
+        node.optional && next.sub_link == SubAbilityLink::ContinuationStep;
     if next_is_performed_gated
         || next_is_co_scoped_anaphoric_consumer
+        || next_is_optional_clause_continuation
         || is_player_scope_local_continuation(&node.effect, &next.effect)
     {
         let tail = detach_after_player_scope_local_chain(&mut next, scope, referent_in_scope);
@@ -5340,6 +5349,8 @@ fn resolve_chain_body(
 
             let initial_waiting_for = state.waiting_for.clone();
             let mut iteration = 0usize;
+            let repeated_full_chain =
+                ability.repeat_for.is_some() && effective.sub_ability.is_some();
             while iteration < iterations {
                 // Snapshot per-iteration ability with parent-target rebinding when
                 // applicable. CR 109.5: the rebind is SINGLE-slot — every reachable
@@ -5392,7 +5403,13 @@ fn resolve_chain_body(
                 // `resolve_effect` does not check `optional`, which is correct
                 // because non-per-iteration loops apply their `optional` once up
                 // front in `resolve_chain_body`.
-                if (kind_driven || member_driven) && iter_effective.optional {
+                if repeated_full_chain {
+                    let mut full_chain_iteration = iter_effective.clone();
+                    full_chain_iteration.repeat_for = None;
+                    full_chain_iteration.copy_count_status =
+                        crate::types::ability::CopyCountStatus::Finalized;
+                    resolve_ability_chain(state, &full_chain_iteration, events, depth.max(1))?;
+                } else if (kind_driven || member_driven) && iter_effective.optional {
                     // CR 608.2c: pass a non-zero depth so the depth==0 prelude
                     // (chain-local state clearing, resolution counter) does not
                     // re-run mid-loop — this iteration continues the current
@@ -5451,6 +5468,9 @@ fn resolve_chain_body(
                     break;
                 }
                 iteration += 1;
+            }
+            if repeated_full_chain {
+                return Ok(());
             }
         } // end shares_quality_failed else
     }

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -4,7 +4,7 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, Effect, EffectKind, EffectScope, ResolvedAbility,
     SacrificeRequirement, SubAbilityLink, TapStateChange, TargetFilter, TargetRef,
 };
-use crate::types::events::GameEvent;
+use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
     ActionResult, AutoMayChoice, GameState, PendingContinuation, WaitingFor,
 };
@@ -158,6 +158,9 @@ pub(super) fn handle_opponent_may_choice(
             if let Some(legal) = target_selection {
                 if !legal.is_empty() {
                     ability.context.optional_effect_performed = true;
+                    state
+                        .player_actions_this_way
+                        .insert((promptee, PlayerActionKind::AcceptedOptionalEffect));
                     if let Some(mut sub) = ability.sub_ability.take() {
                         // CR 608.2c + CR 608.2d: the "If a player does, …"
                         // consequence runs because the player accepted. Carry the
@@ -199,6 +202,9 @@ pub(super) fn handle_opponent_may_choice(
                 resolve_all_declined_opponent_may(state, &ability, events)?;
             } else {
                 ability.context.optional_effect_performed = true;
+                state
+                    .player_actions_this_way
+                    .insert((promptee, PlayerActionKind::AcceptedOptionalEffect));
                 if matches!(ability.effect, Effect::DealDamage { .. }) {
                     ability.targets = vec![TargetRef::Player(promptee)];
                 }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -481,6 +481,13 @@ pub(crate) fn parse_quantity_ref_with_context(
                 });
             }
         }
+        if let Ok((remainder, (relation, action))) = parse_optional_offer_accepted_clause(rest) {
+            if remainder.trim().is_empty() {
+                return Some(QuantityRef::PlayerCount {
+                    filter: PlayerFilter::PerformedActionThisWay { relation, action },
+                });
+            }
+        }
         // CR 608.2c + CR 400.7: "the number of [filter] destroyed/sacrificed
         // this way" — count from the tracked set populated by the preceding
         // destroy/sacrifice in the sub_ability chain. Must run BEFORE
@@ -2112,6 +2119,22 @@ fn parse_investigated_arm(input: &str) -> nom::IResult<&str, PlayerActionKind, O
     .parse(input)
 }
 
+/// "opponent who does" / "players who do" → accepted the optional offer.
+fn parse_optional_offer_accepted_clause(
+    input: &str,
+) -> nom::IResult<&str, (PlayerRelation, PlayerActionKind), OracleError<'_>> {
+    let (input, relation) = alt((
+        value(PlayerRelation::Opponent, tag("opponents ")),
+        value(PlayerRelation::Opponent, tag("opponent ")),
+        value(PlayerRelation::All, tag("players ")),
+        value(PlayerRelation::All, tag("player ")),
+    ))
+    .parse(input)?;
+    let (input, _) = tag("who ").parse(input)?;
+    let (input, _) = alt((tag("does"), tag("do"), tag("did"))).parse(input)?;
+    Ok((input, (relation, PlayerActionKind::AcceptedOptionalEffect)))
+}
+
 /// Parse the clause after "for each" into a QuantityRef.
 /// CR 702.62b: A suspended card is a card in the exile zone with the suspend
 /// keyword and a time counter on it. Counting clauses (`for each suspended card
@@ -2346,6 +2369,14 @@ fn parse_for_each_clause_with_they_controller(
         let (filter, remainder) = parse_type_phrase(after_among);
         if remainder.trim().is_empty() && !matches!(filter, TargetFilter::Any) {
             return Some(QuantityRef::DistinctColorsAmongPermanents { filter });
+        }
+    }
+
+    if let Ok((rest, (relation, action))) = parse_optional_offer_accepted_clause(clause) {
+        if rest.is_empty() {
+            return Some(QuantityRef::PlayerCount {
+                filter: PlayerFilter::PerformedActionThisWay { relation, action },
+            });
         }
     }
 
@@ -5117,6 +5148,20 @@ mod tests {
                 filter: PlayerFilter::PerformedActionThisWay {
                     relation: PlayerRelation::Opponent,
                     action: PlayerActionKind::SearchedLibrary,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn for_each_opponent_who_does_counts_accepted_optional_offer() {
+        let qty = parse_for_each_clause("opponent who does").unwrap();
+        assert_eq!(
+            qty,
+            QuantityRef::PlayerCount {
+                filter: PlayerFilter::PerformedActionThisWay {
+                    relation: PlayerRelation::Opponent,
+                    action: PlayerActionKind::AcceptedOptionalEffect,
                 },
             }
         );

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -79,6 +79,8 @@ pub enum BendingType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PlayerActionKind {
+    /// A player accepted a resolution-time optional effect.
+    AcceptedOptionalEffect,
     SearchedLibrary,
     Scry,
     Surveil,

--- a/crates/engine/tests/integration/tempt_with_discovery.rs
+++ b/crates/engine/tests/integration/tempt_with_discovery.rs
@@ -34,6 +34,12 @@ fn tempt_with_discovery_oracle() -> &'static str {
      and put it onto the battlefield. Then shuffle."
 }
 
+fn tempt_with_bunnies_oracle() -> &'static str {
+    "Tempting Offer — Draw a card and create a 1/1 white Rabbit creature token. \
+     Then each opponent may draw a card and create a 1/1 white Rabbit creature token. \
+     For each opponent who does, you draw a card and you create a 1/1 white Rabbit creature token."
+}
+
 /// CR 207.2c + CR 608.2c + CR 109.5: Tempt with Discovery's full Oracle text
 /// must produce an ability whose 4th sentence uses
 /// `repeat_for: PlayerCount { PerformedActionThisWay { Opponent, SearchedLibrary } }`.
@@ -126,6 +132,159 @@ fn make_land(
     obj.card_types.core_types = vec![CoreType::Land];
     obj.card_types.supertypes.push(Supertype::Basic);
     land
+}
+
+fn make_library_card(
+    state: &mut GameState,
+    card_id: u64,
+    owner: PlayerId,
+    name: impl Into<String>,
+) -> ObjectId {
+    create_object(state, CardId(card_id), owner, name.into(), Zone::Library)
+}
+
+fn player_hand_size(state: &GameState, player: PlayerId) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .hand
+        .len()
+}
+
+fn rabbit_tokens_controlled_by(state: &GameState, player: PlayerId) -> usize {
+    state
+        .objects
+        .values()
+        .filter(|obj| {
+            obj.is_token
+                && obj.controller == player
+                && obj.zone == Zone::Battlefield
+                && obj
+                    .card_types
+                    .subtypes
+                    .iter()
+                    .any(|subtype| subtype == "Rabbit")
+        })
+        .count()
+}
+
+#[test]
+fn tempt_with_bunnies_bonus_counts_opponents_who_accept_offer() {
+    let result = parse_oracle_text(
+        tempt_with_bunnies_oracle(),
+        "Tempt with Bunnies",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+
+    fn walk(def: &engine::types::ability::AbilityDefinition) -> bool {
+        let here_matches = matches!(&*def.effect, Effect::Draw { .. })
+            && matches!(
+                &def.repeat_for,
+                Some(QuantityExpr::Ref {
+                    qty: QuantityRef::PlayerCount {
+                        filter: PlayerFilter::PerformedActionThisWay {
+                            relation: PlayerRelation::Opponent,
+                            action: PlayerActionKind::AcceptedOptionalEffect,
+                        },
+                    },
+                })
+            )
+            && def
+                .sub_ability
+                .as_ref()
+                .is_some_and(|sub| matches!(&*sub.effect, Effect::Token { .. }));
+        if here_matches {
+            return true;
+        }
+        if let Some(sub) = &def.sub_ability {
+            if walk(sub) {
+                return true;
+            }
+        }
+        if let Some(else_branch) = &def.else_ability {
+            if walk(else_branch) {
+                return true;
+            }
+        }
+        false
+    }
+
+    assert!(
+        result.abilities.iter().any(walk),
+        "expected the bonus Rabbit token step to repeat for opponents who accepted \
+         the offer. Parsed abilities: {:#?}",
+        result.abilities
+    );
+}
+
+#[test]
+fn parsed_tempt_with_bunnies_two_accepting_opponents_full_flow() {
+    let parsed = parse_oracle_text(
+        tempt_with_bunnies_oracle(),
+        "Tempt with Bunnies",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    let ability = build_resolved_from_def(&parsed.abilities[0], ObjectId(9100), PlayerId(0));
+
+    let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+    for i in 0..3 {
+        make_library_card(&mut state, 100 + i, PlayerId(0), format!("P0 Card {i}"));
+    }
+    make_library_card(&mut state, 200, PlayerId(1), "P1 Card");
+    make_library_card(&mut state, 300, PlayerId(2), "P2 Card");
+
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::OptionalEffectChoice {
+            player: PlayerId(1),
+            ..
+        }
+    ));
+
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::DecideOptionalEffect { accept: true },
+    )
+    .unwrap();
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::OptionalEffectChoice {
+            player: PlayerId(2),
+            ..
+        }
+    ));
+
+    apply(
+        &mut state,
+        PlayerId(2),
+        GameAction::DecideOptionalEffect { accept: true },
+    )
+    .unwrap();
+
+    assert_eq!(
+        player_hand_size(&state, PlayerId(0)),
+        3,
+        "controller draws once initially and once for each accepting opponent"
+    );
+    assert_eq!(player_hand_size(&state, PlayerId(1)), 1);
+    assert_eq!(player_hand_size(&state, PlayerId(2)), 1);
+    assert_eq!(
+        rabbit_tokens_controlled_by(&state, PlayerId(0)),
+        3,
+        "controller creates one Rabbit initially and one for each accepting opponent"
+    );
+    assert_eq!(rabbit_tokens_controlled_by(&state, PlayerId(1)), 1);
+    assert_eq!(rabbit_tokens_controlled_by(&state, PlayerId(2)), 1);
 }
 
 /// Build a 3-player game state and seed P0's library with `count` basic


### PR DESCRIPTION
## Summary
- parse "for each opponent who does" as a count of opponents who accepted the optional offer
- keep same-sentence continuations inside each scoped optional offer, so accepted opponents draw and create the Rabbit token
- repeat full effect chains when a repeated instruction has a continuation, so the controller's bonus draw also creates the bonus Rabbit token

Fixes #3683

## Verification
- cargo fmt --all
- ./scripts/check-parser-combinators.sh
- cargo test -p engine --test integration tempt_with_bunnies -- --nocapture
- cargo test -p engine --test integration tempt_with_discovery -- --nocapture
- cargo test -p engine oracle_quantity::tests::for_each_opponent_who_does_counts_accepted_optional_offer -- --nocapture
- git diff --check