### PR TITLE
fix(parser): add SourceIsEnchanted for "as long as this creature is enchanted"

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5953,6 +5953,7 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::UnlessPay { .. } => ("UnlessPay", Handled),
         StaticCondition::ControlsCommander { .. } => ("ControlsCommander", Unhandled),
         StaticCondition::SourceIsEquipped => ("SourceIsEquipped", Unhandled),
+        StaticCondition::SourceIsEnchanted => ("SourceIsEnchanted", Unhandled),
         StaticCondition::SourceIsMonstrous => ("SourceIsMonstrous", Unhandled),
         StaticCondition::SourceAttachedToCreature => ("SourceAttachedToCreature", Unhandled),
         StaticCondition::SourceMatchesFilter { .. } => ("SourceMatchesFilter", Unhandled),

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -668,6 +668,7 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceControllerEquals { .. }
         | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsEnchanted
         | StaticCondition::SourceIsMonstrous
         | StaticCondition::SourceAttachedToCreature
         | StaticCondition::SourceMatchesFilter { .. }
@@ -792,6 +793,7 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceControllerEquals { .. }
         | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsEnchanted
         | StaticCondition::SourceIsMonstrous
         | StaticCondition::SourceAttachedToCreature
         | StaticCondition::SourceMatchesFilter { .. }
@@ -1039,6 +1041,15 @@ fn evaluate_condition_with_context(
         StaticCondition::SourceIsEquipped => state.objects.values().any(|obj| {
             obj.attached_to.and_then(|t| t.as_object()) == Some(source_id)
                 && obj.card_types.subtypes.iter().any(|s| s == "Equipment")
+        }),
+        // CR 303.4: True when at least one Aura is attached to the source object.
+        // Aura-twin of `SourceIsEquipped` (CR 301.5a); the only delta is the
+        // subtype check ("Aura" vs "Equipment"). An Aura attaches to objects or
+        // players (CR 303.4), but a creature host is always an Object, so
+        // non-Object hosts are rejected by `as_object`.
+        StaticCondition::SourceIsEnchanted => state.objects.values().any(|obj| {
+            obj.attached_to.and_then(|t| t.as_object()) == Some(source_id)
+                && obj.card_types.subtypes.iter().any(|s| s == "Aura")
         }),
         // CR 701.37: True when the source permanent is monstrous.
         StaticCondition::SourceIsMonstrous => state
@@ -9263,6 +9274,70 @@ mod tests {
             &StaticCondition::SourceIsSaddled,
             PlayerId(0),
             id,
+        ));
+    }
+
+    // CR 303.4: `SourceIsEnchanted` gates a continuous modification on at least
+    // one Aura being attached to the source. No attachment → false; an Aura
+    // (subtype "Aura") attached → true; an Equipment (subtype "Equipment")
+    // attached → FALSE (negative twin — the matcher keys solely on the "Aura"
+    // subtype, mirroring `SourceIsEquipped`'s "Equipment" check). Discriminating:
+    // if the matcher arm or the new variant is reverted this test fails to
+    // compile / evaluates wrong, re-exposing the always-true `Unrecognized`
+    // fallback (Pillar of War / Thran Golem / Gate Hound / Freewind Equenaut).
+    #[test]
+    fn source_is_enchanted_gates_on_attached_aura() {
+        use crate::game::game_object::AttachTarget;
+        let mut state = setup();
+        let creature = make_creature(&mut state, "Enchanted Bear", 2, 2, PlayerId(0));
+
+        // No Aura attached → condition false.
+        assert!(!evaluate_condition_for_test(
+            &state,
+            &StaticCondition::SourceIsEnchanted,
+            PlayerId(0),
+            creature,
+        ));
+
+        // Attach an Equipment (NOT an Aura) → still false (negative twin: the
+        // matcher must not treat Equipment as enchanting).
+        let equipment = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Bonesplitter".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&equipment).unwrap();
+            obj.card_types.subtypes.push("Equipment".to_string());
+            obj.attached_to = Some(AttachTarget::Object(creature));
+        }
+        assert!(!evaluate_condition_for_test(
+            &state,
+            &StaticCondition::SourceIsEnchanted,
+            PlayerId(0),
+            creature,
+        ));
+
+        // Attach an Aura to the source → condition true.
+        let aura = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Holy Strength".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&aura).unwrap();
+            obj.card_types.subtypes.push("Aura".to_string());
+            obj.attached_to = Some(AttachTarget::Object(creature));
+        }
+        assert!(evaluate_condition_for_test(
+            &state,
+            &StaticCondition::SourceIsEnchanted,
+            PlayerId(0),
+            creature,
         ));
     }
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -546,6 +546,7 @@ pub(crate) fn static_condition_uses_unspent_mana(condition: &StaticCondition) ->
         | StaticCondition::SourceIsSaddled
         | StaticCondition::SourceControllerEquals { .. }
         | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsEnchanted
         | StaticCondition::SourceIsMonstrous
         | StaticCondition::SourceAttachedToCreature
         | StaticCondition::SourceMatchesFilter { .. }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2790,6 +2790,7 @@ pub(crate) fn static_condition_to_ability_condition(
         | StaticCondition::SourceIsBlocking
         | StaticCondition::SourceIsBlocked
         | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsEnchanted
         | StaticCondition::SourceIsPaired
         | StaticCondition::SourceIsMonstrous
         // CR 702.171b: the saddled designation is a static-only predicate with no

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1120,6 +1120,16 @@ fn parse_source_is_equipped(input: &str) -> OracleResult<'_, StaticCondition> {
     value(StaticCondition::SourceIsEquipped, tag("is equipped")).parse(rest)
 }
 
