### PR TITLE
feat(parser): set chosen creature type for Conspiracy (compose RemoveAllSubtypes+AddChosenSubtype)

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -7658,6 +7658,75 @@ mod tests {
         );
     }
 
+    // CR 205.1a (SET replace) + CR 613.1d (Layer 4) + CR 613.7a (intra-static
+    // written order): Conspiracy's "Creatures you control are the chosen type"
+    // REPLACES the existing creature subtypes. The composed static
+    // [RemoveAllSubtypes{Creature}, AddChosenSubtype{CreatureType}] must wipe the
+    // base "Goblin" subtype (membership resolved against state.all_creature_types)
+    // and re-add the chosen "Zombie" type, in written order, so Zombie survives.
+    #[test]
+    fn test_chosen_creature_type_sets_subtype() {
+        use crate::types::ability::ChosenAttribute;
+
+        let mut state = setup();
+        // RemoveAllSubtypes{Creature} resolves creature-type membership against
+        // state.all_creature_types — both the wiped Goblin and the re-added Zombie
+        // must be known.
+        state.all_creature_types = vec!["Goblin".to_string(), "Zombie".to_string()];
+
+        let source = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Conspiracy".to_string(),
+            Zone::Battlefield,
+        );
+        let goblin = make_creature(&mut state, "Goblin", 1, 1, PlayerId(0));
+        let ts = state.next_timestamp();
+        {
+            let obj = state.objects.get_mut(&goblin).unwrap();
+            obj.card_types.subtypes.push("Goblin".to_string());
+            // Mirror into base so the layer-evaluation reset (card_types =
+            // base_card_types) doesn't drop the printed Goblin subtype.
+            obj.base_card_types.subtypes.push("Goblin".to_string());
+            obj.timestamp = ts;
+        }
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.chosen_attributes
+                .push(ChosenAttribute::CreatureType("Zombie".to_string()));
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::creature().controller(ControllerRef::You),
+                    ))
+                    .modifications(vec![
+                        ContinuousModification::RemoveAllSubtypes {
+                            set: crate::types::card_type::SubtypeSet::Creature,
+                        },
+                        ContinuousModification::AddChosenSubtype {
+                            kind: ChosenSubtypeKind::CreatureType,
+                        },
+                    ]),
+            );
+        }
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let obj = state.objects.get(&goblin).unwrap();
+        assert!(
+            obj.card_types.subtypes.contains(&"Zombie".to_string()),
+            "Creature should gain the chosen Zombie subtype: {:?}",
+            obj.card_types.subtypes
+        );
+        assert!(
+            !obj.card_types.subtypes.contains(&"Goblin".to_string()),
+            "SET form must wipe the original Goblin subtype: {:?}",
+            obj.card_types.subtypes
+        );
+    }
+
     // CR 608.2d + CR 613.1f: Urborg's "loses [chosen ability] until end of
     // turn" — the chosen Keyword is stored on the source's `chosen_attributes`
     // and read back by `RemoveChosenKeyword` at layer evaluation time. The

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -13637,6 +13637,162 @@ fn parser_shape_arcane_adaptation_chosen_type_applies_to_creatures_you_control()
     }
 }
 
