### PR TITLE
feat(engine): once-per-turn top-of-library cast permission (Assemble the Players, Johann)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2355,6 +2355,7 @@ pub(crate) fn top_of_library_permission_source(
             active_static_definitions(state, obj).find_map(|s| match &s.mode {
                 StaticMode::TopOfLibraryCastPermission {
                     play_mode,
+                    frequency,
                     alt_cost,
                 } => {
                     // Gate by play_mode: Cast permissions cover only spells;
@@ -2367,6 +2368,16 @@ pub(crate) fn top_of_library_permission_source(
                         Some(CardPlayMode::Cast) => true,
                     };
                     if !mode_matches {
+                        return None;
+                    }
+                    // CR 601.2a: A `OncePerTurn` permission winks out for the rest
+                    // of the turn once a spell has been cast through this source
+                    // (Assemble the Players, Johann). `Unlimited` permissions
+                    // (Realmwalker, Future Sight, Bolas's Citadel) never consult
+                    // the used-set.
+                    if matches!(frequency, CastFrequency::OncePerTurn)
+                        && state.top_of_library_cast_permissions_used.contains(&src_id)
+                    {
                         return None;
                     }
                     s.affected.as_ref().map(|f| (f, alt_cost.clone()))
@@ -2436,6 +2447,55 @@ pub(crate) fn top_of_library_alt_ability_cost_for_object(
             }
         },
     )
+}
+
+/// CR 601.2a + CR 401.5: When `object_id` is the current top of `player`'s
+/// library and a `OncePerTurn` `TopOfLibraryCastPermission` static authorizes
+/// casting it, return the granting permanent's `ObjectId` so the cast pipeline
+/// can stamp the per-turn slot in `top_of_library_cast_permissions_used`
+/// (Assemble the Players, Johann). `Unlimited` permissions (Realmwalker,
+/// Future Sight, Bolas's Citadel) return `None` — they never consume a slot.
+///
+/// The source identification mirrors `top_of_library_permission_source`: only a
+/// battlefield permanent the player controls whose active static both matches
+/// the top card's filter and carries `frequency: OncePerTurn` qualifies. When
+/// multiple sources could authorize the cast, the first `OncePerTurn` one found
+/// is the slot consumed (CR 601.2a: each casting consumes exactly one slot).
+pub(crate) fn top_of_library_once_per_turn_source(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+) -> Option<ObjectId> {
+    let player_data = state.players.iter().find(|p| p.id == player)?;
+    let &top_id = player_data.library.front()?;
+    if top_id != object_id {
+        return None;
+    }
+    state.battlefield.iter().copied().find(|&src_id| {
+        let Some(obj) = state.objects.get(&src_id) else {
+            return false;
+        };
+        if obj.controller != player {
+            return false;
+        }
+        active_static_definitions(state, obj).any(|s| {
+            let StaticMode::TopOfLibraryCastPermission {
+                frequency: CastFrequency::OncePerTurn,
+                ..
+            } = &s.mode
+            else {
+                return false;
+            };
+            s.affected.as_ref().is_some_and(|filter| {
+                super::filter::matches_target_filter(
+                    state,
+                    top_id,
+                    filter,
+                    &super::filter::FilterContext::from_source_with_controller(src_id, player),
+                )
+            })
+        })
+    })
 }
 
 /// CR 604.2 + CR 305.1 + CR 701.17d: Find lands in the player's graveyard that
@@ -40253,7 +40313,7 @@ mod tests {
             CardPlayMode, StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
         };
         use crate::types::card_type::CoreType;
-        use crate::types::statics::StaticMode;
+        use crate::types::statics::{CastFrequency, StaticMode};
 
         fn put_creature_on_top_of_library(
             state: &mut GameState,
@@ -40295,6 +40355,7 @@ mod tests {
             );
             let def = StaticDefinition::new(StaticMode::TopOfLibraryCastPermission {
                 play_mode: CardPlayMode::Cast,
+                frequency: CastFrequency::Unlimited,
                 alt_cost: None,
             })
             .affected(TargetFilter::Typed(TypedFilter {
@@ -40375,6 +40436,150 @@ mod tests {
             let top = put_creature_on_top_of_library(&mut state, PlayerId(0), CardId(903));
             let available = spell_objects_available_to_cast(&state, PlayerId(0));
             assert!(!available.contains(&top));
+        }
+
+        /// Install a `OncePerTurn` top-of-library permission (Assemble the
+        /// Players / Johann shape) whose `affected` filter admits any creature.
+        fn install_once_per_turn_creature_static(
+            state: &mut GameState,
+            controller: PlayerId,
+        ) -> ObjectId {
+            let src = create_object(
+                state,
+                CardId(8811),
+                controller,
+                "Assemble (test)".to_string(),
+                Zone::Battlefield,
+            );
+            let def = StaticDefinition::new(StaticMode::TopOfLibraryCastPermission {
+                play_mode: CardPlayMode::Cast,
+                frequency: CastFrequency::OncePerTurn,
+                alt_cost: None,
+            })
+            .affected(TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                controller: None,
+                properties: vec![],
+            }));
+            state
+                .objects
+                .get_mut(&src)
+                .unwrap()
+                .static_definitions
+                .push(def);
+            src
+        }
+
+        /// CR 601.2a + CR 401.5: A `OncePerTurn` top-of-library permission
+        /// (Assemble the Players, Johann) prunes its offer from
+        /// `spell_objects_available_to_cast` once its per-turn slot is consumed,
+        /// and comes back at turn cleanup. This is the discriminating test for
+        /// the new `frequency` axis: reverting the frequency gate in
+        /// `top_of_library_permission_source` makes the `after_consumed`
+        /// assertion fail (the slot would never be honored, so the card stays
+        /// castable). Mirrors the Maralen exile-permission frequency test.
+        #[test]
+        fn once_per_turn_top_of_library_frequency_gates_offer() {
+            let mut state = setup_game_at_main_phase();
+            let player = PlayerId(0);
+            let src = install_once_per_turn_creature_static(&mut state, player);
+            let top = put_creature_on_top_of_library(&mut state, player, CardId(904));
+
+            let before = spell_objects_available_to_cast(&state, player);
+            assert!(
+                before.contains(&top),
+                "OncePerTurn permission must surface the top card before its slot is consumed"
+            );
+
+            // Consume the OncePerTurn slot for this source.
+            state.top_of_library_cast_permissions_used.insert(src);
+            let after_consumed = spell_objects_available_to_cast(&state, player);
+            assert!(
+                !after_consumed.contains(&top),
+                "card must be pruned once the OncePerTurn slot is consumed"
+            );
+
+            // Turn cleanup resets the slot — top card castable again.
+            state.top_of_library_cast_permissions_used.clear();
+            let after_reset = spell_objects_available_to_cast(&state, player);
+            assert!(
+                after_reset.contains(&top),
+                "card returns after the per-turn slot resets at turn cleanup"
+            );
+        }
+
+        /// CR 601.2a: An `Unlimited` top-of-library permission (Realmwalker,
+        /// Future Sight, Mm'menon, Vizier) NEVER consults the per-turn used-set,
+        /// so it keeps offering the top card even after the set is polluted with
+        /// its source id. Guards against accidentally gating the Unlimited shape.
+        #[test]
+        fn unlimited_top_of_library_ignores_used_set() {
+            let mut state = setup_game_at_main_phase();
+            install_realmwalker_static(&mut state, PlayerId(0), "Elf");
+            let top = put_creature_on_top_of_library(&mut state, PlayerId(0), CardId(905));
+
+            // Pollute the used-set with the (Unlimited) source — must be ignored.
+            for &bf in &state.battlefield {
+                state.top_of_library_cast_permissions_used.insert(bf);
+            }
+            let available = spell_objects_available_to_cast(&state, PlayerId(0));
+            assert!(
+                available.contains(&top),
+                "Unlimited permission must ignore the per-turn used-set"
+            );
+        }
+
+        /// CR 601.2a + CR 401.5: The cast-time capture helper
+        /// `top_of_library_once_per_turn_source` returns the granting source for
+        /// a `OncePerTurn` permission (so `finalize_cast` stamps the slot) and
+        /// `None` for the `Unlimited` shape (which never consumes a slot). This
+        /// is the discriminating test for the recording seam: reverting the
+        /// `OncePerTurn` filter in the helper makes the Unlimited case wrongly
+        /// return `Some`, flipping the second assertion.
+        #[test]
+        fn once_per_turn_capture_helper_identifies_source_and_skips_unlimited() {
+            // OncePerTurn source is captured.
+            let mut state = setup_game_at_main_phase();
+            let player = PlayerId(0);
+            let src = install_once_per_turn_creature_static(&mut state, player);
+            let top = put_creature_on_top_of_library(&mut state, player, CardId(906));
+            assert_eq!(
+                top_of_library_once_per_turn_source(&state, player, top),
+                Some(src),
+                "OncePerTurn permission source must be captured for slot consumption"
+            );
+
+            // Unlimited source is NOT captured.
+            let mut state2 = setup_game_at_main_phase();
+            install_realmwalker_static(&mut state2, player, "Elf");
+            let top2 = put_creature_on_top_of_library(&mut state2, player, CardId(907));
+            assert_eq!(
+                top_of_library_once_per_turn_source(&state2, player, top2),
+                None,
+                "Unlimited permission must not be captured — it never consumes a slot"
+            );
+
+            // Capture only applies to the actual top card. Place a second
+            // creature BELOW the top so it is in the library but not on top.
+            let below = create_object(
+                &mut state,
+                CardId(908),
+                player,
+                "Below Top".to_string(),
+                Zone::Library,
+            );
+            {
+                let obj = state.objects.get_mut(&below).unwrap();
+                obj.card_types.core_types = vec![CoreType::Creature];
+            }
+            let pd = state.players.iter_mut().find(|p| p.id == player).unwrap();
+            pd.library.retain(|id| *id != below);
+            pd.library.push_back(below);
+            assert_eq!(
+                top_of_library_once_per_turn_source(&state, player, below),
+                None,
+                "only the current top card is authorized by the top-of-library permission"
+            );
         }
     }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -576,7 +576,7 @@ pub fn spell_objects_available_to_cast(state: &GameState, player: PlayerId) -> V
     // in `Zone::Library` until `finalize_cast` performs the standard zone-
     // change to `Zone::Stack` — there is NO exile step (CR 601.2a:
     // "moves that card from where it is to the stack").
-    if let Some((top_id, _src, _alt)) =
+    if let Some((top_id, _src, _freq, _alt)) =
         top_of_library_permission_source(state, player, Some(CardPlayMode::Cast))
     {
         // Only non-land cards reach the cast path; lands flow through the
@@ -2327,7 +2327,20 @@ fn has_graveyard_cast_permission_without_keyword_constraint(
 
 /// CR 401.5 + CR 118.9 + CR 601.2a: Find the (single) top card of `player`'s
 /// library if a battlefield static grants `TopOfLibraryCastPermission` whose
-/// `affected` filter matches it. Returns `(top_card_id, source_id, alt_cost)`.
+/// `affected` filter matches it. Returns
+/// `(top_card_id, source_id, frequency, alt_cost)` for the *selected*
+/// authorizing permission.
+///
+/// CR 601.2a: When more than one permission can authorize the same top-of-
+/// library cast, an `Unlimited` authorizer (Realmwalker, Future Sight, Bolas's
+/// Citadel) is preferred over a bounded `OncePerTurn` one (Assemble the
+/// Players, Johann). The unlimited permission alone suffices, so the player is
+/// not forced to spend a once-per-turn slot — selecting it preserves the
+/// bounded slot for a later cast this turn. The `frequency` of the selected
+/// source is what drives per-turn-slot consumption at `finalize_cast`; the
+/// selected source/frequency is threaded through the casting context rather
+/// than independently rescanned, so availability and consumption agree on the
+/// single authorizing permission.
 ///
 /// Filter eligibility is re-evaluated each call because the top of library
 /// changes between priority windows; callers (`spell_objects_available_to_cast`,
@@ -2342,17 +2355,28 @@ pub(crate) fn top_of_library_permission_source(
 ) -> Option<(
     ObjectId,
     ObjectId,
+    CastFrequency,
     Option<crate::types::ability::AbilityCost>,
 )> {
     let player_data = state.players.iter().find(|p| p.id == player)?;
     let &top_id = player_data.library.front()?;
-    state.battlefield.iter().find_map(|&src_id| {
-        let obj = state.objects.get(&src_id)?;
+    // CR 601.2a: Collect every permission that can authorize this cast, then
+    // prefer an `Unlimited` authorizer so a bounded `OncePerTurn` slot is only
+    // spent when nothing else authorizes the cast.
+    let mut selected: Option<(
+        ObjectId,
+        CastFrequency,
+        Option<crate::types::ability::AbilityCost>,
+    )> = None;
+    for &src_id in &state.battlefield {
+        let Some(obj) = state.objects.get(&src_id) else {
+            continue;
+        };
         if obj.controller != player {
-            return None;
+            continue;
         }
-        let (filter, alt_cost) =
-            active_static_definitions(state, obj).find_map(|s| match &s.mode {
+        let Some((frequency, alt_cost)) = active_static_definitions(state, obj)
+            .find_map(|s| match &s.mode {
                 StaticMode::TopOfLibraryCastPermission {
                     play_mode,
                     frequency,
@@ -2380,21 +2404,38 @@ pub(crate) fn top_of_library_permission_source(
                     {
                         return None;
                     }
-                    s.affected.as_ref().map(|f| (f, alt_cost.clone()))
+                    s.affected
+                        .as_ref()
+                        .map(|f| (f, *frequency, alt_cost.clone()))
                 }
                 _ => None,
-            })?;
-        if super::filter::matches_target_filter(
-            state,
-            top_id,
-            filter,
-            &super::filter::FilterContext::from_source_with_controller(src_id, player),
-        ) {
-            Some((top_id, src_id, alt_cost))
-        } else {
-            None
+            })
+            .and_then(|(filter, frequency, alt_cost)| {
+                super::filter::matches_target_filter(
+                    state,
+                    top_id,
+                    filter,
+                    &super::filter::FilterContext::from_source_with_controller(src_id, player),
+                )
+                .then_some((frequency, alt_cost))
+            })
+        else {
+            continue;
+        };
+        // CR 601.2a: An `Unlimited` authorizer always wins — it preserves any
+        // bounded slot. Otherwise keep the first match found.
+        let prefer = frequency.is_unlimited()
+            || selected
+                .as_ref()
+                .is_none_or(|(_, sel_freq, _)| !sel_freq.is_unlimited());
+        if prefer {
+            selected = Some((src_id, frequency, alt_cost));
         }
-    })
+        if frequency.is_unlimited() {
+            break;
+        }
+    }
+    selected.map(|(src_id, frequency, alt_cost)| (top_id, src_id, frequency, alt_cost))
 }
 
 /// CR 401.5 + CR 305.1: Return the top-of-library land + source pair when a
@@ -2410,7 +2451,7 @@ pub fn top_of_library_land_playable_by_permission(
     state: &GameState,
     player: PlayerId,
 ) -> Option<(ObjectId, ObjectId)> {
-    let (top_id, src_id, _alt) =
+    let (top_id, src_id, _freq, _alt) =
         top_of_library_permission_source(state, player, Some(CardPlayMode::Play))?;
     let obj = state.objects.get(&top_id)?;
     // CR 305.1: Only lands reach this path; non-land cards under the same
@@ -2439,7 +2480,7 @@ pub(crate) fn top_of_library_alt_ability_cost_for_object(
         return None;
     }
     top_of_library_permission_source(state, player, Some(CardPlayMode::Cast)).and_then(
-        |(top_id, _src, alt)| {
+        |(top_id, _src, _freq, alt)| {
             if top_id == object_id {
                 alt
             } else {
@@ -2450,52 +2491,30 @@ pub(crate) fn top_of_library_alt_ability_cost_for_object(
 }
 
 /// CR 601.2a + CR 401.5: When `object_id` is the current top of `player`'s
-/// library and a `OncePerTurn` `TopOfLibraryCastPermission` static authorizes
-/// casting it, return the granting permanent's `ObjectId` so the cast pipeline
-/// can stamp the per-turn slot in `top_of_library_cast_permissions_used`
-/// (Assemble the Players, Johann). `Unlimited` permissions (Realmwalker,
-/// Future Sight, Bolas's Citadel) return `None` — they never consume a slot.
+/// library, return the `(source, frequency)` of the `TopOfLibraryCastPermission`
+/// static that the cast pipeline *selects* to authorize the cast. This is the
+/// single authority threaded through the casting context to drive per-turn-slot
+/// consumption — it mirrors how `CastingVariant::ExilePermission` /
+/// `GraveyardPermission` carry their authorizing source through `finalize_cast`.
 ///
-/// The source identification mirrors `top_of_library_permission_source`: only a
-/// battlefield permanent the player controls whose active static both matches
-/// the top card's filter and carries `frequency: OncePerTurn` qualifies. When
-/// multiple sources could authorize the cast, the first `OncePerTurn` one found
-/// is the slot consumed (CR 601.2a: each casting consumes exactly one slot).
-pub(crate) fn top_of_library_once_per_turn_source(
+/// Delegates to [`top_of_library_permission_source`], which prefers an
+/// `Unlimited` authorizer when one exists (CR 601.2a: an unlimited permission
+/// alone suffices, so a bounded `OncePerTurn` slot must not be spent when an
+/// unlimited one also matches). `finalize_cast` stamps
+/// `top_of_library_cast_permissions_used` ONLY when the returned `frequency` is
+/// `OncePerTurn` — an `Unlimited` selection never consumes a slot. Returns
+/// `None` when no top-of-library permission authorizes casting `object_id`.
+pub(crate) fn top_of_library_selected_permission(
     state: &GameState,
     player: PlayerId,
     object_id: ObjectId,
-) -> Option<ObjectId> {
-    let player_data = state.players.iter().find(|p| p.id == player)?;
-    let &top_id = player_data.library.front()?;
-    if top_id != object_id {
-        return None;
-    }
-    state.battlefield.iter().copied().find(|&src_id| {
-        let Some(obj) = state.objects.get(&src_id) else {
-            return false;
-        };
-        if obj.controller != player {
-            return false;
-        }
-        active_static_definitions(state, obj).any(|s| {
-            let StaticMode::TopOfLibraryCastPermission {
-                frequency: CastFrequency::OncePerTurn,
-                ..
-            } = &s.mode
-            else {
-                return false;
-            };
-            s.affected.as_ref().is_some_and(|filter| {
-                super::filter::matches_target_filter(
-                    state,
-                    top_id,
-                    filter,
-                    &super::filter::FilterContext::from_source_with_controller(src_id, player),
-                )
-            })
-        })
-    })
+) -> Option<(ObjectId, CastFrequency)> {
+    top_of_library_permission_source(state, player, Some(CardPlayMode::Cast)).and_then(
+        |(top_id, src_id, frequency, _alt)| {
+            // CR 401.5: only the actual top card is authorized by the permission.
+            (top_id == object_id).then_some((src_id, frequency))
+        },
+    )
 }
 
 /// CR 604.2 + CR 305.1 + CR 701.17d: Find lands in the player's graveyard that
@@ -3295,7 +3314,7 @@ fn prepare_spell_cast_with_variant_override_inner(
     // alt-cost branch below, mirroring `ExileWithAltAbilityCost` semantics.
     let top_of_library_permission_src = if obj.zone == Zone::Library && obj.owner == player {
         top_of_library_permission_source(state, player, Some(CardPlayMode::Cast))
-            .filter(|(top_id, _, _)| *top_id == object_id)
+            .filter(|(top_id, _, _, _)| *top_id == object_id)
     } else {
         None
     };
@@ -3430,7 +3449,7 @@ fn prepare_spell_cast_with_variant_override_inner(
     } else if obj.zone == Zone::Library
         && top_of_library_permission_src
             .as_ref()
-            .is_some_and(|(_, _, alt)| alt.is_some())
+            .is_some_and(|(_, _, _, alt)| alt.is_some())
     {
         // CR 401.5 + CR 118.9: Bolas's Citadel — alt-cost rider on the static
         // grant zeros the spell's mana cost; the `AbilityCost` body is paid
@@ -40340,7 +40359,11 @@ mod tests {
             obj_id
         }
 
-        fn install_realmwalker_static(state: &mut GameState, controller: PlayerId, subtype: &str) {
+        fn install_realmwalker_static(
+            state: &mut GameState,
+            controller: PlayerId,
+            subtype: &str,
+        ) -> ObjectId {
             // Synthesize a Realmwalker permanent on the battlefield carrying
             // the `TopOfLibraryCastPermission` static; affected filter is
             // creature spells of the chosen creature type (modeled via a
@@ -40372,6 +40395,7 @@ mod tests {
                 .unwrap()
                 .static_definitions
                 .push(def);
+            src
         }
 
         #[test]
@@ -40529,37 +40553,38 @@ mod tests {
             );
         }
 
-        /// CR 601.2a + CR 401.5: The cast-time capture helper
-        /// `top_of_library_once_per_turn_source` returns the granting source for
-        /// a `OncePerTurn` permission (so `finalize_cast` stamps the slot) and
-        /// `None` for the `Unlimited` shape (which never consumes a slot). This
-        /// is the discriminating test for the recording seam: reverting the
-        /// `OncePerTurn` filter in the helper makes the Unlimited case wrongly
-        /// return `Some`, flipping the second assertion.
+        /// CR 601.2a + CR 401.5: The cast-time selection helper
+        /// `top_of_library_selected_permission` returns the granting source AND
+        /// its frequency for a `OncePerTurn` permission (so `finalize_cast`
+        /// stamps the slot) and an `Unlimited` frequency for the Realmwalker
+        /// shape (which never consumes a slot). This is the discriminating test
+        /// for the recording seam: reverting the `OncePerTurn`-only finalize
+        /// guard would consume a slot for the Unlimited case, but the helper
+        /// faithfully reports the selected frequency so the guard can decide.
         #[test]
-        fn once_per_turn_capture_helper_identifies_source_and_skips_unlimited() {
-            // OncePerTurn source is captured.
+        fn selected_permission_helper_reports_source_and_frequency() {
+            // OncePerTurn source is reported with its OncePerTurn frequency.
             let mut state = setup_game_at_main_phase();
             let player = PlayerId(0);
             let src = install_once_per_turn_creature_static(&mut state, player);
             let top = put_creature_on_top_of_library(&mut state, player, CardId(906));
             assert_eq!(
-                top_of_library_once_per_turn_source(&state, player, top),
-                Some(src),
-                "OncePerTurn permission source must be captured for slot consumption"
+                top_of_library_selected_permission(&state, player, top),
+                Some((src, CastFrequency::OncePerTurn)),
+                "OncePerTurn permission must be selected with its OncePerTurn frequency"
             );
 
-            // Unlimited source is NOT captured.
+            // Unlimited source is reported with Unlimited frequency (never a slot).
             let mut state2 = setup_game_at_main_phase();
-            install_realmwalker_static(&mut state2, player, "Elf");
+            let unlimited_src = install_realmwalker_static(&mut state2, player, "Elf");
             let top2 = put_creature_on_top_of_library(&mut state2, player, CardId(907));
             assert_eq!(
-                top_of_library_once_per_turn_source(&state2, player, top2),
-                None,
-                "Unlimited permission must not be captured — it never consumes a slot"
+                top_of_library_selected_permission(&state2, player, top2),
+                Some((unlimited_src, CastFrequency::Unlimited)),
+                "Unlimited permission must be selected with Unlimited frequency — never consumes a slot"
             );
 
-            // Capture only applies to the actual top card. Place a second
+            // Selection only applies to the actual top card. Place a second
             // creature BELOW the top so it is in the library but not on top.
             let below = create_object(
                 &mut state,
@@ -40576,9 +40601,46 @@ mod tests {
             pd.library.retain(|id| *id != below);
             pd.library.push_back(below);
             assert_eq!(
-                top_of_library_once_per_turn_source(&state, player, below),
+                top_of_library_selected_permission(&state, player, below),
                 None,
                 "only the current top card is authorized by the top-of-library permission"
+            );
+        }
+
+        /// CR 601.2a: When BOTH an `Unlimited` and a `OncePerTurn`
+        /// top-of-library permission match the same top card, the selection
+        /// helper PREFERS the `Unlimited` authorizer so the bounded slot is
+        /// preserved. This is the discriminating test for the
+        /// preserve-bounded-slot fix: reverting the Unlimited-preference in
+        /// `top_of_library_permission_source` (back to "first match wins") lets
+        /// a battlefield-ordering that puts the OncePerTurn source first report
+        /// `OncePerTurn`, flipping this assertion. The cast-path consumption is
+        /// driven by the reported frequency, so reporting `Unlimited` here is
+        /// what prevents the bounded slot from being spent.
+        #[test]
+        fn selection_prefers_unlimited_over_once_per_turn() {
+            // Install the OncePerTurn permission FIRST so it is earlier in
+            // battlefield iteration order — a naive first-match selection would
+            // return it. The Unlimited-preference must still win.
+            let mut state = setup_game_at_main_phase();
+            let player = PlayerId(0);
+            let once_src = install_once_per_turn_creature_static(&mut state, player);
+            let unlimited_src = install_realmwalker_static(&mut state, player, "Elf");
+            // Top card is an Elf creature so BOTH permissions' filters match.
+            let top = put_creature_on_top_of_library(&mut state, player, CardId(909));
+            {
+                let obj = state.objects.get_mut(&top).unwrap();
+                obj.card_types.subtypes = vec!["Elf".to_string()];
+            }
+
+            assert!(
+                once_src != unlimited_src,
+                "test sanity: the two permission sources must be distinct"
+            );
+            assert_eq!(
+                top_of_library_selected_permission(&state, player, top),
+                Some((unlimited_src, CastFrequency::Unlimited)),
+                "Unlimited authorizer must be preferred so the OncePerTurn slot is preserved"
             );
         }
     }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5333,6 +5333,16 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
     } else {
         None
     };
+    // CR 601.2a + CR 401.5: Capture the `OncePerTurn`
+    // `StaticMode::TopOfLibraryCastPermission` source authorizing this cast
+    // BEFORE the card leaves the library for the stack (Assemble the Players,
+    // Johann). `Unlimited` permissions (Realmwalker, Future Sight) return
+    // `None` and never consume a slot.
+    let top_of_library_permission_source = if source_zone == Zone::Library {
+        super::casting::top_of_library_once_per_turn_source(state, player, object_id)
+    } else {
+        None
+    };
     // CR 601.2a + CR 603.7 + CR 611.2a: Capture the tracked-set group of a
     // single-use `PlayFromExile` grant authorizing this cast BEFORE the object
     // leaves exile for the stack.
@@ -5537,6 +5547,13 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
         exile_play_permission_source
     {
         state.exile_play_permissions_used.insert(source);
+    }
+    // CR 601.2a + CR 401.5: Consume the per-turn slot for a `OncePerTurn`
+    // top-of-library permission (Assemble the Players, Johann). The capture
+    // helper already filtered to `OncePerTurn` sources, so any `Some` here is a
+    // slot to stamp.
+    if let Some(source) = top_of_library_permission_source {
+        state.top_of_library_cast_permissions_used.insert(source);
     }
     // CR 601.2a + CR 603.7 + CR 611.2a: A single-use exile-cast grant is spent
     // on this cast. Record the group and strip the now-void `PlayFromExile` grant from

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5333,13 +5333,16 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
     } else {
         None
     };
-    // CR 601.2a + CR 401.5: Capture the `OncePerTurn`
-    // `StaticMode::TopOfLibraryCastPermission` source authorizing this cast
+    // CR 601.2a + CR 401.5: Capture the *selected* authorizing
+    // `StaticMode::TopOfLibraryCastPermission` source — and its frequency —
     // BEFORE the card leaves the library for the stack (Assemble the Players,
-    // Johann). `Unlimited` permissions (Realmwalker, Future Sight) return
-    // `None` and never consume a slot.
+    // Johann). The selection prefers an `Unlimited` authorizer when one exists,
+    // so a `OncePerTurn` slot is only spent when the bounded permission is what
+    // actually authorized this cast. The slot is consumed below ONLY when the
+    // captured frequency is `OncePerTurn`; an `Unlimited` selection (Realmwalker,
+    // Future Sight, Bolas's Citadel) never consumes a slot.
     let top_of_library_permission_source = if source_zone == Zone::Library {
-        super::casting::top_of_library_once_per_turn_source(state, player, object_id)
+        super::casting::top_of_library_selected_permission(state, player, object_id)
     } else {
         None
     };
@@ -5548,11 +5551,15 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
     {
         state.exile_play_permissions_used.insert(source);
     }
-    // CR 601.2a + CR 401.5: Consume the per-turn slot for a `OncePerTurn`
-    // top-of-library permission (Assemble the Players, Johann). The capture
-    // helper already filtered to `OncePerTurn` sources, so any `Some` here is a
-    // slot to stamp.
-    if let Some(source) = top_of_library_permission_source {
+    // CR 601.2a + CR 401.5: Consume the per-turn slot ONLY when the *selected*
+    // authorizing top-of-library permission is `OncePerTurn` (Assemble the
+    // Players, Johann). When an `Unlimited` permission (Realmwalker, Future
+    // Sight, Bolas's Citadel) authorized the cast — even if a OncePerTurn
+    // permission also matched the top card — no bounded slot is spent, so a
+    // second matching top spell remains castable this turn.
+    if let Some((source, crate::types::statics::CastFrequency::OncePerTurn)) =
+        top_of_library_permission_source
+    {
         state.top_of_library_cast_permissions_used.insert(source);
     }
     // CR 601.2a + CR 603.7 + CR 611.2a: A single-use exile-cast grant is spent

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -571,6 +571,9 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
     // open-ended "cards exiled with ~" filter for sources without a per-turn
     // cap.
     state.exile_cast_permissions_used.clear();
+    // CR 601.2a + CR 401.5: Reset per-turn TopOfLibraryCastPermission
+    // once-per-turn tracking (Assemble the Players, Johann, Apprentice Sorcerer).
+    state.top_of_library_cast_permissions_used.clear();
     state.cards_exiled_with_source_this_turn.clear();
     // CR 702.94a: Reset per-player first-card-drawn-this-turn tracking for miracle.
     state.first_card_drawn_this_turn.clear();

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -2061,10 +2061,9 @@ pub(crate) fn try_parse_top_of_library_cast_permission(
 
     // CR 601.2a: Optional once-per-turn frequency prefix. "Once each turn, …"
     // (Assemble the Players) and the longer "Once during each of your turns, …"
-    // synonym both lower to `OncePerTurn`; absence keeps the `Unlimited` shape
-    // (Realmwalker, Future Sight). The prefix consumes the leading "you may"
-    // anchor, so after stripping it the verb-dispatch below re-anchors on the
-    // bare "play "/"cast " token.
+    // synonym both lower to OncePerTurn; absence keeps the Unlimited shape
+    // (Realmwalker, Future Sight). After stripping the prefix, the standard
+    // "you may play/cast" verb-dispatch below is matched.
     let (lower, frequency) = if let Some(r) = nom_tag_lower(lower, lower, "once each turn, ")
         .or_else(|| nom_tag_lower(lower, lower, "once during each of your turns, "))
     {

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -2047,6 +2047,8 @@ pub(crate) fn try_parse_top_of_library_cast_permission(
         let alt_cost = parse_top_of_library_alt_cost_rider(rest, text);
         let mut def = StaticDefinition::new(StaticMode::TopOfLibraryCastPermission {
             play_mode: CardPlayMode::Play,
+            // CR 601.2a: The Bolas's Citadel compound form has no per-turn cap.
+            frequency: CastFrequency::Unlimited,
             alt_cost,
         })
         .affected(TargetFilter::Any)
@@ -2056,6 +2058,20 @@ pub(crate) fn try_parse_top_of_library_cast_permission(
         }
         return Some(def);
     }
+
+    // CR 601.2a: Optional once-per-turn frequency prefix. "Once each turn, …"
+    // (Assemble the Players) and the longer "Once during each of your turns, …"
+    // synonym both lower to `OncePerTurn`; absence keeps the `Unlimited` shape
+    // (Realmwalker, Future Sight). The prefix consumes the leading "you may"
+    // anchor, so after stripping it the verb-dispatch below re-anchors on the
+    // bare "play "/"cast " token.
+    let (lower, frequency) = if let Some(r) = nom_tag_lower(lower, lower, "once each turn, ")
+        .or_else(|| nom_tag_lower(lower, lower, "once during each of your turns, "))
+    {
+        (r, CastFrequency::OncePerTurn)
+    } else {
+        (lower, CastFrequency::Unlimited)
+    };
 
     // Standard form: "you may [play|cast] [filter] from the top of your library".
     let (rest, play_mode) = if let Some(r) = nom_tag_lower(lower, lower, "you may play ") {
@@ -2094,6 +2110,7 @@ pub(crate) fn try_parse_top_of_library_cast_permission(
 
     let mut def = StaticDefinition::new(StaticMode::TopOfLibraryCastPermission {
         play_mode,
+        frequency,
         alt_cost,
     })
     .affected(filter)

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -17032,9 +17032,11 @@ fn top_of_library_cast_permission_realmwalker() {
     match def.mode {
         StaticMode::TopOfLibraryCastPermission {
             play_mode,
+            frequency,
             ref alt_cost,
         } => {
             assert_eq!(play_mode, CardPlayMode::Cast);
+            assert_eq!(frequency, CastFrequency::Unlimited);
             assert!(alt_cost.is_none());
         }
         other => panic!("expected TopOfLibraryCastPermission, got {other:?}"),
@@ -17068,9 +17070,11 @@ fn top_of_library_cast_permission_future_sight_compound() {
     match def.mode {
         StaticMode::TopOfLibraryCastPermission {
             play_mode,
+            frequency,
             ref alt_cost,
         } => {
             assert_eq!(play_mode, CardPlayMode::Play);
+            assert_eq!(frequency, CastFrequency::Unlimited);
             assert!(alt_cost.is_none());
         }
         other => panic!("expected TopOfLibraryCastPermission, got {other:?}"),
@@ -17126,6 +17130,7 @@ fn top_of_library_cast_permission_bolas_alt_cost() {
     match def.mode {
         StaticMode::TopOfLibraryCastPermission {
             play_mode,
+            frequency: CastFrequency::Unlimited,
             alt_cost: Some(crate::types::ability::AbilityCost::PayLife { amount }),
         } => {
             assert_eq!(play_mode, CardPlayMode::Play);
@@ -18891,5 +18896,156 @@ fn damage_not_removed_during_cleanup_rejects_non_cleanup_during() {
         ),
         "a non-\"during cleanup steps\" sentence must not be a cleanup-damage static, got {:?}",
         def.map(|d| d.mode)
+    );
+}
+
+/// CR 401.5 + CR 601.2a: Assemble the Players — "Once each turn, you may cast
+/// a creature spell with power 2 or less from the top of your library." must
+/// lower to a `TopOfLibraryCastPermission { frequency: OncePerTurn }` carrying
+/// the creature + power-2-or-less filter, with ZERO `Effect::Unimplemented`.
+/// Discriminating on the new `frequency` axis: a regression that drops the
+/// once-each-turn prefix would leave `frequency: Unlimited`, flipping this
+/// assertion.
+#[test]
+fn assemble_the_players_once_per_turn_top_of_library() {
+    let parsed = crate::parser::parse_oracle_text(
+        "You may look at the top card of your library any time.\n\
+         Once each turn, you may cast a creature spell with power 2 or less from the top of your library.",
+        "Assemble the Players",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    for a in &parsed.abilities {
+        assert!(
+            !matches!(&*a.effect, Effect::Unimplemented { .. }),
+            "Assemble the Players must emit ZERO Unimplemented, got {:?}",
+            a.effect
+        );
+    }
+    let perm = parsed
+        .statics
+        .iter()
+        .find(|s| matches!(s.mode, StaticMode::TopOfLibraryCastPermission { .. }))
+        .expect("Assemble the Players must produce a TopOfLibraryCastPermission static");
+    match &perm.mode {
+        StaticMode::TopOfLibraryCastPermission {
+            play_mode,
+            frequency,
+            alt_cost,
+        } => {
+            assert_eq!(*play_mode, CardPlayMode::Cast);
+            assert_eq!(*frequency, CastFrequency::OncePerTurn);
+            assert!(alt_cost.is_none());
+        }
+        other => panic!("expected TopOfLibraryCastPermission, got {other:?}"),
+    }
+    match perm.affected.as_ref().expect("affected filter") {
+        TargetFilter::Typed(tf) => {
+            assert!(tf
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Creature)));
+            assert!(tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::PtComparison {
+                    stat: PtStat::Power,
+                    comparator: Comparator::LE,
+                    value: QuantityExpr::Fixed { value: 2 },
+                    ..
+                }
+            )));
+        }
+        other => panic!("expected Typed creature/power filter, got {other:?}"),
+    }
+}
+
+/// CR 401.5 + CR 601.2a: Johann, Apprentice Sorcerer — "Once each turn, you may
+/// cast an instant or sorcery spell from the top of your library." must lower
+/// to `TopOfLibraryCastPermission { frequency: OncePerTurn }` with an
+/// instant-or-sorcery filter and ZERO `Effect::Unimplemented`.
+#[test]
+fn johann_apprentice_sorcerer_once_per_turn_top_of_library() {
+    let parsed = crate::parser::parse_oracle_text(
+        "You may look at the top card of your library any time.\n\
+         Once each turn, you may cast an instant or sorcery spell from the top of your library. \
+         (You still pay its costs. Timing rules still apply.)",
+        "Johann, Apprentice Sorcerer",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &[],
+    );
+    for a in &parsed.abilities {
+        assert!(
+            !matches!(&*a.effect, Effect::Unimplemented { .. }),
+            "Johann must emit ZERO Unimplemented, got {:?}",
+            a.effect
+        );
+    }
+    let perm = parsed
+        .statics
+        .iter()
+        .find(|s| matches!(s.mode, StaticMode::TopOfLibraryCastPermission { .. }))
+        .expect("Johann must produce a TopOfLibraryCastPermission static");
+    match &perm.mode {
+        StaticMode::TopOfLibraryCastPermission {
+            play_mode,
+            frequency,
+            ..
+        } => {
+            assert_eq!(*play_mode, CardPlayMode::Cast);
+            assert_eq!(*frequency, CastFrequency::OncePerTurn);
+        }
+        other => panic!("expected TopOfLibraryCastPermission, got {other:?}"),
+    }
+    match perm.affected.as_ref().expect("affected filter") {
+        TargetFilter::Or { filters } => {
+            assert!(filters.iter().any(|f| matches!(
+                f,
+                TargetFilter::Typed(tf) if tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Instant))
+            )));
+            assert!(filters.iter().any(|f| matches!(
+                f,
+                TargetFilter::Typed(tf) if tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Sorcery))
+            )));
+        }
+        other => panic!("expected instant-or-sorcery Or filter, got {other:?}"),
+    }
+}
+
+/// CR 601.2a: The `frequency` field round-trips through `StaticMode`'s
+/// `Display`/`FromStr` for both the default `Unlimited` (no segment) and the
+/// `OncePerTurn` (tagged `freq=` segment) shapes. Guards the wire-format
+/// backward-compat: the historical 1-/2-segment Unlimited forms must still
+/// parse, and the OncePerTurn shape must survive a Display→FromStr cycle.
+#[test]
+fn top_of_library_frequency_display_roundtrip() {
+    use std::str::FromStr;
+    let unlimited = StaticMode::TopOfLibraryCastPermission {
+        play_mode: CardPlayMode::Cast,
+        frequency: CastFrequency::Unlimited,
+        alt_cost: None,
+    };
+    let once = StaticMode::TopOfLibraryCastPermission {
+        play_mode: CardPlayMode::Cast,
+        frequency: CastFrequency::OncePerTurn,
+        alt_cost: None,
+    };
+    // Unlimited keeps the historical compact form (no freq= segment).
+    assert_eq!(unlimited.to_string(), "TopOfLibraryCastPermission(Cast)");
+    assert_eq!(
+        once.to_string(),
+        "TopOfLibraryCastPermission(Cast,freq=once_per_turn)"
+    );
+    // Round-trip both.
+    assert_eq!(
+        StaticMode::from_str(&unlimited.to_string()).unwrap(),
+        unlimited
+    );
+    assert_eq!(StaticMode::from_str(&once.to_string()).unwrap(), once);
+    // Legacy compact form (no parens variant) still parses to Unlimited.
+    assert_eq!(
+        StaticMode::from_str("TopOfLibraryCastPermission").unwrap(),
+        unlimited
     );
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5915,6 +5915,18 @@ pub struct GameState {
     /// resetting the slot when the source leaves and re-enters play.
     #[serde(default)]
     pub exile_cast_permissions_used: HashSet<ObjectId>,
+    /// CR 601.2a + CR 401.5: Tracks `OncePerTurn`
+    /// `StaticMode::TopOfLibraryCastPermission` sources that have already had a
+    /// spell cast through them this turn (Assemble the Players, Johann,
+    /// Apprentice Sorcerer — "Once each turn, you may cast … from the top of
+    /// your library"). Keyed by the granting permanent's ObjectId. `Unlimited`
+    /// frequency permissions (Realmwalker, Future Sight, Bolas's Citadel) never
+    /// populate this set. Cleared at the start of each turn alongside the other
+    /// per-turn cast-permission slots.
+    /// CR 400.7: Zone change creates a new source `ObjectId`, naturally
+    /// resetting the slot when the source leaves and re-enters play.
+    #[serde(default)]
+    pub top_of_library_cast_permissions_used: HashSet<ObjectId>,
     /// CR 113.6b + CR 601.2a: Per-turn rolling list of cards that have been
     /// exiled "with" each linked-exile source during the current turn. Keyed
     /// by the source's `ObjectId`; the `Vec` is the list of card `ObjectId`s
@@ -7074,6 +7086,7 @@ impl GameState {
             exile_play_permissions_used: HashSet::new(),
             exile_play_single_use_consumed: HashSet::new(),
             exile_cast_permissions_used: HashSet::new(),
+            top_of_library_cast_permissions_used: HashSet::new(),
             cards_exiled_with_source_this_turn: HashMap::new(),
             first_card_drawn_this_turn: HashMap::new(),
             cards_drawn_this_turn: HashMap::new(),

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -932,6 +932,16 @@ pub enum StaticMode {
         /// non-land spells (cast as a spell). `Cast` covers only spells.
         /// Realmwalker = `Cast`; Future Sight + Bolas's Citadel = `Play`.
         play_mode: CardPlayMode,
+        /// CR 601.2a: Per-turn cast frequency, the same axis carried by the
+        /// sibling `GraveyardCastPermission` / `ExileCastPermission` permissions.
+        /// `Unlimited` (default) preserves the Realmwalker / Future Sight /
+        /// Bolas's Citadel shape (no per-turn cap). `OncePerTurn` gates the
+        /// permission to one cast per turn from this source — "Once each turn,
+        /// you may cast … from the top of your library." (Assemble the Players,
+        /// Johann, Apprentice Sorcerer). Tracked by the source's `ObjectId` in
+        /// `GameState::top_of_library_cast_permissions_used`.
+        #[serde(default)]
+        frequency: CastFrequency,
         /// CR 118.9 + CR 119.4: Optional alternative cost paid in lieu of the
         /// spell's mana cost when cast via this permission. Bolas's Citadel
         /// uses `Some(AbilityCost::PayLife { amount: SelfManaValue })`.
@@ -1553,9 +1563,15 @@ impl Hash for StaticMode {
                 play_mode.hash(state);
                 graveyard_destination_replacement.hash(state);
             }
-            StaticMode::TopOfLibraryCastPermission { play_mode, .. } => {
-                // alt_cost contains AbilityCost which lacks Hash; discriminant + play_mode only.
+            StaticMode::TopOfLibraryCastPermission {
+                play_mode,
+                frequency,
+                ..
+            } => {
+                // alt_cost contains AbilityCost which lacks Hash; discriminant +
+                // play_mode + frequency only.
                 play_mode.hash(state);
+                frequency.hash(state);
             }
             StaticMode::CastFromHandFree { frequency, origin } => {
                 frequency.hash(state);
@@ -1833,12 +1849,24 @@ impl fmt::Display for StaticMode {
             }
             StaticMode::TopOfLibraryCastPermission {
                 play_mode,
+                frequency,
                 alt_cost,
             } => {
-                if alt_cost.is_some() {
-                    write!(f, "TopOfLibraryCastPermission({play_mode},alt_cost)")
+                // CR 601.2a: `frequency` is appended as a tagged segment only
+                // when non-default (`OncePerTurn`) so the historical
+                // 1-/2-segment Unlimited forms keep parsing unchanged.
+                let freq_seg = if frequency.is_unlimited() {
+                    String::new()
                 } else {
-                    write!(f, "TopOfLibraryCastPermission({play_mode})")
+                    format!(",freq={frequency}")
+                };
+                if alt_cost.is_some() {
+                    write!(
+                        f,
+                        "TopOfLibraryCastPermission({play_mode}{freq_seg},alt_cost)"
+                    )
+                } else {
+                    write!(f, "TopOfLibraryCastPermission({play_mode}{freq_seg})")
                 }
             }
             StaticMode::CastFromHandFree { frequency, origin } => {
@@ -2211,16 +2239,34 @@ impl FromStr for StaticMode {
             // not the FromStr round-trip), so FromStr defaults alt_cost to None.
             "TopOfLibraryCastPermission" => StaticMode::TopOfLibraryCastPermission {
                 play_mode: CardPlayMode::Cast,
+                frequency: CastFrequency::Unlimited,
                 alt_cost: None,
             },
             s if s.starts_with("TopOfLibraryCastPermission(") => {
+                // Display form: "TopOfLibraryCastPermission(<play_mode>
+                // [,freq=<frequency>][,alt_cost])". The first segment is
+                // positional; the tagged freq= segment and the "alt_cost"
+                // marker are present only when non-default, so the historical
+                // 1-/2-segment forms round-trip unchanged.
                 let inner = s
                     .strip_prefix("TopOfLibraryCastPermission(")
                     .and_then(|s| s.strip_suffix(')'))
                     .unwrap_or("");
-                let pm_token = inner.split(',').next().unwrap_or("Cast");
+                let mut parts = inner.split(',');
+                let play_mode = parts
+                    .next()
+                    .and_then(|p| p.parse().ok())
+                    .unwrap_or(CardPlayMode::Cast);
+                let frequency = parts
+                    .clone()
+                    .find_map(|p| p.strip_prefix("freq="))
+                    .and_then(|f| f.parse().ok())
+                    .unwrap_or(CastFrequency::Unlimited);
                 StaticMode::TopOfLibraryCastPermission {
-                    play_mode: pm_token.parse().unwrap_or(CardPlayMode::Cast),
+                    play_mode,
+                    frequency,
+                    // CR 118.9: the alt_cost payload is preserved through serde,
+                    // not the FromStr round-trip, so FromStr defaults to None.
                     alt_cost: None,
                 }
             }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -437,6 +437,7 @@ mod timely_ward_regression;
 mod tinybones_joins_up_multi_target;
 mod tobita_master_of_winds_flying_grant;
 mod tombstone_stairwell_per_player_tokens;
+mod top_of_library_mixed_permission;
 mod treasured_find_regression;
 mod true_conviction_double_keyword_grant;
 mod turn_control_priority_softlock;

--- a/crates/engine/tests/integration/top_of_library_mixed_permission.rs
+++ b/crates/engine/tests/integration/top_of_library_mixed_permission.rs
@@ -1,0 +1,239 @@
+//! Regression: PR #3949 maintainer review — top-of-library casts must consume a
+//! once-per-turn permission slot ONLY when that bounded permission is what
+//! authorized the cast.
+//!
+//! Bug: with BOTH an `Unlimited` top-of-library permission (Future Sight /
+//! Realmwalker / Bolas's Citadel shape) AND a `OncePerTurn` one (Assemble the
+//! Players / Johann shape) whose filters both match the top card, casting the
+//! top spell burned the once-per-turn slot — even though the unlimited
+//! permission alone authorized the cast — and incorrectly hid the next matching
+//! top spell for the rest of the turn.
+//!
+//! Fix: the casting pipeline now threads the *selected* authorizing permission
+//! source/frequency (preferring an `Unlimited` authorizer) and consumes the
+//! bounded slot only when the selected frequency is `OncePerTurn`.
+//!
+//! CR 601.2a + CR 401.5: a bounded per-turn cast slot is spent only when that
+//! specific bounded permission authorizes the cast; an unlimited permission
+//! that also matches suffices on its own and preserves the bounded slot.
+//!
+//! This drives the REAL production cast path (`GameAction::CastSpell` through
+//! `GameRunner::act` → `finalize_cast`). The two permissions are installed as
+//! synthetic `TopOfLibraryCastPermission` statics on battlefield permanents so
+//! the test does not depend on Assemble/Johann being present in the curated
+//! fixture; the cast target is a real {0} creature (Memnite) whose
+//! characteristics match both filters and which casts for free.
+
+use engine::types::ability::{
+    CardPlayMode, StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::statics::{CastFrequency, StaticMode};
+use engine::types::zones::Zone;
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+use crate::support::shared_card_db as load_db;
+
+/// Move an object to the front of its owner's library so it is the "top card."
+fn move_to_top_of_library(
+    state: &mut engine::types::game_state::GameState,
+    obj_id: ObjectId,
+    owner: PlayerId,
+) {
+    let player = state.players.iter_mut().find(|p| p.id == owner).unwrap();
+    player.library.retain(|id| *id != obj_id);
+    player.library.push_front(obj_id);
+    let obj = state.objects.get_mut(&obj_id).unwrap();
+    obj.zone = Zone::Library;
+}
+
+/// Install a `TopOfLibraryCastPermission` static (with the given frequency)
+/// whose `affected` filter admits any creature onto a fresh battlefield
+/// permanent. Returns that permanent's `ObjectId` (the per-turn slot key).
+fn install_top_of_library_creature_static(
+    state: &mut engine::types::game_state::GameState,
+    controller: PlayerId,
+    frequency: CastFrequency,
+    card_id: CardId,
+) -> ObjectId {
+    let src = engine::game::zones::create_object(
+        state,
+        card_id,
+        controller,
+        format!("TopLib permission ({frequency})"),
+        Zone::Battlefield,
+    );
+    let def = StaticDefinition::new(StaticMode::TopOfLibraryCastPermission {
+        play_mode: CardPlayMode::Cast,
+        frequency,
+        alt_cost: None,
+    })
+    .affected(TargetFilter::Typed(TypedFilter {
+        type_filters: vec![TypeFilter::Creature],
+        controller: None,
+        properties: vec![],
+    }));
+    state
+        .objects
+        .get_mut(&src)
+        .unwrap()
+        .static_definitions
+        .push(def);
+    src
+}
+
+/// CR 601.2a + CR 401.5: casting the top spell while BOTH an `Unlimited` and a
+/// `OncePerTurn` top-of-library permission match it must NOT consume the
+/// once-per-turn slot — the unlimited permission alone authorizes the cast — so
+/// a second matching top spell stays castable this turn.
+///
+/// DISCRIMINATING ASSERTION: `top_of_library_cast_permissions_used` must NOT
+/// contain the once-per-turn source after the cast. Reverting the threading fix
+/// (back to the independent first-`OncePerTurn`-match rescan at finalize) makes
+/// the cast stamp that source, so the set WOULD contain it and the second
+/// castability assertion would also fail.
+#[test]
+fn mixed_unlimited_and_once_per_turn_does_not_burn_bounded_slot() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Two distinct top-of-library creatures (Memnite is a {0} artifact creature
+    // — matches the creature filter and casts for free).
+    let first_top = scenario.add_real_card(P0, "Memnite", Zone::Library, db);
+    let second_top = scenario.add_real_card(P0, "Memnite", Zone::Library, db);
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    // Install BOTH permissions. Order the OncePerTurn one FIRST in battlefield
+    // iteration so a naive first-match would pick it; the Unlimited-preference
+    // must still win.
+    let once_src = install_top_of_library_creature_static(
+        runner.state_mut(),
+        P0,
+        CastFrequency::OncePerTurn,
+        CardId(7_701),
+    );
+    let _unlimited_src = install_top_of_library_creature_static(
+        runner.state_mut(),
+        P0,
+        CastFrequency::Unlimited,
+        CardId(7_702),
+    );
+
+    move_to_top_of_library(runner.state_mut(), first_top, P0);
+
+    // Sanity: the top card is castable before any cast.
+    let available = engine::game::casting::spell_objects_available_to_cast(runner.state(), P0);
+    assert!(
+        available.contains(&first_top),
+        "the top creature must be castable with both permissions active"
+    );
+
+    // Cast the top spell through the REAL cast pipeline.
+    let card_id = runner.state().objects[&first_top].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: first_top,
+            card_id,
+            targets: vec![],
+            payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+        })
+        .expect("casting the {0} top creature via the unlimited permission should succeed");
+
+    // CR 601.2a: the bounded OncePerTurn slot must NOT be consumed — the
+    // Unlimited permission authorized the cast.
+    assert!(
+        !runner
+            .state()
+            .top_of_library_cast_permissions_used
+            .contains(&once_src),
+        "Unlimited permission authorized the cast — the OncePerTurn slot must be preserved, \
+         but it was stamped: used_set={:?}",
+        runner.state().top_of_library_cast_permissions_used,
+    );
+
+    // The first Memnite has left the library for the stack.
+    assert_ne!(
+        runner.state().objects[&first_top].zone,
+        Zone::Library,
+        "the cast top card must have moved off the top of library"
+    );
+
+    // Put the second Memnite on top and verify it is STILL castable — the
+    // once-per-turn slot was preserved, so the offer remains.
+    move_to_top_of_library(runner.state_mut(), second_top, P0);
+    let available_after =
+        engine::game::casting::spell_objects_available_to_cast(runner.state(), P0);
+    assert!(
+        available_after.contains(&second_top),
+        "a second matching top spell must remain castable when no bounded slot was spent"
+    );
+}
+
+/// CR 601.2a + CR 401.5: control case — with ONLY a `OncePerTurn` permission,
+/// casting the top spell DOES consume the slot, and the next matching top spell
+/// is hidden until the slot resets. This is the existing once-per-turn behavior
+/// the fix must keep passing, exercised through the same production cast path.
+///
+/// DISCRIMINATING ASSERTION: after the cast, `top_of_library_cast_permissions_used`
+/// contains the source AND the second top spell is NOT castable. If the fix
+/// wrongly skipped consumption for the bounded-only case, the used-set would be
+/// empty and the second offer would remain — flipping both assertions.
+#[test]
+fn pure_once_per_turn_burns_slot_and_hides_next_top_spell() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let first_top = scenario.add_real_card(P0, "Memnite", Zone::Library, db);
+    let second_top = scenario.add_real_card(P0, "Memnite", Zone::Library, db);
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    let once_src = install_top_of_library_creature_static(
+        runner.state_mut(),
+        P0,
+        CastFrequency::OncePerTurn,
+        CardId(7_701),
+    );
+
+    move_to_top_of_library(runner.state_mut(), first_top, P0);
+
+    let card_id = runner.state().objects[&first_top].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: first_top,
+            card_id,
+            targets: vec![],
+            payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+        })
+        .expect("casting the {0} top creature via the once-per-turn permission should succeed");
+
+    // CR 601.2a: the bounded slot IS consumed — it was the only authorizer.
+    assert!(
+        runner
+            .state()
+            .top_of_library_cast_permissions_used
+            .contains(&once_src),
+        "OncePerTurn permission authorized the cast — its slot must be consumed"
+    );
+
+    // The next matching top spell is hidden for the rest of the turn.
+    move_to_top_of_library(runner.state_mut(), second_top, P0);
+    let available_after =
+        engine::game::casting::spell_objects_available_to_cast(runner.state(), P0);
+    assert!(
+        !available_after.contains(&second_top),
+        "with the once-per-turn slot spent, the next top spell must be hidden this turn"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# feat(engine): once-per-turn top-of-library cast permission (Assemble the Players, Johann)

## Summary

Extends the existing alternative-casting-zone permission primitive for the
"cast a spell from the top of your library" class by adding a per-turn
**frequency** axis to `StaticMode::TopOfLibraryCastPermission`. This is a
parameterization of an existing variant (not a new sibling), aligning it with
its cast-permission siblings `GraveyardCastPermission` and `ExileCastPermission`,
which already carry `frequency: CastFrequency`.

Ships two Standard-legal cards whose top-of-library line was previously
`Effect::Unimplemented`:

- **Assemble the Players** — "Once each turn, you may cast a creature spell with
  power 2 or less from the top of your library."
- **Johann, Apprentice Sorcerer** — "Once each turn, you may cast an instant or
  sorcery spell from the top of your library."

## add-engine-variant gate

This change adds a **field** to an existing variant, not a new variant.

- **Stage 1 (existence):** `CastFrequency` already exists and is the exact axis
  on `GraveyardCastPermission`/`ExileCastPermission`. EXISTS_AS_PARAMETER.
- **Stage 2 (parameterization):** the three cast-permission variants share the
  `frequency` axis; `TopOfLibraryCastPermission` was the only one missing it.
  Adding the field is the consolidation direction the gate endorses, not
  proliferation. EXTEND_OK.
- **Stage 3 (categorical boundary):** `CastFrequency` is CR 601.2a (per-turn cast
  frequency) — the same CR section it governs on its siblings. WITHIN_SECTION.

## Implementation

| File | Purpose |
|---|---|
| `types/statics.rs` | Add `frequency: CastFrequency` to `TopOfLibraryCastPermission`; update `Display`/`FromStr` (tagged `freq=` segment only when non-default — historical Unlimited wire forms parse unchanged), `Hash`. |
| `types/game_state.rs` | New per-turn tracking set `top_of_library_cast_permissions_used` (keyed by source `ObjectId`). |
| `game/turns.rs` | Clear the new set at `start_next_turn` alongside the other per-turn cast-permission slots. |
| `game/casting.rs` | `top_of_library_permission_source` prunes a `OncePerTurn` source whose slot is consumed; new `top_of_library_once_per_turn_source` captures the source at cast time. |
| `game/casting_costs.rs` | Capture the `OncePerTurn` source before the Library→Stack move and stamp its slot in `finalize_cast_with_phyrexian_choices` (the single canonical finalize terminus). |
| `parser/oracle_static/restriction.rs` | Parse optional "Once each turn, …" / "Once during each of your turns, …" prefix on the top-of-library handler → `OncePerTurn`; absence keeps `Unlimited`. Nom-only. |
| `parser/oracle_static/tests.rs`, `game/casting.rs` (tests) | Discriminating parser + runtime tests (see below). |

The `Unlimited` shape (Realmwalker, Future Sight, Bolas's Citadel, Mm'menon,
Vizier of the Menagerie) is unchanged and never consults the per-turn set.

## CR annotations (all grep-verified against docs/MagicCompRules.txt)

- CR 601.2a — per-turn cast frequency (the new axis)
- CR 401.5 — play with / look at the top card of library
- CR 118.9 — alternative costs
- CR 400.7 — zone change creates a new `ObjectId`, naturally resetting the slot

## Tests (discriminating, drive the production path)

Parser (`parse_oracle_text` end-to-end, 0-Unimplemented):
- `assemble_the_players_once_per_turn_top_of_library` — asserts
  `frequency: OncePerTurn` + creature/power-2-or-less filter (reverting the
  once-each-turn prefix would leave `Unlimited`, flipping the assertion).
- `johann_apprentice_sorcerer_once_per_turn_top_of_library` — asserts
  `OncePerTurn` + instant-or-sorcery filter.
- `top_of_library_frequency_display_roundtrip` — wire-format backward-compat.

Runtime (`spell_objects_available_to_cast` — the per-priority-window production
entry point — and the cast-time capture helper):
- `once_per_turn_top_of_library_frequency_gates_offer` — offer present →
  consume slot → offer pruned → reset → offer returns (reverting the frequency
  gate keeps the card castable, failing `after_consumed`).
- `unlimited_top_of_library_ignores_used_set` — Unlimited keeps offering even
  with its source id in the used-set.
- `once_per_turn_capture_helper_identifies_source_and_skips_unlimited` — capture
  returns `Some(src)` for OncePerTurn, `None` for Unlimited, `None` for a
  non-top card.

## Per-card verdicts

SHIPPED (0-Unimplemented on the cast-from-zone line):
- Assemble the Players, Johann Apprentice Sorcerer

Already covered by the primitive (Unlimited top-of-library), cast-from-zone line
parses; remaining unparsed line belongs to the spend-mana-restrict cluster:
- Mm'menon, the Right Hand; Vizier of the Menagerie; The Tomb of Aclazotz
  (fully 0-Unimplemented already)

DEFERRED (need distinct, larger infra beyond the bounded top-of-library
frequency change — honest `Effect::Unimplemented` left in place):
- **Festival of Embers** — graveyard cast with a NEW "During your turn" timing
  axis on `GraveyardCastPermission` + "by paying N life in addition to their
  other costs" additive-life alt cost.
- **Valgavoth, Terror Eater** — persistent exile-play with "pay life equal to
  its mana value rather than pay its mana cost" alt cost on the persistent pool.
- **Azula, Cunning Usurper** — persistent exile-cast + "as though they had
  flash" cast-timing grant + spend-any-color-mana.
- **Laughing Jasper Flint** — one-shot "exile top X, you may cast from among
  those cards until end of turn" effect (windowed pool) + Mercenaries static.
- **Tinybones, Bauble Burglar** — per-card stash-counter exile tracking with
  controller-not-owner provenance (cards you don't own).
- **Dawnhand Dissident** — "by removing three counters from among creatures you
  control" composite alt cost.
- **Osteomancer Adept** — forage alt cost + finality-counter enter rider.
- **Sphinx of Forgotten Lore / Songcrafter Mage** — grant flashback/harmonize
  to a graveyard card (keyword-grant cluster, not this primitive).

## Gate results

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- `cargo check --workspace --all-targets` — exit 0
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — exit 0
- `cargo test -p engine` — all pass except the known-flaky `ai_support::delve_payment_skips_state_clone_per_graveyard_candidate` perf test (global clone-counter pollution under parallel execution; passes in isolation; unrelated to this change)
- CR-annotation diff gate — zero UNVERIFIED
- `cargo coverage` / `cargo semantic-audit` — require `client/public/card-data.json`, intentionally absent in this worktree (verification is per-card `parse_oracle_text` + runtime tests per the batch protocol)

Branch: `card/std-cast-from-zone` @ `184d3480af6fa50746974a22247f8a500bb2f631`
(off `upstream/main` @ `f8acc0303`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
