### PR TITLE
Parse own-mana-cost unless payments

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5094,6 +5094,15 @@ fn resolve_chain_body(
                         cost: ManaCost::generic(amount.max(0) as u32),
                     }
                 }
+                AbilityCost::Mana {
+                    cost: ManaCost::SelfManaCost,
+                } => AbilityCost::Mana {
+                    cost: state
+                        .objects
+                        .get(&ability.source_id)
+                        .map(|obj| obj.mana_cost.clone())
+                        .unwrap_or(ManaCost::NoCost),
+                },
                 other => other.clone(),
             };
             // CR 118.5 + CR 118.12a: Zero-mana unless cost short-circuit.
@@ -8554,6 +8563,57 @@ mod tests {
                     *cost,
                     AbilityCost::Mana {
                         cost: ManaCost::generic(3),
+                    }
+                );
+            }
+            other => panic!("expected WaitingFor::UnlessPayment, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unless_pay_self_mana_cost_resolves_source_printed_cost() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Pendrell Flux".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .expect("source object exists")
+            .mana_cost = ManaCost::generic(2);
+
+        let mut ability = ResolvedAbility::new(
+            Effect::Sacrifice {
+                target: TargetFilter::SelfRef,
+                count: QuantityExpr::Fixed { value: 1 },
+                min_count: 0,
+            },
+            vec![TargetRef::Object(source)],
+            source,
+            PlayerId(0),
+        );
+        ability.unless_pay = Some(crate::types::ability::UnlessPayModifier {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::SelfManaCost,
+            },
+            payer: TargetFilter::Controller,
+        });
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("unless-pay interceptor should arm a payment prompt");
+
+        match &state.waiting_for {
+            WaitingFor::UnlessPayment { player, cost, .. } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(
+                    *cost,
+                    AbilityCost::Mana {
+                        cost: ManaCost::generic(2),
                     }
                 );
             }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1646,6 +1646,29 @@ fn extract_unless_pay_modifier(
         );
     }
 
+    // "unless you pay its mana cost" uses the source object's printed mana cost,
+    // resolved by the unless-payment interceptor before prompting the payer.
+    let self_mana_cost_result: Result<(&str, _), _> =
+        tag::<_, _, OracleError<'_>>("its mana cost").parse(cost_str);
+    if let Ok((rest, _)) = self_mana_cost_result {
+        let tail = rest.trim_start();
+        if tail.is_empty()
+            || tag::<_, _, OracleError<'_>>(".").parse(tail).is_ok()
+            || tag::<_, _, OracleError<'_>>(",").parse(tail).is_ok()
+        {
+            let cleaned = text[..unless_pos].trim().to_string();
+            return (
+                cleaned,
+                Some(UnlessPayModifier {
+                    cost: AbilityCost::Mana {
+                        cost: crate::types::mana::ManaCost::SelfManaCost,
+                    },
+                    payer,
+                }),
+            );
+        }
+    }
+
     // Extract cost symbols
     let cost_end = cost_str
         .find(|c: char| c != '{' && c != '}' && !c.is_alphanumeric())
@@ -20066,6 +20089,28 @@ mod tests {
             unless_pay.cost
         );
         // The effect text should be stripped of the unless clause
+        let execute = def.execute.as_ref().expect("should have execute");
+        assert!(
+            matches!(*execute.effect, Effect::Sacrifice { .. }),
+            "execute should be Sacrifice, got {:?}",
+            execute.effect
+        );
+    }
+
+    #[test]
+    fn trigger_unless_you_pay_its_mana_cost() {
+        let def = parse_trigger_line(
+            "At the beginning of your upkeep, sacrifice this enchantment unless you pay its mana cost.",
+            "Pendrell Flux",
+        );
+        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
+        assert_eq!(unless_pay.payer, TargetFilter::Controller);
+        assert_eq!(
+            unless_pay.cost,
+            AbilityCost::Mana {
+                cost: ManaCost::SelfManaCost,
+            }
+        );
         let execute = def.execute.as_ref().expect("should have execute");
         assert!(
             matches!(*execute.effect, Effect::Sacrifice { .. }),


### PR DESCRIPTION
## Summary
- parse "unless you pay its mana cost" into an unless-payment mana cost using the existing SelfManaCost sentinel
- resolve SelfManaCost against the trigger source's printed mana cost before arming UnlessPayment
- add parser and runtime coverage for the own-mana-cost upkeep-tax shape

Fixes #3791

## Tests
- cargo fmt --all
- CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --lib trigger_unless_you_pay_its_mana_cost -- --nocapture
- CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --lib unless_pay_self_mana_cost_resolves_source_printed_cost -- --nocapture