### PR TITLE
fix(draft): resolve cube cards by oracle id when the cached name is stale

### DIFF
--- a/client/src/components/draft/CubeSetupPanel.tsx
+++ b/client/src/components/draft/CubeSetupPanel.tsx
@@ -79,7 +79,7 @@ export function CubeSetupPanel({ onStart, startLabel, disabled }: CubeSetupPanel
     try {
       setCubeText(await fetchCubeList(cubeUrl));
     } catch (err) {
-      setError(err instanceof Error ? err.message : t("cubeSetup.fetchError"));
+      setError(errorMessage(err, t("cubeSetup.fetchError")));
     } finally {
       setLoading(false);
     }
@@ -91,7 +91,7 @@ export function CubeSetupPanel({ onStart, startLabel, disabled }: CubeSetupPanel
     try {
       await onStart({ cubeName, cubeListText: cubeText, settings });
     } catch (err) {
-      setError(err instanceof Error ? err.message : t("cubeSetup.startError"));
+      setError(errorMessage(err, t("cubeSetup.startError")));
     } finally {
       setLoading(false);
     }
@@ -205,6 +205,20 @@ export function CubeSetupPanel({ onStart, startLabel, disabled }: CubeSetupPanel
       </div>
     </div>
   );
+}
+
+/**
+ * Surface the real failure text from a thrown value. WASM (wasm-bindgen) throws
+ * its `Err(JsValue)` payloads as raw strings, which are NOT `Error` instances —
+ * so a bare `err instanceof Error` check would discard the actual reason (e.g.
+ * "Failed to resolve cube cards: [...]") and show only a generic fallback. Match
+ * the repo-wide `String(err)` convention, keeping the localized fallback solely
+ * for genuinely empty/non-string throws.
+ */
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string" && err.trim().length > 0) return err;
+  return fallback;
 }
 
 function NumberField({

--- a/client/src/services/__tests__/cubeCobra.test.ts
+++ b/client/src/services/__tests__/cubeCobra.test.ts
@@ -28,6 +28,27 @@ describe("fetchCubeList", () => {
     expect(global.fetch).toHaveBeenCalledWith("https://cubecobra.com/cube/api/cubeJSON/abc123");
   });
 
+  it("annotates each card with its oracle id for resilient resolution", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        cards: {
+          mainboard: [
+            { name: "Makdee and Itla, Skysnarers", details: { oracle_id: "be2b9c6d-4ecb" } },
+            { name: "Island", details: { oracle_id: "b2c8-island" } },
+            { name: "Island", details: { oracle_id: "b2c8-island" } },
+          ],
+        },
+      }),
+    });
+
+    // Stale/placeholder names still emit, but carry the oracle id so the engine
+    // can resolve them by id when the name no longer matches a printed card.
+    await expect(fetchCubeList("https://cubecobra.com/cube/list/abc123")).resolves.toBe(
+      "1 Makdee and Itla, Skysnarers [be2b9c6d-4ecb]\n2 Island [b2c8-island]",
+    );
+  });
+
   it("keeps non-CubeCobra URLs as raw text exports", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/client/src/services/cubeCobra.ts
+++ b/client/src/services/cubeCobra.ts
@@ -2,6 +2,7 @@ interface CubeCobraCard {
   name?: unknown;
   details?: {
     name?: unknown;
+    oracle_id?: unknown;
   };
 }
 
@@ -43,18 +44,30 @@ function cubeCobraJsonToCountedList(data: CubeCobraExport): string {
     throw new Error("CubeCobra response did not include a mainboard");
   }
 
-  const counts = new Map<string, number>();
+  // Carry each card's Scryfall oracle id as a `[oracle-id]` annotation. The
+  // engine resolves by name first, falling back to the id when CubeCobra's
+  // cached name no longer matches the printed name (e.g. a cube snapshotted
+  // under a set's pre-reveal placeholder names).
+  const entries = new Map<string, { count: number; oracleId?: string }>();
   for (const card of cards as CubeCobraCard[]) {
     const rawName = typeof card.name === "string" ? card.name : card.details?.name;
     if (typeof rawName !== "string" || rawName.trim().length === 0) {
       throw new Error("CubeCobra response included a card without a name");
     }
     const name = rawName.trim();
-    counts.set(name, (counts.get(name) ?? 0) + 1);
+    const oracleId = typeof card.details?.oracle_id === "string" ? card.details.oracle_id : undefined;
+    const existing = entries.get(name);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      entries.set(name, { count: 1, oracleId });
+    }
   }
 
