### PR TITLE
feat(parser): support passive-voice '{X} in mana cost' casting prohibition

### DIFF
--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -1059,35 +1059,35 @@ pub(crate) fn parse_passive_cant_be_cast(tp: &str, text: &str) -> Option<StaticD
     // printed mana cost contains an {X} symbol. Combines an optional type prefix
     // ("noncreature") with the `HasXInManaCost` filter property. Resolved at cast
     // time by `cant_cast_filter_matches` → `SpellCastRecord.has_x_in_cost`.
-    // allow-noncombinator: pre-tokenized suffix-stripped chunk, not raw Oracle dispatch
-    if let Some(pos) = before_cant.find(" spells with {x} in ") {
-        // Validate the post-prefix modifier is exactly "their mana cost(s)" with
-        // no trailing riders. Reject compound qualifiers (e.g. "...and mana value
-        // 3 or less") so they stay deferred rather than silently dropped.
-        let after_x = &before_cant[pos + " spells with {x} in ".len()..];
-        let after_x_trimmed = after_x.trim().trim_end_matches('.');
-        if after_x_trimmed != "their mana costs" && after_x_trimmed != "their mana cost" {
-            // Unrecognized suffix — bail so the card stays deferred.
-        } else {
-            let type_text = &before_cant[..pos];
-            let (filter, remainder) = parse_type_phrase(type_text);
-            if remainder.trim().is_empty() {
-                // Only accept Typed filters with concrete type_filters; reject
-                // unsupported shapes (AnyOf, bare Any) to avoid silently broadening
-                // the prohibition scope.
-                let tf = match filter {
-                    TargetFilter::Typed(tf) if !tf.type_filters.is_empty() => tf,
-                    _ => return None,
-                };
-                let tf = tf.properties(vec![FilterProp::HasXInManaCost]);
-                return Some(
-                    StaticDefinition::new(StaticMode::CantBeCast {
-                        who: ProhibitionScope::AllPlayers,
-                    })
-                    .affected(TargetFilter::Typed(tf))
-                    .description(text.to_string()),
-                );
-            }
+    fn parse_passive_x_mana_cost_prefix(input: &str) -> OracleResult<'_, &str> {
+        let (input, type_text) = terminated(
+            take_until(" spells with {x} in "),
+            tag(" spells with {x} in "),
+        )
+        .parse(input)?;
+        let (input, _) = alt((tag("their mana costs"), tag("their mana cost"))).parse(input)?;
+        let (input, _) = opt(tag(".")).parse(input)?;
+        let (input, _) = eof(input)?;
+        Ok((input, type_text))
+    }
+    if let Ok((_, type_text)) = parse_passive_x_mana_cost_prefix(before_cant) {
+        let (filter, remainder) = parse_type_phrase(type_text);
+        if remainder.trim().is_empty() {
+            // Only accept Typed filters with concrete type_filters; reject
+            // unsupported shapes (AnyOf, bare Any) to avoid silently broadening
+            // the prohibition scope.
+            let tf = match filter {
+                TargetFilter::Typed(tf) if !tf.type_filters.is_empty() => tf,
+                _ => return None,
+            };
+            let tf = tf.properties(vec![FilterProp::HasXInManaCost]);
+            return Some(
+                StaticDefinition::new(StaticMode::CantBeCast {
+                    who: ProhibitionScope::AllPlayers,
+                })
+                .affected(TargetFilter::Typed(tf))
+                .description(text.to_string()),
+            );
         }
     }
 

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -1054,6 +1054,43 @@ pub(crate) fn parse_passive_cant_be_cast(tp: &str, text: &str) -> Option<StaticD
         );
     }
 
