### PR TITLE
fix(search): allow stated-quality fail to find

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1160,7 +1160,7 @@ export type WaitingFor =
   | { type: "DigChoice"; data: { player: PlayerId; cards: ObjectId[]; keep_count: number; up_to?: boolean; selectable_cards?: ObjectId[]; kept_destination?: Zone | null; rest_destination?: Zone | null } }
   | { type: "SurveilChoice"; data: { player: PlayerId; cards: ObjectId[] } }
   | { type: "RevealChoice"; data: { player: PlayerId; cards: ObjectId[]; filter: unknown; optional?: boolean } }
-  | { type: "SearchChoice"; data: { player: PlayerId; cards: ObjectId[]; count: number; reveal?: boolean; up_to?: boolean; constraint?: SearchSelectionConstraint; split?: SearchDestinationSplit | null } }
+  | { type: "SearchChoice"; data: { player: PlayerId; cards: ObjectId[]; count: number; reveal?: boolean; up_to?: boolean; allows_partial_find?: boolean; constraint?: SearchSelectionConstraint; split?: SearchDestinationSplit | null } }
   | { type: "SearchPartitionChoice"; data: { player: PlayerId; cards: ObjectId[]; primary_destination: Zone; primary_count: number; primary_enter_tapped: boolean; rest_destination: Zone; source_id: ObjectId } }
   | { type: "OutsideGameChoice"; data: { player: PlayerId; source_id: ObjectId; choices: OutsideGameChoiceEntry[]; count: number; reveal?: boolean; up_to?: boolean; destination: Zone } }
   | { type: "ChooseOneOfBranch"; data: { player: PlayerId; controller: PlayerId; source_id: ObjectId; branches: unknown[]; branch_descriptions?: string[]; parent_targets?: TargetRef[]; context?: unknown; remaining_players?: PlayerId[] } }

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -424,7 +424,9 @@ function SearchModal({ data }: { data: SearchChoice["data"] }) {
   const objects = useGameStore((s) => s.gameState?.objects);
   const hoverProps = useInspectHoverProps();
   const [selectedSet, setSelectedSet] = useState<Set<ObjectId>>(new Set());
-  const countValid = data.up_to
+  const allowsPartialFind =
+    data.up_to === true || (data.constraint != null && data.constraint.type !== "None");
+  const countValid = allowsPartialFind
     ? selectedSet.size <= data.count
     : selectedSet.size === data.count;
   const subtitle = searchChoiceSubtitle(data, t);

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -64,6 +64,7 @@ import {
   EFFECT_ZONE_BADGE_KEYS,
   EFFECT_ZONE_VISUAL_CLASSES,
   canAssignDistinctCardTypes,
+  searchChoiceAllowsPartialFind,
   searchChoiceSubtitle,
   type EffectZoneMode,
 } from "./cardChoice/shared.tsx";
@@ -424,9 +425,7 @@ function SearchModal({ data }: { data: SearchChoice["data"] }) {
   const objects = useGameStore((s) => s.gameState?.objects);
   const hoverProps = useInspectHoverProps();
   const [selectedSet, setSelectedSet] = useState<Set<ObjectId>>(new Set());
-  const allowsPartialFind =
-    data.up_to === true || (data.constraint != null && data.constraint.type !== "None");
-  const countValid = allowsPartialFind
+  const countValid = searchChoiceAllowsPartialFind(data)
     ? selectedSet.size <= data.count
     : selectedSet.size === data.count;
   const subtitle = searchChoiceSubtitle(data, t);

--- a/client/src/components/modal/cardChoice/shared.tsx
+++ b/client/src/components/modal/cardChoice/shared.tsx
@@ -68,8 +68,7 @@ export function canAssignDistinctCardTypes(
 
 export function searchChoiceSubtitle(data: SearchChoice["data"], t: TFunction<"game">): string {
   const constraint = data.constraint;
-  const allowsPartialFind =
-    data.up_to === true || (constraint != null && constraint.type !== "None");
+  const allowsPartialFind = searchChoiceAllowsPartialFind(data);
   const opts = { count: data.count };
 
   if (constraint?.type === "MatchEachFilter") {
@@ -91,6 +90,14 @@ export function searchChoiceSubtitle(data: SearchChoice["data"], t: TFunction<"g
   return data.up_to
     ? t("cardChoice.search.subtitleUpTo", opts)
     : t("cardChoice.search.subtitleExact", opts);
+}
+
+export function searchChoiceAllowsPartialFind(data: SearchChoice["data"]): boolean {
+  return (
+    data.up_to === true ||
+    data.allows_partial_find === true ||
+    (data.constraint != null && data.constraint.type !== "None")
+  );
 }
 
 export type EffectZoneMode = "Sacrifice" | "Topdeck" | "Hand" | "Battlefield" | "Untap" | "Tap";

--- a/client/src/components/modal/cardChoice/shared.tsx
+++ b/client/src/components/modal/cardChoice/shared.tsx
@@ -68,20 +68,22 @@ export function canAssignDistinctCardTypes(
 
 export function searchChoiceSubtitle(data: SearchChoice["data"], t: TFunction<"game">): string {
   const constraint = data.constraint;
+  const allowsPartialFind =
+    data.up_to === true || (constraint != null && constraint.type !== "None");
   const opts = { count: data.count };
 
   if (constraint?.type === "MatchEachFilter") {
-    return data.up_to
+    return allowsPartialFind
       ? t("cardChoice.search.subtitleMatchUpTo", opts)
       : t("cardChoice.search.subtitleMatchExact", opts);
   }
   if (constraint?.type === "DistinctQualities") {
-    return data.up_to
+    return allowsPartialFind
       ? t("cardChoice.search.subtitleDistinctUpTo", opts)
       : t("cardChoice.search.subtitleDistinctExact", opts);
   }
   if (constraint?.type === "TotalManaValue") {
-    return data.up_to
+    return allowsPartialFind
       ? t("cardChoice.search.subtitleManaValueUpTo", opts)
       : t("cardChoice.search.subtitleManaValueExact", opts);
   }

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -953,19 +953,20 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             cards,
             count,
             up_to,
+            allows_partial_find,
             constraint,
             ..
         } => {
-            // CR 701.23b/d: constrained (stated-quality) searches enumerate 0..=count
-            // so the legal-action set always contains the empty fail-to-find plus
-            // valid partials; pure-quantity exact-count searches enumerate only
-            // `count`. `combinations(_, 0)` returns `vec![vec![]]`, so the empty
-            // decline survives the constraint filter below.
-            let sizes: Vec<usize> = if *up_to || constraint.permits_partial_find() {
-                (0..=*count).collect()
-            } else {
-                vec![*count]
-            };
+            // CR 701.23b/d: "up to N", hidden-zone stated-quality searches, or
+            // explicit stated-quality selection constraints enumerate 0..=count
+            // so the legal-action set contains fail-to-find plus valid partials.
+            // Pure-quantity exact-count searches enumerate only `count`.
+            let sizes: Vec<usize> =
+                if *up_to || *allows_partial_find || constraint.permits_partial_find() {
+                    (0..=*count).collect()
+                } else {
+                    vec![*count]
+                };
             // Engine-side beam cap. Required (not optional) because every candidate
             // returned here flows into `PlannerServices::validate_candidates`, which
             // clones state + applies the action per candidate. Without a cap, a
@@ -5677,6 +5678,7 @@ mod tests {
             count: 2,
             reveal: false,
             up_to: false,
+            allows_partial_find: false,
             constraint: SearchSelectionConstraint::None,
             split: None,
         };
@@ -5698,6 +5700,7 @@ mod tests {
             count: 2,
             reveal: false,
             up_to: false,
+            allows_partial_find: false,
             constraint: SearchSelectionConstraint::DistinctQualities {
                 qualities: vec![SharedQuality::Name],
             },
@@ -5758,6 +5761,7 @@ mod tests {
             count: 4,
             reveal: false,
             up_to: true,
+            allows_partial_find: false,
             constraint: SearchSelectionConstraint::DistinctQualities {
                 qualities: vec![SharedQuality::Name],
             },

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -398,17 +398,18 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
                 cards,
                 count,
                 up_to,
+                allows_partial_find,
                 constraint,
                 ..
             },
             GameAction::SelectCards { cards: chosen },
         ) => {
-            // CR 701.23b vs CR 701.23d: a stated-quality search (MatchEachFilter,
-            // etc.) may legally find fewer cards than requested — including none.
-            // Mirror the submission guard / candidate generation lower bound so
-            // the validated legal-action path does not drop the legal short/empty
-            // fail-to-find candidate and freeze the AI.
-            let lower_bounded = *up_to || constraint.permits_partial_find();
+            // CR 701.23b vs CR 701.23d: hidden-zone stated-quality searches,
+            // explicit stated-quality constraints, and "up to" searches may
+            // legally find fewer cards than requested — including none. Mirror
+            // the submission guard / candidate generation lower bound so the
+            // validated legal-action path does not drop legal short picks.
+            let lower_bounded = *up_to || *allows_partial_find || constraint.permits_partial_find();
             let exact = if lower_bounded { None } else { Some(*count) };
             selection_mismatch(chosen, cards, exact) || (lower_bounded && chosen.len() > *count)
         }
@@ -2055,6 +2056,7 @@ mod tests {
             count: 2,
             reveal: false,
             up_to: true,
+            allows_partial_find: false,
             constraint: SearchSelectionConstraint::None,
             split: None,
         };
@@ -2093,6 +2095,7 @@ mod tests {
             count: 2,
             reveal: false,
             up_to: false,
+            allows_partial_find: false,
             constraint: SearchSelectionConstraint::None,
             split: None,
         };
@@ -2122,6 +2125,7 @@ mod tests {
             count: 2,
             reveal: false,
             up_to: false,
+            allows_partial_find: false,
             constraint: SearchSelectionConstraint::MatchEachFilter {
                 filters: vec![TargetFilter::Any, TargetFilter::Any],
             },

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -12726,6 +12726,7 @@ mod tests {
             count: 0,
             reveal: false,
             up_to: true,
+            allows_partial_find: false,
             constraint: crate::types::ability::SearchSelectionConstraint::None,
             split: None,
         };

--- a/crates/engine/src/game/effects/search_library.rs
+++ b/crates/engine/src/game/effects/search_library.rs
@@ -262,6 +262,38 @@ fn distinct_string_sets(
     })
 }
 
+fn search_filter_has_stated_quality(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Any | TargetFilter::None => false,
+        TargetFilter::Typed(typed) => {
+            typed.has_meaningful_type_constraint() || typed.controller.is_some()
+        }
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(search_filter_has_stated_quality)
+        }
+        TargetFilter::Not { filter } => search_filter_has_stated_quality(filter),
+        _ => true,
+    }
+}
+
+fn effective_selection_constraint(
+    filter: &TargetFilter,
+    count: usize,
+    source_zones: &[Zone],
+    selection_constraint: SearchSelectionConstraint,
+) -> SearchSelectionConstraint {
+    if !matches!(selection_constraint, SearchSelectionConstraint::None)
+        || source_zones != [Zone::Library]
+        || !search_filter_has_stated_quality(filter)
+    {
+        return selection_constraint;
+    }
+
+    SearchSelectionConstraint::MatchEachFilter {
+        filters: vec![filter.clone(); count],
+    }
+}
+
 /// CR 701.23a + CR 401.2: Search a library — look through it, find card(s) matching criteria, then shuffle.
 /// CR 401.2: Libraries are normally face-down; searching is an exception that lets a player look through cards.
 pub fn resolve(
@@ -407,6 +439,8 @@ pub fn resolve(
     }
 
     let pick_count = count.min(matching.len());
+    let selection_constraint =
+        effective_selection_constraint(&filter, pick_count, &effective_zones, selection_constraint);
 
     // CR 608.2c: Propagate the printed-text selection restriction (e.g.,
     // "with different names") into the choice state so the Select handler
@@ -699,6 +733,61 @@ mod tests {
     }
 
     #[test]
+    fn stated_quality_library_search_can_fail_to_find_with_matches_present() {
+        use crate::game::engine::apply;
+        use crate::types::actions::GameAction;
+
+        let mut state = GameState::new_two_player(42);
+        let forest = add_library_land_with_subtype(&mut state, 1, PlayerId(0), "Forest", "Forest");
+        let island = add_library_land_with_subtype(&mut state, 2, PlayerId(0), "Island", "Island");
+        let swamp = add_library_land_with_subtype(&mut state, 3, PlayerId(0), "Swamp", "Swamp");
+        let filter = TargetFilter::Or {
+            filters: vec![
+                TargetFilter::Typed(TypedFilter::land().subtype("Forest".to_string())),
+                TargetFilter::Typed(TypedFilter::land().subtype("Island".to_string())),
+            ],
+        };
+        let ability = make_search_ability(filter, 1);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::SearchChoice {
+                cards,
+                count,
+                up_to,
+                constraint,
+                ..
+            } => {
+                assert_eq!(*count, 1);
+                assert!(!*up_to, "printed text is not an up-to search");
+                assert!(cards.contains(&forest));
+                assert!(cards.contains(&island));
+                assert!(!cards.contains(&swamp));
+                assert!(matches!(
+                    constraint,
+                    SearchSelectionConstraint::MatchEachFilter { filters }
+                        if filters.len() == 1
+                ));
+            }
+            other => panic!("Expected SearchChoice, got {:?}", other),
+        }
+
+        let result = apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::SelectCards { cards: vec![] },
+        )
+        .unwrap();
+
+        assert!(matches!(result.waiting_for, WaitingFor::Priority { .. }));
+        assert!(state.players[0].library.contains(&forest));
+        assert!(state.players[0].library.contains(&island));
+        assert!(state.players[0].library.contains(&swamp));
+    }
+
+    #[test]
     fn search_up_to_propagates_flag_and_floors_sentinel_to_matching_len() {
         // CR 107.1c: Sarkhan -7 pattern — "any number of Dragon creature cards".
         // Parser emits count=i32::MAX + up_to=true; resolver must floor pick_count
@@ -738,10 +827,13 @@ mod tests {
         resolve(&mut state, &ability, &mut events).unwrap();
 
         match &state.waiting_for {
-            WaitingFor::SearchChoice { cards, .. } => {
+            WaitingFor::SearchChoice {
+                cards, constraint, ..
+            } => {
                 assert_eq!(cards.len(), 2);
                 assert!(cards.contains(&card1));
                 assert!(cards.contains(&card2));
+                assert!(matches!(constraint, SearchSelectionConstraint::None));
             }
             other => panic!("Expected SearchChoice, got {:?}", other),
         }

--- a/crates/engine/src/game/effects/search_library.rs
+++ b/crates/engine/src/game/effects/search_library.rs
@@ -276,22 +276,11 @@ fn search_filter_has_stated_quality(filter: &TargetFilter) -> bool {
     }
 }
 
-fn effective_selection_constraint(
-    filter: &TargetFilter,
-    count: usize,
-    source_zones: &[Zone],
-    selection_constraint: SearchSelectionConstraint,
-) -> SearchSelectionConstraint {
-    if !matches!(selection_constraint, SearchSelectionConstraint::None)
-        || source_zones != [Zone::Library]
-        || !search_filter_has_stated_quality(filter)
-    {
-        return selection_constraint;
-    }
-
-    SearchSelectionConstraint::MatchEachFilter {
-        filters: vec![filter.clone(); count],
-    }
+// CR 701.23b: Hidden-zone searches with a stated quality can fail to find
+// some or all matching cards without converting the search filter into a
+// selection-time constraint.
+fn allows_hidden_zone_partial_find(filter: &TargetFilter, source_zones: &[Zone]) -> bool {
+    source_zones == [Zone::Library] && search_filter_has_stated_quality(filter)
 }
 
 /// CR 701.23a + CR 401.2: Search a library — look through it, find card(s) matching criteria, then shuffle.
@@ -439,8 +428,7 @@ pub fn resolve(
     }
 
     let pick_count = count.min(matching.len());
-    let selection_constraint =
-        effective_selection_constraint(&filter, pick_count, &effective_zones, selection_constraint);
+    let allows_partial_find = allows_hidden_zone_partial_find(&filter, &effective_zones);
 
     // CR 608.2c: Propagate the printed-text selection restriction (e.g.,
     // "with different names") into the choice state so the Select handler
@@ -451,6 +439,7 @@ pub fn resolve(
         count: pick_count,
         reveal,
         up_to,
+        allows_partial_find,
         constraint: selection_constraint,
         // CR 701.23a + CR 608.2c: Carry the cultivate-class split metadata so the
         // SearchChoice-completion handler can partition the found set.
@@ -757,19 +746,20 @@ mod tests {
                 cards,
                 count,
                 up_to,
+                allows_partial_find,
                 constraint,
                 ..
             } => {
                 assert_eq!(*count, 1);
                 assert!(!*up_to, "printed text is not an up-to search");
+                assert!(
+                    *allows_partial_find,
+                    "hidden-zone stated-quality search permits fail-to-find"
+                );
                 assert!(cards.contains(&forest));
                 assert!(cards.contains(&island));
                 assert!(!cards.contains(&swamp));
-                assert!(matches!(
-                    constraint,
-                    SearchSelectionConstraint::MatchEachFilter { filters }
-                        if filters.len() == 1
-                ));
+                assert!(matches!(constraint, SearchSelectionConstraint::None));
             }
             other => panic!("Expected SearchChoice, got {:?}", other),
         }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1716,17 +1716,16 @@ pub(super) fn handle_resolution_choice(
                 count,
                 reveal,
                 up_to,
+                allows_partial_find,
                 constraint,
                 split,
             },
             GameAction::SelectCards { cards: chosen },
         ) => {
-            // CR 701.23b/d: "up to N" OR a stated-quality constraint accepts a
-            // short/empty pick (fail-to-find); a pure quantity search needs
-            // exactly `count`. The subsequent `selection_satisfies_constraint`
-            // re-check validates the distinct-slot consistency of whatever was
-            // chosen, so widening the count bound here is safe.
-            let lower_bounded = up_to || constraint.permits_partial_find();
+            // CR 701.23b/d: "up to N", hidden-zone stated-quality searches, or
+            // explicit stated-quality selection constraints accept a short/empty
+            // pick. A pure quantity search needs exactly `count`.
+            let lower_bounded = up_to || allows_partial_find || constraint.permits_partial_find();
             let valid = if lower_bounded {
                 chosen.len() <= count
             } else {

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -315,6 +315,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         count,
         reveal,
         up_to,
+        allows_partial_find,
         ref constraint,
         ref split,
     } = state.waiting_for
@@ -326,6 +327,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
                 count,
                 reveal,
                 up_to,
+                allows_partial_find,
                 constraint: constraint.clone(),
                 split: split.clone(),
             };
@@ -912,6 +914,7 @@ mod tests {
             count: 1,
             reveal: false,
             up_to: false,
+            allows_partial_find: false,
             constraint: crate::types::ability::SearchSelectionConstraint::None,
             split: None,
         };
@@ -1132,6 +1135,7 @@ mod tests {
             count: 1,
             reveal: false,
             up_to: false,
+            allows_partial_find: false,
             constraint: crate::types::ability::SearchSelectionConstraint::None,
             split: None,
         };

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2966,6 +2966,10 @@ pub enum WaitingFor {
         /// cards. When false, they must select exactly count cards.
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         up_to: bool,
+        /// CR 701.23b: Hidden-zone stated-quality searches may select fewer
+        /// than `count` cards even when the printed text is not an "up to" search.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        allows_partial_find: bool,
         /// CR 608.2c: Selection-time constraint propagated from
         /// `Effect::SearchLibrary.selection_constraint` (e.g., "with different
         /// names"). Enforced by the Select-handler call site and used by the

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -2600,6 +2600,7 @@ mod tests {
             count: 1,
             reveal: false,
             up_to: false,
+            allows_partial_find: false,
             constraint: engine::types::ability::SearchSelectionConstraint::None,
             split: None,
         };
@@ -2904,6 +2905,7 @@ mod tests {
             count: 4,
             reveal: true,
             up_to: true,
+            allows_partial_find: false,
             constraint: SearchSelectionConstraint::DistinctQualities {
                 qualities: vec![SharedQuality::Name],
             },


### PR DESCRIPTION
## Summary

Fixes #3651.

- Treat library-only searches with a stated quality as partial-find searches even when the printed count is exact.
- Reuse the existing `SearchSelectionConstraint::MatchEachFilter` path so the engine, AI candidate generation, and UI all agree that choosing zero cards is legal.
- Update the SearchChoice modal copy and confirm gate to allow zero-card confirmation for constrained fail-to-find searches.
- Add a regression covering a Forest-or-Island library search with matching cards present and an empty selection.

## Verification

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --lib stated_quality_library_search_can_fail_to_find_with_matches_present -- --nocapture`
- `pnpm run type-check` was attempted after temporarily linking installed deps, but it fails on existing missing `three` module declarations in `client/src/components/animation/dice3d/*`.