-  return [...counts.entries()]
-    .map(([name, count]) => `${count} ${name}`)
+  return [...entries.entries()]
+    .map(([name, { count, oracleId }]) =>
+      oracleId ? `${count} ${name} [${oracleId}]` : `${count} ${name}`,
+    )
     .join("\n");
 }
 

--- a/crates/draft-core/src/cube.rs
+++ b/crates/draft-core/src/cube.rs
@@ -13,6 +13,12 @@ use crate::types::{DeckAddableCards, DraftCardInstance, DraftConfig, DraftError,
 pub struct CubeListEntry {
     pub name: String,
     pub count: u32,
+    /// Optional Scryfall oracle id, carried by CubeCobra-fetched lists as a
+    /// trailing `[oracle-id]` annotation. Used as a resolution fallback when the
+    /// source's cached name no longer matches the printed name (e.g. a cube
+    /// snapshotted under a set's pre-reveal placeholder names). Manual paste
+    /// lists omit it.
+    pub oracle_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, Serialize)]
@@ -41,7 +47,7 @@ pub fn parse_cube_list(text: &str) -> Result<Vec<CubeListEntry>, Vec<CubeImportE
             errors.push(CubeImportError::InvalidLine { line: idx + 1 });
             continue;
         };
-        let name = name.trim();
+        let (name, oracle_id) = split_oracle_id(name.trim());
         if count == 0 || name.is_empty() {
             errors.push(CubeImportError::InvalidLine { line: idx + 1 });
             continue;
@@ -50,6 +56,7 @@ pub fn parse_cube_list(text: &str) -> Result<Vec<CubeListEntry>, Vec<CubeImportE
         entries.push(CubeListEntry {
             name: name.to_string(),
             count,
+            oracle_id,
         });
     }
 
@@ -60,6 +67,29 @@ pub fn parse_cube_list(text: &str) -> Result<Vec<CubeListEntry>, Vec<CubeImportE
     }
 }
 
