### PR TITLE
Add Triumphant Chomp

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1982,7 +1982,7 @@ fn quantity_expr_has_unresolved_variable(
         | QuantityExpr::Power {
             exponent: inner, ..
         } => quantity_expr_has_unresolved_variable(state, ability, inner),
-        QuantityExpr::Sum { exprs } => exprs
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => exprs
             .iter()
             .any(|expr| quantity_expr_has_unresolved_variable(state, ability, expr)),
         QuantityExpr::Difference { left, right } => {
@@ -2562,7 +2562,9 @@ fn quantity_expr_target_slot_filter(expr: &QuantityExpr) -> Option<TargetFilter>
         | QuantityExpr::Power {
             exponent: inner, ..
         } => quantity_expr_target_slot_filter(inner),
-        QuantityExpr::Sum { exprs } => exprs.iter().find_map(quantity_expr_target_slot_filter),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().find_map(quantity_expr_target_slot_filter)
+        }
         QuantityExpr::Difference { left, right } => quantity_expr_target_slot_filter(left)
             .or_else(|| quantity_expr_target_slot_filter(right)),
         QuantityExpr::Fixed { .. } => None,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11604,7 +11604,9 @@ fn quantity_expr_is_board_state_relative(expr: &QuantityExpr) -> bool {
         | QuantityExpr::Offset { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
         | QuantityExpr::Multiply { inner, .. } => quantity_expr_is_board_state_relative(inner),
-        QuantityExpr::Sum { exprs } => exprs.iter().all(quantity_expr_is_board_state_relative),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().all(quantity_expr_is_board_state_relative)
+        }
         _ => false,
     }
 }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -918,6 +918,10 @@ fn fmt_quantity(q: &QuantityExpr) -> String {
             let parts: Vec<String> = exprs.iter().map(fmt_quantity).collect();
             format!("({})", parts.join(" + "))
         }
