### PR TITLE
fix(parser): accept "her"/"his" possessive in source power/toughness conditions (Viv Vision, Stature)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1536,6 +1536,15 @@ fn parse_source_power_toughness_condition(input: &str) -> OracleResult<'_, Stati
 fn parse_possessive_property(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = alt((
         tag("its "),
+        // CR 201.5: a possessive pronoun in a self-referential ability refers to
+        // the object that has the ability (the source). Legendary creatures with
+        // she/he pronouns use the gendered possessive instead of "its" (e.g. "if
+        // her power is 4 or greater" — Viv Vision; "if her power is 1 or less" —
+        // Stature). Mirrors the "it " source pronoun already accepted by
+        // `parse_subject_has_property`. ("their" is intentionally omitted — it is
+        // ambiguous between a singular-they object and a player possessive.)
+        tag("her "),
+        tag("his "),
         tag("enchanted creature's "),
         tag("equipped creature's "),
     ))
@@ -9505,6 +9514,45 @@ mod tests {
                 rhs: QuantityExpr::Fixed { value: 3 },
             } => {}
             other => panic!("expected SelfPower LE 3, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_gendered_possessive_pronoun_power_condition() {
+        // CR 201.5: "her"/"his"/"their power is N" refers to the source creature,
+        // mirroring "its power is N". Real cards: Viv Vision ("if her power is 4
+        // or greater") and Stature, Size Shifter ("if her power is 1 or less").
+        // Before this fix the possessive-pronoun form was unmatched, so the gating
+        // condition was silently dropped and the ability fired unconditionally.
+        for (text, expected) in [
+            ("her power is 4 or greater", (Comparator::GE, 4)),
+            ("his power is 4 or greater", (Comparator::GE, 4)),
+            ("her toughness is 1 or less", (Comparator::LE, 1)),
+        ] {
+            let (rest, c) = parse_inner_condition(text)
+                .unwrap_or_else(|e| panic!("{text:?} must parse, got {e:?}"));
+            assert_eq!(rest, "", "{text:?} left remainder");
+            match c {
+                StaticCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref { qty },
+                    comparator,
+                    rhs: QuantityExpr::Fixed { value },
+                } => {
+                    assert!(
+                        matches!(
+                            qty,
+                            QuantityRef::Power {
+                                scope: crate::types::ability::ObjectScope::Source
+                            } | QuantityRef::Toughness {
+                                scope: crate::types::ability::ObjectScope::Source
+                            }
+                        ),
+                        "{text:?} wrong qty ref: {qty:?}"
+                    );
+                    assert_eq!((comparator, value), expected, "{text:?}");
+                }
+                other => panic!("{text:?} expected source P/T comparison, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #3827.

## Summary

The source power/toughness condition combinator (`parse_possessive_property`) matched the possessive subject `its` / `enchanted creature's` / `equipped creature's`, but not the gendered possessive pronouns `her` / `his`. Legendary creatures with she/he pronouns write their self-referential power conditions with that pronoun, so `parse_source_power_toughness_condition` failed, no other condition parser claimed the clause, and the gating condition was **silently dropped** — the ability fired unconditionally:

- **Viv Vision, Teen Synthezoid** — "Whenever Viv Vision attacks, draw a card **if her power is 4 or greater**." drew a card on *every* attack regardless of power.
- **Stature, Size Shifter** — "Stature can't be blocked **if her power is 1 or less**." was treated as *unconditionally* unblockable.

Both are flagged `DroppedCondition` by `cargo semantic-audit`.

## Fix (parser-AST-only)

Add `her ` / `his ` to the possessive-subject `alt` in `parse_possessive_property`, mirroring the existing `its ` arm and the `it ` source pronoun already accepted by the sibling `parse_subject_has_property` (CR 201.5: a pronoun in a self-referential ability refers to the object that has the ability). This emits the **identical** `StaticCondition::QuantityComparison { lhs: Power/Toughness{Source}, comparator, rhs: Fixed(N) }` the runtime already evaluates for `"its power is N"` — no new variant, no runtime change.

`their` is intentionally **excluded**: it is ambiguous between a singular-they object and a player possessive, and no printed card currently uses `their power/toughness is N` (verified via Scryfall).

CR 201.5 (pronoun self-reference), CR 208.1 (power/toughness comparison).

## Tests

- Added `test_gendered_possessive_pronoun_power_condition`: `her power is 4 or greater` → `GE 4`, `his power is 4 or greater` → `GE 4`, `her toughness is 1 or less` → `LE 1`, each a source P/T `QuantityComparison` with empty remainder. (Before this change all three were unmatched.)
- No-regression: the existing `its`/`enchanted creature's`/`equipped creature's` power-condition tests are unchanged.

## Verification

Built and ran locally with the repo's pinned `nightly-2026-04-19`: `cargo test -p engine --lib parser::oracle_nom::condition` → **302 passed, 0 failed** (includes the new test). `cargo fmt --all` clean. The change is two `tag()` arms structurally identical to the lines above them.