### PR TITLE
Fix Nyxbloom Ancient + Mana Reflection mana stacking (#3654)

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -5236,6 +5236,17 @@ fn damage_commute_class(modification: &DamageModification) -> CommuteClass {
     }
 }
 
+/// CR 106.12b + CR 616.1: Mana-production modifiers on the same `ProduceMana`
+/// event. `Multiply` modifiers commute (×2 then ×3 == ×3 then ×2), so Mana
+/// Reflection + Nyxbloom Ancient auto-apply without a degenerate ordering prompt.
+fn mana_commute_class(modification: &crate::types::ability::ManaModification) -> CommuteClass {
+    use crate::types::ability::ManaModification;
+    match modification {
+        ManaModification::Multiply { .. } => CommuteClass::Multiplicative,
+        ManaModification::ReplaceWith { .. } => CommuteClass::NonCommuting,
+    }
+}
+
 /// CR 616.1 classification of a single replacement candidate.
 enum CandidateMateriality {
     /// An order-sensitive shape regardless of the other candidates (zone
@@ -5338,10 +5349,10 @@ fn candidate_materiality(
                 commute: quantity_commute_class(modification),
             };
         }
-        if repl_def.mana_modification.is_some() {
+        if let Some(modification) = repl_def.mana_modification.as_ref() {
             return CandidateMateriality::Writes {
                 field: EventField::ManaType,
-                commute: CommuteClass::NonCommuting,
+                commute: mana_commute_class(modification),
             };
         }
         if let Some(modification) = repl_def.damage_modification.as_ref() {

--- a/crates/engine/tests/integration/issue_3654_nyxbloom_mana_reflection.rs
+++ b/crates/engine/tests/integration/issue_3654_nyxbloom_mana_reflection.rs
@@ -1,0 +1,57 @@
+//! Regression for issue #3654: Nyxbloom Ancient and Mana Reflection must
+//! stack multiplicatively (2× × 3× = 6×) when both are on the battlefield.
+//!
+//! https://github.com/phase-rs/phase/issues/3654
+
+use engine::database::card_db::CardDatabase;
+use engine::game::mana_payment::produce_mana;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::mana::ManaType;
+use engine::types::zones::Zone;
+
+fn load_db() -> Option<&'static CardDatabase> {
+    static DB: std::sync::OnceLock<Option<CardDatabase>> = std::sync::OnceLock::new();
+    DB.get_or_init(|| {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../client/public/card-data.json");
+        CardDatabase::from_export(&path).ok()
+    })
+    .as_ref()
+}
+
+/// CR 106.12b + CR 616.1: Tapping a land with both Mana Reflection (×2) and
+/// Nyxbloom Ancient (×3) on the battlefield produces six mana of the tapped type.
+#[test]
+fn nyxbloom_and_mana_reflection_stack_to_six_mana() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    let _reflection = scenario.add_real_card(P0, "Mana Reflection", Zone::Battlefield, db);
+    let _nyxbloom = scenario.add_real_card(P0, "Nyxbloom Ancient", Zone::Battlefield, db);
+    let forest = scenario.add_real_card(P0, "Forest", Zone::Battlefield, db);
+
+    let mut runner = scenario.build();
+    let state = runner.state_mut();
+
+    let reflection_obj = state
+        .objects
+        .values()
+        .find(|o| o.name == "Mana Reflection")
+        .expect("Mana Reflection on battlefield");
+    assert!(
+        reflection_obj.replacement_definitions.len() > 0,
+        "Mana Reflection must carry ProduceMana replacements"
+    );
+
+    let mut events = Vec::new();
+    produce_mana(state, forest, ManaType::Green, P0, true, &mut events);
+
+    assert_eq!(
+        state.players[0].mana_pool.count_color(ManaType::Green),
+        6,
+        "Mana Reflection (×2) and Nyxbloom Ancient (×3) should produce 6 green mana"
+    );
+}

--- a/crates/engine/tests/integration/issue_3654_nyxbloom_mana_reflection.rs
+++ b/crates/engine/tests/integration/issue_3654_nyxbloom_mana_reflection.rs
@@ -42,7 +42,7 @@ fn nyxbloom_and_mana_reflection_stack_to_six_mana() {
         .find(|o| o.name == "Mana Reflection")
         .expect("Mana Reflection on battlefield");
     assert!(
-        reflection_obj.replacement_definitions.len() > 0,
+        !reflection_obj.replacement_definitions.is_empty(),
         "Mana Reflection must carry ProduceMana replacements"
     );
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -280,6 +280,7 @@ mod issue_3323_nexus_of_fate_extra_turn;
 mod issue_3324_haunted_one;
 mod issue_3325_umbral_mantle;
 mod issue_3425_legend_rule_exemption_scopes;
+mod issue_3654_nyxbloom_mana_reflection;
 mod issue_3660_paradigm_multiple_offers;
 mod issue_3665_smugglers_share;
 mod issue_3681_inferno_titan_divided_damage;


### PR DESCRIPTION
## Summary
- Classify `ManaModification::Multiply` as multiplicatively commuting in CR 616.1 ordering so multiple tap-for-mana doublers auto-apply in sequence
- Fixes Mana Reflection (×2) + Nyxbloom Ancient (×3) producing 6 mana instead of falling through to 1 when an ordering prompt was incorrectly required

## Test plan
- [x] `cargo test -p engine --test integration nyxbloom_and_mana_reflection`
- [x] `cargo clippy -p engine -- -D warnings`

Fixes #3654

Made with [Cursor](https://cursor.com)