### PR TITLE
Add Energybending

### DIFF
--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -2184,6 +2184,115 @@ mod tests {
         )));
     }
 
+    /// CR 305.6 + CR 305.7 + CR 611.2a: Energybending end-to-end. Parsing the
+    /// full Oracle text and resolving the land-type clause against a Forest must
+    /// give that Forest all five basic land subtypes AND the intrinsic mana
+    /// ability for every color (CR 305.6). Drives the real parse → lower →
+    /// resolve → layer pipeline: the `GenericEffect { AddAllBasicLandTypes }`
+    /// over "lands you control" binds a transient continuous effect to the
+    /// Forest, and `apply_intrinsic_basic_land_mana_abilities` grants the five
+    /// `{T}: Add <color>` abilities during layer evaluation.
+    ///
+    /// Revert guard: without the parser change the land-type clause lowers to
+    /// `Effect::Unimplemented`, no GenericEffect is found, and the subtype /
+    /// per-color mana-ability assertions below all fail.
+    #[test]
+    fn energybending_grants_a_forest_all_basic_land_types_and_mana() {
+        use crate::game::layers::evaluate_layers;
+        use crate::parser::oracle::parse_oracle_text;
+        use crate::types::ability::{AbilityCost, AbilityKind, BasicLandType, ManaProduction};
+        use crate::types::mana::ManaColor;
+
+        let parsed = parse_oracle_text(
+            "Lands you control gain all basic land types until end of turn.\nDraw a card.",
+            "Energybending",
+            &[],
+            &["Sorcery".to_string()],
+            &[],
+        );
+        let land_type_effect = parsed
+            .abilities
+            .iter()
+            .map(|ability| (*ability.effect).clone())
+            .find(|effect| {
+                matches!(
+                    effect,
+                    Effect::GenericEffect { static_abilities, .. }
+                        if static_abilities.iter().any(|sd| sd
+                            .modifications
+                            .iter()
+                            .any(|m| matches!(m, ContinuousModification::AddAllBasicLandTypes)))
+                )
+            })
+            .expect("Energybending must lower to a GenericEffect adding all basic land types");
+
+        let mut state = GameState::new_two_player(42);
+        let p0 = PlayerId(0);
+
+        // A single basic Forest under the spell controller's control.
+        let forest = create_object(
+            &mut state,
+            CardId(0),
+            p0,
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let ts = state.next_timestamp();
+            let obj = state.objects.get_mut(&forest).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Forest".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+        }
+
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "Energybending".to_string(),
+            Zone::Stack,
+        );
+
+        let ability = ResolvedAbility::new(land_type_effect, vec![], source, p0);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        let obj = state.objects.get(&forest).unwrap();
+        for land_type in BasicLandType::all() {
+            let subtype = land_type.as_subtype_str().to_string();
+            assert!(
+                obj.card_types.subtypes.contains(&subtype),
+                "Forest must gain the {subtype} basic land type, got {:?}",
+                obj.card_types.subtypes
+            );
+        }
+
+        // CR 305.6: each basic land type grants its intrinsic `{T}: Add <color>`.
+        for color in ManaColor::ALL {
+            let count = obj
+                .abilities
+                .iter()
+                .filter(|a| {
+                    matches!(a.kind, AbilityKind::Activated)
+                        && matches!(a.cost, Some(AbilityCost::Tap))
+                        && matches!(
+                            &*a.effect,
+                            Effect::Mana {
+                                produced: ManaProduction::Fixed { colors, .. },
+                                ..
+                            } if colors.as_slice() == [color]
+                        )
+                })
+                .count();
+            assert_eq!(
+                count, 1,
+                "Forest must produce {color:?} via its intrinsic mana ability after gaining all basic land types"
+            );
+        }
+    }
+
     // ── Issue #444: in-effect "if" gate on GenericEffect StaticDefinitions ──
 
     use crate::game::layers::evaluate_layers;

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -654,6 +654,45 @@ fn parse_isnt_a_core_type(lower: &str) -> Option<CoreType> {
         .and_then(|(_, clause)| predicate(clause).ok().map(|(_, ct)| ct))
 }
 
