### PR TITLE
feat(engine): timing/condition-gated activated-ability cost reductions (Hylda's Crown, Thaumaton Torpedo)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -44105,6 +44105,259 @@ mod tests {
         );
     }
 
+    /// CR 602.2b + CR 601.2f + CR 102.1: Hylda's Crown of Winter —
+    /// "{1}, {T}: Tap target creature. This ability costs {1} less to activate
+    /// during your turn." The {1} mana component reduces to {0} on the
+    /// controller's turn and stays {1} on an opponent's turn. The reduction is
+    /// parsed from the real Oracle clause and applied through the production
+    /// `apply_cost_reduction` seam reached by `can_activate_ability` / activation.
+    ///
+    /// Discriminating assertion: `generic_of(&def)` flips 0 ↔ 1 with
+    /// `state.active_player`. Reverting the "during your turn" parser arm yields
+    /// `condition: None` (`try_parse_cost_reduction` returns None → no reduction
+    /// node), so the on-turn case would read {1} and this assertion fails.
+    #[test]
+    fn hyldas_crown_cost_reduction_applies_only_during_your_turn() {
+        use crate::parser::oracle_cost::try_parse_cost_reduction;
+        use crate::types::ability::{Effect, ParsedCondition};
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+
+        let reduction =
+            try_parse_cost_reduction("this ability costs {1} less to activate during your turn")
+                .expect("Hylda's Crown cost-reduction clause must parse");
+        assert_eq!(
+            reduction.condition,
+            Some(ParsedCondition::IsYourTurn),
+            "during-your-turn clause must gate on IsYourTurn"
+        );
+
+        let make_def = || {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "tap".to_string(),
+                    description: None,
+                },
+            );
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic: 1,
+                },
+            });
+            def.cost_reduction = Some(reduction.clone());
+            def
+        };
+        let generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => *generic,
+            other => panic!("expected Mana cost, got {other:?}"),
+        };
+
+        let mut state = GameState::new_two_player(7);
+        let src = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Hylda's Crown of Winter".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Controller's turn → {1} reduces to {0}.
+        state.active_player = PlayerId(0);
+        let mut def_on = make_def();
+        apply_cost_reduction(&state, &mut def_on, PlayerId(0), src);
+        assert_eq!(
+            generic_of(&def_on),
+            0,
+            "on your turn the {{1}} generic reduces to {{0}}"
+        );
+
+        // Opponent's turn → no reduction, stays {1}.
+        state.active_player = PlayerId(1);
+        let mut def_off = make_def();
+        apply_cost_reduction(&state, &mut def_off, PlayerId(0), src);
+        assert_eq!(
+            generic_of(&def_off),
+            1,
+            "on an opponent's turn the reduction does not apply"
+        );
+    }
+
+    /// CR 602.2b + CR 601.2f + CR 508.1a: Thaumaton Torpedo —
+    /// "{6}, {T}, Sacrifice this artifact: Destroy target nonland permanent. This
+    /// ability costs {3} less to activate if you attacked with a Spacecraft this
+    /// turn." The {6} component reduces to {3} only when the controller declared a
+    /// Spacecraft attacker this turn. Parsed from the real Oracle clause (the
+    /// "this turn" is stripped upstream as a duration before the cost-reduction
+    /// reparse, mirroring production) and applied through `apply_cost_reduction`.
+    ///
+    /// Discriminating assertion: `generic_of(&def)` is 3 with a Spacecraft
+    /// attacker declaration present and 6 without. Reverting the
+    /// `YouAttackedWithAtLeast { filter }` parser arm leaves `condition: None`
+    /// (try_parse_cost_reduction returns None), so the positive case would read
+    /// {6} and this assertion fails. Reverting the runtime filter arm in
+    /// `restrictions::evaluate_condition` would treat the filtered count as the
+    /// unfiltered count (no Spacecraft tracking), failing the negative case.
+    #[test]
+    fn thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker() {
+        use crate::parser::oracle_cost::try_parse_cost_reduction;
+        use crate::types::ability::{Effect, ParsedCondition};
+        use crate::types::card_type::CoreType;
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+
+        // Mirror the production text reaching the reducer: the activated-ability
+        // duration parser peels the trailing " this turn" before the
+        // cost-reduction clause is reparsed from its Unimplemented description.
+        let reduction = try_parse_cost_reduction(
+            "this ability costs {3} less to activate if you attacked with a spacecraft",
+        )
+        .expect("Thaumaton Torpedo cost-reduction clause must parse");
+        assert!(
+            matches!(
+                reduction.condition,
+                Some(ParsedCondition::YouAttackedWithAtLeast {
+                    count: 1,
+                    filter: Some(_)
+                })
+            ),
+            "must gate on a filtered attacked-with condition, got {:?}",
+            reduction.condition
+        );
+
+        let make_def = || {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "destroy".to_string(),
+                    description: None,
+                },
+            );
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic: 6,
+                },
+            });
+            def.cost_reduction = Some(reduction.clone());
+            def
+        };
+        let generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => *generic,
+            other => panic!("expected Mana cost, got {other:?}"),
+        };
+
+        let mut state = GameState::new_two_player(9);
+        let src = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Thaumaton Torpedo".to_string(),
+            Zone::Battlefield,
+        );
+
+        // No attackers declared → no reduction, stays {6}.
+        let mut def_none = make_def();
+        apply_cost_reduction(&state, &mut def_none, PlayerId(0), src);
+        assert_eq!(
+            generic_of(&def_none),
+            6,
+            "no Spacecraft attacker → full {{6}} cost"
+        );
+
+        // Controller declared a non-Spacecraft creature attacker → still no reduction.
+        let goblin = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Goblin".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let o = state.objects.get_mut(&goblin).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+        }
+        state.attacker_declarations_this_turn = vec![state
+            .objects
+            .get(&goblin)
+            .unwrap()
+            .snapshot_for_attack_declaration(goblin)];
+        let mut def_wrong = make_def();
+        apply_cost_reduction(&state, &mut def_wrong, PlayerId(0), src);
+        assert_eq!(
+            generic_of(&def_wrong),
+            6,
+            "a non-Spacecraft attacker must not satisfy the Spacecraft gate"
+        );
+
+        // Controller declared a Spacecraft attacker → {3} reduction applies.
+        let craft = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Some Ship".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let o = state.objects.get_mut(&craft).unwrap();
+            o.card_types.core_types.push(CoreType::Artifact);
+            o.card_types.subtypes.push("Spacecraft".to_string());
+        }
+        state.attacker_declarations_this_turn.push(
+            state
+                .objects
+                .get(&craft)
+                .unwrap()
+                .snapshot_for_attack_declaration(craft),
+        );
+        let mut def_ok = make_def();
+        apply_cost_reduction(&state, &mut def_ok, PlayerId(0), src);
+        assert_eq!(
+            generic_of(&def_ok),
+            3,
+            "Spacecraft attacker present → cost reduced by {{3}}"
+        );
+
+        // Negative: an OPPONENT's Spacecraft attacker must not satisfy "you attacked".
+        let mut state_opp = GameState::new_two_player(11);
+        let src2 = create_object(
+            &mut state_opp,
+            CardId(1),
+            PlayerId(0),
+            "Thaumaton Torpedo".to_string(),
+            Zone::Battlefield,
+        );
+        let opp_ship = create_object(
+            &mut state_opp,
+            CardId(5),
+            PlayerId(1),
+            "Enemy Ship".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let o = state_opp.objects.get_mut(&opp_ship).unwrap();
+            o.card_types.core_types.push(CoreType::Artifact);
+            o.card_types.subtypes.push("Spacecraft".to_string());
+        }
+        state_opp.attacker_declarations_this_turn = vec![state_opp
+            .objects
+            .get(&opp_ship)
+            .unwrap()
+            .snapshot_for_attack_declaration(opp_ship)];
+        let mut def_opp = make_def();
+        apply_cost_reduction(&state_opp, &mut def_opp, PlayerId(0), src2);
+        assert_eq!(
+            generic_of(&def_opp),
+            6,
+            "an opponent's Spacecraft attacker must not satisfy 'you attacked with a Spacecraft'"
+        );
+    }
+
     // --- cluster-04: first-qualifying-spell keyword grant, cast-time snapshot
     // (CR 611.2f). These tests would FAIL if the Cascade/Demonstrate seams
     // re-queried the grant post-record (the `SpellsCastThisTurn == 0` gate would

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1094,14 +1094,38 @@ pub(crate) fn evaluate_condition(
             }) == 0
         }
         ParsedCondition::YouAttackedThisTurn => state.players_attacked_this_turn.contains(&player),
