### PR TITLE
fix(parser): parse "as long as it's modified" static condition

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1130,6 +1130,22 @@ fn parse_source_is_enchanted(input: &str) -> OracleResult<'_, StaticCondition> {
     value(StaticCondition::SourceIsEnchanted, tag("is enchanted")).parse(rest)
 }
 
+/// CR 700.9: "<subject> is modified" → SourceMatchesFilter on a creature filter
+/// carrying FilterProp::Modified (has a counter / is equipped / is enchanted by
+/// the controller's Aura — evaluated by FilterProp::Modified in game/filter.rs).
+/// Reuses SourceMatchesFilter (no new variant); the SelfRef self-static binds the
+/// filter to the source via FilterContext::from_source at layers.rs.
+fn parse_source_is_modified(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = parse_source_subject(input)?;
+    let filter =
+        TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Modified]));
+    value(
+        StaticCondition::SourceMatchesFilter { filter },
+        tag("is modified"),
+    )
+    .parse(rest)
+}
+
 /// CR 701.37: Parse "<subject> is monstrous" → SourceIsMonstrous.
 fn parse_source_is_monstrous(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = parse_source_subject(input)?;
@@ -1213,6 +1229,12 @@ fn parse_source_state_conditions(input: &str) -> OracleResult<'_, StaticConditio
         // "is enchanted by N Auras" (which requires `tag("is enchanted by ")`)
         // still wins; this arm only matches the no-quantifier idiom.
         parse_source_is_enchanted,
+        // CR 700.9: bare "~ is modified" / "this creature is modified" →
+        // SourceMatchesFilter(creature + FilterProp::Modified). Placed after the
+        // enchanted arms (its tag "is modified" shares no prefix with them) and
+        // before the generic `parse_source_is_type` so the specific predicate wins
+        // over "is <type>" dispatch.
+        parse_source_is_modified,
         // CR 122.1: "<subject> has <quantity> <counter_type> counter(s) on it"
         // — covers Unleash/Outlast/Renown bodies, Primordial Hydra's trample gate,
         // and every "as long as it has …" counter-comparator static.
@@ -7991,6 +8013,42 @@ mod tests {
         };
         assert_eq!(comparator, Comparator::EQ);
         assert_eq!(rhs, QuantityExpr::Fixed { value: 2 });
+    }
+
+    // CR 700.9: "is modified" predicate → SourceMatchesFilter(creature +
+    // FilterProp::Modified). Discriminating (fail-on-revert): without the
+    // `parse_source_is_modified` arm "~ is modified" falls through to
+    // `Unrecognized` (always-true), re-breaking Orochi Merge-Keeper / Obstinate
+    // Gargoyle / Skyward Spider. Also a no-regression guard: the equipped/enchanted
+    // siblings must still type to their own dedicated conditions, untouched.
+    #[test]
+    fn test_source_is_modified() {
+        for subj in ["~ is modified", "this creature is modified"] {
+            let (rest, c) = parse_inner_condition(subj).unwrap();
+            assert_eq!(rest, "", "unexpected remainder for {subj:?}");
+            let StaticCondition::SourceMatchesFilter {
+                filter: TargetFilter::Typed(tf),
+            } = c
+            else {
+                panic!("expected SourceMatchesFilter(Typed) for {subj:?}, got {c:?}");
+            };
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "expected Creature type filter, got {tf:?}"
+            );
+            assert!(
+                tf.properties.contains(&FilterProp::Modified),
+                "expected FilterProp::Modified, got {tf:?}"
+            );
+        }
+
+        // No-regression: equipped/enchanted keep their own dedicated conditions.
+        let (rest, c) = parse_inner_condition("~ is equipped").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(c, StaticCondition::SourceIsEquipped);
+        let (rest, c) = parse_inner_condition("~ is enchanted").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(c, StaticCondition::SourceIsEnchanted);
     }
 
     // CR 701.37: SourceIsMonstrous predicate across subjects.

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -720,11 +720,13 @@ fn rewrite_self_pronoun_subject(condition: &str) -> String {
         nom_tag_lower(&lower, &lower, "it's ").or_else(|| nom_tag_lower(&lower, &lower, "it is "))
     {
         // CR 508.1k / CR 509.1g / CR 509.1h: combat-state pronoun siblings of the
-        // tapped/untapped rewrite. Exact-match only — "attacking alone" keeps its
-        // trailing word and is left for SourceAttackingAlone.
+        // tapped/untapped rewrite. CR 700.9: "modified" is the self-state sibling
+        // for "it's modified" (Obstinate Gargoyle, Skyward Spider). Exact-match
+        // only — "attacking alone" keeps its trailing word and is left for
+        // SourceAttackingAlone; "modified creature" never hits this arm.
         if matches!(
             rest.trim(),
-            "tapped" | "untapped" | "attacking" | "blocking" | "blocked"
+            "tapped" | "untapped" | "attacking" | "blocking" | "blocked" | "modified"
         ) {
             return format!("~ is {}", rest.trim());
         }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -18468,6 +18468,78 @@ fn self_pronoun_combat_state_exact_match_excludes_attacking_alone() {
     assert_eq!(buff.condition, Some(StaticCondition::SourceIsAttacking));
 }
 
+#[test]
+fn self_static_resolves_this_creature_is_modified_to_source_filter() {
+    // CR 700.9 / CR 611.3a: "as long as this creature is modified" (Orochi
+    // Merge-Keeper) must type to SourceMatchesFilter on a creature filter carrying
+    // FilterProp::Modified — NOT Unrecognized (which evals always-true, leaving the
+    // granted mana ability on even when unmodified). Discriminating: before EDIT 1
+    // this came back StaticCondition::Unrecognized. Fails on revert.
+    let defs = parse_static_line_multi(
+        "As long as this creature is modified, it has \"{T}: Add {G}{G}.\"",
+    );
+    assert!(!defs.is_empty(), "expected at least one static def");
+    assert!(
+        defs.iter()
+            .all(|d| !matches!(d.condition, Some(StaticCondition::Unrecognized { .. }))),
+        "no def may carry an Unrecognized condition, got {:?}",
+        defs.iter().map(|d| &d.condition).collect::<Vec<_>>()
+    );
+    assert!(
+        defs.iter().any(|d| matches!(
+            &d.condition,
+            Some(StaticCondition::SourceMatchesFilter {
+                filter: TargetFilter::Typed(tf),
+            }) if tf.type_filters.contains(&TypeFilter::Creature)
+                && tf.properties.contains(&FilterProp::Modified)
+        )),
+        "expected SourceMatchesFilter(creature + FilterProp::Modified), got {:?}",
+        defs.iter().map(|d| &d.condition).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn self_static_resolves_it_pronoun_modified_to_source_filter() {
+    // CR 700.9 / CR 611.3a: "as long as it's modified" (Obstinate Gargoyle,
+    // Skyward Spider) — the SelfRef self-pronoun rewrite (EDIT 2) turns "it's
+    // modified" into "~ is modified", which EDIT 1 types to the Modified filter.
+    // Discriminating: before the fix this stayed Unrecognized (always-true). Fails
+    // on revert.
+    let def = parse_static_line("This creature has flying as long as it's modified.")
+        .expect("self static def");
+    assert!(
+        matches!(
+            &def.condition,
+            Some(StaticCondition::SourceMatchesFilter {
+                filter: TargetFilter::Typed(tf),
+            }) if tf.type_filters.contains(&TypeFilter::Creature)
+                && tf.properties.contains(&FilterProp::Modified)
+        ),
+        "expected SourceMatchesFilter(creature + FilterProp::Modified), got {:?}",
+        def.condition
+    );
+}
+
+#[test]
+fn aura_static_does_not_bind_it_pronoun_modified_to_source() {
+    // GUARD (anaphor trap): an Aura's "it" refers to the ENCHANTED creature, not
+    // the Aura source, so "Enchanted creature has flying as long as it's modified"
+    // must NOT collapse to a Source* filter. The ~755 SelfRef guard keeps the
+    // non-SelfRef "it" an honest Unrecognized gap. Proves the rewrite is guarded.
+    let defs = parse_static_line_multi("Enchanted creature has flying as long as it's modified.");
+    assert!(!defs.is_empty(), "expected at least one static def");
+    for d in &defs {
+        assert!(
+            !matches!(
+                d.condition,
+                Some(StaticCondition::SourceMatchesFilter { .. })
+            ),
+            "Aura 'it' must not resolve to a Source filter, got {:?}",
+            d.condition
+        );
+    }
+}
+
 /// CR 702.16p: Benevolent Blessing — "Enchanted creature has protection from the
 /// chosen color. This effect doesn't remove Auras and Equipment you control that
 /// are already attached to it." The trailing inert SBA-exemption sentence must be


### PR DESCRIPTION
Fixes #3937.

## Summary

Static abilities gated on "as long as it's modified" / "as long as this creature is modified" applied **permanently** — the condition parsed to an inert `StaticCondition::Unrecognized`, which the layer system evaluates as always-true:

- **Orochi Merge-Keeper** ("As long as this creature is modified, it has '{T}: Add {G}{G}.'"), **Obstinate Gargoyle** + **Skyward Spider** ("has flying as long as it's modified").

## Root cause

The source-status condition parser had arms for "is equipped" / "is enchanted" / "is monstrous" but no "is modified" arm, so the clause fell through to the `Unrecognized` fallback.

## Fix (parser-AST-only; no new engine variant, no runtime change)

Add a `parse_source_is_modified` arm emitting the existing `StaticCondition::SourceMatchesFilter` on a creature filter carrying `FilterProp::Modified` — already runtime-evaluated (a creature is modified if it has a counter, is equipped, or is enchanted by its controller's Aura — CR 700.9). Also add "modified" to the **SelfRef-guarded** self-pronoun rewrite so the "it's modified" forms resolve to the source. The effect now applies only while the creature is modified.

Because the pronoun rewrite is SelfRef-only, a non-self "it's modified" anaphor (none printed today) stays an honest gap rather than mis-binding to the source. "Five or more modified creatures" (a count condition) is a separate path and is untouched. CR 700.9 / 611.3a.

## Tests

- Discriminating (fail-on-revert): "as long as this creature is modified" and "it's modified" → `SourceMatchesFilter{ creature + Modified }`, not `Unrecognized`.
- Anaphor guard: an Aura "Enchanted creature ... as long as it's modified" does **not** bind to the source (stays `Unrecognized`).
- No-regression: "~ is equipped" → `SourceIsEquipped`, "~ is enchanted" → `SourceIsEnchanted` unchanged.

## Verification

`cargo +nightly test -p engine` (all targets incl. `--test integration`): 0 failed. `clippy -D warnings`, parser-combinator gate, rustfmt: clean. oracle-gen confirms all 3 cards flip `Unrecognized` → `SourceMatchesFilter{Modified}` with their other clauses (Orochi's mana abilities, Gargoyle's Persist, Spider's Ward, the flying grants) intact; no card regresses.
