### PR TITLE
feat(engine): implement Power-up keyword (MSH) — labeled activated ability with per-game limit, MV cost reduction, and tagged-mana/prohibition statics

### DIFF
--- a/.claude/skills/oracle-parser/SKILL.md
+++ b/.claude/skills/oracle-parser/SKILL.md
@@ -273,6 +273,7 @@ Unlabeled handlers interleaved between labeled slots are shown as `—` rows.
 | `3c` | "Channel — {cost}, Discard this card: {effect}" | activated-ability build | `oracle.rs` |
 | `3d` | "Boast — {cost}: {effect}" (implicit attacked-this-turn + once-per-turn restrictions, CR 702.142a) | activated-ability build | `oracle.rs` |
 | `3e` | "Exhaust — {cost}: {effect}" (implicit activate-only-once, CR 702.177a) | activated-ability build | `oracle.rs` |
+| `3e2` | "Power-up — {cost}: {effect}" (activate only once per game, MV cost reduction if entered this turn, CR 602.5b) | activated-ability build | `oracle.rs` |
 | `3f` | "Forecast — {cost}: {effect}" (hand-only, your upkeep, once per turn, CR 702.57a-b) | activated-ability build | `oracle.rs` |
 | `4` | Activated ability — contains `":"` with cost-like prefix | `find_activated_colon()` + `parse_activated_ability_definition()` | `oracle_cost.rs` + `oracle_effect/` |
 | `5-pre` | Trigger-framed "… enters with [counters] on it" — CR 614.1c replacement despite When/Whenever framing | `parse_replacement_line()` | `oracle_replacement.rs` |

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -6042,6 +6042,7 @@ mod tests {
                     expiry: RestrictionExpiry::EndOfTurn,
                     activity: ProhibitedActivity::ActivateAbilities {
                         exemption: ActivationExemption::ManaAbilities,
+                        only_tag: None,
                     },
                 },
             },

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4,7 +4,7 @@ use crate::types::ability::{
     ContinuousModification, CostObjectCount, CostPaidObjectSnapshot, CounterCostSelection,
     Duration, Effect, FilterProp, GameRestriction, ModalSelectionCondition, ObjectScope,
     PlayerFilter, PlayerScope, ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility,
-    RestrictionPlayerScope, StaticDefinition, TargetFilter, TargetRef,
+    RestrictionExpiry, RestrictionPlayerScope, StaticDefinition, TargetFilter, TargetRef,
 };
 use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
