### PR TITLE
Add Hustle

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -6430,6 +6430,78 @@ mod tests {
         );
     }
 
+    /// CR 508.1d + CR 509.1c: Hustle — "Target creature attacks or blocks this
+    /// turn if able." Drives the *full production parse* of Hustle's Oracle text
+    /// through `resolve` → transient continuous effect → `evaluate_layers` →
+    /// combat enforcement, and asserts BOTH the attack requirement (declaring no
+    /// attackers is illegal on the controller's turn) AND the block requirement
+    /// (declaring no blockers is illegal when the forced creature could block)
+    /// reach `combat.rs`.
+    ///
+    /// Revert-proof: on pre-change code the parser does not recognize "attacks or
+    /// blocks this turn if able" — the whole line lowers to `Effect::Unimplemented`,
+    /// the `let Effect::GenericEffect = ...` destructure panics, and neither
+    /// requirement is granted, so both `is_err()` assertions fail.
+    #[test]
+    fn hustle_attacks_or_blocks_reaches_combat_enforcement() {
+        use crate::game::effects::effect::resolve;
+        use crate::game::layers::evaluate_layers;
+        use crate::types::ability::{Duration, Effect, ResolvedAbility, TargetRef};
+
+        let mut state = setup_combat_phase();
+        // The forced creature is controlled by the same player that will declare
+        // attackers (PlayerId(0)); the spell caster is also PlayerId(0).
+        let forced = create_creature(&mut state, PlayerId(0), "Forced Soldier", 2, 2);
+
+        // Production parse of Hustle's full Oracle text — no hand-built effect.
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Target creature attacks or blocks this turn if able.",
+            "Hustle",
+            &[],
+            &["Instant".to_string()],
+            &[],
+        );
+        assert_eq!(parsed.abilities.len(), 1, "Hustle parses one spell ability");
+        let effect = (*parsed.abilities[0].effect).clone();
+        let Effect::GenericEffect { .. } = &effect else {
+            panic!("Hustle must parse to GenericEffect, got {effect:?}");
+        };
+
+        // Bind the spell to the chosen creature target; `affected: ParentTarget`
+        // resolves against `ability.targets` at registration time.
+        let ability =
+            ResolvedAbility::new(effect, vec![TargetRef::Object(forced)], forced, PlayerId(0))
+                .duration(Duration::UntilEndOfTurn);
+        resolve(&mut state, &ability, &mut Vec::new()).unwrap();
+        evaluate_layers(&mut state);
+
+        // CR 508.1d: declaring no attackers is illegal — the forced creature must attack.
+        assert!(
+            declare_attackers(&mut state, &[], &mut Vec::new()).is_err(),
+            "Hustle MustAttack must reach declare_attackers enforcement"
+        );
+
+        // CR 509.1c: now stage a block scenario. PlayerId(1) attacks PlayerId(0);
+        // the forced creature is an untapped, legal blocker, so declaring no
+        // blockers must be illegal.
+        let attacker = create_creature(&mut state, PlayerId(1), "Aggressor", 2, 2);
+        state.active_player = PlayerId(1);
+        state.phase = crate::types::phase::Phase::DeclareBlockers;
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(0))],
+            ..Default::default()
+        });
+        assert!(
+            validate_blockers(&state, &[]).is_err(),
+            "Hustle MustBlock must reach declare_blockers enforcement"
+        );
+        // Sanity: assigning the forced creature as a blocker satisfies the requirement.
+        assert!(
+            validate_blockers(&state, &[(forced, attacker)]).is_ok(),
+            "blocking the attacker should satisfy the MustBlock requirement"
+        );
+    }
+
     #[test]
     fn must_be_blocked_respects_flying_evasion() {
         // MustBeBlocked doesn't force illegal blocks: flying attacker can't be

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -8238,6 +8238,72 @@ mod tests {
         );
     }
 
