### PR TITLE
fix(engine): keep look-at-hand private to the caster (#3263)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -7766,6 +7766,7 @@ mod tests {
                 count: None,
                 selection: crate::types::ability::CardSelectionMode::Chosen,
                 choice_optional: false,
+                reveal: true,
             },
             vec![],
             ObjectId(10),

--- a/crates/engine/src/game/effects/reveal_hand.rs
+++ b/crates/engine/src/game/effects/reveal_hand.rs
@@ -8,31 +8,35 @@ use crate::types::ability::{
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 
-/// CR 701.20a: RevealHand — reveal target player's hand, then let the caster choose a card.
+/// CR 701.20a / CR 701.20e: RevealHand — reveal or privately look at a target
+/// player's hand, then optionally let the caster choose a card.
 ///
-/// Marks all cards in the target player's hand as revealed in `GameState.revealed_cards`
-/// (so `filter_state_for_player` doesn't hide them), emits `CardsRevealed`, and sets
-/// `WaitingFor::RevealChoice` for the caster to select a card matching the filter.
-/// The sub-ability chain (exile, discard, etc.) runs via `pending_continuation`.
+/// Public reveals (`reveal: true`) mark cards in `GameState.revealed_cards` so
+/// `filter_state_for_viewer` shows them to all players. Private looks (`reveal:
+/// false`) record `private_look_ids` / `private_look_player` so only the ability
+/// controller can see the hand. When a post-reveal card choice is required,
+/// `WaitingFor::RevealChoice` is opened for the caster.
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (card_filter, count, random, choice_optional) = match &ability.effect {
+    let (card_filter, count, random, choice_optional, is_reveal) = match &ability.effect {
         Effect::RevealHand {
             card_filter,
             count,
             selection,
             choice_optional,
+            reveal,
             ..
         } => (
             card_filter.clone(),
             count.clone(),
             selection.is_random(),
             *choice_optional,
+            *reveal,
         ),
-        _ => (TargetFilter::Any, None, false, false),
+        _ => (TargetFilter::Any, None, false, false, true),
     };
 
     // Find the target player from resolved targets
@@ -71,20 +75,35 @@ pub fn resolve(
     }
 
     // CR 701.20b: Revealing a card doesn't cause it to leave the zone it's in.
-    for &card_id in &hand {
-        state.revealed_cards.insert(card_id);
+    if is_reveal {
+        for &card_id in &hand {
+            state.revealed_cards.insert(card_id);
+        }
+
+        // Emit event with card names
+        let card_names: Vec<String> = hand
+            .iter()
+            .filter_map(|id| state.objects.get(id).map(|o| o.name.clone()))
+            .collect();
+        events.push(GameEvent::CardsRevealed {
+            player: target_player,
+            card_ids: hand.clone(),
+            card_names,
+        });
+    } else {
+        // CR 701.20e: "Look at" privately shows the hand to the ability controller.
+        state.private_look_ids = hand.clone();
+        state.private_look_player = Some(ability.controller);
     }
 
-    // Emit event with card names
-    let card_names: Vec<String> = hand
-        .iter()
-        .filter_map(|id| state.objects.get(id).map(|o| o.name.clone()))
-        .collect();
-    events.push(GameEvent::CardsRevealed {
-        player: target_player,
-        card_ids: hand.clone(),
-        card_names,
-    });
+    let needs_reveal_choice = choice_optional || !matches!(card_filter, TargetFilter::None);
+    if !needs_reveal_choice {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::Reveal,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
 
     // Filter to only eligible cards for the choice (e.g. "nonland card").
     // CR 107.3a + CR 601.2b: ability-context evaluation for dynamic thresholds.
@@ -98,6 +117,10 @@ pub fn resolve(
     };
 
     if eligible.is_empty() {
+        if !is_reveal {
+            state.private_look_ids.clear();
+            state.private_look_player = None;
+        }
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::Reveal,
             source_id: ability.source_id,
@@ -124,6 +147,7 @@ pub fn resolve(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::visibility::filter_state_for_viewer;
     use crate::game::zones::create_object;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
@@ -137,6 +161,7 @@ mod tests {
                 count: None,
                 selection: crate::types::ability::CardSelectionMode::Chosen,
                 choice_optional: false,
+                reveal: true,
             },
             vec![TargetRef::Player(target_player)],
             ObjectId(100),
@@ -260,6 +285,7 @@ mod tests {
                 count: Some(crate::types::ability::QuantityExpr::Fixed { value: 1 }),
                 selection: crate::types::ability::CardSelectionMode::Random,
                 choice_optional: false,
+                reveal: true,
             },
             vec![TargetRef::Player(PlayerId(1))],
             ObjectId(100),
@@ -276,6 +302,94 @@ mod tests {
             other => panic!("Expected RevealChoice, got {:?}", other),
         }
         assert_eq!(state.revealed_cards.len(), 1);
+    }
+
+    #[test]
+    fn look_at_hand_is_private_to_looker_and_skips_reveal_choice() {
+        let mut state = GameState::new_two_player(42);
+        let card1 = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Secret Bolt".to_string(),
+            Zone::Hand,
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::RevealHand {
+                target: TargetFilter::Player,
+                card_filter: TargetFilter::None,
+                count: None,
+                selection: crate::types::ability::CardSelectionMode::Chosen,
+                choice_optional: false,
+                reveal: false,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            !state.revealed_cards.contains(&card1),
+            "private look must not publish cards via revealed_cards"
+        );
+        assert_eq!(state.private_look_ids, vec![card1]);
+        assert_eq!(state.private_look_player, Some(PlayerId(0)));
+        assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::CardsRevealed { .. })),
+            "private look must not emit CardsRevealed"
+        );
+
+        let looker_view = filter_state_for_viewer(&state, PlayerId(0));
+        assert_eq!(
+            looker_view.objects[&card1].name, "Secret Bolt",
+            "looker must see the privately looked-at hand card"
+        );
+
+        let other_player_view = filter_state_for_viewer(&state, PlayerId(1));
+        assert_eq!(
+            other_player_view.objects[&card1].name, "Secret Bolt",
+            "hand owner always sees their own hand"
+        );
+    }
+
+    #[test]
+    fn look_at_own_hand_does_not_leak_to_opponent() {
+        let mut state = GameState::new_two_player(42);
+        let card1 = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Probe Secret".to_string(),
+            Zone::Hand,
+        );
+
+        let ability = ResolvedAbility::new(
+            Effect::RevealHand {
+                target: TargetFilter::Player,
+                card_filter: TargetFilter::None,
+                count: None,
+                selection: crate::types::ability::CardSelectionMode::Chosen,
+                choice_optional: false,
+                reveal: false,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            ObjectId(100),
+            PlayerId(1),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let opponent_view = filter_state_for_viewer(&state, PlayerId(0));
+        assert_eq!(
+            opponent_view.objects[&card1].name, "Hidden Card",
+            "Gitaxian Probe self-target look must not leak hand contents to the opponent"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1339,9 +1339,13 @@ fn apply_action(
     // CR 701.20e: A bare "look at the top card" peek is visible to the looker
     // only until they act on it. The peek window must survive the action that
     // serves the dependent "you may reveal that card" optional (the looked-at
-    // card is shown while that `OptionalEffectChoice` is pending), then clear on
-    // the next action boundary — mirroring the momentary `revealed_cards` reveal.
-    if !matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }) {
+    // card is shown while that `OptionalEffectChoice` is pending) and any
+    // `RevealChoice` opened by a private look-at-hand, then clear on the next
+    // action boundary — mirroring the momentary `revealed_cards` reveal.
+    if !matches!(
+        state.waiting_for,
+        WaitingFor::OptionalEffectChoice { .. } | WaitingFor::RevealChoice { .. }
+    ) {
         state.private_look_ids.clear();
         state.private_look_player = None;
     }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1657,6 +1657,8 @@ pub(super) fn handle_resolution_choice(
                 for &card_id in &cards {
                     state.revealed_cards.remove(&card_id);
                 }
+                state.private_look_ids.clear();
+                state.private_look_player = None;
                 set_priority(state, player);
                 if decline_runs_continuation {
                     effects::drain_pending_continuation(state, events);
@@ -1695,6 +1697,8 @@ pub(super) fn handle_resolution_choice(
             for &card_id in &cards {
                 state.revealed_cards.remove(&card_id);
             }
+            state.private_look_ids.clear();
+            state.private_look_player = None;
 
             set_priority(state, player);
             // CR 701.20a: For an optional reveal, the stashed continuation is the

--- a/crates/engine/src/game/priority.rs
+++ b/crates/engine/src/game/priority.rs
@@ -462,6 +462,7 @@ mod tests {
                 count: None,
                 selection: crate::types::ability::CardSelectionMode::Chosen,
                 choice_optional: false,
+                reveal: true,
             },
             vec![TargetRef::Player(PlayerId(1))],
             source_id,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -10338,6 +10338,7 @@ pub mod tests {
                                 count: None,
                                 selection: crate::types::ability::CardSelectionMode::Chosen,
                                 choice_optional: false,
+                                reveal: true,
                             },
                         )
                         .sub_ability(

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -22,6 +22,17 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
                 && turn_control::viewer_controls_active_turn(state, viewer))
     };
 
+    // CR 701.20e: A bare "look at" peek privately reveals card(s) to the looking
+    // player only. `dig.rs` and `reveal_hand.rs` record the looker in
+    // `private_look_player`; surface the peeked cards to that player without
+    // leaking them to opponents.
+    let private_look_visible: HashSet<ObjectId> = match state.private_look_player {
+        Some(looker) if can_view_private_for_player(looker) => {
+            state.private_look_ids.iter().copied().collect()
+        }
+        _ => HashSet::new(),
+    };
+
     let opponents = players::opponents(state, viewer);
     let opp_hand_ids: Vec<ObjectId> = opponents
         .iter()
@@ -30,7 +41,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         .flat_map(|opp| filtered.players[opp.0 as usize].hand.iter().copied())
         .collect();
     for obj_id in opp_hand_ids {
-        if !is_visible_revealed_card(state, obj_id) {
+        if !is_visible_revealed_card(state, obj_id) && !private_look_visible.contains(&obj_id) {
             hide_card(&mut filtered, obj_id);
         }
     }
@@ -61,19 +72,6 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         }
     } else {
         HashSet::new()
-    };
-
-    // CR 701.20e: A bare "look at the top card" peek (Dig with keep_count == 0,
-    // reveal == false) privately reveals the card(s) to the looking player only.
-    // `dig.rs` records the looker in `private_look_player`; surface the peeked
-    // cards to that player so they can see the card while deciding a subsequent
-    // "you may reveal that card" optional (Delver of Secrets), without leaking it
-    // to opponents.
-    let private_look_visible: HashSet<ObjectId> = match state.private_look_player {
-        Some(looker) if can_view_private_for_player(looker) => {
-            state.private_look_ids.iter().copied().collect()
-        }
-        _ => HashSet::new(),
     };
 
     let search_visible: HashSet<ObjectId> =

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -782,6 +782,7 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
                 count: None,
                 selection: crate::types::ability::CardSelectionMode::Chosen,
                 choice_optional: false,
+                reveal: true,
             }),
         };
     }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2591,6 +2591,7 @@ pub(super) fn lower_hand_reveal_ast(ast: HandRevealImperativeAst) -> Effect {
                 crate::types::ability::CardSelectionMode::Chosen
             },
             choice_optional: false,
+            reveal: false,
         },
         HandRevealImperativeAst::RevealAll {
             target,
@@ -2601,6 +2602,7 @@ pub(super) fn lower_hand_reveal_ast(ast: HandRevealImperativeAst) -> Effect {
             count: None,
             selection: crate::types::ability::CardSelectionMode::Chosen,
             choice_optional: false,
+            reveal: true,
         },
         HandRevealImperativeAst::RevealPartial { count } => Effect::RevealHand {
             target: TargetFilter::Any,
@@ -2608,6 +2610,7 @@ pub(super) fn lower_hand_reveal_ast(ast: HandRevealImperativeAst) -> Effect {
             count: Some(count),
             selection: crate::types::ability::CardSelectionMode::Chosen,
             choice_optional: false,
+            reveal: true,
         },
         // CR 701.20a: Back-reference reveal — distinct from RevealHand (zone-wide).
         // ParentTarget binds at runtime to the parent ability's affected IDs.
@@ -3337,6 +3340,7 @@ pub(super) fn lower_choose_ast(ast: ChooseImperativeAst) -> Effect {
             count: None,
             selection: crate::types::ability::CardSelectionMode::Chosen,
             choice_optional,
+            reveal: true,
         },
         // CR 700.2: Anaphoric "choose N of them/those" → select from the tracked set
         // populated by the preceding effect (RevealTop, RevealHand, ExileTop, etc.).

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -37064,10 +37064,14 @@ mod tests {
 
         for (text, expected_target) in cases {
             let def = parse_effect_chain(text, AbilityKind::Spell);
-            let Effect::RevealHand { target, .. } = &*def.effect else {
+            let Effect::RevealHand { target, reveal, .. } = &*def.effect else {
                 panic!("Expected RevealHand for {text}, got {:?}", def.effect);
             };
             assert_eq!(*target, expected_target, "{text}");
+            assert!(
+                !*reveal,
+                "look-at-hand phrases must lower to private RevealHand, got {text}"
+            );
         }
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8122,6 +8122,13 @@ pub enum Effect {
         /// card selection optional while the hand reveal itself remains mandatory.
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         choice_optional: bool,
+        /// CR 701.20a vs CR 701.20e: True = cards are revealed (public), false =
+        /// looked at (private to the ability controller).
+        #[serde(
+            default = "default_reveal_public",
+            skip_serializing_if = "std::ops::Not::not"
+        )]
+        reveal: bool,
     },
     /// CR 701.20a: "You may reveal a [FILTER] card from your hand" — optional self-reveal
     /// from the controller's own hand. Distinct from `RevealHand` (target player, used for
@@ -9455,6 +9462,10 @@ fn is_default_search_zones(zones: &[Zone]) -> bool {
 
 fn default_zone_hand() -> Zone {
     Zone::Hand
+}
+
+fn default_reveal_public() -> bool {
+    true
 }
 
 fn default_zone_graveyard() -> Zone {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8124,10 +8124,7 @@ pub enum Effect {
         choice_optional: bool,
         /// CR 701.20a vs CR 701.20e: True = cards are revealed (public), false =
         /// looked at (private to the ability controller).
-        #[serde(
-            default = "default_reveal_public",
-            skip_serializing_if = "std::ops::Not::not"
-        )]
+        #[serde(default = "default_reveal_public")]
         reveal: bool,
     },
     /// CR 701.20a: "You may reveal a [FILTER] card from your hand" — optional self-reveal
@@ -17257,6 +17254,38 @@ mod tests {
         let json = serde_json::to_string(&effect).unwrap();
         let deserialized: Effect = serde_json::from_str(&json).unwrap();
         assert_eq!(effect, deserialized);
+    }
+
+    #[test]
+    fn reveal_hand_private_look_serializes_false_and_roundtrips() {
+        let effect = Effect::RevealHand {
+            target: TargetFilter::Player,
+            card_filter: TargetFilter::None,
+            count: None,
+            selection: CardSelectionMode::Chosen,
+            choice_optional: false,
+            reveal: false,
+        };
+        let json = serde_json::to_string(&effect).unwrap();
+        assert!(
+            json.contains("\"reveal\":false"),
+            "private look must serialize reveal:false, got {json}"
+        );
+        let deserialized: Effect = serde_json::from_str(&json).unwrap();
+        assert_eq!(effect, deserialized);
+    }
+
+    #[test]
+    fn reveal_hand_public_reveal_defaults_true_without_field() {
+        let json = r#"{"type":"RevealHand","target":{"type":"Any"},"card_filter":{"type":"Any"}}"#;
+        let effect: Effect = serde_json::from_str(json).unwrap();
+        let Effect::RevealHand { reveal, .. } = effect else {
+            panic!("expected RevealHand");
+        };
+        assert!(
+            reveal,
+            "legacy card data without reveal must default to public reveal"
+        );
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_3263_gitaxian_probe.rs
+++ b/crates/engine/tests/integration/issue_3263_gitaxian_probe.rs
@@ -6,9 +6,9 @@ use engine::game::effects::resolve_ability_chain;
 use engine::game::visibility::filter_state_for_viewer;
 use engine::game::zones::create_object;
 use engine::parser::oracle_effect::parse_effect_chain;
-use engine::types::ability::{AbilityKind, Effect, TargetFilter, TargetRef};
+use engine::types::ability::{AbilityKind, Effect, TargetRef};
 use engine::types::game_state::GameState;
-use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::identifiers::CardId;
 use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
 
@@ -55,7 +55,7 @@ fn gitaxian_probe_self_look_does_not_leak_hand_to_opponent() {
         vec![TargetRef::Player(PlayerId(1))],
     );
     let mut events = Vec::new();
-    resolve_ability_chain(&mut state, &ability, &mut events).unwrap();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
 
     assert!(
         !state.revealed_cards.contains(&secret_card),

--- a/crates/engine/tests/integration/issue_3263_gitaxian_probe.rs
+++ b/crates/engine/tests/integration/issue_3263_gitaxian_probe.rs
@@ -1,0 +1,86 @@
+//! Regression for GitHub issue #3263 — Gitaxian Probe's "look at target player's
+//! hand" must be private to the caster (CR 701.20e), not a public reveal.
+
+use engine::game::ability_utils::build_resolved_from_def_with_targets;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::visibility::filter_state_for_viewer;
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, TargetFilter, TargetRef};
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const GITAXIAN_PROBE: &str = "Look at target player's hand.\nDraw a card.";
+
+#[test]
+fn gitaxian_probe_self_look_does_not_leak_hand_to_opponent() {
+    let def = parse_effect_chain(GITAXIAN_PROBE, AbilityKind::Spell);
+    let Effect::RevealHand { reveal, .. } = def.effect.as_ref() else {
+        panic!("expected RevealHand head, got {:?}", def.effect);
+    };
+    assert!(
+        !*reveal,
+        "Gitaxian Probe look-at-hand must parse as a private look"
+    );
+
+    let mut state = GameState::new_two_player(3263);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(1),
+        "Gitaxian Probe".to_string(),
+        Zone::Stack,
+    );
+    let secret_card = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(1),
+        "Probe Secret".to_string(),
+        Zone::Hand,
+    );
+    create_object(
+        &mut state,
+        CardId(3),
+        PlayerId(1),
+        "Drawn Card".to_string(),
+        Zone::Library,
+    );
+
+    let ability = build_resolved_from_def_with_targets(
+        &def,
+        source,
+        PlayerId(1),
+        vec![TargetRef::Player(PlayerId(1))],
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events).unwrap();
+
+    assert!(
+        !state.revealed_cards.contains(&secret_card),
+        "self-target look must not publish hand cards via revealed_cards"
+    );
+    assert_eq!(state.private_look_player, Some(PlayerId(1)));
+
+    let opponent_view = filter_state_for_viewer(&state, PlayerId(0));
+    assert_eq!(
+        opponent_view.objects[&secret_card].name, "Hidden Card",
+        "opponent must not see cards from a self-target Gitaxian Probe look"
+    );
+
+    let caster_view = filter_state_for_viewer(&state, PlayerId(1));
+    assert_eq!(
+        caster_view.objects[&secret_card].name, "Probe Secret",
+        "caster still sees their own hand after looking"
+    );
+    assert_eq!(
+        state.players[1].hand.len(),
+        2,
+        "look + draw should leave the original hand card and add one drawn card"
+    );
+    assert!(
+        state.players[1].hand.contains(&secret_card),
+        "looked-at card must remain in hand"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -252,6 +252,7 @@ mod issue_3127_reveal_otherwise_graveyard;
 mod issue_3245_abhorrent_oculus_manifest_dread;
 mod issue_3251_force_of_negation;
 mod issue_3260_phantasmal_image_persist;
+mod issue_3263_gitaxian_probe;
 mod issue_3264_jace_mind_sculptor_minus_twelve;
 mod issue_3265_knowledge_seeker_kwain;
 mod issue_3267_sanwell_rest_on_bottom;

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -5521,6 +5521,7 @@ fn apply_player_target(effect: Effect, target_filter: TargetFilter) -> ConvResul
             count,
             selection,
             choice_optional,
+            reveal,
             ..
         } => Effect::RevealHand {
             target: target_filter,
@@ -5528,7 +5529,7 @@ fn apply_player_target(effect: Effect, target_filter: TargetFilter) -> ConvResul
             count,
             selection,
             choice_optional,
-            reveal: true,
+            reveal,
         },
         // CR 701.10 + CR 115.2: "Target player exiles the top N cards
         // of their library."
@@ -7578,5 +7579,33 @@ mod tests {
         };
         assert_eq!(counter_type, &EngineCounterType::Plus1Plus1);
         assert_eq!(*count, QuantityExpr::Fixed { value: 4 });
+    }
+
+    #[test]
+    fn apply_player_target_preserves_private_reveal_hand_flag() {
+        let private_look = Effect::RevealHand {
+            target: TargetFilter::Any,
+            card_filter: TargetFilter::None,
+            count: None,
+            selection: engine::types::ability::CardSelectionMode::Chosen,
+            choice_optional: false,
+            reveal: false,
+        };
+        let rebound = apply_player_target(private_look, TargetFilter::Player).unwrap();
+        let Effect::RevealHand {
+            target,
+            reveal,
+            card_filter,
+            ..
+        } = rebound
+        else {
+            panic!("expected RevealHand, got {rebound:?}");
+        };
+        assert_eq!(target, TargetFilter::Player);
+        assert_eq!(card_filter, TargetFilter::None);
+        assert!(
+            !reveal,
+            "apply_player_target must preserve reveal:false for private looks"
+        );
     }
 }

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -2315,6 +2315,7 @@ fn convert_many_with_bindings(a: &Action, bindings: &VariableBindings) -> ConvRe
                     count: None,
                     selection: engine::types::ability::CardSelectionMode::Chosen,
                     choice_optional: false,
