### PR TITLE
fix(engine): Sméagol RingTemptsYou targets opponent for reveal (#2020)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -8011,6 +8011,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn build_target_slots_surfaces_player_slot_for_reveal_until_target_opponent() {
+        let state = GameState::new_two_player(42);
+        let ability = ResolvedAbility::new(
+            Effect::RevealUntil {
+                player: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent),
+                ),
+                filter: TargetFilter::Typed(TypedFilter::default().with_type(TypeFilter::Land)),
+                kept_destination: Zone::Battlefield,
+                rest_destination: Zone::Graveyard,
+                enter_tapped: crate::types::zones::EtbTapState::Tapped,
+                enters_attacking: false,
+                kept_optional_to: None,
+                enters_under: None,
+            },
+            vec![],
+            ObjectId(900),
+            PlayerId(0),
+        );
+
+        let slots = build_target_slots(&state, &ability).expect("should build");
+        assert_eq!(slots.len(), 1);
+        assert!(slots[0]
+            .legal_targets
+            .contains(&TargetRef::Player(PlayerId(1))));
+        assert!(
+            !slots[0]
+                .legal_targets
+                .contains(&TargetRef::Player(PlayerId(0))),
+            "target opponent reveal must not allow targeting yourself"
+        );
+    }
+
     /// Issue #933: mass filters can declare a target only through a dynamic
     /// threshold ("power greater than target creature's power"). The target
     /// lives inside `FilterProp::PtComparison.value`, so `DestroyAll` must

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -10766,6 +10766,7 @@ mod tests {
             enter_tapped: crate::types::zones::EtbTapState::Unspecified,
             enters_attacking: false,
             kept_optional_to: None,
+            enters_under: None,
         };
 
         assert_eq!(

--- a/crates/engine/src/game/effects/reveal_until.rs
+++ b/crates/engine/src/game/effects/reveal_until.rs
@@ -31,6 +31,7 @@ pub fn resolve(
         enter_tapped,
         enters_attacking,
         kept_optional_to,
+        enters_under,
     ) = match &ability.effect {
         Effect::RevealUntil {
             player,
@@ -40,6 +41,7 @@ pub fn resolve(
             enter_tapped,
             enters_attacking,
             kept_optional_to,
+            enters_under,
         } => (
             player,
             filter,
@@ -48,6 +50,7 @@ pub fn resolve(
             *enter_tapped,
             *enters_attacking,
             *kept_optional_to,
+            enters_under.as_ref(),
         ),
         _ => return Err(EffectError::MissingParam("RevealUntil".to_string())),
     };
@@ -133,6 +136,12 @@ pub fn resolve(
 
     // Move the matching card to its destination.
     if let Some(hit) = hit_card {
+        let controller_override = super::change_zone::resolve_enters_under_player(
+            state,
+            ability,
+            "RevealUntil",
+            enters_under,
+        )?;
         match kept_destination {
             Zone::Battlefield => {
                 // CR 614.1c + CR 306.5b / CR 310.4b: route the battlefield entry
@@ -145,6 +154,9 @@ pub fn resolve(
                 // dropped (it would double the work the tail already does).
                 let mut req = ZoneMoveRequest::effect(hit, Zone::Battlefield, ability.source_id);
                 req.mods.enter_tapped = enter_tapped;
+                if let Some(controller) = controller_override {
+                    req = req.under_control_of(controller);
+                }
                 match zone_pipeline::move_object(state, req, events) {
                     ZoneMoveResult::Done => {}
                     // CR 303.4f / CR 616.1: the kept card's battlefield entry
@@ -472,6 +484,7 @@ mod tests {
                 enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                 enters_attacking: false,
                 kept_optional_to: None,
+                enters_under: None,
             },
             vec![],
             ObjectId(100),
@@ -496,6 +509,7 @@ mod tests {
                 enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                 enters_attacking: false,
                 kept_optional_to: None,
+                enters_under: None,
             },
             targets,
             ObjectId(100),
@@ -1051,6 +1065,7 @@ mod tests {
                     enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                     enters_attacking: false,
                     kept_optional_to: Some(Zone::Battlefield),
+                    enters_under: None,
                 },
                 vec![],
                 ObjectId(100),
@@ -1168,6 +1183,7 @@ mod tests {
                 enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                 enters_attacking: false,
                 kept_optional_to: Some(Zone::Library),
+                enters_under: None,
             },
             vec![],
             ObjectId(100),
@@ -1239,6 +1255,7 @@ mod tests {
                 enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                 enters_attacking: false,
                 kept_optional_to: Some(Zone::Battlefield),
+                enters_under: None,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/effects/ring.rs
+++ b/crates/engine/src/game/effects/ring.rs
@@ -430,4 +430,42 @@ mod tests {
             }
         ));
     }
+
+    const SMEAGOL_RING_TRIGGER: &str = "Whenever the Ring tempts you, target opponent reveals cards from the top of their library until they reveal a land card. Put that card onto the battlefield tapped under your control and the rest into their graveyard.";
+
+    #[test]
+    fn ring_tempts_you_smeagol_observer_collects_with_opponent_target() {
+        use crate::game::trigger_index;
+        use crate::parser::oracle_trigger::parse_trigger_line;
+        use crate::types::ability::{TargetFilter, TargetRef};
+
+        let mut state = GameState::new_two_player(42);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        let smeagol = make_creature(&mut state, 10, PlayerId(0));
+        let trigger_def = parse_trigger_line(SMEAGOL_RING_TRIGGER, "Sméagol, Helpful Guide");
+        assert_eq!(trigger_def.valid_target, Some(TargetFilter::Player));
+        {
+            let obj = state.objects.get_mut(&smeagol).unwrap();
+            obj.trigger_definitions.push(trigger_def);
+        }
+        trigger_index::reindex_object_triggers(&mut state, smeagol);
+
+        let mut events = Vec::new();
+        let ability =
+            ResolvedAbility::new(Effect::RingTemptsYou, vec![], ObjectId(99), PlayerId(0));
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        triggers::process_triggers(&mut state, &events);
+
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "Sméagol's RingTemptsYou trigger must reach the stack"
+        );
+        let reveal = state.stack.last().unwrap().ability().unwrap();
+        assert!(matches!(reveal.effect, Effect::RevealUntil { .. }));
+        assert_eq!(reveal.targets, vec![TargetRef::Player(PlayerId(1))]);
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6697,6 +6697,7 @@ fn try_parse_reveal_until(tp: TextPair, player: TargetFilter) -> Option<ParsedEf
             enter_tapped: crate::types::zones::EtbTapState::Unspecified,
             enters_attacking: false,
             kept_optional_to: None,
+            enters_under: None,
         }));
     }
 
@@ -6746,6 +6747,7 @@ fn try_parse_reveal_until(tp: TextPair, player: TargetFilter) -> Option<ParsedEf
         enter_tapped: crate::types::zones::EtbTapState::Unspecified,
         enters_attacking: false,
         kept_optional_to: None,
+        enters_under: None,
     }))
 }
 
