### PR TITLE
fix(parser): parse "a player" / leading-instead mill-doubler (Bruvac the Grandiloquent)

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4824,21 +4824,43 @@ fn strip_optional_instead_lead_in(effect_text: &str) -> (bool, &str) {
 enum MillReplacementSubject {
     You,
     Opponent,
+    AnyPlayer,
 }
 
 fn parse_mill_count_replacement(lower: &str, original_text: &str) -> Option<ReplacementDefinition> {
     let ((subject, count), rest) = nom_on_lower(lower, lower, |input| {
         let (input, _) = tag("if ").parse(input)?;
+        // CR 614.1a: the antecedent subject scopes whose mill event is replaced.
         let (input, subject) = alt((
             value(MillReplacementSubject::Opponent, tag("an opponent")),
             value(MillReplacementSubject::Opponent, tag("opponent")),
+            // CR 614.1a: "a player" scopes the replacement to every player's mill
+            // (Bruvac the Grandiloquent), mirroring the "a player" arms in the
+            // proliferate/draw replacement parsers (→ ReplacementPlayerScope::AnyPlayer).
+            value(MillReplacementSubject::AnyPlayer, tag("a player")),
             value(MillReplacementSubject::You, tag("you")),
         ))
         .parse(input)?;
         let (input, _) = tag(" would mill one or more cards, ").parse(input)?;
-        let (input, _) = alt((tag("they mill "), tag("you mill "))).parse(input)?;
+        // CR 614.1a: two printed word orders for the consequence —
+        //   trailing-instead: "they mill twice that many cards instead"
+        //   leading-instead:  "instead that player mills twice that many cards" (Bruvac)
+        let (input, lead_instead) = opt(tag("instead ")).parse(input)?;
+        let (input, _) = alt((
+            tag("they mill "),
+            tag("you mill "),
+            tag("that player mills "),
+        ))
+        .parse(input)?;
         let (input, count) = parse_mill_replacement_count.parse(input)?;
-        let (input, _) = alt((tag(" cards instead"), tag(" instead"))).parse(input)?;
+        let input = if lead_instead.is_some() {
+            // The leading "instead" already supplied the replacement marker; the
+            // tail is just an optional "cards" noun (no second "instead").
+            opt(tag(" cards")).parse(input)?.0
+        } else {
+            let (input, _) = alt((tag(" cards instead"), tag(" instead"))).parse(input)?;
+            input
+        };
         let (input, _) = opt(char('.')).parse(input)?;
         Ok((input, (subject, count)))
     })?;
@@ -4857,8 +4879,16 @@ fn parse_mill_count_replacement(lower: &str, original_text: &str) -> Option<Repl
         ))
         .description(original_text.to_string());
 