+/// Split an optional trailing `[oracle-id]` annotation off a cube line's name.
+/// CubeCobra-fetched lists append each card's Scryfall oracle id so imports stay
+/// resilient when the source's cached name drifts from the printed name; manual
+/// paste lists omit it. Only a bracketed UUID-shaped token is treated as an id,
+/// so card names that happen to end in brackets are left intact.
+fn split_oracle_id(name: &str) -> (&str, Option<String>) {
+    if let Some(without_close) = name.strip_suffix(']') {
+        if let Some((before, candidate)) = without_close.rsplit_once('[') {
+            if is_oracle_id(candidate) {
+                return (before.trim_end(), Some(candidate.to_string()));
+            }
+        }
+    }
+    (name, None)
+}
+
+/// A Scryfall oracle id is a UUID: ASCII hex digits and hyphens, with at least
+/// one hyphen. This guard distinguishes ids from any incidental `[...]` suffix
+/// in a real card name.
+fn is_oracle_id(candidate: &str) -> bool {
+    candidate.contains('-') && candidate.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+}
+
 pub fn cube_cards_from_entries(
     entries: &[CubeListEntry],
     db: &CardDatabase,
@@ -68,7 +98,15 @@ pub fn cube_cards_from_entries(
     let mut errors = Vec::new();
 
     for entry in entries {
-        let Some(face) = db.get_face_by_name(&entry.name) else {
+        // Name first (stable for the vast majority and works for manual paste
+        // lists), oracle id as a fallback for names the source cached wrong.
+        let face = db.get_face_by_name(&entry.name).or_else(|| {
+            entry
+                .oracle_id
+                .as_deref()
+                .and_then(|oracle_id| db.get_face_by_oracle_id(oracle_id))
+        });
+        let Some(face) = face else {
             errors.push(CubeImportError::UnknownCard {
                 name: entry.name.clone(),
             });
@@ -294,6 +332,74 @@ mod tests {
         let unique: HashSet<String> = names.iter().cloned().collect();
         assert_eq!(names.len(), 8);
         assert_eq!(unique.len(), 8);
+    }
+
+    #[test]
+    fn parses_oracle_id_annotation() {
+        let entries = parse_cube_list(
+            "1 Spider-Woman, Stunning Savior [be2b9c6d-4ecb-49ec-b276-4aa93c5dfc00]\n\
+             2 Island\n\
+             1 Weird Card [not-a-uuid!]\n",
+        )
+        .unwrap();
+        // Annotated line: id stripped from the name, captured separately.
+        assert_eq!(entries[0].name, "Spider-Woman, Stunning Savior");
+        assert_eq!(
+            entries[0].oracle_id.as_deref(),
+            Some("be2b9c6d-4ecb-49ec-b276-4aa93c5dfc00")
+        );
+        // Plain manual line: no id.
+        assert_eq!(entries[1].name, "Island");
+        assert_eq!(entries[1].oracle_id, None);
+        // A name that merely ends in brackets (non-UUID) is left intact.
+        assert_eq!(entries[2].name, "Weird Card [not-a-uuid!]");
+        assert_eq!(entries[2].oracle_id, None);
+    }
+
+    #[test]
+    fn cube_cards_resolve_by_oracle_id_when_name_is_stale() {
+        // A card present under its printed name, carrying a known oracle id.
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "spider-woman, stunning savior".to_string(),
+            serde_json::json!({
+                "name": "Spider-Woman, Stunning Savior",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": ["Legendary"], "core_types": ["Creature"], "subtypes": ["Spider", "Hero"] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "scryfall_oracle_id": "be2b9c6d-4ecb-49ec-b276-4aa93c5dfc00", "legalities": {}
+            }),
+        );
+        let db = CardDatabase::from_json_str(&serde_json::to_string(&map).unwrap()).unwrap();
+
+        // The import names the card by a stale pre-reveal placeholder that no
+        // longer exists, but carries the correct oracle id.
+        let entries = vec![CubeListEntry {
+            name: "Makdee and Itla, Skysnarers".to_string(),
+            count: 1,
+            oracle_id: Some("be2b9c6d-4ecb-49ec-b276-4aa93c5dfc00".to_string()),
+        }];
+        let cards = cube_cards_from_entries(&entries, &db).unwrap();
+        assert_eq!(cards.len(), 1);
+        // Resolved to the real printed card via the oracle-id fallback.
+        assert_eq!(cards[0].name, "Spider-Woman, Stunning Savior");
+    }
+
+    #[test]
+    fn cube_cards_unknown_name_without_oracle_id_still_errors() {
+        let db = CardDatabase::from_json_str("{}").unwrap();
+        let entries = vec![CubeListEntry {
+            name: "Not A Card".to_string(),
+            count: 1,
+            oracle_id: None,
+        }];
+        let errors = cube_cards_from_entries(&entries, &db).unwrap_err();
+        assert!(matches!(
+            &errors[0],
+            CubeImportError::UnknownCard { name } if name == "Not A Card"
+        ));
     }
 
     #[test]

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -140,6 +140,20 @@ impl CardDatabase {
         self.face_index.get(&key)
     }
 
+    /// Resolve a face by its Scryfall oracle id. Used as a fallback when a
+    /// name-based lookup fails — e.g. cube/deck imports whose source cached a
+    /// pre-reveal placeholder name that no longer matches the printed name.
+    /// oracle id is stable across renames, alternate art, and split/Room faces
+    /// (which share one oracle id). Returns the first exported face for the id;
+    /// for single-face cards that is unambiguous, and split-card imports resolve
+    /// by name long before this fallback runs.
+    pub fn get_face_by_oracle_id(&self, oracle_id: &str) -> Option<&CardFace> {
+        self.oracle_id_index
+            .get(oracle_id)?
+            .iter()
+            .find_map(|name| self.face_index.get(name))
+    }
+
     pub fn get_face_by_printed_ref(&self, printed_ref: &PrintedCardRef) -> Option<&CardFace> {
         self.oracle_id_index
             .get(&printed_ref.oracle_id)?


### PR DESCRIPTION
CubeCobra cubes can carry a card's pre-reveal placeholder name (e.g. the om1 Spider-Man set's "Makdee and Itla, Skysnarers" for the printed "Spider-Woman, Stunning Savior"). Name-only resolution aborted the entire draft with an opaque "Failed to start cube draft" when even one card's name no longer matched a printed card.

- CardDatabase::get_face_by_oracle_id: oracle-id lookup via the existing index
- CubeListEntry.oracle_id + a trailing [oracle-id] line annotation parsed by parse_cube_list; cube_cards_from_entries resolves by name first, falls back to oracle id
- cubeCobra service emits the [oracle-id] annotation from details.oracle_id
- CubeSetupPanel surfaces wasm-bindgen's raw-string errors instead of discarding them behind a generic localized fallback