@@ -44923,6 +44925,7 @@ mod tests {
                     enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                     enters_attacking: false,
                     kept_optional_to: None,
+                    enters_under: None,
                 } if type_filters.contains(&TypeFilter::Creature)
             ),
             "expected RevealUntil player=Controller, creature->hand, rest->library, got: {:?}",
@@ -44989,6 +44992,7 @@ mod tests {
                     enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                     enters_attacking: false,
                     kept_optional_to: None,
+                    enters_under: None,
                 } if type_filters.contains(&TypeFilter::Creature)
             ),
             "expected RevealUntil player=ParentTargetController, got: {:?}",
@@ -45065,6 +45069,7 @@ mod tests {
                     enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                     enters_attacking: false,
                     kept_optional_to: None,
+                    enters_under: None,
                 } if type_filters.contains(&TypeFilter::Land)
             ),
             "expected RevealUntil(kept=Graveyard, rest=Graveyard), got: {:?}",
@@ -45142,6 +45147,7 @@ mod tests {
                     enter_tapped: crate::types::zones::EtbTapState::Unspecified,
                     enters_attacking: false,
                     kept_optional_to: None,
+                    enters_under: None,
                 } if type_filters.contains(&TypeFilter::Artifact)
             ),
             "expected RevealUntil player=Controller, artifact->battlefield, got: {:?}",

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2896,6 +2896,7 @@ pub(super) fn apply_clause_continuation(
             enter_tapped: tapped,
             enters_attacking: attacking,
             rest_destination: rest_dest,
+            enters_under,
             optional_decline,
         } => {
             let Some(previous) = defs.last_mut() else {
@@ -2907,6 +2908,7 @@ pub(super) fn apply_clause_continuation(
                 enters_attacking,
                 rest_destination,
                 kept_optional_to,
+                enters_under: effect_enters_under,
                 ..
             } = &mut *previous.effect
             {
@@ -2940,6 +2942,7 @@ pub(super) fn apply_clause_continuation(
                 if let Some(rest) = rest_dest {
                     *rest_destination = rest;
                 }
+                *effect_enters_under = enters_under;
             }
         }
         ContinuationAst::GrantExtraTurnAfterControlledTurn => {
@@ -4498,11 +4501,17 @@ pub(super) fn parse_followup_continuation_ast(
             } else {
                 None
             };
+            let enters_under = if nom_primitives::scan_contains(&lower, "under your control") {
+                Some(ControllerRef::You)
+            } else {
+                None
+            };
             Some(ContinuationAst::RevealUntilKept {
                 destination,
                 enter_tapped,
                 enters_attacking,
                 rest_destination: rest,
+                enters_under,
                 optional_decline,
             })
         }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -343,6 +343,8 @@ pub(crate) enum ContinuationAst {
         /// ("tapped and attacking"). Absorbs into `enters_attacking`.
         enters_attacking: bool,
         rest_destination: Option<Zone>,
+        /// CR 110.2a: "under your control" on the kept-card clause.
+        enters_under: Option<ControllerRef>,
         /// CR 701.20a + CR 608.2c: `Some(decline_zone)` when the kept clause is
         /// optional ("you may put that card onto the battlefield"). `destination`
         /// is then the accept zone and `decline_zone` is where the kept card

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1168,10 +1168,19 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
     }
 
     // CR 109.4 + CR 603.7c: Surface TargetFilter::Player when execute
-    // references ControllerRef::TargetPlayer.
+    // references ControllerRef::TargetPlayer, when the effect text names a
+    // target opponent/player (Sméagol, Helpful Guide RingTemptsYou), or when a
+    // RevealUntil names an opponent library without TargetPlayer binding.
     if def.valid_target.is_none() {
-        if let Some(execute) = def.execute.as_deref() {
-            if execute_references_target_player(&execute.effect) {
+        let effect_lower = modifiers.effect_lower.as_str();
+        if scan_contains(effect_lower, "target opponent")
+            || scan_contains(effect_lower, "target player")
+        {
+            def.valid_target = Some(TargetFilter::Player);
+        } else if let Some(execute) = def.execute.as_deref() {
+            if execute_references_target_player(&execute.effect)
+                || execute_references_opponent_player(&execute.effect)
+            {
                 def.valid_target = Some(TargetFilter::Player);
             }
         }
@@ -5631,6 +5640,28 @@ fn execute_references_target_player(effect: &crate::types::ability::Effect) -> b
         }
     }
     false
+}
+
+/// CR 115.1 + CR 701.20a: Returns `true` when a `RevealUntil` (or nested
+/// sub-ability) names an opponent/player library without `TargetPlayer`
+/// binding — e.g. Sméagol's "target opponent reveals..." RingTemptsYou trigger.
+fn execute_references_opponent_player(effect: &crate::types::ability::Effect) -> bool {
+    fn filter_references_opponent(filter: &TargetFilter) -> bool {
+        match filter {
+            TargetFilter::Typed(TypedFilter { controller, .. }) => {
+                matches!(controller, Some(ControllerRef::Opponent))
+            }
+            TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+                filters.iter().any(filter_references_opponent)
+            }
+            TargetFilter::Not { filter } => filter_references_opponent(filter),
+            _ => false,
+        }
+    }
+    match effect {
+        Effect::RevealUntil { player, .. } => filter_references_opponent(player),
+        _ => false,
+    }
 }
 
 /// CR 608.2k: Extract the trigger subject from condition text for pronoun context.
@@ -21764,6 +21795,51 @@ mod tests {
             "Ringwraiths",
         );
         assert_eq!(def.mode, TriggerMode::RingTemptsYou);
+    }
+
+    #[test]
+    fn trigger_ring_tempts_you_target_opponent_reveal_sets_valid_target() {
+        let def = parse_trigger_line(
+            "Whenever the Ring tempts you, target opponent reveals cards from the top of their library until they reveal a land card. Put that card onto the battlefield tapped under your control and the rest into their graveyard.",
+            "Sméagol, Helpful Guide",
+        );
+        assert_eq!(def.mode, TriggerMode::RingTemptsYou);
+        assert_eq!(def.valid_target, Some(TargetFilter::Player));
+        let Effect::RevealUntil {
+            player,
+            filter,
+            kept_destination,
+            rest_destination,
+            enter_tapped,
+            enters_under,
+            ..
+        } = def.execute.as_ref().unwrap().effect.as_ref()
+        else {
+            panic!("expected RevealUntil");
+        };
+        assert!(
+            matches!(
+                player,
+                TargetFilter::Typed(tf) if tf.controller == Some(ControllerRef::Opponent)
+            ),
+            "reveal player must be opponent, got {player:?}"
+        );
+        assert!(
+            matches!(filter, TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Land)),
+            "filter must be land, got {filter:?}"
+        );
+        assert_eq!(*kept_destination, Zone::Battlefield);
+        assert_eq!(*rest_destination, Zone::Graveyard);
+        assert_eq!(
+            *enter_tapped,
+            crate::types::zones::EtbTapState::Tapped,
+            "land must enter tapped"
+        );
+        assert_eq!(
+            *enters_under,
+            Some(ControllerRef::You),
+            "stolen land must enter under ability controller"
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8857,6 +8857,10 @@ pub enum Effect {
         /// kept card unconditionally goes to `kept_destination` (mandatory).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         kept_optional_to: Option<Zone>,
+        /// CR 110.2a: When set, the kept card enters the battlefield under this
+        /// controller ("under your control" on Telemin Performance / Sméagol).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        enters_under: Option<ControllerRef>,
     },
     /// CR 701.57a: Discover N — exile from top until nonland with MV ≤ N,
     /// cast free or put to hand, rest to bottom in random order.
@@ -10277,7 +10281,6 @@ impl Effect {
             | Effect::ChooseFromZone { .. }
             | Effect::ChooseAndSacrificeRest { .. }
             | Effect::GainEnergy { .. }
-            | Effect::RevealUntil { .. }
             | Effect::Discover { .. }
             | Effect::HeistExile
             | Effect::Cascade
@@ -10357,6 +10360,15 @@ impl Effect {
             // spell ability, not in a top-level `target` field.
             | Effect::EpicCopy { .. }
             | Effect::CreateDamageReplacement { .. } => None,
+            // CR 115.1: RevealUntil with a non-context player filter ("target
+            // opponent reveals...") requires a stack-time player target slot.
+            Effect::RevealUntil { player, .. } => {
+                if player.is_context_ref() {
+                    None
+                } else {
+                    Some(player)
+                }
+            }
             // CR 701.23a: SearchLibrary has an optional player target for opponent search.
             Effect::SearchLibrary { target_player, .. } => target_player.as_ref(),
             Effect::ChooseDrawnThisTurnPayOrTopdeck { player, .. } => Some(player),

--- a/crates/engine/tests/integration/issue_2020_smeagol_ring_tempt.rs
+++ b/crates/engine/tests/integration/issue_2020_smeagol_ring_tempt.rs
@@ -1,0 +1,115 @@
+//! Issue #2020 — Sméagol, Helpful Guide RingTemptsYou trigger must target an
+//! opponent so the RevealUntil land-steal effect reveals the chosen library.
+//!
+//! https://github.com/phase-rs/phase/issues/2020
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{TargetFilter, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const SMEAGOL_RING_TRIGGER: &str = "Whenever the Ring tempts you, target opponent reveals cards from the top of their library until they reveal a land card. Put that card onto the battlefield tapped under your control and the rest into their graveyard.";
+const RING_TEMPT_ORACLE: &str = "The Ring tempts you.";
+
+#[test]
+fn smeagol_ring_tempt_reveal_steals_opponent_land() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let smeagol = scenario
+        .add_creature_from_oracle(P0, "Sméagol, Helpful Guide", 4, 2, SMEAGOL_RING_TRIGGER)
+        .id();
+    let forest = scenario.add_card_to_library_top(P1, "Forest");
+    let island = scenario.add_card_to_library_top(P1, "Island");
+
+    let spell = scenario
+        .add_spell_to_hand(P0, "Tempt Spell", false)
+        .from_oracle_text(RING_TEMPT_ORACLE)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+
+    {
+        let forest_obj = runner.state_mut().objects.get_mut(&forest).unwrap();
+        forest_obj.card_types.core_types.push(CoreType::Land);
+        forest_obj.base_card_types = forest_obj.card_types.clone();
+    }
+    {
+        let island_obj = runner.state_mut().objects.get_mut(&island).unwrap();
+        island_obj.card_types.core_types.push(CoreType::Instant);
+        island_obj.base_card_types = island_obj.card_types.clone();
+    }
+
+    let trigger = &runner.state().objects[&smeagol].trigger_definitions[0];
+    assert_eq!(trigger.mode, TriggerMode::RingTemptsYou);
+    assert_eq!(
+        trigger.valid_target,
+        Some(TargetFilter::Player),
+        "parser must surface opponent player target for RevealUntil"
+    );
+
+    runner.cast(spell).resolve();
+
+    let mut resolved = false;
+    for _ in 0..96 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Player(P1)],
+                    })
+                    .expect("target opponent for RingTemptsYou reveal");
+            }
+            WaitingFor::ChooseRingBearer { candidates, .. } => {
+                runner
+                    .act(GameAction::ChooseRingBearer {
+                        target: candidates[0],
+                    })
+                    .expect("choose ring bearer");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => {
+                resolved = true;
+                break;
+            }
+            _ => {
+                runner.act(GameAction::PassPriority).ok();
+            }
+        }
+    }
+
+    assert!(resolved, "ring tempt chain must resolve to priority");
+    assert_eq!(
+        runner.state().ring_level.get(&P0).copied(),
+        Some(1),
+        "ring must have tempted the controller"
+    );
+    let island_in_gy = runner.state().players[1]
+        .graveyard
+        .iter()
+        .any(|id| runner.state().objects[id].name == "Island");
+    assert!(
+        island_in_gy,
+        "reveal must mill opponent Island into graveyard before hitting Forest; gy={:?}",
+        runner.state().players[1]
+            .graveyard
+            .iter()
+            .map(|id| &runner.state().objects[id].name)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        runner.state().objects.values().any(|obj| {
+            obj.zone == Zone::Battlefield
+                && obj.controller == P0
+                && obj.name == "Forest"
+                && obj.tapped
+        }),
+        "opponent's revealed Forest must enter tapped under Sméagol's controller; waiting_for={:?}",
+        runner.state().waiting_for
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -174,6 +174,7 @@ mod issue_1973_rise_of_dark_realms;
 mod issue_1985_dfc_command_zone_cast;
 mod issue_1987_bucknards_everfull_purse;
 mod issue_2011_eldrazi_temple_kozilek_cast;
+mod issue_2020_smeagol_ring_tempt;
 mod issue_2345_lavinia_no_mana_spent;
 mod issue_2348_key_to_the_vault;
 mod issue_2351_aven_interrupter;


### PR DESCRIPTION
## Summary
- Parse RingTemptsYou triggers with "target opponent reveals..." as player-targeted RevealUntil effects
- Surface opponent player target slots for RevealUntil at stack time so auto-targeting selects the opponent
- Apply `enters_under` when the kept-card clause says "under your control"

## Test plan
- [x] `ring_tempts_you_smeagol_observer_collects_with_opponent_target`
- [x] `build_target_slots_surfaces_player_slot_for_reveal_until_target_opponent`
- [x] `trigger_ring_tempts_you_target_opponent_reveal_sets_valid_target`
- [x] `smeagol_ring_tempt_reveal_steals_opponent_land` integration test

Fixes #2020

Made with [Cursor](https://cursor.com)