### PR TITLE
Add Azure Beastbinder

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -6886,6 +6886,201 @@ mod tests {
         );
     }
 
+    /// CR 611.2a + CR 613.1f + CR 613.4b (Azure Beastbinder): drive the REAL
+    /// parser + resolution pipeline. Azure Beastbinder's attack trigger is parsed
+    /// from its printed Oracle text, then resolved (via the same
+    /// `build_resolved_from_def_with_targets` the trigger system uses) against an
+    /// opponent's 5/5 creature that has a keyword and an activated ability. After
+    /// `resolve_ability_chain` registers the transient continuous effects and
+    /// `evaluate_layers` applies them, the target must have:
+    ///   - base power and toughness set to 2/2 (the historical Unimplemented gap),
+    ///   - all abilities and keywords removed.
+    ///
+    /// REVERT-PROOF: reverting either parser fix re-introduces the failure —
+    /// without the "it also" subject strip the base-P/T clause stays
+    /// `Unimplemented` (no SetPower/SetToughness → power/toughness remain 5/5);
+    /// without the `RevealedHasCardType → TargetMatchesFilter` conversion the
+    /// creature-gate evaluates always-false (no revealed card) so the base-P/T
+    /// sub-ability never runs (power/toughness remain 5/5).
+    #[test]
+    fn azure_beastbinder_attack_sets_target_base_pt_and_strips_abilities_e2e() {
+        use crate::game::ability_utils::build_resolved_from_def_with_targets;
+        use crate::game::effects::resolve_ability_chain;
+        use crate::types::ability::TargetRef;
+
+        let mut scenario = GameScenario::new();
+
+        // Source: Azure Beastbinder, parsed from its real Oracle text.
+        let beastbinder = scenario
+            .add_creature(PlayerId(0), "Azure Beastbinder", 3, 3)
+            .from_oracle_text_with_keywords(
+                &["Vigilance"],
+                "Vigilance\n\
+                 This creature can't be blocked by creatures with power 2 or greater.\n\
+                 Whenever this creature attacks, up to one target artifact, creature, or \
+                 planeswalker an opponent controls loses all abilities until your next turn. \
+                 If it's a creature, it also has base power and toughness 2/2 until your next turn.",
+            )
+            .id();
+
+        // Target: an opponent's 5/5 creature with a keyword + an activated ability.
+        let target = {
+            let mut card = scenario.add_creature(PlayerId(1), "Big Beater", 5, 5);
+            card.flying()
+                .with_ability_definition(AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::GainLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                        player: TargetFilter::Controller,
+                    },
+                ));
+            card.id()
+        };
+
+        let mut state = scenario.build().state().clone();
+
+        // Pull the parsed attack-trigger execute body off the source object.
+        let execute = state
+            .objects
+            .get(&beastbinder)
+            .unwrap()
+            .trigger_definitions
+            .iter_all()
+            .find(|t| matches!(t.mode, TriggerMode::Attacks))
+            .and_then(|t| t.execute.clone())
+            .expect("Azure Beastbinder must have a parsed Attacks trigger with an execute body");
+
+        // Resolve the trigger against the chosen target (the 5/5 creature),
+        // exactly as the trigger system would after target selection.
+        let ability = build_resolved_from_def_with_targets(
+            &execute,
+            beastbinder,
+            PlayerId(0),
+            vec![TargetRef::Object(target)],
+        );
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("attack-trigger chain must resolve");
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let obj = state.objects.get(&target).unwrap();
+        // CR 613.4b: base power and toughness set to 2/2.
+        assert_eq!(
+            obj.power,
+            Some(2),
+            "target power must be 2, got {:?}",
+            obj.power
+        );
+        assert_eq!(
+            obj.toughness,
+            Some(2),
+            "target toughness must be 2, got {:?}",
+            obj.toughness
+        );
+        // CR 613.1f: all abilities and keywords removed.
+        assert!(
+            obj.keywords.is_empty(),
+            "target keywords must be stripped, got {:?}",
+            obj.keywords
+        );
+        assert!(
+            obj.abilities.is_empty(),
+            "target abilities must be stripped, got {:?}",
+            obj.abilities
+        );
+    }
+
+    /// CR 109.2 + CR 613.4b: the creature-gate discriminates. When Azure
+    /// Beastbinder's attack targets an opponent's ARTIFACT (non-creature), the
+    /// "if it's a creature" sub-ability must NOT fire — abilities are still
+    /// stripped (head clause) but the base-P/T set does not apply (an artifact
+    /// has no P/T to set). This pins the `TargetMatchesFilter` gate as a real
+    /// discriminator rather than an always-true rider.
+    #[test]
+    fn azure_beastbinder_attack_artifact_target_skips_base_pt() {
+        use crate::game::ability_utils::build_resolved_from_def_with_targets;
+        use crate::game::effects::resolve_ability_chain;
+        use crate::types::ability::TargetRef;
+
+        let mut scenario = GameScenario::new();
+
+        let beastbinder = scenario
+            .add_creature(PlayerId(0), "Azure Beastbinder", 3, 3)
+            .from_oracle_text_with_keywords(
+                &["Vigilance"],
+                "Vigilance\n\
+                 This creature can't be blocked by creatures with power 2 or greater.\n\
+                 Whenever this creature attacks, up to one target artifact, creature, or \
+                 planeswalker an opponent controls loses all abilities until your next turn. \
+                 If it's a creature, it also has base power and toughness 2/2 until your next turn.",
+            )
+            .id();
+
+        // Opponent's noncreature Artifact with an activated ability. `add_creature`
+        // seeds base P/T 0/0; `as_artifact` makes it a noncreature artifact. The
+        // creature-gate must leave its (base) power/toughness at 0 — a fired
+        // base-P/T set would push it to 2.
+        let artifact = {
+            let mut card = scenario.add_creature(PlayerId(1), "Sol Ring", 0, 0);
+            card.as_artifact()
+                .with_ability_definition(AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::GainLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                        player: TargetFilter::Controller,
+                    },
+                ));
+            card.id()
+        };
+
+        let mut state = scenario.build().state().clone();
+
+        let execute = state
+            .objects
+            .get(&beastbinder)
+            .unwrap()
+            .trigger_definitions
+            .iter_all()
+            .find(|t| matches!(t.mode, TriggerMode::Attacks))
+            .and_then(|t| t.execute.clone())
+            .expect("parsed Attacks trigger");
+
+        let ability = build_resolved_from_def_with_targets(
+            &execute,
+            beastbinder,
+            PlayerId(0),
+            vec![TargetRef::Object(artifact)],
+        );
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("attack-trigger chain must resolve");
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let obj = state.objects.get(&artifact).unwrap();
+        // Head clause still strips abilities from the artifact target.
+        assert!(
+            obj.abilities.is_empty(),
+            "artifact target abilities must be stripped, got {:?}",
+            obj.abilities
+        );
+        // The creature-gated base-P/T set must NOT fire: the artifact keeps its
+        // base 0/0 (a fired SetPower/SetToughness would make it 2/2).
+        assert_eq!(
+            obj.power,
+            Some(0),
+            "artifact target must not gain power from the creature-gated clause"
+        );
+        assert_eq!(
+            obj.toughness,
+            Some(0),
+            "artifact target must not gain toughness from the creature-gated clause"
+        );
+    }
+
     #[test]
     fn muraganda_petroglyphs_buffs_only_abilityless_creatures_e2e() {
         // Drive the REAL parser end-to-end: Muraganda Petroglyphs' Oracle text

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5143,6 +5143,168 @@ mod tests {
         }
     }
 