+/// CR 305.6 + CR 305.7 + CR 205.3i: Recognize a "gain all basic land types" /
+/// "gain all land types" predicate (and the `has`/`have`/`are`/`is` copula
+/// variants) and map it to the matching all-land-type continuous modification.
+///
+/// `AddAllBasicLandTypes` adds the five basic land subtypes (Plains, Island,
+/// Swamp, Mountain, Forest — CR 305.6) in addition to a land's existing types;
+/// each grants its intrinsic mana ability per CR 305.6 / CR 305.7.
+/// `AddAllLandTypes` adds every one of the 17 land subtypes (CR 205.3i). Built
+/// for the whole "[lands you control] gain all basic land types until <duration>"
+/// class (Energybending), not a single card. The verb/copula is matched but
+/// otherwise discarded — the affected filter and duration are owned by the
+/// caller (`build_continuous_clause` / the static/anthem parsers).
+fn parse_all_land_types_modification(text: &str) -> Option<ContinuousModification> {
+    let lower = text.trim().trim_end_matches('.').trim().to_lowercase();
+    super::oracle_nom::bridge::nom_parse_lower(&lower, |i| {
+        let (i, _) = opt(alt((
+            tag::<_, _, OracleError<'_>>("gains "),
+            tag("gain "),
+            tag("has "),
+            tag("have "),
+            tag("are "),
+            tag("is "),
+        )))
+        .parse(i)?;
+        // Longer phrase first so "all basic land types" wins over "all land types".
+        all_consuming(alt((
+            value(
+                ContinuousModification::AddAllBasicLandTypes,
+                tag("all basic land types"),
+            ),
+            value(
+                ContinuousModification::AddAllLandTypes,
+                tag("all land types"),
+            ),
+        )))
+        .parse(i)
+    })
+}
+
 pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModification> {
     // Strip "where X is [quantity]" before parsing modifications,
     // but only if the text doesn't contain quoted abilities (which have their
@@ -678,6 +717,14 @@ pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModifi
     // it"), counter-gated, and battlefield sources stay a gap (follow-ups).
     if let Some(source) = parse_grant_all_activated_abilities_source(unquoted_tp.lower) {
         return vec![ContinuousModification::GrantAllActivatedAbilitiesOf { source }];
+    }
+
+    // CR 305.6 + CR 305.7 + CR 205.3i: "gain all basic land types" / "gain all
+    // land types" (and the copula variants) — the whole predicate maps to a
+    // single all-land-type modification. Checked early so the trailing "types"
+    // noun is never mistaken for a P/T or keyword token by the parsers below.
+    if let Some(modification) = parse_all_land_types_modification(unquoted_tp.original) {
+        return vec![modification];
     }
 
     let mut modifications = Vec::new();

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5108,6 +5108,108 @@ fn parse_continuous_modifications_grants_all_activated_abilities_of_exiled() {
     );
 }
 
