### PR TITLE
Fix Walking Bulwark defender attack grant

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -3458,6 +3458,66 @@ mod tests {
         assert!(validate_attackers(&state, &[id]).is_err());
     }
 
+    #[test]
+    fn walking_bulwark_grants_defender_creature_attack_permission() {
+        use crate::game::scenario::GameScenario;
+        use crate::types::game_state::WaitingFor;
+        use crate::types::mana::{ManaType, ManaUnit};
+        use crate::types::phase::Phase;
+
+        // CR 702.3b + CR 611.2c: The resolved ability grants a targeted
+        // defender an until-end-of-turn rule exception that lets it attack.
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let bulwark = scenario
+            .add_creature_from_oracle(
+                PlayerId(0),
+                "Walking Bulwark",
+                0,
+                3,
+                "Defender\n{2}: Until end of turn, target creature with defender gains haste, can attack as though it didn't have defender, and assigns combat damage equal to its toughness rather than its power. Activate only as a sorcery.",
+            )
+            .id();
+        let wall = scenario
+            .add_creature(PlayerId(0), "Target Wall", 0, 4)
+            .defender()
+            .with_summoning_sickness()
+            .id();
+        scenario.with_mana_pool(
+            PlayerId(0),
+            vec![
+                ManaUnit::new(ManaType::Colorless, ObjectId(0), false, Vec::new()),
+                ManaUnit::new(ManaType::Colorless, ObjectId(0), false, Vec::new()),
+            ],
+        );
+
+        let mut runner = scenario.build();
+        runner.activate(bulwark, 0).target_object(wall).resolve();
+
+        assert!(
+            runner
+                .state()
+                .objects
+                .get(&wall)
+                .unwrap()
+                .has_keyword(&Keyword::Haste),
+            "Walking Bulwark must grant haste to the targeted defender"
+        );
+        assert!(
+            validate_attackers(runner.state(), &[wall]).is_ok(),
+            "Walking Bulwark's transient CanAttackWithDefender grant must let the targeted defender attack"
+        );
+
+        runner.advance_to_combat();
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareAttackers { .. }
+        ));
+        runner
+            .declare_attackers(&[(wall, AttackTarget::Player(PlayerId(1)))])
+            .expect("targeted defender should be legal to declare as an attacker");
+    }
+
     /// CR 702.3b + CR 122.1: Demon Wall — "as long as this creature has a
     /// counter on it, it can attack as though it didn't have defender".
     /// Exercises the `CanAttackWithDefender` static gated on

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24151,14 +24151,87 @@ mod tests {
                     Effect::GenericEffect { static_abilities, .. }
                         if static_abilities
                             .iter()
-                            .any(|s| s.mode == StaticMode::CanAttackWithDefender)
+                            .any(|s| s.mode == StaticMode::CanAttackWithDefender
+                                && s.modifications.contains(
+                                    &ContinuousModification::AddStaticMode {
+                                        mode: StaticMode::CanAttackWithDefender,
+                                    },
+                                ))
                 )
             });
             assert!(
                 has_can_attack,
-                "{text:?}: expected a CanAttackWithDefender grant; chain effects: {effects:?}"
+                "{text:?}: expected a CanAttackWithDefender grant with AddStaticMode carrier; chain effects: {effects:?}"
             );
         }
