### PR TITLE
fix(parser): honor Extinction Event parity choice

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -573,6 +573,17 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
                 };
                 parts.push(format!("mv {}{}", fmt_quantity(value), suffix))
             }
+            FilterProp::ManaValueParity { parity } => {
+                let label = match parity {
+                    crate::types::ability::ParitySource::Fixed(parity) => {
+                        format!("{parity:?} mana value").to_lowercase()
+                    }
+                    crate::types::ability::ParitySource::LastNamedChoice => {
+                        "chosen odd/even mana value".to_string()
+                    }
+                };
+                parts.push(label);
+            }
             FilterProp::ManaCostIn { costs } => {
                 parts.push(format!("mana cost in {costs:?}"));
             }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -12,8 +12,8 @@ use crate::game::quantity::{
 };
 use crate::types::ability::{
     ChoiceValue, ChosenAttribute, CombatRelation, CombatRelationSubject, ControllerRef, FilterProp,
-    PtStat, PtValueScope, QuantityExpr, ResolvedAbility, SharedQuality, SharedQualityRelation,
-    TargetFilter, TargetRef, TypeFilter, TypedFilter,
+    Parity, ParitySource, PtStat, PtValueScope, QuantityExpr, ResolvedAbility, SharedQuality,
+    SharedQualityRelation, TargetFilter, TargetRef, TypeFilter, TypedFilter,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::{CoreType, Supertype};
@@ -145,6 +145,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::TargetsOnly { .. }
         | FilterProp::Targets { .. }
         | FilterProp::ColorCount { .. }
+        | FilterProp::ManaValueParity { .. }
         | FilterProp::Token
         | FilterProp::NonToken
         | FilterProp::WasPlayed
@@ -349,6 +350,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::TargetsOnly { .. }
         | FilterProp::Targets { .. }
         | FilterProp::ColorCount { .. }
+        | FilterProp::ManaValueParity { .. }
         | FilterProp::Token
         | FilterProp::NonToken
         | FilterProp::WasPlayed
@@ -2417,6 +2419,10 @@ fn spell_object_matches_property(
             };
             comparator.evaluate(record.mana_value as i32, threshold)
         }
+        FilterProp::ManaValueParity { parity } => {
+            let choice = context.and_then(|ctx| ctx.state.last_named_choice.as_ref());
+            mana_value_matches_parity_source(record.mana_value, parity, choice)
+        }
         FilterProp::IsChosenCreatureType => context.is_some_and(|context| {
             context
                 .state
@@ -2593,6 +2599,9 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
                 false
             }
         },
+        FilterProp::ManaValueParity { parity } => {
+            mana_value_matches_parity_source(record.mana_value, parity, None)
+        }
         // CR 202.1: Exact printed mana cost is not captured in cast-history
         // snapshots. Fail closed rather than approximating with mana value
         // (CR 202.3), which would conflate {W} with {1}.
@@ -2894,6 +2903,32 @@ fn matches_last_chosen_land_or_nonland_kind(
     }
 }
 
+fn parity_from_source(source: &ParitySource, choice: Option<&ChoiceValue>) -> Option<Parity> {
+    match source {
+        ParitySource::Fixed(parity) => Some(*parity),
+        ParitySource::LastNamedChoice => match choice {
+            Some(ChoiceValue::OddOrEven(parity)) => Some(*parity),
+            _ => None,
+        },
+    }
+}
+
+fn mana_value_matches_parity(mana_value: u32, parity: Parity) -> bool {
+    match parity {
+        Parity::Odd => mana_value % 2 == 1,
+        Parity::Even => mana_value % 2 == 0,
+    }
+}
+
+fn mana_value_matches_parity_source(
+    mana_value: u32,
+    source: &ParitySource,
+    choice: Option<&ChoiceValue>,
+) -> bool {
+    parity_from_source(source, choice)
+        .is_some_and(|parity| mana_value_matches_parity(mana_value, parity))
+}
+
 fn attacking_defender_matches(
     state: &GameState,
     source: &SourceContext<'_>,
@@ -3043,6 +3078,10 @@ fn matches_filter_prop(
         FilterProp::Cmc { comparator, value } => {
             let cmc = obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid) as i32;
             comparator.evaluate(cmc, resolve_filter_threshold(state, value, source))
+        }
+        FilterProp::ManaValueParity { parity } => {
+            let mana_value = obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid);
+            mana_value_matches_parity_source(mana_value, parity, state.last_named_choice.as_ref())
         }
         // CR 202.1: Compare exact printed mana cost, not mana value (CR 202.3).
         FilterProp::ManaCostIn { costs } => costs.iter().any(|cost| cost == &obj.mana_cost),