+/// CR 305.6 + CR 305.7 + CR 205.3i: "gain all basic land types" (and the
+/// has/have/are/is copula variants) maps to `AddAllBasicLandTypes`; "gain all
+/// land types" maps to `AddAllLandTypes`. Building-block coverage for the whole
+/// "[lands you control] gain all basic land types until <duration>" class
+/// (Energybending), not a single card.
+#[test]
+fn parse_continuous_modifications_gain_all_basic_land_types() {
+    for predicate in [
+        "gain all basic land types",
+        "gains all basic land types",
+        "have all basic land types",
+        "has all basic land types",
+        "are all basic land types",
+        "is all basic land types",
+        "gain all basic land types.",
+    ] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![ContinuousModification::AddAllBasicLandTypes],
+            "predicate: {predicate}"
+        );
+    }
+
+    // CR 205.3i: the broader "all land types" form grants every land subtype.
+    for predicate in ["gain all land types", "have all land types"] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![ContinuousModification::AddAllLandTypes],
+            "predicate: {predicate}"
+        );
+    }
+
+    // Negative: a single named basic land type must NOT route through the
+    // all-types path (it is owned by the additive/replacement type parsers).
+    assert!(
+        !parse_continuous_modifications("gain all basic land types")
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::AddAllLandTypes)),
+        "'all basic land types' must not be widened to all 17 land types"
+    );
+}
+
+/// CR 305.6 + CR 611.2a: Energybending's full Oracle text — "Lands you control
+/// gain all basic land types until end of turn. Draw a card." — must parse with
+/// ZERO `Effect::Unimplemented`. The land-type clause lowers to a
+/// `GenericEffect { AddAllBasicLandTypes }` over "lands you control" for
+/// `UntilEndOfTurn`, with "Draw a card" chained as a `SequentialSibling`
+/// `Effect::Draw` sub-ability.
+#[test]
+fn energybending_full_oracle_has_no_unimplemented() {
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::{AbilityDefinition, Effect};
+
+    let parsed = parse_oracle_text(
+        "Lands you control gain all basic land types until end of turn.\nDraw a card.",
+        "Energybending",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+
+    // Walk the whole ability tree (each ability plus its sub_ability chain),
+    // since "Draw a card" is chained as a SequentialSibling under the land-type
+    // GenericEffect rather than appearing as a separate top-level ability.
+    fn walk<'a>(ability: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+        out.push(&ability.effect);
+        if let Some(sub) = &ability.sub_ability {
+            walk(sub, out);
+        }
+    }
+    let mut effects = Vec::new();
+    for ability in &parsed.abilities {
+        walk(ability, &mut effects);
+    }
+
+    for effect in &effects {
+        assert!(
+            !matches!(effect, Effect::Unimplemented { .. }),
+            "Energybending must not emit Effect::Unimplemented, got {effect:?}"
+        );
+    }
+    assert!(
+        effects.iter().any(|effect| matches!(
+            effect,
+            Effect::GenericEffect { static_abilities, .. }
+                if static_abilities.iter().any(|sd| sd
+                    .modifications
+                    .iter()
+                    .any(|m| matches!(m, ContinuousModification::AddAllBasicLandTypes)))
+        )),
+        "expected a GenericEffect adding all basic land types, got {:?}",
+        parsed.abilities
+    );
+    assert!(
+        effects
+            .iter()
+            .any(|effect| matches!(effect, Effect::Draw { .. })),
+        "expected a Draw effect, got {:?}",
+        parsed.abilities
+    );
+}
+
 #[test]
 fn static_pump_must_be_blocked_and_goaded_emits_all_defs() {
     let defs = parse_static_line_multi(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Implements **Energybending** end-to-end:

> Lands you control gain all basic land types until end of turn.
> Draw a card.

The land-type clause previously emitted `Effect::Unimplemented`. It now lowers to a `GenericEffect` that applies the existing `ContinuousModification::AddAllBasicLandTypes` to "lands you control" for `Duration::UntilEndOfTurn`. At resolution, the runtime binds one transient continuous effect per matching land; layer evaluation adds the five basic land subtypes (Plains, Island, Swamp, Mountain, Forest) and grants each land its intrinsic `{T}: Add <color>` mana ability (CR 305.6). "Draw a card" already parsed and chains as a `SequentialSibling` sub-ability.

No new engine variants were introduced — the change is a parser-only recognizer that reuses the existing `AddAllBasicLandTypes` / `AddAllLandTypes` continuous modifications and the existing one-shot `GenericEffect` + `add_transient_continuous_effect` machinery. Built for the whole class "[lands you control] gain all basic land types until \<duration\>", not the single card.

Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Files changed

- `crates/engine/src/parser/oracle_static/keyword_grant.rs` — new `parse_all_land_types_modification` nom combinator; recognizes "gain/gains/has/have/are/is all basic land types" → `AddAllBasicLandTypes` and "all land types" → `AddAllLandTypes`, wired as an early return in `parse_continuous_modifications`.
- `crates/engine/src/parser/oracle_static/tests.rs` — building-block parser tests (`parse_continuous_modifications_gain_all_basic_land_types`) and full-oracle zero-`Unimplemented` test (`energybending_full_oracle_has_no_unimplemented`).
- `crates/engine/src/game/effects/effect.rs` — runtime discriminating test (`energybending_grants_a_forest_all_basic_land_types_and_mana`): parses the real oracle text, resolves the GenericEffect against a Forest, asserts all five subtypes and all five colored mana abilities.

## CR references

- CR 305.6 — basic land types and their intrinsic mana abilities (`{T}: Add <color>`).
- CR 305.7 — a land that gains land types in addition to its own keeps its types and gains the new land types and mana abilities.
- CR 205.3i — the 17 land subtypes; the five basic land types among them.
- CR 611.2a — a continuous effect from a resolving spell lasts as stated (until end of turn).

## Track

Developer

## Verification

- `cargo fmt --all` — clean.
- `./scripts/check-parser-combinators.sh` — pass (exit 0).
- Parser diff gate (inline string-dispatch grep over added parser lines) — pass (no output).
- `cargo clippy -p engine --all-targets -- -D warnings` — clean.
- `cargo test -p engine` — 12602 passed; only the pre-existing known-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` failed (unrelated to this change).
- New tests: `parse_continuous_modifications_gain_all_basic_land_types`, `energybending_full_oracle_has_no_unimplemented`, `energybending_grants_a_forest_all_basic_land_types_and_mana` — all pass.
- `cargo coverage` / `cargo semantic-audit` not run: both require `data/card-data.json`, which is absent in this worktree (oracle-gen/gen-card-data are out of scope per the environment).

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
