### PR TITLE
feat(parser): support negative mana-spend restriction "can't be spent to cast nonartifact spells"

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -14389,6 +14389,68 @@ mod tests {
         );
     }
 
+    /// CR 106.6: negative spend form — "this mana can't be spent to cast
+    /// nonartifact spells" (Karn, Legacy Reforged). The mana may pay for artifact
+    /// spells, any ability, and any non-spell cost; only nonartifact SPELLS are
+    /// blocked — the same effective gate as "only to cast artifact spells or
+    /// activate any ability".
+    #[test]
+    fn mana_spend_restriction_cant_cast_nontype_spells() {
+        let result = crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
+            "this mana can't be spent to cast nonartifact spells",
+        );
+        assert_eq!(
+            result.map(|(r, _)| r),
+            Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
+                spell_type: "Artifact".to_string(),
+                ability: crate::types::mana::AbilityActivationScope::Any,
+            })
+        );
+        // Generic over the type word (e.g. "noncreature") and tolerates the
+        // bare lead without "this".
+        let creature = crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
+            "mana cannot be spent to cast noncreature spells.",
+        );
+        assert_eq!(
+            creature.map(|(r, _)| r),
+            Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
+                spell_type: "Creature".to_string(),
+                ability: crate::types::mana::AbilityActivationScope::Any,
+            })
+        );
+    }
+
+    /// CR 106.6: Karn, Legacy Reforged end-to-end — the upkeep mana clause and
+    /// its negative spend restriction parse with no Unimplemented, and the
+    /// produced mana carries the artifact-spells-or-any-ability restriction.
+    #[test]
+    fn karn_legacy_reforged_nonartifact_mana_restriction_parses() {
+        let karn = "At the beginning of your upkeep, add {C} for each artifact you control. \
+                    This mana can't be spent to cast nonartifact spells. Until end of turn, \
+                    you don't lose this mana as steps and phases end.";
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            karn,
+            "Karn, Legacy Reforged",
+            &[],
+            &["Legendary".to_string(), "Creature".to_string()],
+            &[],
+        );
+        let json = serde_json::to_string(&parsed).unwrap();
+        assert!(
+            !json.contains("Unimplemented"),
+            "Karn's mana restriction clause must parse, got Unimplemented: {json}"
+        );
+        assert!(
+            json.contains("OnlyForTypeSpellsOrAbilities")
+                || json.contains("SpellTypeOrAbilityActivation"),
+            "the produced mana must carry the artifact-spells-or-ability restriction: {json}"
+        );
+        assert!(
+            json.contains("Artifact"),
+            "the restriction must name the Artifact spell type: {json}"
+        );
+    }
+
     /// CR 106.6: a bare "… or (to) activate an ability" suffix (no type qualifier)
     /// permits casting the named spell type OR activating *any* ability — the
     /// generic `AbilityActivationScope::Any` form (Sage of the Unknowable, Purple

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -1362,9 +1362,57 @@ fn split_restricted_spell_and_activation(rest: &str) -> (&str, ActivationTail) {
 /// - "spend this mana only to activate abilities" -> `ActivateOnly`
 ///
 /// Returns `(restriction, grants)` where grants are properties conferred to the spell.
+/// Capitalize the first ASCII letter (e.g. "artifact" -> "Artifact"), matching
+/// the casing of the core-type strings stored in `SpellMeta` (the spend-grant
+/// matcher compares case-insensitively, so this is for convention/consistency).
+fn capitalize_first_ascii(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
 pub(crate) fn parse_mana_spend_restriction(
     lower: &str,
 ) -> Option<(ManaSpendRestriction, Vec<ManaSpellGrant>)> {
+    // CR 106.6: negative form — "[this] mana can't be spent to cast non<TYPE>
+    // spells" (Karn, Legacy Reforged: "This mana can't be spent to cast
+    // nonartifact spells"). The mana may pay for <TYPE> spells, any ability, and
+    // any non-spell cost; only non-<TYPE> SPELLS are blocked — the same effective
+    // spend gate as "spend only to cast <TYPE> spells or activate any ability",
+    // so it maps to `SpellTypeOrAbilityActivation { <TYPE>, Any }`.
+    if let Some((_, after_non)) = nom_on_lower(lower, lower, |i| {
+        value(
+            (),
+            (
+                opt(alt((tag("this "), tag("that ")))),
+                alt((
+                    tag("mana can't be spent to cast non"),
+                    tag("mana cannot be spent to cast non"),
+                )),
+            ),
+        )
+        .parse(i)
+    }) {
+        let after_non = after_non.trim().trim_end_matches(['.', '"']).trim();
+        if let Some((type_word, _)) = nom_on_lower(after_non, after_non, |i| {
+            terminated(take_until(" spells"), tag(" spells"))
+                .map(|s: &str| s.trim().to_string())
+                .parse(i)
+        }) {
+            if !type_word.is_empty() {
+                return Some((
+                    ManaSpendRestriction::SpellTypeOrAbilityActivation {
+                        spell_type: capitalize_first_ascii(&type_word),
+                        ability: AbilityActivationScope::Any,
+                    },
+                    vec![],
+                ));
+            }
+        }
+    }
+
     let (_, base) = nom_on_lower(lower, lower, |i| {
         value((), tag("spend this mana only ")).parse(i)
     })?;

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -1563,6 +1563,47 @@ mod tests {
         assert!(!restriction.allows_activation(&["Creature".to_string()], &["Goblin".to_string()]));
     }
 
+    // CR 106.6: Karn, Legacy Reforged — "can't be spent to cast nonartifact
+    // spells" maps to `OnlyForTypeSpellsOrAbilities { Artifact, Any }`: an
+    // artifact spell is payable, a nonartifact spell is not, and ANY ability
+    // activation is payable.
+    #[test]
+    fn nonartifact_restriction_blocks_nonartifact_spells_allows_abilities() {
+        let restriction = ManaRestriction::OnlyForTypeSpellsOrAbilities {
+            spell_type: "Artifact".to_string(),
+            ability: AbilityActivationScope::Any,
+        };
+        let artifact_spell = SpellMeta {
+            types: vec!["Artifact".to_string()],
+            subtypes: vec![],
+            keyword_kinds: vec![],
+            cast_from_zone: None,
+            mana_value: None,
+            color_count: None,
+        };
+        let nonartifact_spell = SpellMeta {
+            types: vec!["Instant".to_string()],
+            subtypes: vec![],
+            keyword_kinds: vec![],
+            cast_from_zone: None,
+            mana_value: None,
+            color_count: None,
+        };
+        assert!(
+            restriction.allows_spell(&artifact_spell),
+            "an artifact spell must be castable with the restricted mana"
+        );
+        assert!(
+            !restriction.allows_spell(&nonartifact_spell),
+            "a nonartifact spell must NOT be castable with the restricted mana"
+        );
+        // `Any` permits activating an ability of any source.
+        assert!(
+            restriction.allows_activation(&["Creature".to_string()], &[]),
+            "any ability activation must be payable with the restricted mana"
+        );
+    }
+
     // CR 106.6: "Spend this mana only to cast Ninja spells" (Turtle Lair, issue
     // #3661) names a creature subtype. The restriction must match against
     // `SpellMeta.subtypes`, not only core types.


### PR DESCRIPTION
## What

"This mana can't be spent to cast nonartifact spells" (Karn, Legacy Reforged) lowered to `Effect::Unimplemented` — the spend-restriction parser only handled the positive "Spend this mana only to cast …" form.

## Fix

Add a negative-form branch to `parse_mana_spend_restriction`: "[this] mana can't be spent to cast non&lt;TYPE&gt; spells" → `ManaSpendRestriction::SpellTypeOrAbilityActivation { spell_type: <TYPE>, ability: Any }`.

This **reuses the existing resolution** (CR 106.6): `SpellTypeOrAbilityActivation` already lowers to `ManaRestriction::OnlyForTypeSpellsOrAbilities { spell_type, ability: Any }`, whose `allows_spell` (the spell must be the type) and `allows_activation` (`Any` ⇒ true) precisely implement "can't be spent to cast non&lt;TYPE&gt; spells": the mana may pay for &lt;TYPE&gt; spells, any ability, and any non-spell cost; only non-&lt;TYPE&gt; *spells* are blocked. No new `ManaRestriction` variant is needed (it would duplicate `OnlyForTypeSpellsOrAbilities`).

Generic over the type word ("nonartifact", "noncreature", …) and tolerant of the bare lead (no "this").

## Tests

- **Parser**: `parse_mana_spend_restriction("this mana can't be spent to cast nonartifact spells")` → `SpellTypeOrAbilityActivation { "Artifact", Any }` (and `noncreature` → `Creature`).
- **Integration**: Karn's full Oracle text parses with 0 `Unimplemented`, and the produced mana carries `OnlyForTypeSpellsOrAbilities { "Artifact", Any }`.
- **Behavioral**: that restriction's `allows_spell` blocks a nonartifact spell and permits an artifact spell; `allows_activation` permits any ability.

Closes #3893