+/// CR 303.4: Parse "<subject> is enchanted" → SourceIsEnchanted.
+/// Aura-twin of `parse_source_is_equipped` (CR 301.5a). The count form
+/// "<subject> is enchanted by N Auras" (`parse_source_enchanted_by_aura_count`)
+/// is tried earlier in the `alt()` so this bare arm only matches the
+/// no-quantifier idiom.
+fn parse_source_is_enchanted(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = parse_source_subject(input)?;
+    value(StaticCondition::SourceIsEnchanted, tag("is enchanted")).parse(rest)
+}
+
 /// CR 701.37: Parse "<subject> is monstrous" → SourceIsMonstrous.
 fn parse_source_is_monstrous(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = parse_source_subject(input)?;
@@ -1198,6 +1208,11 @@ fn parse_source_state_conditions(input: &str) -> OracleResult<'_, StaticConditio
         // CR 303.4 + CR 604.1 + CR 613.1g: "~ is enchanted by exactly N
         // Aura(s)" / "N or more Auras" (Timber Paladin tiered static P/T gates).
         parse_source_enchanted_by_aura_count,
+        // CR 303.4: bare "~ is enchanted" / "this creature is enchanted" →
+        // SourceIsEnchanted. MUST follow the count form above so
+        // "is enchanted by N Auras" (which requires `tag("is enchanted by ")`)
+        // still wins; this arm only matches the no-quantifier idiom.
+        parse_source_is_enchanted,
         // CR 122.1: "<subject> has <quantity> <counter_type> counter(s) on it"
         // — covers Unleash/Outlast/Renown bodies, Primordial Hydra's trample gate,
         // and every "as long as it has …" counter-comparator static.
@@ -7829,6 +7844,38 @@ mod tests {
         let (rest, c) = parse_inner_condition("this creature is equipped").unwrap();
         assert_eq!(rest, "");
         assert_eq!(c, StaticCondition::SourceIsEquipped);
+    }
+
+    // CR 303.4: bare SourceIsEnchanted predicate across subjects.
+    // Discriminating (fail-on-revert): if the `parse_source_is_enchanted` arm
+    // is removed these fall through to `Unrecognized` (evaluates always-true),
+    // re-breaking Pillar of War / Thran Golem / Gate Hound / Freewind Equenaut.
+    #[test]
+    fn test_source_is_enchanted() {
+        let (rest, c) = parse_inner_condition("this creature is enchanted").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(c, StaticCondition::SourceIsEnchanted);
+
+        let (rest, c) = parse_inner_condition("~ is enchanted").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(c, StaticCondition::SourceIsEnchanted);
+    }
+
+    // CR 303.4 + CR 613.1g: no-regression — the bare "is enchanted" arm must
+    // NOT intercept the count/comparison form "is enchanted by N Auras"
+    // (it is tried earlier in the `alt()` and requires `tag("is enchanted by ")`).
+    #[test]
+    fn test_source_is_enchanted_does_not_steal_aura_count() {
+        let (rest, c) = parse_inner_condition("~ is enchanted by exactly two Auras").unwrap();
+        assert_eq!(rest, "");
+        let StaticCondition::QuantityComparison {
+            comparator, rhs, ..
+        } = c
+        else {
+            panic!("expected QuantityComparison (count form), got {c:?}");
+        };
+        assert_eq!(comparator, Comparator::EQ);
+        assert_eq!(rhs, QuantityExpr::Fixed { value: 2 });
     }
 
     // CR 701.37: SourceIsMonstrous predicate across subjects.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -4015,6 +4015,23 @@ fn static_as_long_as_unrecognized_condition() {
 }
 
 #[test]
