### PR TITLE
fix(parser): parse bare "toxic" keyword as Toxic, not Unknown

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -4376,6 +4376,23 @@ mod tests {
     use crate::types::counter::{CounterMatch, CounterType};
 
     #[test]
+    fn strip_target_keyword_instead_parses_toxic_as_typed_keyword() {
+        // "if that creature has toxic, ..." must lower to a real Toxic keyword,
+        // not Unknown("toxic"); runtime has_keyword matches by discriminant, so an
+        // Unknown variant would make the rider silently dead (Hexgold Slash,
+        // Compleat Devotion, Porcelain Zealot). Building-block test, not card-name
+        // hardcoded.
+        let (cond, body) = strip_target_keyword_instead("If that creature has toxic, draw a card.");
+        assert!(matches!(
+            cond,
+            Some(AbilityCondition::TargetHasKeywordInstead {
+                keyword: Keyword::Toxic(_)
+            })
+        ));
+        assert_eq!(body, "draw a card.");
+    }
+
+    #[test]
     fn parse_no_mana_spent_to_cast_target_condition_reads_ability_target_mana() {
         let cond =
             parse_no_mana_spent_to_cast_target_condition_text("no mana was spent to cast it")

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -2183,6 +2183,10 @@ impl FromStr for Keyword {
             "infect" => Ok(Keyword::Infect),
             "afflict" => Ok(Keyword::Afflict(1)),
             "frenzy" => Ok(Keyword::Frenzy(1)),
+            // CR 702.164: Toxic N — bare "toxic" (grant text / "if that creature has toxic"
+            // condition). Parameter defaults to 1; has_keyword matches by discriminant so N
+            // is irrelevant for presence. The colon form ("Toxic:N") is handled above.
+            "toxic" => Ok(Keyword::Toxic(1)),
             "prowess" => Ok(Keyword::Prowess),
             "undying" => Ok(Keyword::Undying),
             "persist" => Ok(Keyword::Persist),
@@ -3753,6 +3757,22 @@ mod tests {
             assert_eq!(counter_type, &CounterType::Plus1Plus1);
             assert_eq!(*count, 3);
         }
+    }
+
+    #[test]
+    fn parse_toxic_colon_and_bare() {
+        // CR 702.164: colon-form carries N (no-regression for the existing path).
+        assert_eq!(Keyword::from_str("Toxic:3").unwrap(), Keyword::Toxic(3));
+        // CR 702.164: bare "toxic" (grant text / "if that creature has toxic"
+        // condition) defaults to Toxic(1) and must NOT fall to Unknown — otherwise
+        // has_keyword (discriminant match) never sees a real Toxic(N) and the rider
+        // is silently dead. Case-insensitive via the from_str normalizer.
+        assert_eq!(Keyword::from_str("toxic").unwrap(), Keyword::Toxic(1));
+        assert_eq!(Keyword::from_str("Toxic").unwrap(), Keyword::Toxic(1));
+        assert_ne!(
+            Keyword::from_str("toxic").unwrap(),
+            Keyword::Unknown("toxic".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3890.

## Summary

"If that creature has toxic, …" conditional riders never fired — the keyword parsed to an inert `Unknown("toxic")` instead of the real `Toxic` keyword:

- **Hexgold Slash** ("…If that creature has toxic, deals 4 damage instead"), **Compleat Devotion** ("…draw a card"), **Porcelain Zealot** ("…instead it gets +2/+2").

The runtime checks keyword presence by `std::mem::discriminant`, so `Unknown("toxic")` can never match a creature's real `Toxic(N)` — the rider was silently dead.

## Root cause

`Keyword::from_str`'s bare-keyword (`name_nospace`) match has arms for `infect`/`afflict`/`frenzy` but no `toxic`, so bare "toxic" (emitted by the condition parser) fell to the `Unknown` catch-all. The colon form "Toxic:N" was already handled.

## Fix (parser-AST-only; no new engine variant, no runtime change)

Add `"toxic" => Ok(Keyword::Toxic(1))` beside the `infect`/`afflict`/`frenzy` arms. The parameter is irrelevant to presence (discriminant match). The runtime already handles real keyword-presence conditions — the identical `infect` path works today (Burn the Impure). CR 702.164 (Toxic).

## Tests

- `Keyword::from_str("toxic")` / `"Toxic"` → `Toxic(1)` (and explicitly not `Unknown`).
- `strip_target_keyword_instead("If that creature has toxic, draw a card.")` → `TargetHasKeywordInstead { keyword: Toxic(_) }` (revert-failing).
- No-regression: `Toxic:3` → `Toxic(3)`; `infect`/`afflict`/`frenzy` unchanged.

## Verification

`cargo +nightly test -p engine --lib`: 12671 passed (incl. the new tests); `--test integration`: 1308 passed, no fixture diff. The only `--lib` failure was the pre-existing flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (a global perf-counter race under parallel runs — confirmed passing in isolation, unrelated to this `from_str` change). `clippy -D warnings`: clean. Parser-combinator gate: clean for this diff.