+    /// CR 611.2a + CR 613.1f + CR 613.4b: Azure Beastbinder's attack trigger —
+    /// "up to one target artifact, creature, or planeswalker an opponent
+    /// controls loses all abilities until your next turn. If it's a creature, it
+    /// also has base power and toughness 2/2 until your next turn." — must parse
+    /// with ZERO `Unimplemented`. The base-P/T-set sub-clause (the historical
+    /// gap, previously `Unimplemented { name: "have" }`) lowers to
+    /// `SetPower{2}`/`SetToughness{2}` on the parent target, and the anaphoric
+    /// "if it's a creature" gate lowers to `TargetMatchesFilter{creature}` (not a
+    /// reveal-context `RevealedHasCardType`, which would evaluate always-false at
+    /// runtime since there is no revealed card — the "it" is the chosen target).
+    #[test]
+    fn azure_beastbinder_attack_trigger_has_no_unimplemented() {
+        use crate::types::ability::{Duration, PlayerScope, TypeFilter};
+
+        // Recursive walk into sub/else chains AND nested GenericEffect grant defs.
+        fn def_has_unimplemented(def: &AbilityDefinition) -> bool {
+            if matches!(&*def.effect, Effect::Unimplemented { .. }) {
+                return true;
+            }
+            if let Effect::GenericEffect {
+                static_abilities, ..
+            } = &*def.effect
+            {
+                let nested = static_abilities
+                    .iter()
+                    .flat_map(|sd| sd.modifications.iter())
+                    .any(|m| match m {
+                        ContinuousModification::GrantAbility { definition } => {
+                            def_has_unimplemented(definition)
+                        }
+                        ContinuousModification::GrantTrigger { trigger } => trigger
+                            .execute
+                            .as_deref()
+                            .is_some_and(def_has_unimplemented),
+                        _ => false,
+                    });
+                if nested {
+                    return true;
+                }
+            }
+            def.sub_ability
+                .as_deref()
+                .is_some_and(def_has_unimplemented)
+                || def
+                    .else_ability
+                    .as_deref()
+                    .is_some_and(def_has_unimplemented)
+        }
+
+        let r = parse(
+            "Vigilance\n\
+             This creature can't be blocked by creatures with power 2 or greater.\n\
+             Whenever this creature attacks, up to one target artifact, creature, or \
+             planeswalker an opponent controls loses all abilities until your next turn. \
+             If it's a creature, it also has base power and toughness 2/2 until your next turn.",
+            "Azure Beastbinder",
+            &[Keyword::Vigilance],
+            &["Creature"],
+            &[],
+        );
+
+        assert_eq!(r.triggers.len(), 1, "exactly one attack trigger: {r:#?}");
+        let execute = r.triggers[0]
+            .execute
+            .as_ref()
+            .expect("attack trigger should have an execute body");
+        assert!(
+            !def_has_unimplemented(execute),
+            "attack trigger body must contain NO Unimplemented effect: {execute:#?}"
+        );
+
+        // Head clause: loses all abilities until your next turn, on the chosen
+        // (up-to-one) opponent-controlled artifact/creature/planeswalker.
+        match &*execute.effect {
+            Effect::GenericEffect {
+                static_abilities,
+                duration,
+                ..
+            } => {
+                assert_eq!(
+                    *duration,
+                    Some(Duration::UntilNextTurnOf {
+                        player: PlayerScope::Controller
+                    }),
+                    "head clause expires at the controller's next turn"
+                );
+                assert!(
+                    static_abilities
+                        .iter()
+                        .flat_map(|s| s.modifications.iter())
+                        .any(|m| matches!(m, ContinuousModification::RemoveAllAbilities)),
+                    "head clause removes all abilities: {static_abilities:?}"
+                );
+            }
+            other => panic!("expected GenericEffect head clause, got {other:?}"),
+        }
+
+        // Sub clause: gated on the target being a creature, sets base P/T 2/2.
+        let sub = execute
+            .sub_ability
+            .as_deref()
+            .expect("base-P/T sub-ability must be present");
+        assert!(
+            matches!(
+                &sub.condition,
+                Some(AbilityCondition::TargetMatchesFilter { filter, .. })
+                    if matches!(
+                        filter,
+                        TargetFilter::Typed(TypedFilter { type_filters, .. })
+                            if type_filters == &vec![TypeFilter::Creature]
+                    )
+            ),
+            "sub clause must gate on TargetMatchesFilter(creature), got {:?}",
+            sub.condition
+        );
+        match &*sub.effect {
+            Effect::GenericEffect {
+                static_abilities,
+                duration,
+                target,
+            } => {
+                assert_eq!(
+                    *target,
+                    Some(TargetFilter::ParentTarget),
+                    "base-P/T set applies to the parent (chosen) target"
+                );
+                assert_eq!(
+                    *duration,
+                    Some(Duration::UntilNextTurnOf {
+                        player: PlayerScope::Controller
+                    }),
+                    "base-P/T set expires at the controller's next turn"
+                );
+                let mods: Vec<_> = static_abilities
+                    .iter()
+                    .flat_map(|s| s.modifications.iter())
+                    .collect();
+                assert!(
+                    mods.iter()
+                        .any(|m| matches!(m, ContinuousModification::SetPower { value: 2 })),
+                    "must contain SetPower(2): {mods:?}"
+                );
+                assert!(
+                    mods.iter()
+                        .any(|m| matches!(m, ContinuousModification::SetToughness { value: 2 })),
+                    "must contain SetToughness(2): {mods:?}"
+                );
+            }
+            other => panic!("expected GenericEffect sub clause, got {other:?}"),
+        }
+
+        // Static line: can't be blocked by power-2+ creatures.
+        assert!(
+            r.statics.iter().any(|s| matches!(
+                s.mode,
+                crate::types::statics::StaticMode::CantBeBlockedBy { .. }
+            )),
+            "can't-be-blocked-by static must parse: {:#?}",
+            r.statics
+        );
+    }
+
     /// Issue #69 (Triad of Fates): "Exile target creature that has a fate counter
     /// on it, then return it to the battlefield…" — the exile target ChangeZone
     /// filter must carry the fate-counter restriction, and the "then return it"

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -626,6 +626,39 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
             .condition
             .as_ref()
             .or(clause_ir.parsed.condition.as_ref());
