### PR TITLE
fix(parser): route "protection from monocolored" to Quality, not CardType

### DIFF
--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -17966,6 +17966,24 @@ fn protection_single_color_unchanged() {
     );
 }
 
+/// CR 702.16a + CR 105.2a: "protection from monocolored" (Guardian of the
+/// Guildpact, Providence of Night) parses end-to-end to the runtime-evaluated
+/// `Quality("monocolored")` (source.color.len() == 1), NOT an inert
+/// `CardType("monocolored")`. Fails if the parse_protection_target fix reverts.
+#[test]
+fn protection_from_monocolored_is_quality() {
+    use crate::types::keywords::{Keyword, ProtectionTarget};
+
+    let mods =
+        parse_continuous_modifications("Enchanted creature has protection from monocolored.");
+    assert!(
+        mods.contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Protection(ProtectionTarget::Quality("monocolored".to_string())),
+        }),
+        "expected Protection(Quality(\"monocolored\")), got {mods:?}"
+    );
+}
+
 /// Broader Ward-cycle class: a single-color Ward with a trailing sentence (Red
 /// Ward form) recovers the keyword via the same ". " split → Color(Red).
 #[test]

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -2387,6 +2387,13 @@ pub(crate) fn parse_protection_target(s: &str) -> ProtectionTarget {
         "red" => ProtectionTarget::Color(ManaColor::Red),
         "green" => ProtectionTarget::Color(ManaColor::Green),
         "multicolored" => ProtectionTarget::Multicolored,
+        // CR 702.16a + CR 105.2a: "protection from monocolored" is a color-count
+        // quality (exactly one color), NOT a card type. Route to the runtime
+        // `source_matches_quality` arm (game/keywords.rs) which already evaluates
+        // `source.color.len() == 1`. Multicolored keeps its dedicated variant;
+        // monocolored reuses the existing Quality variant (no new variant / no game
+        // change). Mirrors parse_hexproof_filter's monocolored→Quality handling.
+        "monocolored" => ProtectionTarget::Quality("monocolored".into()),
         // CR 702.16: "the chosen color" resolves at runtime from chosen_attributes
         "the chosen color" | "chosen color" => ProtectionTarget::ChosenColor,
         // CR 702.16 + CR 205.2: "the chosen card type" resolves at
@@ -3383,6 +3390,48 @@ mod tests {
         assert_eq!(
             Keyword::from_str("Protection:chosen color").unwrap(),
             Keyword::Protection(ProtectionTarget::ChosenColor)
+        );
+    }
+
+    /// CR 702.16a + CR 105.2a: "protection from monocolored" (Guardian of the
+    /// Guildpact, Providence of Night) is a color-count quality routed to the
+    /// runtime `source_matches_quality` arm (`source.color.len() == 1`), NOT a
+    /// card type. Misrouting to `CardType("monocolored")` is inert because
+    /// `source_matches_card_type` only matches core types + subtypes, so the
+    /// grant would do nothing. This test fails if the fix is reverted.
+    #[test]
+    fn parse_protection_target_monocolored_is_quality_not_card_type() {
+        // Fix-discriminating: monocolored must be a Quality, never a CardType.
+        assert_eq!(
+            parse_protection_target("monocolored"),
+            ProtectionTarget::Quality("monocolored".to_string())
+        );
+        assert_ne!(
+            parse_protection_target("monocolored"),
+            ProtectionTarget::CardType("monocolored".to_string())
+        );
+        // End-to-end through Keyword::from_str (the parser dispatch path).
+        assert_eq!(
+            Keyword::from_str("Protection:monocolored").unwrap(),
+            Keyword::Protection(ProtectionTarget::Quality("monocolored".to_string()))
+        );
+        // No-regression: multicolored keeps its dedicated typed variant.
+        assert_eq!(
+            parse_protection_target("multicolored"),
+            ProtectionTarget::Multicolored
+        );
+        // No-regression: colors and chosen-color/card-type arms are unchanged.
+        assert_eq!(
+            parse_protection_target("red"),
+            ProtectionTarget::Color(ManaColor::Red)
+        );
+        assert_eq!(
+            parse_protection_target("the chosen color"),
+            ProtectionTarget::ChosenColor
+        );
+        assert_eq!(
+            parse_protection_target("artifacts"),
+            ProtectionTarget::CardType("artifacts".to_string())
         );
     }
 


### PR DESCRIPTION
Fixes #3781.

## Summary

"Protection from monocolored" granted **no** protection: `parse_protection_target` had a `"multicolored"` arm but no `"monocolored"` arm, so it fell through to `ProtectionTarget::CardType("monocolored")`. At runtime `CardType` is matched by `source_matches_card_type`, which only recognizes card types and subtypes — "monocolored" matches none, so the protection was inert.

- **Guardian of the Guildpact** and **Providence of Night** were unprotected from monocolored sources.

## Fix (parser-AST-only; no new engine variant, no runtime change)

Add one arm routing `"monocolored"` to the existing `ProtectionTarget::Quality("monocolored")`. The runtime quality handler `source_matches_quality` already implements `"monocolored" => source.color.len() == 1` (dispatched via the existing `Quality` arm), so the correct AST is already fully handled — only the parser wasn't emitting it. This mirrors `parse_hexproof_filter`, which already routes monocolored/multicolored to its `Quality` variant. (Multicolored keeps its dedicated `Multicolored` variant — untouched.)

CR 702.16a (protection from a quality, which "can be any characteristic value", not just a card type), CR 105.2a (a monocolored object is exactly one of the five colors).

## Tests

- Discriminating (revert-failing): `parse_protection_target("monocolored")` → `Quality("monocolored")` (and explicitly not `CardType`); `Keyword::from_str("Protection:monocolored")` round-trip; a `parse_continuous_modifications("Enchanted creature has protection from monocolored.")` pipeline test → `Protection(Quality("monocolored"))`.
- No-regression: `multicolored` → `Multicolored`, single color → `Color`, `the chosen color` → `ChosenColor`, genuine card types → `CardType`.

## Verification

`cargo +nightly test -p engine` (all targets): 12562 passed; the only failure is the pre-existing flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (a global perf-counter race under parallel execution — confirmed passing in isolation, unrelated to this parser-only change). `clippy -D warnings`: clean. `rustfmt --check`: clean. Parser-combinator gate: clean for this diff.