+    /// CR 508.1d + CR 509.1c + CR 608.2c + CR 611.2c: Hustle —
+    /// "Target creature attacks or blocks this turn if able." The combined
+    /// requirement must bind BOTH a MustAttack and a MustBlock transient static
+    /// to the targeted creature (`affected == ParentTarget`), carry a typed
+    /// creature target, and emit ZERO `Unimplemented` effects. On reverted main
+    /// the "or blocks" conjunct is unrecognized and the whole line falls to
+    /// `Effect::Unimplemented`.
+    #[test]
+    fn hustle_attacks_or_blocks_this_turn_if_able_binds_both_requirements() {
+        use crate::types::ability::TargetFilter;
+        use crate::types::statics::StaticMode;
+
+        let r = parse(
+            "Target creature attacks or blocks this turn if able.",
+            "Hustle",
+            &[],
+            &["Instant"],
+            &[],
+        );
+        assert!(!r.abilities.is_empty(), "Hustle should parse an ability");
+
+        // No effect anywhere in the parsed abilities may be Unimplemented.
+        for ability in &r.abilities {
+            let mut node = Some(ability);
+            while let Some(d) = node {
+                assert!(
+                    !matches!(&*d.effect, Effect::Unimplemented { .. }),
+                    "Hustle must not emit Unimplemented, got {:?}",
+                    d.effect
+                );
+                node = d.sub_ability.as_deref();
+            }
+        }
+
+        let Effect::GenericEffect {
+            static_abilities,
+            target,
+            ..
+        } = &*r.abilities[0].effect
+        else {
+            panic!("Expected GenericEffect, got {:?}", r.abilities[0].effect);
+        };
+
+        assert!(
+            matches!(target, Some(TargetFilter::Typed(_))),
+            "Hustle must carry a typed creature target, got {target:?}"
+        );
+
+        // Both the attack requirement (CR 508.1d) and the block requirement
+        // (CR 509.1c) must be present, each bound to the chosen creature.
+        let has_must_attack = static_abilities.iter().any(|sd| {
+            sd.mode == StaticMode::MustAttack && sd.affected == Some(TargetFilter::ParentTarget)
+        });
+        let has_must_block = static_abilities.iter().any(|sd| {
+            sd.mode == StaticMode::MustBlock && sd.affected == Some(TargetFilter::ParentTarget)
+        });
+        assert!(
+            has_must_attack,
+            "Hustle must bind MustAttack to ParentTarget, got {static_abilities:?}"
+        );
+        assert!(
+            has_must_block,
+            "Hustle must bind MustBlock to ParentTarget, got {static_abilities:?}"
+        );
+    }
+
     #[test]
     fn no_maximum_hand_size_routes_to_static_parser() {
         let r = parse(

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -8934,13 +8934,17 @@ pub(super) fn must_attack_or_block_static_definitions() -> Vec<StaticDefinition>
 
 /// CR 508.1d / CR 509.1c: True iff `lower` (already lowercased, trimmed) is a
 /// recognized *standalone* combat requirement — "attack(s) [player] this
-/// turn/combat if able" or "must be blocked [this turn] [if able]". Used by
-/// `split_clause_sequence` to gate the trailing-conjunct split of
+/// turn/combat if able", "attack(s) or block(s) this turn/combat if able", or
+/// "must be blocked [this turn] [if able]". Used by `split_clause_sequence` to
+/// gate the trailing-conjunct split of
 /// "gains <keyword> until end of turn and <combat requirement>" so the
 /// requirement reaches its existing standalone parser. Composes the existing
 /// recognizers as Some/None classifiers; their produced AST is discarded.
 pub(crate) fn is_standalone_combat_requirement(lower: &str) -> bool {
     let trimmed = lower.trim().trim_end_matches('.').trim();
+    if try_parse_attack_or_block_if_able(trimmed).is_some() {
+        return true;
+    }
     if try_parse_attack_if_able(trimmed).is_some() {
         return true;
     }
@@ -12589,6 +12593,12 @@ mod tests {
         ));
         assert!(is_standalone_combat_requirement(
             "attacks this turn if able"
+        ));
+        assert!(is_standalone_combat_requirement(
+            "attacks or blocks this turn if able"
+        ));
+        assert!(is_standalone_combat_requirement(
+            "attack or block this combat if able"
         ));
         assert!(is_standalone_combat_requirement(
             "must be blocked this turn if able"

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6783,9 +6783,13 @@ pub(super) fn parse_imperative_family_ast(
             let is_other = ctx.subject.is_some();
             Some(ImperativeFamilyAst::Support { count, is_other })
         }
+        // CR 508.1d + CR 509.1c: "attacks or blocks this turn/combat if able" —
+        // combined forced attack-or-block requirement (Hustle). Tried before the
+        // plain attack recognizer since both share the "attacks" first word.
         // CR 508.1d: "attacks/attack this turn/combat if able" — forced attack requirement.
-        // CR 508.1d: "attacks/attack this turn/combat if able" — forced attack requirement.
-        "attacks" | "attack" => try_parse_attack_if_able(lower),
+        "attacks" | "attack" => {
+            try_parse_attack_or_block_if_able(lower).or_else(|| try_parse_attack_if_able(lower))
+        }
         // CR 509.1b / CR 508.1d: "can't be blocked [this turn]", "can't attack", etc.
         // These appear as subjectless clauses in compound effects (e.g., "gets +2/+0 and can't be blocked this turn").
         "can't" | "cannot" => try_parse_subjectless_cant(lower),
@@ -8828,6 +8832,59 @@ pub(super) fn try_parse_attack_if_able(lower: &str) -> Option<ImperativeFamilyAs
     None
 }
 
+/// CR 508.1d + CR 509.1c: Parse the combined "attacks or blocks ... if able"
+/// requirement (Hustle: "Target creature attacks or blocks this turn if able.").
+///
+/// This is the imperative one-shot analogue of the continuous "attacks or blocks
+/// each combat if able" static. It is the composition of an attack requirement
+/// (CR 508.1d) and a block requirement (CR 509.1c): the creature must attack if
+/// able during its controller's declare-attackers step, and must block if able
+/// during a later declare-blockers step. The combined form emits both
+/// `MustAttack` and `MustBlock` transient statics for the requested duration,
+/// mirroring the bare-form `try_parse_attack_if_able` `MustAttack` path.
+///
+/// Verb axis × phase axis: factor the "attack(s) or block(s)" verb pair out front
+/// (a single `alt()` over the conjugation variants), then map the phase clause to
+/// its duration. Bare/source-granted forms (empty subject) carry `target: None`;
+/// the targeted subject form binds the target via `subject.rs`.
+pub(super) fn try_parse_attack_or_block_if_able(lower: &str) -> Option<ImperativeFamilyAst> {
+    let trimmed = lower.trim_end_matches('.');
+
+    // Each verb's conjugation varies independently: the bare imperative path
+    // passes the raw text ("attacks or blocks …") while the subject path passes a
+    // predicate whose leading verb was already deconjugated ("attack or blocks
+    // …"). Match each verb with its own `alt()` so both arrive here.
+    let result: Result<(&str, Duration), nom::Err<OracleError<'_>>> = (
+        alt((tag("attacks"), tag("attack"))),
+        tag(" or "),
+        alt((tag("blocks"), tag("block"))),
+        preceded(
+            tag(" "),
+            alt((
+                value(Duration::UntilEndOfTurn, tag("this turn if able")),
+                value(
+                    Duration::UntilEndOfCombat,
+                    alt((tag("this combat if able"), tag("that combat if able"))),
+                ),
+            )),
+        ),
+    )
+        .map(|(_, _, _, duration)| duration)
+        .parse(trimmed);
+
+    if let Ok((rest, duration)) = result {
+        if rest.is_empty() {
+            return Some(ImperativeFamilyAst::GainKeyword(Effect::GenericEffect {
+                static_abilities: must_attack_or_block_static_definitions(),
+                duration: Some(duration),
+                target: None,
+            }));
+        }
+    }
+
+    None
+}
+
 /// CR 508.1d: Build the `StaticDefinition` for a transient "attacks if able"
 /// requirement. `Effect::GenericEffect` resolution snapshots only
 /// `static_def.modifications` (the `mode` field is inert for a transient grant —
@@ -8842,6 +8899,37 @@ pub(super) fn must_attack_static_definition() -> StaticDefinition {
             mode: StaticMode::MustAttack,
         },
     ])
