### PR TITLE
refactor(parser): migrate simple quantity call sites to nom

### DIFF
--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -11,7 +11,7 @@ use super::oracle_modal::split_short_label_prefix;
 use super::oracle_nom::bridge::nom_on_lower;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_nom::primitives::{scan_contains, split_once_on};
-use super::oracle_quantity::parse_for_each_clause;
+use super::oracle_nom::quantity as nom_quantity;
 use super::oracle_target::{parse_target, parse_type_phrase};
 use super::oracle_util::parse_count_expr;
 use super::oracle_util::parse_mana_symbols;
@@ -431,8 +431,8 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
                 )
                 .parse(after_n)
                 {
-                    if let Some(qty) =
-                        parse_for_each_clause(for_each_clause.trim().trim_end_matches('.'))
+                    if let Ok((_, qty)) =
+                        nom_quantity::parse_for_each_clause_ref_complete(for_each_clause)
                     {
                         return AbilityCost::PayLife {
                             amount: QuantityExpr::Multiply {
@@ -1008,7 +1008,7 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
 
     // Try parse_for_each_clause first (handles counters, player counts, etc.),
     // then fall back to parse_type_phrase for standard object count patterns.
-    if let Some(qty) = parse_for_each_clause(after_less) {
+    if let Ok((_, qty)) = nom_quantity::parse_for_each_clause_ref_complete(after_less) {
         return Some(CostReduction {
             amount_per,
             count: QuantityExpr::Ref { qty },
@@ -1669,8 +1669,10 @@ mod tests {
     fn cost_pay_life_for_each_counter() {
         // CR 119.4 + CR 122.1: Tornado — "Pay 3 life for each velocity counter
         // on this enchantment". The per-counter multiplier must be preserved.
-        let expected_qty =
-            parse_for_each_clause("velocity counter on this enchantment").expect("for-each clause");
+        let (_, expected_qty) = nom_quantity::parse_for_each_clause_ref_complete(
+            "velocity counter on this enchantment",
+        )
+        .expect("for-each clause");
         assert!(matches!(
             expected_qty,
             QuantityRef::CountersOn {
@@ -1692,9 +1694,11 @@ mod tests {
     #[test]
     fn cost_pay_life_for_each_creature() {
         // Building-block test: the for-each composition covers any
-        // `parse_for_each_clause` form, not just counter scopes. factor: 1 is
+        // `parse_for_each_clause_ref` form, not just counter scopes. factor: 1 is
         // kept intentionally (resolves identically to a bare Ref).
-        let expected_qty = parse_for_each_clause("creature you control").expect("for-each clause");
+        let (_, expected_qty) =
+            nom_quantity::parse_for_each_clause_ref_complete("creature you control")
+                .expect("for-each clause");
         assert_eq!(
             parse_oracle_cost("Pay 1 life for each creature you control"),
             AbilityCost::PayLife {

--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -18,7 +18,6 @@ use super::token::{
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_nom::bridge::nom_on_lower;
-use crate::parser::oracle_quantity;
 use crate::types::ability::{PtValue, QuantityExpr, QuantityRef};
 use crate::types::card_type::Supertype;
 use crate::types::keywords::Keyword;
@@ -75,7 +74,7 @@ pub(crate) fn parse_animation_spec(text: &str, _ctx: &mut ParseContext) -> Optio
         let after_where_lower = after_where.to_lowercase();
         rest = parse_cost_x_become_pt_prefix(before_where).unwrap_or(before_where);
 
-        let qty = oracle_quantity::parse_quantity_ref(&after_where_lower)?;
+        let (_, qty) = nom_quantity::parse_quantity_ref_complete(&after_where_lower).ok()?;
         let dynamic_qty = QuantityExpr::Ref { qty };
         spec.dynamic_power = Some(dynamic_qty.clone());
         spec.dynamic_toughness = Some(dynamic_qty);

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -7,7 +7,7 @@
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while1};
-use nom::combinator::{map, opt, value};
+use nom::combinator::{all_consuming, map, opt, value};
 use nom::multi::separated_list1;
 use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
@@ -30,7 +30,7 @@ use crate::types::ability::{
     PlayerScope, QuantityExpr, QuantityRef, RoundingMode, SharedQuality, TargetFilter,
     ThisWayCause, TypeFilter, TypedFilter, ZoneRef,
 };
-use crate::types::counter::CounterMatch;
+use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::keywords::Keyword;
 use crate::types::player::PlayerCounterKind;
 use crate::types::zones::Zone;
@@ -46,6 +46,16 @@ pub fn parse_quantity(input: &str) -> OracleResult<'_, QuantityExpr> {
         map(parse_number, |n| QuantityExpr::Fixed { value: n as i32 }),
     ))
     .parse(input)
+}
+
+pub fn parse_quantity_ref_complete(input: &str) -> OracleResult<'_, QuantityRef> {
+    let input = input.trim().trim_end_matches('.');
+    all_consuming(parse_quantity_ref).parse(input)
+}
+
+pub fn parse_for_each_clause_ref_complete(input: &str) -> OracleResult<'_, QuantityRef> {
+    let input = input.trim().trim_end_matches('.');
+    all_consuming(parse_for_each_clause_ref).parse(input)
 }
 
 fn parse_quantity_operand(input: &str) -> OracleResult<'_, QuantityExpr> {
@@ -2667,7 +2677,7 @@ fn parse_for_each_clause_ref_with_they_controller(
         // permanent (Gavel of the Righteous: "for each counter on this Equipment").
         // Placed before `parse_for_each_controlled_type` so the bare "counter" token
         // does not commit to a type-phrase fallback.
-        parse_for_each_any_counters_on_source,
+        parse_for_each_counters_on_source,
         parse_for_each_controlled_type,
         // CR 201.2: "for each [other] <type> named <CardName> you control"
         // (Seven Dwarves). The `named X` qualifier sits between the type word
@@ -2679,22 +2689,32 @@ fn parse_for_each_clause_ref_with_they_controller(
     .parse(input)
 }
 
-/// CR 122.1: Parse "counter(s) on [self-ref]" in a "for each" context —
-/// any counter type, source-scoped. Covers the untyped form found in cards
-/// like Gavel of the Righteous ("gets +1/+1 for each counter on this
-/// Equipment"). The typed form ("[type] counter on ~") is already handled
-/// in the legacy `parse_for_each_clause_with_they_controller` path.
-fn parse_for_each_any_counters_on_source(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, _) = alt((tag("counters"), tag("counter"))).parse(input)?;
+/// CR 122.1: Parse "[counter-type] counter(s) on [self-ref]" and
+/// "counter(s) on [self-ref]" in a "for each" context. Covers both typed
+/// source-scoped costs like Tornado ("for each velocity counter on this
+/// enchantment") and untyped source-scoped pumps like Gavel of the Righteous
+/// ("for each counter on this Equipment").
+fn parse_for_each_counters_on_source(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, counter_type) = alt((
+        parse_typed_counter_type_for_each_source,
+        value(None, parse_generic_counter_match),
+    ))
+    .parse(input)?;
     let (rest, _) = tag(" on ").parse(rest)?;
     let (rest, _) = parse_source_self_ref(rest)?;
     Ok((
         rest,
         QuantityRef::CountersOn {
             scope: ObjectScope::Source,
-            counter_type: None,
+            counter_type,
         },
     ))
+}
+
+fn parse_typed_counter_type_for_each_source(input: &str) -> OracleResult<'_, Option<CounterType>> {
+    let (rest, counter_type) = parse_counter_type_typed(input)?;
+    let (rest, _) = parse_counter_word(rest)?;
+    Ok((rest, Some(counter_type)))
 }
 
 /// CR 122.1: Match a source self-reference phrase: "~", "it", or any shared
@@ -4879,6 +4899,19 @@ mod tests {
             parse_for_each_clause_ref("kind of counter among creatures you control").unwrap();
         assert_eq!(rest, "");
         assert!(matches!(q, QuantityRef::DistinctCounterKindsAmong { .. }));
+    }
+
+    #[test]
+    fn parse_for_each_typed_counter_on_source() {
+        let (rest, q) = parse_for_each_clause_ref("velocity counter on this enchantment").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(
+            q,
+            QuantityRef::CountersOn {
+                scope: ObjectScope::Source,
+                counter_type: Some(_),
+            }
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -4194,6 +4194,42 @@ mod tests {
     }
 
     #[test]
+    fn cda_quantity_max_of_two_whichever_greater() {
+        // CR 107.1 + CR 120.4a/120.10: "A or B, whichever is greater" — the
+        // max-of-two-quantities combinator powering Triumphant Chomp. Composes
+        // a `Fixed` constant with the existing "greatest power among <filter>"
+        // aggregate under `QuantityExpr::Max`.
+        let qty = parse_cda_quantity(
+            "2 or the greatest power among Dinosaurs you control, whichever is greater",
+        )
+        .expect("max-of-two quantity should parse");
+        let QuantityExpr::Max { exprs } = qty else {
+            panic!("expected QuantityExpr::Max, got {qty:?}");
+        };
+        assert_eq!(exprs.len(), 2);
+        assert!(matches!(exprs[0], QuantityExpr::Fixed { value: 2 }));
+        assert!(matches!(
+            exprs[1],
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: AggregateFunction::Max,
+                    property: ObjectProperty::Power,
+                    ..
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn cda_quantity_max_falls_through_without_suffix() {
+        // The arm must fire ONLY when "whichever is greater" is present, so a
+        // bare " or " disjunction does not get mis-read as a max.
+        assert!(
+            parse_cda_quantity("2 or the greatest power among Dinosaurs you control").is_none()
+        );
+    }
+
+    #[test]
     fn cda_quantity_greatest_toughness() {
         let qty = parse_cda_quantity("the greatest toughness among creatures you control").unwrap();
         assert!(matches!(

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -4194,42 +4194,6 @@ mod tests {
     }
 
     #[test]
-    fn cda_quantity_max_of_two_whichever_greater() {
-        // CR 107.1 + CR 120.4a/120.10: "A or B, whichever is greater" — the
-        // max-of-two-quantities combinator powering Triumphant Chomp. Composes
-        // a `Fixed` constant with the existing "greatest power among <filter>"
-        // aggregate under `QuantityExpr::Max`.
-        let qty = parse_cda_quantity(
-            "2 or the greatest power among Dinosaurs you control, whichever is greater",
-        )
-        .expect("max-of-two quantity should parse");
-        let QuantityExpr::Max { exprs } = qty else {
-            panic!("expected QuantityExpr::Max, got {qty:?}");
-        };
-        assert_eq!(exprs.len(), 2);
-        assert!(matches!(exprs[0], QuantityExpr::Fixed { value: 2 }));
-        assert!(matches!(
-            exprs[1],
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Power,
-                    ..
-                }
-            }
-        ));
-    }
-
-    #[test]
-    fn cda_quantity_max_falls_through_without_suffix() {
-        // The arm must fire ONLY when "whichever is greater" is present, so a
-        // bare " or " disjunction does not get mis-read as a max.
-        assert!(
-            parse_cda_quantity("2 or the greatest power among Dinosaurs you control").is_none()
-        );
-    }
-
-    #[test]
     fn cda_quantity_greatest_toughness() {
         let qty = parse_cda_quantity("the greatest toughness among creatures you control").unwrap();
         assert!(matches!(

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -22,6 +22,7 @@ use super::oracle_nom::bridge::nom_on_lower;
 use super::oracle_nom::condition::parse_inner_condition;
 use super::oracle_nom::error::OracleResult;
 use super::oracle_nom::primitives as nom_primitives;
+use super::oracle_nom::quantity as nom_quantity;
 use super::oracle_util::{
     normalize_card_name_refs, parse_mana_symbols, parse_subtype, strip_reminder_text,
 };
@@ -359,7 +360,7 @@ fn parse_optional_modifier_suffix(after: &str) -> Option<crate::types::ability::
     ))
     .parse(after_and)
     .ok()?;
-    let qty = crate::parser::oracle_quantity::parse_quantity_ref(modifier_text)?;
+    let (_, qty) = nom_quantity::parse_quantity_ref_complete(modifier_text).ok()?;
     let value = crate::types::ability::QuantityExpr::Ref { qty };
     Some(if sign {
         crate::types::ability::DieRollModifier::Add { value }

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1013,10 +1013,12 @@ pub(crate) fn base_pt_side_to_expr(side: BasePtSide, x_ref: &QuantityRef) -> Qua
 /// Resolve the `QuantityRef` that X binds to for a dynamic base-P/T effect.
 /// Spell-cast contexts (Biomass Mutation) have no explicit "where X is" clause:
 /// X is the cost X paid when the spell was cast, so fall back to `CostXPaid`.
-/// When a "where X is …" expression is present, parse it via `parse_quantity_ref`.
+/// When a "where X is …" expression is present, parse it via the nom quantity grammar.
 pub(crate) fn resolve_base_pt_x_ref(where_x_expression: Option<&str>) -> Option<QuantityRef> {
     if let Some(expr) = where_x_expression {
-        return parse_quantity_ref(expr);
+        return super::oracle_nom::quantity::parse_quantity_ref_complete(expr)
+            .ok()
+            .map(|(_, qty)| qty);
     }
     // CR 107.3m: In a spell-cast context, X refers to the value paid for {X}.
     Some(QuantityRef::CostXPaid)

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -79,7 +79,8 @@ pub(crate) fn parse_keyword_with_where_x(input: &str) -> Option<(Keyword, Option
     let (_, qty_text) = preceded(tag::<_, _, VE<'_>>(", where x is "), nom::combinator::rest)
         .parse(rest)
         .ok()?;
-    let qty = parse_quantity_ref(qty_text.trim())?;
+    let (_, qty) =
+        super::oracle_nom::quantity::parse_quantity_ref_complete(qty_text.trim()).ok()?;
     Some((keyword, Some(qty)))
 }
 
@@ -947,8 +948,8 @@ pub(crate) fn push_grant_clause_modifications(
         .parse(part_lower.as_str())
         {
             if let Some(kind) = crate::types::keywords::DynamicKeywordKind::from_name(kw_name) {
-                if let Some(qty_ref) =
-                    crate::parser::oracle_quantity::parse_quantity_ref(where_expr)
+                if let Ok((_, qty_ref)) =
+                    super::oracle_nom::quantity::parse_quantity_ref_complete(where_expr)
                 {
                     modifications.push(ContinuousModification::AddDynamicKeyword {
                         kind,

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1609,7 +1609,8 @@ pub(crate) enum CombatTaxSubject {
 pub(crate) fn parse_for_each_cost_quantity(input: &str) -> OracleResult<'_, QuantityRef> {
     let (input, _) = tag_no_case::<_, _, OracleError<'_>>(" for each ").parse(input)?;
     let lowered = input.trim_end_matches('.').to_lowercase();
-    let quantity = parse_for_each_clause(&lowered).ok_or_else(|| {
+    let (_, quantity) = super::oracle_nom::quantity::parse_for_each_clause_ref_complete(&lowered)
+        .map_err(|_| {
         nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Fail))
     })?;
     Ok(("", quantity))


### PR DESCRIPTION
Stacked on #3839.\n\nThis migrates low-risk quantity parser call sites to oracle_nom::quantity full-consume helpers, and ports typed source-counter for-each grammar into the nom quantity parser so cost reductions can stop routing through oracle_quantity for that shape.\n\nKept parse_cda_quantity, parse_event_context_quantity, and expression for-each callers on the legacy surface where nom does not yet cover the full behavior.