### PR TITLE
Fix Kappa Cannoneer unblockable trigger

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -4616,6 +4616,64 @@ mod tests {
         assert!(validate_blockers(&state, &[(blocker, attacker)]).is_ok());
     }
 
+    #[test]
+    fn kappa_cannoneer_artifact_enter_trigger_makes_it_unblockable() {
+        use crate::game::scenario::GameScenario;
+        use crate::game::triggers::process_triggers;
+        use crate::game::zones::move_to_zone;
+        use crate::types::actions::GameAction;
+        use crate::types::counter::CounterType;
+        use crate::types::zones::Zone;
+
+        let mut scenario = GameScenario::new();
+        let cannoneer = scenario
+            .add_creature_from_oracle(
+                PlayerId(0),
+                "Kappa Cannoneer",
+                4,
+                4,
+                "Improvise\nWard {4}\nWhenever this creature or another artifact you control enters, put a +1/+1 counter on this creature. It can't be blocked this turn.",
+            )
+            .as_artifact()
+            .id();
+        let artifact = scenario
+            .add_creature_to_hand(PlayerId(0), "Servo", 1, 1)
+            .as_artifact()
+            .id();
+        let blocker = scenario.add_creature(PlayerId(1), "Blocker", 2, 2).id();
+
+        let mut runner = scenario.build();
+        let mut events = Vec::new();
+        move_to_zone(runner.state_mut(), artifact, Zone::Battlefield, &mut events);
+        process_triggers(runner.state_mut(), &events);
+        assert!(
+            runner.state().stack.len() == 1,
+            "artifact ETB should put Kappa Cannoneer's trigger on the stack"
+        );
+        runner
+            .act(GameAction::PassPriority)
+            .expect("active player should pass priority");
+        runner
+            .act(GameAction::PassPriority)
+            .expect("nonactive player should pass priority");
+
+        assert_eq!(
+            runner
+                .state()
+                .objects
+                .get(&cannoneer)
+                .unwrap()
+                .counters
+                .get(&CounterType::Plus1Plus1),
+            Some(&1),
+            "Kappa Cannoneer's trigger should put the counter on itself"
+        );
+        assert!(
+            validate_blockers(runner.state(), &[(blocker, cannoneer)]).is_err(),
+            "Kappa Cannoneer's resolved trigger should make it unblockable this turn"
+        );
+    }
+
     /// CR 509.1b + CR 301.5a: An Equipment-owned `CantBeBlocked` static must
     /// propagate to the equipped creature. Mirrors Silver Shroud Costume,
     /// Whispersilk Cloak, Trailblazer's Boots, etc.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11171,6 +11171,30 @@ fn replace_target_with_self(effect: &mut Effect) {
         Effect::Transform { target, .. } => {
             *target = TargetFilter::SelfRef;
         }
+        Effect::GenericEffect {
+            target,
+            static_abilities,
+            ..
+        } => {
+            if target.as_ref().is_some_and(|target| {
+                matches!(
+                    target,
+                    TargetFilter::ParentTarget | TargetFilter::TriggeringSource
+                )
+            }) {
+                *target = Some(TargetFilter::SelfRef);
+            }
+            for static_def in static_abilities {
+                if static_def.affected.as_ref().is_some_and(|affected| {
+                    matches!(
+                        affected,
+                        TargetFilter::ParentTarget | TargetFilter::TriggeringSource
+                    )
+                }) {
+                    static_def.affected = Some(TargetFilter::SelfRef);
+                }
+            }
+        }
         _ => {
             // Effects without a target field, or outside this anaphor class,
             // stay as-is.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -25654,6 +25654,44 @@ mod tests {
     }
 
     #[test]
+    fn trigger_pronoun_after_self_ref_clause_stays_self_ref_for_generic_effect() {
+        // In "put a counter on this creature. It can't be blocked", the
+        // trailing pronoun refers to the object named by the prior effect
+        // clause, not the artifact/creature whose entry triggered the ability.
+        let def = parse_trigger_line(
+            "Whenever this creature or another artifact you control enters, put a +1/+1 counter on this creature. It can't be blocked this turn.",
+            "Kappa Cannoneer",
+        );
+        let exec = def.execute.as_ref().expect("should have execute");
+        match &*exec.effect {
+            Effect::PutCounter { target, .. } => {
+                assert_eq!(
+                    *target,
+                    TargetFilter::SelfRef,
+                    "the counter clause should target the trigger source itself"
+                );
+            }
+            other => panic!("Expected PutCounter, got {:?}", other),
+        }
+        let sub = exec
+            .sub_ability
+            .as_ref()
+            .expect("should have evasion rider");
+        match &*sub.effect {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => {
+                assert_eq!(
+                    static_abilities[0].affected,
+                    Some(TargetFilter::SelfRef),
+                    "the evasion rider should stay bound to the prior SelfRef clause"
+                );
+            }
+            other => panic!("Expected GenericEffect, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn trigger_equipped_creature_it_resolves_to_triggering_source() {
         // "it" = equipped creature (AttachedTo subject → TriggeringSource)
         let def = parse_trigger_line(


### PR DESCRIPTION
## Summary
- bind GenericEffect pronoun riders back to SelfRef after a prior self-referential clause
- add parser regression for Kappa Cannoneer-style self clause plus evasion rider
- add runtime combat regression that resolves the artifact-enter trigger and rejects blocks

Fixes #855

## Tests
- cargo fmt --all
- CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --lib trigger_pronoun_after_self_ref_clause_stays_self_ref_for_generic_effect -- --nocapture
- CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --lib kappa_cannoneer_artifact_enter_trigger_makes_it_unblockable -- --nocapture