### PR TITLE
Add Teamwork keyword + 9 MSH cards

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1598,6 +1598,30 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             min_count,
             ..
         } => bounded_select_card_candidates(*player, choices, *min_count..=*count),
+        // CR 601.2f + CR 208.1: The aggregate Crew/Saddle/Teamwork tap cost is
+        // paid by ANY creature subset whose summed current power satisfies the
+        // advertised comparator — not a fixed cardinality. Enumerate minimal-cover
+        // subsets (mirroring crew/saddle) so the AI/MP legal-action set offers
+        // them; measure each creature via the same current-power authority, and
+        // evaluate acceptance through the same `satisfied_by` the payment
+        // validator uses, so all three seams agree. The `aggregate: None`
+        // (fixed-count) form falls through to the exact-`count` selection below.
+        WaitingFor::PayCost {
+            player,
+            kind:
+                PayCostKind::TapCreatures {
+                    aggregate: Some(aggregate),
+                },
+            choices,
+            ..
+        } => minimal_power_subset_candidates(
+            state,
+            *player,
+            choices,
+            |total| aggregate.satisfied_by(total),
+            crate::game::casting_costs::tap_creature_power_contribution,
+            |cards| GameAction::SelectCards { cards },
+        ),
         WaitingFor::PayCost {
             player,
             choices,
@@ -4005,8 +4029,14 @@ fn crew_vehicle_candidates(
         state,
         player,
         eligible_creatures,
-        crew_power as i32,
-        crate::types::statics::CrewAction::Crew,
+        |total| total >= crew_power as i32,
+        |state, id| {
+            crate::game::static_abilities::object_crew_power_contribution(
+                state,
+                id,
+                crate::types::statics::CrewAction::Crew,
+            )
+        },
         |creature_ids| GameAction::CrewVehicle {
             vehicle_id,
             creature_ids,
@@ -4028,8 +4058,14 @@ fn saddle_mount_candidates(
         state,
         player,
         eligible_creatures,
-        saddle_power as i32,
-        crate::types::statics::CrewAction::Saddle,
+        |total| total >= saddle_power as i32,
+        |state, id| {
+            crate::game::static_abilities::object_crew_power_contribution(
+                state,
+                id,
+                crate::types::statics::CrewAction::Saddle,
+            )
+        },
         |creature_ids| GameAction::SaddleMount {
             mount_id,
             creature_ids,
@@ -4037,43 +4073,46 @@ fn saddle_mount_candidates(
     )
 }
 
-/// Shared engine policy for power-threshold subset selection (Crew/Saddle).
-/// Enumerates only the **minimal-size** valid covers, with creatures explored
-/// in ascending-power order so the lowest-power valid cover is yielded first.
-/// Capped at 20 candidates within the minimal size for search bounding.
-fn minimal_power_subset_candidates<F>(
+/// Shared engine policy for power-threshold subset selection (Crew/Saddle/
+/// Teamwork). Enumerates only the **minimal-size** valid covers, with creatures
+/// explored in ascending-power order so the lowest-power valid cover is yielded
+/// first. Capped at 20 candidates within the minimal size for search bounding.
+///
+/// `power_of` is the per-creature power accessor: each cost family measures
+/// contribution through its own authority (Crew/Saddle via
+/// `object_crew_power_contribution`, which honors "as though its power were N
+/// greater"/"uses its toughness"; Teamwork via the plain current-power sum). The
+/// candidate enumerator MUST use the same authority as that family's activation
+/// gate and announcement validator — measuring power any other way yields zero
+/// valid covers and hangs the controller with an empty legal-action set.
+///
+/// `satisfies` evaluates a candidate subset's summed power against the cost's
+/// constraint (Crew/Saddle: `>= N`; Teamwork: the advertised comparator via
+/// `TapCreaturesAggregate::satisfied_by`). The minimal-cover early-break assumes
+/// the constraint is monotone non-decreasing in the total (the only shapes
+/// produced today — `>=`/`>`); a future non-monotone comparator would need a
+/// different enumeration policy, but the payment validator remains the exact
+/// authority regardless.
+fn minimal_power_subset_candidates<S, P, F>(
     state: &GameState,
     player: PlayerId,
     eligible_creatures: &[crate::types::identifiers::ObjectId],
-    threshold: i32,
-    action: crate::types::statics::CrewAction,
+    satisfies: S,
+    power_of: P,
     wrap: F,
 ) -> Vec<CandidateAction>
 where
+    S: Fn(i32) -> bool,
+    P: Fn(&GameState, crate::types::identifiers::ObjectId) -> i32,
     F: Fn(Vec<crate::types::identifiers::ObjectId>) -> GameAction,
 {
     const MAX_CANDIDATES: usize = 20;
 
-    // CR 702.122c / 702.171a: a creature's contribution toward the crew/saddle
-    // threshold may be modified ("as though its power were N greater" / "using
-    // its toughness rather than its power"). The activation gate and the
-    // announcement validator both measure power via `object_crew_power_contribution`,
-    // so the candidate enumerator must use the same authority — measuring raw
-    // `power` here disagrees with those seams and yields zero valid covers for
-    // Pilot-style creatures (e.g. Deathless Pilot, "crews as though its power
-    // were 2 greater"), hanging the controller with an empty legal-action set.
     let mut creatures_with_power: Vec<(crate::types::identifiers::ObjectId, i32)> =
         eligible_creatures
             .iter()
             .filter(|&&id| state.objects.contains_key(&id))
-            .map(|&id| {
-                (
-                    id,
-                    crate::game::static_abilities::object_crew_power_contribution(
-                        state, id, action,
-                    ),
-                )
-            })
+            .map(|&id| (id, power_of(state, id)))
             .collect();
     // Ascending-power sort with id tie-break makes enumeration deterministic
     // and surfaces low-power covers first within each subset size.
@@ -4094,7 +4133,7 @@ where
                         .map(|(_, p)| *p)
                 })
                 .sum();
-            if total >= threshold {
+            if satisfies(total) {
                 actions.push(candidate(wrap(combo), TacticalClass::Utility, Some(player)));
                 if actions.len() >= MAX_CANDIDATES {
                     return actions;

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -493,6 +493,26 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
                 || chosen.len() < *min_count
                 || chosen.len() > *count
         }
+        // CR 601.2f + CR 208.1: the aggregate Crew/Saddle/Teamwork tap cost
+        // accepts ANY creature subset (drawn from `choices`, no duplicates)
+        // whose summed CURRENT positive power satisfies the advertised comparator
+        // — not a fixed cardinality. Evaluates through the same `satisfied_by`
+        // the payment validator (`handle_tap_creatures_for_spell_cost`) uses, so
+        // both seams agree on which subsets are legal.
+        (
+            WaitingFor::PayCost {
+                kind:
+                    PayCostKind::TapCreatures {
+                        aggregate: Some(aggregate),
+                    },
+                choices,
+                ..
+            },
+            GameAction::SelectCards { cards: chosen },
+        ) => {
+            let total = crate::game::casting_costs::tap_creatures_total_power(state, chosen);
+            selection_mismatch(chosen, choices, None) || !aggregate.satisfied_by(total)
+        }
         // CR 118.3 + CR 605.3b: every other PayCost kind selects exactly `count`.
         (WaitingFor::PayCost { choices, count, .. }, GameAction::SelectCards { cards: chosen }) => {
             selection_mismatch(chosen, choices, Some(*count))

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -2576,7 +2576,7 @@ pub fn synthesize_conspire(face: &mut CardFace) {
     if face.additional_cost.is_none() {
         face.additional_cost = Some(AdditionalCost::Optional {
             cost: AbilityCost::TapCreatures {
-                count: 2,
+                requirement: crate::types::ability::TapCreaturesRequirement::count(2),
                 filter: conspire_tap_filter(),
             },
             repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
@@ -2653,6 +2653,43 @@ fn is_conspire_copy_trigger(t: &TriggerDefinition) -> bool {
                 }
             ) && a.repeat_for.is_none()
         })
+}
+
+/// CR 601.2b/f: Teamwork N — "As an additional cost to cast this spell, you may
+/// tap any number of creatures you control with total power N or more." Builds
+/// the optional additional cost. Unlike Conspire, Teamwork adds no trigger: the
+/// spell's body references whether the cost was paid via an `AdditionalCostPaid`
+/// condition (parsed from "if this spell was cast using teamwork").
+///
+/// The tap requirement is the aggregate "total power N or greater" shape shared
+/// with Crew (CR 702.122a) and Saddle (CR 702.171a); CR 208.1 defines power.
+/// Mirrors `synthesize_conspire`'s optional-additional-cost construction.
+pub fn synthesize_teamwork(face: &mut CardFace) {
+    // allow-raw-authority: parse-time read of the printed Teamwork(N) keyword to extract N for cost synthesis (not a runtime effective-keyword query)
+    let Some(n) = face.keywords.iter().find_map(|k| match k {
+        Keyword::Teamwork(n) => Some(*n),
+        _ => None,
+    }) else {
+        return;
+    };
+
+    if face.additional_cost.is_none() {
+        face.additional_cost = Some(AdditionalCost::Optional {
+            cost: AbilityCost::TapCreatures {
+                requirement: crate::types::ability::TapCreaturesRequirement::total_power_at_least(
+                    n as i32,
+                ),
+                filter: teamwork_tap_filter(),
+            },
+            repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
+        });
+    }
+}
+
+/// CR 601.2b: "creatures you control" — Teamwork's tap-cost candidate filter.
+/// (No color-sharing constraint, unlike Conspire.)
+pub fn teamwork_tap_filter() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You))
 }
 
 /// CR 702.69a: The `AbilityDefinition` produced by a Gravestorm trigger — a
@@ -8912,6 +8949,10 @@ pub fn synthesize_all(face: &mut CardFace) {
     // CR 702.78a: Conspire — optional "tap two color-sharing creatures" additional
     // cost + a copy-once-on-cast trigger gated on that cost being paid.
     synthesize_conspire(face);
+    // CR 601.2b/f: Teamwork N — optional "tap any number of creatures you control
+    // with total power N or more" additional cost. The body's "if this spell was
+    // cast using teamwork" condition reads the resulting additional-cost-paid flag.
+    synthesize_teamwork(face);
     // CR 702.69a: Gravestorm — copy this spell for each permanent put into a
     // graveyard from the battlefield this turn.
     synthesize_gravestorm(face);
@@ -19126,10 +19167,14 @@ mod conspire_synthesis_tests {
         // CR 702.78a: optional "tap two color-sharing creatures" additional cost.
         match face.additional_cost.as_ref().expect("additional_cost set") {
             AdditionalCost::Optional {
-                cost: AbilityCost::TapCreatures { count, filter },
+                cost:
+                    AbilityCost::TapCreatures {
+                        requirement,
+                        filter,
+                    },
                 repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
             } => {
-                assert_eq!(*count, 2);
+                assert_eq!(requirement.fixed_count(), Some(2));
                 let TargetFilter::Typed(tf) = filter else {
                     panic!("expected typed creature filter, got {filter:?}");
                 };

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12168,9 +12168,7 @@ pub fn handle_activate_ability(
             pending_tap.activation_ability_index = Some(ability_index);
             return Ok(WaitingFor::PayCost {
                 player,
-                kind: PayCostKind::TapCreatures {
-                    power_threshold: None,
-                },
+                kind: PayCostKind::TapCreatures { aggregate: None },
                 choices: eligible,
                 count: count as usize,
                 min_count: 0,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4,7 +4,7 @@ use crate::types::ability::{
     ContinuousModification, CostObjectCount, CostPaidObjectSnapshot, CounterCostSelection,
     Duration, Effect, FilterProp, GameRestriction, ModalSelectionCondition, ObjectScope,
     PlayerFilter, PlayerScope, ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility,
-    RestrictionPlayerScope, StaticDefinition, TargetFilter, TargetRef,
+    RestrictionPlayerScope, StaticDefinition, TapCreaturesRequirement, TargetFilter, TargetRef,
 };
 use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
@@ -10955,9 +10955,14 @@ fn find_craft_materials_cost(cost: &AbilityCost) -> Option<(CostObjectCount, &Ta
     }
 }
 
-pub(super) fn find_tap_creatures_cost(cost: &AbilityCost) -> Option<(u32, &TargetFilter)> {
+pub(super) fn find_tap_creatures_cost(
+    cost: &AbilityCost,
+) -> Option<(&TapCreaturesRequirement, &TargetFilter)> {
     match cost {
-        AbilityCost::TapCreatures { count, filter } => Some((*count, filter)),
+        AbilityCost::TapCreatures {
+            requirement,
+            filter,
+        } => Some((requirement, filter)),
         AbilityCost::Composite { costs } => costs.iter().find_map(find_tap_creatures_cost),
         _ => None,
     }
@@ -12141,7 +12146,15 @@ pub fn handle_activate_ability(
         // CR 118.3: Pre-check for tap-creatures activation costs. Non-mana
         // activated abilities use the same WaitingFor flow as flashback tap
         // costs; completion resumes through `finish_pending_cost_or_cast`.
-        if let Some((count, filter)) = find_tap_creatures_cost(cost) {
+        if let Some((requirement, filter)) = find_tap_creatures_cost(cost) {
+            // CR 602.1a: Activated-ability tap costs are fixed-count today
+            // (Convoke-style). The aggregate "total power N" form is reserved for
+            // Crew/Saddle/Teamwork, which are not dispatched through this path.
+            let count = requirement.fixed_count().ok_or_else(|| {
+                EngineError::ActionNotAllowed(
+                    "Aggregate-power tap cost is not valid for this activation".into(),
+                )
+            })?;
             let eligible =
                 find_eligible_tap_creatures_for_cost(state, player, source_id, cost, filter);
             if eligible.len() < count as usize {
@@ -12155,7 +12168,9 @@ pub fn handle_activate_ability(
             pending_tap.activation_ability_index = Some(ability_index);
             return Ok(WaitingFor::PayCost {
                 player,
-                kind: PayCostKind::TapCreatures,
+                kind: PayCostKind::TapCreatures {
+                    power_threshold: None,
+                },
                 choices: eligible,
                 count: count as usize,
                 min_count: 0,
@@ -28517,7 +28532,7 @@ mod tests {
             obj.modal.as_mut().unwrap().max_choices = 3;
             obj.keywords
                 .push(Keyword::Escalate(AbilityCost::TapCreatures {
-                    count: 1,
+                    requirement: crate::types::ability::TapCreaturesRequirement::count(1),
                     filter: TargetFilter::Typed(TypedFilter::creature()),
                 }));
         }
@@ -28531,7 +28546,7 @@ mod tests {
 
         match &state.waiting_for {
             WaitingFor::PayCost {
-                kind: PayCostKind::TapCreatures,
+                kind: PayCostKind::TapCreatures { .. },
                 count,
                 choices: creatures,
                 resume: CostResume::Spell { .. },

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1773,27 +1773,51 @@ pub(crate) fn handle_blight_choice(
 }
 
 /// CR 702.34a: Tap creatures cost — complete the tap-creatures cost after player selection.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_tap_creatures_for_spell_cost(
     state: &mut GameState,
     player: PlayerId,
     pending: PendingCast,
     count: usize,
+    power_threshold: Option<i32>,
     legal_creatures: &[ObjectId],
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    if chosen.len() != count {
-        return Err(EngineError::InvalidAction(format!(
-            "Must tap exactly {} creature(s), got {}",
-            count,
-            chosen.len()
-        )));
-    }
+    // CR 601.2b: Validate the chosen set against the cost's requirement shape.
+    // `power_threshold == None` is fixed-count (tap exactly `count`); `Some(n)`
+    // is the aggregate Crew/Saddle/Teamwork form (tap any number whose total
+    // positive power, CR 208.1, is at least `n`).
     for id in chosen {
         if !legal_creatures.contains(id) {
             return Err(EngineError::InvalidAction(
                 "Selected creature not eligible for tapping".to_string(),
             ));
+        }
+    }
+    match power_threshold {
+        None => {
+            if chosen.len() != count {
+                return Err(EngineError::InvalidAction(format!(
+                    "Must tap exactly {} creature(s), got {}",
+                    count,
+                    chosen.len()
+                )));
+            }
+        }
+        Some(threshold) => {
+            let total_positive_power: i32 = chosen
+                .iter()
+                .filter_map(|id| state.objects.get(id))
+                .map(|obj| obj.power.unwrap_or(0))
+                .filter(|&p| p > 0)
+                .sum();
+            if total_positive_power < threshold {
+                return Err(EngineError::InvalidAction(format!(
+                    "Tapped creatures' total power {total_positive_power} is less than the \
+                     required {threshold}"
+                )));
+            }
         }
     }
 
@@ -4061,9 +4085,12 @@ fn pay_additional_cost_with_source(
                 state, player, amount, pending,
             );
         }
-        AbilityCost::TapCreatures { count, ref filter } => {
-            // CR 702.34a: Tap untapped creatures matching filter as a cost.
-            // The source is eligible unless a {T} cost is also present in the
+        AbilityCost::TapCreatures {
+            ref requirement,
+            ref filter,
+        } => {
+            // CR 601.2b: Tap untapped creatures matching filter as a cost. The
+            // source is eligible unless a {T} cost is also present in the
             // activation cost (in which case the source was already tapped, so
             // !obj.tapped naturally excludes it).
             let eligible: Vec<ObjectId> = state
@@ -4086,17 +4113,56 @@ fn pay_additional_cost_with_source(
                     })
                 })
                 .collect();
-            if eligible.len() < count as usize {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough eligible creatures to tap".into(),
-                ));
-            }
+            // CR 601.2b: The two requirement shapes drive different prompts.
+            // Fixed-count taps exactly `count`; aggregate (Crew/Saddle/Teamwork)
+            // taps any number whose total positive power (CR 208.1) meets the
+            // threshold, so the player may select up to every eligible creature.
+            let (kind, count, min_count) = match requirement {
+                crate::types::ability::TapCreaturesRequirement::Count { count } => {
+                    if eligible.len() < *count as usize {
+                        return Err(EngineError::ActionNotAllowed(
+                            "Not enough eligible creatures to tap".into(),
+                        ));
+                    }
+                    (
+                        PayCostKind::TapCreatures {
+                            power_threshold: None,
+                        },
+                        *count as usize,
+                        0,
+                    )
+                }
+                crate::types::ability::TapCreaturesRequirement::Aggregate {
+                    stat: crate::types::ability::TapCreaturesAggregateStat::TotalPower,
+                    comparator,
+                    value,
+                } => {
+                    let total_positive_power: i32 = eligible
+                        .iter()
+                        .filter_map(|id| state.objects.get(id))
+                        .map(|obj| obj.power.unwrap_or(0))
+                        .filter(|&p| p > 0)
+                        .sum();
+                    if !comparator.evaluate(total_positive_power, *value) {
+                        return Err(EngineError::ActionNotAllowed(
+                            "Not enough total creature power to pay this cost".into(),
+                        ));
+                    }
+                    (
+                        PayCostKind::TapCreatures {
+                            power_threshold: Some(*value),
+                        },
+                        eligible.len(),
+                        0,
+                    )
+                }
+            };
             return Ok(WaitingFor::PayCost {
                 player,
-                kind: PayCostKind::TapCreatures,
+                kind,
                 choices: eligible,
-                count: count as usize,
-                min_count: 0,
+                count,
+                min_count,
                 resume: CostResume::Spell {
                     spell: Box::new(pending),
                 },
@@ -4410,7 +4476,7 @@ pub(super) fn effective_conspire_additional_cost(
         .any(|keyword| matches!(keyword, Keyword::Conspire))
         .then(|| AdditionalCost::Optional {
             cost: AbilityCost::TapCreatures {
-                count: 2,
+                requirement: crate::types::ability::TapCreaturesRequirement::count(2),
                 filter: crate::database::synthesis::conspire_tap_filter(),
             },
             repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
@@ -9120,10 +9186,18 @@ mod tests {
         match waiting {
             WaitingFor::OptionalCostChoice { cost, .. } => match cost {
                 AdditionalCost::Optional {
-                    cost: AbilityCost::TapCreatures { count, filter },
+                    cost:
+                        AbilityCost::TapCreatures {
+                            requirement,
+                            filter,
+                        },
                     repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
                 } => {
-                    assert_eq!(count, 2, "conspire taps exactly two creatures");
+                    assert_eq!(
+                        requirement.fixed_count(),
+                        Some(2),
+                        "conspire taps exactly two creatures"
+                    );
                     match filter {
                         TargetFilter::Typed(tf) => {
                             assert!(tf.type_filters.contains(&TypeFilter::Creature));

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5,8 +5,8 @@ use crate::types::ability::{
     AbilityKind, AdditionalCost, AdditionalCostInstance, AdditionalCostOrigin, BeholdCostAction,
     CastTimingPermission, CostPaidObjectSnapshot, CounterCostSelection, Effect, KickerVariant,
     QuantityExpr, QuantityRef, ReplacementDefinition, ResolvedAbility, SacrificeCost,
-    SacrificeRequirement, SpellCastingOptionKind, StaticCondition, TargetFilter, TypeFilter,
-    TypedFilter, EXILE_COST_X,
+    SacrificeRequirement, SpellCastingOptionKind, StaticCondition, TapCreaturesAggregate,
+    TargetFilter, TypeFilter, TypedFilter, EXILE_COST_X,
 };
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
@@ -1772,6 +1772,31 @@ pub(crate) fn handle_blight_choice(
     finish_pending_cost_or_cast(state, player, pending, events)
 }
 
+/// CR 208.1 + CR 601.2f: A single creature's contribution toward an aggregate
+/// total-power tap cost (Crew/Saddle/Teamwork). Reads the creature's CURRENT,
+/// layer-evaluated power (`GameObject::power`, the post-continuous-effects value
+/// written by the layer system — anthems and +1/+1 counters are already folded
+/// in), and clamps negative power to 0 so a debuffed creature contributes
+/// nothing rather than reducing the total.
+pub(crate) fn tap_creature_power_contribution(state: &GameState, id: ObjectId) -> i32 {
+    state
+        .objects
+        .get(&id)
+        .and_then(|obj| obj.power)
+        .filter(|&p| p > 0)
+        .unwrap_or(0)
+}
+
+/// CR 208.1 + CR 601.2f: Sum the CURRENT positive power of a set of creatures
+/// toward an aggregate total-power tap cost. Single authority shared by the
+/// activation gate, the AI candidate enumerator, and the selection validator so
+/// every seam agrees on which subsets satisfy the threshold.
+pub(crate) fn tap_creatures_total_power(state: &GameState, ids: &[ObjectId]) -> i32 {
+    ids.iter()
+        .map(|&id| tap_creature_power_contribution(state, id))
+        .sum()
+}
+
 /// CR 702.34a: Tap creatures cost — complete the tap-creatures cost after player selection.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_tap_creatures_for_spell_cost(
@@ -1779,15 +1804,15 @@ pub(crate) fn handle_tap_creatures_for_spell_cost(
     player: PlayerId,
     pending: PendingCast,
     count: usize,
-    power_threshold: Option<i32>,
+    aggregate: Option<TapCreaturesAggregate>,
     legal_creatures: &[ObjectId],
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     // CR 601.2b: Validate the chosen set against the cost's requirement shape.
-    // `power_threshold == None` is fixed-count (tap exactly `count`); `Some(n)`
-    // is the aggregate Crew/Saddle/Teamwork form (tap any number whose total
-    // positive power, CR 208.1, is at least `n`).
+    // `aggregate == None` is fixed-count (tap exactly `count`); `Some(a)` is the
+    // aggregate Crew/Saddle/Teamwork form (tap any number whose total positive
+    // power, CR 208.1, satisfies the advertised comparator vs `a.value`).
     for id in chosen {
         if !legal_creatures.contains(id) {
             return Err(EngineError::InvalidAction(
@@ -1795,7 +1820,7 @@ pub(crate) fn handle_tap_creatures_for_spell_cost(
             ));
         }
     }
-    match power_threshold {
+    match aggregate {
         None => {
             if chosen.len() != count {
                 return Err(EngineError::InvalidAction(format!(
@@ -1805,17 +1830,13 @@ pub(crate) fn handle_tap_creatures_for_spell_cost(
                 )));
             }
         }
-        Some(threshold) => {
-            let total_positive_power: i32 = chosen
-                .iter()
-                .filter_map(|id| state.objects.get(id))
-                .map(|obj| obj.power.unwrap_or(0))
-                .filter(|&p| p > 0)
-                .sum();
-            if total_positive_power < threshold {
+        Some(aggregate) => {
+            let total_positive_power = tap_creatures_total_power(state, chosen);
+            if !aggregate.satisfied_by(total_positive_power) {
                 return Err(EngineError::InvalidAction(format!(
-                    "Tapped creatures' total power {total_positive_power} is less than the \
-                     required {threshold}"
+                    "Tapped creatures' total power {total_positive_power} does not satisfy the \
+                     required {:?} {}",
+                    aggregate.comparator, aggregate.value
                 )));
             }
         }
@@ -2898,8 +2919,8 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
 
     // CR 601.2b/f + CR 113.2c: non-kicker keyword additional costs with
     // independently functioning instances are announced through a queue. This
-    // preserves one payment record per Casualty/Offspring/Squad/Replicate
-    // instance while leaving Kicker on its existing `kickers_paid` path.
+    // preserves one payment record per Casualty/Offspring/Squad/Replicate/
+    // Teamwork instance while leaving Kicker on its existing `kickers_paid` path.
     let mut additional_cost_queue = Vec::new();
     additional_cost_queue.extend(effective_casualty_additional_cost_instances(
         state, player, object_id,
@@ -2911,6 +2932,9 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
         state, player, object_id,
     ));
     additional_cost_queue.extend(effective_replicate_additional_cost_instances(
+        state, player, object_id,
+    ));
+    additional_cost_queue.extend(effective_teamwork_additional_cost_instances(
         state, player, object_id,
     ));
     let obj_additional_matches_instance = obj_additional.as_ref().is_some_and(|cost| {
@@ -4115,8 +4139,9 @@ fn pay_additional_cost_with_source(
                 .collect();
             // CR 601.2b: The two requirement shapes drive different prompts.
             // Fixed-count taps exactly `count`; aggregate (Crew/Saddle/Teamwork)
-            // taps any number whose total positive power (CR 208.1) meets the
-            // threshold, so the player may select up to every eligible creature.
+            // taps any number whose total positive power (CR 208.1) satisfies the
+            // advertised comparator, so the player may select up to every
+            // eligible creature.
             let (kind, count, min_count) = match requirement {
                 crate::types::ability::TapCreaturesRequirement::Count { count } => {
                     if eligible.len() < *count as usize {
@@ -4125,32 +4150,34 @@ fn pay_additional_cost_with_source(
                         ));
                     }
                     (
-                        PayCostKind::TapCreatures {
-                            power_threshold: None,
-                        },
+                        PayCostKind::TapCreatures { aggregate: None },
                         *count as usize,
                         0,
                     )
                 }
                 crate::types::ability::TapCreaturesRequirement::Aggregate {
-                    stat: crate::types::ability::TapCreaturesAggregateStat::TotalPower,
+                    stat,
                     comparator,
                     value,
                 } => {
-                    let total_positive_power: i32 = eligible
-                        .iter()
-                        .filter_map(|id| state.objects.get(id))
-                        .map(|obj| obj.power.unwrap_or(0))
-                        .filter(|&p| p > 0)
-                        .sum();
-                    if !comparator.evaluate(total_positive_power, *value) {
+                    // CR 601.2f + CR 208.1: Snapshot the full constraint so the
+                    // payment validator honors the advertised comparator. The
+                    // precheck below uses the same `satisfied_by` evaluation as
+                    // the candidate enumerator and selection validator.
+                    let aggregate = crate::types::ability::TapCreaturesAggregate {
+                        stat: *stat,
+                        comparator: *comparator,
+                        value: *value,
+                    };
+                    let total_positive_power = tap_creatures_total_power(state, &eligible);
+                    if !aggregate.satisfied_by(total_positive_power) {
                         return Err(EngineError::ActionNotAllowed(
-                            "Not enough total creature power to pay this cost".into(),
+                            "Eligible creatures' total power does not satisfy this cost".into(),
                         ));
                     }
                     (
                         PayCostKind::TapCreatures {
-                            power_threshold: Some(*value),
+                            aggregate: Some(aggregate),
                         },
                         eligible.len(),
                         0,
@@ -4494,6 +4521,46 @@ pub(super) fn effective_replicate_additional_cost(
         .into_iter()
         .next()
         .map(|instance| instance.cost)
+}
+
+/// CR 601.2b/f: Return the optional Teamwork additional cost ("tap any number of
+/// creatures you control with total power N or more") as a queue instance
+/// stamped with `AdditionalCostOrigin::Teamwork`. Queuing it (rather than the
+/// generic `face.additional_cost` path, which stamps `Other`) lets "cast using
+/// teamwork" riders test the Teamwork payment specifically and lets Teamwork
+/// compose with another object additional cost. Mirrors
+/// `effective_squad_additional_cost_instances`; the produced cost matches the
+/// `synthesize_teamwork` form so the `obj_additional_matches_instance` dedup
+/// suppresses the legacy `face.additional_cost` copy.
+pub(super) fn effective_teamwork_additional_cost_instances(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+) -> Vec<AdditionalCostInstance> {
+    super::casting::effective_spell_keyword_instances(state, player, object_id)
+        .into_iter()
+        .filter_map(|keyword| match keyword {
+            Keyword::Teamwork(n) => Some(n),
+            _ => None,
+        })
+        .enumerate()
+        .map(|(ordinal, n)| {
+            AdditionalCostInstance::new_with_ordinal(
+                AdditionalCostOrigin::Teamwork,
+                u32::try_from(ordinal).unwrap_or(u32::MAX),
+                AdditionalCost::Optional {
+                    cost: AbilityCost::TapCreatures {
+                        requirement:
+                            crate::types::ability::TapCreaturesRequirement::total_power_at_least(
+                                n as i32,
+                            ),
+                        filter: crate::database::synthesis::teamwork_tap_filter(),
+                    },
+                    repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
+                },
+            )
+        })
+        .collect()
 }
 
 pub(super) fn effective_offspring_additional_cost_instances(

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -21,7 +21,8 @@
 
 use crate::types::ability::{
     is_variable_remove_counter_cost_count, AbilityCost, Comparator, CounterCostSelection,
-    FilterProp, QuantityExpr, QuantityRef, TargetFilter, TypedFilter,
+    FilterProp, QuantityExpr, QuantityRef, TapCreaturesAggregateStat, TapCreaturesRequirement,
+    TargetFilter, TypedFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::identifiers::ObjectId;
@@ -206,8 +207,11 @@ impl AbilityCost {
             AbilityCost::Composite { costs } => {
                 let has_tap = costs.iter().any(|c| matches!(c, AbilityCost::Tap));
                 costs.iter().all(|c| match c {
-                    AbilityCost::TapCreatures { count, filter } if has_tap => {
-                        has_enough_tap_creatures(state, player, source, *count, filter, true)
+                    AbilityCost::TapCreatures {
+                        requirement,
+                        filter,
+                    } if has_tap => {
+                        has_enough_tap_creatures(state, player, source, requirement, filter, true)
                     }
                     other => other.is_payable_for_mana_ability(state, player, source),
                 })
@@ -388,9 +392,10 @@ impl AbilityCost {
             // is also present (handled by the Composite arm); otherwise the
             // source is a valid choice (e.g. Morcant's "Tap three untapped
             // Elves" has no {T}, so Morcant herself is eligible).
-            AbilityCost::TapCreatures { count, filter } => {
-                has_enough_tap_creatures(state, player, source, *count, filter, false)
-            }
+            AbilityCost::TapCreatures {
+                requirement,
+                filter,
+            } => has_enough_tap_creatures(state, player, source, requirement, filter, false),
             // CR 601.2b: RemoveCounter requires counters on the implied target.
             // If `target` is None, the source must have the required counters.
             // Otherwise, at least one matching permanent must carry N counters.
@@ -533,8 +538,11 @@ impl AbilityCost {
             AbilityCost::Composite { costs } => {
                 let has_tap = costs.iter().any(|c| matches!(c, AbilityCost::Tap));
                 costs.iter().all(|c| match c {
-                    AbilityCost::TapCreatures { count, filter } if has_tap => {
-                        has_enough_tap_creatures(state, player, source, *count, filter, true)
+                    AbilityCost::TapCreatures {
+                        requirement,
+                        filter,
+                    } if has_tap => {
+                        has_enough_tap_creatures(state, player, source, requirement, filter, true)
                     }
                     other => other.is_payable(state, player, source),
                 })
@@ -580,31 +588,44 @@ impl AbilityCost {
     }
 }
 
+/// CR 601.2b: A `TapCreatures` cost is payable iff the untapped, filter-matching
+/// creatures the player controls satisfy its `requirement`: at least `count` of
+/// them for `Count`, or aggregate total positive power meeting the comparator
+/// for `Aggregate` (Crew CR 702.122a / Saddle CR 702.171a / Teamwork). CR 208.1:
+/// power is the aggregate axis; negative powers contribute 0 (mirrors the
+/// sacrifice-aggregate payability check).
 fn has_enough_tap_creatures(
     state: &GameState,
     player: PlayerId,
     source: ObjectId,
-    count: u32,
+    requirement: &TapCreaturesRequirement,
     filter: &TargetFilter,
     exclude_source: bool,
 ) -> bool {
     let ctx = FilterContext::from_source(state, source);
-    state
-        .battlefield
-        .iter()
-        .copied()
-        .filter(|&id| {
-            if exclude_source && id == source {
-                return false;
-            }
-            state.objects.get(&id).is_some_and(|o| {
-                o.controller == player
-                    && !o.tapped
-                    && matches_target_filter(state, id, filter, &ctx)
-            })
+    let eligible = state.battlefield.iter().copied().filter(|&id| {
+        if exclude_source && id == source {
+            return false;
+        }
+        state.objects.get(&id).is_some_and(|o| {
+            o.controller == player && !o.tapped && matches_target_filter(state, id, filter, &ctx)
         })
-        .count()
-        >= count as usize
+    });
+    match requirement {
+        TapCreaturesRequirement::Count { count } => eligible.count() >= *count as usize,
+        TapCreaturesRequirement::Aggregate {
+            stat: TapCreaturesAggregateStat::TotalPower,
+            comparator,
+            value,
+        } => {
+            let total_positive_power: i32 = eligible
+                .filter_map(|id| state.objects.get(&id))
+                .map(|obj| obj.power.unwrap_or(0))
+                .filter(|&p| p > 0)
+                .sum();
+            comparator.evaluate(total_positive_power, *value)
+        }
+    }
 }
 
 /// CR 117.1 + CR 118.3: Infer the source zone for a non-self
@@ -907,7 +928,7 @@ mod tests {
     fn tap_creatures_standalone_includes_source() {
         let mut scenario = GameScenario::new();
         let cost = AbilityCost::TapCreatures {
-            count: 3,
+            requirement: TapCreaturesRequirement::count(3),
             filter: elf_filter(),
         };
         // Place exactly 3 Elves controlled by P0 — including the source.
@@ -941,7 +962,7 @@ mod tests {
             costs: vec![
                 AbilityCost::Tap,
                 AbilityCost::TapCreatures {
-                    count: 2,
+                    requirement: TapCreaturesRequirement::count(2),
                     filter: elf_filter(),
                 },
             ],

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1283,7 +1283,7 @@ mod tests {
     use crate::game::scenario::GameScenario;
     use crate::types::ability::{
         BeholdCostAction, CardSelectionMode, CostObjectCount, DiscardSelfScope, Effect,
-        NinjutsuVariant, QuantityExpr, SacrificeCost,
+        NinjutsuVariant, QuantityExpr, SacrificeCost, TapCreaturesRequirement,
     };
     use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::mana::ManaCost;
@@ -1331,7 +1331,7 @@ mod tests {
             },
             AbilityCost::CollectEvidence { .. } => AbilityCost::CollectEvidence { amount: 1 },
             AbilityCost::TapCreatures { .. } => AbilityCost::TapCreatures {
-                count: 1,
+                requirement: TapCreaturesRequirement::count(1),
                 filter: TargetFilter::Any,
             },
             AbilityCost::RemoveCounter { .. } => AbilityCost::RemoveCounter {
@@ -1432,7 +1432,7 @@ mod tests {
             },
             AbilityCost::CollectEvidence { amount: 0 },
             AbilityCost::TapCreatures {
-                count: 0,
+                requirement: TapCreaturesRequirement::count(0),
                 filter: TargetFilter::Any,
             },
             AbilityCost::RemoveCounter {
@@ -1706,7 +1706,7 @@ mod tests {
         let mut scenario = GameScenario::new();
         let src = scenario.add_creature(P0, "Lord", 2, 2).id();
         let cost = AbilityCost::TapCreatures {
-            count: 2,
+            requirement: TapCreaturesRequirement::count(2),
             filter: TargetFilter::Typed(TypedFilter::creature()),
         };
         // Only the source creature is present (1 < 2).

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -2354,15 +2354,18 @@ fn apply_action(
                         &mut events,
                     )?
                 }
-                PayCostKind::TapCreatures => engine_casting::handle_tap_creatures_for_spell_cost(
-                    state,
-                    *player,
-                    *pending_cast.clone(),
-                    *count,
-                    choices,
-                    &chosen,
-                    &mut events,
-                )?,
+                PayCostKind::TapCreatures { power_threshold } => {
+                    engine_casting::handle_tap_creatures_for_spell_cost(
+                        state,
+                        *player,
+                        *pending_cast.clone(),
+                        *count,
+                        *power_threshold,
+                        choices,
+                        &chosen,
+                        &mut events,
+                    )?
+                }
                 PayCostKind::Behold { action } => engine_casting::handle_behold_for_cost(
                     state,
                     *player,
@@ -2385,14 +2388,18 @@ fn apply_action(
             CostResume::ManaAbility {
                 mana_ability: pending_mana_ability,
             } => match kind {
-                PayCostKind::TapCreatures => engine_casting::handle_tap_creatures_for_mana_ability(
-                    state,
-                    *count,
-                    choices,
-                    pending_mana_ability,
-                    &chosen,
-                    &mut events,
-                )?,
+                // CR 605.1a: mana-ability tap costs are always fixed-count; the
+                // aggregate power_threshold form never resumes a mana ability.
+                PayCostKind::TapCreatures { .. } => {
+                    engine_casting::handle_tap_creatures_for_mana_ability(
+                        state,
+                        *count,
+                        choices,
+                        pending_mana_ability,
+                        &chosen,
+                        &mut events,
+                    )?
+                }
                 PayCostKind::Discard => engine_casting::handle_discard_for_mana_ability(
                     state,
                     *count,
@@ -11964,7 +11971,7 @@ mod tests {
                     costs: vec![
                         AbilityCost::Tap,
                         AbilityCost::TapCreatures {
-                            count: 1,
+                            requirement: crate::types::ability::TapCreaturesRequirement::count(1),
                             filter: crate::types::ability::TypedFilter::creature()
                                 .controller(crate::types::ability::ControllerRef::You)
                                 .into(),
@@ -12002,7 +12009,7 @@ mod tests {
             result.waiting_for,
             WaitingFor::PayCost {
                 player: PlayerId(0),
-                kind: PayCostKind::TapCreatures,
+                kind: PayCostKind::TapCreatures { .. },
                 count: 1,
                 resume: CostResume::ManaAbility { .. },
                 ..
@@ -12435,7 +12442,7 @@ mod tests {
                     costs: vec![
                         AbilityCost::Tap,
                         AbilityCost::TapCreatures {
-                            count: 1,
+                            requirement: crate::types::ability::TapCreaturesRequirement::count(1),
                             filter: TypedFilter::creature()
                                 .controller(ControllerRef::You)
                                 .into(),
@@ -12491,7 +12498,7 @@ mod tests {
         match result.waiting_for {
             WaitingFor::PayCost {
                 player,
-                kind: PayCostKind::TapCreatures,
+                kind: PayCostKind::TapCreatures { .. },
                 count,
                 choices: creatures,
                 resume: CostResume::ManaAbility { .. },
@@ -12567,7 +12574,7 @@ mod tests {
                     costs: vec![
                         AbilityCost::Tap,
                         AbilityCost::TapCreatures {
-                            count: 2,
+                            requirement: crate::types::ability::TapCreaturesRequirement::count(2),
                             filter: TypedFilter::creature()
                                 .with_type(TypeFilter::Subtype("Elf".to_string()))
                                 .controller(ControllerRef::You)
@@ -12617,7 +12624,7 @@ mod tests {
         match result.waiting_for {
             WaitingFor::PayCost {
                 player,
-                kind: PayCostKind::TapCreatures,
+                kind: PayCostKind::TapCreatures { .. },
                 count,
                 choices: creatures,
                 resume: CostResume::Spell { .. },
@@ -12674,7 +12681,7 @@ mod tests {
                     costs: vec![
                         AbilityCost::Tap,
                         AbilityCost::TapCreatures {
-                            count: 1,
+                            requirement: crate::types::ability::TapCreaturesRequirement::count(1),
                             filter: TypedFilter::creature()
                                 .with_type(TypeFilter::Subtype("Elf".to_string()))
                                 .controller(ControllerRef::You)

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -2354,13 +2354,13 @@ fn apply_action(
                         &mut events,
                     )?
                 }
-                PayCostKind::TapCreatures { power_threshold } => {
+                PayCostKind::TapCreatures { aggregate } => {
                     engine_casting::handle_tap_creatures_for_spell_cost(
                         state,
                         *player,
                         *pending_cast.clone(),
                         *count,
-                        *power_threshold,
+                        *aggregate,
                         choices,
                         &chosen,
                         &mut events,
@@ -2389,7 +2389,7 @@ fn apply_action(
                 mana_ability: pending_mana_ability,
             } => match kind {
                 // CR 605.1a: mana-ability tap costs are always fixed-count; the
-                // aggregate power_threshold form never resumes a mana ability.
+                // aggregate form never resumes a mana ability.
                 PayCostKind::TapCreatures { .. } => {
                     engine_casting::handle_tap_creatures_for_mana_ability(
                         state,

--- a/crates/engine/src/game/engine_casting.rs
+++ b/crates/engine/src/game/engine_casting.rs
@@ -133,11 +133,13 @@ pub(super) fn handle_return_to_hand_for_cost(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn handle_tap_creatures_for_spell_cost(
     state: &mut GameState,
     player: PlayerId,
     pending_cast: PendingCast,
     count: usize,
+    power_threshold: Option<i32>,
     creatures: &[ObjectId],
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
@@ -147,6 +149,7 @@ pub(super) fn handle_tap_creatures_for_spell_cost(
         player,
         pending_cast,
         count,
+        power_threshold,
         creatures,
         chosen,
         events,

--- a/crates/engine/src/game/engine_casting.rs
+++ b/crates/engine/src/game/engine_casting.rs
@@ -1,4 +1,6 @@
-use crate::types::ability::{AbilityCost, AdditionalCost, BeholdCostAction, TargetFilter};
+use crate::types::ability::{
+    AbilityCost, AdditionalCost, BeholdCostAction, TapCreaturesAggregate, TargetFilter,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
     CollectEvidenceResume, GameState, PendingCast, PendingManaAbility, WaitingFor,
@@ -139,7 +141,7 @@ pub(super) fn handle_tap_creatures_for_spell_cost(
     player: PlayerId,
     pending_cast: PendingCast,
     count: usize,
-    power_threshold: Option<i32>,
+    aggregate: Option<TapCreaturesAggregate>,
     creatures: &[ObjectId],
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
@@ -149,7 +151,7 @@ pub(super) fn handle_tap_creatures_for_spell_cost(
         player,
         pending_cast,
         count,
-        power_threshold,
+        aggregate,
         creatures,
         chosen,
         events,

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1089,9 +1089,7 @@ pub(super) fn advance_mana_ability_activation(
             }
             return Ok(WaitingFor::PayCost {
                 player: pending.player,
-                kind: PayCostKind::TapCreatures {
-                    power_threshold: None,
-                },
+                kind: PayCostKind::TapCreatures { aggregate: None },
                 choices: creatures,
                 count,
                 min_count: 0,

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1089,7 +1089,9 @@ pub(super) fn advance_mana_ability_activation(
             }
             return Ok(WaitingFor::PayCost {
                 player: pending.player,
-                kind: PayCostKind::TapCreatures,
+                kind: PayCostKind::TapCreatures {
+                    power_threshold: None,
+                },
                 choices: creatures,
                 count,
                 min_count: 0,
@@ -1608,8 +1610,19 @@ where
                 super::quantity::resolve_quantity(state, amount, player, source_id).max(0) as u32;
             pay_life_cost(state, player, resolved, events)?
         }
-        Some(AbilityCost::TapCreatures { count, filter }) => {
-            for _ in 0..*count {
+        Some(AbilityCost::TapCreatures {
+            requirement,
+            filter,
+        }) => {
+            // CR 605.1a: Mana-ability tap costs (Convoke-style) are fixed-count
+            // only; the aggregate "total power N" form is reserved for
+            // Crew/Saddle/Teamwork, which are never mana abilities.
+            let count = requirement.fixed_count().ok_or_else(|| {
+                EngineError::InvalidAction(
+                    "Aggregate-power tap cost is not valid for a mana ability".to_string(),
+                )
+            })?;
+            for _ in 0..count {
                 let chosen_id = chosen_tappers.next().ok_or_else(|| {
                     EngineError::InvalidAction(
                         "Missing tapped creature selection for mana ability".to_string(),
@@ -1750,8 +1763,18 @@ where
                                 .max(0) as u32;
                         pay_life_cost(state, player, resolved, events)?
                     }
-                    AbilityCost::TapCreatures { count, filter } => {
-                        for _ in 0..*count {
+                    AbilityCost::TapCreatures {
+                        requirement,
+                        filter,
+                    } => {
+                        // CR 605.1a: mana-ability tap costs are fixed-count only.
+                        let count = requirement.fixed_count().ok_or_else(|| {
+                            EngineError::InvalidAction(
+                                "Aggregate-power tap cost is not valid for a mana ability"
+                                    .to_string(),
+                            )
+                        })?;
+                        for _ in 0..count {
                             let chosen_id = chosen_tappers.next().ok_or_else(|| {
                                 EngineError::InvalidAction(
                                     "Missing tapped creature selection for mana ability"
@@ -2407,7 +2430,9 @@ fn tap_creature_cost_choice(
     source_id: ObjectId,
     cost: &Option<AbilityCost>,
 ) -> Option<(usize, Vec<ObjectId>)> {
-    let (count, filter) = super::casting::find_tap_creatures_cost(cost.as_ref()?)?;
+    let (requirement, filter) = super::casting::find_tap_creatures_cost(cost.as_ref()?)?;
+    // CR 605.1a: mana-ability tap costs (Convoke-style) are fixed-count only.
+    let count = requirement.fixed_count()?;
     let creatures = state
         .battlefield
         .iter()

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1362,11 +1362,10 @@ mod tests {
                 kind: crate::types::ability::SpellCastingOptionKind::AlternativeCost,
                 cost:
                     Some(AbilityCost::TapCreatures {
-                        count: 1,
-                        filter: _,
+                        ref requirement, ..
                     }),
                 condition: None,
-            } => {}
+            } if requirement.fixed_count() == Some(1) => {}
             other => panic!("expected TapCreatures alt-cost, got {other:?}"),
         }
     }
@@ -1384,11 +1383,10 @@ mod tests {
                 kind: crate::types::ability::SpellCastingOptionKind::AlternativeCost,
                 cost:
                     Some(AbilityCost::TapCreatures {
-                        count: 3,
-                        filter: _,
+                        ref requirement, ..
                     }),
                 condition: None,
-            } => {}
+            } if requirement.fixed_count() == Some(3) => {}
             other => panic!("expected TapCreatures(count=3) alt-cost, got {other:?}"),
         }
     }
@@ -1484,15 +1482,14 @@ mod tests {
                 kind: crate::types::ability::SpellCastingOptionKind::AlternativeCost,
                 cost:
                     Some(AbilityCost::TapCreatures {
-                        count: 1,
-                        filter: _,
+                        ref requirement, ..
                     }),
                 condition:
                     Some(ParsedCondition::YouControlSubtypeCountAtLeast {
                         ref subtype,
                         count: 1,
                     }),
-            } if subtype == "plains" => {}
+            } if subtype == "plains" && requirement.fixed_count() == Some(1) => {}
             other => panic!("expected TapCreatures + Plains-control condition, got {other:?}"),
         }
     }

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -20,8 +20,8 @@ use super::oracle_util::parse_number;
 use super::oracle_util::TextPair;
 use crate::types::ability::{
     AbilityCost, BeholdCostAction, CostReduction, CounterCostSelection, FilterProp, PlayerScope,
-    QuantityExpr, QuantityRef, SacrificeCost, TargetFilter, TypedFilter, EXILE_COST_X,
-    REMOVE_COUNTER_COST_ALL, REMOVE_COUNTER_COST_ANY_NUMBER, REMOVE_COUNTER_COST_X,
+    QuantityExpr, QuantityRef, SacrificeCost, TapCreaturesRequirement, TargetFilter, TypedFilter,
+    EXILE_COST_X, REMOVE_COUNTER_COST_ALL, REMOVE_COUNTER_COST_ANY_NUMBER, REMOVE_COUNTER_COST_X,
 };
 use crate::types::counter::parse_counter_match;
 use crate::types::zones::Zone;
@@ -155,7 +155,10 @@ fn fixup_bare_noun_continuations(costs: &mut [AbilityCost]) {
                         };
                     }
                     PrecedingVerb::TapCreatures => {
-                        costs[i] = AbilityCost::TapCreatures { count: 1, filter };
+                        costs[i] = AbilityCost::TapCreatures {
+                            requirement: TapCreaturesRequirement::count(1),
+                            filter,
+                        };
                     }
                 }
             }
@@ -789,7 +792,10 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
             let target_text = format!("target {filter_text}");
             let (filter, remainder) = parse_target(&target_text);
             if remainder.trim().is_empty() {
-                return AbilityCost::TapCreatures { count, filter };
+                return AbilityCost::TapCreatures {
+                    requirement: TapCreaturesRequirement::count(count),
+                    filter,
+                };
             }
         }
     }
@@ -1618,7 +1624,7 @@ mod tests {
         assert_eq!(
             parse_oracle_cost("Tapped four untapped Humans you control"),
             AbilityCost::TapCreatures {
-                count: 4,
+                requirement: TapCreaturesRequirement::count(4),
                 filter: TargetFilter::Typed(TypedFilter {
                     type_filters: vec![TypeFilter::Subtype("Human".to_string())],
                     controller: Some(ControllerRef::You),
@@ -1818,7 +1824,7 @@ mod tests {
         assert_eq!(
             parse_oracle_cost("Tap an untapped creature you control"),
             AbilityCost::TapCreatures {
-                count: 1,
+                requirement: TapCreaturesRequirement::count(1),
                 filter: TargetFilter::Typed(
                     TypedFilter::creature().controller(crate::types::ability::ControllerRef::You)
                 ),

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -18,10 +18,10 @@ use super::super::oracle_util::{parse_comparison_suffix, parse_subtype, TextPair
 use super::{parse_effect_chain, scan_contains_phrase, ParseContext};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, AbilityKind, CastManaObjectScope, CastManaSpentMetric,
-    CastVariantPaid, Comparator, ControllerRef, CountScope, Duration, Effect, FilterProp,
-    ObjectScope, ParsedCondition, PlayerScope, QuantityExpr, QuantityRef, StaticCondition,
-    TargetFilter, TypeFilter, TypedFilter,
+    AbilityCondition, AbilityDefinition, AbilityKind, AdditionalCostOrigin, CastManaObjectScope,
+    CastManaSpentMetric, CastVariantPaid, Comparator, ControllerRef, CountScope, Duration, Effect,
+    FilterProp, ObjectScope, ParsedCondition, PlayerScope, QuantityExpr, QuantityRef,
+    StaticCondition, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
@@ -428,6 +428,28 @@ pub(super) fn strip_additional_cost_conditional(text: &str) -> (Option<AbilityCo
         // take priority. Returns early with the typed condition.
         if let Some((cond, rest)) = strip_quantified_kicker_conditional(text, &lower) {
             return (Some(cond), rest);
+        }
+        // CR 601.2b/f: "if this spell was cast using teamwork, [body]" gates the
+        // body specifically on the Teamwork additional-cost payment (origin
+        // Teamwork), so a different optional/imposed additional cost on the same
+        // spell does not satisfy it. The leading-"instead" form folds to
+        // `AdditionalCostPaidInstead` via the shared `instead` handling below, so
+        // only the non-instead form is peeled here.
+        if let Ok((_, (_, rest))) =
+            nom_primitives::split_once_on(lower.as_str(), " was cast using teamwork, ")
+        {
+            let is_instead = tag::<_, _, OracleError<'_>>("instead")
+                .parse(rest.trim_start())
+                .is_ok();
+            if !is_instead {
+                let offset = text.len() - rest.len();
+                return (
+                    Some(AbilityCondition::additional_cost_paid_origin(
+                        AdditionalCostOrigin::Teamwork,
+                    )),
+                    text[offset..].to_string(),
+                );
+            }
         }
         nom_primitives::split_once_on(lower.as_str(), " was kicked, ")
             .or_else(|_| nom_primitives::split_once_on(lower.as_str(), " was bargained, "))

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -432,6 +432,14 @@ pub(super) fn strip_additional_cost_conditional(text: &str) -> (Option<AbilityCo
         nom_primitives::split_once_on(lower.as_str(), " was kicked, ")
             .or_else(|_| nom_primitives::split_once_on(lower.as_str(), " was bargained, "))
             .or_else(|_| nom_primitives::split_once_on(lower.as_str(), " was beheld, "))
+            // CR 601.2b/f: Teamwork is an optional additional cast cost; "if this
+            // spell was cast using teamwork" gates the body on the same
+            // `additional_cost_paid` flag as kicker/bargain. The leading-"instead"
+            // form (Cruel Alliance, Too Evil to Stay Dead) is folded to
+            // `AdditionalCostPaidInstead` by the shared `instead` handling below.
+            .or_else(|_| {
+                nom_primitives::split_once_on(lower.as_str(), " was cast using teamwork, ")
+            })
             .ok()
             .map(|(_, (_, rest))| {
                 let offset = text.len() - rest.len();

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1508,6 +1508,10 @@ fn is_numeric_count_keyword(name: &str) -> bool {
             tag("devour"),
             tag("toxic"),
             tag("saddle"),
+            // Teamwork N — leading integer is the total-power threshold (mirrors
+            // Crew/Saddle). The "(As an additional cost ...)" reminder text is
+            // stripped before keyword parsing.
+            tag("teamwork"),
             tag("soulshift"),
             tag("backup"),
             tag("firebending"),
@@ -1533,7 +1537,7 @@ fn normalize_escalate_cost(cost: AbilityCost) -> AbilityCost {
                 scope: EffectScope::Single,
                 state: TapStateChange::Tap,
             } => AbilityCost::TapCreatures {
-                count: 1,
+                requirement: crate::types::ability::TapCreaturesRequirement::count(1),
                 filter: target,
             },
             effect => AbilityCost::EffectCost {
@@ -1671,6 +1675,7 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Devour(_) => "devour".to_string(),
         Keyword::Toxic(_) => "toxic".to_string(),
         Keyword::Saddle(_) => "saddle".to_string(),
+        Keyword::Teamwork(_) => "teamwork".to_string(),
         Keyword::Soulshift(_) => "soulshift".to_string(),
         Keyword::Backup(_) => "backup".to_string(),
         Keyword::Squad(_) => "squad".to_string(),
@@ -1990,6 +1995,7 @@ pub(crate) fn is_keyword_cost_line(lower: &str) -> bool {
         "entwine",
         "toxic",
         "saddle",
+        "teamwork",
         "soulshift",
         "backup",
         "squad",
@@ -3578,12 +3584,14 @@ mod tests {
             "flashback\u{2014}tap three untapped white creatures you control",
         )
         .unwrap();
-        let Keyword::Flashback(FlashbackCost::NonMana(AbilityCost::TapCreatures { count, .. })) =
-            kw
+        let Keyword::Flashback(FlashbackCost::NonMana(AbilityCost::TapCreatures {
+            requirement,
+            ..
+        })) = kw
         else {
             panic!("expected NonMana(TapCreatures), got {:?}", kw);
         };
-        assert_eq!(count, 3);
+        assert_eq!(requirement.fixed_count(), Some(3));
     }
 
     /// CR 702.34a regression: simple `Flashback {cost}` (Cackling Counterpart,
@@ -3660,10 +3668,10 @@ mod tests {
     fn parse_keyword_from_oracle_escalate_tap_creature_cost() {
         let kw = parse_keyword_from_oracle("escalate\u{2014}tap an untapped creature you control")
             .unwrap();
-        let Keyword::Escalate(AbilityCost::TapCreatures { count, .. }) = kw else {
+        let Keyword::Escalate(AbilityCost::TapCreatures { requirement, .. }) = kw else {
             panic!("expected Escalate(TapCreatures), got {:?}", kw);
         };
-        assert_eq!(count, 1);
+        assert_eq!(requirement.fixed_count(), Some(1));
     }
 
     /// CR 303.4a + CR 702.5: "Enchant creature, land, or planeswalker"

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -520,8 +520,15 @@ fn parse_modal_static_condition(
 fn parse_modal_additional_cost_condition(
     input: &str,
 ) -> nom::IResult<&str, ModalSelectionCondition, OracleError<'_>> {
-    if let Ok((rest, _)) =
-        tag::<_, _, OracleError<'_>>("this spell's additional cost was paid").parse(input)
+    if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>("this spell's additional cost was paid"),
+        // CR 601.2b/f: Teamwork is an optional additional cast cost; the modal
+        // "choose both instead" upgrade gates on the same `additional_cost_paid`
+        // flag (read via `AdditionalCostPaymentSource::Any`) as kicker/bargain.
+        tag("this spell was cast using teamwork"),
+        tag("it was cast using teamwork"),
+    ))
+    .parse(input)
     {
         return Ok((
             rest,

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -7,9 +7,10 @@ use nom::sequence::{delimited, preceded, terminated};
 use nom::Parser;
 
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, AbilityKind, AdditionalCostPaymentSource, ChoiceType,
-    Effect, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint, PlayerFilter,
-    ReplacementDefinition, StaticCondition, TargetFilter, TargetSelectionMode, TriggerCondition,
+    AbilityCondition, AbilityDefinition, AbilityKind, AdditionalCostOrigin,
+    AdditionalCostPaymentSource, ChoiceType, Effect, ModalChoice, ModalSelectionCondition,
+    ModalSelectionConstraint, PlayerFilter, ReplacementDefinition, StaticCondition, TargetFilter,
+    TargetSelectionMode, TriggerCondition,
 };
 use crate::types::replacements::ReplacementEvent;
 
@@ -520,15 +521,32 @@ fn parse_modal_static_condition(
 fn parse_modal_additional_cost_condition(
     input: &str,
 ) -> nom::IResult<&str, ModalSelectionCondition, OracleError<'_>> {
+    // CR 601.2b/f: Teamwork is an optional additional cast cost; the modal
+    // "choose both instead" upgrade gates specifically on the Teamwork payment.
+    // Stamping `origin: Some(Teamwork)` makes the rider test the Teamwork tap
+    // payment, not any optional additional cost — so it composes correctly with
+    // another object additional cost on the same spell.
     if let Ok((rest, _)) = alt((
-        tag::<_, _, OracleError<'_>>("this spell's additional cost was paid"),
-        // CR 601.2b/f: Teamwork is an optional additional cast cost; the modal
-        // "choose both instead" upgrade gates on the same `additional_cost_paid`
-        // flag (read via `AdditionalCostPaymentSource::Any`) as kicker/bargain.
-        tag("this spell was cast using teamwork"),
+        tag::<_, _, OracleError<'_>>("this spell was cast using teamwork"),
         tag("it was cast using teamwork"),
     ))
     .parse(input)
+    {
+        return Ok((
+            rest,
+            ModalSelectionCondition::AdditionalCostPaid {
+                source: AdditionalCostPaymentSource::Any,
+                origin: Some(AdditionalCostOrigin::Teamwork),
+                origin_ordinal: None,
+                variant: None,
+                kicker_cost: None,
+                min_count: 1,
+            },
+        ));
+    }
+
+    if let Ok((rest, _)) =
+        tag::<_, _, OracleError<'_>>("this spell's additional cost was paid").parse(input)
     {
         return Ok((
             rest,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -40,9 +40,9 @@ use crate::types::ability::{
     CoinFlipResult, Comparator, ControllerRef, CounterTriggerFilter, DamageKindFilter,
     DestinationConstraint, Effect, FilterProp, ObjectScope, OriginConstraint, ParsedCondition,
     PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, RenownSubject,
-    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, StaticCondition, TargetFilter,
-    TriggerCondition, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
-    UnlessPayModifier, ZoneChangeClause,
+    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, StaticCondition,
+    TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition,
+    TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
 };
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
@@ -1967,7 +1967,10 @@ fn parse_unless_alt_cost(after_unless: &str) -> Option<AbilityCost> {
 /// the shared target parser.
 fn parse_unless_tap_untapped_cost(rest: &str) -> Option<AbilityCost> {
     let (count, filter) = parse_unless_counted_target_filter(rest)?;
-    Some(AbilityCost::TapCreatures { count, filter })
+    Some(AbilityCost::TapCreatures {
+        requirement: TapCreaturesRequirement::count(count),
+        filter,
+    })
 }
 
 /// CR 118.12 + CR 701.7: Parse the tail of "you exile ..." unless costs.
@@ -21011,8 +21014,11 @@ mod tests {
         );
         let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
         match &unless_pay.cost {
-            AbilityCost::TapCreatures { count, filter } => {
-                assert_eq!(*count, 1);
+            AbilityCost::TapCreatures {
+                requirement,
+                filter,
+            } => {
+                assert_eq!(requirement.fixed_count(), Some(1));
                 let is_creature = match filter {
                     TargetFilter::Typed(tf) => {
                         tf.type_filters.contains(&TypeFilter::Creature)
@@ -21047,8 +21053,11 @@ mod tests {
         );
         let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
         match &unless_pay.cost {
-            AbilityCost::TapCreatures { count, filter: _ } => {
-                assert_eq!(*count, 1);
+            AbilityCost::TapCreatures {
+                requirement,
+                filter: _,
+            } => {
+                assert_eq!(requirement.fixed_count(), Some(1));
             }
             other => panic!("cost should be TapCreatures, got {:?}", other),
         }
@@ -21067,8 +21076,11 @@ mod tests {
         );
         let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
         match &unless_pay.cost {
-            AbilityCost::TapCreatures { count, filter } => {
-                assert_eq!(*count, 2);
+            AbilityCost::TapCreatures {
+                requirement,
+                filter,
+            } => {
+                assert_eq!(requirement.fixed_count(), Some(2));
                 let has_creature = match filter {
                     TargetFilter::Typed(tf) => tf.type_filters.contains(&TypeFilter::Creature),
                     TargetFilter::And { filters } => filters.iter().any(|f| {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5804,6 +5804,28 @@ pub enum TapCreaturesAggregateStat {
     TotalPower,
 }
 
+/// CR 601.2f + CR 208.1: The aggregate constraint a `TapCreatures` cost payment
+/// must satisfy (Crew CR 702.122a / Saddle CR 702.171a / Teamwork). Snapshots
+/// the `TapCreaturesRequirement::Aggregate` `{ stat, comparator, value }` triple
+/// into the interactive payment state (`PayCostKind::TapCreatures`) so the
+/// candidate enumerator and selection validator honor the advertised comparator
+/// instead of hard-coding `>=`. Bundling the three fields keeps them from
+/// desyncing (a lone `value` cannot drift from its comparator/stat).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TapCreaturesAggregate {
+    pub stat: TapCreaturesAggregateStat,
+    pub comparator: Comparator,
+    pub value: i32,
+}
+
+impl TapCreaturesAggregate {
+    /// CR 208.1: Evaluate whether a chosen set's summed current power satisfies
+    /// this aggregate constraint.
+    pub fn satisfied_by(&self, total_power: i32) -> bool {
+        self.comparator.evaluate(total_power, self.value)
+    }
+}
+
 /// How many creatures must be tapped, or what aggregate constraint the chosen
 /// set must satisfy, for a `TapCreatures` cost.
 ///
@@ -6419,6 +6441,12 @@ pub enum AdditionalCostOrigin {
     Offspring,
     Squad,
     Replicate,
+    /// CR 601.2b/f: Teamwork's optional "tap any number of creatures with total
+    /// power N or more" additional cost. A dedicated origin lets "this spell was
+    /// cast using teamwork" riders test the Teamwork payment specifically (not
+    /// any optional additional cost) and lets Teamwork compose with another
+    /// object additional cost in the announcement queue.
+    Teamwork,
     #[default]
     Other,
 }
@@ -13201,6 +13229,21 @@ impl AbilityCondition {
             subject: ObjectScope::Source,
             source: AdditionalCostPaymentSource::Any,
             origin: None,
+            origin_ordinal: None,
+            variant: None,
+            kicker_cost: None,
+            min_count: 1,
+        }
+    }
+
+    /// CR 601.2b/f: "if this spell was cast using [keyword]" — gates on a
+    /// specific additional-cost origin (e.g. Teamwork) being paid, so the rider
+    /// is not satisfied by an unrelated optional additional cost on the spell.
+    pub fn additional_cost_paid_origin(origin: AdditionalCostOrigin) -> Self {
+        AbilityCondition::AdditionalCostPaid {
+            subject: ObjectScope::Source,
+            source: AdditionalCostPaymentSource::Any,
+            origin: Some(origin),
             origin_ordinal: None,
             variant: None,
             kicker_cost: None,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5795,6 +5795,72 @@ impl SacrificeRequirement {
     }
 }
 
+/// Aggregate statistic for a tap-creatures-cost selection constraint.
+///
+/// CR 208.1: power is the aggregate axis. Currently only `TotalPower` (Crew
+/// CR 702.122a, Saddle CR 702.171a, Teamwork). Mirrors `SacrificeAggregateStat`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TapCreaturesAggregateStat {
+    TotalPower,
+}
+
+/// How many creatures must be tapped, or what aggregate constraint the chosen
+/// set must satisfy, for a `TapCreatures` cost.
+///
+/// `Count { count }` is the fixed-number form (Conspire's "tap two creatures",
+/// Convoke-style "tap N creatures"). `Aggregate { stat, comparator, value }` is
+/// the "tap any number of creatures with total power N or greater" form used by
+/// Crew (CR 702.122a), Saddle (CR 702.171a), and Teamwork. Mirrors
+/// `SacrificeRequirement` so the two cost families share one parameterization
+/// shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "requirement", rename_all = "snake_case")]
+pub enum TapCreaturesRequirement {
+    #[serde(rename = "count")]
+    Count {
+        #[serde(default = "default_one")]
+        count: u32,
+    },
+    Aggregate {
+        stat: TapCreaturesAggregateStat,
+        comparator: Comparator,
+        value: i32,
+    },
+}
+
+impl Default for TapCreaturesRequirement {
+    fn default() -> Self {
+        Self::Count { count: 1 }
+    }
+}
+
+impl TapCreaturesRequirement {
+    pub fn count(n: u32) -> Self {
+        Self::Count { count: n }
+    }
+
+    /// "Tap any number of creatures you control with total power `value` or
+    /// greater" (Crew/Saddle/Teamwork).
+    pub fn total_power_at_least(value: i32) -> Self {
+        Self::Aggregate {
+            stat: TapCreaturesAggregateStat::TotalPower,
+            comparator: Comparator::GE,
+            value,
+        }
+    }
+
+    pub fn fixed_count(&self) -> Option<u32> {
+        match self {
+            Self::Count { count } => Some(*count),
+            Self::Aggregate { .. } => None,
+        }
+    }
+
+    pub fn is_aggregate(&self) -> bool {
+        matches!(self, Self::Aggregate { .. })
+    }
+}
+
 /// CR 701.21: Sacrifice cost payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SacrificeCost {
@@ -5951,8 +6017,19 @@ pub enum AbilityCost {
     CollectEvidence {
         amount: u32,
     },
+    /// CR 601.2b: Tap creatures as an additional/activation cost. The
+    /// `requirement` axis selects between a fixed count (Conspire's "tap two
+    /// creatures") and an aggregate "any number with total power N or greater"
+    /// constraint (Crew CR 702.122a / Saddle CR 702.171a / Teamwork). Legacy JSON
+    /// that carries a bare `count` field (no `requirement` discriminant)
+    /// deserializes into `Count { count }` via `deserialize_tap_creatures_requirement`.
     TapCreatures {
-        count: u32,
+        #[serde(
+            default,
+            alias = "count",
+            deserialize_with = "deserialize_tap_creatures_requirement"
+        )]
+        requirement: TapCreaturesRequirement,
         filter: TargetFilter,
     },
     /// CR 122.1 + CR 601.2h: Remove `count` counters matching `counter_type`
@@ -9517,6 +9594,31 @@ pub enum Effect {
 
 fn default_one() -> u32 {
     1
+}
+
+/// Deserialize a `TapCreaturesRequirement`, accepting both the current tagged
+/// map form (`{"requirement":"count","count":N}` /
+/// `{"requirement":"aggregate","stat":"TotalPower","comparator":"GE","value":N}`)
+/// and the legacy bare-integer form (`"count": N`, routed here via the
+/// `#[serde(alias = "count")]` on the field). The legacy integer maps to
+/// `Count { count }`, preserving compatibility with pre-parameterization card
+/// data and fixtures.
+fn deserialize_tap_creatures_requirement<'de, D>(
+    deserializer: D,
+) -> Result<TapCreaturesRequirement, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        Legacy(u32),
+        Tagged(TapCreaturesRequirement),
+    }
+    Ok(match Repr::deserialize(deserializer)? {
+        Repr::Legacy(count) => TapCreaturesRequirement::Count { count },
+        Repr::Tagged(req) => req,
+    })
 }
 
 fn default_player_filter_controller() -> PlayerFilter {
@@ -17034,7 +17136,7 @@ mod tests {
                 filter: Some(TypedFilter::creature().into()),
             },
             AbilityCost::TapCreatures {
-                count: 2,
+                requirement: TapCreaturesRequirement::count(2),
                 filter: TypedFilter::creature()
                     .controller(ControllerRef::You)
                     .into(),
@@ -17678,7 +17780,7 @@ mod tests {
         #[test]
         fn tap_other_creatures() {
             let cost = AbilityCost::TapCreatures {
-                count: 2,
+                requirement: TapCreaturesRequirement::count(2),
                 filter: TargetFilter::Any,
             };
             assert_eq!(cost.categories(), vec![CostCategory::TapsOtherCreatures]);

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2460,7 +2460,17 @@ pub enum PayCostKind {
         #[serde(default)]
         selection: CounterCostSelection,
     },
-    TapCreatures,
+    /// CR 601.2b: Tap creatures as a cost. `power_threshold` distinguishes the
+    /// two `TapCreaturesRequirement` shapes at the interactive payment layer:
+    /// `None` is the fixed-count form (player taps exactly `WaitingFor::PayCost`
+    /// `count` creatures; Conspire/Convoke), while `Some(n)` is the aggregate
+    /// "tap any number with total power n or greater" form (Crew CR 702.122a /
+    /// Saddle CR 702.171a / Teamwork) — the chosen set may be any size whose
+    /// total positive power (CR 208.1) is at least `n`.
+    TapCreatures {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        power_threshold: Option<i32>,
+    },
     Behold {
         action: BeholdCostAction,
     },
@@ -8316,7 +8326,9 @@ mod tests {
         // variant here does not lose mid-cast tracking.
         let tap_mana = WaitingFor::PayCost {
             player: PlayerId(0),
-            kind: PayCostKind::TapCreatures,
+            kind: PayCostKind::TapCreatures {
+                power_threshold: None,
+            },
             choices: vec![ObjectId(1)],
             count: 1,
             min_count: 0,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -12,8 +12,8 @@ use super::ability::{
     ChosenAttribute, Comparator, ContinuousModification, CostPaidObjectSnapshot,
     CounterCostSelection, DelayedTriggerCondition, Duration, EffectKind, GameRestriction,
     KeywordAction, KickerVariant, LibraryPosition, ModalChoice, QuantityExpr, ResolvedAbility,
-    SearchDestinationSplit, SearchSelectionConstraint, StaticCondition, TargetFilter, TargetRef,
-    ThisWayCause, TriggerCondition, TriggerDefinition,
+    SearchDestinationSplit, SearchSelectionConstraint, StaticCondition, TapCreaturesAggregate,
+    TargetFilter, TargetRef, ThisWayCause, TriggerCondition, TriggerDefinition,
 };
 use super::attribution::ObjectAttribution;
 use super::card::CardFace;
@@ -2460,16 +2460,19 @@ pub enum PayCostKind {
         #[serde(default)]
         selection: CounterCostSelection,
     },
-    /// CR 601.2b: Tap creatures as a cost. `power_threshold` distinguishes the
-    /// two `TapCreaturesRequirement` shapes at the interactive payment layer:
-    /// `None` is the fixed-count form (player taps exactly `WaitingFor::PayCost`
-    /// `count` creatures; Conspire/Convoke), while `Some(n)` is the aggregate
-    /// "tap any number with total power n or greater" form (Crew CR 702.122a /
-    /// Saddle CR 702.171a / Teamwork) — the chosen set may be any size whose
-    /// total positive power (CR 208.1) is at least `n`.
+    /// CR 601.2b: Tap creatures as a cost. `aggregate` distinguishes the two
+    /// `TapCreaturesRequirement` shapes at the interactive payment layer: `None`
+    /// is the fixed-count form (player taps exactly `WaitingFor::PayCost` `count`
+    /// creatures; Conspire/Convoke), while `Some(aggregate)` is the aggregate
+    /// "tap any number satisfying the constraint" form (Crew CR 702.122a / Saddle
+    /// CR 702.171a / Teamwork) — the chosen set may be any size whose total
+    /// positive power (CR 208.1) satisfies `aggregate`'s comparator vs its value.
+    /// Carrying the full `TapCreaturesAggregate` (not just a threshold int) keeps
+    /// the payment validator honoring the advertised comparator instead of
+    /// hard-coding `>=`.
     TapCreatures {
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        power_threshold: Option<i32>,
+        aggregate: Option<TapCreaturesAggregate>,
     },
     Behold {
         action: BeholdCostAction,
@@ -8326,9 +8329,7 @@ mod tests {
         // variant here does not lose mid-cast tracking.
         let tap_mana = WaitingFor::PayCost {
             player: PlayerId(0),
-            kind: PayCostKind::TapCreatures {
-                power_threshold: None,
-            },
+            kind: PayCostKind::TapCreatures { aggregate: None },
             choices: vec![ObjectId(1)],
             count: 1,
             min_count: 0,

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -807,6 +807,23 @@ pub enum Keyword {
     Toxic(u32),
     /// CR 702.171a: Saddle N — tap creatures with total power N+ to saddle this Mount.
     Saddle(u32),
+    /// Teamwork N — "As an additional cost to cast this spell, you may tap any
+    /// number of creatures you control with total power N or more." The spell's
+    /// body then references whether this optional cost was paid ("if this spell
+    /// was cast using teamwork, ...").
+    ///
+    /// Teamwork is not yet in the printed Comprehensive Rules (Marvel Super
+    /// Heroes set keyword). Its tap-any-number-with-total-power-N cost is
+    /// structurally identical to Crew (CR 702.122a) and Saddle (CR 702.171a); it
+    /// is an optional additional cast cost per CR 601.2b/f, and is a keyword
+    /// ability per CR 702.
+    ///
+    /// Runtime: `database::synthesis::synthesize_teamwork` builds an
+    /// `AdditionalCost::Optional { cost: TapCreatures { requirement:
+    /// Aggregate { TotalPower, GE, N }, .. } }`. Paying it sets the spell's
+    /// `additional_cost_paid` flag, which the body's `AdditionalCostPaid`
+    /// condition reads (mirrors Conspire).
+    Teamwork(u32),
     /// CR 702.46: Soulshift N — when this creature dies, return target Spirit card
     /// with mana value N or less from your graveyard to your hand.
     Soulshift(u32),
@@ -1244,6 +1261,7 @@ impl Keyword {
             | Keyword::Reinforce { .. }
             | Keyword::Ripple(_)
             | Keyword::Saddle(_)
+            | Keyword::Teamwork(_)
             | Keyword::Scavenge(_)
             | Keyword::Soulshift(_)
             | Keyword::Spectacle(_)
@@ -1316,6 +1334,9 @@ impl Keyword {
                 | Keyword::Impending { .. }
                 | Keyword::MoreThanMeetsTheEye(_)
                 | Keyword::Freerunning(_)
+                // CR 601.2b/f: Teamwork is an optional additional cast cost; it
+                // is inert on a non-cast token copy.
+                | Keyword::Teamwork(_)
         )
     }
 
@@ -2051,6 +2072,9 @@ impl FromStr for Keyword {
                 "toxic" => return Ok(Keyword::Toxic(p.parse().unwrap_or(1))),
                 // CR 702.171a
                 "saddle" => return Ok(Keyword::Saddle(p.parse().unwrap_or(1))),
+                // Teamwork N — optional additional cast cost (CR 601.2b/f);
+                // tap-any-number-with-total-power-N mirrors Crew/Saddle.
+                "teamwork" => return Ok(Keyword::Teamwork(p.parse().unwrap_or(1))),
                 // CR 702.46
                 "soulshift" => return Ok(Keyword::Soulshift(p.parse().unwrap_or(1))),
                 // CR 702.165
@@ -2956,6 +2980,8 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         // CR 702.164 / CR 702.171a / CR 702.46 / CR 702.165
         "Toxic" => Ok(Keyword::Toxic(uint(data))),
         "Saddle" => Ok(Keyword::Saddle(uint(data))),
+        // Teamwork N — optional additional cast cost (CR 601.2b/f).
+        "Teamwork" => Ok(Keyword::Teamwork(uint(data))),
         "Soulshift" => Ok(Keyword::Soulshift(uint(data))),
         "Backup" => Ok(Keyword::Backup(uint(data))),
         // Avatar crossover: Firebending

--- a/crates/engine/tests/conspire_granted_keyword.rs
+++ b/crates/engine/tests/conspire_granted_keyword.rs
@@ -137,9 +137,9 @@ fn wort_grants_conspire_offers_cost_and_copies_when_paid() {
             matches!(
                 cost,
                 engine::types::ability::AdditionalCost::Optional {
-                    cost: engine::types::ability::AbilityCost::TapCreatures { count: 2, .. },
+                    cost: engine::types::ability::AbilityCost::TapCreatures { ref requirement, .. },
                     repeatability: engine::types::ability::AdditionalCostRepeatability::Once,
-                }
+                } if requirement.fixed_count() == Some(2)
             ),
             "granted Conspire must surface an optional TapCreatures{{2}} cost: {cost:?}"
         ),
@@ -153,7 +153,7 @@ fn wort_grants_conspire_offers_cost_and_copies_when_paid() {
 
     match runner.state().waiting_for.clone() {
         WaitingFor::PayCost {
-            kind: PayCostKind::TapCreatures,
+            kind: PayCostKind::TapCreatures { .. },
             choices,
             count,
             ..

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -425,6 +425,8 @@ mod surveil_rest_pile_redirect_continuation;
 mod swans_prevention_followup;
 mod tales_of_the_ancestors_catch_up_draw;
 mod talon_gates_from_hand_activation;
+mod teamwork_aggregate_legal_actions;
+mod teamwork_origin_composition;
 mod teferi_time_raveler_sorcery_speed_lock;
 mod tempt_with_discovery;
 mod terra_herald_optional_prompt;

--- a/crates/engine/tests/integration/teamwork_aggregate_legal_actions.rs
+++ b/crates/engine/tests/integration/teamwork_aggregate_legal_actions.rs
@@ -1,0 +1,208 @@
+//! Teamwork aggregate tap cost — AI/MP legal-action enumeration must offer
+//! power-thresholded creature SUBSETS, not a fixed full-set cardinality.
+//!
+//! PR #3916 parameterizes `AbilityCost::TapCreatures` with an aggregate
+//! `TotalPower` requirement — the Teamwork form "tap any number of creatures you
+//! control with total power N or more" (CR 601.2b/f), the same shape as Crew
+//! (CR 702.122a) and Saddle (CR 702.171a). The payment validator
+//! (`handle_tap_creatures_for_spell_cost`) already accepts any subset whose
+//! summed current power meets the threshold, but two AI-facing seams treated the
+//! aggregate form like the fixed-count form: candidate generation
+//! (`ai_support::candidates`) emitted only a single full-cardinality
+//! `[eligible.len()]` selection, and the legality predicate
+//! (`ai_support::cheap_reject_candidate`) validated with exact-cardinality
+//! `Some(count)` semantics. Together these left `legal_actions` (the AI /
+//! multiplayer-server legal-action set) unable to present any legal minimal
+//! subset, so AI and MP players could never pay Teamwork unless tapping every
+//! eligible creature.
+//!
+//! These tests drive the real cast/payment pipeline to the `PayCost`
+//! tap-creatures window and assert `legal_actions` offers a sub-full-size
+//! qualifying subset and rejects a sub-threshold one. They fail against the
+//! pre-fix fixed-cardinality behavior, and the current-power test fails if base
+//! P/T (rather than layer-evaluated power) is summed.
+
+use engine::ai_support::legal_actions;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{CastPaymentMode, PayCostKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+/// Teamwork 3 spell with a no-target body and {0} mana cost so the cast reaches
+/// the optional Teamwork cost without any target or mana detours.
+const TEAMWORK_3: &str = "Teamwork 3 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 3 or more.)\nYou gain 1 life.";
+
+fn select(cards: Vec<ObjectId>) -> GameAction {
+    GameAction::SelectCards { cards }
+}
+
+fn offers(actions: &[GameAction], cards: &[ObjectId]) -> bool {
+    actions
+        .iter()
+        .any(|a| matches!(a, GameAction::SelectCards { cards: c } if c.as_slice() == cards))
+}
+
+/// Cast the Teamwork spell, pay the optional Teamwork cost, and stop at the
+/// `PayCost` tap-creatures window. Panics if that window is never reached.
+fn cast_and_reach_tap_paycost(runner: &mut GameRunner, spell: ObjectId) -> i32 {
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the Teamwork spell must be accepted");
+
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalCost { pay: true })
+                    .expect("opting to pay teamwork must be accepted");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalizing {0} mana cost must be accepted");
+            }
+            WaitingFor::PayCost {
+                kind:
+                    PayCostKind::TapCreatures {
+                        aggregate: Some(aggregate),
+                    },
+                ..
+            } => return aggregate.value,
+            other => panic!("unexpected window before tap-creatures payment: {other:?}"),
+        }
+    }
+    panic!("never reached the tap-creatures PayCost window");
+}
+
+fn setup(powers: [(i32, i32); 3]) -> (GameRunner, [ObjectId; 3], ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let c0 = scenario
+        .add_creature(P0, "Alpha", powers[0].0, powers[0].1)
+        .id();
+    let c1 = scenario
+        .add_creature(P0, "Bravo", powers[1].0, powers[1].1)
+        .id();
+    let c2 = scenario
+        .add_creature(P0, "Charlie", powers[2].0, powers[2].1)
+        .id();
+    let mut builder = scenario.add_spell_to_hand_from_oracle(P0, "Squad Up", false, TEAMWORK_3);
+    builder.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let spell = builder.id();
+    (scenario.build(), [c0, c1, c2], spell)
+}
+
+/// With three eligible creatures of power [3, 1, 1] and Teamwork 3, the engine
+/// must offer the single power-3 creature alone (total power 3 >= 3) as a legal
+/// payment, and must NOT offer a lone power-1 creature (total power 1 < 3).
+///
+/// Pre-fix, candidate generation emitted only the full `[c0, c1, c2]` selection
+/// and the legality predicate rejected anything but exactly three creatures, so
+/// the `offers(&actions, &[c0])` assertion below is false. It passes only with
+/// the subset fix.
+#[test]
+fn teamwork_aggregate_offers_minimal_qualifying_subset() {
+    let (mut runner, [c0, c1, _c2], spell) = setup([(3, 3), (1, 1), (1, 1)]);
+    let threshold = cast_and_reach_tap_paycost(&mut runner, spell);
+    assert_eq!(
+        threshold, 3,
+        "Teamwork 3 surfaces an aggregate threshold of 3"
+    );
+
+    let actions = legal_actions(runner.state());
+    assert!(
+        offers(&actions, &[c0]),
+        "the single power-3 creature alone (total 3 >= 3) must be an offered legal payment, \
+         got {actions:?}"
+    );
+    assert!(
+        !offers(&actions, &[c1]),
+        "a lone power-1 creature (total 1 < 3) is sub-threshold and must NOT be offered"
+    );
+
+    // The engine accepts the qualifying minimal subset through the real pipeline.
+    runner
+        .act(select(vec![c0]))
+        .expect("engine must accept the qualifying single-creature subset");
+    assert!(
+        runner.state().objects[&c0].tapped,
+        "the chosen power-3 creature must be tapped"
+    );
+    assert!(
+        !runner.state().objects[&c1].tapped,
+        "minimal-subset payment must not tap the other creatures"
+    );
+}
+
+/// A sub-threshold selection (one power-1 creature, total 1 < 3) is rejected by
+/// the real payment pipeline — a correctness guard alongside the legal-action
+/// enumeration above.
+#[test]
+fn teamwork_aggregate_pipeline_rejects_subthreshold_subset() {
+    let (mut runner, [_c0, c1, _c2], spell) = setup([(3, 3), (1, 1), (1, 1)]);
+    cast_and_reach_tap_paycost(&mut runner, spell);
+    assert!(
+        runner.act(select(vec![c1])).is_err(),
+        "tapping a single power-1 creature (total 1 < 3) must be rejected"
+    );
+}
+
+/// The aggregate threshold is measured against CURRENT (layer-evaluated) power,
+/// not base P/T. A base-2 creature carrying a +1/+1 counter has current power 3,
+/// so it alone satisfies Teamwork 3 — and must be offered as a single-creature
+/// payment. If base power (2) were summed, no single-creature cover would exist
+/// and this single-element subset would not be offered.
+#[test]
+fn teamwork_aggregate_subset_counts_current_not_base_power() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let c0 = scenario.add_creature(P0, "Boosted", 2, 2).id();
+    let c1 = scenario.add_creature(P0, "Small A", 1, 1).id();
+    let _c2 = scenario.add_creature(P0, "Small B", 1, 1).id();
+    scenario.with_counter(c0, CounterType::Plus1Plus1, 1);
+    let mut builder = scenario.add_spell_to_hand_from_oracle(P0, "Squad Up", false, TEAMWORK_3);
+    builder.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let spell = builder.id();
+    let mut runner = scenario.build();
+
+    // Apply continuous effects so the +1/+1 counter is folded into current power.
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    assert_eq!(
+        runner.state().objects[&c0].power,
+        Some(3),
+        "current power must reflect the +1/+1 counter (base 2 + 1)"
+    );
+
+    cast_and_reach_tap_paycost(&mut runner, spell);
+    let actions = legal_actions(runner.state());
+    assert!(
+        offers(&actions, &[c0]),
+        "the counter-boosted creature (current power 3 >= 3) must be offered alone, got {actions:?}"
+    );
+    assert!(
+        !offers(&actions, &[c1]),
+        "a lone power-1 creature (total 1 < 3) must NOT be offered"
+    );
+
+    runner
+        .act(select(vec![c0]))
+        .expect("engine must accept the counter-boosted single-creature subset");
+    assert!(runner.state().objects[&c0].tapped);
+}

--- a/crates/engine/tests/integration/teamwork_origin_composition.rs
+++ b/crates/engine/tests/integration/teamwork_origin_composition.rs
@@ -1,0 +1,209 @@
+//! Teamwork is its own additional-cost ORIGIN (PR #3916 review blocker #1).
+//!
+//! Before the fix, Teamwork's optional tap cost was installed into the generic
+//! `face.additional_cost` slot and its payment was recorded with
+//! `AdditionalCostOrigin::Other`. Consequently "if this spell was cast using
+//! teamwork" parsed to `AdditionalCostPaid { origin: None }`, which is satisfied
+//! by ANY additional-cost payment — so a different additional cost on the same
+//! spell wrongly triggered the Teamwork rider, and Teamwork could not compose
+//! with another object additional cost (the single `face.additional_cost` slot
+//! held only one).
+//!
+//! The fix gives Teamwork a dedicated `AdditionalCostOrigin::Teamwork`, queues it
+//! through the keyword-cost announcement queue (so it coexists with another
+//! additional cost), and parses the rider to `origin: Some(Teamwork)` so it tests
+//! the Teamwork payment specifically.
+//!
+//! This test drives the real cast pipeline for a spell carrying BOTH Casualty
+//! (another queued additional cost, whose payment sets the shared
+//! `additional_cost_paid` flag) AND Teamwork. Paying Casualty but DECLINING
+//! Teamwork must leave "cast using teamwork" FALSE (no life gain). Against the
+//! pre-fix `origin: None` behavior the Casualty payment satisfies the rider and
+//! the +7 life assertion flips.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{AbilityCost, AdditionalCost};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, PayCostKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+// Casualty 1 + Teamwork 2. The body's only effect is the Teamwork-gated life
+// gain, so any life change directly reads whether "cast using teamwork" was true.
+const CASUALTY_AND_TEAMWORK: &str = "Casualty 1 (As you cast this spell, you may sacrifice a creature with power 1 or greater. When you do, copy this spell.)\nTeamwork 2 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 2 or more.)\nIf this spell was cast using teamwork, you gain 7 life.";
+
+/// Returns true if an `AdditionalCost` is the Teamwork tap cost (vs Casualty's
+/// sacrifice cost).
+fn is_teamwork_cost(cost: &AdditionalCost) -> bool {
+    matches!(
+        cost,
+        AdditionalCost::Optional {
+            cost: AbilityCost::TapCreatures { .. },
+            ..
+        }
+    )
+}
+
+/// Drive the cast paying Casualty (sacrificing `fodder`) but DECLINING Teamwork.
+fn cast_paying_casualty_declining_teamwork(
+    runner: &mut GameRunner,
+    spell: ObjectId,
+    fodder: ObjectId,
+) {
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the spell must be accepted");
+
+    for _ in 0..24 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice { cost, .. } => {
+                // Decline Teamwork; pay Casualty.
+                let pay = !is_teamwork_cost(&cost);
+                runner
+                    .act(GameAction::DecideOptionalCost { pay })
+                    .expect("optional-cost decision must be accepted");
+            }
+            WaitingFor::PayCost {
+                kind: PayCostKind::TapCreatures { .. },
+                ..
+            } => panic!("Teamwork was declined; no tap-creatures payment should be requested"),
+            WaitingFor::PayCost {
+                kind: PayCostKind::Sacrifice,
+                ..
+            } => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![fodder],
+                    })
+                    .expect("paying the Casualty sacrifice must be accepted");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalizing {0} mana cost must be accepted");
+            }
+            _ => return,
+        }
+    }
+    panic!("cast did not settle to priority");
+}
+
+fn resolve_stack(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+}
+
+#[test]
+fn casualty_payment_does_not_satisfy_teamwork_rider() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // A creature to feed Casualty's sacrifice (power 1 >= Casualty 1).
+    let fodder = scenario.add_creature(P0, "Fodder", 1, 1).id();
+    let mut builder =
+        scenario.add_spell_to_hand_from_oracle(P0, "Twin Strike", false, CASUALTY_AND_TEAMWORK);
+    builder.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let spell = builder.id();
+    let mut runner = scenario.build();
+    let life_before = runner.state().players[0].life;
+
+    cast_paying_casualty_declining_teamwork(&mut runner, spell, fodder);
+    resolve_stack(&mut runner);
+
+    assert!(
+        !runner.state().battlefield.contains(&fodder),
+        "the Casualty sacrifice must have been paid"
+    );
+    assert_eq!(
+        runner.state().players[0].life,
+        life_before,
+        "paying Casualty (a NON-teamwork additional cost) must NOT satisfy 'cast using \
+         teamwork' — the +7 life rider must not fire"
+    );
+}
+
+/// Conversely, paying Teamwork (declining Casualty) DOES satisfy the rider. This
+/// exercises the queued-Teamwork payment recording its dedicated
+/// `AdditionalCostOrigin::Teamwork`, which the `origin: Some(Teamwork)` rider
+/// then reads — proving the composing spell still resolves the Teamwork upgrade.
+#[test]
+fn teamwork_payment_satisfies_teamwork_rider_when_composed_with_casualty() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // A 2/2 to tap for Teamwork 2 (total power 2 >= 2); also Casualty-eligible,
+    // but we decline Casualty here.
+    let tapper = scenario.add_creature(P0, "Tapper", 2, 2).id();
+    let mut builder =
+        scenario.add_spell_to_hand_from_oracle(P0, "Twin Strike", false, CASUALTY_AND_TEAMWORK);
+    builder.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let spell = builder.id();
+    let mut runner = scenario.build();
+    let life_before = runner.state().players[0].life;
+    let card_id = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the spell must be accepted");
+
+    for _ in 0..24 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice { cost, .. } => {
+                // Pay Teamwork; decline Casualty.
+                let pay = is_teamwork_cost(&cost);
+                runner
+                    .act(GameAction::DecideOptionalCost { pay })
+                    .expect("optional-cost decision must be accepted");
+            }
+            WaitingFor::PayCost {
+                kind: PayCostKind::TapCreatures { .. },
+                ..
+            } => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![tapper],
+                    })
+                    .expect("tapping the 2/2 (total power 2 >= 2) must pay Teamwork");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalizing {0} mana cost must be accepted");
+            }
+            _ => break,
+        }
+    }
+    resolve_stack(&mut runner);
+
+    assert!(
+        runner.state().objects[&tapper].tapped,
+        "the Teamwork tap creature must be tapped"
+    );
+    assert_eq!(
+        runner.state().players[0].life,
+        life_before + 7,
+        "paying Teamwork must satisfy 'cast using teamwork' — the +7 life rider fires"
+    );
+}

--- a/crates/engine/tests/teamwork_keyword.rs
+++ b/crates/engine/tests/teamwork_keyword.rs
@@ -16,7 +16,8 @@ use engine::game::layers::evaluate_layers;
 use engine::game::scenario::{GameRunner, GameScenario};
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
-    AbilityCost, AdditionalCost, Effect, TapCreaturesAggregateStat, TapCreaturesRequirement,
+    AbilityCost, AdditionalCost, Comparator, Effect, TapCreaturesAggregateStat,
+    TapCreaturesRequirement,
 };
 use engine::types::actions::GameAction;
 use engine::types::game_state::{CastPaymentMode, PayCostKind, WaitingFor};
@@ -263,14 +264,19 @@ fn team_tactics_with_teamwork_grants_double_strike_and_trample() {
     // Tap the 3/3 (total power 3 >= Teamwork 1) to pay the aggregate cost.
     match runner.state().waiting_for.clone() {
         WaitingFor::PayCost {
-            kind: PayCostKind::TapCreatures { power_threshold },
+            kind: PayCostKind::TapCreatures { aggregate },
             choices,
             ..
         } => {
+            let aggregate = aggregate.expect("Teamwork surfaces an aggregate constraint");
             assert_eq!(
-                power_threshold,
-                Some(1),
+                aggregate.value, 1,
                 "Teamwork 1 must surface an aggregate power threshold of 1"
+            );
+            assert_eq!(
+                aggregate.comparator,
+                Comparator::GE,
+                "Teamwork's aggregate constraint is total power >= N"
             );
             assert!(
                 choices.contains(&target),

--- a/crates/engine/tests/teamwork_keyword.rs
+++ b/crates/engine/tests/teamwork_keyword.rs
@@ -1,0 +1,441 @@
+//! Teamwork N — optional additional cast cost "tap any number of creatures you
+//! control with total power N or more" (CR 601.2b/f; tap-any-number-total-power
+//! mirrors Crew CR 702.122a / Saddle CR 702.171a). The spell's body references
+//! whether the cost was paid via "if this spell was cast using teamwork", which
+//! parses to the same `additional_cost_paid` gate as kicker/bargain.
+//!
+//! Two layers are verified:
+//!   1. Parse coverage — each shipped MSH Teamwork card's full oracle text parses
+//!      with zero `Effect::Unimplemented` (the keyword line + every body clause).
+//!   2. Runtime discrimination — casting WITHOUT paying teamwork yields the base
+//!      effect; casting WITH teamwork (tapping creatures with total power >= N)
+//!      yields the upgraded/both effect. The divergence fails on revert.
+
+use engine::game::keywords::has_keyword;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityCost, AdditionalCost, Effect, TapCreaturesAggregateStat, TapCreaturesRequirement,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, PayCostKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+// ---------------------------------------------------------------------------
+// Oracle text constants (verbatim from /tmp/msh-effort/cards.md)
+// ---------------------------------------------------------------------------
+
+const TEAM_TACTICS: &str = "Teamwork 1 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 1 or more.)\nTarget creature gains double strike until end of turn. If this spell was cast using teamwork, that creature also gains trample until end of turn.";
+
+const WE_SAY_THEE_NAY: &str = "Teamwork 2 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 2 or more.)\nCounter target spell unless its controller pays {2}. Counter that spell unless its controller pays {4} instead if this spell was cast using teamwork.";
+
+const CRUEL_ALLIANCE: &str = "Teamwork 2 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 2 or more.)\nExile target creature with mana value 3 or less. If this spell was cast using teamwork, instead exile target creature and you gain 3 life.";
+
+const WIDOWS_BITE: &str = "Teamwork 3 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 3 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Target creature gains deathtouch until end of turn.\n• Target creature gets -2/-2 until end of turn.";
+
+const GO_NUTS: &str = "Teamwork 3 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 3 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Put a +1/+1 counter on target creature.\n• Target creature you control fights target creature an opponent controls.";
+
+const HULK_SMASH: &str = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Destroy target noncreature artifact.\n• Target creature you control deals damage equal to its power to target creature an opponent controls.";
+
+const MURDOCKS_CRUSADE: &str = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Street Justice — Exile target creature with toughness 4 or greater.\n• Legal Justice — Exile target enchantment with mana value 4 or greater.";
+
+const TOO_EVIL_TO_STAY_DEAD: &str = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose target creature card in your graveyard with mana value 4 or less. If this spell was cast using teamwork, instead choose target creature card in your graveyard. Return the chosen card to the battlefield.";
+
+const ATLANTIS_ATTACKS: &str = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Target player creates a 6/5 blue Leviathan creature token with hexproof.\n• Return one or two target nonland permanents to their owners' hands.";
+
+// ---------------------------------------------------------------------------
+// Parse helpers
+// ---------------------------------------------------------------------------
+
+fn parse_spell(
+    name: &str,
+    oracle: &str,
+    types: &[&str],
+) -> engine::parser::oracle::ParsedAbilities {
+    let type_strings: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+    parse_oracle_text(oracle, name, &[], &type_strings, &[])
+}
+
+/// Assert that no parsed ability/trigger carries an `Unimplemented` effect at
+/// the top level or in a linked sub-ability chain (`Effect::Unimplemented` is
+/// the authoritative "parser couldn't handle this" marker; effect chains are
+/// modeled via `sub_ability` links, not a container variant).
+fn assert_no_unimplemented(parsed: &engine::parser::oracle::ParsedAbilities, name: &str) {
+    fn check_def(def: &engine::types::ability::AbilityDefinition, name: &str) {
+        assert!(
+            !matches!(*def.effect, Effect::Unimplemented { .. }),
+            "{name}: Unimplemented effect: {:?}",
+            def.effect
+        );
+        if let Some(sub) = def.sub_ability.as_deref() {
+            check_def(sub, name);
+        }
+    }
+    for def in &parsed.abilities {
+        check_def(def, name);
+    }
+    for trig in &parsed.triggers {
+        if let Some(def) = trig.execute.as_deref() {
+            check_def(def, name);
+        }
+    }
+    // Modal modes are flattened into `parsed.abilities` (one ability per bullet),
+    // so the loop above already covers them.
+}
+
+/// Every shipped Teamwork card parses with zero Unimplemented effects. Reverting
+/// the keyword/condition/synthesis wiring re-introduces Unimplemented on these.
+#[test]
+fn shipped_teamwork_cards_parse_without_unimplemented() {
+    let cards: &[(&str, &str, &[&str])] = &[
+        ("Team Tactics", TEAM_TACTICS, &["Instant"]),
+        ("We Say Thee Nay!", WE_SAY_THEE_NAY, &["Instant"]),
+        ("Cruel Alliance", CRUEL_ALLIANCE, &["Sorcery"]),
+        ("Widow's Bite", WIDOWS_BITE, &["Instant"]),
+        ("Go Nuts!", GO_NUTS, &["Sorcery"]),
+        ("HULK SMASH!", HULK_SMASH, &["Sorcery"]),
+        ("Murdock's Crusade", MURDOCKS_CRUSADE, &["Sorcery"]),
+        ("Too Evil to Stay Dead", TOO_EVIL_TO_STAY_DEAD, &["Sorcery"]),
+        ("Atlantis Attacks", ATLANTIS_ATTACKS, &["Sorcery"]),
+    ];
+    for (name, oracle, types) in cards {
+        let parsed = parse_spell(name, oracle, types);
+        assert_no_unimplemented(&parsed, name);
+    }
+}
+
+/// The Teamwork keyword line parses to `Keyword::Teamwork(N)` and synthesis (run
+/// inside `build_face_from_oracle`/`synthesize_all`) turns it into the optional
+/// aggregate-power tap cost. Here we verify the keyword extraction + that the
+/// synthesized additional cost is the aggregate form (not a fixed count).
+#[test]
+fn teamwork_keyword_extracts_and_synthesizes_aggregate_tap_cost() {
+    use engine::database::synthesis::synthesize_teamwork;
+    use engine::types::card::CardFace;
+
+    let mut face = CardFace {
+        keywords: vec![Keyword::Teamwork(3)],
+        ..CardFace::default()
+    };
+    synthesize_teamwork(&mut face);
+    match face.additional_cost.as_ref().expect("additional_cost set") {
+        AdditionalCost::Optional {
+            cost: AbilityCost::TapCreatures { requirement, .. },
+            ..
+        } => match requirement {
+            TapCreaturesRequirement::Aggregate {
+                stat: TapCreaturesAggregateStat::TotalPower,
+                value,
+                ..
+            } => assert_eq!(*value, 3, "Teamwork 3 requires total power 3"),
+            other => panic!("expected aggregate total-power tap requirement, got {other:?}"),
+        },
+        other => panic!("expected optional TapCreatures additional cost, got {other:?}"),
+    }
+}
+
+// DEFERRED: Earth's Mightiest Heroes (Teamwork 5). The body "reveal top eight,
+// you may put A creature card onto the battlefield; if cast using teamwork, put
+// ANY NUMBER of creature cards instead; rest to graveyard" parses to a single
+// `Effect::Dig { keep_count: u32::MAX, up_to: true, .. }` — it collapses the
+// base (one) and upgraded (any number) keep counts into "any number"
+// unconditionally, with no `AdditionalCostPaid`-gated count switch. Shipping it
+// would silently let the no-teamwork case put any number of creatures, which is
+// wrong. Deferred until the reveal-N effect supports a teamwork-conditional
+// keep_count; the Teamwork keyword itself is shipped and the other nine cards
+// reuse existing effects cleanly.
+
+// ---------------------------------------------------------------------------
+// Runtime discrimination — Team Tactics (Teamwork 1)
+//
+// Body: "Target creature gains double strike until end of turn. If this spell
+// was cast using teamwork, that creature also gains trample until end of turn."
+//
+// The base ability grants DoubleStrike unconditionally; the linked sub-ability
+// grants Trample gated on `AbilityCondition::AdditionalCostPaid`. The two casts
+// below diverge ONLY in whether the optional Teamwork cost is paid:
+//   - declined  -> DoubleStrike, NOT Trample
+//   - paid      -> DoubleStrike AND Trample
+// Reverting any of {keyword parse, synthesis, "cast using teamwork" condition,
+// additional_cost_paid wiring} collapses this divergence and fails these.
+// ---------------------------------------------------------------------------
+
+fn has_kw(runner: &mut GameRunner, id: ObjectId, keyword: &Keyword) -> bool {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    has_keyword(&runner.state().objects[&id], keyword)
+}
+
+/// Build a scenario where P0 has Team Tactics (cost {0}) in hand and one 3/3
+/// creature as both the spell target and an eligible teamwork tapper (power 3
+/// >= Teamwork 1). Returns (runner, spell_id, target_id).
+fn setup_team_tactics() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Target creature; also the eligible teamwork tap creature (power 3 >= 1).
+    let target = scenario.add_creature(P0, "Bear", 3, 3).id();
+    let mut builder =
+        scenario.add_spell_to_hand_from_oracle(P0, "Team Tactics", true, TEAM_TACTICS);
+    builder.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let spell = builder.id();
+    let runner = scenario.build();
+    (runner, spell, target)
+}
+
+#[test]
+fn team_tactics_without_teamwork_grants_double_strike_only() {
+    let (mut runner, spell, target) = setup_team_tactics();
+    let card_id = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Team Tactics must be accepted");
+
+    // The optional Teamwork cost is offered; decline it.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalCostChoice { .. }
+        ),
+        "Teamwork must surface an optional additional cost, got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::DecideOptionalCost { pay: false })
+        .expect("declining teamwork must be accepted");
+
+    // Choose the spell target.
+    drive_single_target(&mut runner, target);
+    resolve_stack(&mut runner);
+
+    assert!(
+        has_kw(&mut runner, target, &Keyword::DoubleStrike),
+        "target must gain double strike"
+    );
+    assert!(
+        !has_kw(&mut runner, target, &Keyword::Trample),
+        "WITHOUT teamwork, target must NOT gain trample"
+    );
+}
+
+#[test]
+fn team_tactics_with_teamwork_grants_double_strike_and_trample() {
+    let (mut runner, spell, target) = setup_team_tactics();
+    let card_id = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Team Tactics must be accepted");
+
+    // Pay the optional Teamwork cost.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalCostChoice { .. }
+        ),
+        "Teamwork must surface an optional additional cost, got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("paying teamwork must be accepted");
+
+    // Tap the 3/3 (total power 3 >= Teamwork 1) to pay the aggregate cost.
+    match runner.state().waiting_for.clone() {
+        WaitingFor::PayCost {
+            kind: PayCostKind::TapCreatures { power_threshold },
+            choices,
+            ..
+        } => {
+            assert_eq!(
+                power_threshold,
+                Some(1),
+                "Teamwork 1 must surface an aggregate power threshold of 1"
+            );
+            assert!(
+                choices.contains(&target),
+                "the 3/3 must be an eligible teamwork tap creature"
+            );
+        }
+        other => panic!("expected PayCost TapCreatures after paying teamwork, got {other:?}"),
+    }
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![target],
+        })
+        .expect("tapping the 3/3 (total power 3 >= 1) must pay teamwork");
+    assert!(
+        runner.state().objects[&target].tapped,
+        "the teamwork tap creature must be tapped"
+    );
+
+    drive_single_target(&mut runner, target);
+    resolve_stack(&mut runner);
+
+    assert!(
+        has_kw(&mut runner, target, &Keyword::DoubleStrike),
+        "target must gain double strike"
+    );
+    assert!(
+        has_kw(&mut runner, target, &Keyword::Trample),
+        "WITH teamwork, target must ALSO gain trample"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Runtime discrimination — Cruel Alliance (Teamwork 2)
+//
+// Body: "Exile target creature with mana value 3 or less. If this spell was
+// cast using teamwork, instead exile target creature and you gain 3 life."
+//
+// The teamwork-paid path uses the "instead" upgrade. The observable divergence
+// is the +3 life gain that only occurs on the teamwork path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cruel_alliance_with_teamwork_gains_three_life() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // P0's tap creature (power 2 >= Teamwork 2).
+    let tapper = scenario.add_creature(P0, "Tapper", 2, 2).id();
+    // An opponent creature to exile (any MV — the teamwork "instead" form has no
+    // MV restriction).
+    let victim = scenario.add_creature(PlayerId(1), "Big Threat", 6, 6).id();
+    let mut builder =
+        scenario.add_spell_to_hand_from_oracle(P0, "Cruel Alliance", false, CRUEL_ALLIANCE);
+    builder.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let spell = builder.id();
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    let life_before = runner.state().players[0].life;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Cruel Alliance must be accepted");
+
+    // Drive the cast: the engine may surface target selection, the optional
+    // teamwork cost, and the tap-creatures payment in any order. Pay teamwork
+    // (tapping the 2/2, total power 2 >= 2) and target the victim.
+    drive_cast_paying_teamwork(&mut runner, &[tapper], victim);
+    resolve_stack(&mut runner);
+
+    assert!(
+        runner.state().objects[&tapper].tapped,
+        "the teamwork tap creature must be tapped"
+    );
+    assert_eq!(
+        runner.state().players[0].life,
+        life_before + 3,
+        "the teamwork 'instead' path must gain 3 life"
+    );
+    assert!(
+        !runner.state().battlefield.contains(&victim),
+        "the teamwork 'instead' path exiles the targeted creature"
+    );
+}
+
+/// Drive a cast that PAYS the optional teamwork cost: at each window, accept the
+/// optional cost, tap `tappers` for the aggregate power cost, and choose
+/// `target` at any target-selection window. Order-agnostic so it tolerates the
+/// engine surfacing target-before-cost or cost-before-target.
+fn drive_cast_paying_teamwork(runner: &mut GameRunner, tappers: &[ObjectId], target: ObjectId) {
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalCost { pay: true })
+                    .expect("paying teamwork must be accepted");
+            }
+            WaitingFor::PayCost {
+                kind: PayCostKind::TapCreatures { .. },
+                ..
+            } => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: tappers.to_vec(),
+                    })
+                    .expect("tapping creatures for teamwork must be accepted");
+            }
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(engine::types::ability::TargetRef::Object(target)),
+                    })
+                    .expect("choosing the target must be accepted");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalizing {0} cost must be accepted");
+            }
+            _ => return,
+        }
+    }
+}
+
+/// Drive a single `TargetSelection` window choosing `target`.
+fn drive_single_target(runner: &mut GameRunner, target: ObjectId) {
+    for _ in 0..8 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(engine::types::ability::TargetRef::Object(target)),
+                    })
+                    .expect("choosing the target must be accepted");
+                return;
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("finalizing {0} cost must be accepted");
+            }
+            _ => return,
+        }
+    }
+}
+
+/// Resolve the stack to empty by passing priority.
+fn resolve_stack(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        if runner.state().stack.is_empty()
+            && !matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+        {
+            break;
+        }
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+}

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -2001,9 +2001,7 @@ mod tests {
             choosable_objects(
                 &WaitingFor::PayCost {
                     player: PlayerId(0),
-                    kind: PayCostKind::TapCreatures {
-                        power_threshold: None,
-                    },
+                    kind: PayCostKind::TapCreatures { aggregate: None },
                     choices: vec![ObjectId(30)],
                     count: 1,
                     min_count: 0,

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -2001,7 +2001,9 @@ mod tests {
             choosable_objects(
                 &WaitingFor::PayCost {
                     player: PlayerId(0),
-                    kind: PayCostKind::TapCreatures,
+                    kind: PayCostKind::TapCreatures {
+                        power_threshold: None,
+                    },
                     choices: vec![ObjectId(30)],
                     count: 1,
                     min_count: 0,

--- a/crates/mtgish-import/src/convert/cost.rs
+++ b/crates/mtgish-import/src/convert/cost.rs
@@ -5,8 +5,8 @@
 //! cover the overwhelming majority of activated ability costs.
 
 use engine::types::ability::{
-    AbilityCost, CounterCostSelection, QuantityExpr, SacrificeCost, TargetFilter,
-    REMOVE_COUNTER_COST_ALL,
+    AbilityCost, CounterCostSelection, QuantityExpr, SacrificeCost, TapCreaturesRequirement,
+    TargetFilter, REMOVE_COUNTER_COST_ALL,
 };
 use engine::types::ManaCost;
 use engine::types::Zone;
@@ -53,12 +53,12 @@ pub fn convert(cost: &Cost) -> ConvResult<AbilityCost> {
             TargetFilter::SelfRef => AbilityCost::Tap,
             // Tapping a different specific permanent — fold into TapCreatures-shaped cost.
             other => AbilityCost::TapCreatures {
-                count: 1,
+                requirement: TapCreaturesRequirement::count(1),
                 filter: other,
             },
         },
         Cost::TapAPermanent(filter) => AbilityCost::TapCreatures {
-            count: 1,
+            requirement: TapCreaturesRequirement::count(1),
             filter: convert_permanents(filter)?,
         },
         Cost::SacrificeAPermanent(filter) => {
@@ -124,15 +124,15 @@ pub fn convert(cost: &Cost) -> ConvResult<AbilityCost> {
         },
 
         // CR 701.26 + CR 602.5b: Tap N permanents matching a filter.
-        // Engine `TapCreatures.count` is `u32`; X-bound / dynamic counts
-        // strict-fail with a precise extension request — the converter is
-        // correct, the engine slot is too narrow.
+        // Engine `TapCreaturesRequirement::Count.count` is `u32`; X-bound /
+        // dynamic counts strict-fail with a precise extension request — the
+        // converter is correct, the engine slot is too narrow.
         Cost::TapNumberPermanents(n, filter) => AbilityCost::TapCreatures {
-            count: fixed_count_or_engine_gap(
+            requirement: TapCreaturesRequirement::count(fixed_count_or_engine_gap(
                 n,
                 "AbilityCost::TapCreatures",
                 "count: QuantityExpr (X-bound / dynamic count)",
-            )?,
+            )?),
             filter: convert_permanents(filter)?,
         },
 

--- a/crates/phase-ai/src/policies/payment_selection.rs
+++ b/crates/phase-ai/src/policies/payment_selection.rs
@@ -277,7 +277,7 @@ fn payment_cost(
             _ => card_value(state, obj_id) * 0.5,
         },
         PayCostKind::RemoveCounter { .. } => permanent_value(state, obj_id) * 0.5,
-        PayCostKind::TapCreatures => permanent_value(state, obj_id) * 0.35,
+        PayCostKind::TapCreatures { .. } => permanent_value(state, obj_id) * 0.35,
         PayCostKind::Behold { .. } => card_value(state, obj_id) * 0.1,
         PayCostKind::Sacrifice => sacrifice_cost(state, obj_id, penalties),
     }

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -336,7 +336,10 @@ fn resolve_choice(
         // behavior — Discard / Sacrifice / Exile / RemoveCounter PayCost kinds
         // fall through to the catch-all below, as their old variants did).
         WaitingFor::PayCost {
-            kind: PayCostKind::ReturnToHand | PayCostKind::Behold { .. } | PayCostKind::TapCreatures,
+            kind:
+                PayCostKind::ReturnToHand
+                | PayCostKind::Behold { .. }
+                | PayCostKind::TapCreatures { .. },
             ..
         }
         | WaitingFor::ManaPayment { .. }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Implements the new Marvel Super Heroes keyword **Teamwork N** — "As an additional
cost to cast this spell, you may tap any number of creatures you control with
total power N or more" — and ships 9 of the 10 MSH Teamwork cards.

Teamwork is expressed entirely through existing optional-additional-cost
machinery (no bespoke system), exactly mirroring Conspire:

- `Keyword::Teamwork(u32)` parses from the keyword line and `synthesize_teamwork`
  attaches an `AdditionalCost::Optional { cost: TapCreatures { .. } }`.
- The tap requirement is a new **parameterization** of the existing
  `AbilityCost::TapCreatures` cost: `requirement: TapCreaturesRequirement` is
  either `Count { count }` (the old fixed-count form, Conspire/Convoke) or
  `Aggregate { stat: TotalPower, comparator, value }` (the "tap any number with
  total power N or greater" form shared by Crew/Saddle/Teamwork). This mirrors
  `SacrificeRequirement` exactly — no new sibling cost variant was added.
- Paying the optional cost sets the spell's `additional_cost_paid` flag (the same
  flag kicker/bargain set), and the body's "if this spell was cast using
  teamwork" condition reads it via the existing `AbilityCondition::AdditionalCostPaid`
  / `ModalSelectionCondition::AdditionalCostPaid` (incl. the modal "Choose one. /
  choose both instead" upgrade).

**SHIPPED (9, zero `Unimplemented`):** Team Tactics, We Say Thee Nay!, Cruel
Alliance, Widow's Bite, Go Nuts!, HULK SMASH!, Murdock's Crusade, Too Evil to
Stay Dead, Atlantis Attacks.

**DEFERRED (1):** Earth's Mightiest Heroes. Its body "reveal top eight, you may
put A creature card onto the battlefield; if cast using teamwork, put ANY NUMBER
instead" parses to a single `Effect::Dig { keep_count: u32::MAX, up_to: true }`
that collapses the base (one) and upgraded (any number) keep counts into
"any number" unconditionally — with no `AdditionalCostPaid`-gated count switch.
Shipping it would silently let the no-teamwork case put any number of creatures,
which is wrong. The Teamwork keyword itself is fully shipped; only this one card
body waits for a teamwork-conditional `keep_count` in the reveal-N effect.

Tier: Frontier
Model: claude-opus-4-8
Thinking: high

## Files changed

Types:
- `types/keywords.rs` — `Keyword::Teamwork(u32)` variant + KeywordKind/from_str/serde/is_spell_casting_only wiring.
- `types/ability.rs` — `TapCreaturesAggregateStat`, `TapCreaturesRequirement` (Count|Aggregate); `AbilityCost::TapCreatures` now carries `requirement` (legacy `count` JSON deserializes via `deserialize_tap_creatures_requirement`).
- `types/game_state.rs` — `PayCostKind::TapCreatures { power_threshold: Option<i32> }` distinguishes fixed-count vs aggregate at the interactive payment layer.

Synthesis / runtime:
- `database/synthesis.rs` — `synthesize_teamwork` builds the optional aggregate tap cost; wired into `synthesize_all`.
- `game/cost_payability.rs` — `has_enough_tap_creatures` evaluates both requirement shapes (count vs total positive power).
- `game/casting_costs.rs` — interactive `TapCreatures` flow drives the aggregate prompt; the spell-cost handler validates total power ≥ threshold.
- `game/engine.rs`, `game/engine_casting.rs`, `game/casting.rs`, `game/mana_abilities.rs`, `game/costs.rs` — threaded the requirement/power_threshold through the cost pipeline; mana/activated-ability tap costs remain fixed-count.

Parser:
- `parser/oracle_keyword.rs` — "Teamwork N" recognized as a numeric-count keyword and a keyword-cost line (reminder text stripped).
- `parser/oracle_effect/conditions.rs` — "was cast using teamwork, [body]" gates the body on `additional_cost_paid` (leading-"instead" folds to `AdditionalCostPaidInstead`).
- `parser/oracle_modal.rs` — modal "If this spell was cast using teamwork, choose both instead" upgrade.
- `parser/oracle_cost.rs`, `parser/oracle_trigger.rs`, `parser/oracle_casting.rs` — call-site migrations to the parameterized `TapCreatures`.

Tests:
- `tests/teamwork_keyword.rs` — parse coverage (9 cards, 0 Unimplemented), synthesis shape, and runtime with/without-teamwork discriminating tests.
- `tests/conspire_granted_keyword.rs` — pattern migration for the new `TapCreatures` field shape.

## CR references

- CR 601.2b / CR 601.2f — Teamwork is an optional additional cost announced at cast.
- CR 702 — Teamwork is a keyword ability (not yet in the printed CR; a new MSH keyword, annotated as such in code).
- CR 702.122a (Crew) / CR 702.171a (Saddle) — precedent for "tap any number of untapped creatures you control with total power N or greater".
- CR 208.1 — power is the aggregate axis.
- CR 700.2 — modal "Choose one / choose both instead".
- CR 602.1a / CR 605.1a — activated-ability and mana-ability tap costs remain fixed-count only.

All CR numbers grep-verified against `docs/MagicCompRules.txt` (Teamwork itself
is absent from the printed CR and is documented as such, not annotated with a
fabricated number).

## Track

Developer

## Verification

- `cargo fmt --all` — clean.
- `./scripts/check-parser-combinators.sh` — pass; inline parser-diff gate (contains/split/find on added lines) — clean (only `nom_primitives::split_once_on`, the established combinator building block, matching the existing kicker/bargain arms).
- `cargo clippy -p engine --lib --tests -- -D warnings` — clean (exit 0).
- `cargo test -p engine` — 12599 passed, 1 failed (`ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`, the known pre-existing flaky test, unrelated to this change), 6 ignored.
- `cargo test -p engine --test teamwork_keyword` — 5 passed.
- `cargo test -p engine --no-run` — all integration test targets compile.
- `cargo coverage` / `cargo semantic-audit` — compiled clean in tool profile; could not run card-data analysis because `card-data.json` is absent in the isolated worktree (no MTGJSON pipeline here). Per-card parse coverage is verified instead by `tests/teamwork_keyword.rs::shipped_teamwork_cards_parse_without_unimplemented`.

## Scope Expansion

This PR introduces the Teamwork keyword infrastructure: a new keyword variant, a
parameterization of the existing tap-creatures cost (`TapCreaturesRequirement`,
mirroring `SacrificeRequirement`), the interactive aggregate-power payment flow,
and the parser arms for the keyword line + "cast using teamwork" body/modal
conditions. The infrastructure is general — it unlocks any future "tap any number
with total power N" additional cost, and the body condition reuses the shared
`AdditionalCostPaid` gate.

## Validation Failures

None.

## CI Failures

None.