+    // --- "[Type] spells with {X} in their mana costs can't be cast" (passive voice) ---
+    // CR 101.2 + CR 107.3: Gaddock Teeg class — prohibits casting spells whose
+    // printed mana cost contains an {X} symbol. Combines an optional type prefix
+    // ("noncreature") with the `HasXInManaCost` filter property. Resolved at cast
+    // time by `cant_cast_filter_matches` → `SpellCastRecord.has_x_in_cost`.
+    // allow-noncombinator: pre-tokenized suffix-stripped chunk, not raw Oracle dispatch
+    if let Some(pos) = before_cant.find(" spells with {x} in ") {
+        // Validate the post-prefix modifier is exactly "their mana cost(s)" with
+        // no trailing riders. Reject compound qualifiers (e.g. "...and mana value
+        // 3 or less") so they stay deferred rather than silently dropped.
+        let after_x = &before_cant[pos + " spells with {x} in ".len()..];
+        let after_x_trimmed = after_x.trim().trim_end_matches('.');
+        if after_x_trimmed != "their mana costs" && after_x_trimmed != "their mana cost" {
+            // Unrecognized suffix — bail so the card stays deferred.
+        } else {
+            let type_text = &before_cant[..pos];
+            let (filter, remainder) = parse_type_phrase(type_text);
+            if remainder.trim().is_empty() {
+                // Only accept Typed filters with concrete type_filters; reject
+                // unsupported shapes (AnyOf, bare Any) to avoid silently broadening
+                // the prohibition scope.
+                let tf = match filter {
+                    TargetFilter::Typed(tf) if !tf.type_filters.is_empty() => tf,
+                    _ => return None,
+                };
+                let tf = tf.properties(vec![FilterProp::HasXInManaCost]);
+                return Some(
+                    StaticDefinition::new(StaticMode::CantBeCast {
+                        who: ProhibitionScope::AllPlayers,
+                    })
+                    .affected(TargetFilter::Typed(tf))
+                    .description(text.to_string()),
+                );
+            }
+        }
+    }
+
     // --- "Spells with the chosen name can't be cast" (passive voice) ---
     // CR 101.2 + CR 201.2: the name-lock hatebears — Meddling Mage, Nevermore,
     // Voidstone Gargoyle. The active-voice equivalent ("[subject] can't cast

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -12401,6 +12401,34 @@ fn cant_cast_spells_with_chosen_name_parenthetical() {
     assert_eq!(def.affected, Some(TargetFilter::HasChosenName));
 }
 
+/// CR 101.2 + CR 107.3: Gaddock Teeg class — passive-voice prohibition on
+/// spells with {X} in their mana cost. Combines a type prefix ("noncreature")
+/// with `HasXInManaCost`. The engine enforces this via `cant_cast_filter_matches`
+/// → `SpellCastRecord.has_x_in_cost`.
+#[test]
+fn passive_noncreature_spells_with_x_in_mana_cost_cant_be_cast() {
+    let def = parse_static_line("Noncreature spells with {X} in their mana costs can't be cast.")
+        .unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::CantBeCast {
+            who: ProhibitionScope::AllPlayers,
+        }
+    );
+    let Some(TargetFilter::Typed(tf)) = &def.affected else {
+        panic!("expected Typed filter, got {:?}", def.affected);
+    };
+    assert!(
+        tf.type_filters
+            .contains(&TypeFilter::Non(Box::new(TypeFilter::Creature))),
+        "expected noncreature type filter, got {tf:?}"
+    );
+    assert!(
+        tf.properties.contains(&FilterProp::HasXInManaCost),
+        "expected HasXInManaCost property, got {tf:?}"
+    );
+}
+
 // CR 201.3 / CR 113.6: Petrified Hamlet — "Lands with the chosen name
 // have \"{T}: Add {C}.\"" grants a quoted mana ability to every land
 // whose name matches the CardName persisted on the source by the


### PR DESCRIPTION
## Summary

Adds parser support for the passive-voice "{X} in mana cost" casting prohibition pattern, enabling Gaddock Teeg's second ability: "Noncreature spells with {X} in their mana costs can't be cast."

## Root Cause

The engine already enforces `HasXInManaCost` via `cant_cast_filter_matches` → `SpellCastRecord.has_x_in_cost` (used by cost-reduction and trigger paths). The gap was purely in the static-ability parser: `parse_passive_cant_be_cast` had no branch recognizing the passive-voice `"[Type] spells with {X} in their mana costs can't be cast"` shape.

## Changes

- `crates/engine/src/parser/oracle_static/restriction.rs`: New branch in `parse_passive_cant_be_cast` that detects `" spells with {x} in "` in the pre-tokenized, suffix-stripped chunk, extracts the optional type prefix via `parse_type_phrase`, and emits `CantBeCast{AllPlayers}` with `affected = Typed(type_filter + HasXInManaCost)`.

- `crates/engine/src/parser/oracle_static/tests.rs`: New test `cant_cast_noncreature_spells_with_x_in_mana_cost` asserting the full round-trip: Oracle text → `StaticMode::CantBeCast{AllPlayers}` with `affected = Typed(Non(Creature) + HasXInManaCost)`.

## CR References (grep-verified)

- **CR 101.2**: Effects that prohibit casting apply to all players unless scoped
- **CR 107.3**: The {X} symbol in a mana cost represents a variable amount

## Class Coverage

This covers the Gaddock Teeg class. Siblings with the same passive-voice `{X}` prohibition shape: none currently printed (Gaddock Teeg is unique). The active-voice `{X}` filter (`HasXInManaCost`) is already used by cost-reduction (Goblin Electromancer family) and trigger conditions.

## Card Data Impact

Gaddock Teeg moves from 1-gap (`static_structure`) to fully parsed. The Card data CI job confirms the card now parses without gaps.
