### PR TITLE
fix(pod): align Pod Size dropdown using anchored MenuSelect on mobile Host a Pod

### DIFF
--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -185,17 +185,25 @@ export function MenuSelect({
     if (!trigger) return;
 
     const rect = trigger.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
+    const viewport = window.visualViewport;
+    const viewportLeft = viewport?.offsetLeft ?? 0;
+    const viewportWidth = viewport?.width ?? window.innerWidth;
     const viewportTop = getViewportTop();
     const viewportBottom = getViewportBottom();
-    const width = Math.min(
-      rect.width,
-      viewportWidth - MENU_VIEWPORT_PADDING_PX * 2,
-    );
-    const left = Math.max(
-      MENU_VIEWPORT_PADDING_PX,
-      Math.min(rect.left, viewportWidth - width - MENU_VIEWPORT_PADDING_PX),
-    );
+
+    // Pin the menu to the trigger's box; only nudge when the menu would clip.
+    let width = rect.width;
+    let left = rect.left;
+    const minLeft = viewportLeft + MENU_VIEWPORT_PADDING_PX;
+    const maxRight = viewportLeft + viewportWidth - MENU_VIEWPORT_PADDING_PX;
+
+    if (left + width > maxRight) {
+      left = Math.max(minLeft, maxRight - width);
+    }
+    if (left < minLeft) {
+      left = minLeft;
+      width = Math.min(width, maxRight - minLeft);
+    }
     const spaceBelow = Math.max(0, viewportBottom - rect.bottom - MENU_GAP_PX);
     const spaceAbove = Math.max(0, rect.top - viewportTop - MENU_GAP_PX);
     const openUp = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -8,12 +8,12 @@
  * 4. Deckbuilding: LimitedDeckBuilder (reuses Quick Draft component)
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { CardPreview } from "../components/card/CardPreview";
-import { SelectField } from "../components/ui/SelectField";
+import { MenuSelect } from "../components/ui/MenuSelect";
 import type { CardHoverInfo } from "../components/card/CardPreview";
 import { ScreenChrome } from "../components/chrome/ScreenChrome";
 import { CubeSetupPanel } from "../components/draft/CubeSetupPanel";
@@ -71,6 +71,17 @@ function PodSetup() {
     ? t("podSetup.policyCompetitiveDesc")
     : t("podSetup.policyCasualDesc");
   const podSizeDescription = t("podSetup.podSizeDesc", { count: config.podSize });
+  const podSizeItems = useMemo(
+    () =>
+      [4, 6, 8].map((n) => ({
+        value: String(n),
+        label: t("podSetup.playerCount", { count: n }),
+      })),
+    [t],
+  );
+  const podSizeLabel =
+    podSizeItems.find((item) => item.value === String(config.podSize))?.label ??
+    t("podSetup.playerCount", { count: config.podSize });
 
   if (mode === "choose") {
     return (
@@ -240,20 +251,19 @@ function PodSetup() {
           <p className="text-xs text-white/40">{policyDescription}</p>
         </div>
 
-        {/* Pod size */}
         <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium text-white/60">{t("podSetup.podSize")}</label>
-          <SelectField
-            value={config.podSize}
-            onChange={(e) => setConfig({ podSize: Number(e.target.value) })}
-            className="w-32 rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-white outline-none focus:border-emerald-400/40"
-          >
-            {[4, 6, 8].map((n) => (
-              <option key={n} value={n}>
-                {t("podSetup.playerCount", { count: n })}
-              </option>
-            ))}
-          </SelectField>
+          <span className="text-sm font-medium text-white/60">{t("podSetup.podSize")}</span>
+          <MenuSelect
+            ariaLabel={t("podSetup.podSize")}
+            label={podSizeLabel}
+            selectedValue={String(config.podSize)}
+            items={podSizeItems}
+            onSelect={(value) => setConfig({ podSize: Number(value) })}
+            menuLayout="dropdown"
+            fitContainer
+            wrapperClassName="w-full max-w-[8rem]"
+            className="min-h-[44px] !rounded-lg border border-white/10 !bg-black/30 px-3 !py-2 text-base text-white shadow-none !hover:bg-black/30 !focus-visible:ring-emerald-400/50"
+          />
           <p className="text-xs text-white/40">{podSizeDescription}</p>
         </div>
 


### PR DESCRIPTION
## Summary

Fixes the misaligned **Pod Size** dropdown on the mobile **Host a Pod** setup screen.

- Replaces the native `<select>` (`SelectField`) with `MenuSelect` using `menuLayout="dropdown"`
- Ensures the dropdown is portaled and correctly repositioned on scroll/resize instead of relying on the browser-native popup
- Improves anchored dropdown positioning to stay aligned with the trigger on mobile viewports

## Problem

The Pod Size control previously used a native `<select>` element. On mobile:

- The browser-native popup did not respect in-app scrolling containers
- After scrolling the Host a Pod form, the dropdown would appear visually detached from the trigger
- Positioning drifted due to mismatch between viewport and scroll container geometry

This resulted in inconsistent and unreliable alignment on mobile devices.

## Solution

Switched to the existing `MenuSelect` component and improved anchored positioning logic:

- Uses `menuLayout="dropdown"` for anchored dropdown behavior
- Menu is portaled to `document.body` for consistent layering
- Pins menu position using trigger’s `left` and `width`
- Accounts for `visualViewport` on mobile for accurate positioning during zoom/scroll
- Applies conditional viewport-clipping correction only when overflow would occur

This aligns Pod Size behavior with other dropdowns in the app (Deck Builder, Cube Setup, Filters).

## Test Plan

- [ ] Open **Draft → Host a Pod** on a viewport below 820px
- [ ] Scroll the setup form, then open **Pod Size**
- [ ] Confirm dropdown aligns exactly with trigger (same width, flush left edge)
- [ ] Select 4, 6, and 8 players → label and description update correctly
- [ ] Verify menu does not shift after scrolling before interaction
- [ ] Confirm other `MenuSelect` dropdowns (Deck Builder filters, etc.) still behave correctly on mobile and desktop

## Screenshots

### Before

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/330be275-6cfb-435f-8714-5caa4f8ebcdf" />

### After

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/d545cc79-f334-40f0-a728-bd37c7616011" />
