### PR TITLE
feat(engine): reveal-until a fixed count of cards (Fathom Trawl)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -8032,6 +8032,7 @@ mod tests {
                 enters_attacking: false,
                 kept_optional_to: None,
                 enters_under: None,
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
             },
             vec![],
             ObjectId(900),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -10799,6 +10799,7 @@ mod tests {
             enters_attacking: false,
             kept_optional_to: None,
             enters_under: None,
+            count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
         };
 
         assert_eq!(

--- a/crates/engine/src/game/effects/reveal_until.rs
+++ b/crates/engine/src/game/effects/reveal_until.rs
@@ -11,13 +11,17 @@ use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
-/// CR 701.20a: Reveal cards from the top of the controller's library one at a
-/// time until a card matching the filter is found. The matching card goes to
-/// `kept_destination`, the remaining revealed cards go to `rest_destination`.
+/// CR 701.20a: Reveal cards from the top of the revealing player's library one
+/// at a time until `count` cards matching the filter are found (`count == 1` is
+/// the common "until you reveal a card matching the filter" shape; `count > 1`
+/// models "until you reveal N cards", e.g. Fathom Trawl's three). The matching
+/// cards go to `kept_destination`, the remaining revealed cards to
+/// `rest_destination`.
 ///
 /// All revealed cards are marked as publicly revealed and a `CardsRevealed`
-/// event is emitted. If the library is exhausted without finding a match, all
-/// revealed cards go to `rest_destination`.
+/// event is emitted. If the library is exhausted before `count` matches are
+/// found, the matches found go to `kept_destination` and the rest to
+/// `rest_destination`.
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,
@@ -32,6 +36,7 @@ pub fn resolve(
         enters_attacking,
         kept_optional_to,
         enters_under,
+        count,
     ) = match &ability.effect {
         Effect::RevealUntil {
             player,
@@ -42,6 +47,7 @@ pub fn resolve(
             enters_attacking,
             kept_optional_to,
             enters_under,
+            count,
         } => (
             player,
             filter,
@@ -51,9 +57,17 @@ pub fn resolve(
             *enters_attacking,
             *kept_optional_to,
             enters_under.as_ref(),
+            count,
         ),
         _ => return Err(EffectError::MissingParam("RevealUntil".to_string())),
     };
+
+    // CR 701.20a: how many matching cards to reveal before stopping. `1` is the
+    // common "until you reveal a card matching the filter" shape; `> 1` models
+    // "until you reveal N cards" (e.g. Fathom Trawl's three). A count below 1 is
+    // meaningless for a reveal-until, so clamp to at least one.
+    let target_count =
+        crate::game::quantity::resolve_quantity_with_targets(state, count, ability).max(1) as usize;
 
     // CR 109.5 + CR 701.20a: Resolve which player's library is revealed.
     // `Controller` → activator (Jalira-style "you reveal..."); `ParentTargetController`
@@ -71,20 +85,23 @@ pub fn resolve(
     // Snapshot library (top = index 0) to iterate without borrow conflicts.
     let library: Vec<ObjectId> = player.library.iter().copied().collect();
     let mut revealed_misses: Vec<ObjectId> = Vec::new();
-    let mut hit_card: Option<ObjectId> = None;
+    let mut hit_cards: Vec<ObjectId> = Vec::new();
 
     // CR 107.3a + CR 601.2b: Evaluate the filter with the ability in scope so
     // dynamic thresholds (e.g. `Variable("X")`) resolve correctly.
     let ctx = FilterContext::from_ability(ability);
 
-    // CR 701.20a: Reveal cards one at a time.
+    // CR 701.20a: Reveal cards one at a time until `target_count` cards match the
+    // filter (or the library is exhausted).
     for &card_id in &library {
         // Mark as revealed (CR 701.20b: card stays in library zone during reveal).
         state.revealed_cards.insert(card_id);
 
         if matches_target_filter(state, card_id, filter, &ctx) {
-            hit_card = Some(card_id);
-            break;
+            hit_cards.push(card_id);
+            if hit_cards.len() >= target_count {
+                break;
+            }
         } else {
             revealed_misses.push(card_id);
         }
@@ -92,9 +109,7 @@ pub fn resolve(
 
     // Build the full list of revealed card IDs for the event.
     let mut all_revealed: Vec<ObjectId> = revealed_misses.clone();
-    if let Some(hit) = hit_card {
-        all_revealed.push(hit);
-    }
+    all_revealed.extend(hit_cards.iter().copied());
 
     // Emit CardsRevealed for all revealed cards.
     let card_names: Vec<String> = all_revealed
@@ -109,6 +124,30 @@ pub fn resolve(
 
     // Store revealed IDs for downstream reference.
     state.last_revealed_ids = all_revealed;
+
+    // CR 701.20a: the multi-match "until you reveal N cards" form (N > 1, e.g.
+    // Fathom Trawl). All matching cards go to `kept_destination` and the rest to
+    // `rest_destination`, delivered as one simultaneous batch. The single-match
+    // form (N == 1) keeps its dedicated tail below (optional-keep choice,
+    // enters-attacking, per-zone deferral) byte-for-byte. The count parser only
+    // produces N > 1 for the unconditional-keep shape, so `kept_optional_to` is
+    // always `None` here.
+    if target_count > 1 {
+        return resolve_multi_match(
+            state,
+            ability,
+            revealing_player,
+            kept_destination,
+            rest_destination,
+            enter_tapped,
+            enters_under,
+            &hit_cards,
+            &revealed_misses,
+            events,
+        );
+    }
+
+    let hit_card: Option<ObjectId> = hit_cards.first().copied();
 
     // CR 701.20a + CR 608.2c: "You may put that card onto the battlefield" — when
     // the kept destination is a controller choice and a hit was found, pause for
@@ -312,6 +351,109 @@ pub fn resolve(
     Ok(())
 }
 
+/// CR 701.20a: Resolve the multi-match ("until you reveal N cards", N > 1) form.
+/// Every matching card goes to `kept_destination` and every non-matching revealed
+/// card to `rest_destination`, delivered through a single simultaneous batch so
+/// per-card `Moved` redirects fire (CR 614.6) and a mid-batch CR 616.1 ordering
+/// pause defers the marker-clear + `EffectResolved` onto a cleanup-only
+/// `RevealRestPile` completion (mirroring the single-match tail). The count parser
+/// only emits N > 1 for the unconditional-keep shape, so there is no optional-keep
+/// (`kept_optional_to`) or `enters_attacking` handling here.
+#[allow(clippy::too_many_arguments)]
+fn resolve_multi_match(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    revealing_player: PlayerId,
+    kept_destination: Zone,
+    rest_destination: Zone,
+    enter_tapped: crate::types::zones::EtbTapState,
+    enters_under: Option<&crate::types::ability::ControllerRef>,
+    hit_cards: &[ObjectId],
+    revealed_misses: &[ObjectId],
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    // CR 110.2a: resolve any "under your control" override for a battlefield keep.
+    let controller_override = super::change_zone::resolve_enters_under_player(
+        state,
+        ability,
+        "RevealUntil",
+        enters_under,
+    )?;
+
+    let mut reqs: Vec<ZoneMoveRequest> =
+        Vec::with_capacity(hit_cards.len() + revealed_misses.len());
+
+    // CR 701.20a: the matching cards → `kept_destination`. A battlefield keep
+    // carries the effect's tap-state / control override; a Library keep keeps the
+    // historical bottom placement.
+    for &hit in hit_cards {
+        let mut req = ZoneMoveRequest::effect(hit, kept_destination, ability.source_id);
+        match kept_destination {
+            Zone::Battlefield => {
+                req.mods.enter_tapped = enter_tapped;
+                if let Some(controller) = controller_override {
+                    req = req.under_control_of(controller);
+                }
+            }
+            Zone::Library => {
+                req = req.at_library_position(LibraryPosition::Bottom);
+            }
+            _ => {}
+        }
+        reqs.push(req);
+    }
+
+    // CR 701.20a + CR 614.6: the rest pile → `rest_destination`. A Library rest
+    // pile is placed on the bottom in a random order; any other destination is a
+    // flat per-card move (each card anchors its own attribution).
+    match rest_destination {
+        Zone::Library => reqs.extend(library_bottom_requests_in_random_order(
+            state,
+            revealed_misses,
+        )),
+        dest => reqs.extend(
+            revealed_misses
+                .iter()
+                .map(|&card_id| ZoneMoveRequest::effect(card_id, dest, card_id)),
+        ),
+    }
+
+    let mut clear_markers: Vec<ObjectId> = revealed_misses.to_vec();
+    clear_markers.extend(hit_cards.iter().copied());
+
+    // CR 603.10a + CR 616.1: deliver kept + rest as one simultaneous batch. On a
+    // synchronous completion, clear the reveal markers and emit `EffectResolved`
+    // inline (matching the single-match tail). On a mid-batch redirect pause,
+    // defer that cleanup onto a `RevealRestPile` completion so it runs once the
+    // pile lands and `EffectResolved` never lands over the parked prompt.
+    match zone_pipeline::move_objects_simultaneously_then(state, reqs, None, events) {
+        zone_pipeline::BatchMoveResult::Done => {}
+        zone_pipeline::BatchMoveResult::NeedsChoice => {
+            zone_pipeline::defer_completion_on_pause(
+                state,
+                BatchCompletion::RevealRestPile {
+                    player: revealing_player,
+                    rest_cards: Vec::new(),
+                    rest_destination,
+                    clear_markers,
+                    publish_tracked_set: None,
+                    emit_reveal_until_resolved: Some(ability.source_id),
+                },
+            );
+            return Ok(());
+        }
+    }
+
+    for &card_id in &clear_markers {
+        state.revealed_cards.remove(&card_id);
+    }
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::RevealUntil,
+        source_id: ability.source_id,
+    });
+    Ok(())
+}
+
 /// CR 109.5: Resolve the `player` filter on a [`RevealUntil`] effect into a
 /// concrete [`PlayerId`]. Mirrors [`crate::game::effects::token::resolve_token_owner`]:
 /// `Controller` → activator; `ParentTargetController` → controller of the parent
@@ -485,6 +627,7 @@ mod tests {
                 enters_attacking: false,
                 kept_optional_to: None,
                 enters_under: None,
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
             },
             vec![],
             ObjectId(100),
@@ -510,6 +653,7 @@ mod tests {
                 enters_attacking: false,
                 kept_optional_to: None,
                 enters_under: None,
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
             },
             targets,
             ObjectId(100),
@@ -587,6 +731,115 @@ mod tests {
             _ => None,
         });
         assert_eq!(revealed.unwrap().len(), 3);
+    }
+
+    fn make_reveal_until_ability_with_count(
+        controller: PlayerId,
+        filter: TargetFilter,
+        kept_destination: Zone,
+        rest_destination: Zone,
+        count: i32,
+    ) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::RevealUntil {
+                player: TargetFilter::Controller,
+                filter,
+                kept_destination,
+                rest_destination,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                kept_optional_to: None,
+                enters_under: None,
+                count: crate::types::ability::QuantityExpr::Fixed { value: count },
+            },
+            vec![],
+            ObjectId(100),
+            controller,
+        )
+    }
+
+    /// CR 701.20a + CR 115.1d: the multi-count form (Fathom Trawl). Reveal until
+    /// THREE creatures match: all three are kept, the interleaved non-matching
+    /// cards become the rest pile, and a card past the third match is never
+    /// revealed. With `count == 1` this same resolver keeps its single-match
+    /// behavior (exercised by `reveal_until_finds_creature_puts_to_hand`).
+    #[test]
+    fn reveal_until_count_three_keeps_three_matches() {
+        let mut state = GameState::new_two_player(42);
+
+        // Library top→bottom (creation order): creature, land, creature, land,
+        // creature, land. Revealing until 3 creatures match consumes the first
+        // five cards (3 creatures + 2 interleaved lands); the 6th (a land) is
+        // never reached.
+        let mut creatures = Vec::new();
+        let mut lands = Vec::new();
+        for i in 0..6u64 {
+            let is_creature = i % 2 == 0;
+            let id = create_object(
+                &mut state,
+                CardId(i + 1),
+                PlayerId(0),
+                if is_creature { "Bear" } else { "Forest" }.to_string(),
+                Zone::Library,
+            );
+            let core = if is_creature {
+                CoreType::Creature
+            } else {
+                CoreType::Land
+            };
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(core);
+            if is_creature {
+                creatures.push(id);
+            } else {
+                lands.push(id);
+            }
+        }
+
+        let ability = make_reveal_until_ability_with_count(
+            PlayerId(0),
+            TargetFilter::Typed(crate::types::ability::TypedFilter::creature()),
+            Zone::Hand,
+            Zone::Library,
+            3,
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // All three matching creatures kept to hand.
+        for c in &creatures {
+            assert!(
+                state.players[0].hand.contains(c),
+                "creature {c:?} should be kept to hand"
+            );
+            assert!(
+                !state.players[0].library.contains(c),
+                "creature {c:?} must not stay in library"
+            );
+        }
+        // The two revealed-miss lands return to the library; the third (never
+        // revealed) land is still there too.
+        for l in &lands {
+            assert!(
+                state.players[0].library.contains(l),
+                "land {l:?} should be in the library"
+            );
+        }
+        // CardsRevealed covers the 3 creatures + 2 interleaved lands (the 6th
+        // card is never revealed).
+        let revealed = events
+            .iter()
+            .find_map(|e| match e {
+                GameEvent::CardsRevealed { card_ids, .. } => Some(card_ids.clone()),
+                _ => None,
+            })
+            .expect("CardsRevealed emitted");
+        assert_eq!(revealed.len(), 5, "revealed: {revealed:?}");
     }
 
     /// C5 discriminating test (CR 614.6 + CR 701.20a): a kept card placed back
@@ -1066,6 +1319,7 @@ mod tests {
                     enters_attacking: false,
                     kept_optional_to: Some(Zone::Battlefield),
                     enters_under: None,
+                    count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
                 },
                 vec![],
                 ObjectId(100),
@@ -1184,6 +1438,7 @@ mod tests {
                 enters_attacking: false,
                 kept_optional_to: Some(Zone::Library),
                 enters_under: None,
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
             },
             vec![],
             ObjectId(100),
@@ -1256,6 +1511,7 @@ mod tests {
                 enters_attacking: false,
                 kept_optional_to: Some(Zone::Battlefield),
                 enters_under: None,
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6602,7 +6602,10 @@ fn parse_reveal_cards_from_library_until(input: &str) -> nom::IResult<&str, (), 
 
 fn parse_reveal_until_prefix(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
     let (input, _) = parse_reveal_cards_from_library_until(input)?;
-    // Active-voice pronoun + matching verb form.
+    // Active-voice pronoun + matching verb form. Stops before the count
+    // quantifier — the caller (`try_parse_reveal_until`) consumes the article
+    // ("a"/"an" → one match) or a spelled count ("three" → N matches) via
+    // `parse_reveal_until_count`.
     let (input, _) = alt((
         tag("you reveal "),
         tag("they reveal "),
@@ -6611,8 +6614,27 @@ fn parse_reveal_until_prefix(input: &str) -> nom::IResult<&str, (), OracleError<
         tag("it reveals "),
     ))
     .parse(input)?;
-    let (input, _) = nom_primitives::parse_article(input)?;
     Ok((input, ()))
+}
+
+/// CR 701.20a + CR 115.1d: Parse the count quantifier that follows
+/// `"until <pronoun> reveal[s] "`. `"a"`/`"an"` → exactly one match (the
+/// singular reveal-until shape); a spelled or digit count (`"three"`) → that
+/// many matches (Fathom Trawl). Dynamic counts (`"X"`, `"that many"`) are not
+/// modeled — they leave the input unconsumed so the whole active parse fails
+/// closed to `Unimplemented` rather than mis-modeling a battlefield / shuffle /
+/// per-opponent continuation as a flat hand/library reveal.
+fn parse_reveal_until_count(input: &str) -> OracleResult<'_, QuantityExpr> {
+    // "a"/"an" → one. `parse_article` consumes the trailing space, so the filter
+    // noun follows immediately (matching the pre-count behavior).
+    if let Ok((rest, ())) = nom_primitives::parse_article(input) {
+        return Ok((rest, QuantityExpr::Fixed { value: 1 }));
+    }
+    // A spelled/digit count ("two", "three", …) followed by a space before the
+    // (plural) filter noun.
+    let (rest, n) = nom_primitives::parse_number(input)?;
+    let (rest, _) = tag(" ").parse(rest)?;
+    Ok((rest, QuantityExpr::Fixed { value: n as i32 }))
 }
 
 /// CR 701.20a: Parse the **passive-voice** prefix `"reveal[s] cards from the top of
@@ -6635,6 +6657,13 @@ fn parse_reveal_until_active_filter_text(input: &str) -> OracleResult<'_, &str> 
     // *whole* alt in one `all_consuming` would NOT backtrack: `alt` commits to
     // the first matching arm before `all_consuming` checks the remainder.
     alt((
+        // Plural head-noun ("three nonland cards") for the multi-count form;
+        // tried first so the singular `" card"` arm does not capture "nonland"
+        // and strand a trailing "s".
+        all_consuming(terminated(
+            take_until(" cards"),
+            (tag(" cards"), opt(tag("."))),
+        )),
         all_consuming(terminated(
             take_until(" card"),
             (tag(" card"), opt(tag("."))),
@@ -6766,7 +6795,20 @@ fn try_parse_reveal_until(tp: TextPair, player: TargetFilter) -> Option<ParsedEf
     let active_result = nom_on_lower(tp.original, tp.lower, parse_reveal_until_prefix);
     if let Some((_, rest_orig)) = active_result {
         let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
-        let (_, filter_text) = parse_reveal_until_active_filter_text(rest_lower).ok()?;
+        // CR 701.20a + CR 115.1d: consume the count quantifier ("a"/"an" → one,
+        // "three" → N). A non-fixed count (X / "that many") fails this parse and
+        // falls through to the passive form, ultimately failing closed.
+        let (after_count_lower, count) = parse_reveal_until_count(rest_lower).ok()?;
+        // CR 810 + CR 701.20a: a multi-card reveal for anyone other than the
+        // controller ("each opponent ... until X land cards") needs per-player
+        // resolution this single-revealing-player effect does not model — fail
+        // closed instead of mis-resolving it to one player.
+        if !matches!(count, QuantityExpr::Fixed { value: 1 })
+            && !matches!(player, TargetFilter::Controller)
+        {
+            return None;
+        }
+        let (_, filter_text) = parse_reveal_until_active_filter_text(after_count_lower).ok()?;
         let filter = build_reveal_until_filter(filter_text);
         return Some(parsed_clause(Effect::RevealUntil {
             player,
@@ -6777,6 +6819,7 @@ fn try_parse_reveal_until(tp: TextPair, player: TargetFilter) -> Option<ParsedEf
             enters_attacking: false,
             kept_optional_to: None,
             enters_under: None,
+            count,
         }));
     }
 
@@ -6827,6 +6870,9 @@ fn try_parse_reveal_until(tp: TextPair, player: TargetFilter) -> Option<ParsedEf
         enters_attacking: false,
         kept_optional_to: None,
         enters_under: None,
+        // CR 701.20a: the passive "until a/an <filter> is revealed" form is always
+        // singular — one match.
+        count: QuantityExpr::Fixed { value: 1 },
     }))
 }
 
@@ -45200,6 +45246,7 @@ mod tests {
                     enters_attacking: false,
                     kept_optional_to: None,
                     enters_under: None,
+                    count: _,
                 } if type_filters.contains(&TypeFilter::Creature)
             ),
             "expected RevealUntil player=Controller, creature->hand, rest->library, got: {:?}",
@@ -45207,6 +45254,85 @@ mod tests {
         );
         // No sub_ability — destinations are baked in
         assert!(def.sub_ability.is_none(), "should have no sub_ability");
+    }
+
+    /// CR 701.20a + CR 115.1d: the multi-count form "until you reveal N cards"
+    /// (Fathom Trawl — three nonland cards into hand, rest on the bottom). The
+    /// parser must consume the spelled count and emit `count = Fixed(3)`, not drop
+    /// the clause to `Unimplemented` (the singular path requires an article).
+    #[test]
+    fn reveal_until_three_nonland_cards_parses_count_three() {
+        let def = parse_effect_chain(
+            "Reveal cards from the top of your library until you reveal three nonland cards. \
+             Put the nonland cards revealed this way into your hand, then put the rest of the \
+             revealed cards on the bottom of your library in any order.",
+            AbilityKind::Activated,
+        );
+        let Effect::RevealUntil {
+            player,
+            filter,
+            kept_destination,
+            rest_destination,
+            count,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected RevealUntil, got {:?}", def.effect);
+        };
+        assert!(
+            matches!(player, TargetFilter::Controller),
+            "player: {player:?}"
+        );
+        assert_eq!(*kept_destination, Zone::Hand);
+        assert_eq!(*rest_destination, Zone::Library);
+        assert_eq!(
+            *count,
+            QuantityExpr::Fixed { value: 3 },
+            "count should be the spelled-out three"
+        );
+        // The plural "cards" head-noun must not leak into the filter: it stays a
+        // nonland (Non(Land)) creature-agnostic filter.
+        assert!(
+            matches!(
+                filter,
+                TargetFilter::Typed(TypedFilter { type_filters, .. })
+                    if type_filters.iter().any(|t| matches!(t, TypeFilter::Non(b) if matches!(**b, TypeFilter::Land)))
+            ),
+            "filter should be nonland, got {filter:?}"
+        );
+        // The "Put the nonland cards revealed this way into your hand, then put the
+        // rest on the bottom" continuation is fully covered by the baked-in
+        // kept/rest destinations — it must be swallowed, not left as a redundant
+        // ChangeZone sub-ability that would double-move the revealed cards.
+        assert!(
+            def.sub_ability.is_none(),
+            "continuation should be swallowed, got sub_ability {:?}",
+            def.sub_ability
+        );
+    }
+
+    /// CR 810 + CR 701.20a: dynamic / multi-player counts are not modeled and must
+    /// FAIL CLOSED (→ `Unimplemented`), never mis-parse into a flat single-player
+    /// hand/library reveal. Covers the `X` count (Kindred Summons / Mind Grind),
+    /// the "that many" count (Mass Polymorph), and the per-opponent multi-card
+    /// reveal (Mind Grind's "each opponent ... until X land cards").
+    #[test]
+    fn reveal_until_dynamic_or_multiplayer_counts_fail_closed() {
+        for line in [
+            // X count, single player, onto battlefield (Kindred Summons shape).
+            "Reveal cards from the top of your library until you reveal X creature cards.",
+            // "that many" dynamic count (Mass Polymorph shape).
+            "Reveal cards from the top of your library until you reveal that many creature cards.",
+            // Per-opponent multi-card reveal (Mind Grind shape).
+            "Each opponent reveals cards from the top of their library until they reveal X land cards.",
+        ] {
+            let def = parse_effect_chain(line, AbilityKind::Activated);
+            assert!(
+                !matches!(&*def.effect, Effect::RevealUntil { .. }),
+                "unsupported count must not parse to RevealUntil: {line:?} -> {:?}",
+                def.effect
+            );
+        }
     }
 
     /// CR 701.20a + CR 205.3m: "reveal cards ... until you reveal a Time Lord