-        ParsedCondition::YouAttackedWithAtLeast { count } => {
-            state
-                .attacking_creatures_this_turn
-                .get(&player)
-                .copied()
-                .unwrap_or(0)
-                >= *count
-        }
+        // CR 508.1a: "you attacked with N+ [filter] this turn". Unfiltered uses
+        // the fast per-player count; filtered scans declaration-time snapshots so
+        // attackers that have left the battlefield still count.
+        ParsedCondition::YouAttackedWithAtLeast { count, filter } => match filter {
+            None => {
+                state
+                    .attacking_creatures_this_turn
+                    .get(&player)
+                    .copied()
+                    .unwrap_or(0)
+                    >= *count
+            }
+            Some(filter) => {
+                let filter_ctx = crate::game::filter::FilterContext::from_source_with_controller(
+                    source_id, player,
+                );
+                state
+                    .attacker_declarations_this_turn
+                    .iter()
+                    .filter(|record| {
+                        record.lki.controller == player
+                            && crate::game::filter::matches_target_filter_on_attack_declaration_record(
+                                state,
+                                record,
+                                filter,
+                                &filter_ctx,
+                            )
+                    })
+                    .count() as u32
+                    >= *count
+            }
+        },
         ParsedCondition::YouPlayedLandThisTurn => state
             .players
             .get(usize::from(player.0))

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5489,6 +5489,123 @@ mod tests {
         parse_oracle_text(text, name, &keyword_names, &types, &subtypes)
     }
 
