### PR TITLE
fix(parser): parse "remove one or more [type] counters" cost as chosen-X

### DIFF
--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -261,6 +261,17 @@ fn parse_remove_counter_quantity_and_kind(
     {
         return Some((REMOVE_COUNTER_COST_X, counter_type));
     }
+    // CR 107.3 + CR 601.2b: "one or more" counters is a player-chosen variable
+    // count (X), announced at activation; "that much" / "counters removed this
+    // way" then scale by the chosen value.
+    if let Ok((_, counter_type)) = all_consuming(preceded(
+        tag::<_, _, E<'_>>("one or more "),
+        parse_remove_counter_kind,
+    ))
+    .parse(input)
+    {
+        return Some((REMOVE_COUNTER_COST_X, counter_type));
+    }
     if let Ok((_, (count, counter_type))) = all_consuming(pair(
         terminated(nom_primitives::parse_number, tag::<_, _, E<'_>>(" ")),
         parse_remove_counter_kind,
@@ -1411,6 +1422,55 @@ mod tests {
             "'any number of' should be encoded separately from literal X"
         );
         assert!(matches!(counter_type, CounterMatch::OfType(_)));
+    }
+
+    // "Remove one or more [type] counters" is a player-chosen variable count
+    // (CR 107.3 / 601.2b), not a literal 1. Before the fix, parse_number ate
+    // "one" as 1 and "or more +1/+1" leaked into a Generic counter type.
+    #[test]
+    fn parse_remove_one_or_more_counters_uses_x_sentinel() {
+        let (count, counter_type) =
+            parse_remove_counter_quantity_and_kind("one or more +1/+1 counters")
+                .expect("should parse 'one or more' counter removal");
+
+        assert_eq!(
+            count, REMOVE_COUNTER_COST_X,
+            "'one or more' should be encoded as the X sentinel, not literal 1"
+        );
+        assert_eq!(
+            counter_type,
+            CounterMatch::OfType(crate::types::counter::CounterType::Plus1Plus1),
+            "counter type must be typed +1/+1, not Generic(\"or more +1/+1\")"
+        );
+    }
+
+    #[test]
+    fn parse_remove_one_or_more_generic_counters_uses_x_sentinel() {
+        let (count, counter_type) =
+            parse_remove_counter_quantity_and_kind("one or more charge counters")
+                .expect("should parse 'one or more' generic counter removal");
+
+        assert_eq!(count, REMOVE_COUNTER_COST_X);
+        assert_eq!(
+            counter_type,
+            CounterMatch::OfType(crate::types::counter::CounterType::Generic(
+                "charge".to_string()
+            )),
+        );
+    }
+
+    // No-regression: the new tag("one or more ") must NOT over-match a bare
+    // singular "one [type] counter", which is a literal count of 1.
+    #[test]
+    fn parse_remove_one_singular_counter_uses_literal_one() {
+        let (count, counter_type) = parse_remove_counter_quantity_and_kind("one +1/+1 counter")
+            .expect("should parse singular 'one' counter removal");
+
+        assert_eq!(count, 1, "bare 'one' is a literal count of 1");
+        assert_eq!(
+            counter_type,
+            CounterMatch::OfType(crate::types::counter::CounterType::Plus1Plus1),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3899.

## Summary

"Remove one or more [type] counters" activation costs mis-parsed — the counter type was corrupted into a stringly-typed value and the count was fixed at 1, instead of the player-chosen amount:

- **Simic Manipulator**, **Ooze Flux**, **Arcee, Sharpshooter** ("+1/+1"), **Jetfire, Ingenious Scientist** ("+1/+1"), **Rasputin, the Oneiromancer** (first ability, "dream").

Before: `RemoveCounter { count: 1, counter_type: OfType(Generic("or more +1/+1")) }`.

## Root cause

`parse_remove_counter_quantity_and_kind` had quantity arms for `all` / `any number of` / `x` / `<number>` but **no `one or more` arm**, so "one or more +1/+1 counters" fell to the numeric arm — `parse_number` consumed "one" as the literal `1`, and the leftover "or more +1/+1 counters" was shredded into the bogus counter kind.

## Fix (parser-AST-only; no new engine variant, no runtime change)

Add the missing sibling arm (after the `x ` arm, before the numeric arm) mapping "one or more `<kind>` counters" → `(REMOVE_COUNTER_COST_X, OfType(<typed>))`. The counter type is now recognized, and the count routes through the existing chosen-X runtime (the same path the `any number of` / `x` sibling costs use: prompts for the count, caps by available counters, feeds `EventContextAmount`, which the "deals that much damage" / "counters removed this way" effects read). CR 107.3 / 601.2b / 122.1.

Simic Manipulator, Ooze Flux, and Arcee become fully modeled. Rasputin's first ability and Jetfire have a separate pre-existing gap in their "add that much {C}" effect body that is unrelated to this cost (the cost is now correct either way).

## Tests

- Discriminating (fails on revert): `parse_remove_counter_quantity_and_kind("one or more +1/+1 counters")` → `(REMOVE_COUNTER_COST_X, OfType(Plus1Plus1))` — explicitly not `(1, OfType(Generic("or more +1/+1")))`. (Mentally reverting the arm yields `left: 1, right: 4294967295`.)
- Generic counter: "one or more charge counters" → `(X, OfType(Generic("charge")))`.
- No-regression: singular "one +1/+1 counter" still → `(1, Plus1Plus1)` (the new `tag("one or more ")` does not over-match bare "one"); all/any-number/x/numeric siblings unchanged.

## Verification

`cargo +nightly test -p engine` (all targets incl. `--test integration`): 12707 passed; the only failure was the pre-existing flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (global perf-counter race under parallel runs — confirmed passing in isolation, unrelated). `clippy -D warnings`, parser-combinator gate, rustfmt: clean. Per-card oracle-gen before/after confirms no coverage-honesty flip (the cost already parsed — only its payload quality changes).