@@ -3669,6 +3708,11 @@ fn zone_change_record_matches_property(
             record.mana_value as i32,
             resolve_filter_threshold(state, value, source),
         ),
+        // CR 202.3 + CR 608.2c: The event-time mana value is fixed in the
+        // snapshot; the chosen odd/even quality is read from resolution state.
+        FilterProp::ManaValueParity { parity } => {
+            mana_value_matches_parity_source(record.mana_value, parity, state.last_named_choice.as_ref())
+        }
         // CR 202.1: Zone-change records currently snapshot mana value, not the
         // full printed mana cost. Exact-cost predicates fail closed here.
         FilterProp::ManaCostIn { .. } => false,

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -2915,8 +2915,8 @@ fn parity_from_source(source: &ParitySource, choice: Option<&ChoiceValue>) -> Op
 
 fn mana_value_matches_parity(mana_value: u32, parity: Parity) -> bool {
     match parity {
-        Parity::Odd => mana_value % 2 == 1,
-        Parity::Even => mana_value % 2 == 0,
+        Parity::Odd => !mana_value.is_multiple_of(2),
+        Parity::Even => mana_value.is_multiple_of(2),
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -8897,6 +8897,7 @@ fn try_parse_bolster(lower: &str) -> Option<Effect> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::ability::ParitySource;
 
     fn typed_leg(filter: &TargetFilter) -> Option<&TypedFilter> {
         match filter {
@@ -9759,6 +9760,28 @@ mod tests {
             filters[1],
             TargetFilter::Typed(TypedFilter::default().subtype("Spacecraft".to_string()))
         );
+    }
+
+    #[test]
+    fn parse_exile_each_creature_with_mana_value_chosen_quality() {
+        let input = "exile each creature with mana value of the chosen quality";
+        let lower = input.to_lowercase();
+        let result = parse_zone_counter_ast(input, &lower, &mut ParseContext::default());
+        let Some(ZoneCounterImperativeAst::Exile {
+            origin: None,
+            target: TargetFilter::Typed(filter),
+            all: true,
+            enter_with_counters,
+        }) = result
+        else {
+            panic!("{input}: expected mass exile parity filter, got {result:?}");
+        };
+
+        assert!(enter_with_counters.is_empty());
+        assert!(filter.type_filters.contains(&TypeFilter::Creature));
+        assert!(filter.properties.contains(&FilterProp::ManaValueParity {
+            parity: ParitySource::LastNamedChoice,
+        }));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -9,8 +9,8 @@ use nom::Parser;
 
 use crate::types::ability::{
     AggregateFunction, AttachmentKind, CombatRelation, CombatRelationSubject, Comparator,
-    ControllerRef, FilterProp, ObjectProperty, ObjectScope, PtStat, PtValueScope, QuantityExpr,
-    QuantityRef, SeatDirection, SharedQuality, SharedQualityRelation, TargetFilter,
+    ControllerRef, FilterProp, ObjectProperty, ObjectScope, ParitySource, PtStat, PtValueScope,
+    QuantityExpr, QuantityRef, SeatDirection, SharedQuality, SharedQualityRelation, TargetFilter,
     TargetSelectionMode, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::Supertype;
@@ -3589,6 +3589,28 @@ pub(crate) fn parse_mana_value_suffix(
         return Some((prop, text.len() - after.len()));
     }
 
+    if let Ok((after, _)) = (
+        alt((
+            tag::<_, _, OracleError<'_>>("with "),
+            tag::<_, _, OracleError<'_>>("that have "),
+            tag::<_, _, OracleError<'_>>("that each have "),
+        )),
+        tag::<_, _, OracleError<'_>>("mana value of "),
+        alt((
+            tag::<_, _, OracleError<'_>>("the chosen quality"),
+            tag::<_, _, OracleError<'_>>("that quality"),
+        )),
+    )
+        .parse(trimmed)
+    {
+        return Some((
+            FilterProp::ManaValueParity {
+                parity: ParitySource::LastNamedChoice,
+            },
+            text.len() - after.len(),
+        ));
+    }
+
     let (rest, _) = alt((
         tag::<_, _, OracleError<'_>>("with mana value "),
         tag::<_, _, OracleError<'_>>("that have mana value "),
@@ -7154,6 +7176,17 @@ mod tests {
                 }
             ]))
         );
+    }
+
+    #[test]
+    fn mana_value_chosen_quality_suffix_maps_to_parity_choice() {
+        let (filter, rest) = parse_target("creatures with mana value of the chosen quality");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        let typed = typed_leg(&filter).expect("expected typed creature filter");
+        assert!(typed.type_filters.contains(&TypeFilter::Creature));
+        assert!(typed.properties.contains(&FilterProp::ManaValueParity {
+            parity: ParitySource::LastNamedChoice,
+        }));
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -488,6 +488,17 @@ pub enum Parity {
     Even,
 }
 
+/// Source for odd/even parity predicates over mana value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
+pub enum ParitySource {
+    /// A fixed printed odd/even quality.
+    Fixed(Parity),
+    /// CR 608.2c: Reads the most recent odd/even named choice made earlier in
+    /// the same resolving instruction sequence.
+    LastNamedChoice,
+}
+
 /// A branch in a d20/d6/d4 result table (CR 706.2).
 /// Each branch covers a contiguous range of die results and maps to an effect.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2310,6 +2321,12 @@ pub enum FilterProp {
     Cmc {
         comparator: Comparator,
         value: QuantityExpr,
+    },
+    /// CR 202.3 + CR 608.2c: Matches objects whose mana value has the selected
+    /// odd/even quality, either fixed or chosen earlier in the same resolving
+    /// instruction sequence.
+    ManaValueParity {
+        parity: ParitySource,
     },
     /// CR 202.1: Matches objects whose printed mana cost is exactly one of `costs`.
     /// Distinct from `Cmc`/mana value (CR 202.3): "{0} or {1}" must not match

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -25,7 +25,7 @@ pub mod zones;
 pub use ability::{
     AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AdditionalCost, BasicLandType,
     ChosenAttribute, ChosenSubtypeKind, ContinuousModification, ControllerRef, Duration, Effect,
-    EffectError, FilterProp, ManaProduction, ManaSpendRestriction, Parity, PtValue,
+    EffectError, FilterProp, ManaProduction, ManaSpendRestriction, Parity, ParitySource, PtValue,
     ReplacementDefinition, ResolvedAbility, StaticCondition, StaticDefinition, TargetFilter,
     TargetRef, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
 };

--- a/crates/engine/tests/extinction_event_3270.rs
+++ b/crates/engine/tests/extinction_event_3270.rs
@@ -1,0 +1,64 @@
+//! Runtime regression for #3270 — Extinction Event's odd/even choice.
+//!
+//! "Choose odd or even. Exile each creature with mana value of the chosen
+//! quality."
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const EXTINCTION_EVENT: &str =
+    "Choose odd or even. Exile each creature with mana value of the chosen quality.";
+
+#[test]
+fn extinction_event_exiles_only_the_chosen_mana_value_parity() {
+    let mut scenario = GameScenario::new_n_player(2, 3270);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let odd_creature = scenario
+        .add_creature(P0, "Odd Creature", 3, 3)
+        .with_mana_cost(ManaCost::generic(3))
+        .id();
+    let even_creature = scenario
+        .add_creature(P1, "Even Creature", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let zero_creature = scenario
+        .add_creature(P1, "Zero Creature", 1, 1)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let extinction_event = scenario
+        .add_spell_to_hand_from_oracle(P0, "Extinction Event", false, EXTINCTION_EVENT)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+
+    runner.cast(extinction_event).resolve();
+    let WaitingFor::NamedChoice { options, .. } = &runner.state().waiting_for else {
+        panic!(
+            "Extinction Event must pause on odd/even choice, got {}",
+            runner.waiting_for_kind()
+        );
+    };
+    assert!(options.iter().any(|choice| choice == "Odd"));
+    assert!(options.iter().any(|choice| choice == "Even"));
+
+    runner
+        .act(GameAction::ChooseOption {
+            choice: "Odd".to_string(),
+        })
+        .expect("ChooseOption(Odd) must resolve");
+    runner.advance_until_stack_empty();
+
+    let zone_of = |id| runner.state().objects[&id].zone;
+
+    // CR 202.3 + CR 608.2c: the chosen odd/even quality filters mana value.
+    assert_eq!(zone_of(odd_creature), Zone::Exile);
+    assert_eq!(zone_of(even_creature), Zone::Battlefield);
+    assert_eq!(zone_of(zero_creature), Zone::Battlefield);
+}


### PR DESCRIPTION
Fixes #3270

## Summary
- add a reusable `ManaValueParity` filter property keyed by fixed or last named odd/even choice
- parse "mana value of the chosen quality" into that filter for mass exile effects
- cover Extinction Event through parser tests and a cast-pipeline regression

## Verification
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine chosen_quality -- --nocapture`
- `CARGO_TARGET_DIR=/home/a/Dev/dripsmvcp/phase/target cargo test -p engine --test extinction_event_3270 -- --nocapture`
