### PR TITLE
fix(parser): scale cost reduction by domain ('for each basic land type')

### DIFF
--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -2582,6 +2582,47 @@ mod tests {
         );
     }
 
+    /// CR 305.6 + CR 601.2f: domain-scaled cost reduction — "costs {N} less to
+    /// activate/cast for each basic land type among lands you control" — must
+    /// resolve to the `BasicLandTypeCount` (domain) quantity. Covers Jodah's
+    /// Codex / Wandering Treefolk / Radha's Firebrand (activate) and Scion of
+    /// Draco (cast). Regression for the previously-dropped `for each` domain arm.
+    #[test]
+    fn cost_reduction_for_each_basic_land_type_is_domain() {
+        use crate::types::ability::{ControllerRef, QuantityRef};
+
+        // Activated-ability form (Jodah's Codex, Wandering Treefolk).
+        let activate = try_parse_cost_reduction(
+            "this ability costs {1} less to activate for each basic land type among lands you control",
+        )
+        .expect("domain cost reduction (activate) should parse");
+        assert_eq!(activate.amount_per, 1);
+        assert_eq!(activate.condition, None);
+        assert_eq!(
+            activate.count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::BasicLandTypeCount {
+                    controller: ControllerRef::You,
+                },
+            },
+        );
+
+        // Spell form (Scion of Draco).
+        let cast = try_parse_cost_reduction(
+            "this spell costs {2} less to cast for each basic land type among lands you control",
+        )
+        .expect("domain cost reduction (cast) should parse");
+        assert_eq!(cast.amount_per, 2);
+        assert_eq!(
+            cast.count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::BasicLandTypeCount {
+                    controller: ControllerRef::You,
+                },
+            },
+        );
+    }
+
     /// #3223: the self cost-reduction *head* recognizer matches both the bare
     /// sentence and a sentence carrying a trailing "if [condition]" tail; it
     /// rejects unrelated effect sentences. Drives the upstream

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2535,9 +2535,8 @@ fn parse_basic_land_types_among_lands_controlled_by_ref(
     let (rest, _) = tag(" among lands ").parse(rest)?;
     let (rest, controller) = alt((
         value(ControllerRef::You, tag("you control")),
-        // CR 109.5: "they control" binds to the caller-supplied controller — the
-        // iterating/scoped player inside a `for each` clause (`ScopedPlayer`), or
-        // an anaphoric target player in a "the number of …" reference.
+        // The caller supplies the anaphoric "they control" binding: the iterating
+        // player inside a `for each` clause, or a target player in "the number of …".
         value(they_controller, tag("they control")),
     ))
     .parse(rest)?;
@@ -2548,8 +2547,8 @@ fn parse_basic_land_types_among_lands_controlled_by_ref(
 fn parse_basic_land_type_count(input: &str) -> OracleResult<'_, QuantityRef> {
     preceded(
         tag("the number of "),
-        // CR 109.5: anaphoric "the number of basic land types among lands they
-        // control" binds "they" to a target player (not a for-each scope here).
+        // In a quantity reference, anaphoric "they control" binds to a target
+        // player rather than a `for each` scoped player.
         |i| parse_basic_land_types_among_lands_controlled_by_ref(i, ControllerRef::TargetPlayer),
     )
     .parse(input)
@@ -2765,7 +2764,7 @@ fn parse_for_each_clause_ref_with_they_controller(
         // Scion of Draco). Reuses the shared bare-domain-suffix combinator and
         // must precede the generic `<type> you control` arm so the leading
         // "basic land type" is not mis-consumed as a creature/permanent type.
-        // CR 109.5: "they control" binds to the iterating/scoped player here.
+        // Anaphoric "they control" binds to the iterating/scoped player here.
         |i| parse_basic_land_types_among_lands_controlled_by_ref(i, they_controller.clone()),
         parse_for_each_controlled_type,
         // CR 201.2: "for each [other] <type> named <CardName> you control"
@@ -6904,10 +6903,9 @@ mod tests {
         );
         assert_eq!(rest, "");
 
-        // CR 109.5: inside a `for each` clause, "they control" binds to the
-        // iterating/scoped player (the default `they_controller`), NOT a target
-        // player — so per-player/per-opponent domain reducers count the right
-        // player's lands.
+        // Inside a `for each` clause, "they control" binds to the iterating/scoped
+        // player (the default `they_controller`), NOT a target player — so
+        // per-player/per-opponent domain reducers count the right player's lands.
         let (_, q_they) =
             parse_for_each_clause_ref_complete("basic land type among lands they control").unwrap();
         assert_eq!(

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2753,6 +2753,12 @@ fn parse_for_each_clause_ref_with_they_controller(
         // Placed before `parse_for_each_controlled_type` so the bare "counter" token
         // does not commit to a type-phrase fallback.
         parse_for_each_counters_on_source,
+        // CR 305.6: "for each basic land type among lands you/they control" —
+        // domain scaling (Jodah's Codex, Wandering Treefolk, Radha's Firebrand,
+        // Scion of Draco). Reuses the shared bare-domain-suffix combinator and
+        // must precede the generic `<type> you control` arm so the leading
+        // "basic land type" is not mis-consumed as a creature/permanent type.
+        parse_basic_land_types_among_lands_controlled_by_ref,
         parse_for_each_controlled_type,
         // CR 201.2: "for each [other] <type> named <CardName> you control"
         // (Seven Dwarves). The `named X` qualifier sits between the type word
@@ -6871,6 +6877,34 @@ mod tests {
             }
         );
         assert_eq!(rest, "");
+    }
+
+    /// CR 305.6 + CR 601.2f: domain must be reachable through the `for each`
+    /// clause path (not just `parse_quantity_ref`), so domain-scaled cost
+    /// reducers — "costs {1} less to activate for each basic land type among
+    /// lands you control" (Jodah's Codex, Wandering Treefolk, Scion of Draco) —
+    /// resolve their reduction quantity instead of dropping to `Unimplemented`.
+    #[test]
+    fn parse_for_each_clause_ref_handles_domain() {
+        let (rest, q) =
+            parse_for_each_clause_ref_complete("basic land type among lands you control").unwrap();
+        assert_eq!(
+            q,
+            QuantityRef::BasicLandTypeCount {
+                controller: ControllerRef::You,
+            }
+        );
+        assert_eq!(rest, "");
+
+        // "they control" controller axis (e.g. an opponent-scoped reducer).
+        let (_, q_they) =
+            parse_for_each_clause_ref_complete("basic land type among lands they control").unwrap();
+        assert_eq!(
+            q_they,
+            QuantityRef::BasicLandTypeCount {
+                controller: ControllerRef::TargetPlayer,
+            }
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -636,8 +636,9 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         parse_target_life_ref,
         parse_basic_land_type_count,
         // Bare suffix form — reachable when a parent combinator has already
-        // consumed "there are N " (see `parse_there_are_conditions`).
-        parse_basic_land_types_among_lands_controlled_by_ref,
+        // consumed "there are N " (see `parse_there_are_conditions`). Anaphoric
+        // "they control" binds to a target player here (not a for-each scope).
+        |i| parse_basic_land_types_among_lands_controlled_by_ref(i, ControllerRef::TargetPlayer),
         parse_devotion_ref,
         parse_counters_among_ref,
         // CR 402.1: "the player with the {most|fewest} cards in hand" — the
@@ -2527,13 +2528,17 @@ fn parse_target_life_ref(input: &str) -> OracleResult<'_, QuantityRef> {
 /// appears after "for each"; the plural form appears after "the number of".
 fn parse_basic_land_types_among_lands_controlled_by_ref(
     input: &str,
+    they_controller: ControllerRef,
 ) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = tag("basic land type").parse(input)?;
     let (rest, _) = opt(tag("s")).parse(rest)?;
     let (rest, _) = tag(" among lands ").parse(rest)?;
     let (rest, controller) = alt((
         value(ControllerRef::You, tag("you control")),
-        value(ControllerRef::TargetPlayer, tag("they control")),
+        // CR 109.5: "they control" binds to the caller-supplied controller — the
+        // iterating/scoped player inside a `for each` clause (`ScopedPlayer`), or
+        // an anaphoric target player in a "the number of …" reference.
+        value(they_controller, tag("they control")),
     ))
     .parse(rest)?;
     Ok((rest, QuantityRef::BasicLandTypeCount { controller }))
@@ -2543,7 +2548,9 @@ fn parse_basic_land_types_among_lands_controlled_by_ref(
 fn parse_basic_land_type_count(input: &str) -> OracleResult<'_, QuantityRef> {
     preceded(
         tag("the number of "),
-        parse_basic_land_types_among_lands_controlled_by_ref,
+        // CR 109.5: anaphoric "the number of basic land types among lands they
+        // control" binds "they" to a target player (not a for-each scope here).
+        |i| parse_basic_land_types_among_lands_controlled_by_ref(i, ControllerRef::TargetPlayer),
     )
     .parse(input)
 }
@@ -2758,7 +2765,8 @@ fn parse_for_each_clause_ref_with_they_controller(
         // Scion of Draco). Reuses the shared bare-domain-suffix combinator and
         // must precede the generic `<type> you control` arm so the leading
         // "basic land type" is not mis-consumed as a creature/permanent type.
-        parse_basic_land_types_among_lands_controlled_by_ref,
+        // CR 109.5: "they control" binds to the iterating/scoped player here.
+        |i| parse_basic_land_types_among_lands_controlled_by_ref(i, they_controller.clone()),
         parse_for_each_controlled_type,
         // CR 201.2: "for each [other] <type> named <CardName> you control"
         // (Seven Dwarves). The `named X` qualifier sits between the type word
@@ -6896,13 +6904,16 @@ mod tests {
         );
         assert_eq!(rest, "");
 
-        // "they control" controller axis (e.g. an opponent-scoped reducer).
+        // CR 109.5: inside a `for each` clause, "they control" binds to the
+        // iterating/scoped player (the default `they_controller`), NOT a target
+        // player — so per-player/per-opponent domain reducers count the right
+        // player's lands.
         let (_, q_they) =
             parse_for_each_clause_ref_complete("basic land type among lands they control").unwrap();
         assert_eq!(
             q_they,
             QuantityRef::BasicLandTypeCount {
-                controller: ControllerRef::TargetPlayer,
+                controller: ControllerRef::ScopedPlayer,
             }
         );
     }


### PR DESCRIPTION
Fixes #3945.

## What

"Domain â€”" cost reducers that scale by domain â€” **"costs {N} less to activate/cast for each basic land type among lands you control"** â€” were dropping to `Unimplemented`. The for-each clause parser (`parse_for_each_clause_ref`) had no domain arm, so no for-each context could reference domain.

Cards fixed (confirmed against Scryfall):

- **Jodah's Codex** â€” "Domain â€” {5}, {T}: Draw a card. This ability costs {1} less to activate for each basic land type among lands you control."
- **Wandering Treefolk** â€” "Domain â€” {7}{G}: Seek a creature card. This ability costs {1} less to activate for each basic land type among lands you control."
- **Radha's Firebrand** (+ Alchemy `A-`) â€” activated ability costs {1} less per domain.
- **Llanowar Greenwidow** (Alchemy `A-`) â€” activated ability costs {1} less per domain.
- **Scion of Draco** â€” "Domain â€” This spell costs {2} less to cast for each basic land type among lands you control." (spell-cost form; its cost reduction now parses â€” the separate multi-color conditional keyword-grant line on the card remains an unrelated gap.)

## How

`QuantityRef::BasicLandTypeCount` (domain, CR 305.6) and its phrase combinator `parse_basic_land_types_among_lands_controlled_by_ref` ("basic land type[s] among lands you/they control") already existed â€” the combinator's own doc comment even notes *"The singular form appears after 'for each'"* â€” but it was never wired into the `parse_for_each_clause_ref` alternation. This adds that one arm, placed **before** the generic `<type> you control` arm so the leading "basic land type" is not mis-consumed as a creature/permanent type.

No new effect, quantity, or runtime code: the domain quantity's resolver (`resolve_quantity_with_targets` â†’ distinct basic land types among the controller's lands) and the cost-reduction application (`apply_cost_reduction`) already exist. This is a pure parser-composition fix that unlocks domain in **every** for-each context (cost reduction now; draw/counters/damage "for each basic land type" for free).

## Verification

- New unit tests:
  - `parse_for_each_clause_ref_handles_domain` â€” the for-each clause parser yields `BasicLandTypeCount` for both the "you control" and "they control" controller axes.
  - `cost_reduction_for_each_basic_land_type_is_domain` â€” the production cost-reduction parser (`try_parse_cost_reduction`) yields `CostReduction { count: BasicLandTypeCount(You) }` for both the activate form (`{1}` less) and the cast form (`{2}` less, Scion of Draco).
- All pre-existing domain tests (runtime `domain_counts_distinct_basic_land_types`, etc.) still pass.
- Regenerated `card-data.json` (whole-DB unimplemented count drops 3309 â†’ 3304): Jodah's Codex, Wandering Treefolk, Radha's Firebrand (+ Alchemy `A-`), and A-Llanowar Greenwidow now carry the `BasicLandTypeCount` cost reduction and are fully implemented; Scion of Draco's cost reduction now resolves too (its unrelated keyword-grant line is the only remaining `Unimplemented` part).
- `cargo fmt`, the parser-combinator gate, and `clippy -D warnings` (engine + phase-ai) are green.

## CR

CR 305.6 (basic land types / domain), CR 601.2f (activation cost reduction), CR 118.7 (cost reduction floors at {0}).