+                    reveal: true,
                 },
                 Effect::DiscardCard {
                     count: 1,
@@ -2344,6 +2345,7 @@ fn convert_many_with_bindings(a: &Action, bindings: &VariableBindings) -> ConvRe
                     count: None,
                     selection: engine::types::ability::CardSelectionMode::Chosen,
                     choice_optional: false,
+                    reveal: true,
                 },
                 Effect::ChangeZone {
                     origin: Some(Zone::Hand),
@@ -3612,6 +3614,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
             count: None,
             selection: engine::types::ability::CardSelectionMode::Chosen,
             choice_optional: false,
+            reveal: true,
         },
 
         // CR 701.20a: "Reveal the top N cards of your library." Engine
@@ -5525,6 +5528,7 @@ fn apply_player_target(effect: Effect, target_filter: TargetFilter) -> ConvResul
             count,
             selection,
             choice_optional,
+            reveal: true,
         },
         // CR 701.10 + CR 115.2: "Target player exiles the top N cards
         // of their library."

--- a/crates/phase-ai/src/policies/hand_disruption.rs
+++ b/crates/phase-ai/src/policies/hand_disruption.rs
@@ -289,6 +289,7 @@ mod tests {
                     count: None,
                     selection: engine::types::ability::CardSelectionMode::Chosen,
                     choice_optional: false,
+                    reveal: true,
                 },
             ),
         );
