### PR TITLE
feat(data): release-gate to hide configured sets from the preview card pool

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,17 @@ jobs:
     timeout-minutes: 30
     outputs:
       card_data_filename: ${{ steps.card-data-hash.outputs.filename }}
+    env:
+      # Release-gate: Marvel Super Heroes (MSH/MSC/TMSH) are implemented in the
+      # engine but must NOT be playable or visible on the preview/staging site
+      # until release (2026-06-26). GATED_SETS makes the data generators drop
+      # these sets from the deployed card pool: card-data.json (deck search +
+      # gameplay), set-list.json (set pickers / draft UI), and draft-pools.json
+      # (draftable sets). Reprint-aware — a card also printed in a non-gated set
+      # stays available. Local dev is unaffected (GATED_SETS is unset there).
+      # TO UNLOCK ON RELEASE: delete this `GATED_SETS` line (or set it empty) and
+      # re-run the deploy.
+      GATED_SETS: MSH,MSC,TMSH
     steps:
       - uses: actions/checkout@v4
         with:

--- a/crates/draft-core/src/bin/draft_pool_gen.rs
+++ b/crates/draft-core/src/bin/draft_pool_gen.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::process;
 
 use draft_core::extraction::extract_all_set_pools;
+use engine::database::set_gating;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -25,13 +26,25 @@ fn main() {
         process::exit(1);
     }
 
