### PR TITLE
fix(engine): exile countered spells directly (Force of Negation)

### DIFF
--- a/crates/engine/src/game/effects/counter.rs
+++ b/crates/engine/src/game/effects/counter.rs
@@ -141,11 +141,18 @@ pub fn resolve(
                 if is_spell {
                     // CR 701.6a: A countered spell is put into its owner's
                     // graveyard — unless cast via an alt-cost keyword that
-                    // exiles on leaving the stack (Flashback, Harmonize).
+                    // exiles on leaving the stack (Flashback, Harmonize), or
+                    // the counter ability carries a CR 614.1a "exile it instead
+                    // of putting it into its owner's graveyard" rider (Force
+                    // of Negation, No More Lies, Defabricate).
                     // CR 702.34a / CR 702.127a / CR 702.180a: the exile destination
                     // is a static destination rule (not a replacement), so it is
                     // selected here, before the pipeline consult.
-                    let dest = if exiles_on_counter {
+                    let exile_instead_of_graveyard_on_counter = ability
+                        .sub_ability
+                        .as_deref()
+                        .is_some_and(super::cast_from_zone::is_graveyard_exile_rider_subability);
+                    let dest = if exiles_on_counter || exile_instead_of_graveyard_on_counter {
                         Zone::Exile
                     } else {
                         Zone::Graveyard
@@ -602,6 +609,65 @@ mod tests {
 
         assert!(state.stack.is_empty());
         assert!(state.exile.contains(&obj_id));
+        assert!(!state.players[1].graveyard.contains(&obj_id));
+    }
+
+    #[test]
+    fn counter_exile_rider_exiles_countered_spell_without_graveyard() {
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Countered Spell".to_string(),
+            Zone::Stack,
+        );
+        state.stack.push_back(StackEntry {
+            id: obj_id,
+            source_id: obj_id,
+            controller: PlayerId(1),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(1),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+
+        let exile_rider = ResolvedAbility::new(
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                origin: Some(Zone::Graveyard),
+                target: TargetFilter::ParentTarget,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut ability = ResolvedAbility::new(
+            Effect::Counter {
+                target: TargetFilter::Any,
+                source_rider: None,
+            },
+            vec![TargetRef::Object(obj_id)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        ability.sub_ability = Some(Box::new(exile_rider));
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(state.stack.is_empty());
+        assert_eq!(state.objects[&obj_id].zone, Zone::Exile);
         assert!(!state.players[1].graveyard.contains(&obj_id));
     }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5706,9 +5706,13 @@ fn resolve_chain_body(
         // exile-instead rider by stamping the granted casting permission. Do
         // not also execute the parser's structural `ChangeZone { ParentTarget }`
         // rider as an immediate move, or the graveyard card leaves before the
-        // player can cast it.
-        if matches!(&ability.effect, Effect::CastFromZone { .. })
-            && cast_from_zone::is_graveyard_exile_rider_subability(sub)
+        // player can cast it. Counter consumes the same structural rider during
+        // `counter::resolve` (stack -> exile directly) — skip the follow-up
+        // graveyard -> exile move so the spell never passes through the graveyard.
+        if matches!(
+            &ability.effect,
+            Effect::CastFromZone { .. } | Effect::Counter { .. }
+        ) && cast_from_zone::is_graveyard_exile_rider_subability(sub)
         {
             return Ok(());
         }

--- a/crates/engine/tests/integration/issue_3251_force_of_negation.rs
+++ b/crates/engine/tests/integration/issue_3251_force_of_negation.rs
@@ -1,0 +1,75 @@
+//! Issue #3251 — Force of Negation exiles countered spells directly, not via graveyard.
+//!
+//! https://github.com/phase-rs/phase/issues/3251
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const FORCE_OF_NEGATION_ORACLE: &str = "If it's not your turn, you may exile a blue card from your hand rather than pay this spell's mana cost.\n\
+Counter target noncreature spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.";
+
+fn put_noncreature_spell_on_stack(
+    runner: &mut engine::game::scenario::GameRunner,
+    controller: engine::types::player::PlayerId,
+) -> ObjectId {
+    let spell = engine::game::zones::create_object(
+        runner.state_mut(),
+        CardId(701),
+        controller,
+        "Shock".to_string(),
+        Zone::Stack,
+    );
+    if let Some(obj) = runner.state_mut().objects.get_mut(&spell) {
+        obj.card_types.core_types = vec![CoreType::Instant];
+    }
+    runner.state_mut().stack.push_back(StackEntry {
+        id: spell,
+        source_id: spell,
+        controller,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(701),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    spell
+}
+
+#[test]
+fn force_of_negation_exiles_countered_spell_without_graveyard() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let fon = scenario
+        .add_spell_to_hand_from_oracle(P0, "Force of Negation", true, FORCE_OF_NEGATION_ORACLE)
+        .id();
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Blue);
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Blue);
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Blue);
+
+    let mut runner = scenario.build();
+    let opponent_spell = put_noncreature_spell_on_stack(&mut runner, P1);
+
+    runner.cast(fon).target_objects(&[opponent_spell]).resolve();
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "Force of Negation must counter the target spell"
+    );
+    assert_eq!(
+        runner.state().objects.get(&opponent_spell).map(|o| o.zone),
+        Some(Zone::Exile),
+        "countered spell must exile directly instead of passing through graveyard"
+    );
+    assert!(
+        !runner.state().players[1]
+            .graveyard
+            .contains(&opponent_spell),
+        "countered spell must not enter the graveyard"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -250,6 +250,7 @@ mod issue_2941_vivien_reid;
 mod issue_2943_kayas_wrath;
 mod issue_3127_reveal_otherwise_graveyard;
 mod issue_3245_abhorrent_oculus_manifest_dread;
+mod issue_3251_force_of_negation;
 mod issue_3260_phantasmal_image_persist;
 mod issue_3264_jace_mind_sculptor_minus_twelve;
 mod issue_3265_knowledge_seeker_kwain;


### PR DESCRIPTION
## Summary
- Fixes #3251: counter abilities with an "exile it instead of putting it into its owner's graveyard" rider (Force of Negation, No More Lies, Defabricate) now route countered spells stack → exile during counter resolution.
- Skips the parser's structural graveyard → exile sub-ability so the spell never passes through the graveyard.

## Test plan
- [x] `cargo test -p engine --lib counter_exile_rider_exiles_countered_spell_without_graveyard`
- [x] `cargo test -p engine --test integration force_of_negation_exiles`
- [x] `cargo fmt --all`
- [x] `./scripts/check-parser-combinators.sh upstream/main`


Made with [Cursor](https://cursor.com)