@@ -355,6 +356,7 @@ mod tests {
                     count: None,
                     selection: engine::types::ability::CardSelectionMode::Chosen,
                     choice_optional: false,
+                    reveal: true,
                 },
             )
             .sub_ability(AbilityDefinition::new(
@@ -424,6 +426,7 @@ mod tests {
                 count: None,
                 selection: engine::types::ability::CardSelectionMode::Chosen,
                 choice_optional: false,
+                reveal: true,
             },
             Vec::new(),
             peek,
@@ -551,6 +554,7 @@ mod tests {
                 count: None,
                 selection: engine::types::ability::CardSelectionMode::Chosen,
                 choice_optional: false,
+                reveal: true,
             },
             Vec::new(),
             peek,
@@ -641,6 +645,7 @@ mod tests {
                 count: None,
                 selection: engine::types::ability::CardSelectionMode::Chosen,
                 choice_optional: false,
+                reveal: true,
             },
             Vec::new(),
             peek,
@@ -703,6 +708,7 @@ mod tests {
             count: None,
             selection: engine::types::ability::CardSelectionMode::Chosen,
             choice_optional: false,
+            reveal: true,
         };
         assert!(reveal_hand_matches_chosen_player_target(
             &state,
@@ -723,6 +729,7 @@ mod tests {
             count: None,
             selection: engine::types::ability::CardSelectionMode::Chosen,
             choice_optional: false,
+            reveal: true,
         };
         assert!(!reveal_hand_matches_chosen_player_target(
             &state,


### PR DESCRIPTION
## Summary

Fix Gitaxian Probe (and every other "look at target player's hand" effect) leaking hand contents to opponents. "Look at" is now modeled as a private look (CR 701.20e), distinct from public hand reveals like Thoughtseize (CR 701.20a).

Closes #3263

## Problem

When a player cast Gitaxian Probe targeting themselves, their opponent could see the looked-at hand cards. The parser already recognized "look at … hand" Oracle text, but lowered it to `Effect::RevealHand` and ran it through the same public-reveal path as "reveal their hand":

- Cards were inserted into `revealed_cards` (visible to all players via `filter_state_for_viewer`)
- `CardsRevealed` events were emitted
- `RevealChoice` was opened even when the effect had no "choose a card from it" clause (e.g. Gitaxian Probe → Draw a card)

Under the Comprehensive Rules, **look** shows information only to the looking player; **reveal** shows it to everyone.

## Solution

Mirror the existing `Dig { reveal: bool }` split:

| Oracle verb | `RevealHand.reveal` | Runtime behavior |
|---|---|---|
| "look at … hand" | `false` | `private_look_ids` / `private_look_player`; no `CardsRevealed`; skip `RevealChoice` when there is no post-look card choice |
| "reveal … hand" | `true` (default) | Existing public reveal path unchanged |

### Key changes

- **`Effect::RevealHand`**: add `reveal: bool` (serde default `true` for backward compatibility with existing card data)
- **Parser** (`lower_hand_reveal_ast`): `HandRevealImperativeAst::LookAt` → `reveal: false`; reveal variants → `reveal: true`
- **`reveal_hand.rs`**: branch on `reveal` for public vs private handling; only open `RevealChoice` when a post-reveal card choice is actually required (`choice_optional` or non-`None` `card_filter`)
- **`visibility.rs`**: extend `private_look_visible` to opponent hand redaction (previously only applied to library peeks)
- **`engine.rs` / `engine_resolution_choices.rs`**: preserve and clear the private-look window through `RevealChoice` the same way library peeks do

## Test plan

- [x] `reveal_hand::look_at_hand_is_private_to_looker_and_skips_reveal_choice`
- [x] `reveal_hand::look_at_own_hand_does_not_leak_to_opponent`
- [x] `parse_look_at_possessive_hands_targets_player_axes` asserts `reveal: false`
- [x] `issue_3263_gitaxian_probe::gitaxian_probe_self_look_does_not_leak_hand_to_opponent`
- [ ] Existing Thoughtseize / Devour Intellect / Dread Fugue reveal-hand tests still pass (public reveal + `RevealChoice` unchanged)
- [ ] Manual: cast Gitaxian Probe targeting yourself; opponent's client must show hidden hand cards, caster sees their hand normally

```bash
cargo test -p engine reveal_hand::
cargo test -p engine issue_3263_gitaxian_probe
cargo test -p engine parse_look_at_possessive_hands_targets_player_axes
```