+}
+
+/// CR 509.1c: Build the `StaticDefinition` for a transient "blocks if able"
+/// requirement. Mirrors [`must_attack_static_definition`]: the `MustBlock` mode
+/// must be carried by an explicit `AddStaticMode` modification so the transient
+/// `Effect::GenericEffect` grant reaches the layer system and `combat.rs`
+/// declare-blockers enforcement (the `mode` field on `StaticDefinition` is inert
+/// for transient grants — `snapshot_transient_modifications` reads only
+/// `modifications`).
+pub(super) fn must_block_static_definition() -> StaticDefinition {
+    use crate::types::statics::StaticMode;
+    StaticDefinition::new(StaticMode::MustBlock).modifications(vec![
+        ContinuousModification::AddStaticMode {
+            mode: StaticMode::MustBlock,
+        },
+    ])
+}
+
+/// CR 508.1d + CR 509.1c: Build both static definitions for the combined
+/// "attacks or blocks ... if able" requirement (Hustle). The requirement is the
+/// composition of an attack requirement (CR 508.1d, obeyed during the
+/// controller's declare-attackers step) and a block requirement (CR 509.1c,
+/// obeyed during a later declare-blockers step) — each is checked independently
+/// at its own step, exactly as the continuous "attacks or blocks each combat if
+/// able" static (`try_parse_scoped_must_attack_block`) emits both
+/// `MustAttack` and `MustBlock`.
+pub(super) fn must_attack_or_block_static_definitions() -> Vec<StaticDefinition> {
+    vec![
+        must_attack_static_definition(),
+        must_block_static_definition(),
+    ]
 }
 
 /// CR 508.1d / CR 509.1c: True iff `lower` (already lowercased, trimmed) is a

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -454,6 +454,35 @@ fn try_parse_subject_restriction_clause(
     if let Some(verb_start) = find_predicate_start(text) {
         let subject = text[..verb_start].trim();
         let predicate = deconjugate_verb(text[verb_start..].trim());
+        // CR 508.1d + CR 509.1c: "[subject] attacks or blocks this turn/combat if
+        // able" (Hustle) — the combined requirement re-binds BOTH MustAttack and
+        // MustBlock statics to the subject. Tried before the plain attack
+        // recognizer since both share the "attacks" verb prefix; the combined
+        // form is the strict superset and must win.
+        if let Some(ImperativeFamilyAst::GainKeyword(Effect::GenericEffect { duration, .. })) =
+            imperative::try_parse_attack_or_block_if_able(&predicate)
+        {
+            let application = parse_subject_application(subject, ctx)?;
+            let affected = static_affected_for_application(&application);
+            let static_abilities = imperative::must_attack_or_block_static_definitions()
+                .into_iter()
+                .map(|def| def.affected(affected.clone()))
+                .collect();
+            return Some(ParsedEffectClause {
+                effect: Effect::GenericEffect {
+                    static_abilities,
+                    duration: duration.clone(),
+                    target: application.target,
+                },
+                distribute: None,
+                multi_target: application.multi_target,
+                duration,
+                sub_ability: None,
+                condition: None,
+                optional: application.is_optional,
+                unless_pay: None,
+            });
+        }
         // Classify via the existing recognizer. Only the bare GenericEffect form
         // (MustAttack) is re-bound here; the player-bound `ForceAttack` form
         // ("attacks you/that player …") has its own targeted handling and must


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Implements **Hustle** — "Target creature attacks or blocks this turn if able." — end-to-end in the engine.

Hustle is the imperative one-shot form of the combined attack-or-block requirement. Per CR 508.1d (attack requirements) and CR 509.1c (block requirements), "attacks or blocks ... if able" is the composition of an attack requirement (obeyed during the controller's declare-attackers step) and a block requirement (obeyed during a later declare-blockers step), each checked independently at its own step. This is exactly how the existing continuous "attacks or blocks each combat if able" static is modeled (`try_parse_scoped_must_attack_block` emits `[MustAttack, MustBlock]`); this PR adds the one-shot, targeted "this turn / this combat" analogue and builds it for the whole "attacks or blocks ... if able" class, not just this card.

No new engine variants: the change reuses `Effect::GenericEffect`, `StaticMode::MustAttack`, and `StaticMode::MustBlock`, binding both transient statics to the chosen creature via `affected: ParentTarget` (mirroring the existing single-requirement "Target creature attacks this turn if able" path).

Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Files changed

- `crates/engine/src/parser/oracle_effect/imperative.rs` — new combinator recognizer `try_parse_attack_or_block_if_able` (verb-pair × phase axis, nom only); new `must_block_static_definition` and `must_attack_or_block_static_definitions` building-block helpers; bare-imperative dispatch now tries the combined form before the plain attack form.
- `crates/engine/src/parser/oracle_effect/subject.rs` — subject-form arm re-binds BOTH MustAttack and MustBlock to the targeted creature for "[subject] attacks or blocks ... if able" (tried before the plain attack recognizer; combined form is the strict superset).
- `crates/engine/src/parser/oracle.rs` — parser test asserting Hustle parses to a `GenericEffect` carrying MustAttack + MustBlock both bound to `ParentTarget`, a typed creature target, and ZERO `Unimplemented`.
- `crates/engine/src/game/combat.rs` — runtime discriminating test driving the full production parse through `resolve` → `evaluate_layers` → combat enforcement; asserts both attack and block requirements reach `combat.rs`.

## CR references

- CR 508.1d — attack requirements ("a creature attacks if able"); the MustAttack half of the combined requirement.
- CR 509.1c — block requirements ("a creature must block"); the MustBlock half.
- CR 608.2c — one-shot resolution/anaphora binding (the chosen target).
- CR 611.2c — continuous-effect affected-set determined when the effect begins (per-target SpecificObject TCE via `ParentTarget`).

## Track

Developer

## Verification

- `cargo fmt --all` — clean.
- `./scripts/check-parser-combinators.sh` — pass (exit 0).
- Parser diff gate (inline grep for string-dispatch on added parser lines) — pass (no output).
- `cargo clippy -p engine --all-targets -- -D warnings` — clean.
- `cargo test -p engine` — 12601 passed, 1 failed. The only failure is the pre-existing known-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (a state-clone-count assertion unrelated to combat/parser).
- Both new tests pass:
  - `parser::oracle::tests::hustle_attacks_or_blocks_this_turn_if_able_binds_both_requirements`
  - `game::combat::tests::hustle_attacks_or_blocks_reaches_combat_enforcement`
- `cargo semantic-audit` / `cargo coverage` — not runnable in this isolated worktree (require `client/public/card-data.json` / `data/mtgjson`, which are gitignored and absent; tool binaries compile clean).

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