-    if matches!(subject, MillReplacementSubject::Opponent) {
-        def.valid_player = Some(ReplacementPlayerScope::Opponent);
+    // CR 614.1a: scope the replacement to the antecedent subject's mill events.
+    match subject {
+        MillReplacementSubject::Opponent => {
+            def.valid_player = Some(ReplacementPlayerScope::Opponent);
+        }
+        MillReplacementSubject::AnyPlayer => {
+            def.valid_player = Some(ReplacementPlayerScope::AnyPlayer);
+        }
+        // "you" keeps the default controller-only scope (valid_player = None).
+        MillReplacementSubject::You => {}
     }
 
     Some(def)
@@ -12849,6 +12879,42 @@ mod tests {
 
         assert_eq!(def.event, ReplacementEvent::Mill);
         assert_eq!(def.valid_player, Some(ReplacementPlayerScope::Opponent));
+        let execute = def.execute.as_ref().expect("mill replacement must execute");
+        match &*execute.effect {
+            Effect::Mill {
+                count,
+                target,
+                destination,
+            } => {
+                assert_eq!(target, &TargetFilter::Controller);
+                assert_eq!(destination, &Zone::Graveyard);
+                assert_eq!(
+                    count,
+                    &QuantityExpr::Multiply {
+                        factor: 2,
+                        inner: Box::new(QuantityExpr::Ref {
+                            qty: QuantityRef::EventContextAmount
+                        })
+                    }
+                );
+            }
+            other => panic!("expected Mill execute, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_bruvac_player_mill_replacement_leading_instead() {
+        // CR 614.1a: Bruvac the Grandiloquent's actual printed Oracle text uses
+        // the "a player" antecedent and the leading-`instead` consequence word
+        // order. Both must parse to an AnyPlayer-scoped 2x mill replacement.
+        let text =
+            "If a player would mill one or more cards, instead that player mills twice that many cards.";
+        let def = parse_replacement_line(text, "Bruvac the Grandiloquent")
+            .expect("must parse Bruvac mill replacement");
+
+        assert_eq!(def.event, ReplacementEvent::Mill);
+        // Scopes to every player's mill (not just the controller's / an opponent's).
+        assert_eq!(def.valid_player, Some(ReplacementPlayerScope::AnyPlayer));
         let execute = def.execute.as_ref().expect("mill replacement must execute");
         match &*execute.effect {
             Effect::Mill {


### PR DESCRIPTION
Fixes #3819.

## Summary

Bruvac the Grandiloquent — "If a player would mill one or more cards, instead that player mills twice that many cards." — produced **no** mill replacement, so its only ability did nothing and mills were never doubled.

`parse_mill_count_replacement` (`crates/engine/src/parser/oracle_replacement.rs`) only recognized the `you` / `an opponent` subject and the **trailing-`instead`** consequence order (`"they mill … cards instead"`). Bruvac uses the `a player` subject and the **leading-`instead`** order (`"instead that player mills …"`), so the line fell through and `parse_replacement_line` returned `None`.

## Fix (parser-AST-only; one new `MillReplacementSubject` variant, no runtime change)

1. Add a `"a player"` subject arm → `MillReplacementSubject::AnyPlayer`, mirroring the `"a player"` antecedent the sibling proliferate/draw replacement parsers already route to `ReplacementPlayerScope::AnyPlayer`.
2. Accept the leading-`instead` consequence word order (`opt("instead ")` + `"that player mills "`) alongside the existing trailing-`instead` order. When `instead` leads, the tail is just an optional `" cards"` noun (the leading `instead` is the replacement marker), so the existing trailing-`instead` branch is left untouched.
3. Map `AnyPlayer` → `ReplacementPlayerScope::AnyPlayer` via an exhaustive `match` (replacing the prior `if matches!(…Opponent…)`; `you` keeps the default controller-only scope).

`ReplacementPlayerScope::AnyPlayer` already exists and is already honored at runtime in `game/replacement.rs` (used by the proliferate, energy, and player-counter replacements), so the produced AST is fully supported end-to-end — only the parser wasn't emitting it. The milled player is taken from the in-flight event (identical to the existing `Opponent`-scoped path), so no effect-target change is needed.

CR 614.1a (replacement effects — the rule annotated on every sibling on this dispatch path).

## Tests

- Added `parses_bruvac_player_mill_replacement_leading_instead`: Bruvac's **actual printed** Oracle text → `ReplacementEvent::Mill`, `valid_player = Some(AnyPlayer)`, `count = 2 × EventContextAmount`. (The pre-existing `parses_opponent_mill_replacement_with_multiplier` test is labeled "Bruvac" but exercises a paraphrase — `"an opponent … they mill twice that many cards instead"` — so the real wording was previously untested.)
- No-regression: traced `parses_opponent_mill_replacement_with_multiplier` and `…_with_offset` — both still parse unchanged (the trailing-`instead` branch is byte-for-byte the prior logic).

## Verification

Change is surgical and mirrors the immediately-adjacent sibling arms (each addition is a `value(…, tag(…))` / `opt(tag(…))` of the same shape as the lines above it, plus one enum variant and one exhaustive `match`). `cargo fmt` style matches the surrounding code. I do not have a local Rust toolchain on this machine, so I am relying on repo CI (clippy `-D warnings`, `test-engine`, fmt) to run the full compile + suite; the new and existing unit tests above are the discriminating coverage.