@@ -45267,6 +45393,7 @@ mod tests {
                     enters_attacking: false,
                     kept_optional_to: None,
                     enters_under: None,
+                    count: _,
                 } if type_filters.contains(&TypeFilter::Creature)
             ),
             "expected RevealUntil player=ParentTargetController, got: {:?}",
@@ -45344,6 +45471,7 @@ mod tests {
                     enters_attacking: false,
                     kept_optional_to: None,
                     enters_under: None,
+                    count: _,
                 } if type_filters.contains(&TypeFilter::Land)
             ),
             "expected RevealUntil(kept=Graveyard, rest=Graveyard), got: {:?}",
@@ -45422,6 +45550,7 @@ mod tests {
                     enters_attacking: false,
                     kept_optional_to: None,
                     enters_under: None,
+                    count: _,
                 } if type_filters.contains(&TypeFilter::Artifact)
             ),
             "expected RevealUntil player=Controller, artifact->battlefield, got: {:?}",

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -4473,7 +4473,16 @@ pub(super) fn parse_followup_continuation_ast(
             if nom_primitives::scan_contains(&lower, "put that card")
                 || nom_primitives::scan_contains(&lower, "puts that card")
                 || nom_primitives::scan_contains(&lower, "put it")
-                || nom_primitives::scan_contains(&lower, "puts it") =>
+                || nom_primitives::scan_contains(&lower, "puts it")
+                // CR 701.20a: the multi-count kept clause "put the <filter> cards
+                // revealed this way into your hand / onto the battlefield" (Fathom
+                // Trawl's "Put the nonland cards revealed this way into your hand").
+                // Distinct from "put those cards" (the whole pile to one zone,
+                // handled by the next arm), so exclude it here.
+                || (nom_primitives::scan_contains(&lower, "cards revealed this way")
+                    && (nom_primitives::scan_contains(&lower, "into your hand")
+                        || nom_primitives::scan_contains(&lower, "onto the battlefield"))
+                    && !nom_primitives::scan_contains(&lower, "those cards")) =>
         {
             let (destination, enter_tapped, enters_attacking) =
                 if nom_primitives::scan_contains(&lower, "onto the battlefield") {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8873,6 +8873,15 @@ pub enum Effect {
         /// controller ("under your control" on Telemin Performance / Sméagol).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         enters_under: Option<ControllerRef>,
+        /// CR 701.20a: How many matching cards to reveal before stopping. `1`
+        /// (the serde default) is the common "until you reveal a card matching
+        /// the filter" shape; `> 1` models "until you reveal N cards" (a fixed
+        /// count, e.g. Fathom Trawl's three, or `X`, e.g. Mind Grind). All
+        /// matching cards go to `kept_destination`, the rest to
+        /// `rest_destination`. Counts `> 1` are only produced for the
+        /// unconditional-keep form (`kept_optional_to == None`).
+        #[serde(default = "default_reveal_until_count")]
+        count: QuantityExpr,
     },
     /// CR 701.57a: Discover N — exile from top until nonland with MV ≤ N,
     /// cast free or put to hand, rest to bottom in random order.
@@ -9526,6 +9535,13 @@ pub(crate) fn default_target_filter_any() -> TargetFilter {
 /// Default number of random nonland cards a Heist looks at (Arena reminder: 3).
 fn default_heist_look_count() -> u8 {
     3
+}
+
+/// Serde default for `Effect::RevealUntil::count`: the singular "until you
+/// reveal a card matching the filter" reading (one match) when `count` is
+/// omitted, preserving every pre-existing serialized single-reveal ability.
+fn default_reveal_until_count() -> QuantityExpr {
+    QuantityExpr::Fixed { value: 1 }
 }
 
 pub(crate) fn default_target_filter_permanent() -> TargetFilter {


### PR DESCRIPTION
Fixes #3934.

## What

Parameterizes the existing `Effect::RevealUntil` with a `count: QuantityExpr` so it can model "reveal cards from the top of your library until you reveal **N** cards" â€” not just the singular "until you reveal **a** card" shape. The motivating card is **Fathom Trawl** (`{3}{U}{U}`): "Reveal cards from the top of your library until you reveal **three** nonland cards. Put the nonland cards revealed this way into your hand, then put the rest of the revealed cards on the bottom of your library in any order."

This is a *parameterization* of the existing variant (per "parameterize, don't proliferate"), not a new sibling effect. The `count` field has a serde default of `Fixed(1)`, so every existing serialized ability and all current single-reveal cards are unchanged byte-for-byte.

## How

- **Types** (`types/ability.rs`): add `count: QuantityExpr` to `RevealUntil` with `#[serde(default = "default_reveal_until_count")]` â†’ `Fixed(1)`.
- **Resolver** (`game/effects/reveal_until.rs`): the reveal loop now accumulates up to `target_count` matches. `count == 1` keeps the existing single-match path verbatim (optional-keep choice, enters-attacking, per-zone deferral) â€” zero behavioral change. `count > 1` routes all matching cards â†’ `kept_destination` and the rest â†’ `rest_destination` through one `move_objects_simultaneously_then` batch, deferring marker-clear + `EffectResolved` onto a cleanup-only `RevealRestPile` completion on a CR 616.1 ordering pause (mirrors the single-match tail).
- **Parser** (`parser/oracle_effect/mod.rs`): the active-voice form consumes a count quantifier via `parse_reveal_until_count` â€” `"a"/"an"` â†’ `Fixed(1)`, a spelled/digit number â†’ `Fixed(N)`. The filter-text matcher gained a plural `" cards"` arm so the head-noun does not leak into the filter.
- **Continuation swallow** (`parser/oracle_effect/sequence.rs`): the kept-clause recognizer now also matches "put the *<filter>* cards revealed this way into your hand / onto the battlefield", so Fathom Trawl's continuation is folded into the baked-in destinations instead of leaking a redundant `ChangeZone` sub-ability.

## Fail-closed scope (CR 810 / CR 701.20a)

Only **fixed** counts for a single revealing player are modeled. Everything else deterministically falls through to `Unimplemented` rather than mis-modeling a battlefield/shuffle/per-opponent continuation as a flat hand/library reveal:

- **Kindred Summons** â€” count is a dynamic "creatures you control of the chosen type" ref *and* it shuffles the rest into the library.
- **Mass Polymorph** â€” "that many" dynamic count, onto the battlefield.
- **Mind Grind** â€” per-opponent ("each opponent â€¦ until X land cards"); this single-revealing-player effect can't iterate opponents.

A `count > 1` is additionally guarded to `player == Controller`.

## Verification

- `cargo test -p engine --lib reveal_until` â€” 44 pass, including 3 new tests: the multi-count resolver (`reveal_until_count_three_keeps_three_matches`), the Fathom Trawl parse (`reveal_until_three_nonland_cards_parses_count_three`, asserts `count = Fixed(3)`, `Non(Land)` â†’ Hand, rest â†’ Library, **and `sub_ability` is `None`**), and the fail-closed cases (`reveal_until_dynamic_or_multiplayer_counts_fail_closed`). Every pre-existing reveal-until test still passes.
- Regenerated `card-data.json`: Fathom Trawl â†’ `RevealUntil { count: Fixed(3), kept: Hand, rest: Library }` with no sub-ability; Kindred Summons / Mass Polymorph / Mind Grind remain `Unimplemented`. Across all **98** cards that parse to `RevealUntil`, **zero** carry a redundant tracked-set `ChangeZone`/`PutAtLibraryPosition` sub-ability (no regressions).
- `cargo fmt`, the parser-combinator gate, and `clippy -D warnings` (engine + phase-ai) are green.

## CR

CR 701.20a (reveal-until), CR 109.5 (which player's library), CR 115.1d (count quantifier), CR 603.10a / CR 616.1 (simultaneous batch + ordering pause), CR 810 (team / multi-player scope out).