+    /// Build a single-face `CardFace` from an oracle `text` through the real
+    /// synthesis path (`build_oracle_face`), so coverage checks recurse into
+    /// granted abilities and effect payloads exactly as production does.
+    #[cfg(test)]
+    fn oracle_face_for(
+        name: &str,
+        text: &str,
+        types: &[&str],
+        subtypes: &[&str],
+    ) -> crate::types::card::CardFace {
+        use crate::database::mtgjson::{AtomicCard, AtomicIdentifiers};
+        let card = AtomicCard {
+            name: name.to_string(),
+            mana_cost: Some("{4}{B}".to_string()),
+            colors: vec!["B".to_string()],
+            color_identity: vec!["B".to_string()],
+            power: Some("3".to_string()),
+            toughness: Some("3".to_string()),
+            loyalty: None,
+            defense: None,
+            text: Some(text.to_string()),
+            layout: "normal".to_string(),
+            type_line: Some(types.join(" ")),
+            types: types.iter().map(|s| s.to_string()).collect(),
+            subtypes: subtypes.iter().map(|s| s.to_string()).collect(),
+            supertypes: Vec::new(),
+            keywords: None,
+            side: None,
+            face_name: None,
+            mana_value: 5.0,
+            legalities: Default::default(),
+            leadership_skills: None,
+            printings: Vec::new(),
+            rulings: Vec::new(),
+            is_game_changer: false,
+            identifiers: AtomicIdentifiers {
+                scryfall_oracle_id: Some(format!("{}-oracle", name.to_lowercase())),
+                scryfall_id: Some(format!("{}-face", name.to_lowercase())),
+            },
+            foreign_data: Vec::new(),
+        };
+        crate::database::synthesis::build_oracle_face(&card, None)
+    }
+
+    /// CR 602.2b + CR 601.2f + CR 102.1: Hylda's Crown of Winter parses with zero
+    /// unimplemented parts. The whole card is two activated abilities; the only
+    /// previously-failing fragment was the "This ability costs {1} less to
+    /// activate during your turn" cost-reduction clause, now extracted as
+    /// `cost_reduction` with `condition: IsYourTurn`. (Runtime under/over-the-gate
+    /// discrimination lives in `game::casting::tests::
+    /// hyldas_crown_cost_reduction_applies_only_during_your_turn`.)
+    #[test]
+    fn hyldas_crown_full_card_supported_with_during_your_turn_cost_reduction() {
+        let face = oracle_face_for(
+            "Hylda's Crown of Winter",
+            "{1}, {T}: Tap target creature. This ability costs {1} less to activate during your turn.\n{3}, Sacrifice Hylda's Crown of Winter: Draw a card for each tapped creature your opponents control.",
+            &["Legendary", "Artifact"],
+            &[],
+        );
+        let gaps = crate::game::coverage::card_face_gaps(&face);
+        assert!(
+            gaps.is_empty(),
+            "Hylda's Crown must be fully supported, gaps: {gaps:?}"
+        );
+        let tap_ability = face
+            .abilities
+            .iter()
+            .find(|a| a.cost_reduction.is_some())
+            .expect("the tap ability must carry the extracted cost reduction");
+        assert_eq!(
+            tap_ability.cost_reduction.as_ref().unwrap().condition,
+            Some(crate::types::ability::ParsedCondition::IsYourTurn),
+            "cost reduction must gate on IsYourTurn"
+        );
+    }
+
+    /// CR 602.2b + CR 601.2f + CR 508.1a: Thaumaton Torpedo parses with zero
+    /// unimplemented parts. The card is a single activated ability; the only
+    /// previously-failing fragment was the "This ability costs {3} less to
+    /// activate if you attacked with a Spacecraft this turn" cost-reduction
+    /// clause, now extracted with a filtered `YouAttackedWithAtLeast` gate.
+    /// (Runtime discrimination — Spacecraft attacker required, opponent's
+    /// Spacecraft excluded — lives in `game::casting::tests::
+    /// thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker`.)
+    #[test]
+    fn thaumaton_torpedo_full_card_supported_with_spacecraft_attacked_cost_reduction() {
+        let face = oracle_face_for(
+            "Thaumaton Torpedo",
+            "{6}, {T}, Sacrifice this artifact: Destroy target nonland permanent. This ability costs {3} less to activate if you attacked with a Spacecraft this turn.",
+            &["Artifact"],
+            &[],
+        );
+        let gaps = crate::game::coverage::card_face_gaps(&face);
+        assert!(
+            gaps.is_empty(),
+            "Thaumaton Torpedo must be fully supported, gaps: {gaps:?}"
+        );
+        let ability = face
+            .abilities
+            .iter()
+            .find(|a| a.cost_reduction.is_some())
+            .expect("the destroy ability must carry the extracted cost reduction");
+        assert!(
+            matches!(
+                ability.cost_reduction.as_ref().unwrap().condition,
+                Some(
+                    crate::types::ability::ParsedCondition::YouAttackedWithAtLeast {
+                        count: 1,
+                        filter: Some(_)
+                    }
+                )
+            ),
+            "cost reduction must gate on a filtered attacked-with condition, got {:?}",
+            ability.cost_reduction
+        );
+    }
+
     /// CR 106.6 + CR 702.6a: Hydraulic Helper — the full card must parse with
     /// zero `Effect::Unimplemented` parts. "Defender" extracts as a keyword and
     /// the `{T}: Add {U}` mana ability carries the negative spend restriction

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
+use nom::character::complete::{multispace0, one_of};
 use nom::combinator::{all_consuming, opt, value};
 use nom::sequence::terminated;
 use nom::Parser;
