### PR TITLE
Add Gallant Fowlknight

### DIFF
--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -1634,6 +1634,121 @@ mod tests {
             .contains(&Keyword::Flying));
     }
 
+    /// CR 608.2c + CR 611.2a + CR 702.7: Gallant Fowlknight ETB end-to-end —
+    /// "creatures you control get +1/+0 until end of turn. Kithkin creatures you
+    /// control also gain first strike until end of turn." After resolving the
+    /// full parsed chain (PumpAll + the subtype-filtered first-strike grant)
+    /// through the production effect resolver and layer evaluation, BOTH
+    /// controlled creatures gain +1/+0, but ONLY the Kithkin gains first strike.
+    /// Reverting `strip_trailing_additive_adverb` drops the second sentence to
+    /// `Effect::Unimplemented`, leaving the non-Kithkin and the Kithkin alike
+    /// without first strike — the Kithkin first-strike assertion then fails.
+    #[test]
+    fn gallant_fowlknight_first_strike_only_on_kithkin_after_resolution() {
+        use crate::game::layers::evaluate_layers;
+        use crate::parser::oracle_effect::parse_effect_chain;
+        use crate::types::ability::AbilityKind;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Gallant Fowlknight".to_string(),
+            Zone::Battlefield,
+        );
+        let kithkin = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Kithkin Ally".to_string(),
+            Zone::Battlefield,
+        );
+        let non_kithkin = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Plain Bear".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [kithkin, non_kithkin] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+        }
+        // Only the first creature is a Kithkin.
+        state
+            .objects
+            .get_mut(&kithkin)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Kithkin".to_string());
+
+        // Parse the real ETB effect body (the two chained sentences).
+        let parsed = parse_effect_chain(
+            "creatures you control get +1/+0 until end of turn. Kithkin creatures \
+             you control also gain first strike until end of turn.",
+            AbilityKind::Spell,
+        );
+
+        // Resolve every clause in the chain through the production resolver.
+        let mut node: Option<&crate::types::ability::AbilityDefinition> = Some(&parsed);
+        let mut resolved_any_unimplemented = false;
+        while let Some(def) = node {
+            if matches!(*def.effect, Effect::Unimplemented { .. }) {
+                resolved_any_unimplemented = true;
+            }
+            let ability = ResolvedAbility::new((*def.effect).clone(), vec![], source, PlayerId(0))
+                .duration(def.duration.clone().unwrap_or(Duration::UntilEndOfTurn));
+            let mut events = Vec::new();
+            // Drive through the top-level effect dispatcher so `PumpAll` routes to
+            // `pump::resolve_all` and the `GenericEffect` first-strike grant
+            // routes to `effect::resolve` — the same dispatch the stack uses.
+            crate::game::effects::resolve_effect(&mut state, &ability, &mut events).unwrap();
+            node = def.sub_ability.as_deref();
+        }
+        assert!(
+            !resolved_any_unimplemented,
+            "the parsed chain must not contain Unimplemented clauses"
+        );
+
+        evaluate_layers(&mut state);
+
+        // Both controlled creatures gain +1/+0 from the PumpAll clause.
+        assert_eq!(
+            state.objects.get(&kithkin).unwrap().power,
+            Some(3),
+            "Kithkin must get +1/+0"
+        );
+        assert_eq!(
+            state.objects.get(&non_kithkin).unwrap().power,
+            Some(3),
+            "non-Kithkin must also get +1/+0"
+        );
+
+        // Only the Kithkin gains first strike from the subtype-filtered grant.
+        assert!(
+            state
+                .objects
+                .get(&kithkin)
+                .unwrap()
+                .has_keyword(&Keyword::FirstStrike),
+            "Kithkin must gain first strike"
+        );
+        assert!(
+            !state
+                .objects
+                .get(&non_kithkin)
+                .unwrap()
+                .has_keyword(&Keyword::FirstStrike),
+            "non-Kithkin must NOT gain first strike"
+        );
+    }
+
     // CR 305.1 + CR 611.1 + CR 611.2c + CR 115.1: A `GenericEffect` whose target
     // slot resolves to a player (Pardic Miner: "Target player can't play lands
     // this turn") must register a transient continuous effect bound to

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -17455,6 +17455,85 @@ mod tests {
         }
     }
 