+fn static_enchanted_or_equipped_stays_unrecognized() {
+    // Novice Knight: "As long as this creature is enchanted or equipped, ~ has
+    // first strike." The rhs "equipped" elides its subject, so the disjunction
+    // cannot be decomposed — the whole condition falls through to Unrecognized
+    // (no regression: it is Unrecognized today, and the new bare "is enchanted"
+    // arm intentionally does NOT salvage half of it).
+    let def =
+        parse_static_line("As long as this creature is enchanted or equipped, ~ has first strike.")
+            .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert!(matches!(
+        def.condition,
+        Some(StaticCondition::Unrecognized { .. })
+    ));
+}
+
+#[test]
 fn static_has_keyword_as_long_as() {
     let def = parse_static_line("Tarmogoyf has trample as long as a land card is in a graveyard.")
         .unwrap();

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2822,6 +2822,7 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
         | StaticCondition::SourceIsBlocking
         | StaticCondition::SourceIsBlocked
         | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsEnchanted
         | StaticCondition::SourceIsPaired
         | StaticCondition::SourceIsMonstrous
         // CR 110.5b + CR 611.2b: `IsTapped { scope }` is a duration-only

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5200,6 +5200,11 @@ pub enum StaticCondition {
     /// CR 301.5a: True when at least one Equipment is attached to the source object.
     /// Used for "as long as ~ is equipped" statics (Auriok Steelshaper, etc.).
     SourceIsEquipped,
+    /// CR 303.4: True when at least one Aura is attached to the source object.
+    /// Aura-twin of `SourceIsEquipped` (CR 301.5). Used for "as long as this
+    /// creature is enchanted" statics (Pillar of War, Thran Golem, Gate Hound,
+    /// Freewind Equenaut).
+    SourceIsEnchanted,
     /// CR 701.37: True when the source permanent is monstrous.
     /// Read from `GameObject::monstrous` (existing bool field).
     /// Used for "as long as this creature is monstrous" statics (Fleecemane Lion, etc.).


### PR DESCRIPTION
Fixes #3923.

## Summary

Static abilities gated on "as long as this creature is enchanted" applied **permanently** — the condition parsed to an inert `StaticCondition::Unrecognized`, which the layer system evaluates as always-true:

- **Pillar of War** (attack-despite-defender), **Thran Golem** (+2/+2 + flying/first strike/trample), **Gate Hound** (vigilance anthem), **Freewind Equenaut**, **Flaring Flame-Kin** — each applied with no Aura attached.

## Root cause

The source-subject condition parser had arms for "is equipped" / "is monstrous" / "is saddled" but none for "is enchanted", so it fell through to the `Unrecognized` fallback — and there was no `SourceIsEnchanted` condition at all.

## Fix (bounded engine extension; mirrors `SourceIsEquipped` exactly)

Add `StaticCondition::SourceIsEnchanted` as the Aura-twin of the existing `SourceIsEquipped` (same attacher scan, subtype `Aura` vs `Equipment`), wired through every site its sibling occupies: the variant decl, the parser arm (`parse_source_is_enchanted`), the layer-system runtime matcher, the population/quantity classifiers, the two lowering paths (`=> None`), and the coverage feature map (`Unhandled`, matching the sibling — diagnostic-only). The effect now applies only while an Aura is attached.

The bare "is enchanted" arm is ordered after the "is enchanted by N Auras" count form, so the latter still wins. "is enchanted or equipped" (Novice Knight) — a subject-eliding disjunction — remains an honest gap. No game runtime-logic change beyond the new matcher. CR 303.4 / 301.5 / 611.3a.

## Tests

- Discriminating (fail-on-revert): `parse_inner_condition("this creature is enchanted")` → `SourceIsEnchanted` (not `Unrecognized`).
- No-regression: "is enchanted by exactly two Auras" still → the count variant (the bare arm doesn't intercept).
- Runtime/layer: the condition is **false** with no Aura, **true** with an Aura attached, and **false** with an *Equipment* attached (negative twin — reverting the subtype check fails this).
- Novice Knight "enchanted or equipped" stays `Unrecognized` (no regression).

## Verification

`cargo +nightly check --workspace`: clean (no `StaticCondition` literal breaks in other crates). `cargo +nightly test -p engine` (all targets incl. `--test integration`): 12765 lib + 1319 integration passed; the only failure was the pre-existing flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (global perf-counter race under parallel runs — confirmed passing in isolation, unrelated). `clippy -D warnings`, parser-combinator gate, rustfmt: clean. Per-card check confirms the 5 statics flip `Unrecognized` → `SourceIsEnchanted` (supported); Novice Knight stays an honest gap; no other card regresses.