+// CR 205.1a (SET replace) + CR 613.1d (Layer 4) + CR 607.2d (chosen-link):
+// Conspiracy's "Creatures you control are the chosen type." (no "in addition to")
+// REPLACES the existing creature subtypes. It must compose RemoveAllSubtypes{Creature}
+// then AddChosenSubtype{CreatureType}, in that written order (CR 613.7a), mirroring
+// Frogify — NOT fall through to an Unimplemented static.
+#[test]
+fn parse_conspiracy_sets_chosen_creature_type() {
+    let def = parse_static_line("Creatures you control are the chosen type.").unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let mods = &def.modifications;
+    assert!(
+        mods.contains(&ContinuousModification::RemoveAllSubtypes {
+            set: crate::types::card_type::SubtypeSet::Creature,
+        }),
+        "SET form must wipe creature subtypes: {mods:?}"
+    );
+    assert!(
+        mods.contains(&ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }),
+        "SET form must re-add the chosen creature type: {mods:?}"
+    );
+    // CR 613.7a written-order: RemoveAllSubtypes must precede AddChosenSubtype so
+    // the re-added chosen type survives the wipe.
+    let pos = |m: &ContinuousModification| mods.iter().position(|x| x == m).unwrap();
+    assert!(
+        pos(&ContinuousModification::RemoveAllSubtypes {
+            set: crate::types::card_type::SubtypeSet::Creature,
+        }) < pos(&ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }),
+        "RemoveAllSubtypes must precede AddChosenSubtype: {mods:?}"
+    );
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert!(tf
+                .type_filters
+                .iter()
+                .any(|filter| matches!(filter, TypeFilter::Creature)));
+        }
+        other => panic!("Expected Some(Typed filter), got {other:?}"),
+    }
+}
+
+// CR 205.1b (in-addition retain): regression — Arcane Adaptation's additive form
+// must NOT emit RemoveAllSubtypes; it stays a single AddChosenSubtype.
+#[test]
+fn parse_arcane_adaptation_adds_chosen_creature_type() {
+    let def = parse_static_line(
+        "Creatures you control are the chosen type in addition to their other types.",
+    )
+    .unwrap();
+    let mods = &def.modifications;
+    assert!(
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. })),
+        "additive form must NOT wipe creature subtypes: {mods:?}"
+    );
+    assert_eq!(
+        mods,
+        &vec![ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }],
+        "additive form must be a single AddChosenSubtype: {mods:?}"
+    );
+}
+
+// CR 205.1a + CR 607.2d: full Conspiracy oracle. The battlefield SET static must be
+// present (composed RemoveAllSubtypes + AddChosenSubtype) AND the non-battlefield
+// "the same is true for ..." tail must surface as an Unimplemented residual (the
+// multi-zone type application is honestly gapped).
+#[test]
+fn parse_conspiracy_full_oracle_sets_static_and_gaps_tail() {
+    let oracle = "As this enchantment enters, choose a creature type.\nCreatures you control are the chosen type. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+    let result = crate::parser::oracle::parse_oracle_text(
+        oracle,
+        "Conspiracy",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    let has_set_static = result.statics.iter().any(|def| {
+        def.modifications
+            .contains(&ContinuousModification::RemoveAllSubtypes {
+                set: crate::types::card_type::SubtypeSet::Creature,
+            })
+            && def
+                .modifications
+                .contains(&ContinuousModification::AddChosenSubtype {
+                    kind: ChosenSubtypeKind::CreatureType,
+                })
+    });
+    assert!(
+        has_set_static,
+        "Conspiracy must produce the composed SET static: {:?}",
+        result.statics
+    );
+    let tail_gapped = result.abilities.iter().any(|ability| {
+        matches!(
+            *ability.effect,
+            crate::types::ability::Effect::Unimplemented { description: Some(ref frag), .. }
+                // allow-noncombinator: test assertion on a gapped Unimplemented fragment, not parser dispatch
+                if frag.contains("creature spells you control")
+        )
+    });
+    assert!(
+        tail_gapped,
+        "the 'same is true for ...' multi-zone tail must be gapped as Unimplemented: {:?}",
+        result.abilities
+    );
+}
+
+// CR 205.1b: full Arcane Adaptation oracle (regression). The additive static must be
+// present (AddChosenSubtype, no RemoveAllSubtypes) AND the tail gapped.
+#[test]
+fn parse_arcane_adaptation_full_oracle_adds_static_and_gaps_tail() {
+    let oracle = "As Arcane Adaptation enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.";
+    let result = crate::parser::oracle::parse_oracle_text(
+        oracle,
+        "Arcane Adaptation",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    let has_additive_static = result.statics.iter().any(|def| {
+        def.modifications
+            .contains(&ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::CreatureType,
+            })
+            && !def
+                .modifications
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::RemoveAllSubtypes { .. }))
+    });
+    assert!(
+        has_additive_static,
+        "Arcane Adaptation must produce the additive static: {:?}",
+        result.statics
+    );
+    let tail_gapped = result.abilities.iter().any(|ability| {
+        matches!(
+            *ability.effect,
+            crate::types::ability::Effect::Unimplemented { description: Some(ref frag), .. }
+                // allow-noncombinator: test assertion on a gapped Unimplemented fragment, not parser dispatch
+                if frag.contains("creature spells you control")
+        )
+    });
+    assert!(
+        tail_gapped,
+        "the 'same is true for ...' tail must be gapped as Unimplemented: {:?}",
+        result.abilities
+    );
+}
+
 // CR 607.2d + CR 301.7: Lifecraft Engine grants the chosen creature subtype to
 // Vehicle permanents you control — not the Creature card type. The additive-type
 // fallback must not mis-tokenize "the chosen creature type" as AddType(Creature).

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -69,6 +69,12 @@ pub(crate) enum ChosenCreatureTypeStaticScope {
     VehicleCreatures,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChosenCreatureTypeApplication {
+    Additive,
+    Replacing,
+}
+
 impl ChosenCreatureTypeStaticScope {
     fn target_filter(self) -> TargetFilter {
         match self {
@@ -89,7 +95,7 @@ pub(crate) fn parse_arcane_adaptation_chosen_type_static(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    let ((scope, is_additive), _) = nom_on_lower(
+    let ((scope, application), _) = nom_on_lower(
         tp.original,
         tp.lower,
         parse_chosen_creature_type_static_sentence_with_scope,
@@ -105,21 +111,22 @@ pub(crate) fn parse_arcane_adaptation_chosen_type_static(
     // RemoveAllSubtypes{Creature} retains against state.all_creature_types, so the
     // added chosen subtype SURVIVES the wipe (CR 613.7a intra-static written order)
     // and an artifact creature keeps its artifact subtypes (CR 205.1a).
-    let modifications = if is_additive {
-        vec![ContinuousModification::AddChosenSubtype {
+    let modifications = match application {
+        ChosenCreatureTypeApplication::Additive => vec![ContinuousModification::AddChosenSubtype {
             kind: ChosenSubtypeKind::CreatureType,
-        }]
-    } else {
-        match scope {
+        }],
+        ChosenCreatureTypeApplication::Replacing => match scope {
             ChosenCreatureTypeStaticScope::Creatures
-            | ChosenCreatureTypeStaticScope::EachCreature => vec![
-                ContinuousModification::RemoveAllSubtypes {
-                    set: crate::types::card_type::SubtypeSet::Creature,
-                },
-                ContinuousModification::AddChosenSubtype {
-                    kind: ChosenSubtypeKind::CreatureType,
-                },
-            ],
+            | ChosenCreatureTypeStaticScope::EachCreature => {
+                vec![
+                    ContinuousModification::RemoveAllSubtypes {
+                        set: crate::types::card_type::SubtypeSet::Creature,
+                    },
+                    ContinuousModification::AddChosenSubtype {
+                        kind: ChosenSubtypeKind::CreatureType,
+                    },
+                ]
+            }
             // CR 301.7: a Vehicle-subtype grant has no known SET printing
             // (Lifecraft Engine is always additive). Fall back to additive so a
             // hypothetical non-additive vehicle line is never silently wiped of
@@ -129,7 +136,7 @@ pub(crate) fn parse_arcane_adaptation_chosen_type_static(
                     kind: ChosenSubtypeKind::CreatureType,
                 }]
             }
-        }
+        },
     };
 
     Some(
@@ -142,9 +149,9 @@ pub(crate) fn parse_arcane_adaptation_chosen_type_static(
 
 fn parse_chosen_creature_type_static_sentence_with_scope(
     input: &str,
-) -> OracleResult<'_, (ChosenCreatureTypeStaticScope, bool)> {
-    let (input, (scope, is_additive)) = parse_chosen_creature_type_static_scope_body(input)?;
-    Ok((input, (scope, is_additive)))
+) -> OracleResult<'_, (ChosenCreatureTypeStaticScope, ChosenCreatureTypeApplication)> {
+    let (input, (scope, application)) = parse_chosen_creature_type_static_scope_body(input)?;
+    Ok((input, (scope, application)))
 }
 
 pub(crate) fn parse_chosen_creature_type_static_prefix(input: &str) -> OracleResult<'_, ()> {
@@ -160,15 +167,19 @@ pub(crate) fn parse_chosen_creature_type_static_prefix(input: &str) -> OracleRes
 /// omits it and replaces the creature types.
 fn parse_chosen_creature_type_static_scope_body(
     input: &str,
-) -> OracleResult<'_, (ChosenCreatureTypeStaticScope, bool)> {
+) -> OracleResult<'_, (ChosenCreatureTypeStaticScope, ChosenCreatureTypeApplication)> {
     let (input, (pronoun, scope)) = parse_chosen_creature_type_static_subject(input)?;
     let (input, _) =
         alt((tag(" the chosen type"), tag(" the chosen creature type"))).parse(input)?;
     let (input, addition) =
         opt((tag(" in addition to "), tag(pronoun), tag(" other types"))).parse(input)?;
-    let is_additive = addition.is_some();
+    let application = if addition.is_some() {
+        ChosenCreatureTypeApplication::Additive
+    } else {
+        ChosenCreatureTypeApplication::Replacing
+    };
     let (input, _) = opt(tag(".")).parse(input)?;
-    Ok((input, (scope, is_additive)))
+    Ok((input, (scope, application)))
 }
 
 pub(crate) fn parse_chosen_creature_type_static_subject(

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -89,27 +89,62 @@ pub(crate) fn parse_arcane_adaptation_chosen_type_static(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    let (scope, _) = nom_on_lower(
+    let ((scope, is_additive), _) = nom_on_lower(
         tp.original,
         tp.lower,
         parse_chosen_creature_type_static_sentence_with_scope,
     )?;
 
+    // CR 205.1b (in-addition retain) vs CR 205.1a (SET replace) + CR 613.1d
+    // (Layer 4) + CR 607.2d (chosen-link). The additive forms (Arcane Adaptation,
+    // Lifecraft Engine, Xenograft) add the chosen creature type while retaining
+    // existing subtypes. The SET form (Conspiracy: "Creatures you control are the
+    // chosen type") REPLACES the existing creature subtypes, modeled by composing
+    // RemoveAllSubtypes{Creature} (wipe) then AddChosenSubtype (re-add the chosen
+    // type) — the IDENTICAL pattern parse_enchanted_is_type uses (Frogify/Lignify).
+    // RemoveAllSubtypes{Creature} retains against state.all_creature_types, so the
+    // added chosen subtype SURVIVES the wipe (CR 613.7a intra-static written order)
+    // and an artifact creature keeps its artifact subtypes (CR 205.1a).
+    let modifications = if is_additive {
+        vec![ContinuousModification::AddChosenSubtype {
+            kind: ChosenSubtypeKind::CreatureType,
+        }]
+    } else {
+        match scope {
+            ChosenCreatureTypeStaticScope::Creatures
+            | ChosenCreatureTypeStaticScope::EachCreature => vec![
+                ContinuousModification::RemoveAllSubtypes {
+                    set: crate::types::card_type::SubtypeSet::Creature,
+                },
+                ContinuousModification::AddChosenSubtype {
+                    kind: ChosenSubtypeKind::CreatureType,
+                },
+            ],
+            // CR 301.7: a Vehicle-subtype grant has no known SET printing
+            // (Lifecraft Engine is always additive). Fall back to additive so a
+            // hypothetical non-additive vehicle line is never silently wiped of
+            // its non-creature subtypes.
+            ChosenCreatureTypeStaticScope::VehicleCreatures => {
+                vec![ContinuousModification::AddChosenSubtype {
+                    kind: ChosenSubtypeKind::CreatureType,
+                }]
+            }
+        }
+    };
+
     Some(
         StaticDefinition::continuous()
             .affected(scope.target_filter())
-            .modifications(vec![ContinuousModification::AddChosenSubtype {
-                kind: ChosenSubtypeKind::CreatureType,
-            }])
+            .modifications(modifications)
             .description(description.to_string()),
     )
 }
 
 fn parse_chosen_creature_type_static_sentence_with_scope(
     input: &str,
-) -> OracleResult<'_, ChosenCreatureTypeStaticScope> {
-    let (input, scope) = parse_chosen_creature_type_static_scope_body(input)?;
-    Ok((input, scope))
+) -> OracleResult<'_, (ChosenCreatureTypeStaticScope, bool)> {
+    let (input, (scope, is_additive)) = parse_chosen_creature_type_static_scope_body(input)?;
+    Ok((input, (scope, is_additive)))
 }
 
 pub(crate) fn parse_chosen_creature_type_static_prefix(input: &str) -> OracleResult<'_, ()> {
@@ -117,19 +152,23 @@ pub(crate) fn parse_chosen_creature_type_static_prefix(input: &str) -> OracleRes
     Ok((input, ()))
 }
 
+/// CR 205.1a / CR 205.1b + CR 607.2d: Parse the "<scope> are the chosen [creature]
+/// type [in addition to their other types]" body, returning the affected scope and
+/// whether the effect is additive (CR 205.1b "in addition") or replacing (CR 205.1a
+/// SET — Conspiracy's bare "are the chosen type"). The "in addition to ..." suffix is
+/// OPTIONAL: Arcane Adaptation / Lifecraft Engine / Xenograft are additive; Conspiracy
+/// omits it and replaces the creature types.
 fn parse_chosen_creature_type_static_scope_body(
     input: &str,
-) -> OracleResult<'_, ChosenCreatureTypeStaticScope> {
+) -> OracleResult<'_, (ChosenCreatureTypeStaticScope, bool)> {
     let (input, (pronoun, scope)) = parse_chosen_creature_type_static_subject(input)?;
-    let (input, _) = alt((
-        tag(" the chosen type in addition to "),
-        tag(" the chosen creature type in addition to "),
-    ))
-    .parse(input)?;
-    let (input, _) = tag(pronoun).parse(input)?;
-    let (input, _) = tag(" other types").parse(input)?;
+    let (input, _) =
+        alt((tag(" the chosen type"), tag(" the chosen creature type"))).parse(input)?;
+    let (input, addition) =
+        opt((tag(" in addition to "), tag(pronoun), tag(" other types"))).parse(input)?;
+    let is_additive = addition.is_some();
     let (input, _) = opt(tag(".")).parse(input)?;
-    Ok((input, scope))
+    Ok((input, (scope, is_additive)))
 }
 
 pub(crate) fn parse_chosen_creature_type_static_subject(


### PR DESCRIPTION
## What

Conspiracy's "Creatures you control are the chosen type." (SET / replace form) lowered to `Effect::Unimplemented`. Arcane Adaptation's ADD form ("...the chosen type **in addition to their other types**") already worked — the chosen-creature-type static parser hard-required the "in addition to ... other types" suffix.

## Fix

Make the "in addition to &lt;pronoun&gt; other types" suffix **optional** in `parse_chosen_creature_type_static_scope_body` (split the previously-fused `" the chosen type in addition to "` tag into `" the chosen type"` + an `opt(...)` suffix), returning whether the clause was additive.

For the SET (non-additive) form, emit a two-modification static — **no new enum variant**, composing two existing modifications (the same pattern `parse_enchanted_is_type` already uses for Frogify/Lignify):

```
[ RemoveAllSubtypes { set: SubtypeSet::Creature },   // CR 205.1a — replace creature subtypes
  AddChosenSubtype  { kind: CreatureType } ]          // add the chosen type
```

Intra-static modifications apply in written order with dependency edges suppressed (CR 613.7a), and `RemoveAllSubtypes { Creature }` retains against the creature-type set only — so the chosen type survives the wipe and an artifact creature keeps its artifact subtypes (CR 205.1a). The additive (Arcane Adaptation) path is unchanged (`AddChosenSubtype` only). The SET branch is gated to "creatures you control" scopes (Vehicle scope stays additive).

### Honest scope

The trailing "The same is true for creature spells you control and creature cards you own that aren't on the battlefield." clause is **left `Unimplemented`** (via the existing tail path, same as Maskwood Nexus) — phase does not model continuous type effects on the stack / in hidden zones. Conspiracy is therefore *partial*, not falsely "supported": the battlefield SET form is correct; the multi-zone clause is a visible gap.

## Tests

- **Parser:** "Creatures you control are the chosen type." → `[RemoveAllSubtypes{Creature}, AddChosenSubtype{CreatureType}]` with the wipe ordered before the add (not `Unimplemented`); regression that the additive form emits `AddChosenSubtype` only; full-oracle tests assert the static is present **and** the multi-zone tail surfaces as `Unimplemented`.
- **Runtime (layers):** chosen type "Zombie" — a controlled creature with base subtype "Goblin" becomes a Zombie and loses Goblin through `evaluate_layers` (discriminating: the "loses Goblin" half fails if the SET wipe is reverted).

CR 205.1a / 205.1b / 613.1d / 607.2d / 613.7a verified against `docs/MagicCompRules.txt`. Engine lib (12767) + integration (1319) green; workspace clippy `-D warnings` clean.

Closes #3925
