### PR TITLE
fix(parser): bind "as long as it's attacking/blocking/blocked" to the source

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5926,9 +5926,11 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::Not { .. } => ("Not", Handled),
         StaticCondition::DefendingPlayerControls { .. } => ("DefendingPlayerControls", Unhandled),
         StaticCondition::SourceAttackingAlone => ("SourceAttackingAlone", Unhandled),
-        StaticCondition::SourceIsAttacking => ("SourceIsAttacking", Unhandled),
-        StaticCondition::SourceIsBlocking => ("SourceIsBlocking", Unhandled),
-        StaticCondition::SourceIsBlocked => ("SourceIsBlocked", Unhandled),
+        // CR 508.1k / 509.1g / 509.1h: runtime-evaluated against the live combat
+        // attacker/blocker sets (conditions.rs:81 / layers.rs:1118 / layers.rs:1123).
+        StaticCondition::SourceIsAttacking => ("SourceIsAttacking", Handled),
+        StaticCondition::SourceIsBlocking => ("SourceIsBlocking", Handled),
+        StaticCondition::SourceIsBlocked => ("SourceIsBlocked", Handled),
         StaticCondition::IsMonarch => ("IsMonarch", Handled),
         StaticCondition::IsInitiative => ("IsInitiative", Handled),
         StaticCondition::NoMonarch => ("NoMonarch", Handled),

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -703,11 +703,15 @@ pub(crate) fn parse_typed_you_control_subject_filter(
 ///    attached-subject statics (an Aura/Equipment whose "it" refers to the
 ///    enchanted/equipped creature) the pronoun is not the source.
 /// 2. Only the bare source-STATE predicates that `~ is …` already resolves to a
-///    typed condition are rewritten. "it" is otherwise overloaded: "it's your
+///    typed condition are rewritten — the tapped/untapped pair plus their
+///    combat-state siblings "attacking"/"blocking"/"blocked"
+///    (CR 508.1k / 509.1g / 509.1h). "it" is otherwise overloaded: "it's your
 ///    turn" is impersonal (a turn reference, not the source); "it's a Wall" /
 ///    "it's red" / "it's legendary" are type/characteristic gates with their own
 ///    parse paths. Rewriting those would break or mis-bind them, so they are
-///    left untouched.
+///    left untouched. The match is EXACT, so "it's attacking alone" keeps its
+///    trailing word and falls through to `SourceAttackingAlone` rather than
+///    collapsing to `SourceIsAttacking`.
 ///
 /// Returns the condition unchanged when neither guard matches.
 fn rewrite_self_pronoun_subject(condition: &str) -> String {
@@ -715,7 +719,13 @@ fn rewrite_self_pronoun_subject(condition: &str) -> String {
     if let Some(rest) =
         nom_tag_lower(&lower, &lower, "it's ").or_else(|| nom_tag_lower(&lower, &lower, "it is "))
     {
-        if matches!(rest.trim(), "tapped" | "untapped") {
+        // CR 508.1k / CR 509.1g / CR 509.1h: combat-state pronoun siblings of the
+        // tapped/untapped rewrite. Exact-match only — "attacking alone" keeps its
+        // trailing word and is left for SourceAttackingAlone.
+        if matches!(
+            rest.trim(),
+            "tapped" | "untapped" | "attacking" | "blocking" | "blocked"
+        ) {
             return format!("~ is {}", rest.trim());
         }
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -18086,6 +18086,85 @@ fn aura_static_does_not_bind_it_pronoun_to_source() {
     }
 }
 
+#[test]
+fn self_static_resolves_it_pronoun_combat_state_to_source() {
+    // CR 508.1k / 509.1g / 509.1h: "it" in a self-referential combat-state gate
+    // refers to the source, so "as long as it's attacking/blocking/blocked" must
+    // type to the same Source* condition as the explicit "~ is …" form — not fall
+    // through to Unrecognized. Discriminating: before EDIT 1 these came back
+    // StaticCondition::Unrecognized { text: "it's attacking" }, which evals
+    // always-true (a permanent buff). Fails on revert.
+    let attacking = parse_static_line("This creature gets +1/+0 as long as it's attacking.") // Grasping Scoundrel
+        .expect("self static def");
+    assert_eq!(
+        attacking.condition,
+        Some(StaticCondition::SourceIsAttacking),
+        "expected SourceIsAttacking, got {:?}",
+        attacking.condition
+    );
+
+    let blocking = parse_static_line("This creature gets +1/+0 as long as it's blocking.")
+        .expect("self static def");
+    assert_eq!(
+        blocking.condition,
+        Some(StaticCondition::SourceIsBlocking),
+        "expected SourceIsBlocking, got {:?}",
+        blocking.condition
+    );
+
+    let blocked = parse_static_line("This creature gets +1/+0 as long as it's blocked.")
+        .expect("self static def");
+    assert_eq!(
+        blocked.condition,
+        Some(StaticCondition::SourceIsBlocked),
+        "expected SourceIsBlocked, got {:?}",
+        blocked.condition
+    );
+}
+
+#[test]
+fn aura_static_does_not_bind_it_pronoun_combat_state_to_source() {
+    // GUARD (anaphor trap): Tahngarth's Rage shape — the Aura's "it" refers to the
+    // ENCHANTED creature, not the Aura source, so it must NOT collapse to
+    // SourceIsAttacking. The ~745 SelfRef guard keeps it an honest Unrecognized gap.
+    let defs = parse_static_line_multi("Enchanted creature gets +3/+0 as long as it's attacking.");
+    assert!(!defs.is_empty(), "expected at least one static def");
+    for d in &defs {
+        assert_ne!(
+            d.condition,
+            Some(StaticCondition::SourceIsAttacking),
+            "Aura 'it' must not resolve to the source, got {:?}",
+            d.condition
+        );
+        assert_eq!(
+            d.condition,
+            Some(StaticCondition::Unrecognized {
+                text: "it's attacking".to_string(),
+            }),
+            "Aura combat-state gate must stay an honest Unrecognized gap, got {:?}",
+            d.condition
+        );
+    }
+}
+
+#[test]
+fn self_pronoun_combat_state_exact_match_excludes_attacking_alone() {
+    // NO-REGRESSION: the rewrite is exact-match. "it's attacking alone" must NOT
+    // hit the new arm (rest.trim() == "attacking alone" != the three literals);
+    // it stays routed to SourceAttackingAlone via its existing path. Exercised
+    // end-to-end via parse_static_line (rewrite_self_pronoun_subject is private to
+    // the anthem module), mirroring self_static_resolves_it_pronoun_subject_to_source.
+    let def = parse_static_line("This creature can't be blocked as long as it's attacking alone.")
+        .expect("self static def");
+    assert_eq!(def.condition, Some(StaticCondition::SourceAttackingAlone));
+
+    // And the bare "it's attacking" sibling DOES collapse to SourceIsAttacking,
+    // confirming the two literals route differently.
+    let buff = parse_static_line("This creature gets +1/+0 as long as it's attacking.")
+        .expect("self static def");
+    assert_eq!(buff.condition, Some(StaticCondition::SourceIsAttacking));
+}
+
 /// CR 702.16p: Benevolent Blessing — "Enchanted creature has protection from the
 /// chosen color. This effect doesn't remove Auras and Equipment you control that
 /// are already attached to it." The trailing inert SBA-exemption sentence must be


### PR DESCRIPTION
Fixes #3911.

## Summary

SelfRef continuous statics gated on "as long as it's attacking / blocking / blocked" applied **permanently** — the condition parsed to an inert `StaticCondition::Unrecognized`, which the layer system evaluates as always-true:

- **Grasping Scoundrel** (+1/+0 "as long as it's attacking"), **Soltari Lancer**, **Voldaren Stinger**, **Thorned Moloch**, **Unchained Berserker**, **Spirit of the Night**, **Kor Scythemaster**, **Kitesail Corsair**, **Purraj of Urborg**, **Blood Petal Celebrant**, **Vivid Flying Fish** (11 cards).

## Root cause

The SelfRef pronoun canonicalizer (`rewrite_self_pronoun_subject`) rewrites "it's tapped" / "it's untapped" → "~ is tapped/untapped" but had no arm for the combat-state siblings, so "it's attacking/blocking/blocked" fell through to the `Unrecognized` fallback. The explicit-subject form "~ is attacking" already parses to `SourceIsAttacking` (runtime-evaluated against the combat state).

## Fix (parser + coverage-classifier; no new engine variant, no runtime change)

- **Parser** (`anthem.rs`): add `attacking`/`blocking`/`blocked` to the exact-match pronoun-rewrite arm, routing "it's attacking" → "~ is attacking" → the existing `SourceIsAttacking` / `SourceIsBlocking` / `SourceIsBlocked` condition. Exact-match keeps "it's attacking alone" on its own `SourceAttackingAlone` path; the SelfRef guard leaves recipient-anaphor Auras ("Enchanted creature ... as long as it's attacking") as honest gaps.
- **Coverage classifier** (`coverage.rs`): flip those three conditions `Unhandled` → `Handled` to match runtime reality — they are genuinely runtime-evaluated (the eval queries the combat attacker/blocker sets), so the prior mark was stale. This lets the fixed cards count as supported and un-regresses existing "~ is attacking" statics.

CR 508.1k / 509.1g / 509.1h.

## Tests

- Discriminating (fail-on-revert): a SelfRef static "gets +1/+0 as long as it's attacking" → `SourceIsAttacking` (resp. blocking/blocked), not `Unrecognized`.
- Guard (anaphor trap): an EnchantedBy static "Enchanted creature gets +3/+0 as long as it's attacking" stays `Unrecognized` (not corrupted to SelfRef `SourceIsAttacking`) — proves the SelfRef guard.
- No-regression: "it's tapped"/"it's untapped" still rewrite; "it's attacking alone" → `SourceAttackingAlone`; explicit "~ is attacking" unchanged.

## Verification

`cargo +nightly test -p engine` (all targets incl. `--test integration`): 12713 passed; the only failure was the pre-existing flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (global perf-counter race under parallel runs — confirmed passing in isolation, unrelated). `clippy -D warnings`, parser-combinator gate, rustfmt: clean. Coverage repro: the 11 SelfRef cards flip to supported via `SourceIsAttacking`, existing "~ is attacking" emitters un-regress, the recipient-anaphor Auras stay honest `Unrecognized` gaps, and no other card regresses.
