### PR TITLE
Add Iron Fist, Living Weapon and Red Hulk (damage = X to any other target)

### DIFF
--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -4385,4 +4385,284 @@ mod tests {
         assert_eq!(state.objects[&own_creature].damage_marked, 1);
         assert_eq!(state.objects[&opp_creature].damage_marked, 1);
     }
+
+    // --- "deals damage equal to <source quantity> to any other target" ---
+    //
+    // CR 120.1 + CR 115.4: A creature's ability that deals damage "equal to his
+    // power" / "equal to the number of +1/+1 counters on him" to "any other
+    // target" parses to `Effect::DealDamage { amount: <source quantity>, target:
+    // Typed{ properties: [Another] } }`. Per CR 115.4 "another target" excludes
+    // the ability's own source from the legal targets (the `Another` marker),
+    // while the runtime still enumerates players + creatures/planeswalkers/
+    // battles (Screaming Nemesis precedent). These tests drive the real parsed
+    // output through the activation/resolution pipeline.
+
+    /// Extract the activated ability definition that a parsed "gains
+    /// \"{T}: …\" until end of turn" trigger grants.
+    #[cfg(test)]
+    fn extract_granted_ability(
+        oracle: &str,
+        card_name: &str,
+    ) -> crate::types::ability::AbilityDefinition {
+        use crate::types::ability::{ContinuousModification, Effect};
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            oracle,
+            card_name,
+            &[],
+            &["Creature".into()],
+            &[],
+        );
+        let trigger = parsed
+            .triggers
+            .into_iter()
+            .next()
+            .expect("cast trigger present");
+        let execute = trigger.execute.expect("trigger has an execute ability");
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = &*execute.effect
+        else {
+            panic!(
+                "expected GenericEffect granting an ability, got {:?}",
+                execute.effect
+            );
+        };
+        let modification = static_abilities
+            .iter()
+            .flat_map(|s| s.modifications.iter())
+            .find_map(|m| match m {
+                ContinuousModification::GrantAbility { definition } => Some((**definition).clone()),
+                _ => None,
+            });
+        modification.expect("a GrantAbility modification")
+    }
+
+    /// CR 120.1 + CR 115.4 + CR 208.3 — DISCRIMINATING runtime gate for Iron
+    /// Fist, Living Weapon. Its cast-trigger grants "{T}: ~ deals damage equal
+    /// to his power to any other target". Parsing the full card, attaching the
+    /// granted ability to a 4-power Iron Fist, and activating it at an opponent
+    /// creature must deal exactly 4 damage. Reverting the gendered-pronoun
+    /// quantity fix makes "his power" fall to `Effect::Unimplemented`, so the
+    /// granted ability deals no damage and `ActivateAbility` never reaches a
+    /// damage resolution — this assertion flips.
+    #[test]
+    fn iron_fist_granted_ability_deals_damage_equal_to_power() {
+        use crate::game::scenario::GameScenario;
+        use crate::types::phase::Phase;
+
+        const P0: PlayerId = PlayerId(0);
+        const P1: PlayerId = PlayerId(1);
+
+        let granted = extract_granted_ability(
+            "Whenever you cast a spell that targets a creature you control, Iron Fist gains \
+             \"{T}: Iron Fist deals damage equal to his power to any other target\" until end of turn.",
+            "Iron Fist, Living Weapon",
+        );
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let iron_fist = scenario
+            .add_creature(P0, "Iron Fist, Living Weapon", 4, 4)
+            .with_ability_definition(granted)
+            .id();
+        let victim = scenario.add_creature(P1, "Opp Bear", 2, 2).id();
+        let mut runner = scenario.build();
+
+        let ability_index = runner.state().objects[&iron_fist].abilities.len() - 1;
+        let outcome = runner
+            .activate(iron_fist, ability_index)
+            .target_object(victim)
+            .resolve();
+
+        // CR 208.3: damage equals the source's power (4).
+        assert_eq!(
+            outcome.state().objects[&victim].damage_marked,
+            4,
+            "Iron Fist must deal damage equal to his power (4) to the chosen other target"
+        );
+    }
+
+    /// CR 115.4 — DISCRIMINATING runtime gate that "any OTHER target" (i.e.
+    /// "another target") excludes the source. Iron Fist's granted ability must
+    /// NOT offer Iron Fist itself as a legal target. If the `Another` exclusion
+    /// were lost, the source would appear in the legal-target set.
+    #[test]
+    fn iron_fist_granted_ability_excludes_itself_as_target() {
+        use crate::game::scenario::GameScenario;
+        use crate::types::actions::GameAction;
+        use crate::types::game_state::WaitingFor;
+        use crate::types::phase::Phase;
+        use crate::types::TargetRef;
+
+        const P0: PlayerId = PlayerId(0);
+        const P1: PlayerId = PlayerId(1);
+
+        let granted = extract_granted_ability(
+            "Whenever you cast a spell that targets a creature you control, Iron Fist gains \
+             \"{T}: Iron Fist deals damage equal to his power to any other target\" until end of turn.",
+            "Iron Fist, Living Weapon",
+        );
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let iron_fist = scenario
+            .add_creature(P0, "Iron Fist, Living Weapon", 4, 4)
+            .with_ability_definition(granted)
+            .id();
+        let victim = scenario.add_creature(P1, "Opp Bear", 2, 2).id();
+        let mut runner = scenario.build();
+
+        let ability_index = runner.state().objects[&iron_fist].abilities.len() - 1;
+        runner
+            .act(GameAction::ActivateAbility {
+                source_id: iron_fist,
+                ability_index,
+            })
+            .expect("activation announced");
+
+        let WaitingFor::TargetSelection { target_slots, .. } = &runner.state().waiting_for else {
+            panic!(
+                "expected TargetSelection after activation, got {:?}",
+                runner.state().waiting_for
+            );
+        };
+        let legal = &target_slots[0].legal_targets;
+        assert!(
+            !legal.contains(&TargetRef::Object(iron_fist)),
+            "'any other target' must exclude the source (Iron Fist), got {legal:?}"
+        );
+        assert!(
+            legal.contains(&TargetRef::Object(victim)),
+            "the opponent creature must be a legal target, got {legal:?}"
+        );
+    }
+
+    /// CR 120.1 + CR 122.1 + CR 115.4 — DISCRIMINATING runtime gate for Red
+    /// Hulk's Enrage reflex. Its reflexive "he deals damage equal to the number
+    /// of +1/+1 counters on him to any other target" parses to
+    /// `DealDamage { amount: CountersOn{Source, P1P1}, target: Another }`.
+    /// Resolving that effect against a Red Hulk carrying 3 +1/+1 counters must
+    /// deal 3 damage to the chosen other target, and must exclude Red Hulk
+    /// itself. Reverting the "on him" source-pronoun fix routes the reflex to
+    /// `Effect::Unimplemented`, dealing 0 damage — this flips.
+    #[test]
+    fn red_hulk_reflex_deals_damage_equal_to_counter_count() {
+        use crate::game::scenario::GameScenario;
+        use crate::types::actions::GameAction;
+        use crate::types::counter::CounterType;
+        use crate::types::game_state::WaitingFor;
+        use crate::types::phase::Phase;
+        use crate::types::TargetRef;
+
+        const P0: PlayerId = PlayerId(0);
+        const P1: PlayerId = PlayerId(1);
+
+        // Pull the reflexive damage effect out of the parsed enrage trigger so the
+        // runtime test exercises the real parser output.
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Reach, trample\nEnrage — Whenever Red Hulk is dealt damage, put a +1/+1 \
+             counter on him. When you do, he deals damage equal to the number of +1/+1 \
+             counters on him to any other target.",
+            "Red Hulk",
+            &[],
+            &["Creature".into()],
+            &[],
+        );
+        let trigger = parsed.triggers.into_iter().next().expect("enrage trigger");
+        let execute = trigger.execute.expect("trigger execute");
+        let reflex = execute
+            .sub_ability
+            .as_deref()
+            .expect("reflexive when-you-do sub-ability")
+            .clone();
+        assert!(
+            matches!(
+                &*reflex.effect,
+                crate::types::ability::Effect::DealDamage {
+                    amount: crate::types::ability::QuantityExpr::Ref {
+                        qty: crate::types::ability::QuantityRef::CountersOn {
+                            scope: crate::types::ability::ObjectScope::Source,
+                            counter_type: Some(CounterType::Plus1Plus1),
+                        },
+                    },
+                    ..
+                }
+            ),
+            "reflex must deal damage equal to +1/+1 counters on the source, got {:?}",
+            reflex.effect
+        );
+
+        // Attach the reflexive damage as a no-cost activated ability so it can be
+        // driven through the activation/resolution pipeline; Red Hulk carries 3
+        // counters.
+        let mut ability = reflex;
+        ability.kind = crate::types::ability::AbilityKind::Activated;
+        ability.cost = None;
+        ability.condition = None;
+
+        // Build a fresh scenario for each assertion: the announce-and-inspect
+        // pass leaves a target prompt open, so the resolve pass uses its own
+        // runner.
+        let build_red_hulk = |ability: crate::types::ability::AbilityDefinition| {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            let red_hulk = {
+                let mut builder = scenario.add_creature(P0, "Red Hulk", 7, 7);
+                builder.with_plus_counters(3);
+                builder.with_ability_definition(ability);
+                builder.id()
+            };
+            let victim = scenario.add_creature(P1, "Opp Bear", 2, 2).id();
+            (scenario.build(), red_hulk, victim)
+        };
+
+        // CR 115.4: "any other target" ("another target") excludes the source.
+        {
+            let (mut runner, red_hulk, victim) = build_red_hulk(ability.clone());
+            let ability_index = runner.state().objects[&red_hulk].abilities.len() - 1;
+            runner
+                .act(GameAction::ActivateAbility {
+                    source_id: red_hulk,
+                    ability_index,
+                })
+                .expect("activation announced");
+            let WaitingFor::TargetSelection { target_slots, .. } = &runner.state().waiting_for
+            else {
+                panic!(
+                    "expected TargetSelection, got {:?}",
+                    runner.state().waiting_for
+                );
+            };
+            assert!(
+                !target_slots[0]
+                    .legal_targets
+                    .contains(&TargetRef::Object(red_hulk)),
+                "'any other target' must exclude Red Hulk itself"
+            );
+            assert!(
+                target_slots[0]
+                    .legal_targets
+                    .contains(&TargetRef::Object(victim)),
+                "the opponent creature must be a legal target"
+            );
+        }
+
+        // CR 122.1: damage equals the number of +1/+1 counters on the source (3).
+        {
+            let (mut runner, red_hulk, victim) = build_red_hulk(ability);
+            let ability_index = runner.state().objects[&red_hulk].abilities.len() - 1;
+            let outcome = runner
+                .activate(red_hulk, ability_index)
+                .target_object(victim)
+                .resolve();
+            assert_eq!(
+                outcome.state().objects[&victim].damage_marked,
+                3,
+                "Red Hulk's reflex must deal damage equal to its +1/+1 counter count (3)"
+            );
+        }
+        // Silence the unused CounterType import on builds where the matches! arm
+        // already consumed it via the qualified path.
+        let _ = CounterType::Plus1Plus1;
+    }
 }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -19512,4 +19512,124 @@ mod pipeline_snapshot_tests {
         );
         assert!(!has_unimplemented(&def));
     }
