### PR TITLE
Fix nontoken+adjective filters dropping color/supertype/modified

### DIFF
--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -650,7 +650,7 @@ mod tests {
         ControllerRef, FilterProp, ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef,
         TargetFilter, TypeFilter,
     };
-    use crate::types::mana::ManaCost;
+    use crate::types::mana::{ManaColor, ManaCost};
     use crate::types::zones::Zone;
 
     #[test]
@@ -1320,6 +1320,47 @@ mod tests {
                 condition: None,
             } if sac.requirement.fixed_count() == Some(3) => {}
             other => panic!("expected Sacrifice(count=3) alt-cost, got {other:?}"),
+        }
+    }
+
+    /// Issue #3677: Flare of Denial — "sacrifice a nontoken blue creature" must
+    /// keep BOTH the `NonToken` negation and the `blue creature` type/color
+    /// filter. Before the fix to `parse_type_phrase`'s color-prefix scan (which
+    /// only ran before the `non-` negation loop), the color and creature type
+    /// were silently dropped, leaving a filter that matched any nontoken
+    /// permanent — including a land — as a valid alternative-cost payment.
+    #[test]
+    fn alt_cost_sacrifice_nontoken_colored_creature_arm() {
+        let option = parse_spell_casting_option_line(
+            "You may sacrifice a nontoken blue creature rather than pay this spell's mana cost.",
+            "Flare of Denial",
+        )
+        .expect("alt-cost should parse");
+        match option {
+            SpellCastingOption {
+                kind: crate::types::ability::SpellCastingOptionKind::AlternativeCost,
+                cost: Some(AbilityCost::Sacrifice(ref sac)),
+                condition: None,
+            } if sac.requirement.fixed_count() == Some(1) => match &sac.target {
+                TargetFilter::Typed(tf) => {
+                    assert!(
+                        tf.type_filters.contains(&TypeFilter::Creature),
+                        "expected Creature type filter, got {tf:?}"
+                    );
+                    assert!(
+                        tf.properties.contains(&FilterProp::NonToken),
+                        "expected NonToken property, got {tf:?}"
+                    );
+                    assert!(
+                        tf.properties.contains(&FilterProp::HasColor {
+                            color: ManaColor::Blue
+                        }),
+                        "expected blue HasColor property, got {tf:?}"
+                    );
+                }
+                other => panic!("expected Typed sacrifice target, got {other:?}"),
+            },
+            other => panic!("expected Sacrifice(count=1) alt-cost, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1720,6 +1720,51 @@ pub fn parse_type_phrase_with_ctx<'a>(
         break;
     }
 
+    // CR 205.4a: A supertype adjective can also appear AFTER a `non-`
+    // token-identity/type negation prefix (e.g. "nontoken legendary permanent"
+    // in Cadric, Soul Kindler / issue #3677 class). The pre-negation arm above
+    // only fires when the supertype word leads the phrase, so a leading
+    // "nontoken " left it unparsed, dropping the legendary restriction entirely.
+    // Mirrors the post-negation `historic` re-check directly below.
+    if let Ok((rest, supertype)) = nom_target::parse_supertype_prefix(&lower[pos..]) {
+        if !properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::HasSupertype { .. }))
+        {
+            properties.push(FilterProp::HasSupertype { value: supertype });
+            pos += lower[pos..].len() - rest.len();
+        }
+    }
+
+    // CR 105.1 + CR 105.2: A color adjective can also appear AFTER a `non-`
+    // token-identity/type negation prefix (e.g. "nontoken blue creature",
+    // Flare of Denial / issue #3677). The pre-negation arm above only fires
+    // when the color word leads the phrase, so a leading "nontoken " left the
+    // color word — and therefore the entire creature-type filter behind it —
+    // unparsed, silently degrading the cost to "sacrifice a nontoken
+    // permanent" (which a land never is, so any permanent paid the alt cost).
+    // Mirrors the post-negation `historic` re-check directly below.
+    if color_prop.is_none() {
+        if let Some((prop, color_len)) =
+            parse_color_prefix(&lower[pos..]).or_else(|| parse_color_quality_prefix(&lower[pos..]))
+        {
+            properties.push(prop);
+            pos += color_len;
+        }
+    }
+
+    // CR 700.4 + CR 700.9: A "modified" adjective can also appear AFTER a
+    // `non-` token-identity/type negation prefix (e.g. "nontoken modified
+    // creature" in Akki Ember-Keeper / issue #3677 class). The pre-negation
+    // arm above only fires when "modified" leads the phrase. Mirrors the
+    // post-negation `historic` re-check directly below.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("modified ").parse(&lower[pos..]) {
+        if starts_with_type_phrase_lead(rest) && !properties.contains(&FilterProp::Modified) {
+            properties.push(FilterProp::Modified);
+            pos += lower[pos..].len() - rest.len();
+        }
+    }
+
     let mut adjective_type_filters: Vec<TypeFilter> = Vec::new();
 
     // CR 700.6: "historic" adjective prefix can appear AFTER negation prefixes
@@ -2628,19 +2673,24 @@ pub(crate) fn starts_with_type_word(text: &str) -> bool {
         }
     }
     // CR 205.4b: Negated type prefix: "noncreature spell", "nonland permanent",