+        // CR 608.2c + CR 109.2: When a "if it's a [type], it ..." card-type gate
+        // sits on a clause whose effect acts on the parent target (the anaphoric
+        // "it" resolved to the previously-targeted object — e.g. Azure Beastbinder's
+        // "If it's a creature, it also has base power and toughness 2/2"), the
+        // type description refers to that *permanent*, not a revealed card. The
+        // chunk parser emits `RevealedHasCardType` for every "if it's a [type]"
+        // head, but that variant evaluates against the last revealed/zone-changed
+        // card and would be ALWAYS-FALSE here (no reveal context), silently
+        // dropping the rider. Convert it to `TargetMatchesFilter` (the same
+        // conversion the Disintegrate/Carbonize damage-rider path performs via
+        // `card_type_condition_as_target_match`) so the gate evaluates against the
+        // bound parent target.
+        //
+        // Two guards keep genuine reveal-context gates (Goblin Guide:
+        // "defending player reveals the top card of their library. If it's a
+        // land card, that player puts it into their hand."; Delver-class)
+        // untouched:
+        //   1. The gated effect must target `ParentTarget` (the "it" anaphor).
+        //   2. No prior clause in the chain may publish a revealed/zone-changed
+        //      subject — that is exactly the source `RevealedHasCardType` reads
+        //      at resolution (`last_revealed_ids` / `last_zone_changed_ids`), so
+        //      when such a publisher exists the "it" really is the revealed card
+        //      and the original variant is correct.
+        let chain_has_revealed_subject = defs
+            .iter()
+            .any(|d| effect_publishes_revealed_subject(&d.effect));
+        let converted_condition = effective_condition.and_then(|cond| {
+            (!chain_has_revealed_subject
+                && matches!(def.effect.target_filter(), Some(TargetFilter::ParentTarget)))
+            .then(|| super::conditions::card_type_condition_as_target_match(cond))
+            .flatten()
+        });
+        let effective_condition = converted_condition.as_ref().or(effective_condition);
         if let Some(cond) = effective_condition {
             // CR 603.4 + CR 608.2h: An in-effect `if` on a continuous
             // keyword-grant clause (Odric, Lunarch Marshal) must gate each
@@ -1645,6 +1678,36 @@ pub(crate) fn rewrite_token_created_this_way_unimplemented(
             .or(Some(Duration::UntilEndOfTurn)),
         target: Some(TargetFilter::LastCreated),
     })