+
+    /// CR 120.1 + CR 208.3 + CR 115.4: Iron Fist, Living Weapon — the cast
+    /// trigger grants "{T}: ~ deals damage equal to his power to any other
+    /// target". The granted ability's inner effect must parse to a concrete
+    /// `DealDamage { Power{Source}, Another }`, not `Effect::Unimplemented`.
+    #[test]
+    fn iron_fist_living_weapon_grants_damage_equal_to_power_any_other_target() {
+        use crate::types::ability::{
+            ContinuousModification, Effect, FilterProp, ObjectScope, QuantityExpr, QuantityRef,
+            TargetFilter, TypedFilter,
+        };
+
+        let p = parse_oracle_text(
+            "Whenever you cast a spell that targets a creature you control, Iron Fist gains \
+             \"{T}: Iron Fist deals damage equal to his power to any other target\" until end of turn.",
+            "Iron Fist, Living Weapon",
+            &[],
+            &["Creature".into()],
+            &[],
+        );
+
+        let execute = p.triggers[0]
+            .execute
+            .as_ref()
+            .expect("cast trigger has an execute ability");
+        assert!(!has_unimplemented(execute), "no Unimplemented in Iron Fist");
+
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = &*execute.effect
+        else {
+            panic!("expected GenericEffect, got {:?}", execute.effect);
+        };
+        let granted = static_abilities
+            .iter()
+            .flat_map(|s| s.modifications.iter())
+            .find_map(|m| match m {
+                ContinuousModification::GrantAbility { definition } => Some(definition),
+                _ => None,
+            })
+            .expect("a GrantAbility modification");
+
+        assert!(
+            matches!(
+                &*granted.effect,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Ref {
+                        qty: QuantityRef::Power {
+                            scope: ObjectScope::Source,
+                        },
+                    },
+                    target: TargetFilter::Typed(TypedFilter { properties, .. }),
+                    ..
+                } if properties.iter().any(|prop| matches!(prop, FilterProp::Another))
+            ),
+            "granted ability must deal damage equal to source power to any other target, got {:?}",
+            granted.effect
+        );
+    }
+
+    /// CR 120.1 + CR 122.1 + CR 115.4: Red Hulk — the Enrage trigger puts a
+    /// +1/+1 counter on the source, then a reflexive "when you do" deals damage
+    /// equal to the number of +1/+1 counters on the source to any other target.
+    /// The reflexive damage must parse concretely, not to `Effect::Unimplemented`.
+    #[test]
+    fn red_hulk_enrage_reflex_damage_equal_to_counters_any_other_target() {
+        use crate::types::ability::{
+            Effect, FilterProp, ObjectScope, QuantityExpr, QuantityRef, TargetFilter, TypedFilter,
+        };
+        use crate::types::counter::CounterType;
+
+        let p = parse_oracle_text(
+            "Reach, trample\nEnrage — Whenever Red Hulk is dealt damage, put a +1/+1 \
+             counter on him. When you do, he deals damage equal to the number of +1/+1 \
+             counters on him to any other target.",
+            "Red Hulk",
+            &["Reach".into(), "Trample".into()],
+            &["Creature".into()],
+            &[],
+        );
+
+        let execute = p.triggers[0]
+            .execute
+            .as_ref()
+            .expect("enrage trigger has an execute ability");
+        assert!(!has_unimplemented(execute), "no Unimplemented in Red Hulk");
+
+        // Head: put a +1/+1 counter on the source.
+        assert!(
+            matches!(
+                &*execute.effect,
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            ),
+            "enrage head must put a +1/+1 counter on the source, got {:?}",
+            execute.effect
+        );
+
+        // Reflexive sub: deal damage equal to +1/+1 counters on source to any other target.
+        let reflex = execute
+            .sub_ability
+            .as_deref()
+            .expect("reflexive when-you-do sub-ability");
+        assert!(matches!(
+            &*reflex.effect,
+            Effect::DealDamage {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Source,
+                        counter_type: Some(CounterType::Plus1Plus1),
+                    },
+                },
+                target: TargetFilter::Typed(TypedFilter { properties, .. }),
+                ..
+            } if properties.iter().any(|prop| matches!(prop, FilterProp::Another))
+        ), "reflex must deal damage equal to source's +1/+1 counters to any other target, got {:?}", reflex.effect);
+    }
 }

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -860,10 +860,19 @@ fn parse_number_of_counters_on_object(input: &str) -> OracleResult<'_, QuantityR
 }
 
 /// Parse the object scope for counter references: "it", "that creature", "that permanent", etc.