-    // "non-Saga token" (Good King Mog XII chapter II — issue #3294).
+    // "non-Saga token" (Good King Mog XII chapter II — issue #3294), and
+    // negated-adjective compounds like "nontoken modified creature" (Akki
+    // Ember-Keeper / issue #3677 class) or "nontoken legendary permanent"
+    // (Cadric, Soul Kindler). Recurses into `starts_with_type_phrase_lead`
+    // (rather than only `parse_core_type`/`parse_token_suffix`) so the article
+    // guard recognizes every adjective that can lead a type phrase after a
+    // `non-` prefix — color, supertype, "modified", "renowned", "historic" —
+    // not just bare core types and tokens.
     if let Ok((after_non, _)) = alt((tag::<_, _, OracleError<'_>>("non-"), tag("non"))).parse(text)
     {
-        // Consume the negated word up to whitespace, then check for a core type or
-        // standalone "token"/"tokens" after the negation.
+        // Consume the negated word up to whitespace, then check what follows.
         if let Ok((after_space, _)) = (
             take_till::<_, _, OracleError<'_>>(|c: char| c.is_whitespace()),
             tag::<_, _, OracleError<'_>>(" "),
         )
             .parse(after_non)
         {
-            if parse_core_type(after_space).0.is_some() || parse_token_suffix(after_space).is_some()
-            {
+            if starts_with_type_phrase_lead(after_space) {
                 return true;
             }
         }
@@ -5956,6 +6006,57 @@ mod tests {
             TargetFilter::And { filters } => filters.iter().find_map(typed_leg),
             _ => None,
         }
+    }
+
+    /// Issue #3677 (Flare of Denial): "sacrifice a nontoken blue creature" must
+    /// capture the color AND the creature type, not just the NonToken negation.
+    /// Before the fix, the color-prefix scan ran only BEFORE the `non-` negation
+    /// loop, so a leading "nontoken " left "blue creature" unconsumed and the
+    /// resulting filter silently matched any nontoken permanent — including a
+    /// land, which is never a token, allowing the alt cost to be paid with a
+    /// colorless land instead of a blue creature.
+    #[test]
+    fn nontoken_color_creature_captures_color_and_type() {
+        let (filter, rest) = parse_type_phrase("nontoken blue creature");
+        assert_eq!(rest.trim(), "");
+        let tf = typed_leg(&filter).expect("expected typed filter");
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
+        assert!(tf.properties.contains(&FilterProp::NonToken));
+        assert!(tf.properties.contains(&FilterProp::HasColor {
+            color: ManaColor::Blue
+        }));
+    }
+
+    /// Issue #3677 class (Cadric, Soul Kindler): "another nontoken legendary
+    /// permanent you control" must capture the Legendary supertype, not just
+    /// the NonToken negation. Same root cause as the color case above — the
+    /// supertype-prefix scan only ran BEFORE the `non-` negation loop.
+    #[test]
+    fn nontoken_legendary_permanent_captures_supertype() {
+        let (filter, rest) = parse_type_phrase("another nontoken legendary permanent you control");
+        assert_eq!(rest.trim(), "");
+        let tf = typed_leg(&filter).expect("expected typed filter");
+        assert!(tf.type_filters.contains(&TypeFilter::Permanent));
+        assert!(tf.properties.contains(&FilterProp::NonToken));
+        assert!(tf.properties.contains(&FilterProp::HasSupertype {
+            value: Supertype::Legendary
+        }));
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+    }
+
+    /// Issue #3677 class (Akki Ember-Keeper): "a nontoken modified creature
+    /// you control" must capture the Modified property, not just the
+    /// NonToken negation. Same root cause as the color case above — the
+    /// "modified" adjective scan only ran BEFORE the `non-` negation loop.
+    #[test]
+    fn nontoken_modified_creature_captures_modified_property() {
+        let (filter, rest) = parse_type_phrase("a nontoken modified creature you control");
+        assert_eq!(rest.trim(), "");
+        let tf = typed_leg(&filter).expect("expected typed filter");
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
+        assert!(tf.properties.contains(&FilterProp::NonToken));
+        assert!(tf.properties.contains(&FilterProp::Modified));
+        assert_eq!(tf.controller, Some(ControllerRef::You));
     }
 
     /// CR 201.2 (issue #2016): the "named <CardName>" suffix must terminate the


### PR DESCRIPTION
## Summary
- "sacrifice a nontoken blue creature" (Flare of Denial) parsed into a Sacrifice filter with only `NonToken` set — the color and `Creature` type were silently dropped, letting any nontoken permanent (including a land) pay the alt cost. Reported in #3677.
- Root cause: `parse_type_phrase`'s color/supertype/"modified" adjective scans ran *before* the `non-` negation loop, so a leading `"nontoken "` left whatever adjective followed unparsed. Only `"historic"` had a post-negation re-check arm.
- Added matching post-negation re-checks for color and supertype, and closed the same gap for "modified".
- Fixed `starts_with_type_word`'s negation branch to recurse into `starts_with_type_phrase_lead` (not just core-type/token) so leading-article stripping handles these compounds too.

This is a class-level fix, not a single-card patch — it also corrects:
- The entire Flare cycle (Denial, Cultivation, Duplication, Fortitude, Malice)
- Cadric, Soul Kindler ("another nontoken legendary permanent")
- Akki Ember-Keeper ("a nontoken modified creature")

Closes #3677

## Test plan
- [x] New regression tests: `nontoken_color_creature_captures_color_and_type`, `nontoken_legendary_permanent_captures_supertype`, `nontoken_modified_creature_captures_modified_property` (oracle_target.rs), `alt_cost_sacrifice_nontoken_colored_creature_arm` (oracle_casting.rs)
- [x] `cargo test -p engine --lib` — 12,583 passing (1 pre-existing flaky test under parallel execution, unrelated, passes in isolation)
- [x] `cargo clippy -p engine --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --all` applied
