### PR TITLE
feat(engine): MSH Wave 1 — Connive trigger + play-from-exile (4 cards)

### DIFF
--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -108,9 +108,12 @@ pub fn resolve(
         ReplacementResult::Execute(_) => {}
         ReplacementResult::Prevented => {
             // Draw was prevented — skip the discard step
+            // CR 701.50b + CR 701.50c: the EffectResolved carries the CONNIVER's
+            // id (LKI if it left the battlefield) so "whenever a creature you
+            // control connives" matches the conniving permanent, not the source.
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::Connive,
-                source_id: ability.source_id,
+                source_id: conniver_id,
             });
             return Ok(());
         }
@@ -153,9 +156,12 @@ pub fn resolve(
         return Ok(());
     }
 
+    // CR 701.50b + CR 701.50c: the EffectResolved carries the CONNIVER's id (LKI
+    // if it left the battlefield) so "whenever a creature you control connives"
+    // matches the conniving permanent, not the causing source.
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::Connive,
-        source_id: ability.source_id,
+        source_id: conniver_id,
     });
     Ok(())
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2245,7 +2245,7 @@ pub(super) fn handle_resolution_choice(
             WaitingFor::ConniveDiscard {
                 player,
                 conniver_id,
-                source_id,
+                source_id: _,
                 cards,
                 count,
             },
@@ -2286,9 +2286,12 @@ pub(super) fn handle_resolution_choice(
             };
 
             effects::connive::add_connive_counters(state, conniver_id, nonland_count, events);
+            // CR 701.50b + CR 701.50c: the EffectResolved carries the CONNIVER's
+            // id (LKI if it left the battlefield) so "whenever a creature you
+            // control connives" matches the conniving permanent, not the source.
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::Connive,
-                source_id,
+                source_id: conniver_id,
             });
             ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
         }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -398,6 +398,7 @@ pub(crate) fn keys_from_trigger_def(def: &TriggerDefinition) -> (Keys, bool) {
         TriggerMode::Explored => push(TriggerEventKey::Explored),
         TriggerMode::Discover => push(TriggerEventKey::DiscoverResolved),
         TriggerMode::Adapt => push(TriggerEventKey::AdaptResolved),
+        TriggerMode::Connives => push(TriggerEventKey::ConniveResolved),
         TriggerMode::Exerted => push(TriggerEventKey::Exerted),
         TriggerMode::Enlisted => push(TriggerEventKey::Enlisted),
         TriggerMode::Foretell => push(TriggerEventKey::Foretold),
@@ -680,6 +681,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         EffectKind::Explore => push(TriggerEventKey::Explored),
         EffectKind::Discover => push(TriggerEventKey::DiscoverResolved),
         EffectKind::Adapt => push(TriggerEventKey::AdaptResolved),
+        EffectKind::Connive => push(TriggerEventKey::ConniveResolved),
         EffectKind::Renown => push(TriggerEventKey::Renowned),
         EffectKind::Monstrosity => push(TriggerEventKey::BecomesMonstrous),
         EffectKind::ManifestDread => push(TriggerEventKey::ManifestDreadResolved),
@@ -771,7 +773,6 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::Choose
         | EffectKind::ChooseDamageSource
         | EffectKind::Suspect
-        | EffectKind::Connive
         | EffectKind::PhaseOut
         | EffectKind::PhaseIn
         | EffectKind::ForceBlock

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -44,6 +44,7 @@ pub fn trigger_matcher(mode: TriggerMode) -> Option<TriggerMatcher> {
         TriggerMode::Enlisted => match_enlisted,
         TriggerMode::Discover => match_discover,
         TriggerMode::Adapt => match_adapt,
+        TriggerMode::Connives => match_connives,
         TriggerMode::Foretell => match_foretell,
         TriggerMode::DamagePreventedOnce => match_unimplemented,
         TriggerMode::AttackersDeclared | TriggerMode::AttackersDeclaredOneTarget => {
@@ -419,6 +420,7 @@ pub fn build_trigger_registry() -> HashMap<TriggerMode, TriggerMatcher> {
 
     r.insert(TriggerMode::Discover, match_discover);
     r.insert(TriggerMode::Adapt, match_adapt);
+    r.insert(TriggerMode::Connives, match_connives);
     r.insert(TriggerMode::Foretell, match_foretell);
     r.insert(TriggerMode::Enlisted, match_enlisted);
     // CR 702.26b: Phasing triggers fire when a permanent phases out.
@@ -2402,8 +2404,21 @@ pub(super) fn match_play_card(
     source_id: ObjectId,
     state: &GameState,
 ) -> bool {
-    match_spell_cast(event, trigger, source_id, state)
-        || match_land_played(event, trigger, source_id, state)
+    if match_spell_cast(event, trigger, source_id, state) {
+        return true;
+    }
+    // CR 601.1a + CR 305.1: the land-play half honors the same play-origin
+    // constraint the cast half routes through `spell_cast_origin`. The shared
+    // `PlayCard` def can't carry the origin on `valid_card` (the cast half's
+    // spell is on the stack at fire time, not its play origin), so the land
+    // half consults `spell_cast_origin` directly here. `Any` → matches every
+    // origin → plain "play a land" triggers are unaffected.
+    if let GameEvent::LandPlayed { from_zone, .. } = event {
+        if !trigger.spell_cast_origin.matches_from(&Some(*from_zone)) {
+            return false;
+        }
+    }
+    match_land_played(event, trigger, source_id, state)
 }
 
 pub(super) fn match_mana_added(
@@ -2900,6 +2915,30 @@ pub(super) fn match_adapt(
         valid_card_matches(trigger, state, *adapted_id, source_id)
     } else {
         *adapted_id == source_id
+    }
+}
+
+/// CR 701.50b: Connives — fires when a permanent connives.
+/// `valid_card` scopes the CONNIVER (the permanent that connived). With no
+/// filter, this is "this creature connives" — match the source by identity
+/// (Ultron's self-connive).
+pub(super) fn match_connives(
+    event: &GameEvent,
+    trigger: &TriggerDefinition,
+    source_id: ObjectId,
+    state: &GameState,
+) -> bool {
+    let GameEvent::EffectResolved {
+        kind: EffectKind::Connive,
+        source_id: conniver_id,
+    } = event
+    else {
+        return false;
+    };
+    if trigger.valid_card.is_some() {
+        valid_card_matches(trigger, state, *conniver_id, source_id)
+    } else {
+        *conniver_id == source_id
     }
 }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7287,6 +7287,8 @@ fn try_parse_event(
         Exploits,
         /// CR 701.44b: A permanent "explores" after the explore process completes.
         Explores,
+        /// CR 701.50b: A permanent "connives" after the connive process completes.
+        Connives,
         /// CR 702.100b: A creature "evolves" when +1/+1 counters are put on it
         /// as a result of its evolve ability resolving.
         Evolves,
@@ -7441,6 +7443,9 @@ fn try_parse_event(
             // CR 701.44b: "explores" / "explore" — explore trigger
             value(SimpleEvent::Explores, tag("explores")),
             value(SimpleEvent::Explores, tag("explore")),
+            // CR 701.50b: "connives" — connive trigger (fires after the connive
+            // process completes).
+            value(SimpleEvent::Connives, tag("connives")),
             // CR 702.100b: "evolves" / "evolve" — evolve trigger
             value(SimpleEvent::Evolves, tag("evolves")),
             value(SimpleEvent::Evolves, tag("evolve")),
@@ -7598,6 +7603,15 @@ fn try_parse_event(
                 }
                 // CR 701.44b: "explores" fires after the explore process completes.
                 def.mode = TriggerMode::Explored;
+                def.valid_card = Some(subject.clone());
+            }
+            SimpleEvent::Connives => {
+                if !remaining.trim().is_empty() {
+                    return None;
+                }
+                // CR 701.50b: "connives" fires after the connive process completes.
+                // `subject` ("a creature you control" / "~") scopes the conniver.
+                def.mode = TriggerMode::Connives;
                 def.valid_card = Some(subject.clone());
             }
             SimpleEvent::Evolves => {
@@ -9978,10 +9992,15 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
     // both via `match_play_card`. Matched before the land-play arm; the
     // "a card" object cannot match the land-play helper's "a land"/"another land"
     // object, so neither shadows the other.
-    if parse_play_card_trigger_subject(lower).is_some() {
+    if let Some(origin) = parse_play_card_trigger_subject(lower) {
         let mut def = make_base();
         def.mode = TriggerMode::PlayCard;
         def.valid_target = Some(TargetFilter::Controller);
+        // CR 601.1a + CR 400.1: the cast half honors the play origin via
+        // `spell_cast_origin`; `match_play_card` gates the land half on the same
+        // constraint. `Any` (no "from <zone>" tail) preserves plain play-card
+        // triggers unchanged.
+        def.spell_cast_origin = origin;
         return Some((TriggerMode::PlayCard, def));
     }
 
@@ -12491,13 +12510,15 @@ fn is_land_play_filter(tf: &TypedFilter) -> bool {
 /// (Recycle, Null Profusion, Jinxed Ring).
 ///
 /// Decomposed into axes (prefix × verb × object) via nom combinators, mirroring
-/// `parse_land_play_trigger_subject`. Returns `Some(())` when the full
-/// "you play a card" subject is present and is followed only by end-of-input or
-/// the effect comma (so "you play a card from your graveyard" does not match).
+/// `parse_land_play_trigger_subject`. Returns `Some(OriginConstraint)` when the
+/// full "you play a card" subject is present, capturing an optional `from <zone>`
+/// tail: "you play a card from exile" yields an exile-origin constraint, while
+/// bare "you play a card" yields the unrestricted (`Any`) origin. The subject
+/// must be followed only by end-of-input, the effect comma, or that zone tail.
 /// Restricted to the exact second-person bare-card form. Qualified variants
 /// such as "a player plays a card exiled with ~" need additional linked-card
 /// filtering before they can safely share this parser arm.
-fn parse_play_card_trigger_subject(lower: &str) -> Option<()> {
+fn parse_play_card_trigger_subject(lower: &str) -> Option<OriginConstraint> {
     let (after_prefix, _) = alt((
         tag::<_, _, OracleError<'_>>("whenever "),
         tag::<_, _, OracleError<'_>>("when "),
@@ -12513,13 +12534,20 @@ fn parse_play_card_trigger_subject(lower: &str) -> Option<()> {
     let (after_card, _) = tag::<_, _, OracleError<'_>>("a card")
         .parse(after_verb)
         .ok()?;
+    // CR 601.1a + CR 400.1: An optional "from <zone>" tail restricts the play
+    // origin ("whenever you play a card from exile"). The shared cast-origin
+    // combinator consumes the "from " prefix and the zone phrase; absent a
+    // "from" clause it returns `Any` (plain "whenever you play a card"). This
+    // mirrors the Rocco, Street Chef cast-from-zone shape.
+    let (after_origin, origin) =
+        parse_origin_constraint_tail(after_card.trim_start(), parse_cast_origin_zone).ok()?;
     // The subject must be the whole condition: either end-of-input, or the
     // effect comma ("..., draw a card.") follows directly. `eof` / `tag(",")`
     // reject any further qualifier text.
     alt((value((), eof), value((), tag::<_, _, OracleError<'_>>(","))))
-        .parse(after_card)
+        .parse(after_origin.trim_start())
         .ok()?;
-    Some(())
+    Some(origin)
 }
 
 /// CR 725.1: Parse "whenever/when [subject] become(s) the monarch" trigger.

--- a/crates/engine/src/types/triggers.rs
+++ b/crates/engine/src/types/triggers.rs
@@ -158,6 +158,9 @@ pub enum TriggerEventKey {
     DiscoverResolved,
     /// CR 701.46a: An adapt resolution.
     AdaptResolved,
+    /// CR 701.50b: A permanent connived (the connive process — draw, discard,
+    /// maybe +1/+1 — completed).
+    ConniveResolved,
     /// CR 701.43d: A creature was exerted.
     Exerted,
     /// CR 702.154c: A creature enlisted another creature.
@@ -428,6 +431,9 @@ pub enum TriggerMode {
     // Adapt / amass / learn / venture
     /// CR 701.46: Triggers when a creature adapts.
     Adapt,
+    /// CR 701.50b: Triggers when a permanent connives (after the connive process
+    /// completes).
+    Connives,
     /// CR 702.143: Triggers when a card is foretold.
     Foretell,
     /// CR 701.16: Triggers when a player investigates.
@@ -593,6 +599,7 @@ impl FromStr for TriggerMode {
             "ClassLevelGained" => TriggerMode::ClassLevelGained,
             "CommitCrime" => TriggerMode::CommitCrime,
             "ConjureAll" => TriggerMode::ConjureAll,
+            "Connives" => TriggerMode::Connives,
             "CollectEvidence" => TriggerMode::CollectEvidence,
             "CounterAdded" => TriggerMode::CounterAdded,
             "CounterAddedOnce" => TriggerMode::CounterAddedOnce,
@@ -862,6 +869,7 @@ mod tests {
             "ClassLevelGained",
             "CommitCrime",
             "ConjureAll",
+            "Connives",
             "CollectEvidence",
             "CounterAdded",
             "CounterAddedOnce",
@@ -996,8 +1004,8 @@ mod tests {
             }
         }
         assert!(
-            known_count >= 146,
-            "Expected 146+ known trigger modes, got {known_count}"
+            known_count >= 147,
+            "Expected 147+ known trigger modes, got {known_count}"
         );
     }
 }

--- a/crates/engine/tests/connive_trigger_msh_wave1.rs
+++ b/crates/engine/tests/connive_trigger_msh_wave1.rs
@@ -1,0 +1,218 @@
+//! MSH Wave 1 — `TriggerMode::Connives` ("whenever [subject] connives").
+//!
+//! Building-block coverage for the connive-payoff class: Glorious Purpose, Iron
+//! Monger (Sadistic Tycoon), and Ultron, Unlimited all carry a "whenever a
+//! creature you control connives" / self-connive trigger. These cards are not in
+//! the local test fixture (MSH is release-gated), so the tests drive the real
+//! parser + trigger pipeline through representative Oracle text.
+//!
+//! CR 701.50b: a permanent "connives" after the connive process completes; the
+//! `EffectResolved { kind: Connive }` event must carry the CONNIVER's id (CR
+//! 701.50c LKI), not the causing source — otherwise "whenever a creature you
+//! control connives" is evaluated against the wrong object.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::GameScenario;
+use engine::game::triggers::process_triggers;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, ResolvedAbility, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+/// Parse a connive activated ability ("{T}: Target creature you control
+/// connives.") and return its definition, for re-targeting at an arbitrary
+/// conniver from an arbitrary source.
+fn connive_def() -> engine::types::ability::AbilityDefinition {
+    let parsed = parse_oracle_text(
+        "{T}: Target creature you control connives.",
+        "Connive Source",
+        &[],
+        &["Artifact".to_string()],
+        &[],
+    );
+    parsed
+        .abilities
+        .iter()
+        .find(|a| matches!(a.effect.as_ref(), Effect::Connive { .. }))
+        .expect("must parse a Connive activated ability")
+        .clone()
+}
+
+/// Drive priority until the stack empties (resolving the connive payoff
+/// trigger). Stops at the first non-priority wait so the turn does not advance.
+fn drain_priority(runner: &mut engine::game::scenario::GameRunner) {
+    let mut guard = 0;
+    while !runner.state().stack.is_empty() {
+        guard += 1;
+        assert!(guard < 60, "stack did not drain");
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+/// Glorious Purpose class + the CR 701.50c conviver-id fix (load-bearing).
+///
+/// A creature you control connives, caused by an EXTERNAL source whose own
+/// characteristics do NOT satisfy the watcher's "a creature you control" filter
+/// (here: an opponent's creature). The watcher must fire because the event
+/// carries the CONNIVER's id, not the source's.
+///
+/// Revert-failing assertion: with the pre-fix `source_id: ability.source_id`,
+/// the `EffectResolved` carries the opponent's source id, the watcher filter
+/// "a creature you control" rejects it, and no life is gained.
+#[test]
+fn connive_watcher_fires_on_external_conniver_via_conniver_id() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    // One nonland card so the connive draw + auto-discard completes without a
+    // discard prompt (empty hand → draw 1 → discard 1).
+    scenario.with_library_top(P0, &["Lib A"]);
+
+    // Watcher: "whenever a creature you control connives, you gain 2 life."
+    scenario.add_creature_from_oracle(
+        P0,
+        "Glorious Watcher",
+        2,
+        2,
+        "Whenever a creature you control connives, you gain 2 life.",
+    );
+    // The conniver — a plain creature you control.
+    let conniver = scenario.add_creature(P0, "Conniver", 2, 2).id();
+    // External source: an OPPONENT's creature (a creature, but not yours).
+    let external_source = scenario.add_creature(P1, "Opponent Source", 1, 1).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let life_before = runner.life(P0);
+
+    // Resolve a connive on `conniver` whose ability source is the opponent's
+    // creature and whose controller is P0 (so P0 draws/discards).
+    let def = connive_def();
+    let ability = ResolvedAbility {
+        targets: vec![TargetRef::Object(conniver)],
+        ..build_resolved_from_def(&def, external_source, P0)
+    };
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("connive must resolve");
+
+    process_triggers(runner.state_mut(), &events);
+    drain_priority(&mut runner);
+
+    assert_eq!(
+        runner.life(P0),
+        life_before + 2,
+        "watcher must fire on the CONNIVER (a creature you control), gaining 2 life — \
+         pre-fix the event carried the opponent source id and no life was gained"
+    );
+}
+
+/// Negative case: an OPPONENT's creature connives. "a creature you control" must
+/// reject it — no life gained.
+#[test]
+fn connive_watcher_ignores_opponent_conniver() {
+    let mut scenario = GameScenario::new_n_player(2, 9);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P1, &["Lib A"]);
+
+    scenario.add_creature_from_oracle(
+        P0,
+        "Glorious Watcher",
+        2,
+        2,
+        "Whenever a creature you control connives, you gain 2 life.",
+    );
+    // The conniver is the OPPONENT's creature.
+    let opp_conniver = scenario.add_creature(P1, "Opp Conniver", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let life_before = runner.life(P0);
+
+    let def = connive_def();
+    // Controller P1 (the opponent) drives the connive on their own creature.
+    let ability = ResolvedAbility {
+        targets: vec![TargetRef::Object(opp_conniver)],
+        ..build_resolved_from_def(&def, opp_conniver, P1)
+    };
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("connive must resolve");
+
+    process_triggers(runner.state_mut(), &events);
+    drain_priority(&mut runner);
+
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "an opponent's conniver must not trigger 'a creature you control connives'"
+    );
+}
+
+/// Ultron, Unlimited class — self-connive trigger ("whenever ~ connives"). The
+/// no-filter identity branch of `match_connives` (`*conniver_id == source_id`)
+/// is exercised when the watcher and the conniver are the same permanent.
+#[test]
+fn connive_self_trigger_fires_for_the_conniving_source() {
+    let mut scenario = GameScenario::new_n_player(2, 11);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Lib A"]);
+
+    // Self-referential connive payoff: "whenever ~ connives, you gain 2 life."
+    let ultron = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Ultron Self",
+            3,
+            3,
+            "Whenever this creature connives, you gain 2 life.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let life_before = runner.life(P0);
+
+    // Ultron connives itself (source == conniver).
+    let def = connive_def();
+    let ability = ResolvedAbility {
+        targets: vec![TargetRef::Object(ultron)],
+        ..build_resolved_from_def(&def, ultron, P0)
+    };
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("connive must resolve");
+
+    process_triggers(runner.state_mut(), &events);
+    drain_priority(&mut runner);
+
+    assert_eq!(
+        runner.life(P0),
+        life_before + 2,
+        "a permanent's self-connive must fire its own 'whenever ~ connives' trigger"
+    );
+}

--- a/crates/engine/tests/klaw_play_from_exile_trigger_msh_wave1.rs
+++ b/crates/engine/tests/klaw_play_from_exile_trigger_msh_wave1.rs
@@ -1,0 +1,160 @@
+//! MSH Wave 1 — Klaw, Master of Sound: "Whenever you play a card from exile, …".
+//!
+//! `PlayCard` triggers now accept an optional `from <zone>` origin tail. Klaw is
+//! not in the local fixture (MSH is release-gated), so this drives the real
+//! parser + trigger matcher through representative Oracle text.
+//!
+//! "Play a card" = cast a spell OR play a land (CR 601.1a). The cast half routes
+//! the origin through `spell_cast_origin` (already runtime-honored by
+//! `match_spell_cast`, exercised by Rocco, Street Chef). This test pins the LAND
+//! half: `match_play_card` gates `LandPlayed` events on the same
+//! `spell_cast_origin` constraint (CR 305.1). One test exercises both the parser
+//! (D.2 — capturing `from exile`) and the matcher gate (D.3):
+//!   * Revert D.2 (origin stays `Any`) ⇒ the hand-play case fires ⇒ assertion fails.
+//!   * Revert D.3 (no land-half gate)  ⇒ the hand-play case fires ⇒ assertion fails.
+
+use engine::game::scenario::GameScenario;
+use engine::game::triggers::process_triggers;
+use engine::game::zones::create_object;
+use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::CardId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+const KLAW_ORACLE: &str = "Whenever you play a card from exile, you gain 2 life.";
+
+fn drain_priority(runner: &mut engine::game::scenario::GameRunner) {
+    let mut guard = 0;
+    while !runner.state().stack.is_empty() {
+        guard += 1;
+        assert!(guard < 60, "stack did not drain");
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+/// Play a land FROM EXILE ⇒ Klaw fires (gain 2 life).
+#[test]
+fn klaw_fires_on_land_played_from_exile() {
+    let mut scenario = GameScenario::new_n_player(2, 13);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Klaw, Master of Sound", 2, 3, KLAW_ORACLE);
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let land = create_object(
+        runner.state_mut(),
+        CardId(50_000),
+        P0,
+        "Some Land".to_string(),
+        Zone::Battlefield,
+    );
+
+    let life_before = runner.life(P0);
+    let events = vec![GameEvent::LandPlayed {
+        object_id: land,
+        player_id: P0,
+        from_zone: Zone::Exile,
+    }];
+    process_triggers(runner.state_mut(), &events);
+    drain_priority(&mut runner);
+
+    assert_eq!(
+        runner.life(P0),
+        life_before + 2,
+        "playing a land from exile must fire 'whenever you play a card from exile'"
+    );
+}
+
+/// Play a land FROM HAND ⇒ Klaw does NOT fire. This is the discriminating
+/// negative: without the parser origin capture (D.2) or the land-half origin
+/// gate (D.3), this hand play would also fire.
+#[test]
+fn klaw_does_not_fire_on_land_played_from_hand() {
+    let mut scenario = GameScenario::new_n_player(2, 17);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Klaw, Master of Sound", 2, 3, KLAW_ORACLE);
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let land = create_object(
+        runner.state_mut(),
+        CardId(50_001),
+        P0,
+        "Some Land".to_string(),
+        Zone::Battlefield,
+    );
+
+    let life_before = runner.life(P0);
+    let events = vec![GameEvent::LandPlayed {
+        object_id: land,
+        player_id: P0,
+        from_zone: Zone::Hand,
+    }];
+    process_triggers(runner.state_mut(), &events);
+    drain_priority(&mut runner);
+
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "playing a land from hand must NOT fire the from-exile trigger"
+    );
+}
+
+/// Negative: an OPPONENT playing a land from exile must not fire Klaw
+/// (`valid_target = Controller`).
+#[test]
+fn klaw_does_not_fire_on_opponent_land_from_exile() {
+    let mut scenario = GameScenario::new_n_player(2, 19);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Klaw, Master of Sound", 2, 3, KLAW_ORACLE);
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let land = create_object(
+        runner.state_mut(),
+        CardId(50_002),
+        P1,
+        "Opp Land".to_string(),
+        Zone::Battlefield,
+    );
+
+    let life_before = runner.life(P0);
+    let events = vec![GameEvent::LandPlayed {
+        object_id: land,
+        player_id: P1,
+        from_zone: Zone::Exile,
+    }];
+    process_triggers(runner.state_mut(), &events);
+    drain_priority(&mut runner);
+
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "an opponent playing a land from exile must not fire Klaw (controller-scoped)"
+    );
+}


### PR DESCRIPTION
Cluster A (Connive trigger): emit the connive EffectResolved event stamped with
the conniving creature (conniver_id) instead of the causing ability's source_id
at all 3 sites — the Adapt/Explore convention the matcher relies on (CR 701.50b/c
LKI). Zero-regression: nothing consumed the event before (no-op arm of
trigger_index). New TriggerMode::Connives + TriggerEventKey::ConniveResolved
(siblings of Explores/Evolves), dual-registered, with a nom 'whenever [subject]
connives' parser arm. Unlocks Glorious Purpose, Iron Monger, Ultron.

Cluster D (Klaw, Master of Sound): 'whenever you play a card from exile' routes
the from-zone qualifier through spell_cast_origin (cast half) + an OriginConstraint
gate on the land half inside match_play_card, without touching valid_card InZone.
matches_from(Any)=true keeps plain land-play / landfall triggers unaffected.

Loki (becomes-target-of-ability) deferred to a focused follow-up. 6 discriminating
pipeline tests.