+        QuantityExpr::Max { exprs } => {
+            let parts: Vec<String> = exprs.iter().map(fmt_quantity).collect();
+            format!("max({})", parts.join(", "))
+        }
         QuantityExpr::UpTo { max } => format!("up to {}", fmt_quantity(max)),
         QuantityExpr::Power { base, exponent } => {
             format!("{}^{}", base, fmt_quantity(exponent))
@@ -5519,7 +5523,7 @@ fn extract_quantity_features(qty: &QuantityExpr, features: &mut HashMap<String, 
         QuantityExpr::DivideRounded { inner, .. } => {
             extract_quantity_features(inner, features);
         }
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
                 extract_quantity_features(inner, features);
             }

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -447,7 +447,7 @@ fn snapshot_quantity_expr(expr: &mut QuantityExpr, state: &GameState, ability: &
         | QuantityExpr::DivideRounded { inner, .. } => {
             snapshot_quantity_expr(inner, state, ability);
         }
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for e in exprs.iter_mut() {
                 snapshot_quantity_expr(e, state, ability);
             }

--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -592,6 +592,12 @@ fn snapshot_resolution_context_quantity(expr: &QuantityExpr, events: &[GameEvent
                 .map(|e| snapshot_resolution_context_quantity(e, events))
                 .collect(),
         },
+        QuantityExpr::Max { exprs } => QuantityExpr::Max {
+            exprs: exprs
+                .iter()
+                .map(|e| snapshot_resolution_context_quantity(e, events))
+                .collect(),
+        },
         QuantityExpr::UpTo { max } => QuantityExpr::UpTo {
             max: Box::new(snapshot_resolution_context_quantity(max, events)),
         },

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1958,7 +1958,9 @@ fn quantity_expr_references_demonstrative(qty: &QuantityExpr) -> bool {
         | QuantityExpr::DivideRounded { inner, .. } => {
             quantity_expr_references_demonstrative(inner)
         }
-        QuantityExpr::Sum { exprs } => exprs.iter().any(quantity_expr_references_demonstrative),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(quantity_expr_references_demonstrative)
+        }
         QuantityExpr::Difference { left, right } => {
             quantity_expr_references_demonstrative(left)
                 || quantity_expr_references_demonstrative(right)
@@ -2083,7 +2085,7 @@ fn collect_clause_minimum_refs<'a>(expr: &'a QuantityExpr, out: &mut Vec<&'a Qua
         | QuantityExpr::Power {
             exponent: inner, ..
         } => collect_clause_minimum_refs(inner, out),
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for e in exprs {
                 collect_clause_minimum_refs(e, out);
             }
@@ -2895,7 +2897,9 @@ fn quantity_expr_references_tracked_set(qty: &QuantityExpr) -> bool {
         | QuantityExpr::ClampMin { inner, .. }
         | QuantityExpr::Multiply { inner, .. }
         | QuantityExpr::DivideRounded { inner, .. } => quantity_expr_references_tracked_set(inner),
-        QuantityExpr::Sum { exprs } => exprs.iter().any(quantity_expr_references_tracked_set),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(quantity_expr_references_tracked_set)
+        }
         QuantityExpr::UpTo { max } => quantity_expr_references_tracked_set(max),
         QuantityExpr::Power { exponent, .. } => quantity_expr_references_tracked_set(exponent),
         QuantityExpr::Difference { left, right } => {

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -193,7 +193,9 @@ pub(crate) fn quantity_expr_uses_recipient(expr: &QuantityExpr) -> bool {
         | QuantityExpr::Offset { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
         | QuantityExpr::Multiply { inner, .. } => quantity_expr_uses_recipient(inner),
-        QuantityExpr::Sum { exprs } => exprs.iter().any(quantity_expr_uses_recipient),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(quantity_expr_uses_recipient)
+        }
         QuantityExpr::UpTo { max } => quantity_expr_uses_recipient(max),
         QuantityExpr::Power { exponent, .. } => quantity_expr_uses_recipient(exponent),
         QuantityExpr::Difference { left, right } => {
@@ -226,7 +228,9 @@ pub(crate) fn quantity_expr_uses_object_count(expr: &QuantityExpr) -> bool {
         | QuantityExpr::Offset { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
         | QuantityExpr::Multiply { inner, .. } => quantity_expr_uses_object_count(inner),
-        QuantityExpr::Sum { exprs } => exprs.iter().any(quantity_expr_uses_object_count),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(quantity_expr_uses_object_count)
+        }
         QuantityExpr::UpTo { max } => quantity_expr_uses_object_count(max),
         QuantityExpr::Power { exponent, .. } => quantity_expr_uses_object_count(exponent),
         QuantityExpr::Difference { left, right } => {
@@ -367,7 +371,7 @@ pub(crate) fn entered_object_perturbs_quantity_expr(
         | QuantityExpr::Multiply { inner, .. } => {
             entered_object_perturbs_quantity_expr(state, entered, ctx, inner)
         }
-        QuantityExpr::Sum { exprs } => exprs
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => exprs
             .iter()
             .any(|e| entered_object_perturbs_quantity_expr(state, entered, ctx, e)),
         QuantityExpr::UpTo { max } => {
@@ -580,7 +584,7 @@ pub fn resolve_quantity_with_ctx(
 
 /// Compose recursively-resolved inner values for the non-leaf
 /// `QuantityExpr` variants (`DivideRounded`, `Offset`, `Multiply`, `Sum`,
-/// `Power`, `UpTo`, `Difference`). All resolver entry points share this
+/// `Power`, `UpTo`, `Difference`, `Max`). All resolver entry points share this
 /// logic; only the leaf arms (`Fixed`, `Ref`) differ in context handling.
 /// `recurse` is a closure the caller supplies that re-enters its own
 /// resolver with the inner expression.
@@ -630,6 +634,12 @@ fn fold_compose(expr: &QuantityExpr, recurse: impl Fn(&QuantityExpr) -> i32) -> 
         // same operation as an absolute value; it confirms only that the
         // resulting amount is non-negative.)
         QuantityExpr::Difference { left, right } => (recurse(left) - recurse(right)).abs(),
+        // CR 107.1: the maximum of the computed integer operands. CR 120.4a /
+        // CR 120.10 establish the in-rules "the greatest of the calculated
+        // amounts" precedent for taking a maximum over multiple computed
+        // values; "whichever is greater" itself has no dedicated CR number.
+        // CR 107.2: an empty operand list (undeterminable) resolves to 0.
+        QuantityExpr::Max { exprs } => exprs.iter().map(&recurse).max().unwrap_or(0),
         QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => {
             unreachable!("fold_compose called on leaf variant — caller must dispatch leaves first")
         }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1857,6 +1857,15 @@ fn resolve_event_replacement_quantity(expr: &QuantityExpr, event_count: u32) -> 
             }
             Some(total)
         }
+        // CR 107.1: the maximum of the computed operand values; empty → 0.
+        QuantityExpr::Max { exprs } => {
+            let mut best: Option<i32> = None;
+            for inner in exprs {
+                let value = resolve_event_replacement_quantity(inner, event_count)?;
+                best = Some(best.map_or(value, |b| b.max(value)));
+            }
+            Some(best.unwrap_or(0))
+        }
         // CR 107.1c + CR 608.2d: For replacement quantity resolution, treat
         // `UpTo` transparently as its upper bound — the replacement-effect
         // pipeline does not honor "may pick fewer" semantics (the choice

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -851,7 +851,7 @@ fn quantity_expr_uses_filter_prop(
         | QuantityExpr::Offset { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
         | QuantityExpr::Multiply { inner, .. } => quantity_expr_uses_filter_prop(inner, pred),
-        QuantityExpr::Sum { exprs } => exprs
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => exprs
             .iter()
             .any(|inner| quantity_expr_uses_filter_prop(inner, pred)),
         QuantityExpr::Fixed { .. } => false,

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -605,6 +605,12 @@ fn rebind_counter_quantity_scope(count: QuantityExpr, scope: ObjectScope) -> Qua
                 .map(|expr| rebind_counter_quantity_scope(expr, scope))
                 .collect(),
         },
+        QuantityExpr::Max { exprs } => QuantityExpr::Max {
+            exprs: exprs
+                .into_iter()
+                .map(|expr| rebind_counter_quantity_scope(expr, scope))
+                .collect(),
+        },
         QuantityExpr::UpTo { max } => QuantityExpr::UpTo {
             max: Box::new(rebind_counter_quantity_scope(*max, scope)),
         },

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -8303,6 +8303,12 @@ fn rebind_costpaid_scope_to_recipient(expr: QuantityExpr) -> QuantityExpr {
                 .map(rebind_costpaid_scope_to_recipient)
                 .collect(),
         },
+        QuantityExpr::Max { exprs } => QuantityExpr::Max {
+            exprs: exprs
+                .into_iter()
+                .map(rebind_costpaid_scope_to_recipient)
+                .collect(),
+        },
         QuantityExpr::UpTo { max } => QuantityExpr::UpTo {
             max: Box::new(rebind_costpaid_scope_to_recipient(*max)),
         },

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5662,7 +5662,7 @@ fn rebind_cost_paid_object_pt_to_target(expr: &mut QuantityExpr) {
         } => {
             rebind_cost_paid_object_pt_to_target(inner);
         }
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
                 rebind_cost_paid_object_pt_to_target(inner);
             }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11456,7 +11456,7 @@ fn rebind_source_amount(expr: &mut QuantityExpr, target: ObjectScope) {
         | QuantityExpr::Power {
             exponent: inner, ..
         } => rebind_source_amount(inner, target),
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
                 rebind_source_amount(inner, target);
             }
@@ -12370,7 +12370,7 @@ fn rewrite_quantity_controller(expr: &mut QuantityExpr, from: ControllerRef, to:
         } => {
             rewrite_quantity_controller(inner, from, to);
         }
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
                 rewrite_quantity_controller(inner, from.clone(), to.clone());
             }
@@ -12410,7 +12410,7 @@ fn rebind_anaphoric_object_scope(expr: &mut QuantityExpr, scope: ObjectScope) {
         } => {
             rebind_anaphoric_object_scope(inner, scope);
         }
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
                 rebind_anaphoric_object_scope(inner, scope);
             }
@@ -15532,7 +15532,7 @@ fn rewrite_condition_quantity_expr(expr: &mut QuantityExpr) {
         | QuantityExpr::Multiply { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
         | QuantityExpr::Offset { inner, .. } => rewrite_condition_quantity_expr(inner),
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
                 rewrite_condition_quantity_expr(inner);
             }
@@ -15644,7 +15644,7 @@ fn rewrite_player_scope_refs(def: &mut AbilityDefinition) {
             | QuantityExpr::Multiply { inner, .. }
             | QuantityExpr::ClampMin { inner, .. }
             | QuantityExpr::Offset { inner, .. } => rewrite_quantity_expr(inner),
-            QuantityExpr::Sum { exprs } => {
+            QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
                 for inner in exprs {
                     rewrite_quantity_expr(inner);
                 }
@@ -15759,7 +15759,7 @@ pub(crate) fn rewrite_player_quantity_refs_to_source_chosen(def: &mut AbilityDef
             | QuantityExpr::Multiply { inner, .. }
             | QuantityExpr::ClampMin { inner, .. }
             | QuantityExpr::Offset { inner, .. } => rewrite_qty(inner),
-            QuantityExpr::Sum { exprs } => {
+            QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
                 for inner in exprs {
                     rewrite_qty(inner);
                 }
@@ -15821,7 +15821,7 @@ pub(crate) fn rewrite_event_player_quantity_refs_to_scoped(def: &mut AbilityDefi
             | QuantityExpr::Multiply { inner, .. }
             | QuantityExpr::ClampMin { inner, .. }
             | QuantityExpr::Offset { inner, .. } => rewrite_qty(inner),
-            QuantityExpr::Sum { exprs } => {
+            QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
                 for inner in exprs {
                     rewrite_qty(inner);
                 }
@@ -15883,7 +15883,7 @@ fn quantity_expr_references_controller_life_gained(expr: &QuantityExpr) -> bool 
         | QuantityExpr::Power {
             exponent: inner, ..
         } => quantity_expr_references_controller_life_gained(inner),
-        QuantityExpr::Sum { exprs } => exprs
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => exprs
             .iter()
             .any(quantity_expr_references_controller_life_gained),
         QuantityExpr::Difference { left, right } => {
@@ -15924,7 +15924,7 @@ pub(crate) fn rewrite_gained_life_that_many_distribution_refs(def: &mut AbilityD
             | QuantityExpr::Power {
                 exponent: inner, ..
             } => rewrite_qty(inner),
-            QuantityExpr::Sum { exprs } => {
+            QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
                 for inner in exprs {
                     rewrite_qty(inner);
                 }
@@ -15974,7 +15974,7 @@ fn rewrite_rounding_mode(def: &mut AbilityDefinition, mode: RoundingMode) {
             QuantityExpr::Multiply { inner, .. }
             | QuantityExpr::ClampMin { inner, .. }
             | QuantityExpr::Offset { inner, .. } => rewrite_quantity_expr(inner, mode),
-            QuantityExpr::Sum { exprs } => {
+            QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
                 for inner in exprs {
                     rewrite_quantity_expr(inner, mode);
                 }

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -963,6 +963,12 @@ pub(super) fn scope_token_for_each_to_iterating_player(expr: QuantityExpr) -> Qu
                 .map(scope_token_for_each_to_iterating_player)
                 .collect(),
         },
+        QuantityExpr::Max { exprs } => QuantityExpr::Max {
+            exprs: exprs
+                .into_iter()
+                .map(scope_token_for_each_to_iterating_player)
+                .collect(),
+        },
         other => other,
     }
 }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -835,6 +835,50 @@ pub(crate) fn parse_cda_quantity_with_context(
         }
     }
 
+    // CR 107.1 + CR 120.4a/120.10: "A or B, whichever is greater" — the maximum
+    // of two recursively-parsed quantity operands (Triumphant Chomp:
+    // "2 or the greatest power among Dinosaurs you control, whichever is
+    // greater"). Composes `QuantityExpr::Max` over the existing CDA grammar so
+    // the whole "greater of two computed values" class types instead of falling
+    // through to an unresolved `Variable` (which resolves to 0 at runtime — a
+    // silent no-op). The comma form is tried first so the operand list never
+    // keeps a trailing comma; the arm fires only when the "whichever is greater"
+    // suffix is present AND both operands parse as quantities, so unrelated
+    // " or " text (type lists, modal choices) falls through untouched.
+    fn parse_max_operand(text: &str, ctx: &mut ParseContext) -> Option<QuantityExpr> {
+        if let Some(qty) = parse_cda_quantity_with_context(text, ctx) {
+            return Some(qty);
+        }
+        // The CDA grammar has no standalone-constant arm, so fold a bare integer
+        // operand to `Fixed` here, mirroring the integer-offset fallback in the
+        // binary-arithmetic arm below.
+        let (rest, n) = nom_primitives::parse_number(text.trim()).ok()?;
+        rest.trim()
+            .is_empty()
+            .then_some(QuantityExpr::Fixed { value: n as i32 })
+    }
+    for suffix in [", whichever is greater", " whichever is greater"] {
+        let Ok((_, (operands, tail))) = nom_primitives::split_once_on(text, suffix) else {
+            continue;
+        };
+        if !tail.trim().is_empty() {
+            continue;
+        }
+        let Ok((_, (left_text, right_text))) = nom_primitives::split_once_on(operands, " or ")
+        else {
+            continue;
+        };
+        let Some(left) = parse_max_operand(left_text, ctx) else {
+            continue;
+        };
+        let Some(right) = parse_max_operand(right_text, ctx) else {
+            continue;
+        };
+        return Some(QuantityExpr::Max {
+            exprs: vec![left, right],
+        });
+    }
+
     // CR 107.x: Binary arithmetic over two dynamic quantities, e.g. "the number
     // of Caves you control plus the number of Cave cards in your graveyard"
     // (Calamitous Cave-In) or "the number of cards in their hand minus 4"
@@ -4175,6 +4219,42 @@ mod tests {
                 }
             }
         ));
+    }
+
+    #[test]
+    fn cda_quantity_max_of_two_whichever_greater() {
+        // CR 107.1 + CR 120.4a/120.10: "A or B, whichever is greater" — the
+        // max-of-two-quantities combinator powering Triumphant Chomp. Composes
+        // a `Fixed` constant with the existing "greatest power among <filter>"
+        // aggregate under `QuantityExpr::Max`.
+        let qty = parse_cda_quantity(
+            "2 or the greatest power among Dinosaurs you control, whichever is greater",
+        )
+        .expect("max-of-two quantity should parse");
+        let QuantityExpr::Max { exprs } = qty else {
+            panic!("expected QuantityExpr::Max, got {qty:?}");
+        };
+        assert_eq!(exprs.len(), 2);
+        assert!(matches!(exprs[0], QuantityExpr::Fixed { value: 2 }));
+        assert!(matches!(
+            exprs[1],
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: AggregateFunction::Max,
+                    property: ObjectProperty::Power,
+                    ..
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn cda_quantity_max_falls_through_without_suffix() {
+        // The arm must fire ONLY when "whichever is greater" is present, so a
+        // bare " or " disjunction does not get mis-read as a max.
+        assert!(
+            parse_cda_quantity("2 or the greatest power among Dinosaurs you control").is_none()
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -2314,7 +2314,7 @@ pub(crate) fn rewrite_variable_x_to_cost_x_paid(expr: &mut QuantityExpr) {
         | QuantityExpr::Offset { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
         | QuantityExpr::Multiply { inner, .. } => rewrite_variable_x_to_cost_x_paid(inner),
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
                 rewrite_variable_x_to_cost_x_paid(inner);
             }

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1510,6 +1510,12 @@ pub(crate) fn rebind_source_object_quantity_expr_to_recipient(expr: QuantityExpr
             left: Box::new(rebind_source_object_quantity_expr_to_recipient(*left)),
             right: Box::new(rebind_source_object_quantity_expr_to_recipient(*right)),
         },
+        QuantityExpr::Max { exprs } => QuantityExpr::Max {
+            exprs: exprs
+                .into_iter()
+                .map(rebind_source_object_quantity_expr_to_recipient)
+                .collect(),
+        },
         other => other,
     }
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2549,6 +2549,9 @@ fn substitute_another_in_expr(expr: &QuantityExpr) -> QuantityExpr {
             left: Box::new(substitute_another_in_expr(left)),
             right: Box::new(substitute_another_in_expr(right)),
         },
+        QuantityExpr::Max { exprs } => QuantityExpr::Max {
+            exprs: exprs.iter().map(substitute_another_in_expr).collect(),
+        },
         other => other.clone(),
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4539,6 +4539,22 @@ pub enum QuantityExpr {
         left: Box<QuantityExpr>,
         right: Box<QuantityExpr>,
     },
+    /// The maximum of N independent quantity expressions. Powers the
+    /// "A or B, whichever is greater" / "the greatest of A, B, …" Oracle
+    /// templating class (Triumphant Chomp: `max(2, greatest power among
+    /// Dinosaurs you control)`). A general arithmetic peer of
+    /// `Sum`/`Offset`/`Multiply`/`Difference`: composes any "greater of"
+    /// card from existing `QuantityExpr` leaves. Mirrors `Sum`'s `Vec` shape
+    /// so it generalizes from two operands to N.
+    ///
+    /// CR 107.1: the only numbers Magic uses are integers — this maximizes
+    /// computed integer amounts. CR 120.4a / CR 120.10 establish the in-rules
+    /// "the greatest of the calculated amounts" precedent for taking a maximum
+    /// over multiple computed values. "Whichever is greater" itself has no
+    /// dedicated CR number (cf. `Difference`, likewise an Oracle templating
+    /// convention without a dedicated rule); CR 107.2 authorizes the empty
+    /// fallback to 0.
+    Max { exprs: Vec<QuantityExpr> },
 }
 
 /// CR 107: Back-compatible `Deserialize` for [`QuantityExpr`]. Accepts BOTH the
@@ -4608,6 +4624,9 @@ impl<'de> serde::Deserialize<'de> for QuantityExpr {
                         left: Box<QuantityExpr>,
                         right: Box<QuantityExpr>,
                     },
+                    Max {
+                        exprs: Vec<QuantityExpr>,
+                    },
                 }
                 let tagged: Tagged =
                     serde_json::from_value(value).map_err(serde::de::Error::custom)?;
@@ -4632,6 +4651,7 @@ impl<'de> serde::Deserialize<'de> for QuantityExpr {
                     Tagged::UpTo { max } => QuantityExpr::UpTo { max },
                     Tagged::Power { base, exponent } => QuantityExpr::Power { base, exponent },
                     Tagged::Difference { left, right } => QuantityExpr::Difference { left, right },
+                    Tagged::Max { exprs } => QuantityExpr::Max { exprs },
                 })
             }
             _ => Err(serde::de::Error::custom(
@@ -4681,7 +4701,9 @@ impl QuantityExpr {
             | QuantityExpr::Power {
                 exponent: inner, ..
             } => inner.contains_x(),
-            QuantityExpr::Sum { exprs } => exprs.iter().any(QuantityExpr::contains_x),
+            QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+                exprs.iter().any(QuantityExpr::contains_x)
+            }
             QuantityExpr::Difference { left, right } => left.contains_x() || right.contains_x(),
             QuantityExpr::Fixed { .. } | QuantityExpr::Ref { .. } => false,
         }
@@ -4708,7 +4730,9 @@ impl QuantityExpr {
             | QuantityExpr::Power {
                 exponent: inner, ..
             } => inner.contains_vote_count(),
-            QuantityExpr::Sum { exprs } => exprs.iter().any(QuantityExpr::contains_vote_count),
+            QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+                exprs.iter().any(QuantityExpr::contains_vote_count)
+            }
             QuantityExpr::Difference { left, right } => {
                 left.contains_vote_count() || right.contains_vote_count()
             }

--- a/crates/engine/tests/triumphant_chomp.rs
+++ b/crates/engine/tests/triumphant_chomp.rs
@@ -1,0 +1,140 @@
+//! Integration test for Triumphant Chomp (The Lost Caverns of Ixalan).
+//!
+//! Oracle:
+//!   "Triumphant Chomp deals damage to target creature equal to 2 or the
+//!    greatest power among Dinosaurs you control, whichever is greater."
+//!
+//! Exercises the new max-of-two-quantities combinator `QuantityExpr::Max`:
+//! the damage amount is `max(2, greatest power among Dinosaurs you control)`.
+//! The scenarios drive the FULL cast pipeline (parse → cast → target →
+//! resolve → mark damage) and discriminate the max semantics — with either
+//! the parser arm or the resolver arm reverted, the value phrase fails to
+//! parse, the spell becomes Unimplemented, and every scenario marks 0 damage.
+//!
+//! CR 107.1 + CR 120.4a/120.10: maximum of computed integer amounts
+//!   ("the greatest of the calculated amounts").
+//! CR 608.2h: "the greatest power among …" is a present-tense snapshot taken
+//!   as the spell resolves.
+//! CR 120.3: damage dealt to a creature is marked on it.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::CastPaymentMode;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::WaitingFor;
+
+const CHOMP_TEXT: &str = "Triumphant Chomp deals damage to target creature equal to 2 or the \
+     greatest power among Dinosaurs you control, whichever is greater.";
+
+/// Cast Triumphant Chomp targeting an opponent's 0/10 wall and return the
+/// damage marked on it. `dino_power` optionally adds one Dinosaur under the
+/// caster's control with that power.
+fn run_chomp(dino_power: Option<i32>) -> u32 {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let chomp_id = scenario
+        .add_spell_to_hand_from_oracle(P0, "Triumphant Chomp", false, CHOMP_TEXT)
+        .id();
+
+    // A non-Dinosaur decoy under the caster's control. It is never counted by
+    // "the greatest power among Dinosaurs you control", but it guarantees ≥2
+    // legal creature targets so the engine always prompts for a target
+    // (a lone legal target is auto-assigned) and the test deterministically
+    // aims at the opponent's wall.
+    scenario.add_creature(P0, "Scout", 0, 1).id();
+
+    if let Some(power) = dino_power {
+        scenario
+            .add_creature(P0, "Ranging Raptors", power, 5)
+            .with_subtypes(vec!["Dinosaur"])
+            .id();
+    }
+
+    // Toughness 10 so the wall survives every expected amount and the marked
+    // damage can be read back exactly.
+    let target_id = scenario.add_creature(P1, "Wall", 0, 10).id();
+
+    // {R} for Triumphant Chomp.
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![])],
+    );
+
+    let mut runner = scenario.build();
+    let chomp_card_id = runner.state().objects[&chomp_id].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: chomp_id,
+            card_id: chomp_card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Triumphant Chomp must succeed");
+
+    let mut targeted = false;
+    for _ in 0..20 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TargetSelection { target_slots, .. } => {
+                assert!(
+                    target_slots[0]
+                        .legal_targets
+                        .contains(&TargetRef::Object(target_id)),
+                    "the opponent's creature must be a legal target for Triumphant Chomp",
+                );
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Object(target_id)],
+                    })
+                    .expect("targeting the opponent's creature must succeed");
+                targeted = true;
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    break;
+                }
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            other => panic!("unexpected waiting state during Triumphant Chomp cast: {other:?}"),
+        }
+    }
+    assert!(targeted, "the target-selection prompt must have fired");
+
+    runner.state().objects[&target_id].damage_marked
+}
+
+/// max(2, 4) = 4 — the Dinosaur's power exceeds the floor, so it wins.
+#[test]
+fn triumphant_chomp_uses_dino_power_when_greater() {
+    assert_eq!(
+        run_chomp(Some(4)),
+        4,
+        "with a power-4 Dinosaur the amount is max(2, 4) = 4; 0 means the \
+         QuantityExpr::Max parser or resolver arm was reverted",
+    );
+}
+
+/// max(2, 0) = 2 — with no Dinosaurs the aggregate is 0 and the constant floor
+/// wins.
+#[test]
+fn triumphant_chomp_uses_floor_two_without_dinosaurs() {
+    assert_eq!(
+        run_chomp(None),
+        2,
+        "with no Dinosaurs the amount is max(2, 0) = 2; 0 means the \
+         QuantityExpr::Max parser or resolver arm was reverted",
+    );
+}
+
+/// max(2, 1) = 2 — a small Dinosaur cannot drag the amount below the floor.
+/// Distinguishes a genuine max from a "use the aggregate" mis-parse.
+#[test]
+fn triumphant_chomp_floor_beats_small_dino() {
+    assert_eq!(run_chomp(Some(1)), 2, "max(2, 1) must be 2, not 1");
+}

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -269,7 +269,7 @@ fn rewrite_bound_x_in_quantity_expr(expr: &mut QuantityExpr, binding: &QuantityE
         | QuantityExpr::Power {
             exponent: inner, ..
         } => rewrite_bound_x_in_quantity_expr(inner, binding),
-        QuantityExpr::Sum { exprs } => exprs
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => exprs
             .iter_mut()
             .map(|inner| rewrite_bound_x_in_quantity_expr(inner, binding))
             .sum(),

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -2739,7 +2739,7 @@ fn rewrite_variable_x_to_cost_x_paid(expr: &mut QuantityExpr) {
         | QuantityExpr::ClampMin { inner, .. }
         | QuantityExpr::Offset { inner, .. }
         | QuantityExpr::Multiply { inner, .. } => rewrite_variable_x_to_cost_x_paid(inner),
-        QuantityExpr::Sum { exprs } => {
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
                 rewrite_variable_x_to_cost_x_paid(inner);
             }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary
Adds engine support for **Triumphant Chomp** (The Lost Caverns of Ixalan, Standard-legal): `{R}` Sorcery — "Triumphant Chomp deals damage to target creature equal to 2 or the greatest power among Dinosaurs you control, whichever is greater."

The only gap was the **max-of-two-quantities** combinator ("A or B, whichever is greater"). The damage verb and the "the greatest power among `<filter>`" aggregate were already supported. This adds a new compositional `QuantityExpr::Max { exprs: Vec<QuantityExpr> }` variant (paralleling the existing `Sum`), one nom parser arm, one resolver arm, and the corresponding arms at every exhaustive `QuantityExpr` match site — covering the whole "greater of two computed values" class, not just this card.

## Files changed
- `crates/engine/src/types/ability.rs` — `QuantityExpr::Max` variant + serde `Tagged` mirror + `contains_x`/`contains_vote_count`
- `crates/engine/src/parser/oracle_quantity.rs` — nom parse arm for "A or B, whichever is greater" + parser tests
- `crates/engine/src/game/quantity.rs` — `Max` resolver arm in `fold_compose` + predicate-walk arms
- `crates/engine/src/game/replacement.rs` — `Max` event-replacement resolver (computes max)
- `crates/engine/src/game/coverage.rs` — `Max` feature-extraction + `max(...)` formatter
- `crates/engine/src/game/effects/effect.rs`, `crates/engine/src/game/effects/mod.rs`, `crates/engine/src/game/effects/delayed_trigger.rs`, `crates/engine/src/game/ability_utils.rs` — `Max` arms (snapshot/walks)
- `crates/engine/src/parser/oracle.rs`, `crates/engine/src/parser/oracle_effect/mod.rs`, `crates/engine/src/parser/oracle_effect/lower.rs`, `crates/engine/src/parser/oracle_effect/counter.rs`, `crates/engine/src/parser/oracle_effect/imperative.rs`, `crates/engine/src/parser/oracle_effect/token.rs`, `crates/engine/src/parser/oracle_replacement.rs`, `crates/engine/src/parser/oracle_static/shared.rs`, `crates/engine/src/parser/oracle_trigger.rs` — `Max` arms in quantity rewriters/walkers
- `crates/engine/src/game/casting.rs` — `Max` arm in board-state-relative check
- `crates/engine/tests/triumphant_chomp.rs` — end-to-end discriminating integration test

## CR references
- `CR 107.1` — the only numbers Magic uses are integers (max of computed integer amounts)
- `CR 107.2` — an undeterminable number is 0 (empty-operand fallback)
- `CR 120.4a` / `CR 120.10` — in-rules "the greatest of the calculated amounts" precedent for a maximum over computed values ("whichever is greater" has no dedicated CR number; documented as an Oracle templating convention, mirroring the existing `QuantityExpr::Difference`)
- `CR 608.2h` — "the greatest power among …" is a present-tense snapshot taken at resolution
- `CR 120.3` — damage dealt to a creature is marked on it

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: medium

## Tier
Tier: Frontier

## Anchored on
- `crates/engine/src/types/ability.rs:4492` — extends the existing `QuantityExpr::Sum { exprs: Vec<QuantityExpr> }` compositional variant (same `Vec` shape, same layer)
- `crates/engine/src/parser/oracle_quantity.rs:850` — mirrors the existing binary-arithmetic (`" plus "`/`" minus "`) nom arm in `parse_cda_quantity_with_context` (`split_once_on` + recursive operand parsing)
- `crates/engine/src/game/quantity.rs:603` — mirrors the `Sum` arm in the centralized `fold_compose` resolver

## Verification
Developer track — all commands run locally against the pinned `nightly-2026-04-19` toolchain:
- `cargo fmt --all` — clean
- `cargo clippy-strict` (`--all-targets -D warnings`, full workspace incl. `mtgish-import`) — clean
- `./scripts/check-parser-combinators.sh` — clean (exit 0)
- `cargo test -p engine` — 12607 pass. The new `tests/triumphant_chomp.rs` (3) and parser unit tests (2) pass. One unrelated pre-existing test, `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`, is a perf guard that reads a process-global `perf_counters` atomic and is not `#[serial]`; it flakes only under `cargo test`'s shared-process parallel runner (concurrent tests inflate the counter) and **passes in isolation** (`cargo test -p engine --lib delve_payment_skips_state_clone_per_graveyard_candidate` → 1 passed). CI's `cargo nextest` runs each test in its own process, so it is unaffected. Unrelated to this change.
- `./scripts/gen-card-data.sh` — `Triumphant Chomp`: 0 Unimplemented entries
- `cargo coverage` — `Triumphant Chomp`: `supported: true`, `gap_count: 0`
- `cargo semantic-audit` — `Triumphant Chomp`: 0 findings

Review: `review-impl` ran in fresh context (round 1 raised 1 MED + 3 LOW — three rewrite-helper `Max` arms and one board-state-relative arm — all addressed with code); an independent fresh-context clean-review cross-check returned zero findings.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