+///
+/// CR 122.1 + CR 608.2k: A creature's ability that counts "+1/+1 counters on
+/// him" / "on her" / "on them" refers to that same source object's counters
+/// (Red Hulk's Enrage reflex). The gendered/plural objective pronouns are
+/// interchangeable with the neuter "it" for the source — same rationale as
+/// `parse_self_possessive`.
 fn parse_counter_object_scope(input: &str) -> OracleResult<'_, ObjectScope> {
     alt((
         value(ObjectScope::Source, tag("it")),
         value(ObjectScope::Source, tag("~")),
+        value(ObjectScope::Source, tag("him")),
+        value(ObjectScope::Source, tag("her")),
+        value(ObjectScope::Source, tag("them")),
         value(ObjectScope::Target, tag("that creature")),
         value(ObjectScope::Target, tag("that permanent")),
         value(ObjectScope::Target, tag("that artifact")),
@@ -1781,74 +1790,66 @@ fn parse_scoped_zone_ref(input: &str) -> OracleResult<'_, (ZoneRef, CountScope)>
     .parse(input)
 }
 
-/// Parse "its power" / "~'s power" / "this creature's power" / "this card's power".
+/// Parse the possessive form of a source self-reference: "its", "~'s",
+/// "this creature's", "this card's", or a gendered/plural pronoun ("his",
+/// "her", "their").
+///
+/// CR 208.3 + CR 608.2k: A creature's ability that says "his power" / "her
+/// power" / "their power" refers to that same source object's power (recently
+/// templated this way on Marvel's Spider-Man cards such as Iron Fist, Living
+/// Weapon). The gendered/plural pronouns are interchangeable with the neuter
+/// "its" for the purpose of referencing the ability's own source — modern
+/// templating used "its" exclusively, so admitting the gendered forms here
+/// keeps the whole "his/her/their <characteristic>" class on one path rather
+/// than special-casing one card.
+fn parse_self_possessive(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((
+            tag("its"),
+            tag("~'s"),
+            tag("this creature's"),
+            tag("this card's"),
+            tag("his"),
+            tag("her"),
+            tag("their"),
+        )),
+    )
+    .parse(input)
+}
+
+/// Parse "its power" / "~'s power" / "this creature's power" / "this card's
+/// power" / "his power" / "her power" / "their power".
 ///
 /// CR 400.7 + CR 208.3: Scavenge and other graveyard-activated effects reference
 /// the source via "this card's power" because the source is a card (not a
 /// creature) when the ability is activated. `SelfPower` is LKI-aware at