+}
+
+/// CR 608.2c + CR 701.20: True when this effect publishes a revealed or
+/// zone-changed subject at resolution — i.e. it populates the
+/// `last_revealed_ids` / `last_zone_changed_ids` trackers that
+/// `AbilityCondition::RevealedHasCardType` reads. When a prior clause in a
+/// chain is such a publisher, a following "if it's a [type]" gate refers to
+/// THAT card (Goblin Guide: reveal-then-conditional-recall), so the
+/// `RevealedHasCardType` reading is correct and must not be rewritten to a
+/// `TargetMatchesFilter` parent-target reading. Reveal-class effects populate
+/// `last_revealed_ids` directly; zone-change-class effects emit `ZoneChanged`
+/// events that populate `last_zone_changed_ids`.
+fn effect_publishes_revealed_subject(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        // Reveal-class (populate last_revealed_ids).
+        Effect::Reveal { .. }
+            | Effect::RevealTop { .. }
+            | Effect::RevealHand { .. }
+            | Effect::Dig { .. }
+            | Effect::ExileFromTopUntil { .. }
+            | Effect::Clash
+            | Effect::TurnFaceUp { .. }
+            // Zone-change-class (emit ZoneChanged → last_zone_changed_ids).
+            | Effect::ChangeZone { .. }
+            | Effect::ChangeZoneAll { .. }
+            | Effect::ExileTop { .. }
+            | Effect::Mill { .. }
+            | Effect::SearchLibrary { .. }
+    )
 }
 
 /// Rewrite any `TargetFilter::ParentTarget` sitting in the target slot of

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -854,6 +854,24 @@ pub(super) fn parse_subject_application(
         return None;
     }
 
