### PR TITLE
fix(parser): parse "Remove one or more [type] counters" cost (#3899)

### DIFF
--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -261,6 +261,18 @@ fn parse_remove_counter_quantity_and_kind(
     {
         return Some((REMOVE_COUNTER_COST_X, counter_type));
     }
+    // CR 601.2b: "one or more [kind]" is a free player-chosen amount — the same
+    // chosen-amount path as "any number of". This MUST precede the numeric arm
+    // below: otherwise `parse_number` consumes "one" as the literal 1 and the
+    // leftover "or more [kind]" is shredded into a bogus counter kind (#3899).
+    if let Ok((_, counter_type)) = all_consuming(preceded(
+        tag::<_, _, E<'_>>("one or more "),
+        parse_remove_counter_kind,
+    ))
+    .parse(input)
+    {
+        return Some((REMOVE_COUNTER_COST_ANY_NUMBER, counter_type));
+    }
     if let Ok((_, (count, counter_type))) = all_consuming(pair(
         terminated(nom_primitives::parse_number, tag::<_, _, E<'_>>(" ")),
         parse_remove_counter_kind,
@@ -1410,6 +1422,41 @@ mod tests {
             "'any number of' should be encoded separately from literal X"
         );
         assert!(matches!(counter_type, CounterMatch::OfType(_)));
+    }
+
+    #[test]
+    fn parse_one_or_more_counters_uses_any_number_sentinel() {
+        // Issue #3899: "one or more +1/+1 counters" is a free player-chosen
+        // amount (≥1) — the same chosen-amount path as "any number of". It must
+        // NOT be consumed by the numeric arm ("one" → 1) which previously shred
+        // the leftover "or more +1/+1" into a corrupted Generic counter kind.
+        use crate::types::counter::CounterType;
+        let (count, counter_type) =
+            parse_remove_counter_quantity_and_kind("one or more +1/+1 counters")
+                .expect("should parse 'one or more' counter removal");
+        assert_eq!(
+            count, REMOVE_COUNTER_COST_ANY_NUMBER,
+            "'one or more' should use the chosen-amount sentinel, not literal 1"
+        );
+        assert_eq!(
+            counter_type,
+            CounterMatch::OfType(CounterType::Plus1Plus1),
+            "counter type must be the typed +1/+1, not a corrupted Generic string"
+        );
+    }
+
+    #[test]
+    fn parse_one_or_more_typed_counters_preserves_kind() {
+        // Issue #3899: generalizes across counter kinds (Rasputin's dream counters).
+        use crate::types::counter::CounterType;
+        let (count, counter_type) =
+            parse_remove_counter_quantity_and_kind("one or more dream counters")
+                .expect("should parse 'one or more dream counters'");
+        assert_eq!(count, REMOVE_COUNTER_COST_ANY_NUMBER);
+        assert_eq!(
+            counter_type,
+            CounterMatch::OfType(CounterType::Generic("dream".to_string()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes #3899. "Remove one or more [type] counters" activation costs mis-parsed: `parse_remove_counter_quantity_and_kind` had arms for `all` / `any number of` / `x` / `<number>` but **no `one or more` arm**, so the input hit the numeric arm — `parse_number` consumed "one" as the literal `1`, and the leftover "or more +1/+1 counters" was shredded into a corrupted `Generic("or more +1/+1")` counter kind:

`RemoveCounter { count: 1, counter_type: OfType(Generic("or more +1/+1")) }`

## Fix
Add a `"one or more <kind>"` arm **before** the numeric arm, mapping to the free player-chosen `REMOVE_COUNTER_COST_ANY_NUMBER` sentinel with the correctly-typed counter — the same chosen-amount path the engine already runs for the `any number of` sibling (prompt for count, cap by available, feed the "that much" / "number removed this way" scaling). Parser-only — no new engine variant, no runtime change.

Simic Manipulator, Ooze Flux, and Arcee, Sharpshooter become correctly modeled. (Rasputin / Jetfire have a separate pre-existing gap in their mana-adding effect body, unrelated to this cost.)

## Files changed
- `crates/engine/src/parser/oracle_cost.rs` — new arm + 2 tests

## Tests
- `parse_one_or_more_counters_uses_any_number_sentinel` — +1/+1 → `(ANY_NUMBER, OfType(Plus1Plus1))`
- `parse_one_or_more_typed_counters_preserves_kind` — dream → `(ANY_NUMBER, OfType(Generic("dream")))`

## Verification
`cargo test -p engine --lib -- parse_one_or_more` → 2 passed. `cargo clippy -p engine --all-targets -- -D warnings` → clean.

## CR references
- CR 601.2b (chosen-amount cost) / CR 122.1 (counters)

Model: claude-opus-4-8 (Claude Code)