+    }
+
+    #[test]
+    fn walking_bulwark_compound_grants_target_haste_and_defender_attack_permission() {
+        let def = parse_effect_chain(
+            "Until end of turn, target creature with defender gains haste, can attack as though it didn't have defender, and assigns combat damage equal to its toughness rather than its power",
+            AbilityKind::Activated,
+        );
+
+        let mut effects: Vec<&Effect> = Vec::new();
+        let mut node = Some(&def);
+        while let Some(d) = node {
+            effects.push(&d.effect);
+            node = d.sub_ability.as_deref();
+        }
+
+        let has_haste = effects.iter().any(|e| {
+            matches!(
+                e,
+                Effect::GenericEffect { static_abilities, .. }
+                    if static_abilities
+                        .iter()
+                        .any(|s| s.modifications.contains(
+                            &ContinuousModification::AddKeyword {
+                                keyword: Keyword::Haste,
+                            },
+                        ))
+            )
+        });
+        assert!(
+            has_haste,
+            "expected target haste grant; chain effects: {effects:?}"
+        );
+
+        let has_can_attack = effects.iter().any(|e| {
+            matches!(
+                e,
+                Effect::GenericEffect { static_abilities, .. }
+                    if static_abilities
+                        .iter()
+                        .any(|s| s.mode == StaticMode::CanAttackWithDefender
+                            && s.modifications.contains(
+                                &ContinuousModification::AddStaticMode {
+                                    mode: StaticMode::CanAttackWithDefender,
+                                },
+                            ))
+            )
+        });
+        assert!(
+            has_can_attack,
+            "expected CanAttackWithDefender grant; chain effects: {effects:?}"
+        );
+
+        let has_assign_toughness = effects.iter().any(|e| {
+            matches!(
+                e,
+                Effect::GenericEffect { static_abilities, .. }
+                    if static_abilities
+                        .iter()
+                        .any(|s| s
+                            .modifications
+                            .contains(&ContinuousModification::AssignDamageFromToughness))
+            )
+        });
+        assert!(
+            has_assign_toughness,
+            "expected combat damage assignment grant; chain effects: {effects:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -668,6 +668,9 @@ fn try_parse_can_attack_with_defender(
         effect: Effect::GenericEffect {
             static_abilities: vec![StaticDefinition::new(StaticMode::CanAttackWithDefender)
                 .affected(affected)
+                .modifications(vec![ContinuousModification::AddStaticMode {
+                    mode: StaticMode::CanAttackWithDefender,
+                }])
                 .description(text.to_string())],
             duration: duration.clone(),
             target: application.target,
@@ -2093,6 +2096,25 @@ fn build_continuous_clause(
     let (predicate_text, fallback_duration) = super::strip_trailing_duration(&normalized);
     let duration = duration.or(fallback_duration);
 
+    if let Some(static_abilities) =
+        build_defender_attack_continuous_compound(&application, predicate_text)
+    {
+        return Some(ParsedEffectClause {
+            effect: Effect::GenericEffect {
+                static_abilities,
+                duration: duration.clone(),
+                target: application.target,
+            },
+            duration,
+            sub_ability: None,
+            distribute: None,
+            multi_target: None,
+            condition: None,
+            optional: false,
+            unless_pay: None,
+        });
+    }
+
     let modifications = parse_continuous_modifications(predicate_text);
     if modifications.is_empty() {
         return None;
@@ -2931,6 +2953,78 @@ fn build_restriction_clause(
         optional: false,
         unless_pay: None,
     })
+}
+
+fn build_defender_attack_continuous_compound(
+    application: &SubjectApplication,
+    predicate_text: &str,
+) -> Option<Vec<StaticDefinition>> {
+    // CR 702.3b + CR 510.1c + CR 611.2c: A resolved ability can grant one
+    // targeted creature multiple continuous pieces at once: characteristics
+    // (haste), a defender attack rule exception, and toughness-based damage
+    // assignment. Split only the grammar that contains the defender exception so
+    // ordinary keyword lists continue through the shared continuous parser.
+    let segments = split_continuous_compound_segments(predicate_text);
+    if segments.len() < 2
+        || !segments
+            .iter()
+            .any(|segment| is_can_attack_despite_defender_predicate(&segment.to_lowercase()))
+    {
+        return None;
+    }
+
+    let affected = static_affected_for_application(application);
+    let mut static_abilities = Vec::new();
+
+    for segment in segments {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            continue;
+        }
+        let lower = segment.to_lowercase();
+        if is_can_attack_despite_defender_predicate(&lower) {
+            static_abilities.push(
+                StaticDefinition::new(StaticMode::CanAttackWithDefender)
+                    .affected(affected.clone())
+                    .modifications(vec![ContinuousModification::AddStaticMode {
+                        mode: StaticMode::CanAttackWithDefender,
+                    }])
+                    .description(segment.to_string()),
+            );
+            continue;
+        }
+
+        let modifications = parse_continuous_modifications(segment);
+        if modifications.is_empty() {
+            return None;
+        }
+        static_abilities.push(
+            StaticDefinition::continuous()
+                .affected(affected.clone())
+                .modifications(modifications)
+                .description(segment.to_string()),
+        );
+    }
+
+    (!static_abilities.is_empty()).then_some(static_abilities)
+}
+
+fn split_continuous_compound_segments(predicate_text: &str) -> Vec<&str> {
+    predicate_text
+        .trim()
+        .trim_end_matches('.')
+        .split(',')
+        .map(|segment| strip_leading_conjunction(segment.trim()))
+        .collect()
+}
+
+fn strip_leading_conjunction(segment: &str) -> &str {
+    let lower = segment.to_lowercase();
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("and ").parse(lower.as_str()) {
+        let consumed = lower.len() - rest.len();
+        return segment[consumed..].trim_start();
+    }
+    segment
 }
 
 // CR 613.2 layer 6 + CR 509.1b: Combat / untap restriction modes granted


### PR DESCRIPTION
Fixes #618.

## Summary
- Preserve CanAttackWithDefender as an AddStaticMode carrier for transient effects.
- Split defender-attack continuous compounds so haste, defender attack permission, and toughness-based damage assignment all apply to the targeted creature.
- Add parser and combat regressions for Walking Bulwark.

## Verification
- cargo fmt --all
- CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --lib walking_bulwark_compound_grants_target_haste_and_defender_attack_permission -- --nocapture
- CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --lib walking_bulwark_grants_defender_creature_attack_permission -- --nocapture
- CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --lib walls_that_attack_compound_yields_pump_and_can_attack -- --nocapture
- git diff --check