-    let pools = match extract_all_set_pools(&sets_dir) {
+    let mut pools = match extract_all_set_pools(&sets_dir) {
         Ok(p) => p,
         Err(e) => {
             eprintln!("Error extracting set pools: {e}");
             process::exit(1);
         }
     };
+
+    // Release-gate: drop gated sets so they can't be drafted. No-op when
+    // GATED_SETS is unset/empty. See `engine::database::set_gating`.
+    let gated_sets = set_gating::gated_sets_from_env();
+    if !gated_sets.is_empty() {
+        let before = pools.len();
+        pools.retain(|code, _| !set_gating::is_set_gated(code, &gated_sets));
+        eprintln!(
+            "Set gating active: excluded {} draftable set(s)",
+            before - pools.len()
+        );
+    }
 
     if pools.is_empty() {
         eprintln!(

--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -9,7 +9,7 @@ use engine::database::mtgjson::{load_atomic_cards, AtomicCard, Ruling, SetFile};
 use engine::database::synthesis::{
     build_oracle_face, build_oracle_face_multi, layout_faces, map_layout, LayoutKind,
 };
-use engine::database::{BracketLists, BracketSignals, CardDatabase};
+use engine::database::{set_gating, BracketLists, BracketSignals, CardDatabase};
 use engine::game::coverage::{
     audit_semantic, card_face_has_unimplemented_parts, format_semantic_audit_markdown,
 };
@@ -869,6 +869,23 @@ fn main() {
         }
     }
 
+    // Release-gate: drop cards available ONLY through gated sets (reprint-aware).
+    // No-op when GATED_SETS is unset/empty. See `database::set_gating`.
+    let gated_sets = set_gating::gated_sets_from_env();
+    if !gated_sets.is_empty() {
+        let before = face_index.len();
+        face_index.retain(|_, entry| !set_gating::is_card_gated(&entry.printings, &gated_sets));
+        eprintln!(
+            "Set gating active ({}): excluded {} card face(s) available only via gated sets",
+            {
+                let mut codes: Vec<&str> = gated_sets.iter().map(String::as_str).collect();
+                codes.sort_unstable();
+                codes.join(",")
+            },
+            before - face_index.len()
+        );
+    }
+
     let json = serde_json::to_string(&face_index).expect("Failed to serialize card data");
     if let Some(ref out_path) = output {
         std::fs::write(out_path, &json)
@@ -1112,9 +1129,13 @@ fn run_set_list(remaining_args: &[String]) {
     let raw: SetListFile = serde_json::from_str(&contents)
         .unwrap_or_else(|e| panic!("Failed to parse {}: {e}", input.display()));
 
+    // Release-gate: hide gated sets from the picker / draft / deck-builder UIs.
+    // No-op when GATED_SETS is unset/empty. See `database::set_gating`.
+    let gated_sets = set_gating::gated_sets_from_env();
     let projected: BTreeMap<String, SetListEntry> = raw
         .data
         .into_iter()
+        .filter(|s| !set_gating::is_set_gated(&s.code, &gated_sets))
         .map(|s| {
             (
                 s.code.clone(),

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -11,6 +11,7 @@ pub mod meld;
 pub mod mtgjson;
 pub mod oracle_loader;
 pub mod search;
+pub mod set_gating;
 pub mod synthesis;
 pub mod unearth;
 

--- a/crates/engine/src/database/set_gating.rs
+++ b/crates/engine/src/database/set_gating.rs
@@ -1,0 +1,154 @@
+//! Release-gate for hiding configured Magic sets from the playable card pool.
+//!
+//! A single environment variable, `GATED_SETS` (comma-separated set codes,
+//! case-insensitive), is read at card-data / set-list / draft-pool *generation*
+//! time. When unset or empty, gating is a no-op and the generated artifacts are
+//! identical to ungated builds — existing builds are unaffected.
+//!
+//! To gate a set before release, generate with `GATED_SETS=MSH,MSC,TMSH`. To
+//! unlock on release, regenerate without the variable. There are no hardcoded
+//! set codes here: the codes come only from the environment.
+//!
+//! This is data-pipeline tooling, not game-rules logic, so no Comprehensive
+//! Rules annotations apply.
+
+use std::collections::HashSet;
+
+/// Name of the environment variable that lists gated set codes.
+pub const GATED_SETS_ENV: &str = "GATED_SETS";
+
+/// Parse `GATED_SETS` into an uppercased set of set codes.
+///
+/// Empty/unset → empty set (no gating). Whitespace around each code is trimmed
+/// and empty entries are dropped, so `"MSH, MSC ,"` yields `{MSH, MSC}`. Codes
+/// are uppercased for case-insensitive comparison against MTGJSON set codes.
+pub fn gated_sets_from_env() -> HashSet<String> {
+    parse_gated_sets(&std::env::var(GATED_SETS_ENV).unwrap_or_default())
+}
+
+/// Parse a raw comma-separated string into an uppercased set of set codes.
+///
+/// Factored out from [`gated_sets_from_env`] so the parsing logic is unit
+/// testable without mutating process environment.
+pub fn parse_gated_sets(raw: &str) -> HashSet<String> {
+    raw.split(',')
+        .map(|code| code.trim().to_uppercase())
+        .filter(|code| !code.is_empty())
+        .collect()
+}
+
+/// Whether a single set code should be hidden from set-list / draft-pool output.
+///
+/// Comparison is case-insensitive; `gated` is expected to already be uppercased
+/// (as produced by [`parse_gated_sets`]).
+pub fn is_set_gated(code: &str, gated: &HashSet<String>) -> bool {
+    !gated.is_empty() && gated.contains(&code.to_uppercase())
+}
+
+/// Reprint-aware predicate: should this card be dropped from the playable pool?
+///
+/// A card is gated only when **every** set it has been printed in is gated —
+/// i.e. it is obtainable exclusively through gated sets (a new card for the
+/// gated set). A card that is also printed in any non-gated set (a reprint such
+/// as Divine Visitation) is always kept: gating a set must never ban a card
+/// that is legally available elsewhere.
+///
+/// A card with no recorded printings is never gated (there is no gated printing
+/// to key off, and dropping it would be a silent data-loss surprise).
+pub fn is_card_gated(printings: &[String], gated: &HashSet<String>) -> bool {
+    if gated.is_empty() || printings.is_empty() {
+        return false;
+    }
+    printings
+        .iter()
+        .all(|set| gated.contains(&set.to_uppercase()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(codes: &[&str]) -> HashSet<String> {
+        codes.iter().map(|c| c.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_empty_yields_empty_set() {
+        assert!(parse_gated_sets("").is_empty());
+        assert!(parse_gated_sets("   ").is_empty());
+        assert!(parse_gated_sets(",, ,").is_empty());
+    }
+
+    #[test]
+    fn parse_trims_uppercases_and_filters_blanks() {
+        assert_eq!(
+            parse_gated_sets("MSH,MSC, TMSH"),
+            set(&["MSH", "MSC", "TMSH"])
+        );
+    }
+
+    #[test]
+    fn parse_is_case_insensitive() {
+        assert_eq!(parse_gated_sets("msh, Msc"), set(&["MSH", "MSC"]));
+    }
+
+    #[test]
+    fn set_gating_is_noop_when_unset() {
+        let gated = set(&[]);
+        assert!(!is_set_gated("MSH", &gated));
+    }
+
+    #[test]
+    fn set_gating_matches_case_insensitively() {
+        let gated = set(&["MSH", "MSC"]);
+        assert!(is_set_gated("msh", &gated));
+        assert!(is_set_gated("MSH", &gated));
+        assert!(!is_set_gated("DOM", &gated));
+    }
+
+    #[test]
+    fn card_gated_when_all_printings_gated() {
+        let gated = set(&["MSH", "MSC", "TMSH"]);
+        assert!(is_card_gated(
+            &["MSH".to_string(), "MSC".to_string()],
+            &gated
+        ));
+    }
+
+    #[test]
+    fn card_kept_when_reprinted_in_non_gated_set() {
+        let gated = set(&["MSH", "MSC", "TMSH"]);
+        // Divine Visitation-style reprint: gated set + a legal Standard set.
+        assert!(!is_card_gated(
+            &["MSH".to_string(), "DOM".to_string()],
+            &gated
+        ));
+    }
+
+    #[test]
+    fn card_kept_when_no_gated_printing() {
+        let gated = set(&["MSH", "MSC", "TMSH"]);
+        assert!(!is_card_gated(
+            &["DOM".to_string(), "M21".to_string()],
+            &gated
+        ));
+    }
+
+    #[test]
+    fn card_kept_when_no_printings_recorded() {
+        let gated = set(&["MSH"]);
+        assert!(!is_card_gated(&[], &gated));
+    }
+
+    #[test]
+    fn card_never_gated_when_env_empty() {
+        let gated = set(&[]);
+        assert!(!is_card_gated(&["MSH".to_string()], &gated));
+    }
+
+    #[test]
+    fn card_gating_is_case_insensitive() {
+        let gated = set(&["MSH"]);
+        assert!(is_card_gated(&["msh".to_string()], &gated));
+    }
+}


### PR DESCRIPTION
Adds a GATED_SETS env-var release-gate so a set's cards can be implemented in
the engine but kept off the deployed/preview site until release. New
database::set_gating module (single authority): gated_sets_from_env() +
reprint-aware is_card_gated(printings) (a card is gated only if ALL its
printings are gated — a card also printed in a non-gated set stays available)
+ is_set_gated(code). Applied at three generation chokepoints:
- card-data.json (oracle-gen main) — the deck-search + gameplay card pool
- set-list.json (oracle-gen set-list) — set pickers / draft UI
- draft-pools.json (draft-pool-gen) — draftable sets
Unset/empty GATED_SETS is a no-op (backward compatible; local dev unaffected).
deploy.yml activates it for staging with GATED_SETS=MSH,MSC,TMSH (Marvel Super
Heroes), gated until release; unlock by removing that env line and re-deploying.
Functionally verified: set-list drops MSH/MSC with the env set, keeps them without.

Note: coverage-data.json is derived from the gated card pool, so the public
preview coverage dashboard also hides gated sets while active (local coverage,
with GATED_SETS unset, is unaffected).