@@ -466,12 +466,26 @@ fn is_blocked_by_cant_activate_abilities(
         let GameRestriction::ProhibitActivity {
             source,
             affected_players,
-            activity: ProhibitedActivity::ActivateAbilities { exemption },
-            ..
+            expiry,
+            activity:
+                ProhibitedActivity::ActivateAbilities {
+                    exemption,
+                    only_tag,
+                },
         } = restriction
         else {
             return false;
         };
+        // CR 514.2 + CR 500.7: A `UntilEndOfNextTurnOf` prohibition (Kang's "during
+        // that turn, power-up abilities can't be activated") is created PRE-ARMED and
+        // only takes force during the granted extra turn. It stays dormant on the
+        // creating turn until that player's next untap step CONVERTS it to
+        // `EndOfTurn` (turns.rs). While still pre-armed it is not yet in force, so it
+        // must not block activations on the creation turn — the expiry variant is the
+        // single source of truth shared with the untap-step arming.
+        if matches!(expiry, RestrictionExpiry::UntilEndOfNextTurnOf { .. }) {
+            return false;
+        }
         let source_controller = state
             .objects
             .get(source)
@@ -480,6 +494,14 @@ fn is_blocked_by_cant_activate_abilities(
             restriction_scope_matches_player(source_controller, affected_players, caster);
         if !caster_affected {
             return false;
+        }
+        // CR 101.2 + CR 602.5: A tag-scoped prohibition (Kang → power-up) applies
+        // only to abilities carrying that keyword tag; every other activation is
+        // still legal. `None` prohibits all activations (legacy behavior).
+        if let Some(required_tag) = only_tag {
+            if activating_ability.ability_tag != Some(*required_tag) {
+                return false;
+            }
         }
         match exemption {
             ActivationExemption::None => true,
@@ -10150,9 +10172,15 @@ pub fn can_pay_ability_mana_cost_after_auto_tap_excluding(
     super::layers::flush_layers(&mut simulated);
 
     let (source_types, source_subtypes) = activation_source_types(&simulated, source_id);
+    // CR 106.6: All current callers of this preview path are tag-`None`
+    // activations (mana abilities, ninjutsu, AI affordability). The real
+    // tag-scoped gate (Quinjet power-up restriction) runs at payment time in
+    // `pay_ability_mana_cost_*`, since `is_payable` defers mana affordability to
+    // the payment step (CR 601.2g).
     let activation_ctx = PaymentContext::Activation {
         source_types: &source_types,
         source_subtypes: &source_subtypes,
+        ability_tag: None,
     };
 
     can_pay_mana_cost_after_auto_tap_with_context(
@@ -10413,9 +10441,18 @@ pub(super) fn pay_ability_mana_cost(
     player: PlayerId,
     source_id: ObjectId,
     cost: &crate::types::mana::ManaCost,
+    ability_tag: Option<crate::types::ability::AbilityTag>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
-    pay_ability_mana_cost_excluding(state, player, source_id, cost, events, &HashSet::new())
+    pay_ability_mana_cost_excluding(
+        state,
+        player,
+        source_id,
+        cost,
+        ability_tag,
+        events,
+        &HashSet::new(),
+    )
 }
 
 pub(super) fn pay_ability_mana_cost_excluding(
@@ -10423,6 +10460,7 @@ pub(super) fn pay_ability_mana_cost_excluding(
     player: PlayerId,
     source_id: ObjectId,
     cost: &crate::types::mana::ManaCost,
+    ability_tag: Option<crate::types::ability::AbilityTag>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
 ) -> Result<(), EngineError> {
@@ -10431,17 +10469,20 @@ pub(super) fn pay_ability_mana_cost_excluding(
         player,
         source_id,
         cost,
+        ability_tag,
         None,
         events,
         excluded_sources,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn pay_ability_mana_cost_with_choices_excluding(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
     cost: &crate::types::mana::ManaCost,
+    ability_tag: Option<crate::types::ability::AbilityTag>,
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
@@ -10452,6 +10493,7 @@ pub(super) fn pay_ability_mana_cost_with_choices_excluding(
     let activation_ctx = PaymentContext::Activation {
         source_types: &source_types,
         source_subtypes: &source_subtypes,
+        ability_tag,
     };
 
     let _spent_units = auto_tap_and_pay_cost_excluding(
@@ -10680,6 +10722,22 @@ pub(super) fn activation_source_types(
             (types, subtypes)
         })
         .unwrap_or_default()
+}
+
+/// CR 106.6: Read the keyword tag of the ability at `ability_index` on
+/// `source_id`. Threaded into `PaymentContext::Activation` so tag-scoped mana
+/// spend restrictions (Quinjet: "spend this mana only to activate power-up
+/// abilities") can gate which mana is eligible for the activation being paid.
+pub(super) fn activation_ability_tag(
+    state: &GameState,
+    source_id: ObjectId,
+    ability_index: usize,
+) -> Option<crate::types::ability::AbilityTag> {
+    state
+        .objects
+        .get(&source_id)
+        .and_then(|obj| obj.abilities.get(ability_index))
+        .and_then(|def| def.ability_tag)
 }
 
 /// CR 106.6: When mana with spell grants is spent to cast a spell, apply those
@@ -11391,6 +11449,7 @@ fn can_pay_ability_cost_now(
     player: PlayerId,
     source_id: ObjectId,
     cost: &AbilityCost,
+    ability_tag: Option<crate::types::ability::AbilityTag>,
 ) -> bool {
     let excluded_sources = ability_mana_payment_excluded_sources(cost, source_id);
     super::costs::can_pay(
@@ -11400,6 +11459,7 @@ fn can_pay_ability_cost_now(
         cost,
         &super::costs::PaymentScope::Activation {
             excluded_sources: &excluded_sources,
+            ability_tag,
         },
     )
 }
@@ -11517,11 +11577,9 @@ pub fn can_activate_ability_now(
     }
     // CR 601.2f: Apply self-referential cost reduction before affordability check.
     apply_cost_reduction(state, &mut ability_def, player, source_id);
-    if ability_def
-        .cost
-        .as_ref()
-        .is_some_and(|cost| !can_pay_ability_cost_now(state, player, source_id, cost))
-    {
+    if ability_def.cost.as_ref().is_some_and(|cost| {
+        !can_pay_ability_cost_now(state, player, source_id, cost, ability_def.ability_tag)
+    }) {
         return false;
     }
 
@@ -12201,9 +12259,14 @@ pub fn handle_activate_ability(
                     ));
                 }
                 stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
-                if let PaymentOutcome::Paused { remaining_cost } =
-                    pay_ability_cost_for_activation(state, player, source_id, cost, events)?
-                {
+                if let PaymentOutcome::Paused { remaining_cost } = pay_ability_cost_for_activation(
+                    state,
+                    player,
+                    source_id,
+                    cost,
+                    activation_ability_tag(state, source_id, ability_index),
+                    events,
+                )? {
                     state.pending_cast = Some(Box::new(pending_activation_after_cost_pause(
                         source_id,
                         resolved.clone(),
@@ -12291,9 +12354,14 @@ pub fn handle_activate_ability(
             ));
         }
         stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
-        if let PaymentOutcome::Paused { remaining_cost } =
-            pay_ability_cost_for_activation(state, player, source_id, cost, events)?
-        {
+        if let PaymentOutcome::Paused { remaining_cost } = pay_ability_cost_for_activation(
+            state,
+            player,
+            source_id,
+            cost,
+            activation_ability_tag(state, source_id, ability_index),
+            events,
+        )? {
             state.pending_cast = Some(Box::new(pending_activation_after_cost_pause(
                 source_id,
                 resolved.clone(),
@@ -12541,6 +12609,14 @@ fn apply_static_activated_ability_cost_reduction(
     ability_def: &mut AbilityDefinition,
     source_id: ObjectId,
 ) {
+    // CR 601.2f: A `ReduceAbilityCost` static keyed on a keyword (e.g. "power-up")
+    // also reduces a tagged activated ability whose tag matches that keyword
+    // (Hulk reduces other creatures' power-up abilities). Read the activating
+    // ability's tag keyword before the mutable borrow of its cost below.
+    let active_keyword = ability_def
+        .ability_tag
+        .map(crate::types::ability::AbilityTag::keyword_str);
+
     let Some(cost) = ability_def.cost.as_mut() else {
         return;
     };
@@ -12555,7 +12631,7 @@ fn apply_static_activated_ability_cost_reduction(
         else {
             continue;
         };
-        if keyword != "activated" || *amount == 0 {
+        if (keyword != "activated" && Some(keyword.as_str()) != active_keyword) || *amount == 0 {
             continue;
         }
         if def.affected.as_ref().is_some_and(|filter| {
@@ -13257,7 +13333,15 @@ mod tests {
         ));
 
         let mut events = Vec::new();
-        pay_ability_mana_cost(&mut state, PlayerId(0), ability_source, &cost, &mut events).unwrap();
+        pay_ability_mana_cost(
+            &mut state,
+            PlayerId(0),
+            ability_source,
+            &cost,
+            None,
+            &mut events,
+        )
+        .unwrap();
 
         assert!(state.objects.get(&restricted_source).unwrap().tapped);
         assert_eq!(state.players[0].mana_pool.mana.len(), 0);
@@ -15315,6 +15399,7 @@ mod tests {
             expiry: RestrictionExpiry::EndOfTurn,
             activity: ProhibitedActivity::ActivateAbilities {
                 exemption: ActivationExemption::ManaAbilities,
+                only_tag: None,
             },
         });
 
@@ -30667,7 +30752,13 @@ mod tests {
             TargetFilter::Typed(TypedFilter::creature()),
             1,
         ));
-        assert!(can_pay_ability_cost_now(&state, PlayerId(0), source, &cost));
+        assert!(can_pay_ability_cost_now(
+            &state,
+            PlayerId(0),
+            source,
+            &cost,
+            None
+        ));
     }
 
     #[test]
@@ -30691,7 +30782,8 @@ mod tests {
             &state,
             PlayerId(0),
             source,
-            &cost
+            &cost,
+            None
         ));
     }
 
@@ -36853,7 +36945,7 @@ mod tests {
                 "cost must be unpayable when the source has no +1/+1 counters"
             );
             assert!(
-                !can_pay_ability_cost_now(&state, PlayerId(0), source, &cost),
+                !can_pay_ability_cost_now(&state, PlayerId(0), source, &cost, None),
                 "can_pay_ability_cost_now must reject an unpayable remove-counter cost"
             );
         }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2264,7 +2264,14 @@ pub(super) fn push_activated_ability_to_stack(
             ));
         }
         if let super::casting::PaymentOutcome::Paused { remaining_cost } =
-            super::casting::pay_ability_cost_for_activation(state, player, source_id, cost, events)?
+            super::casting::pay_ability_cost_for_activation(
+                state,
+                player,
+                source_id,
+                cost,
+                super::casting::activation_ability_tag(state, source_id, ability_index),
+                events,
+            )?
         {
             let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
             pending.activation_cost = remaining_cost;
@@ -6427,6 +6434,7 @@ fn auto_tap_mana_sources_inner(
                     let activation_ctx = PaymentContext::Activation {
                         source_types: &source_types,
                         source_subtypes: &source_subtypes,
+                        ability_tag: ability_def.ability_tag,
                     };
                     auto_tap_mana_sources_inner(
                         state,
@@ -7151,7 +7159,7 @@ pub fn finalize_mana_payment(
     if let Some(pending_ref) = state.pending_cast.as_ref() {
         let mana_cost = pending_ref.cost.clone();
         let source_id = pending_ref.object_id;
-        if pending_ref.activation_ability_index.is_some() {
+        if let Some(ability_index) = pending_ref.activation_ability_index {
             let excluded_sources = pending_ref
                 .activation_cost
                 .as_ref()
@@ -7167,6 +7175,11 @@ pub fn finalize_mana_payment(
             let activation_ctx = PaymentContext::Activation {
                 source_types: &source_types,
                 source_subtypes: &source_subtypes,
+                ability_tag: super::casting::activation_ability_tag(
+                    state,
+                    source_id,
+                    ability_index,
+                ),
             };
             if let Some(waiting) = maybe_pause_for_phyrexian_choice(
                 state,
@@ -7214,6 +7227,7 @@ pub fn finalize_mana_payment(
             player,
             pending.object_id,
             &pending.cost,
+            super::casting::activation_ability_tag(state, pending.object_id, ability_index),
             events,
             &excluded_sources,
         )?;
@@ -7378,6 +7392,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
             player,
             pending.object_id,
             &pending.cost,
+            super::casting::activation_ability_tag(state, pending.object_id, ability_index),
             Some(phyrexian_choices),
             events,
             &excluded_sources,

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -484,6 +484,7 @@ fn pay_activation_costs_after_target_selection(
             player,
             pending.object_id,
             &pending.cost,
+            super::casting::activation_ability_tag(state, pending.object_id, ability_index),
             events,
             &excluded_sources,
         )?;
@@ -538,6 +539,7 @@ fn pay_activation_costs_after_target_selection(
                 player,
                 pending.object_id,
                 activation_cost,
+                super::casting::activation_ability_tag(state, pending.object_id, ability_index),
                 events,
             )?
         {

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -176,6 +176,11 @@ fn find_eligible_exile_targets(
 pub(crate) enum PaymentScope<'a> {
     Activation {
         excluded_sources: &'a HashSet<ObjectId>,
+        /// CR 106.6: Keyword tag of the activated ability whose cost is being
+        /// paid. Threaded into `PaymentContext::Activation` so tag-scoped mana
+        /// spend restrictions (Quinjet → power-up) gate eligible mana. Resolution
+        /// scope never carries a tag (resolution-time costs aren't activations).
+        ability_tag: Option<crate::types::ability::AbilityTag>,
     },
     /// `ability` is normally the PAYER-ADJUSTED `ResolvedAbility` clone
     /// (controller swapped to the resolved payer, per `effects/pay.rs`). All
@@ -279,7 +284,7 @@ pub fn pay_ability_cost(
     cost: &AbilityCost,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
-    pay_ability_cost_for_activation(state, player, source_id, cost, events).map(|_| ())
+    pay_ability_cost_for_activation(state, player, source_id, cost, None, events).map(|_| ())
 }
 
 pub(crate) fn pay_ability_cost_for_activation(
@@ -287,6 +292,7 @@ pub(crate) fn pay_ability_cost_for_activation(
     player: PlayerId,
     source_id: ObjectId,
     cost: &AbilityCost,
+    ability_tag: Option<crate::types::ability::AbilityTag>,
     events: &mut Vec<GameEvent>,
 ) -> Result<PaymentOutcome, EngineError> {
     let excluded_sources = ability_mana_payment_excluded_sources(cost, source_id);
@@ -298,6 +304,7 @@ pub(crate) fn pay_ability_cost_for_activation(
         events,
         &PaymentScope::Activation {
             excluded_sources: &excluded_sources,
+            ability_tag,
         },
     )?;
     // CR 601.2h: "Unpayable costs can't be paid." Activation scope maps a
@@ -405,15 +412,19 @@ fn pay_ability_cost_inner(
             // 106.6: restriction enforcement routes through `allows_activation`
             // (not `allows_spell`) via the activation context built from the
             // source permanent's types.
-            PaymentScope::Activation { excluded_sources } => {
+            PaymentScope::Activation {
+                excluded_sources,
+                ability_tag,
+            } => {
                 if excluded_sources.is_empty() {
-                    pay_ability_mana_cost(state, player, source_id, cost, events)?;
+                    pay_ability_mana_cost(state, player, source_id, cost, *ability_tag, events)?;
                 } else {
                     pay_ability_mana_cost_excluding(
                         state,
                         player,
                         source_id,
                         cost,
+                        *ability_tag,
                         events,
                         excluded_sources,
                     )?;
@@ -1549,6 +1560,7 @@ mod tests {
             let excluded = ability_mana_payment_excluded_sources(&cost, src);
             let scope = PaymentScope::Activation {
                 excluded_sources: &excluded,
+                ability_tag: None,
             };
             assert!(
                 can_pay(&scenario.state, P0, src, &cost, &scope),
@@ -1576,6 +1588,7 @@ mod tests {
         let excluded = ability_mana_payment_excluded_sources(&cost, src);
         let scope = PaymentScope::Activation {
             excluded_sources: &excluded,
+            ability_tag: None,
         };
         let mut events = Vec::new();
         let outcome =
@@ -1614,6 +1627,7 @@ mod tests {
             P0,
             src,
             &graveyard_cost,
+            None,
             &mut Vec::new(),
         );
         assert!(matches!(rejected, Err(EngineError::ActionNotAllowed(_))));
@@ -1629,6 +1643,7 @@ mod tests {
             P0,
             src,
             &battlefield_cost,
+            None,
             &mut Vec::new(),
         )
         .expect("battlefield self-return cost should be payable");
@@ -1645,6 +1660,7 @@ mod tests {
             cost,
             &PaymentScope::Activation {
                 excluded_sources: &excluded,
+                ability_tag: None,
             },
         )
     }

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -18,7 +18,8 @@ use crate::game::ability_utils::flatten_targets_in_chain;
 use crate::game::game_object::AttachTarget;
 use crate::game::stack::{stack_display_groups, StackDisplayGroup};
 use crate::types::ability::{
-    GameRestriction, KeywordAction, ProhibitedActivity, RestrictionPlayerScope, TargetRef,
+    GameRestriction, KeywordAction, ProhibitedActivity, RestrictionExpiry, RestrictionPlayerScope,
+    TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
@@ -381,12 +382,22 @@ fn player_status_views(state: &GameState) -> Vec<PlayerStatusView> {
             source,
             affected_players,
             activity,
-            ..
+            expiry,
         } = restriction
         else {
             // DamagePreventionDisabled has no per-player axis — see fn docs.
             continue;
         };
+        // CR 514.2 + CR 500.7: a `UntilEndOfNextTurnOf` prohibition (Kang's "during
+        // that [extra] turn, power-up abilities can't be activated") is created
+        // pre-armed and only takes force during the granted turn, after the untap
+        // step converts it to `EndOfTurn` (turns.rs). Suppress the HUD status badge
+        // while it is still dormant so this display seam agrees with the activation
+        // gate (`is_blocked_by_cant_activate_abilities`) — they share the expiry
+        // variant as the single source of truth.
+        if matches!(expiry, RestrictionExpiry::UntilEndOfNextTurnOf { .. }) {
+            continue;
+        }
         let kind = match activity {
             ProhibitedActivity::CastSpells { .. } => PlayerConditionKind::CantCastSpells,
             ProhibitedActivity::ActivateAbilities { .. } => {
@@ -1254,6 +1265,7 @@ mod tests {
             expiry: RestrictionExpiry::EndOfTurn,
             activity: ProhibitedActivity::ActivateAbilities {
                 exemption: ActivationExemption::ManaAbilities,
+                only_tag: None,
             },
         });
         // CR 614.16: no per-player axis — must NOT produce a status row.

--- a/crates/engine/src/game/effects/add_restriction.rs
+++ b/crates/engine/src/game/effects/add_restriction.rs
@@ -81,24 +81,31 @@ fn fill_runtime_fields(
 
     match restriction {
         GameRestriction::ProhibitActivity { expiry, .. } => {
-            // CR 514.2: "until [the end of] your next turn" restrictions expire
-            // relative to the controller's next turn. The restriction-expiry
-            // system tracks only `UntilPlayerNextTurn` (begin-of-next-turn), so
-            // both readings map to it here — the precise end-of-next-turn timing
-            // matters only for continuous effects / play-permissions (handled in
-            // the layer prune); no printed restriction uses "end of next turn".
-            if let Some(
-                crate::types::ability::Duration::UntilNextTurnOf {
-                    player: crate::types::ability::PlayerScope::Controller,
+            use crate::types::ability::{Duration, PlayerScope};
+            match ability.duration.as_ref() {
+                // CR 514.2 + CR 611.2a: "until your next turn" expires at the
+                // *beginning* of the controller's next turn.
+                Some(Duration::UntilNextTurnOf {
+                    player: PlayerScope::Controller,
+                }) => {
+                    *expiry = RestrictionExpiry::UntilPlayerNextTurn {
+                        player: ability.controller,
+                    };
                 }
-                | crate::types::ability::Duration::UntilEndOfNextTurnOf {
-                    player: crate::types::ability::PlayerScope::Controller,
-                },
-            ) = ability.duration.as_ref()
-            {
-                *expiry = RestrictionExpiry::UntilPlayerNextTurn {
-                    player: ability.controller,
-                };
+                // CR 514.2 + CR 500.7: "during [the controller's] next turn …"
+                // (Kang) persists through that entire turn and expires at its
+                // cleanup. Lower to the pre-armed `UntilEndOfNextTurnOf` marker,
+                // which the untap step converts to `EndOfTurn` (mirroring
+                // `prune_until_next_turn_effects`) so the existing cleanup prune
+                // ends it at THAT turn's cleanup.
+                Some(Duration::UntilEndOfNextTurnOf {
+                    player: PlayerScope::Controller,
+                }) => {
+                    *expiry = RestrictionExpiry::UntilEndOfNextTurnOf {
+                        player: ability.controller,
+                    };
+                }
+                _ => {}
             }
         }
         GameRestriction::DamagePreventionDisabled { .. } => {}
@@ -207,6 +214,7 @@ mod tests {
                     expiry: RestrictionExpiry::EndOfTurn,
                     activity: ProhibitedActivity::ActivateAbilities {
                         exemption: crate::types::statics::ActivationExemption::ManaAbilities,
+                        only_tag: None,
                     },
                 },
             },
@@ -241,6 +249,7 @@ mod tests {
                     expiry: RestrictionExpiry::EndOfTurn,
                     activity: ProhibitedActivity::ActivateAbilities {
                         exemption: crate::types::statics::ActivationExemption::ManaAbilities,
+                        only_tag: None,
                     },
                 },
             },

--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -280,6 +280,9 @@ pub(crate) fn resolve_restrictions(
                 ability: *ability,
             }),
             ManaSpendRestriction::ActivateOnly => Some(ManaRestriction::OnlyForActivation),
+            ManaSpendRestriction::ActivateTagged(tag) => {
+                Some(ManaRestriction::OnlyForTaggedActivation(*tag))
+            }
             ManaSpendRestriction::XCostOnly => Some(ManaRestriction::OnlyForXCosts),
             ManaSpendRestriction::SpellWithKeywordKind(kind) => {
                 Some(ManaRestriction::OnlyForSpellWithKeywordKind(*kind))

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3079,12 +3079,18 @@ fn apply_action(
                     .find(|p| p.id == player)
                     .map(|p| p.mana_pool.clone())
                     .ok_or_else(|| EngineError::InvalidAction("Player not found".to_string()))?;
-                let current_shards = if pending_ref.activation_ability_index.is_some() {
+                let activation_ability_index = pending_ref.activation_ability_index;
+                let current_shards = if let Some(ability_index) = activation_ability_index {
                     let (source_types, source_subtypes) =
                         casting::activation_source_types(state, spell_object);
                     let activation_ctx = crate::types::mana::PaymentContext::Activation {
                         source_types: &source_types,
                         source_subtypes: &source_subtypes,
+                        ability_tag: casting::activation_ability_tag(
+                            state,
+                            spell_object,
+                            ability_index,
+                        ),
                     };
                     let any_color = casting::player_can_spend_as_any_color_for_payment(
                         state,

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -315,6 +315,8 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
                 // CR 702.165a: Backup is a triggered ability — it never emits a
                 // `KeywordAbilityActivated` event, so this arm is unreachable.
                 AbilityTag::Backup => " activates backup: ",
+                // CR 602.5b: Power-up activation.
+                AbilityTag::PowerUp => " activates power-up: ",
             };
             vec![
                 player_seg(state, *player_id),

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -2221,11 +2221,15 @@ fn pay_mana_sub_cost(
 ) -> Result<(), EngineError> {
     if hybrid_plan.is_none() {
         let excluded_sources = std::collections::HashSet::from([source_id]);
+        // CR 605.1a: A mana ability never carries a power-up tag (power-up
+        // abilities can't produce mana), so the tag-scoped activation context is
+        // `None` here — Quinjet's {R}{R} must not pay another mana ability's cost.
         return super::casting::pay_ability_mana_cost_excluding(
             state,
             player,
             source_id,
             cost,
+            None,
             events,
             &excluded_sources,
         );
@@ -2238,9 +2242,12 @@ fn pay_mana_sub_cost(
     // mana (e.g. Heart of Ramos) would silently pay through for the {R} half
     // of a hypothetical "{R}: Add {G}{G}" mana ability.
     let (source_types, source_subtypes) = super::casting::activation_source_types(state, source_id);
+    // CR 605.1a: Mana abilities never carry a power-up tag, so `ability_tag` is
+    // `None` for the mana-ability sub-cost activation context.
     let ctx = PaymentContext::Activation {
         source_types: &source_types,
         source_subtypes: &source_subtypes,
+        ability_tag: None,
     };
     let pool = &mut state.players[player.0 as usize].mana_pool;
     let (spent, _life) = match hybrid_plan {
@@ -3418,6 +3425,7 @@ mod tests {
         let non_elemental_activation = PaymentContext::Activation {
             source_types: &non_elemental_types,
             source_subtypes: &non_elemental_subtypes,
+            ability_tag: None,
         };
         let mut pool_clone2 = pool.clone();
         assert!(
@@ -3431,6 +3439,7 @@ mod tests {
         let elemental_activation = PaymentContext::Activation {
             source_types: &non_elemental_types,
             source_subtypes: &elemental_subtypes,
+            ability_tag: None,
         };
         assert!(
             pool_clone2

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -2969,6 +2969,7 @@ mod tests {
         let goblin_activation = PaymentContext::Activation {
             source_types: &source_types,
             source_subtypes: &source_subtypes,
+            ability_tag: None,
         };
         assert!(can_pay_for_spell(
             &pool,

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1,8 +1,8 @@
 use crate::game::game_object::GameObject;
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityTag, ActivationRestriction, CastingPermission,
-    CastingRestriction, ControllerRef, FilterProp, ParsedCondition, QuantityExpr,
-    SpellCastingOptionKind, TargetFilter, TypeFilter,
+    AbilityCost, AbilityDefinition, ActivationRestriction, CastingPermission, CastingRestriction,
+    ControllerRef, FilterProp, ParsedCondition, QuantityExpr, SpellCastingOptionKind, TargetFilter,
+    TypeFilter,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
@@ -574,20 +574,20 @@ fn effective_activation_limit(
     let Some(tag) = ability_tag else {
         return 1; // No tag → default once-per-turn
     };
-    let keyword = match tag {
-        AbilityTag::Boast => "boast",
-        AbilityTag::Evolve => "evolve",
-        AbilityTag::Exhaust => "exhaust",
-        AbilityTag::Outlast => "outlast",
-        // CR 702.29: Cycling has no per-turn activation limit. Unreachable here —
-        // this fn is only called for abilities carrying an `OnlyOnceEachTurn`
-        // restriction, which the synthesized cycling ability never has.
-        AbilityTag::Cycling => "cycling",
-        // CR 702.165a: Backup is a triggered ability — it is never activated, so
-        // it carries no activation limit and this arm is unreachable here.
-        AbilityTag::Backup => "backup",
-    };
-    // Scan battlefield for ModifyActivationLimit statics that affect this keyword
+    activation_limit_from_statics(state, player, source_id, tag.keyword_str())
+}
+
+/// CR 602.5b: Scan the battlefield for `ModifyActivationLimit` statics that
+/// raise the activation cap for `keyword`-tagged abilities on `source_id`. The
+/// static is scope-agnostic (it reads no per-turn/per-game counter), so both the
+/// per-turn (`effective_activation_limit`) and per-game
+/// (`effective_activation_limit_per_game`) paths share this scan. Base limit 1.
+fn activation_limit_from_statics(
+    state: &crate::types::game_state::GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    keyword: &str,
+) -> u32 {
     let mut limit: u32 = 1;
     for (bf_obj, static_def) in
         crate::game::functioning_abilities::battlefield_active_statics(state)
@@ -619,6 +619,28 @@ fn effective_activation_limit(
         }
     }
     limit
+}
+
+/// CR 602.5b: Compute the effective per-game activation limit for
+/// an ability carrying `ActivationRestriction::OnlyOnce`. Base limit 1, raised by
+/// `ModifyActivationLimit` statics (Wonder Man / Hollywood Hero). Returns only
+/// the cap — the per-game counter comparison stays in the `OnlyOnce` consult arm,
+/// so the per-game and per-turn counters/scopes are never conflated.
+fn effective_activation_limit_per_game(
+    state: &crate::types::game_state::GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    ability_index: usize,
+) -> u32 {
+    let ability_tag = state
+        .objects
+        .get(&source_id)
+        .and_then(|obj| obj.abilities.get(ability_index))
+        .and_then(|def| def.ability_tag);
+    let Some(tag) = ability_tag else {
+        return 1; // No tag → default once-per-game
+    };
+    activation_limit_from_statics(state, player, source_id, tag.keyword_str())
 }
 
 fn has_activate_as_instant_permission(
@@ -722,13 +744,15 @@ fn activation_restriction_applies(
         }
         // CR 602.5b: Per-object activation limit. `zones::move_to_zone` clears
         // this count when CR 400.7 makes the stored id represent a new object.
+        // ModifyActivationLimit statics (Wonder Man) may raise the per-game cap
+        // above 1, so the gate is `count < limit`, not `count == 0`.
         ActivationRestriction::OnlyOnce => {
-            state
+            let count = state
                 .activated_abilities_this_game
                 .get(&key)
                 .copied()
-                .unwrap_or(0)
-                == 0
+                .unwrap_or(0);
+            count < effective_activation_limit_per_game(state, player, source_id, ability_index)
         }
         // CR 602.5b: Per-turn activation count limit (e.g. "Activate only twice each turn").
         ActivationRestriction::MaxTimesEachTurn { count } => {

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -734,6 +734,25 @@ pub fn execute_untap_with_choices(
     state.pending_damage_replacements.retain(|r| {
         !matches!(r.expiry, Some(RestrictionExpiry::UntilPlayerNextTurn { player }) if player == active)
     });
+    // CR 514.2 + CR 500.7: Arm "until the end of the player's next turn"
+    // restrictions (Kang's power-up prohibition) when that player's next turn
+    // begins — convert to `EndOfTurn` so the cleanup-step prune (`execute_cleanup`)
+    // ends them at THIS turn's cleanup, persisting through the whole turn.
+    // Mirrors `prune_until_next_turn_effects` (layers.rs). NOTE: if the granted
+    // turn is SKIPPED/PREVENTED before its untap step, this conversion never runs
+    // and the restriction is never armed/pruned — a documented narrow edge shared
+    // with the analogous `Duration::UntilEndOfNextTurnOf` arming.
+    {
+        use crate::types::ability::GameRestriction;
+        for restriction in state.restrictions.iter_mut() {
+            if let GameRestriction::ProhibitActivity { expiry, .. } = restriction {
+                if matches!(expiry, RestrictionExpiry::UntilEndOfNextTurnOf { player } if *player == active)
+                {
+                    *expiry = RestrictionExpiry::EndOfTurn;
+                }
+            }
+        }
+    }
     state.restrictions.retain(|restriction| {
         use crate::types::ability::GameRestriction;
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -11,10 +11,10 @@ use serde::{Deserialize, Serialize};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag,
     ActivationRestriction, AdditionalCost, CastTimingPermission, CastingRestriction, ChoiceType,
-    ChosenSubtypeKind, ContinuousModification, DelayedTriggerCondition, Effect, FilterProp,
-    ManaProduction, ModalChoice, ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef,
-    ReplacementDefinition, SolveCondition, SpellCastingOption, StaticCondition, StaticDefinition,
-    TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter,
+    ChosenSubtypeKind, ContinuousModification, CostReduction, DelayedTriggerCondition, Effect,
+    FilterProp, ManaProduction, ModalChoice, ParsedCondition, PlayerFilter, QuantityExpr,
+    QuantityRef, ReplacementDefinition, SolveCondition, SpellCastingOption, StaticCondition,
+    StaticDefinition, TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter,
 };
 use crate::types::format::DeckCopyLimit;
 use crate::types::keywords::{EscapeCost, FlashbackCost, Keyword, KeywordKind};
@@ -2448,6 +2448,46 @@ pub(crate) fn parse_oracle_ir(
                 def.ability_tag = Some(AbilityTag::Exhaust);
                 extract_cost_reduction_from_chain(&mut def);
                 extract_mana_spend_trigger_from_chain(&mut def);
+                result.abilities.push(def);
+                i += 1;
+                continue;
+            }
+        }
+
+        // Priority 3e2: Power-up — "Power-up — {cost}: {effect}" (CR 602.5b).
+        // Power-up is a keyword-labeled activated ability (like Exhaust): it can
+        // be activated only once per game, and its cost is reduced by the source's
+        // mana value if it entered the battlefield this turn. The cost reduction is
+        // set from the keyword definition (not parsed from reminder text, which
+        // `strip_reminder_text` removes).
+        if let Some(((), rest_original)) = nom_on_lower(&line, &lower, |i| {
+            value((), alt((tag("power-up \u{2014} "), tag("power-up -- ")))).parse(i)
+        }) {
+            if let Some(colon_pos) = find_activated_colon(rest_original) {
+                let cost_text = rest_original[..colon_pos].trim();
+                let effect_text = rest_original[colon_pos + 1..].trim();
+                let (effect_text, constraints) = strip_activated_constraints(effect_text);
+                let cost = parse_oracle_cost(cost_text);
+                ctx.subject = None;
+                ctx.actor = None;
+                let mut def =
+                    parse_effect_chain_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
+                def.cost = Some(cost);
+                def.description = Some(line.to_string());
+                def.activation_restrictions.extend(constraints.restrictions);
+                // CR 602.5b: power-up may be activated only once per game.
+                def.activation_restrictions
+                    .push(ActivationRestriction::OnlyOnce);
+                def.ability_tag = Some(AbilityTag::PowerUp);
+                // CR 602.2b + CR 601.2f + CR 302.6: the activation cost's generic
+                // mana is reduced by the source's mana value if it entered this turn.
+                def.cost_reduction = Some(CostReduction {
+                    amount_per: 1,
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::SelfManaValue,
+                    },
+                    condition: Some(ParsedCondition::SourceEnteredThisTurn),
+                });
                 result.abilities.push(def);
                 i += 1;
                 continue;

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -10,8 +10,8 @@ use nom::Parser;
 use crate::parser::oracle_nom::error::OracleResult;
 use crate::parser::oracle_nom::primitives as nom_primitives;
 use crate::types::ability::{
-    AbilityKind, Comparator, Effect, LinkedExileScope, ManaContribution, ManaProduction,
-    ManaSpendRestriction, QuantityExpr, QuantityRef,
+    AbilityKind, AbilityTag, Comparator, Effect, LinkedExileScope, ManaContribution,
+    ManaProduction, ManaSpendRestriction, QuantityExpr, QuantityRef,
 };
 use crate::types::keywords::KeywordKind;
 use crate::types::mana::{
@@ -1409,6 +1409,20 @@ pub(crate) fn parse_mana_spend_restriction(
     })?;
     let base = base.trim_end_matches(['.', '"']);
     let base_lower = base.to_lowercase();
+
+    // CR 106.6: "spend this mana only to activate power-up abilities" -- tag-scoped.
+    // Try BEFORE the broader "to activate abilities" arm (more-specific-first) so
+    // Quinjet's {R}{R} does not collapse to ActivateOnly.
+    if nom_on_lower(base, &base_lower, |i| {
+        value((), tag("to activate power-up abilities")).parse(i)
+    })
+    .is_some()
+    {
+        return Some((
+            ManaSpendRestriction::ActivateTagged(AbilityTag::PowerUp),
+            vec![],
+        ));
+    }
 
     // "spend this mana only to activate abilities" -- activation-only
     if nom_on_lower(base, &base_lower, |i| {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -88,7 +88,7 @@ use crate::game::triggers;
 use crate::parser::oracle_effect::subject::parse_subject_application;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
-    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction,
+    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AggregateFunction,
     BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
     ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard, ConjureSource,
     ContinuousModification, ControllerRef, CopyRetargetPermission, DamageModification,
@@ -2177,10 +2177,61 @@ fn try_parse_cant_activate_non_mana_abilities_effect(
                 expiry: RestrictionExpiry::EndOfTurn,
                 activity: ProhibitedActivity::ActivateAbilities {
                     exemption: ActivationExemption::ManaAbilities,
+                    only_tag: None,
                 },
             },
         },
         duration: None,
+        sub_ability: None,
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
+/// CR 500.7 + CR 514.2 + CR 602.5: "During that turn, power-up abilities can't
+/// be activated" — Kang's clause appended after "Take an extra turn after this
+/// one." Prohibits the controller's power-up activations throughout the granted
+/// extra turn. The restriction is pre-armed (`Duration::UntilEndOfNextTurnOf`,
+/// lowered to `RestrictionExpiry::UntilEndOfNextTurnOf` and converted to
+/// `EndOfTurn` at the extra turn's untap step), so it persists through that whole
+/// turn and expires at its cleanup.
+fn try_parse_during_that_turn_powerup_prohibition(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
+    nom_on_lower(tp.original, tp.lower, |input| {
+        value(
+            (),
+            preceded(
+                tag("during that turn, "),
+                tag("power-up abilities can't be activated"),
+            ),
+        )
+        .parse(input)
+    })
+    .filter(|((), rest)| rest.trim_matches(['.', ' ']).is_empty())?;
+
+    Some(ParsedEffectClause {
+        effect: Effect::AddRestriction {
+            restriction: GameRestriction::ProhibitActivity {
+                source: ObjectId(0),
+                // CR 500.7: "power-up abilities can't be activated" during that
+                // turn is an unrestricted prohibition (no player subject) — no
+                // player is exempt, so it affects all players (and creates no
+                // target slot, unlike `TargetedPlayer`).
+                affected_players: RestrictionPlayerScope::AllPlayers,
+                expiry: RestrictionExpiry::EndOfTurn,
+                activity: ProhibitedActivity::ActivateAbilities {
+                    exemption: ActivationExemption::None,
+                    only_tag: Some(AbilityTag::PowerUp),
+                },
+            },
+        },
+        // Pre-armed end-of-next-turn anchor — `fill_runtime_fields` lowers this
+        // to `RestrictionExpiry::UntilEndOfNextTurnOf { player: controller }`.
+        duration: Some(Duration::UntilEndOfNextTurnOf {
+            player: PlayerScope::Controller,
+        }),
         sub_ability: None,
         distribute: None,
         multi_target: None,
@@ -4937,6 +4988,13 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // CR 101.2: "Your opponents can't cast spells this turn" — blanket temporary prohibition.
     // Must run AFTER cast_only_from_zones (more specific "from zones" check).
     if let Some(clause) = try_parse_cant_cast_spells_effect(tp) {
+        return clause;
+    }
+
+    // CR 500.7 + CR 602.5: "During that turn, power-up abilities can't be
+    // activated" (Kang). Tag-scoped prohibition for the granted extra turn — try
+    // before the generic non-mana-ability prohibition.
+    if let Some(clause) = try_parse_during_that_turn_powerup_prohibition(tp) {
         return clause;
     }
 
@@ -43204,6 +43262,7 @@ mod tests {
                     affected_players: RestrictionPlayerScope::ParentTargetedPlayer,
                     activity: ProhibitedActivity::ActivateAbilities {
                         exemption: ActivationExemption::ManaAbilities,
+                        ..
                     },
                     ..
                 }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2180,6 +2180,56 @@ pub(crate) fn parse_static_line_inner(
         }
     }
 
+    // --- "Power-up abilities of [subject] cost {N} less to activate" ---
+    // CR 601.2f: Class-scoped power-up activation cost reduction (Hulk / Gamma
+    // Goliath: "Power-up abilities of other creatures you control cost {3} less
+    // to activate"). The keyword is the ability tag ("power-up"); the static
+    // runtime gate matches the activating ability's tag. The `<subject>` filter
+    // ("other creatures you control") is routed through `parse_type_phrase`,
+    // which handles the "other" self-exclusion.
+    if let Some(((subject, amount), _)) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (i, _) = tag("power-up abilities of ").parse(i)?;
+        let (i, subject) = take_until(" cost ").parse(i)?;
+        let (i, _) = tag(" cost ").parse(i)?;
+        let (i, amount) =
+            nom::sequence::delimited(tag("{"), nom_primitives::parse_number, tag("}")).parse(i)?;
+        let (i, _) = tag(" less to activate").parse(i)?;
+        Ok((i, (subject.to_string(), amount)))
+    }) {
+        let (affected, _rest) = parse_type_phrase(&subject);
+        return Some(
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                keyword: "power-up".to_string(),
+                amount,
+                minimum_mana: parse_activated_cost_reduction_minimum_mana(tp.lower),
+                dynamic_count: None,
+            })
+            .affected(affected)
+            .description(text.to_string()),
+        );
+    }
+
+    // --- "Each power-up ability of [subject] can be activated an additional time" ---
+    // CR 602.5b: Class-scoped power-up activation-limit raise (Wonder
+    // Man / Hollywood Hero). Power-up's base limit is once-per-game; "an additional
+    // time" with no per-turn qualifier raises the per-game cap to 2.
+    if let Some((subject, _)) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (i, _) = tag("each power-up ability of ").parse(i)?;
+        let (i, subject) = take_until(" can be activated an additional time").parse(i)?;
+        let (i, _) = tag(" can be activated an additional time").parse(i)?;
+        Ok((i, subject.to_string()))
+    }) {
+        let (affected, _rest) = parse_type_phrase(&subject);
+        return Some(
+            StaticDefinition::new(StaticMode::ModifyActivationLimit {
+                keyword: "power-up".to_string(),
+                new_limit: 2,
+            })
+            .affected(affected)
+            .description(text.to_string()),
+        );
+    }
+
     // --- "[Enchanted/Equipped] [type]'s activated abilities cost {N} less to activate" ---
     // CR 303.4 + CR 602.1 + CR 601.2f: Aura/Equipment-granted activated ability
     // cost reduction for the attached object (Power Artifact).

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3917,6 +3917,20 @@ fn try_parse_keyword_activation_trigger(lower: &str) -> Option<(TriggerMode, Tri
             def.mode = TriggerMode::KeywordAbilityActivated(AbilityTag::Boast);
             return Some((TriggerMode::KeywordAbilityActivated(AbilityTag::Boast), def));
         }
+        // CR 602.1 + CR 603.1b: Match "a power-up ability" — Marvel Boy triggers
+        // when its controller activates a power-up ability (one of two trigger
+        // conditions split from the dual-condition text by `split_and_when_compound`).
+        if tag::<_, _, OracleError<'_>>("a power-up ability")
+            .parse(rest)
+            .is_ok()
+        {
+            let mut def = make_base();
+            def.mode = TriggerMode::KeywordAbilityActivated(AbilityTag::PowerUp);
+            return Some((
+                TriggerMode::KeywordAbilityActivated(AbilityTag::PowerUp),
+                def,
+            ));
+        }
         #[derive(Clone, Copy)]
         enum KeywordActivationSubject {
             SelfRef,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -1462,6 +1462,9 @@ pub enum ManaSpendRestriction {
     /// "Spend this mana only to activate abilities."
     /// Cannot be used to cast spells; only for ability activation costs.
     ActivateOnly,
+    /// CR 106.6: "Spend this mana only to activate power-up abilities." Keyed on
+    /// the activating ability's keyword tag (Quinjet Technician).
+    ActivateTagged(AbilityTag),
     /// "Spend this mana only on costs that include {X}."
     /// Only permits spending on spells or abilities with {X} in their cost.
     XCostOnly,
@@ -1586,8 +1589,14 @@ pub enum ProhibitedActivity {
         spell_filter: Option<TargetFilter>,
     },
     /// CR 101.2 + CR 602.5 + CR 605.1a: Prevent activating abilities, optionally
-    /// exempting mana abilities.
-    ActivateAbilities { exemption: ActivationExemption },
+    /// exempting mana abilities. `only_tag = None` prohibits all activations;
+    /// `Some(tag)` scopes the prohibition to abilities carrying that keyword tag
+    /// (Kang → power-up), leaving every other activation legal.
+    ActivateAbilities {
+        exemption: ActivationExemption,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        only_tag: Option<AbilityTag>,
+    },
 }
 
 /// When a game restriction expires.
@@ -1596,7 +1605,19 @@ pub enum ProhibitedActivity {
 pub enum RestrictionExpiry {
     EndOfTurn,
     EndOfCombat,
-    UntilPlayerNextTurn { player: PlayerId },
+    UntilPlayerNextTurn {
+        player: PlayerId,
+    },
+    /// CR 514.2 + CR 500.7: Mirrors `Duration::UntilEndOfNextTurnOf`. Created
+    /// pre-armed; at `player`'s next untap step it is CONVERTED to
+    /// `RestrictionExpiry::EndOfTurn` (mirroring `prune_until_next_turn_effects`),
+    /// so the existing cleanup-step prune ends it at THAT turn's cleanup — it
+    /// persists through `player`'s entire next turn (Kang's extra turn). It
+    /// survives the creating turn's own cleanup because that turn's untap step
+    /// already passed before creation.
+    UntilEndOfNextTurnOf {
+        player: PlayerId,
+    },
 }
 
 /// Limits the scope of a game restriction to specific sources or targets.
@@ -11809,6 +11830,26 @@ pub enum AbilityTag {
     Cycling,
     /// CR 702.165a: ability originated from a Backup keyword definition.
     Backup,
+    /// CR 602.5b + CR 602.1: This ability originated from a Power-up keyword definition.
+    PowerUp,
+}
+
+impl AbilityTag {
+    /// CR 602.1: Canonical lowercase keyword string for this ability tag.
+    /// Single authority shared by the per-turn and per-game activation-limit
+    /// paths and the static activated-ability cost-reduction gate, so the
+    /// tag→keyword mapping lives in one place.
+    pub fn keyword_str(self) -> &'static str {
+        match self {
+            AbilityTag::Boast => "boast",
+            AbilityTag::Evolve => "evolve",
+            AbilityTag::Exhaust => "exhaust",
+            AbilityTag::Outlast => "outlast",
+            AbilityTag::Cycling => "cycling",
+            AbilityTag::Backup => "backup",
+            AbilityTag::PowerUp => "power-up",
+        }
+    }
 }
 
 /// Structured activation-time restrictions parsed from Oracle text.
@@ -17428,6 +17469,54 @@ mod tests {
         let json = serde_json::to_string(&filter).unwrap();
         let deserialized: TargetFilter = serde_json::from_str(&json).unwrap();
         assert_eq!(filter, deserialized);
+    }
+
+    #[test]
+    fn power_up_keyword_types_serde_roundtrip() {
+        // CR 602.5b: new AbilityTag leaf.
+        let tag = AbilityTag::PowerUp;
+        let json = serde_json::to_string(&tag).unwrap();
+        assert_eq!(serde_json::from_str::<AbilityTag>(&json).unwrap(), tag);
+        assert_eq!(tag.keyword_str(), "power-up");
+
+        // CR 500.7 + CR 514.2: new RestrictionExpiry temporal anchor.
+        let expiry = RestrictionExpiry::UntilEndOfNextTurnOf {
+            player: crate::types::player::PlayerId(1),
+        };
+        let json = serde_json::to_string(&expiry).unwrap();
+        assert_eq!(
+            serde_json::from_str::<RestrictionExpiry>(&json).unwrap(),
+            expiry
+        );
+
+        // CR 101.2 + CR 602.5: only_tag parameterization round-trips, and an
+        // omitted only_tag (legacy serialized state) defaults to None.
+        let activity = ProhibitedActivity::ActivateAbilities {
+            exemption: ActivationExemption::None,
+            only_tag: Some(AbilityTag::PowerUp),
+        };
+        let json = serde_json::to_string(&activity).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ProhibitedActivity>(&json).unwrap(),
+            activity
+        );
+        let legacy: ProhibitedActivity =
+            serde_json::from_str(r#"{"type":"ActivateAbilities","exemption":"None"}"#).unwrap();
+        assert_eq!(
+            legacy,
+            ProhibitedActivity::ActivateAbilities {
+                exemption: ActivationExemption::None,
+                only_tag: None,
+            }
+        );
+
+        // CR 106.6: tag-scoped mana-spend parser restriction round-trips.
+        let restriction = ManaSpendRestriction::ActivateTagged(AbilityTag::PowerUp);
+        let json = serde_json::to_string(&restriction).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ManaSpendRestriction>(&json).unwrap(),
+            restriction
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use super::ability::Comparator;
+use super::ability::{AbilityTag, Comparator};
 use super::events::GameEvent;
 use super::identifiers::ObjectId;
 use super::keywords::{Keyword, KeywordKind};
@@ -274,10 +274,12 @@ pub enum PaymentContext<'a> {
     /// Payment for a spell being cast — consult `allows_spell`.
     Spell(&'a SpellMeta),
     /// Payment for an activated ability — consult `allows_activation` using
-    /// the source permanent's core types and subtypes.
+    /// the source permanent's core types and subtypes plus the ability's
+    /// keyword tag (CR 106.6, for tag-scoped restrictions like Quinjet's).
     Activation {
         source_types: &'a [String],
         source_subtypes: &'a [String],
+        ability_tag: Option<AbilityTag>,
     },
     /// Payment for a cost during spell or ability resolution. Current
     /// restriction variants name spell-casting or ability-activation use, so
@@ -363,6 +365,11 @@ pub enum ManaRestriction {
     /// "Spend this mana only to activate abilities."
     /// Cannot be used for casting spells — activation-only.
     OnlyForActivation,
+    /// CR 106.6: "Spend this mana only to activate power-up abilities." Keyed on
+    /// the activating ability's keyword tag (Quinjet Technician), a distinct axis
+    /// from `OnlyForTypeSpellsOrAbilities` (which keys on the source permanent's
+    /// type) and `OnlyForActivation` (which permits any activation).
+    OnlyForTaggedActivation(AbilityTag),
     /// "Spend this mana only on costs that include {X}."
     /// Only permits spending on spells or abilities with {X} in their cost.
     OnlyForXCosts,
@@ -480,6 +487,8 @@ impl ManaRestriction {
             }
             // Activation-only mana cannot be used to cast spells.
             ManaRestriction::OnlyForActivation => false,
+            // CR 106.6: Tag-scoped activation mana cannot be used to cast spells.
+            ManaRestriction::OnlyForTaggedActivation(_) => false,
             // CR 106.6: X-cost restriction — conservatively disallow for spells.
             // Full X-cost detection requires ManaCost inspection at the call site.
             ManaRestriction::OnlyForXCosts => false,
@@ -534,7 +543,12 @@ impl ManaRestriction {
     /// on a permanent whose core types include `source_types` and subtypes include
     /// `source_subtypes`.
     /// CR 106.6: Used for "or activate abilities of creatures" restrictions.
-    pub fn allows_activation(&self, source_types: &[String], source_subtypes: &[String]) -> bool {
+    pub fn allows_activation(
+        &self,
+        source_types: &[String],
+        source_subtypes: &[String],
+        ability_tag: Option<AbilityTag>,
+    ) -> bool {
         match self {
             // Spell-only restrictions don't permit ability activation.
             ManaRestriction::OnlyForSpell
@@ -563,10 +577,15 @@ impl ManaRestriction {
             },
             // Activation-only mana always allows ability activation.
             ManaRestriction::OnlyForActivation => true,
+            // CR 106.6: Tag-scoped mana — payable only for an activation whose
+            // ability carries the matching keyword tag (Quinjet → power-up).
+            ManaRestriction::OnlyForTaggedActivation(required_tag) => {
+                ability_tag == Some(*required_tag)
+            }
             // CR 106.6: Disjunction — the activation is payable if any branch allows it.
             ManaRestriction::OnlyForAny(subs) => subs
                 .iter()
-                .any(|r| r.allows_activation(source_types, source_subtypes)),
+                .any(|r| r.allows_activation(source_types, source_subtypes, ability_tag)),
             // X-cost mana can be used for abilities with {X} in their cost.
             // TODO: Check if the ability has {X} in its cost once that data is available.
             ManaRestriction::OnlyForXCosts | ManaRestriction::ConvokePayment => false,
@@ -583,7 +602,8 @@ impl ManaRestriction {
             PaymentContext::Activation {
                 source_types,
                 source_subtypes,
-            } => self.allows_activation(source_types, source_subtypes),
+                ability_tag,
+            } => self.allows_activation(source_types, source_subtypes, *ability_tag),
             PaymentContext::Effect => false,
         }
     }
@@ -1645,9 +1665,17 @@ mod tests {
             },
         ]);
         // An Assassin source's ability is allowed via the second branch.
-        assert!(restriction.allows_activation(&["Creature".to_string()], &["Assassin".to_string()]));
+        assert!(restriction.allows_activation(
+            &["Creature".to_string()],
+            &["Assassin".to_string()],
+            None
+        ));
         // A non-Assassin source's ability is allowed by no branch.
-        assert!(!restriction.allows_activation(&["Creature".to_string()], &["Goblin".to_string()]));
+        assert!(!restriction.allows_activation(
+            &["Creature".to_string()],
+            &["Goblin".to_string()],
+            None
+        ));
     }
 
     // CR 106.6: "Spend this mana only to cast Ninja spells" (Turtle Lair, issue
@@ -1707,6 +1735,7 @@ mod tests {
         assert!(!restriction.allows(&PaymentContext::Activation {
             source_types: &source_types,
             source_subtypes: &source_subtypes,
+            ability_tag: None,
         }));
         assert!(!restriction.allows(&PaymentContext::Effect));
     }
@@ -1766,7 +1795,7 @@ mod tests {
         assert!(!restriction.allows_spell(&elf_creature));
         let source_types = vec!["Creature".to_string()];
         let source_subtypes = vec!["Elf".to_string()];
-        assert!(!restriction.allows_activation(&source_types, &source_subtypes));
+        assert!(!restriction.allows_activation(&source_types, &source_subtypes, None));
     }
 
     #[test]
@@ -1982,10 +2011,14 @@ mod tests {
         };
         let elemental_creature_types = vec!["Creature".to_string()];
         let elemental_subtypes = vec!["Elemental".to_string(), "Shaman".to_string()];
-        assert!(restriction.allows_activation(&elemental_creature_types, &elemental_subtypes));
+        assert!(restriction.allows_activation(
+            &elemental_creature_types,
+            &elemental_subtypes,
+            None
+        ));
 
         let goblin_subtypes = vec!["Goblin".to_string()];
-        assert!(!restriction.allows_activation(&elemental_creature_types, &goblin_subtypes));
+        assert!(!restriction.allows_activation(&elemental_creature_types, &goblin_subtypes, None));
 
         // Core-type match also satisfies the check (e.g., "Artifact sources").
         let artifact_restriction = ManaRestriction::OnlyForTypeSpellsOrAbilities {
@@ -1994,7 +2027,7 @@ mod tests {
         };
         let artifact_types = vec!["Artifact".to_string()];
         let no_subtypes: Vec<String> = vec![];
-        assert!(artifact_restriction.allows_activation(&artifact_types, &no_subtypes));
+        assert!(artifact_restriction.allows_activation(&artifact_types, &no_subtypes, None));
     }
 
     // CR 106.6: `AbilityActivationScope::Any` — "cast a colorless spell or to
@@ -2029,8 +2062,12 @@ mod tests {
         assert!(restriction.allows_spell(&colorless_spell));
         assert!(!restriction.allows_spell(&colored_spell));
         // Ability half: any activation is permitted, regardless of source type.
-        assert!(restriction.allows_activation(&["Goblin".to_string()], &[]));
-        assert!(restriction.allows_activation(&["Land".to_string()], &["Forest".to_string()]));
+        assert!(restriction.allows_activation(&["Goblin".to_string()], &[], None));
+        assert!(restriction.allows_activation(
+            &["Land".to_string()],
+            &["Forest".to_string()],
+            None
+        ));
     }
 
     #[test]
@@ -2066,10 +2103,12 @@ mod tests {
         assert!(restriction.allows(&PaymentContext::Activation {
             source_types: &artifact_types,
             source_subtypes: &no_subtypes,
+            ability_tag: None,
         }));
         assert!(!restriction.allows(&PaymentContext::Activation {
             source_types: &creature_types,
             source_subtypes: &no_subtypes,
+            ability_tag: None,
         }));
         assert!(!restriction.allows(&PaymentContext::Effect));
     }
@@ -2130,13 +2169,17 @@ mod tests {
         };
         let colorless_creature_types = vec!["Creature".to_string(), "Colorless".to_string()];
         let eldrazi_subtypes = vec!["Eldrazi".to_string()];
-        assert!(restriction.allows_activation(&colorless_creature_types, &eldrazi_subtypes));
+        assert!(restriction.allows_activation(&colorless_creature_types, &eldrazi_subtypes, None));
 
         let colored_creature_types = vec!["Creature".to_string()];
-        assert!(!restriction.allows_activation(&colored_creature_types, &eldrazi_subtypes));
+        assert!(!restriction.allows_activation(&colored_creature_types, &eldrazi_subtypes, None));
 
         let construct_subtypes = vec!["Construct".to_string()];
-        assert!(!restriction.allows_activation(&colorless_creature_types, &construct_subtypes));
+        assert!(!restriction.allows_activation(
+            &colorless_creature_types,
+            &construct_subtypes,
+            None
+        ));
     }
 
     #[test]
@@ -2260,7 +2303,7 @@ mod tests {
         };
         let source_types = vec!["Creature".to_string()];
         let source_subtypes: Vec<String> = vec![];
-        assert!(!restriction.allows_activation(&source_types, &source_subtypes));
+        assert!(!restriction.allows_activation(&source_types, &source_subtypes, None));
     }
 
     // CR 105.2 + CR 106.6: "Spend this mana only to cast spells with exactly N
@@ -2288,7 +2331,7 @@ mod tests {
         assert!(!restriction.allows_spell(&SpellMeta::default()));
         // CR 105.2: a color-count gate names spell casting, so it rejects ability
         // activation.
-        assert!(!restriction.allows_activation(&["Creature".to_string()], &[]));
+        assert!(!restriction.allows_activation(&["Creature".to_string()], &[], None));
     }
 
     // CR 105.2: colorless spells have a color count of 0, so "exactly 0 colors"
@@ -2393,7 +2436,7 @@ mod tests {
         // No recorded cast-from zone → ineligible.
         assert!(!restriction.allows_spell(&SpellMeta::default()));
         // Zone-gated spend is spell-casting only.
-        assert!(!restriction.allows_activation(&["Creature".to_string()], &[]));
+        assert!(!restriction.allows_activation(&["Creature".to_string()], &[], None));
     }
 
     #[test]

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -2614,7 +2614,7 @@ mod tests {
         // No recorded cast-from zone → ineligible (conservative).
         assert!(!restriction.allows_spell(&SpellMeta::default()));
         // Still spell-casting only — never permits ability activation.
-        assert!(!restriction.allows_activation(&["Creature".to_string()], &[]));
+        assert!(!restriction.allows_activation(&["Creature".to_string()], &[], None));
     }
 
     // CR 106.6 + CR 400.7: backward-compat for the zone-spend restriction. The

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -387,6 +387,7 @@ mod phantom_general_token_anthem;
 mod plaguecrafter_etb_class;
 mod ponder_decline_shuffle_regression;
 mod power_fist_combat_damage_regression;
+mod power_up_keyword;
 mod primo_unbounded_fractal_counters;
 mod proliferate_zero_counter;
 mod quirion_ranger_activation;

--- a/crates/engine/tests/integration/power_up_keyword.rs
+++ b/crates/engine/tests/integration/power_up_keyword.rs
@@ -1,0 +1,986 @@
+//! Runtime pipeline tests for the Power-up keyword mechanic (MSH/MSC).
+//!
+//! Power-up is a keyword-labeled activated ability (like Exhaust): `Power-up —
+//! {cost}: {effect}`, activatable only once per game, with its activation cost's
+//! generic reduced by the source's mana value if it entered this turn. These
+//! tests drive the real parse→activation pipeline (`add_creature_from_oracle`
+//! re-parses the Oracle text with the new parser; `GameRunner` drives `apply()`),
+//! and each carries a revert-failing assertion (not an AST-shape assertion).
+//!
+//! CR 602.5b (verified docs/MagicCompRules.txt:2541): activate only once.
+//! CR 602.2b + CR 601.2f + CR 302.6: cost reduced by source MV if it entered
+//! this turn.
+//! CR 106.6: tag-scoped mana spend restriction (Quinjet).
+//! CR 500.7 + CR 514.2: Kang's extra-turn power-up prohibition.
+//! CR 603.1b: Marvel Boy's dual-condition trigger.
+
+use engine::types::ability::AbilityTag;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaRestriction, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+
+/// Locate the index of the (only) power-up-tagged ability on `object`.
+fn power_up_index(runner: &GameRunner, object: ObjectId) -> usize {
+    runner.state().objects[&object]
+        .abilities
+        .iter()
+        .position(|a| a.ability_tag == Some(AbilityTag::PowerUp))
+        .expect("object must have a power-up-tagged ability (parser produced the tag)")
+}
+
+fn p1p1_on(runner: &GameRunner, object: ObjectId) -> u32 {
+    runner.state().objects[&object]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Replace `player`'s mana pool with `n` colorless units (no restrictions).
+fn refill_colorless(runner: &mut GameRunner, player: PlayerId, n: usize) {
+    let pool = &mut runner.state_mut().players[player.0 as usize].mana_pool;
+    pool.clear();
+    for _ in 0..n {
+        pool.add(ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Parses as a tagged activated ability + once-per-game enforcement.
+// ---------------------------------------------------------------------------
+
+/// CR 602.5b: a power-up ability may be activated only once per GAME. Activate a
+/// power-up, then attempt it again on a later turn → illegal.
+///
+/// Revert-failing assertion: the second `ActivateAbility` returns `Err`, and
+/// `activated_abilities_this_game` stays at 1. If the `OnlyOnce` push the parser
+/// adds is reverted, the ability is unrestricted and the second activation
+/// succeeds. (Per-turn `OnlyOnceEachTurn` would reset across turns; this is per
+/// game, so the later-turn retry is still rejected.)
+#[test]
+fn power_up_activates_only_once_per_game() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let hero = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Power Hero",
+            3,
+            3,
+            "Power-up — {2}: Put two +1/+1 counters on Power Hero.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let idx = power_up_index(&runner, hero);
+
+    refill_colorless(&mut runner, P0, 6);
+    runner.activate(hero, idx).resolve();
+    assert!(
+        p1p1_on(&runner, hero) >= 2,
+        "first power-up activation must land two +1/+1 counters"
+    );
+    assert_eq!(
+        runner
+            .state()
+            .activated_abilities_this_game
+            .get(&(hero, idx))
+            .copied(),
+        Some(1),
+        "the per-game activation counter must record exactly one activation"
+    );
+
+    // Advance through to a later turn (passing priority crosses turn boundaries),
+    // so a per-turn limit would have reset.
+    runner.advance_to_phase(Phase::End);
+    runner.advance_to_phase(Phase::Upkeep);
+    runner.advance_to_phase(Phase::PreCombatMain);
+    refill_colorless(&mut runner, P0, 6);
+
+    let retry = runner.act(GameAction::ActivateAbility {
+        source_id: hero,
+        ability_index: idx,
+    });
+    assert!(
+        retry.is_err(),
+        "a second power-up activation on a later turn must be illegal (once per game)"
+    );
+    assert_eq!(
+        runner
+            .state()
+            .activated_abilities_this_game
+            .get(&(hero, idx))
+            .copied(),
+        Some(1),
+        "the per-game counter must remain 1 after the rejected second activation"
+    );
+}
+
+/// Sibling/negative: a plain `Activate only once each turn` ability (no power-up
+/// tag) DOES reset across turns. Proves the per-game limit is specific to the
+/// `OnlyOnce` restriction the power-up parser pushes, not a global change.
+#[test]
+fn once_each_turn_ability_resets_across_turns() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let pinger = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Each-Turn Pinger",
+            2,
+            2,
+            "{2}: Put a +1/+1 counter on Each-Turn Pinger. Activate only once each turn.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let idx = pinger_index(&runner, pinger);
+
+    refill_colorless(&mut runner, P0, 4);
+    runner.activate(pinger, idx).resolve();
+    let after_first = p1p1_on(&runner, pinger);
+    assert!(after_first >= 1, "first activation lands a counter");
+
+    // A second activation on the SAME turn is rejected (once each turn).
+    refill_colorless(&mut runner, P0, 4);
+    let same_turn = runner.act(GameAction::ActivateAbility {
+        source_id: pinger,
+        ability_index: idx,
+    });
+    assert!(
+        same_turn.is_err(),
+        "a once-each-turn ability cannot be activated twice in the same turn"
+    );
+
+    // Simulate the per-turn reset that `start_next_turn` performs at a turn
+    // change (clearing `activated_abilities_this_turn`). P0 remains active and
+    // holds priority, so the retry exercises only the per-turn-limit reset — a
+    // per-game `OnlyOnce` ability would still be rejected after this reset.
+    runner.state_mut().activated_abilities_this_turn.clear();
+    refill_colorless(&mut runner, P0, 4);
+
+    let retry = runner.act(GameAction::ActivateAbility {
+        source_id: pinger,
+        ability_index: idx,
+    });
+    assert!(
+        retry.is_ok(),
+        "a once-each-turn ability must be activatable again after the per-turn counter resets"
+    );
+}
+
+fn pinger_index(runner: &GameRunner, object: ObjectId) -> usize {
+    use engine::types::ability::ActivationRestriction;
+    runner.state().objects[&object]
+        .abilities
+        .iter()
+        .position(|a| {
+            a.activation_restrictions
+                .contains(&ActivationRestriction::OnlyOnceEachTurn)
+        })
+        .expect("must have a once-each-turn ability")
+}
+
+// ---------------------------------------------------------------------------
+// 2. Entered-this-turn cost reduction (M3) — reduce generic by source MV.
+// ---------------------------------------------------------------------------
+
+/// CR 602.2b + CR 601.2f + CR 302.6: the power-up cost's generic is reduced by
+/// the source's mana value when it entered this turn. A creature with printed
+/// mana value 3 reduces a `{3}` power-up to `{0}` the entering turn.
+///
+/// Revert-failing assertion: with ZERO mana funded, the activation SUCCEEDS the
+/// entering turn (cost reduced to {0}) and lands its counters. If the
+/// `cost_reduction` field the parser sets is reverted, {3} is not reduced and
+/// the zero-mana activation fails.
+#[test]
+fn power_up_cost_reduced_by_source_mana_value_when_entered_this_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Printed mana value 3 ({1}{R}{R}); power-up costs {3}.
+    let hulk = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Mini Hulk",
+            4,
+            4,
+            "Power-up — {3}: Put three +1/+1 counters on Mini Hulk.",
+        )
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+            generic: 1,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    // Mark the creature as having entered THIS turn so the reduction gate holds.
+    let this_turn = runner.state().turn_number;
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&hulk)
+        .unwrap()
+        .entered_battlefield_turn = Some(this_turn);
+
+    let idx = power_up_index(&runner, hulk);
+    // Fund ZERO mana — the activation can only succeed if {3} is reduced to {0}.
+    runner.state_mut().players[P0.0 as usize].mana_pool.clear();
+
+    runner.activate(hulk, idx).resolve();
+    assert!(
+        p1p1_on(&runner, hulk) >= 3,
+        "power-up entering this turn must be free (cost reduced by MV 3 → {{0}}); \
+         the zero-mana activation must land its three counters"
+    );
+}
+
+/// Negative: a power-up source that entered a PRIOR turn gets NO reduction, so a
+/// zero-mana activation of a `{3}` power-up is rejected. Proves the reduction is
+/// gated on `SourceEnteredThisTurn`, not unconditional.
+#[test]
+fn power_up_cost_not_reduced_when_entered_prior_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let hulk = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Old Hulk",
+            4,
+            4,
+            "Power-up — {3}: Put three +1/+1 counters on Old Hulk.",
+        )
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+            generic: 1,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    // `add_creature` already set entered_battlefield_turn to a PRIOR turn; with
+    // zero mana the unreduced {3} cost cannot be paid.
+    runner.state_mut().players[P0.0 as usize].mana_pool.clear();
+    let idx = power_up_index(&runner, hulk);
+
+    let attempt = runner.act(GameAction::ActivateAbility {
+        source_id: hulk,
+        ability_index: idx,
+    });
+    assert!(
+        attempt.is_err(),
+        "a power-up that entered a prior turn gets no reduction; a zero-mana {{3}} \
+         activation must be rejected"
+    );
+    assert_eq!(
+        p1p1_on(&runner, hulk),
+        0,
+        "no counters land when the unreduced power-up cost is unaffordable"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Hulk static — reduces OTHER controlled power-up abilities by {3}.
+// ---------------------------------------------------------------------------
+
+/// CR 601.2f: Hulk's static reduces the power-up activation cost of OTHER
+/// creatures you control by {3}; it does NOT reduce Hulk's own (the "other"
+/// self-exclusion).
+///
+/// Revert-failing assertion: with exactly {3} funded, the OTHER creature's `{6}`
+/// power-up (reduced to {3}) is affordable and lands counters; remove Hulk and
+/// the same {3} no longer covers the unreduced {6}. The "Hulk's own unaffected"
+/// sibling is asserted by funding only {3} for Hulk's own {6} power-up → rejected.
+#[test]
+fn hulk_static_reduces_other_power_up_abilities() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let hulk = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Gamma Hulk",
+            5,
+            5,
+            "Power-up abilities of other creatures you control cost {3} less to activate.\n\
+             Power-up — {6}: Put five +1/+1 counters on Gamma Hulk.",
+        )
+        .id();
+    let ally = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Ally Hero",
+            2,
+            2,
+            "Power-up — {6}: Put two +1/+1 counters on Ally Hero.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let ally_idx = power_up_index(&runner, ally);
+
+    // Fund exactly {3}: only affordable if Hulk's static reduces the ally's {6}
+    // power-up by 3.
+    refill_colorless(&mut runner, P0, 3);
+    runner.activate(ally, ally_idx).resolve();
+    assert!(
+        p1p1_on(&runner, ally) >= 2,
+        "Hulk's static must reduce the ally's {{6}} power-up to {{3}}, making it affordable"
+    );
+
+    // Hulk's OWN power-up is NOT reduced ("other"): with only {3}, the {6} is
+    // unaffordable.
+    let hulk_idx = power_up_index(&runner, hulk);
+    refill_colorless(&mut runner, P0, 3);
+    let own = runner.act(GameAction::ActivateAbility {
+        source_id: hulk,
+        ability_index: hulk_idx,
+    });
+    assert!(
+        own.is_err(),
+        "Hulk's static excludes itself (\"other\"); its own {{6}} power-up is not reduced"
+    );
+}
+
+/// Revert anchor for the static: with NO Hulk on the battlefield, the ally's
+/// {6} power-up is unaffordable at {3}. Proves the reduction comes from the
+/// static, not a baseline change.
+#[test]
+fn power_up_without_hulk_static_is_not_reduced() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let ally = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Lone Hero",
+            2,
+            2,
+            "Power-up — {6}: Put two +1/+1 counters on Lone Hero.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let idx = power_up_index(&runner, ally);
+    refill_colorless(&mut runner, P0, 3);
+
+    let attempt = runner.act(GameAction::ActivateAbility {
+        source_id: ally,
+        ability_index: idx,
+    });
+    assert!(
+        attempt.is_err(),
+        "without Hulk's static, the {{6}} power-up is not reduced and {{3}} is insufficient"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Wonder Man static — raises the per-game power-up limit to 2.
+// ---------------------------------------------------------------------------
+
+/// CR 602.5b: Wonder Man's static lets each power-up ability of
+/// permanents you control be activated an ADDITIONAL time (per game cap 2).
+///
+/// Revert-failing assertion: with Wonder Man present, the ally activates its
+/// power-up TWICE; the third is illegal. Without the `effective_activation_limit_per_game`
+/// change (the `OnlyOnce` arm reverting to `== 0`), the second activation would
+/// already be rejected.
+#[test]
+fn wonder_man_static_raises_power_up_limit_to_two() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let _wonder = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Wonder Hero",
+            4,
+            4,
+            "Each power-up ability of permanents you control can be activated an additional time.",
+        )
+        .id();
+    let ally = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Buddy Hero",
+            2,
+            2,
+            "Power-up — {1}: Put a +1/+1 counter on Buddy Hero.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let idx = power_up_index(&runner, ally);
+
+    refill_colorless(&mut runner, P0, 2);
+    runner.activate(ally, idx).resolve();
+    refill_colorless(&mut runner, P0, 2);
+    // Second activation is legal because Wonder Man raised the cap to 2.
+    let second = runner.act(GameAction::ActivateAbility {
+        source_id: ally,
+        ability_index: idx,
+    });
+    assert!(
+        second.is_ok(),
+        "Wonder Man raises the per-game power-up cap to 2; the second activation must be legal"
+    );
+    runner.advance_until_stack_empty();
+
+    refill_colorless(&mut runner, P0, 2);
+    // Third activation exceeds the cap of 2.
+    let third = runner.act(GameAction::ActivateAbility {
+        source_id: ally,
+        ability_index: idx,
+    });
+    assert!(
+        third.is_err(),
+        "the third power-up activation exceeds the raised cap of 2"
+    );
+}
+
+/// Negative: Wonder Man's static keys on the "power-up" tag, so it does NOT
+/// raise the limit of a non-power-up `OnlyOnce` ability.
+#[test]
+fn wonder_man_does_not_raise_non_power_up_once_limit() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let _wonder = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Wonder Hero",
+            4,
+            4,
+            "Each power-up ability of permanents you control can be activated an additional time.",
+        )
+        .id();
+    // A non-power-up "activate only once" ability (e.g. an Exhaust-style line).
+    let other = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Exhaust Hero",
+            2,
+            2,
+            "Exhaust — {1}: Put a +1/+1 counter on Exhaust Hero.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    use engine::types::ability::ActivationRestriction;
+    let idx = runner.state().objects[&other]
+        .abilities
+        .iter()
+        .position(|a| {
+            a.ability_tag == Some(AbilityTag::Exhaust)
+                && a.activation_restrictions
+                    .contains(&ActivationRestriction::OnlyOnce)
+        })
+        .expect("must have an exhaust OnlyOnce ability");
+
+    refill_colorless(&mut runner, P0, 2);
+    runner.activate(other, idx).resolve();
+    refill_colorless(&mut runner, P0, 2);
+
+    let second = runner.act(GameAction::ActivateAbility {
+        source_id: other,
+        ability_index: idx,
+    });
+    assert!(
+        second.is_err(),
+        "Wonder Man's power-up-tagged static must not raise an exhaust OnlyOnce limit"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Quinjet mana restriction (M4/M5) — tag-scoped spend gate.
+// ---------------------------------------------------------------------------
+
+/// CR 106.6: mana with `OnlyForTaggedActivation(PowerUp)` pays a power-up
+/// activation but is rejected for a non-power-up activation. This drives the
+/// REAL activation pipeline (the threaded `PaymentContext::Activation.ability_tag`),
+/// not just `restriction.allows(...)`.
+///
+/// Revert-failing assertion: with ONLY tagged mana in the pool, the power-up
+/// activation succeeds (mana consumed, counter lands) but the non-power-up
+/// activation is rejected. If the tag threading through `pay_ability_mana_cost*`
+/// is reverted, the context tag is lost and the restricted mana would (wrongly)
+/// pay the non-power-up activation too.
+#[test]
+fn tagged_mana_pays_power_up_but_not_other_activations() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let hero = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Restricted Hero",
+            2,
+            2,
+            "Power-up — {1}: Put a +1/+1 counter on Restricted Hero.",
+        )
+        .id();
+    // A non-power-up activated ability funded by the same restricted mana.
+    let other = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Plain Pinger",
+            2,
+            2,
+            "{1}: Put a +1/+1 counter on Plain Pinger.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let power_idx = power_up_index(&runner, hero);
+
+    // The non-power-up activated ability index (no tag).
+    let other_idx = runner.state().objects[&other]
+        .abilities
+        .iter()
+        .position(|a| a.ability_tag.is_none() && a.cost.is_some())
+        .expect("plain pinger must have an untagged activated ability");
+
+    // Try to pay the non-power-up activation with ONLY power-up-restricted mana →
+    // rejected (the {R}{R} can't pay it).
+    set_tagged_mana(&mut runner, P0, 1);
+    let other_attempt = runner.act(GameAction::ActivateAbility {
+        source_id: other,
+        ability_index: other_idx,
+    });
+    assert!(
+        other_attempt.is_err(),
+        "power-up-restricted mana must not pay a non-power-up activation"
+    );
+
+    // The same restricted mana DOES pay the power-up activation.
+    set_tagged_mana(&mut runner, P0, 1);
+    runner.activate(hero, power_idx).resolve();
+    assert!(
+        p1p1_on(&runner, hero) >= 1,
+        "power-up-restricted mana must pay the power-up activation and land a counter"
+    );
+}
+
+fn set_tagged_mana(runner: &mut GameRunner, player: PlayerId, n: usize) {
+    let pool = &mut runner.state_mut().players[player.0 as usize].mana_pool;
+    pool.clear();
+    for _ in 0..n {
+        pool.add(ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
+            false,
+            vec![ManaRestriction::OnlyForTaggedActivation(
+                AbilityTag::PowerUp,
+            )],
+        ));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Marvel Boy trigger — fires on power-up activation only.
+// ---------------------------------------------------------------------------
+
+/// CR 602.1 + CR 603.1b: "whenever you activate a power-up ability" triggers.
+///
+/// Revert-failing assertion: activating a power-up ability puts a +1/+1 counter
+/// on Marvel Boy; activating a NON-power-up ability does not. If the trigger arm
+/// is reverted, the parser drops the condition and no counter ever lands.
+#[test]
+fn marvel_boy_triggers_only_on_power_up_activation() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let marvel = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Marvel Boy",
+            2,
+            2,
+            "Whenever you activate a power-up ability, put a +1/+1 counter on Marvel Boy.",
+        )
+        .id();
+    let hero = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Counter Hero",
+            2,
+            2,
+            "Power-up — {1}: Put a +1/+1 counter on Counter Hero.",
+        )
+        .id();
+    let plain = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Plain Hero",
+            2,
+            2,
+            "{1}: Put a +1/+1 counter on Plain Hero.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+
+    let before = p1p1_on(&runner, marvel);
+
+    // Activate the NON-power-up ability first: must NOT trigger Marvel Boy.
+    let plain_idx = runner.state().objects[&plain]
+        .abilities
+        .iter()
+        .position(|a| a.ability_tag.is_none() && a.cost.is_some())
+        .expect("plain hero has an untagged activated ability");
+    refill_colorless(&mut runner, P0, 1);
+    runner.activate(plain, plain_idx).resolve();
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        p1p1_on(&runner, marvel),
+        before,
+        "a non-power-up activation must NOT trigger Marvel Boy"
+    );
+
+    // Activate the power-up ability: Marvel Boy gains a counter.
+    let power_idx = power_up_index(&runner, hero);
+    refill_colorless(&mut runner, P0, 1);
+    runner.activate(hero, power_idx).resolve();
+    runner.advance_until_stack_empty();
+    assert!(
+        p1p1_on(&runner, marvel) > before,
+        "a power-up activation must trigger Marvel Boy (+1/+1 counter)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Kang prohibition (B1/B2) — blocks power-up throughout the extra turn.
+// ---------------------------------------------------------------------------
+
+/// Drive the real apply()/turn pipeline forward until the active player reaches
+/// `Phase::PreCombatMain` of turn number `target_turn`, declaring no
+/// attackers/blockers when combat opens. Crossing turns this way runs the
+/// untap-step arming (turns.rs converts `UntilEndOfNextTurnOf` → `EndOfTurn`)
+/// and the cleanup-step prune exactly as in production.
+fn advance_to_main_of_turn(runner: &mut GameRunner, target_turn: u32) {
+    for _ in 0..400 {
+        if runner.state().turn_number >= target_turn
+            && runner.state().phase == Phase::PreCombatMain
+            && matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+        {
+            return;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declare no attackers while advancing turns");
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("declare no blockers while advancing turns");
+            }
+            other => panic!(
+                "unexpected prompt advancing to turn {target_turn}: {other:?} \
+                 (phase={:?}, turn={})",
+                runner.state().phase,
+                runner.state().turn_number,
+            ),
+        }
+    }
+    panic!(
+        "failed to reach PreCombatMain of turn {target_turn} (now turn {}, phase {:?})",
+        runner.state().turn_number,
+        runner.state().phase,
+    );
+}
+
+/// CR 500.7 + CR 514.2 + CR 602.5: Kang's "during that turn, power-up abilities
+/// can't be activated" scopes the prohibition to the GRANTED EXTRA TURN ONLY. The
+/// restriction is created pre-armed (`UntilEndOfNextTurnOf`) when Kang resolves on
+/// turn N, must stay DORMANT for the rest of turn N, arms (converts to
+/// `EndOfTurn`) at the extra turn's untap step, blocks power-up throughout that
+/// turn, then is pruned at the extra turn's cleanup.
+///
+/// This drives the full resolve→extra-turn→post-extra-turn pipeline. Discriminating
+/// (revert-failing) assertion: on the CREATION turn a controller-side power-up
+/// ability is STILL LEGAL — under the buggy "active on creation turn" reading
+/// (expiry discarded in `is_blocked_by_cant_activate_abilities`) it would be
+/// wrongly rejected. The extra-turn block and post-extra-turn expiry confirm the
+/// arming/pruning lifecycle.
+#[test]
+fn kang_prohibits_power_up_during_extra_turn_only() {
+    use engine::types::ability::{GameRestriction, ProhibitedActivity, RestrictionExpiry};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let kang = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Kang",
+            3,
+            3,
+            "Power-up — {1}: Put a +1/+1 counter on Kang. Take an extra turn after this one. \
+             During that turn, power-up abilities can't be activated.",
+        )
+        .id();
+    // `hero` exercises the creation-turn dormancy (activated on turn N); `hero2`
+    // is reserved (never consumed) so the extra-turn block and post-expiry
+    // legality are caused by the prohibition alone, not the once-per-game limit.
+    let hero = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Extra Hero",
+            2,
+            2,
+            "Power-up — {1}: Put a +1/+1 counter on Extra Hero.",
+        )
+        .id();
+    let hero2 = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Reserve Hero",
+            2,
+            2,
+            "Power-up — {1}: Put a +1/+1 counter on Reserve Hero.",
+        )
+        .id();
+    // Untagged ability — must stay legal even while the power-up prohibition is
+    // armed (only_tag scoping).
+    let plain = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Plain Hero",
+            2,
+            2,
+            "{1}: Put a +1/+1 counter on Plain Hero.",
+        )
+        .id();
+
+    // CR 104.3c / 704.5c: stock both libraries so neither player decks out (and
+    // ends the game) while this test advances P0 through Kang's granted extra turn
+    // and on to P0's following turn — the multi-turn advance crosses several draw
+    // steps, which would otherwise trigger a draw-from-empty loss before the
+    // post-expiry assertion is reached.
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Forest");
+        scenario.add_card_to_library_top(P1, "Forest");
+    }
+
+    let mut runner = scenario.build();
+    assert_eq!(
+        runner.state().active_player,
+        P0,
+        "Kang's controller must be the active player for the extra-turn test"
+    );
+    let kang_idx = power_up_index(&runner, kang);
+
+    refill_colorless(&mut runner, P0, 1);
+    runner.activate(kang, kang_idx).resolve();
+    runner.advance_until_stack_empty();
+
+    let creation_turn = runner.state().turn_number;
+
+    // Kang granted P0 an extra turn and added a power-up-scoped, pre-armed
+    // prohibition.
+    assert!(
+        runner.state().extra_turns.contains(&P0),
+        "Kang must grant its controller an extra turn"
+    );
+    let prohibition_is_prearmed = runner.state().restrictions.iter().any(|r| {
+        matches!(
+            r,
+            GameRestriction::ProhibitActivity {
+                activity: ProhibitedActivity::ActivateAbilities {
+                    only_tag: Some(AbilityTag::PowerUp),
+                    ..
+                },
+                expiry: RestrictionExpiry::UntilEndOfNextTurnOf { .. },
+                ..
+            }
+        )
+    });
+    assert!(
+        prohibition_is_prearmed,
+        "Kang must add a power-up-scoped prohibition that is pre-armed \
+         (UntilEndOfNextTurnOf) on the creation turn"
+    );
+
+    // === Step 1 (revert-failing): on the creation turn the prohibition is
+    // DORMANT, so a controller-side power-up ability is STILL LEGAL. The buggy
+    // reading (expiry discarded) would reject this.
+    let hero_idx = power_up_index(&runner, hero);
+    refill_colorless(&mut runner, P0, 1);
+    let creation_turn_attempt = runner.act(GameAction::ActivateAbility {
+        source_id: hero,
+        ability_index: hero_idx,
+    });
+    assert!(
+        creation_turn_attempt.is_ok(),
+        "power-up must remain legal on the CREATION turn — Kang's prohibition is \
+         scoped to the extra turn only (pre-armed, not yet in force)"
+    );
+    runner.advance_until_stack_empty();
+
+    // === Step 2: enter the granted extra turn (N+1). Its untap step arms the
+    // prohibition (converts to EndOfTurn); power-up is now BLOCKED throughout.
+    advance_to_main_of_turn(&mut runner, creation_turn + 1);
+    assert_eq!(
+        runner.state().active_player,
+        P0,
+        "the turn after Kang's must be P0's granted extra turn"
+    );
+    let hero2_idx = power_up_index(&runner, hero2);
+    refill_colorless(&mut runner, P0, 1);
+    let extra_turn_attempt = runner.act(GameAction::ActivateAbility {
+        source_id: hero2,
+        ability_index: hero2_idx,
+    });
+    assert!(
+        extra_turn_attempt.is_err(),
+        "power-up must be blocked during the granted extra turn (prohibition armed)"
+    );
+
+    // Sibling/negative: an untagged ability is unaffected by the power-up-only
+    // prohibition, even while it is armed during the extra turn.
+    let plain_idx = runner.state().objects[&plain]
+        .abilities
+        .iter()
+        .position(|a| a.ability_tag.is_none() && a.cost.is_some())
+        .expect("plain hero has an untagged ability");
+    refill_colorless(&mut runner, P0, 1);
+    let plain_attempt = runner.act(GameAction::ActivateAbility {
+        source_id: plain,
+        ability_index: plain_idx,
+    });
+    assert!(
+        plain_attempt.is_ok(),
+        "a non-power-up activation must remain legal under a power-up-only prohibition"
+    );
+    runner.advance_until_stack_empty();
+
+    // === Step 3: the prohibition is pruned at the extra turn's cleanup. By P0's
+    // next turn (N+3) it has expired and power-up is legal again.
+    advance_to_main_of_turn(&mut runner, creation_turn + 3);
+    assert_eq!(
+        runner.state().active_player,
+        P0,
+        "should be back on a P0 turn two turns after the extra turn"
+    );
+    let prohibition_remains = runner.state().restrictions.iter().any(|r| {
+        matches!(
+            r,
+            GameRestriction::ProhibitActivity {
+                activity: ProhibitedActivity::ActivateAbilities {
+                    only_tag: Some(AbilityTag::PowerUp),
+                    ..
+                },
+                ..
+            }
+        )
+    });
+    assert!(
+        !prohibition_remains,
+        "the power-up prohibition must be pruned at the extra turn's cleanup"
+    );
+    refill_colorless(&mut runner, P0, 1);
+    let post_expiry_attempt = runner.act(GameAction::ActivateAbility {
+        source_id: hero2,
+        ability_index: hero2_idx,
+    });
+    assert!(
+        post_expiry_attempt.is_ok(),
+        "power-up must be legal again once Kang's prohibition has expired"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Kang skipped-extra-turn arming-leak edge (FIX 3) — documented known leak.
+// ---------------------------------------------------------------------------
+
+/// FIX 3 (documented narrow edge): the arming conversion fires only at the
+/// granted turn's untap step. If that turn is SKIPPED before its untap step, the
+/// `UntilEndOfNextTurnOf` restriction is never converted to `EndOfTurn` and never
+/// pruned — it wrongly persists. This test records the KNOWN LEAK as a regression
+/// anchor for a future shared robust-arming fix (it asserts the leak EXISTS, so
+/// it will start failing once the edge is fixed, prompting an update).
+#[test]
+fn kang_skipped_extra_turn_leaks_prohibition_known_edge() {
+    use engine::types::ability::{
+        GameRestriction, ProhibitedActivity, RestrictionExpiry, RestrictionPlayerScope,
+    };
+    use engine::types::statics::ActivationExemption;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let _filler = scenario.add_creature(P0, "Filler", 1, 1).id();
+    let mut runner = scenario.build();
+
+    // Inject the pre-armed prohibition keyed to P0, as Kang's lowering would after
+    // granting P0 an extra turn. The arming conversion only fires at P0's untap
+    // step (when `player == active`). If the granted P0 turn is skipped/prevented,
+    // that untap never runs, so the restriction is never converted/pruned.
+    runner
+        .state_mut()
+        .restrictions
+        .push(GameRestriction::ProhibitActivity {
+            source: ObjectId(0),
+            affected_players: RestrictionPlayerScope::AllPlayers,
+            expiry: RestrictionExpiry::UntilEndOfNextTurnOf { player: P0 },
+            activity: ProhibitedActivity::ActivateAbilities {
+                exemption: ActivationExemption::None,
+                only_tag: Some(AbilityTag::PowerUp),
+            },
+        });
+
+    // Simulate the OPPONENT's (P1's) untap step running while the restriction is
+    // keyed to P0 — exactly the "skipped P0 extra turn" condition (no P0 untap
+    // runs). The untap pre-pass converts only matching `player == active`, so a
+    // P1 untap must NOT arm P0's restriction.
+    runner.state_mut().active_player = P1;
+    let mut events = Vec::new();
+    engine::game::turns::execute_untap_with_choices(
+        runner.state_mut(),
+        &mut events,
+        &std::collections::HashSet::new(),
+    );
+
+    // KNOWN LEAK: the restriction is still present, un-armed (still
+    // `UntilEndOfNextTurnOf`, not converted to `EndOfTurn`), because no untap step
+    // matching `player: P0` ran.
+    let still_present = runner.state().restrictions.iter().any(|r| {
+        matches!(
+            r,
+            GameRestriction::ProhibitActivity {
+                expiry: RestrictionExpiry::UntilEndOfNextTurnOf { player },
+                ..
+            } if *player == P0
+        )
+    });
+    assert!(
+        still_present,
+        "documented edge: when the granted extra turn's untap never runs, the \
+         un-armed prohibition persists (remove this assertion once robust arming \
+         is implemented and convert it to assert the restriction is gone)"
+    );
+}

--- a/crates/engine/tests/restricted_mana_not_from_zone.rs
+++ b/crates/engine/tests/restricted_mana_not_from_zone.rs
@@ -64,7 +64,7 @@ fn rejects_spell_with_unknown_origin() {
 #[test]
 fn never_allows_ability_activation() {
     // CR 106.6: zone-gated spend is spell-casting only.
-    assert!(!not_from_hand_restriction().allows_activation(&["Artifact".to_string()], &[]));
+    assert!(!not_from_hand_restriction().allows_activation(&["Artifact".to_string()], &[], None));
 }
 
 /// Drive the REAL mana-payment route: `ManaPool::spend_for` with


### PR DESCRIPTION
Adds the Power-up labeled activated-ability mechanic (Marvel Super Heroes):
- AbilityTag::PowerUp on the existing labeled-ability subsystem
- once-per-game activation limit (CR 602.5b) with ModifyActivationLimit statics
  raising it (Wonder Man) and a per-game OnlyOnce restriction
- cost reduction by source mana value when it entered this turn (Hulk)
- ManaRestriction::OnlyForTaggedActivation for power-up-only mana (Quinjet)
- ProhibitedActivity::ActivateAbilities { only_tag } + RestrictionExpiry::
  UntilEndOfNextTurnOf for Kang's 'during that turn' prohibition, created
  pre-armed and converted to EndOfTurn at the granted turn's untap step so it
  stays dormant on the creation turn (CR 514.2 / CR 500.7)
- HUD status-view seam suppresses the badge while the prohibition is dormant,
  agreeing with the activation gate

Covers Kang, Hulk (Gamma Goliath), Wonder Man, Marvel Boy, Nick Fury, Quinjet
Technician, Jack of Hearts. 14 discriminating integration tests.