@@ -220,15 +221,20 @@ fn parse_you_attacked_with_filter(text: &str) -> Option<ParsedCondition> {
     if matches!(filter, TargetFilter::Any) {
         return None;
     }
-    // Consume an optional trailing " this turn" with a combinator, then require
-    // the phrase to be fully consumed so unrecognized qualifiers stay an honest
-    // gap. The duration suffix may already be stripped upstream, so it is
-    // optional.
-    let remainder = remainder.trim();
-    let (after, _) = opt(tag::<_, _, OracleError<'_>>("this turn"))
+    // Consume an optional trailing " this turn" and any trailing punctuation with
+    // combinators (no manual string trimming), then require the phrase to be fully
+    // consumed so unrecognized qualifiers stay an honest gap. The duration suffix
+    // may already be stripped upstream, so it is optional.
+    let (remainder, _) = multispace0::<_, OracleError<'_>>(remainder).ok()?;
+    let (remainder, _) = opt(tag::<_, _, OracleError<'_>>("this turn"))
         .parse(remainder)
         .ok()?;
-    if !after.trim().is_empty() {
+    let (remainder, _) = multispace0::<_, OracleError<'_>>(remainder).ok()?;
+    let (remainder, _) = opt(one_of::<_, _, OracleError<'_>>(".,;"))
+        .parse(remainder)
+        .ok()?;
+    let (remainder, _) = multispace0::<_, OracleError<'_>>(remainder).ok()?;
+    if !remainder.is_empty() {
         return None;
     }
     Some(ParsedCondition::YouAttackedWithAtLeast {

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -148,6 +148,7 @@ fn parse_condition_text(text: &str) -> Option<ParsedCondition> {
     {
         return Some(ParsedCondition::YouAttackedWithAtLeast {
             count: count as u32,
+            filter: None,
         });
     }
     if let Some(count) =
@@ -155,7 +156,18 @@ fn parse_condition_text(text: &str) -> Option<ParsedCondition> {
     {
         return Some(ParsedCondition::YouAttackedWithAtLeast {
             count: count as u32,
+            filter: None,
         });
+    }
+    // CR 508.1a: "you attacked with a/an <filter> this turn" — at least one
+    // attacker of the given kind. Distinct from the numeric "N creatures"
+    // thresholds above (which carry no type qualifier). The trailing "this turn"
+    // may already be stripped upstream (e.g. an activated-ability duration
+    // parser peels it before the cost-reduction condition is reparsed), so both
+    // the suffixed and bare forms are accepted. Thaumaton Torpedo: "...if you
+    // attacked with a Spacecraft this turn".
+    if let Some(condition) = parse_you_attacked_with_filter(text) {
+        return Some(condition);
     }
     if all_consuming(alt((
         value(
@@ -187,6 +199,42 @@ fn parse_condition_text(text: &str) -> Option<ParsedCondition> {
         return Some(condition);
     }
     None
+}
+
+/// CR 508.1a: Parse "you attacked with a/an <filter>[ this turn]" into a
+/// `ParsedCondition::YouAttackedWithAtLeast { count: 1, filter }`. The `<filter>`
+/// is delegated to `parse_type_phrase` so the whole class of attacker qualifiers
+/// (Spacecraft, Vehicle, a specific creature type, …) is covered by the shared
+/// type-phrase combinator rather than a per-card literal. Returns `None` unless
+/// the entire phrase after the filter is consumed (modulo an optional " this
+/// turn"), keeping unrecognized qualifiers an honest gap.
+fn parse_you_attacked_with_filter(text: &str) -> Option<ParsedCondition> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("you attacked with ")
+        .parse(text)
+        .ok()?;
+    let (filter, remainder) = parse_type_phrase(rest);
+    // Reject the bare/untyped case: `parse_type_phrase` returns `Any` when no
+    // type word matched, which would over-match "you attacked with three or more
+    // creatures this turn" (handled by the numeric thresholds above). Require a
+    // concrete typed filter here.
+    if matches!(filter, TargetFilter::Any) {
+        return None;
+    }
+    // Consume an optional trailing " this turn" with a combinator, then require
+    // the phrase to be fully consumed so unrecognized qualifiers stay an honest
+    // gap. The duration suffix may already be stripped upstream, so it is
+    // optional.
+    let remainder = remainder.trim();
+    let (after, _) = opt(tag::<_, _, OracleError<'_>>("this turn"))
+        .parse(remainder)
+        .ok()?;
+    if !after.trim().is_empty() {
+        return None;
+    }
+    Some(ParsedCondition::YouAttackedWithAtLeast {
+        count: 1,
+        filter: Some(filter),
+    })
 }
 
 fn parse_quantity_restriction_condition(text: &str) -> Option<ParsedCondition> {
@@ -1245,6 +1293,43 @@ mod tests {
     use crate::types::ability::{
         ControllerRef, CountScope, FilterProp, QuantityExpr, TargetFilter, TypeFilter,
     };
+
+    /// CR 508.1a: "you attacked with a/an <filter>[ this turn]" parses to a
+    /// filtered `YouAttackedWithAtLeast { count: 1 }`, both with and without the
+    /// trailing "this turn" (the latter is the shape reaching the parser after an
+    /// upstream duration strip). The unfiltered numeric thresholds remain
+    /// `filter: None`, and the bare-creature numeric form must NOT be captured by
+    /// the typed arm.
+    #[test]
+    fn attacked_with_filter_condition_parses_typed_and_preserves_numeric() {
+        for text in [
+            "you attacked with a spacecraft this turn",
+            "you attacked with a spacecraft",
+        ] {
+            match parse_restriction_condition(text) {
+                Some(ParsedCondition::YouAttackedWithAtLeast {
+                    count: 1,
+                    filter: Some(TargetFilter::Typed(tf)),
+                }) => assert!(
+                    tf.type_filters
+                        .iter()
+                        .any(|f| matches!(f, TypeFilter::Subtype(s) if s == "Spacecraft")),
+                    "expected Spacecraft subtype, got {:?} for {text}",
+                    tf.type_filters
+                ),
+                other => panic!("expected filtered attacked-with for {text}, got {other:?}"),
+            }
+        }
+        // Numeric thresholds stay unfiltered.
+        assert_eq!(
+            parse_restriction_condition("you attacked with 3 or more creatures this turn"),
+            Some(ParsedCondition::YouAttackedWithAtLeast {
+                count: 3,
+                filter: None,
+            }),
+            "numeric attacker threshold must stay filter: None"
+        );
+    }
 
     /// CR 508.1 + CR 601.3: a presence-style restriction condition ("Cast this
     /// spell only if a creature is attacking you" — Confront the Assault)

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -1073,6 +1073,35 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
 
     let after_mana = after_mana.trim_start();
 
+    // CR 602.2b + CR 601.2f + CR 102.1 timing-gated flat form:
+    // "... less to activate during your turn[s]" / "... less to cast during your
+    // turn[s]". CR 102.1 makes "your turn" the controller-is-active-player test,
+    // so this is exactly the `IsYourTurn` flat conditional (count = Fixed(1)).
+    // Checked before the generic "if [condition]" form because "during your turn"
+    // is not introduced by "if". Hylda's Crown of Winter: "This ability costs {1}
+    // less to activate during your turn."
+    if nom_on_lower(after_mana, after_mana, |i| {
+        value(
+            (),
+            (
+                alt((
+                    tag("less to activate during your "),
+                    tag("less to cast during your "),
+                )),
+                alt((tag("turns"), tag("turn"))),
+            ),
+        )
+        .parse(i)
+    })
+    .is_some_and(|((), rest)| rest.trim().trim_end_matches('.').trim().is_empty())
+    {
+        return Some(CostReduction {
+            amount_per,
+            count: QuantityExpr::Fixed { value: 1 },
+            condition: Some(crate::types::ability::ParsedCondition::IsYourTurn),
+        });
+    }
+
     // CR 602.2b + CR 601.2f conditional flat form: "... less to activate if [condition]" /
     // "... less to cast if [condition]". The reduction is a flat {amount_per}
     // (count = Fixed(1)) gated by `condition`. Checked before the "for each"
@@ -2182,6 +2211,61 @@ mod tests {
     #[test]
     fn cost_reduction_unrecognized_returns_none() {
         assert!(try_parse_cost_reduction("something else entirely").is_none());
+    }
+
+    /// CR 602.2b + CR 601.2f + CR 102.1: the "during your turn[s]" timing-gated
+    /// flat form maps to a `Fixed(1)` reduction gated by `IsYourTurn`, for both
+    /// the activate and cast verb axes and both turn-plurality forms. This is the
+    /// building-block test behind Hylda's Crown of Winter.
+    #[test]
+    fn cost_reduction_during_your_turn_maps_to_is_your_turn() {
+        use crate::types::ability::ParsedCondition;
+        for text in [
+            "this ability costs {1} less to activate during your turn",
+            "this ability costs {2} less to activate during your turns",
+            "this spell costs {1} less to cast during your turn",
+        ] {
+            let r = try_parse_cost_reduction(text).unwrap_or_else(|| panic!("must parse: {text}"));
+            assert_eq!(r.count, QuantityExpr::Fixed { value: 1 }, "{text}");
+            assert_eq!(
+                r.condition,
+                Some(ParsedCondition::IsYourTurn),
+                "during-your-turn must gate on IsYourTurn: {text}"
+            );
+        }
+        // "{2} less to activate during your turn" keeps amount_per = 2.
+        let two =
+            try_parse_cost_reduction("this ability costs {2} less to activate during your turns")
+                .unwrap();
+        assert_eq!(two.amount_per, 2);
+    }
+
+    /// CR 508.1a + CR 601.2f: the conditional flat form gated by "you attacked
+    /// with a <filter>" extracts a filtered `YouAttackedWithAtLeast { count: 1 }`.
+    /// The trailing "this turn" is stripped upstream as a duration before the
+    /// reparse, so the bare form is what reaches the reducer (Thaumaton Torpedo).
+    #[test]
+    fn cost_reduction_if_attacked_with_filter_gate() {
+        use crate::types::ability::ParsedCondition;
+        let r = try_parse_cost_reduction(
+            "this ability costs {3} less to activate if you attacked with a spacecraft",
+        )
+        .expect("must parse filtered attacked-with gate");
+        assert_eq!(r.amount_per, 3);
+        assert_eq!(r.count, QuantityExpr::Fixed { value: 1 });
+        match r.condition {
+            Some(ParsedCondition::YouAttackedWithAtLeast {
+                count: 1,
+                filter: Some(TargetFilter::Typed(tf)),
+            }) => assert!(
+                tf.type_filters
+                    .iter()
+                    .any(|f| matches!(f, TypeFilter::Subtype(s) if s == "Spacecraft")),
+                "expected Spacecraft subtype filter, got {:?}",
+                tf.type_filters
+            ),
+            other => panic!("expected filtered attacked-with gate, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -1073,13 +1073,15 @@ pub(crate) fn try_parse_cost_reduction(text: &str) -> Option<CostReduction> {
 
     let after_mana = after_mana.trim_start();
 
-    // CR 602.2b + CR 601.2f + CR 102.1 timing-gated flat form:
-    // "... less to activate during your turn[s]" / "... less to cast during your
-    // turn[s]". CR 102.1 makes "your turn" the controller-is-active-player test,
-    // so this is exactly the `IsYourTurn` flat conditional (count = Fixed(1)).
-    // Checked before the generic "if [condition]" form because "during your turn"
-    // is not introduced by "if". Hylda's Crown of Winter: "This ability costs {1}
-    // less to activate during your turn."
+    // CR 602.2b: An activated ability's analog to a spell's mana cost is its activation cost.
+    // CR 601.2f: Cost reductions reduce that cost, with the mana component floored at {0}.
+    // CR 102.1: The active player is the player whose turn it is, so "during your
+    //           turn" is the controller-is-active-player test.
+    // Timing-gated flat form ("... less to activate during your turn[s]" / "... less
+    // to cast during your turn[s]") is therefore exactly the `IsYourTurn` flat
+    // conditional (count = Fixed(1)). Checked before the generic "if [condition]"
+    // form because "during your turn" is not introduced by "if". Hylda's Crown of
+    // Winter: "This ability costs {1} less to activate during your turn."
     if nom_on_lower(after_mana, after_mana, |i| {
         value(
             (),

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5441,8 +5441,18 @@ pub enum ParsedCondition {
     },
     YouControlNoCreatures,
     YouAttackedThisTurn,
+    /// CR 508.1a: True when the player declared at least `count` attackers this
+    /// turn. `filter: None` counts every attacker the player declared (backed by
+    /// the fast `state.attacking_creatures_this_turn` counter — "you attacked
+    /// with N+ creatures this turn"). `filter: Some(_)` counts only attackers
+    /// matching the filter from the declaration-time snapshot
+    /// `state.attacker_declarations_this_turn` (Thaumaton Torpedo — "you attacked
+    /// with a Spacecraft this turn"), so attackers that have since left the
+    /// battlefield still count.
     YouAttackedWithAtLeast {
         count: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<TargetFilter>,
     },
     /// True when the player has already used at least one land play this turn.
     /// The count is tracked on `Player::lands_played_this_turn` from

--- a/crates/engine/tests/conditional_cost_reduction_3223.rs
+++ b/crates/engine/tests/conditional_cost_reduction_3223.rs
@@ -142,6 +142,23 @@ This ability costs {4} less to activate if an opponent controls four or more non
     );
 }
 
+#[test]
+fn thaumaton_torpedo_cost_reduction_carries_spacecraft_attacker_condition() {
+    // #3223 follow-up: this gap is now filled by PR #3950, which models the
+    // "if you attacked with a <filter> this turn" gate as a filtered
+    // `YouAttackedWithAtLeast { count: 1, filter: Some(Spacecraft) }` condition.
+    let card = "Thaumaton Torpedo";
+    let oracle = "{6}, {T}, Sacrifice this artifact: Destroy target nonland permanent. \
+This ability costs {3} less to activate if you attacked with a Spacecraft this turn.";
+    let ability = ability_with_cost_reduction(oracle, card);
+    let reduction = find_cost_reduction(&ability).unwrap();
+    assert_flat_conditional(reduction, 3, card);
+    assert!(
+        !has_surviving_cost_reduction_gap(&ability),
+        "{card}: no Unimplemented 'less to activate' node should survive"
+    );
+}
+
 // --- Coverage-honesty negatives: unmodeled conditions MUST stay a loud gap. ---
 
 /// Asserts no ability in the parse captured a cost reduction, and that an
@@ -182,14 +199,5 @@ fn wayta_trainer_prodigy_cost_reduction_stays_gapped() {
 {2}{G}, {T}: Target creature you control fights another target creature. \
 This ability costs {2} less to activate if it targets two creatures you control.\n\
 If a creature you control being dealt damage causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.";
-    assert_cost_reduction_stays_gapped(oracle, card);
-}
-
-#[test]
-fn thaumaton_torpedo_cost_reduction_stays_gapped() {
-    // Unmodeled condition: "if you attacked with a Spacecraft this turn."
-    let card = "Thaumaton Torpedo";
-    let oracle = "{6}, {T}, Sacrifice this artifact: Destroy target nonland permanent. \
-This ability costs {3} less to activate if you attacked with a Spacecraft this turn.";
     assert_cost_reduction_stays_gapped(oracle, card);
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# Standard cost-reduction cluster: timing/condition-gated activated-ability cost reductions

Extends the existing cost-reduction infrastructure (`CostReduction` for activated
abilities, `StaticMode::ModifyCost` for spells, `try_parse_cost_reduction`) to
cover two previously-unimplemented gate shapes in the Standard cost-reduction
cluster. No new effect/static variants were created — only one parameterization
of an existing `ParsedCondition` variant and two new parser arms that reuse the
existing runtime cost-reduction seam.

## What changed (reuse vs new)

- **Reuse:** the whole runtime path is unchanged — `apply_cost_reduction`
  (`game/casting.rs`) already evaluates `CostReduction.condition` via
  `restrictions::evaluate_condition`. Both shipped cards plug straight into it.
- **New parser arm (`oracle_cost.rs`):** "this ability/spell costs {N} less to
  activate/cast **during your turn[s]**" → `CostReduction { condition:
  IsYourTurn, count: Fixed(1) }` (CR 102.1 makes "your turn" the
  controller-is-active-player test).
- **New parser arm (`oracle_condition.rs`):** "you attacked with a/an
  **\<filter\>** [this turn]" → a filtered attacker condition, delegating the
  filter to the shared `parse_type_phrase` so the whole attacker-qualifier class
  is covered (Spacecraft, Vehicle, any creature type), not a per-card literal.
- **Parameterization (add-engine-variant gate APPROVED):** extended the existing
  `ParsedCondition::YouAttackedWithAtLeast { count }` with an optional
  `filter: Option<TargetFilter>`. Gate result: Stage 1 DOES_NOT_EXIST (only a
  count-only form existed), Stage 2 the `YouAttacked*` cluster smell makes this a
  parameterization rather than a new sibling, Stage 3 WITHIN_SECTION (CR 508.1a,
  the filter rides on `TargetFilter`). Unfiltered counts use the fast
  `state.attacking_creatures_this_turn`; filtered counts scan
  `state.attacker_declarations_this_turn` declaration-time snapshots so attackers
  that have left the battlefield still count.

## Shipped (0-unimplemented, discriminating runtime test)

- **Hylda's Crown of Winter** — "{1}, {T}: Tap target creature. This ability
  costs {1} less to activate during your turn." The {1} component reduces to {0}
  on your turn, stays {1} on an opponent's turn.
- **Thaumaton Torpedo** — "{6}, {T}, Sacrifice this artifact: Destroy target
  nonland permanent. This ability costs {3} less to activate if you attacked with
  a Spacecraft this turn." The {6} reduces to {3} only when the controller
  declared a Spacecraft attacker this turn; an opponent's Spacecraft does not
  count.

## Deferred (need other infra; cost-reduction fragment honest-`unimplemented`)

| Card | Why deferred |
|---|---|
| Boom Scholar | Exhaust keyword (cluster-exhaust) |
| Goblin Maskmaker | face-down spell system |
| Doc Aurlock | line 1 (graveyard/exile cost reduction) already works; line 2 needs Plot |
| Inquisitive Glimmer | line 1 (enchantment cost reduction) already works; line 2 needs Unlock-cost reduction |
| Hollow Marauder | cost reduction works; ETB "for each opponent who didn't discard …" is the gap |
| Rottenmouth Viper | cost reduction works; blight-counter "each opponent loses 4 life unless …" loop is the gap |
| The Pride of Hull Clade | cost reduction works; granted ability "draw cards equal to its toughness" is the gap |
| The Skullspore Nexus | cost reduction works; "create a Fungus Dinosaur with base P/T = total power" token trigger is the gap |
| Rowan, Scion of War / Will, Scion of Peace | turn-scoped, color-filtered, **dynamic-amount** ("X = life lost/gained this turn") multi-spell cost reduction. Needs a new rest-of-turn non-consuming cost-reduction primitive (the existing `PendingSpellCostReduction` is one-shot/next-spell). Heavy new casting-stack infra — deferred. |
| The Dominion Bracelet | granted-ability cost reduction parses, but the core "You control target opponent during their next turn" is unimplemented |
| Firion, Wild Rose Warrior | granted-token-copy cost reduction is honest-`unimplemented` inside `CopyTokenOf.additional_modifications` (coverage currently reports this card green — a separate false-green in `card_face_has_unimplemented_parts`, out of scope here) |
| Temporal Intervention | Void keyword cost-reduction condition |

## CR evidence (grep-verified against docs/MagicCompRules.txt)

- CR 102.1 — active player is the player whose turn it is
- CR 508.1a — declare attackers
- CR 601.2f — cost-reduction folding (generic floor {0})
- CR 602.2b — an activated ability's analog to a spell's mana cost is its activation cost

## Tests

Runtime (drive production `apply_cost_reduction`, revert-failing):
- `game::casting::tests::hyldas_crown_cost_reduction_applies_only_during_your_turn`
- `game::casting::tests::thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker`

Full-card coverage (real `build_oracle_face` + `card_face_gaps`, recurses granted abilities):
- `parser::oracle::tests::hyldas_crown_full_card_supported_with_during_your_turn_cost_reduction`
- `parser::oracle::tests::thaumaton_torpedo_full_card_supported_with_spacecraft_attacked_cost_reduction`

Building-block parser:
- `parser::oracle_cost::tests::cost_reduction_during_your_turn_maps_to_is_your_turn`
- `parser::oracle_cost::tests::cost_reduction_if_attacked_with_filter_gate`
- `parser::oracle_condition::tests::attacked_with_filter_condition_parses_typed_and_preserves_numeric`

## Gates

cargo fmt --all · check-parser-combinators.sh · check-engine-authorities.sh
upstream/main · cargo check --workspace --all-targets · cargo clippy --workspace
--exclude phase-tauri --all-targets -D warnings · cargo test -p engine — all green.