+    // CR 608.2c: A trailing "also" adverb is a natural-language additive
+    // connector ("it also has …", "that creature also gains …") with no
+    // semantic weight on the subject — it modifies the verb, not the
+    // referent. `find_predicate_start` leaves it on the subject side because
+    // it is not a predicate verb, so strip it here so the bare anaphor/typed
+    // subject resolves identically to its non-"also" form. Mirrors the
+    // self-ref "also" strip in `oracle_effect/mod.rs` (Expressive Firedancer),
+    // generalized to every subject the subject-predicate parser accepts.
+    let subject = subject
+        .trim()
+        // allow-noncombinator: structural adverb cleanup on already-isolated subject text (not parsing dispatch); mirrors the self-ref "also" strip in oracle_effect/mod.rs (PATTERNS.md §9)
+        .strip_suffix(" also")
+        .map(str::trim_end)
+        .unwrap_or(subject);
+    if subject.trim().is_empty() {
+        return None;
+    }
+
     let lower = subject.to_lowercase();
 
     if let Ok((_, _)) = all_consuming((


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Implements **Azure Beastbinder** end-to-end. The attack trigger previously emitted `Effect::Unimplemented` on the "have base power and toughness 2/2" sub-clause. Two general parser fixes close the gap (no card-specific special-casing, no new engine variants):

1. **Anaphoric "it also" subject** (`oracle_effect/subject.rs`): `parse_subject_application` now strips a trailing `" also"` adverb so the anaphoric subject "it also has/gains/gets X" resolves identically to "it" → `ParentTarget`. CR 608.2c additive connector — the adverb modifies the verb, not the referent. This routes "(it) has base power and toughness 2/2" through the existing `parse_continuous_modifications` building block, producing `SetPower{2}` + `SetToughness{2}` (layer 7b base-P/T set, CR 613.4b) on the parent target.

2. **Anaphoric "if it's a creature" gate on a targeted effect** (`oracle_effect/lower.rs`): when a single-`CoreType` `RevealedHasCardType` gate sits on a clause whose effect targets `ParentTarget` AND no prior clause in the chain publishes a revealed/zone-changed subject, it is converted to `TargetMatchesFilter` (the same conversion the Disintegrate/Carbonize damage-rider path uses via `card_type_condition_as_target_match`). Without this the gate evaluates always-false at runtime (no revealed card) and the base-P/T set would silently never run. The reveal/zone-change publisher guard (`effect_publishes_revealed_subject`) preserves genuine reveal-context cards (Goblin Guide, Coiling Oracle, Delver-class).

All other sub-parts were already supported on upstream/main: Vigilance, the can't-be-blocked-by-power-2+ static, "loses all abilities until your next turn" (`RemoveAllAbilities` + `Duration::UntilNextTurnOf{Controller}`), and the "up to one target" optional targeting over the artifact/creature/planeswalker `Or` filter.

Verdict: **SUPPORTED**.

Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Files changed

- `crates/engine/src/parser/oracle_effect/subject.rs` — strip trailing `" also"` adverb in `parse_subject_application` (anaphoric "it also" → "it").
- `crates/engine/src/parser/oracle_effect/lower.rs` — convert `RevealedHasCardType` → `TargetMatchesFilter` for parent-target-anaphor card-type gates, guarded against reveal/zone-change-context chains; add `effect_publishes_revealed_subject` helper.
- `crates/engine/src/parser/oracle.rs` — parse test: full Azure Beastbinder oracle text asserts ZERO `Unimplemented` and the correct typed shape.
- `crates/engine/src/game/layers.rs` — two runtime e2e tests through the real resolution + layer pipeline.

## CR references

- CR 608.2c — later text modifies earlier text; anaphoric "it"/"also" resolution.
- CR 109.2 — an unqualified card-type description refers to a permanent on the battlefield (the targeted object).
- CR 613.4b — layer 7b: effects that set base power and/or toughness.
- CR 613.1f — layer 6: ability-removing effects.
- CR 611.2a — continuous-effect duration ("until your next turn").
- CR 701.20 — Reveal (reveal-class publishers guarded against false conversion).

## Track

Developer

## Verification

- `cargo fmt --all` — clean.
- `./scripts/check-parser-combinators.sh` — pass.
- `cargo clippy -p engine --all-targets -- -D warnings` — clean.
- `cargo test -p engine` — 12602 passed; the only failure is the known parallel-execution-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (passes in isolation; unrelated to this diff).
- Parser string-dispatch diff gate — pass (no added dispatch lines).
- CR-annotation diff gate — all annotations grep-verified against `docs/MagicCompRules.txt`.
- Revert-proof: reverting either fix flips the e2e assertion `target.power == 2` to `5` (verified by temporary revert).

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