-/// resolution time (see `game/quantity.rs`), so all four phrasings resolve
-/// identically.
+/// resolution time (see `game/quantity.rs`), so all phrasings resolve
+/// identically. See `parse_self_possessive` for the gendered-pronoun rationale.
 fn parse_self_power_ref(input: &str) -> OracleResult<'_, QuantityRef> {
-    alt((
-        value(
-            QuantityRef::Power {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-            tag("its power"),
-        ),
-        value(
-            QuantityRef::Power {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-            tag("~'s power"),
-        ),
-        value(
-            QuantityRef::Power {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-            tag("this creature's power"),
-        ),
-        value(
-            QuantityRef::Power {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-            tag("this card's power"),
-        ),
+    let (rest, _) = parse_self_possessive(input)?;
+    let (rest, _) = tag(" power").parse(rest)?;
+    Ok((
+        rest,
+        QuantityRef::Power {
+            scope: crate::types::ability::ObjectScope::Source,
+        },
     ))
-    .parse(input)
 }
 
 /// Parse "its toughness" / "~'s toughness" / "this creature's toughness" /
-/// "this card's toughness". See `parse_self_power_ref` for the card-vs-creature
-/// rationale.
+/// "this card's toughness" / "his toughness" / "her toughness" /
+/// "their toughness". See `parse_self_power_ref` for the card-vs-creature
+/// rationale and `parse_self_possessive` for the gendered-pronoun rationale.
 fn parse_self_toughness_ref(input: &str) -> OracleResult<'_, QuantityRef> {
-    alt((
-        value(
-            QuantityRef::Toughness {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-            tag("its toughness"),
-        ),
-        value(
-            QuantityRef::Toughness {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-            tag("~'s toughness"),
-        ),
-        value(
-            QuantityRef::Toughness {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-            tag("this creature's toughness"),
-        ),
-        value(
-            QuantityRef::Toughness {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-            tag("this card's toughness"),
-        ),
+    let (rest, _) = parse_self_possessive(input)?;
+    let (rest, _) = tag(" toughness").parse(rest)?;
+    Ok((
+        rest,
+        QuantityRef::Toughness {
+            scope: crate::types::ability::ObjectScope::Source,
+        },
     ))
-    .parse(input)
 }
 
 /// Parse damage-history references such as Chandra's Incinerator's
@@ -5282,12 +5283,59 @@ mod tests {
             "~'s power",
             "this creature's power",
             "this card's power",
+            // CR 208.3 + CR 608.2k: gendered/plural possessive pronouns are
+            // interchangeable with "its" for the source's own power (Iron Fist,
+            // Living Weapon — "deals damage equal to his power").
+            "his power",
+            "her power",
+            "their power",
         ] {
             let (rest, q) = parse_quantity_ref(phrase).unwrap();
             assert_eq!(
                 q,
                 QuantityRef::Power {
                     scope: crate::types::ability::ObjectScope::Source
+                },
+                "phrase: {phrase}"
+            );
+            assert_eq!(rest, "", "phrase: {phrase}");
+        }
+    }
+
+    /// CR 208.3 + CR 608.2k: gendered/plural possessive pronouns reference the
+    /// source's own toughness, mirroring the power phrasings.
+    #[test]
+    fn test_parse_quantity_ref_self_toughness_gendered_pronouns() {
+        for phrase in ["his toughness", "her toughness", "their toughness"] {
+            let (rest, q) = parse_quantity_ref(phrase).unwrap();
+            assert_eq!(
+                q,
+                QuantityRef::Toughness {
+                    scope: crate::types::ability::ObjectScope::Source
+                },
+                "phrase: {phrase}"
+            );
+            assert_eq!(rest, "", "phrase: {phrase}");
+        }
+    }
+
+    /// CR 122.1 + CR 608.2k: "the number of +1/+1 counters on him/her/them"
+    /// counts counters on the ability's own source — the gendered/plural
+    /// objective pronouns are interchangeable with "it" (Red Hulk's Enrage
+    /// reflex: "damage equal to the number of +1/+1 counters on him").
+    #[test]
+    fn test_parse_quantity_ref_counters_on_source_gendered_pronouns() {
+        for phrase in [
+            "the number of +1/+1 counters on him",
+            "the number of +1/+1 counters on her",
+            "the number of +1/+1 counters on them",
+        ] {
+            let (rest, q) = parse_quantity_ref(phrase).unwrap();
+            assert_eq!(
+                q,
+                QuantityRef::CountersOn {
+                    scope: crate::types::ability::ObjectScope::Source,
+                    counter_type: Some(crate::types::counter::CounterType::Plus1Plus1),
                 },
                 "phrase: {phrase}"
             );


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Implements two MSH (Marvel's Spider-Man) cards that share the gap "deals damage
equal to `<source quantity>` to any other target". **Both shipped.**

- **Iron Fist, Living Weapon** — its cast trigger grants `"{T}: ~ deals damage
  equal to his power to any other target"` until end of turn. The granted
  ability now resolves to `DealDamage { amount: Power{Source}, target: Another }`.
- **Red Hulk** — Enrage: when dealt damage, put a +1/+1 counter on it; the
  reflexive "when you do" deals damage equal to the number of +1/+1 counters on
  it to any other target. Now resolves to
  `DealDamage { amount: CountersOn{Source, P1P1}, target: Another }`.

The entire surrounding infrastructure (granted-temp-ability, reflexive
when-you-do, "any other target" filter, `FilterProp::Another` source exclusion,
`Power{Source}` / `CountersOn{Source}` runtime resolution) already existed
(Screaming Nemesis precedent for "deal damage to any other target"). The only
gap was the **quantity parser** not recognising the gendered/plural source
pronouns "his"/"him" (modern templating used "its"/"it" exclusively). The fix is
parser-only.

Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Files changed

- `crates/engine/src/parser/oracle_nom/quantity.rs` — new `parse_self_possessive`
  combinator (its / ~'s / this creature's / this card's / his / her / their);
  `parse_self_power_ref` and `parse_self_toughness_ref` refactored to compose it;
  `parse_counter_object_scope` extended with `him`/`her`/`them` →
  `ObjectScope::Source`. Plus building-block unit tests.
- `crates/engine/src/parser/oracle.rs` — full-card parser shape tests (0
  Unimplemented) for both cards.
- `crates/engine/src/game/effects/deal_damage.rs` — discriminating runtime tests
  driving the parsed output through the activation/resolution pipeline.

No new engine enum variants — reuses `Effect::DealDamage`,
`QuantityRef::Power{Source}`, `QuantityRef::CountersOn{Source}`, and
`FilterProp::Another`.

## CR references

All grep-verified against `docs/MagicCompRules.txt`:

- **CR 120.1** — objects deal damage to battles, creatures, planeswalkers, players.
- **CR 115.4** — "any target"/"another target" may be creatures, players,
  planeswalkers, or battles; "another target" excludes the source.
- **CR 208.3** — an object's power.
- **CR 122.1** — counters on an object.
- **CR 608.2k** — an effect referring to a specific object previously referred to
  by the ability's trigger/cost.

## Track

Developer

## Verification

- `cargo fmt --all` — pass
- `./scripts/check-parser-combinators.sh` — pass
- inline parser string-dispatch gate (contains/find/split/… on added parser
  lines) — pass (no offending lines)
- `cargo clippy -p engine --all-targets -- -D warnings` — pass
- `cargo test -p engine` — pass (12606 tests; only the pre-existing known-flaky
  `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`
  fails, unrelated)
- CR-annotation diff gate — pass (all CR numbers grep-verified)

Discriminating tests (verified to flip on revert of the fix):
- `iron_fist_granted_ability_deals_damage_equal_to_power` — 4-power Iron Fist's
  granted `{T}:` ability deals 4 to a chosen opponent creature. Revert → 0.
- `iron_fist_granted_ability_excludes_itself_as_target` — Iron Fist itself is not
  a legal target.
- `red_hulk_reflex_deals_damage_equal_to_counter_count` — 3 +1/+1 counters → 3
  damage to a chosen other target; Red Hulk itself excluded. Revert → reflex
  is `Effect::Unimplemented`.
- Plus full-card 0-Unimplemented parser shape tests and building-block unit tests
  for the new quantity grammar.

`cargo coverage` / `cargo semantic-audit` require `card-data.json`, which is
absent in this isolated worktree by design — not run (environment limit, not a
code issue).

## Scope Expansion

None. (No new infra; parser-only extension reusing existing effect/quantity/
filter building blocks. The fix covers the whole "deals damage equal to
`<source quantity>` to any other target" class with gendered/plural source
pronouns, not just these two cards.)

## Validation Failures

None.

## CI Failures

None.