+    /// CR 608.2c + CR 611.2a + CR 702.7: Gallant Fowlknight's ETB — the
+    /// pump's "also gain first strike" continuation on a subtype-filtered
+    /// controlled set ("Kithkin creatures you control also gain first strike
+    /// until end of turn") must parse end-to-end with ZERO `Unimplemented`. The
+    /// chain must carry both the all-creatures `PumpAll` and a
+    /// `GenericEffect { AddKeyword(FirstStrike) }` whose `affected` filter is
+    /// restricted to Kithkin creatures you control. Reverting the additive-"also"
+    /// strip in `strip_trailing_additive_adverb` regresses the second sentence to
+    /// an unimplemented "kithkin" effect and fails the zero-unimpl walk.
+    #[test]
+    fn gallant_fowlknight_subtype_also_grant_parses_without_unimplemented() {
+        let oracle = "When this creature enters, creatures you control get +1/+0 \
+                      until end of turn. Kithkin creatures you control also gain \
+                      first strike until end of turn.";
+        let parsed = parse(
+            oracle,
+            "Gallant Fowlknight",
+            &[],
+            &["Creature"],
+            &["Kithkin"],
+        );
+
+        let etb = parsed
+            .triggers
+            .iter()
+            .find_map(|t| t.execute.as_deref())
+            .expect("ETB trigger must carry an execute chain");
+
+        // Walk the whole effect chain collecting every effect node.
+        let mut effects: Vec<&Effect> = Vec::new();
+        let mut node = Some(etb);
+        while let Some(d) = node {
+            assert!(
+                !matches!(*d.effect, Effect::Unimplemented { .. }),
+                "Gallant Fowlknight chain must have no Unimplemented, got {:?}",
+                d.effect
+            );
+            effects.push(&d.effect);
+            node = d.sub_ability.as_deref();
+        }
+
+        // First clause: pump every creature you control +1/+0.
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::PumpAll { power, .. } if *power == PtValue::Fixed(1))),
+            "expected a PumpAll(+1/+0) clause, got {effects:?}"
+        );
+
+        // Second clause: first strike grant restricted to Kithkin creatures you control.
+        let first_strike_grant = effects.iter().find_map(|e| match e {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => static_abilities.iter().find(|sd| {
+                sd.modifications
+                    .contains(&ContinuousModification::AddKeyword {
+                        keyword: Keyword::FirstStrike,
+                    })
+            }),
+            _ => None,
+        });
+        let grant = first_strike_grant.unwrap_or_else(|| {
+            panic!("expected a GenericEffect granting first strike, got {effects:?}")
+        });
+        let Some(TargetFilter::Typed(tf)) = &grant.affected else {
+            panic!(
+                "first strike grant must carry a Typed affected filter, got {:?}",
+                grant.affected
+            );
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::You), "{tf:?}");
+        assert!(tf.type_filters.contains(&TypeFilter::Creature), "{tf:?}");
+        assert!(
+            tf.type_filters
+                .contains(&TypeFilter::Subtype("Kithkin".to_string())),
+            "first strike grant must be restricted to Kithkin, got {tf:?}"
+        );
+    }
+
     /// hand-grant line through the full `parse_oracle_text` pipeline.
     #[test]
     fn hand_grant_reaches_statics_through_full_pipeline() {

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -24,6 +24,7 @@ use crate::types::phase::Phase;
 use crate::types::statics::{ProhibitionScope, StaticMode};
 
 use super::super::oracle_keyword::parse_keyword_from_oracle;
+use super::super::oracle_nom::bridge::nom_on_lower;
 use super::super::oracle_nom::duration::parse_duration;
 use super::super::oracle_nom::error::OracleResult;
 use super::super::oracle_nom::primitives as nom_primitives;
@@ -172,7 +173,12 @@ where
 
 fn extract_subject_text(text: &str) -> Option<String> {
     let verb_start = find_predicate_start(text)?;
-    let subject = text[..verb_start].trim();
+    // CR 608.2c: drop the additive "also" connector (see
+    // `strip_trailing_additive_adverb`) so the re-extracted subject phrase used
+    // by `subject_predicate_ast_from_clause` matches the one parsed inside
+    // `try_parse_subject_continuous_clause`. Without this the AST subject falls
+    // back to `TargetFilter::Any` (broadcasting the grant to every permanent).
+    let subject = strip_trailing_additive_adverb(text[..verb_start].trim());
     if subject.is_empty() {
         None
     } else {
@@ -254,7 +260,17 @@ fn try_parse_subject_continuous_clause(
     ctx: &mut ParseContext,
 ) -> Option<ParsedEffectClause> {
     let verb_start = find_predicate_start(text)?;
-    let subject = text[..verb_start].trim();
+    // CR 608.2c: An additive "also" sitting between a filter subject and its
+    // continuous verb ("Kithkin creatures you control *also* gain first strike
+    // until end of turn") is a natural-language connector with no semantic
+    // weight — it chains this grant onto a preceding effect (the pump in
+    // "creatures you control get +1/+0 ... . <subtype> creatures you control
+    // also gain <keyword> ..."). Strip it so the residual filter subject routes
+    // through the standard subject grammar; without the strip the trailing
+    // "also" leaks into `parse_target`, which rejects the subject and drops the
+    // whole grant to `Effect::Unimplemented`. Mirrors the self-ref additive
+    // strip in `parse_effect_clause_inner` ("~ also gains ...").
+    let subject = strip_trailing_additive_adverb(text[..verb_start].trim());
     let predicate = text[verb_start..].trim();
     // CR 109.5: "you" as a player subject never participates in continuous-
     // clause parsing — the predicate is always an imperative effect (draw,
@@ -3745,6 +3761,38 @@ pub(crate) const PREDICATE_VERBS: &[&str] = &[
     "win",
 ];
 
+/// CR 608.2c: Strip a trailing additive "also" connector from a filter-subject
+/// phrase. In a chained grant ("<subject> also gain <keyword> ...") the "also"
+/// is the additive adverb linking this continuous effect to a sibling clause and
+/// carries no selection semantics. `find_predicate_start` lands the verb split
+/// after the "also", so the residual subject is "<filter> also"; left intact the
+/// trailing word leaks into `parse_target` and fails the subject match. Returns
+/// the subject unchanged when no additive "also" is present, or when the head is
+/// empty (a bare "also" has no filter to grant against).
+///
+/// Pattern 2a (`oracle_nom/PATTERNS.md`): the whole subject is parsed and the
+/// fixed suffix is consumed last. `all_consuming` anchors " also" to the END, so
+/// a non-terminal "also" (e.g. "also creatures you control") is not matched. The
+/// lowercase head's byte length maps 1:1 onto `subject` for case preservation.
+fn strip_trailing_additive_adverb(subject: &str) -> &str {
+    let lower = subject.to_lowercase();
+    // Return the head's byte length (not a borrow of the temporary `lower`) so the
+    // closure result is owned; map it back onto `subject` for case preservation.
+    let parsed = nom_on_lower(subject, &lower, |input| {
+        all_consuming(terminated(
+            map(take_until::<_, _, OracleError<'_>>(" also"), str::len),
+            tag(" also"),
+        ))
+        .parse(input)
+    });
+    match parsed {
+        Some((head_len, _)) if !subject[..head_len].trim_end().is_empty() => {
+            subject[..head_len].trim_end()
+        }
+        _ => subject,
+    }
+}
+
 fn is_restriction_predicate_verb(token: &str) -> bool {
     // CR 613.1d: "isn't"/"aren't" head a layer-4 type-removal predicate ("~ isn't
     // a creature until end of turn", Blink's Alien Angel token). Recognizing the
@@ -3863,6 +3911,36 @@ mod tests {
     fn become_named_plain_captures_full_name() {
         let (_, name) = strip_become_name_override("becomes a creature named Serra Angel");
         assert_eq!(name.as_deref(), Some("Serra Angel"));
+    }
+
+    /// CR 608.2c: the additive-"also" strip is a building block — it removes the
+    /// trailing connector for any filter subject, is case-insensitive, leaves
+    /// non-additive subjects untouched, and refuses to strip a bare "also" that
+    /// would leave no filter.
+    #[test]
+    fn strip_trailing_additive_adverb_building_block() {
+        // Trailing additive "also" is stripped, original case preserved.
+        assert_eq!(
+            strip_trailing_additive_adverb("Kithkin creatures you control also"),
+            "Kithkin creatures you control"
+        );
+        // Case-insensitive on the connector.
+        assert_eq!(
+            strip_trailing_additive_adverb("Goblins you control ALSO"),
+            "Goblins you control"
+        );
+        // No trailing "also" → unchanged.
+        assert_eq!(
+            strip_trailing_additive_adverb("creatures you control"),
+            "creatures you control"
+        );
+        // A non-terminal "also" is not a trailing connector → unchanged.
+        assert_eq!(
+            strip_trailing_additive_adverb("also creatures you control"),
+            "also creatures you control"
+        );
+        // Bare "also" has no filter to grant against → not stripped to empty.
+        assert_eq!(strip_trailing_additive_adverb("also"), "also");
     }
 
     /// CR 702.3b: the subjectless conjunct recognizer accepts every grammatical


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary
Parse the "also gain <keyword>" continuation of Gallant Fowlknight's ETB: a subtype-filtered, controlled-set, until-end-of-turn keyword grant chained from a pump via "also". Builds for the class "<subject> creatures you control also gain <keyword> until end of turn", not just this card.

Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Files changed
- `crates/engine/src/parser/oracle_effect/subject.rs` — new `strip_trailing_additive_adverb` building block (nom Pattern 2a); applied in `try_parse_subject_continuous_clause` and `extract_subject_text` so a trailing additive "also" between a filter subject and its continuous verb is dropped (CR 608.2c). Plus a building-block unit test.
- `crates/engine/src/parser/oracle.rs` — full-pipeline parser regression test: Gallant Fowlknight parses with zero `Unimplemented`; the chain carries `PumpAll(+1/+0)` and a `GenericEffect{AddKeyword(FirstStrike)}` whose `affected` filter is restricted to Kithkin creatures you control.
- `crates/engine/src/game/effects/effect.rs` — runtime discriminating test: resolves the real parsed ETB chain through `effects::resolve_effect` + `evaluate_layers`; both controlled creatures get +1/+0 but only the Kithkin gains first strike.

No new engine enum variants. The second clause already had runtime support (`Effect::GenericEffect` + `ContinuousModification::AddKeyword`); the gap was purely the parser dropping the additive-"also" continuation to `Unimplemented`.

## CR references
- CR 608.2c — read the whole text / apply the rules of English: "also" is an additive connector with no selection semantics (governs the strip).
- CR 611.2a — continuous effect from a spell/ability lasts as stated ("until end of turn").
- CR 702.7 — First Strike.

Grep evidence (against `docs/MagicCompRules.txt`):
- `608.2c` → "…read the whole text and apply the rules of English to the text."
- `611.2a` → "A continuous effect … lasts as long as stated … (such as 'until end of turn')."
- `702.7` → "First Strike".

## Track
Developer

## Verification
- `cargo fmt --all` — clean.
- `./scripts/check-parser-combinators.sh` — exit 0.
- `cargo clippy -p engine --all-targets -- -D warnings` — clean, zero warnings.
- `cargo test -p engine` — full engine lib: 12601+ passed; only failure is the known flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (instructed to ignore). The three new tests pass.
- Revert-proof check: reverting the strip at both call sites makes both Gallant Fowlknight tests fail with `Unimplemented { name: "kithkin", description: "Kithkin creatures you control also gain first strike" }`; restored to green.
- `cargo coverage` / `cargo semantic-audit` — require `card-data.json`/`data/mtgjson`, which are gitignored and absent in this isolated worktree; cannot produce signal here (environment limitation, not a defect).

## Scope Expansion
None. One new private parser helper (`strip_trailing_additive_adverb`), no new engine variants, no new effect types.

## Validation Failures
None.

## CI Failures
None.
