### PR TITLE
feat(engine): negated cast-from-zone mana spend restriction via ZoneSpendPolarity (Mm'menon)

### DIFF
--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -311,8 +311,8 @@ pub(crate) fn resolve_restrictions(
                     count: *count,
                 })
             }
-            ManaSpendRestriction::SpellFromZone(zone) => {
-                Some(ManaRestriction::OnlyForSpellFromZone(*zone))
+            ManaSpendRestriction::SpellFromZone(zs) => {
+                Some(ManaRestriction::OnlyForSpellFromZone(*zs))
             }
             // CR 106.6: Disjunction — recursively lower each branch. If every branch
             // dropped (e.g. an unresolvable `ChosenCreatureType` with no chosen type),

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -14800,6 +14800,60 @@ At the beginning of your upkeep, add {C} for each artifact you control. This man
         );
     }
 
+    // CR 106.6 + CR 400.7: Mm'menon, the Right Hand grants its artifacts a mana
+    // ability whose produced mana is spend-restricted to spells cast from
+    // anywhere other than hand. The granted-ability text must parse end-to-end
+    // (no `Effect::Unimplemented`) and the inner mana effect must carry the
+    // `SpellFromZone { Hand, NotFrom }` restriction.
+    #[test]
+    fn mmmenon_granted_mana_carries_not_from_hand_restriction() {
+        let oracle = "Flying\n\
+You may look at the top card of your library any time.\n\
+You may cast artifact spells from the top of your library.\n\
+Artifacts you control have \"{T}: Add {U}. Spend this mana only to cast a spell from anywhere other than your hand.\"";
+        let parsed = super::parse_oracle_text(
+            oracle,
+            "Mm'menon, the Right Hand",
+            &[],
+            &["Legendary".to_string(), "Creature".to_string()],
+            &[],
+        );
+
+        // The granted mana ability lives inside a `GrantAbility` continuous
+        // modification of one of the parsed statics. Walk the typed tree and
+        // assert the granted ability's mana effect carries the not-from-hand
+        // restriction (and is not an `Unimplemented` gap).
+        use crate::types::ability::{ContinuousModification, Effect, ManaSpendRestriction};
+        use crate::types::mana::{ZoneSpend, ZoneSpendPolarity};
+        use crate::types::zones::Zone;
+
+        let expected = ManaSpendRestriction::SpellFromZone(ZoneSpend {
+            zone: Zone::Hand,
+            polarity: ZoneSpendPolarity::NotFrom,
+        });
+        let mut found = false;
+        for st in &parsed.statics {
+            for modification in &st.modifications {
+                if let ContinuousModification::GrantAbility { definition } = modification {
+                    assert!(
+                        !matches!(*definition.effect, Effect::Unimplemented { .. }),
+                        "Mm'menon's granted mana ability must not be Unimplemented: {definition:?}"
+                    );
+                    if let Effect::Mana { restrictions, .. } = &*definition.effect {
+                        if restrictions.contains(&expected) {
+                            found = true;
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            found,
+            "Mm'menon's granted mana must carry the not-from-hand restriction; statics={:?}",
+            parsed.statics
+        );
+    }
+
     #[test]
     fn mana_spend_restriction_x_cost_only() {
         use crate::parser::oracle_effect::mana::parse_mana_spend_restriction;
@@ -15114,19 +15168,43 @@ At the beginning of your upkeep, add {C} for each artifact you control. This man
 
     #[test]
     fn mana_spend_restriction_from_graveyard() {
+        use crate::types::mana::{ZoneSpend, ZoneSpendPolarity};
         assert_eq!(
             crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
                 "spend this mana only to cast a spell from your graveyard"
             )
             .map(|(r, _)| r),
-            Some(ManaSpendRestriction::SpellFromZone(Zone::Graveyard))
+            Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
+                zone: Zone::Graveyard,
+                polarity: ZoneSpendPolarity::From,
+            }))
         );
         assert_eq!(
             crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
                 "spend this mana only to cast spells from exile"
             )
             .map(|(r, _)| r),
-            Some(ManaSpendRestriction::SpellFromZone(Zone::Exile))
+            Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
+                zone: Zone::Exile,
+                polarity: ZoneSpendPolarity::From,
+            }))
+        );
+    }
+
+    // CR 106.6 + CR 400.7: Mm'menon, the Right Hand — "from anywhere other than
+    // your hand" parses to the `NotFrom` polarity over `Zone::Hand`.
+    #[test]
+    fn mana_spend_restriction_not_from_hand() {
+        use crate::types::mana::{ZoneSpend, ZoneSpendPolarity};
+        assert_eq!(
+            crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
+                "spend this mana only to cast a spell from anywhere other than your hand"
+            )
+            .map(|(r, _)| r),
+            Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
+                zone: Zone::Hand,
+                polarity: ZoneSpendPolarity::NotFrom,
+            }))
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -16,6 +16,7 @@ use crate::types::ability::{
 use crate::types::keywords::KeywordKind;
 use crate::types::mana::{
     AbilityActivationScope, ManaColor, ManaRestriction, ManaSpellGrant, SpellCostCriterion,
+    ZoneSpend, ZoneSpendPolarity,
 };
 use crate::types::zones::Zone;
 
@@ -1510,11 +1511,16 @@ fn parse_single_cast_clause(rest: &str) -> Option<ManaSpendRestriction> {
         });
     }
 
-    // CR 106.6 + CR 400.7: "[a spell|spells] from your graveyard" / "from exile"
-    // — zone-gated spend (no keyword required). Checked before the type-phrase
+    // CR 106.6 + CR 400.7: "[a spell|spells] from [your] <zone>" / "from anywhere
+    // other than [your] <zone>" — zone-gated spend (no keyword required), where
+    // the leading "anywhere other than" upgrades the reading to the `NotFrom`
+    // polarity (Mm'menon, the Right Hand). Checked before the type-phrase
     // fallback, which does not recognize a "from <zone>" tail.
-    if let Some(zone) = parse_spell_from_zone(rest) {
-        return Some(ManaSpendRestriction::SpellFromZone(zone));
+    if let Some((zone, polarity)) = parse_spell_from_zone(rest) {
+        return Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
+            zone,
+            polarity,
+        }));
     }
 
     // CR 106.6: Check for an "or activate …" ability-activation suffix. If
@@ -1699,23 +1705,30 @@ fn parse_spell_with_keyword(rest: &str) -> Option<(KeywordKind, Option<Zone>)> {
     Some((kind, Some(zone)))
 }
 
-/// CR 106.6 + CR 400.7: Parse "[a spell|spells] from <zone>" (the post-"to cast"
-/// remainder of a zone-gated spend restriction) into the origin `Zone`. Handles
-/// graveyard / exile / hand with the usual "your"/"a" determiners. Returns
-/// `None` when the remainder is not a bare spell-from-zone phrase (e.g. it
-/// carries a keyword or type qualifier handled by other arms).
-fn parse_spell_from_zone(rest: &str) -> Option<Zone> {
+/// CR 106.6 + CR 400.7: Parse "[a spell|spells] from [anywhere other than ]<zone>"
+/// (the post-"to cast" remainder of a zone-gated spend restriction) into the
+/// origin `Zone` and its inclusion/exclusion polarity. Handles graveyard / exile
+/// / hand with the usual "your"/"a" determiners. The optional "anywhere other
+/// than " prefix flips the reading to [`ZoneSpendPolarity::NotFrom`] (Mm'menon,
+/// the Right Hand — "from anywhere other than your hand"). Returns `None` when
+/// the remainder is not a bare spell-from-zone phrase (e.g. it carries a keyword
+/// or type qualifier handled by other arms).
+fn parse_spell_from_zone(rest: &str) -> Option<(Zone, ZoneSpendPolarity)> {
     let rest_lower = rest.to_lowercase();
-    let (_, after_prefix) = nom_on_lower(rest, &rest_lower, |i| {
-        value(
-            (),
-            (
-                alt((tag("a spell"), tag("spells"))),
-                tag(" from "),
-                opt(alt((tag("your "), tag("a ")))),
-            ),
-        )
-        .parse(i)
+    // Consume "[a spell|spells] from " then, optionally, the "anywhere other
+    // than " exclusion marker; the determiner ("your"/"a") follows in both
+    // readings. The presence of the exclusion marker selects the polarity.
+    let (polarity, after_prefix) = nom_on_lower(rest, &rest_lower, |i| {
+        let (i, _) = alt((tag("a spell"), tag("spells"))).parse(i)?;
+        let (i, _) = tag(" from ").parse(i)?;
+        let (i, exclusion) = opt(tag("anywhere other than ")).parse(i)?;
+        let polarity = if exclusion.is_some() {
+            ZoneSpendPolarity::NotFrom
+        } else {
+            ZoneSpendPolarity::From
+        };
+        let (i, _) = opt(alt((tag("your "), tag("a ")))).parse(i)?;
+        Ok((i, polarity))
     })?;
     let after_lower = after_prefix.to_lowercase();
     let (zone, _) = nom_on_lower(after_prefix, &after_lower, |i| {
@@ -1726,7 +1739,7 @@ fn parse_spell_from_zone(rest: &str) -> Option<Zone> {
         )))
         .parse(i)
     })?;
-    Some(zone)
+    Some((zone, polarity))
 }
 
 /// CR 106.6: Parse the "[spells|a spell] with mana value N [or greater|or
@@ -3361,6 +3374,34 @@ mod tests {
                 comparator: Comparator::GE,
                 value: 5,
             })
+        );
+    }
+
+    // CR 106.6 + CR 400.7: Mm'menon, the Right Hand — "from anywhere other than
+    // your hand" lowers to the `NotFrom` polarity over `Zone::Hand`, while the
+    // existing positive "from your graveyard" reading stays `From`.
+    #[test]
+    fn mana_spend_restriction_not_from_hand() {
+        assert_eq!(
+            parse_mana_spend_restriction(
+                "spend this mana only to cast a spell from anywhere other than your hand"
+            )
+            .map(|(r, _)| r),
+            Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
+                zone: Zone::Hand,
+                polarity: ZoneSpendPolarity::NotFrom,
+            }))
+        );
+        // The exclusion marker must not bleed into the inclusion reading.
+        assert_eq!(
+            parse_mana_spend_restriction(
+                "spend this mana only to cast a spell from your graveyard"
+            )
+            .map(|(r, _)| r),
+            Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
+                zone: Zone::Graveyard,
+                polarity: ZoneSpendPolarity::From,
+            }))
         );
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -16,7 +16,9 @@ use super::game_state::{
 };
 use super::identifiers::{ObjectId, TrackedSetId};
 use super::keywords::{Keyword, KeywordKind};
-use super::mana::{AbilityActivationScope, ManaColor, ManaCost, ManaType, SpellCostCriterion};
+use super::mana::{
+    AbilityActivationScope, ManaColor, ManaCost, ManaType, SpellCostCriterion, ZoneSpend,
+};
 use super::phase::Phase;
 use super::player::{PlayerCounterKind, PlayerId};
 use super::replacements::ReplacementEvent;
@@ -1491,10 +1493,16 @@ pub enum ManaSpendRestriction {
     /// [`Comparator`] — one variant per color-count reading. `count` is N.
     SpellWithColorCount { comparator: Comparator, count: u32 },
     /// CR 106.6 + CR 400.7: "Spend this mana only to cast spells from your
-    /// graveyard" / "from exile". Gates spending on the spell's cast-from zone
-    /// alone — a distinct axis from [`ManaSpendRestriction::SpellWithKeywordKindFromZone`],
-    /// which additionally requires a keyword. Resolved against `SpellMeta.cast_from_zone`.
-    SpellFromZone(Zone),
+    /// graveyard" / "from exile" ([`From`](super::mana::ZoneSpendPolarity::From))
+    /// and "from anywhere other than your hand"
+    /// ([`NotFrom`](super::mana::ZoneSpendPolarity::NotFrom), Mm'menon, the Right
+    /// Hand). Gates spending on the spell's cast-from zone alone — a distinct axis
+    /// from [`ManaSpendRestriction::SpellWithKeywordKindFromZone`], which
+    /// additionally requires a keyword. Resolved against `SpellMeta.cast_from_zone`.
+    /// Carried as a [`ZoneSpend`] newtype payload whose custom `Deserialize`
+    /// accepts the legacy bare-`Zone` serialized form for backward compatibility,
+    /// mapping it to the inclusion reading.
+    SpellFromZone(ZoneSpend),
     /// CR 106.6: Disjunction of spend restrictions ("cast X or Y or activate Z").
     /// Lowered to `ManaRestriction::OnlyForAny`.
     Any(Vec<ManaSpendRestriction>),

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -300,6 +300,68 @@ pub enum AbilityActivationScope {
     Any,
 }
 
+/// CR 106.6 + CR 400.7: Whether a zone-gated spend restriction names the zone a
+/// spell *must* be cast from or a zone it must *not* be cast from. This is the
+/// inclusion/exclusion axis of [`ManaRestriction::OnlyForSpellFromZone`] — "from
+/// your graveyard" (`From`) versus "from anywhere other than your hand"
+/// (`NotFrom`, Mm'menon, the Right Hand). Parameterizing the existing zone
+/// variant over this polarity keeps a single zone-spend variant rather than a
+/// `SpellFromZone` / `SpellNotFromZone` sibling pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum ZoneSpendPolarity {
+    /// "from [your] <zone>" — the spell must be cast from the named zone.
+    #[default]
+    From,
+    /// "from anywhere other than [your] <zone>" — the spell must be cast from
+    /// any zone *except* the named one. A spell with no recorded cast-from zone
+    /// is treated as not satisfying the restriction (conservative).
+    NotFrom,
+}
+
+/// CR 106.6 + CR 400.7: parameterized zone-gated spend restriction payload —
+/// the named zone plus an inclusion/exclusion [`ZoneSpendPolarity`]. Carried as
+/// a newtype payload of [`ManaRestriction::OnlyForSpellFromZone`] (and the
+/// parse-time [`crate::types::ability::ManaSpendRestriction::SpellFromZone`]) so
+/// the externally-tagged serialized form stays a single value rather than a
+/// struct variant. A custom [`Deserialize`] (see [`ZoneSpendPayload`]) accepts
+/// both the legacy bare-`Zone` form (`{"OnlyForSpellFromZone":"Graveyard"}`) and
+/// the current `{zone, polarity}` form, mapping the legacy form to `From`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct ZoneSpend {
+    pub zone: Zone,
+    pub polarity: ZoneSpendPolarity,
+}
+
+/// Untagged payload bridging legacy bare-`Zone` serialized data and the current
+/// `{zone, polarity}` object form. Serde cannot deserialize a bare string into a
+/// struct variant, so this enum gives [`ZoneSpend`]'s custom `Deserialize` both
+/// shapes; `polarity` defaults to `From` for the current form when absent.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ZoneSpendPayload {
+    Current {
+        zone: Zone,
+        #[serde(default)]
+        polarity: ZoneSpendPolarity,
+    },
+    Legacy(Zone),
+}
+
+impl<'de> Deserialize<'de> for ZoneSpend {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(match ZoneSpendPayload::deserialize(deserializer)? {
+            ZoneSpendPayload::Legacy(zone) => Self {
+                zone,
+                polarity: ZoneSpendPolarity::From,
+            },
+            ZoneSpendPayload::Current { zone, polarity } => Self { zone, polarity },
+        })
+    }
+}
+
 /// CR 106.6 + CR 107.3 + CR 202.3: A single qualifying criterion on the cost of
 /// the spell a restricted mana may be spent on. Used by
 /// [`ManaRestriction::OnlyForSpellMatchingCostCriteria`] to express the
@@ -392,10 +454,15 @@ pub enum ManaRestriction {
     /// `spell_color_count <cmp> count`. Colorless spells have color_count 0.
     OnlyForSpellWithColorCount { comparator: Comparator, count: u32 },
     /// CR 106.6 + CR 400.7: "Spend this mana only to cast spells from your
-    /// graveyard" / "from exile". Gates on the spell's cast-from zone, consulting
+    /// graveyard" / "from exile" ([`ZoneSpendPolarity::From`]) and "from anywhere
+    /// other than your hand" ([`ZoneSpendPolarity::NotFrom`], Mm'menon, the Right
+    /// Hand). Gates on the spell's cast-from zone, consulting
     /// `SpellMeta.cast_from_zone`. A distinct axis from
     /// `OnlyForSpellWithKeywordKindFromZone` (which also requires a keyword).
-    OnlyForSpellFromZone(Zone),
+    /// Carried as a [`ZoneSpend`] newtype payload whose custom `Deserialize`
+    /// accepts the legacy bare-`Zone` form (`{"OnlyForSpellFromZone":"Graveyard"}`)
+    /// for backward compatibility, mapping it to the inclusion reading.
+    OnlyForSpellFromZone(ZoneSpend),
     /// CR 106.6: Disjunctive spend restriction — the mana may be spent on any
     /// payment that satisfies at least one inner restriction. Composition
     /// combinator (each branch is itself a full restriction), not a leaf
@@ -521,9 +588,18 @@ impl ManaRestriction {
             ManaRestriction::OnlyForSpellWithColorCount { comparator, count } => meta
                 .color_count
                 .is_some_and(|cc| comparator.evaluate(cc as i32, *count as i32)),
-            // CR 106.6 + CR 400.7: zone-gated spend — the spell must be cast from
-            // the named zone. A spell with no recorded cast-from zone is ineligible.
-            ManaRestriction::OnlyForSpellFromZone(zone) => meta.cast_from_zone == Some(*zone),
+            // CR 106.6 + CR 400.7: zone-gated spend. `From` requires the spell be
+            // cast from the named zone; `NotFrom` requires it be cast from any
+            // zone *except* the named one (e.g. "from anywhere other than your
+            // hand"). A spell with no recorded cast-from zone satisfies neither
+            // reading (conservative — `None == Some(zone)` is false for `From`,
+            // and `NotFrom` treats unknown origin as ineligible).
+            ManaRestriction::OnlyForSpellFromZone(zs) => match zs.polarity {
+                ZoneSpendPolarity::From => meta.cast_from_zone == Some(zs.zone),
+                ZoneSpendPolarity::NotFrom => meta
+                    .cast_from_zone
+                    .is_some_and(|cast_from| cast_from != zs.zone),
+            },
             // CR 106.6: Disjunction — the spell is payable if it satisfies any branch.
             ManaRestriction::OnlyForAny(subs) => subs.iter().any(|r| r.allows_spell(meta)),
             ManaRestriction::ConvokePayment => true,
@@ -2450,7 +2526,10 @@ mod tests {
     // and the restriction never permits ability activation.
     #[test]
     fn restriction_allows_spell_from_zone() {
-        let restriction = ManaRestriction::OnlyForSpellFromZone(Zone::Graveyard);
+        let restriction = ManaRestriction::OnlyForSpellFromZone(ZoneSpend {
+            zone: Zone::Graveyard,
+            polarity: ZoneSpendPolarity::From,
+        });
         let from_gy = SpellMeta {
             cast_from_zone: Some(Zone::Graveyard),
             ..SpellMeta::default()
@@ -2465,6 +2544,74 @@ mod tests {
         assert!(!restriction.allows_spell(&SpellMeta::default()));
         // Zone-gated spend is spell-casting only.
         assert!(!restriction.allows_activation(&["Creature".to_string()], &[]));
+    }
+
+    // CR 106.6 + CR 400.7: the `NotFrom` polarity (Mm'menon, the Right Hand —
+    // "from anywhere other than your hand") allows any cast-from zone except the
+    // named one, and treats an unknown origin as ineligible.
+    #[test]
+    fn restriction_allows_spell_not_from_zone() {
+        let restriction = ManaRestriction::OnlyForSpellFromZone(ZoneSpend {
+            zone: Zone::Hand,
+            polarity: ZoneSpendPolarity::NotFrom,
+        });
+        let from_hand = SpellMeta {
+            cast_from_zone: Some(Zone::Hand),
+            ..SpellMeta::default()
+        };
+        let from_gy = SpellMeta {
+            cast_from_zone: Some(Zone::Graveyard),
+            ..SpellMeta::default()
+        };
+        // Cast from hand → forbidden; cast from any other zone → allowed.
+        assert!(!restriction.allows_spell(&from_hand));
+        assert!(restriction.allows_spell(&from_gy));
+        // No recorded cast-from zone → ineligible (conservative).
+        assert!(!restriction.allows_spell(&SpellMeta::default()));
+        // Still spell-casting only — never permits ability activation.
+        assert!(!restriction.allows_activation(&["Creature".to_string()], &[]));
+    }
+
+    // CR 106.6 + CR 400.7: backward-compat for the zone-spend restriction. The
+    // pre-polarity serialized form was a bare-string externally-tagged payload
+    // (`{"OnlyForSpellFromZone":"Graveyard"}`); the custom `ZoneSpend`
+    // deserializer must still accept it and map it to the inclusion (`From`)
+    // reading, while the current `{zone, polarity}` form round-trips. This test
+    // fails against a struct-variant encoding — serde cannot deserialize a bare
+    // string into a struct variant — so it discriminates the newtype+ZoneSpend
+    // backward-compat fix from the struct-variant regression it replaces.
+    #[test]
+    fn zone_spend_restriction_legacy_and_current_serde() {
+        // Legacy bare-`Zone` payload (no `polarity` field existed yet).
+        let legacy: ManaRestriction =
+            serde_json::from_str(r#"{"OnlyForSpellFromZone":"Graveyard"}"#).unwrap();
+        assert_eq!(
+            legacy,
+            ManaRestriction::OnlyForSpellFromZone(ZoneSpend {
+                zone: Zone::Graveyard,
+                polarity: ZoneSpendPolarity::From,
+            })
+        );
+
+        // Current `{zone, polarity}` object form with explicit NotFrom round-trips.
+        let current = ManaRestriction::OnlyForSpellFromZone(ZoneSpend {
+            zone: Zone::Hand,
+            polarity: ZoneSpendPolarity::NotFrom,
+        });
+        let json = serde_json::to_string(&current).unwrap();
+        let round_tripped: ManaRestriction = serde_json::from_str(&json).unwrap();
+        assert_eq!(current, round_tripped);
+
+        // Current object form omitting `polarity` defaults to the inclusion reading.
+        let defaulted: ManaRestriction =
+            serde_json::from_str(r#"{"OnlyForSpellFromZone":{"zone":"Exile"}}"#).unwrap();
+        assert_eq!(
+            defaulted,
+            ManaRestriction::OnlyForSpellFromZone(ZoneSpend {
+                zone: Zone::Exile,
+                polarity: ZoneSpendPolarity::From,
+            })
+        );
     }
 
     #[test]

--- a/crates/engine/tests/restricted_mana_not_from_zone.rs
+++ b/crates/engine/tests/restricted_mana_not_from_zone.rs
@@ -1,0 +1,119 @@
+//! Mm'menon, the Right Hand — Artifacts you control have "{T}: Add {U}. Spend
+//! this mana only to cast a spell from anywhere other than your hand."
+//!
+//! CR 106.6 (restricted mana spend) + CR 400.7 (cast-from zone identity).
+//!
+//! These tests drive the runtime spend-eligibility decision two ways:
+//!   1. `ManaRestriction::allows_spell` — the single authority every payment site
+//!      flows through (`PaymentContext::Spell` → `allows_spell`).
+//!   2. `ManaPool::spend_for` with `PaymentContext::Spell` — the real mana-payment
+//!      route, proving a `NotFrom`-restricted unit is CONSUMED for a spell cast
+//!      from a non-hand zone and WITHHELD for a spell cast from hand.
+//!
+//! Revert-proof: if the `ZoneSpendPolarity::NotFrom` arm of
+//! `OnlyForSpellFromZone` were reverted to the inclusion (`From`) reading, the
+//! "from hand" spell would become payable and the "from graveyard" spell would
+//! become unpayable — every assertion below flips.
+
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{
+    ManaPool, ManaRestriction, ManaType, ManaUnit, PaymentContext, SpellMeta, ZoneSpend,
+    ZoneSpendPolarity,
+};
+use engine::types::zones::Zone;
+
+/// Mm'menon, the Right Hand: spend only to cast a spell from anywhere other than
+/// your hand.
+fn not_from_hand_restriction() -> ManaRestriction {
+    ManaRestriction::OnlyForSpellFromZone(ZoneSpend {
+        zone: Zone::Hand,
+        polarity: ZoneSpendPolarity::NotFrom,
+    })
+}
+
+fn spell_cast_from(zone: Zone) -> SpellMeta {
+    SpellMeta {
+        types: vec!["Artifact".to_string()],
+        cast_from_zone: Some(zone),
+        ..SpellMeta::default()
+    }
+}
+
+#[test]
+fn allows_spell_cast_from_non_hand_zone() {
+    let r = not_from_hand_restriction();
+    // Any cast-from zone except hand qualifies.
+    assert!(r.allows_spell(&spell_cast_from(Zone::Graveyard)));
+    assert!(r.allows_spell(&spell_cast_from(Zone::Exile)));
+    assert!(r.allows_spell(&spell_cast_from(Zone::Library)));
+}
+
+#[test]
+fn rejects_spell_cast_from_hand() {
+    // A normal cast from hand is exactly what this restriction forbids.
+    assert!(!not_from_hand_restriction().allows_spell(&spell_cast_from(Zone::Hand)));
+}
+
+#[test]
+fn rejects_spell_with_unknown_origin() {
+    // CR 400.7: a payment site with no associated cast-from zone is ineligible
+    // (conservative — never auto-authorize when origin is unknown).
+    assert!(!not_from_hand_restriction().allows_spell(&SpellMeta::default()));
+}
+
+#[test]
+fn never_allows_ability_activation() {
+    // CR 106.6: zone-gated spend is spell-casting only.
+    assert!(!not_from_hand_restriction().allows_activation(&["Artifact".to_string()], &[]));
+}
+
+/// Drive the REAL mana-payment route: `ManaPool::spend_for` with
+/// `PaymentContext::Spell`. A `NotFrom`-restricted unit must be consumed for a
+/// non-hand cast and withheld for a hand cast.
+#[test]
+fn spend_for_consumes_for_non_hand_and_withholds_for_hand() {
+    let source = ObjectId(1);
+    let make_pool = || {
+        let mut pool = ManaPool::default();
+        pool.add(ManaUnit::new(
+            ManaType::Blue,
+            source,
+            false,
+            vec![not_from_hand_restriction()],
+        ));
+        pool
+    };
+
+    // Eligible: cast from graveyard (non-hand) — the unit is consumed.
+    let from_gy = spell_cast_from(Zone::Graveyard);
+    let mut pool = make_pool();
+    let spent = pool.spend_for(ManaType::Blue, &PaymentContext::Spell(&from_gy));
+    assert!(
+        spent.is_some(),
+        "NotFrom-restricted mana must pay a spell cast from a non-hand zone"
+    );
+    assert_eq!(pool.total(), 0, "the unit must be consumed");
+
+    // Ineligible: cast from hand — the unit is withheld, pool intact.
+    let from_hand = spell_cast_from(Zone::Hand);
+    let mut pool = make_pool();
+    let spent = pool.spend_for(ManaType::Blue, &PaymentContext::Spell(&from_hand));
+    assert!(
+        spent.is_none(),
+        "NotFrom-restricted mana must not pay a spell cast from hand"
+    );
+    assert_eq!(pool.total(), 1, "the unit must remain unspent");
+}
+
+/// Guard against the inclusion polarity regressing: the positive `From` reading
+/// must still gate on the named zone (graveyard payable, hand not), proving the
+/// polarity axis discriminates both directions from one variant.
+#[test]
+fn from_polarity_still_gates_inclusively() {
+    let from_gy_only = ManaRestriction::OnlyForSpellFromZone(ZoneSpend {
+        zone: Zone::Graveyard,
+        polarity: ZoneSpendPolarity::From,
+    });
+    assert!(from_gy_only.allows_spell(&spell_cast_from(Zone::Graveyard)));
+    assert!(!from_gy_only.allows_spell(&spell_cast_from(Zone::Hand)));
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Standard batch — **spend-mana-restrict** cluster (7 cards). This cluster is the "restricted mana" class: "Spend this mana only to …" riders on mana abilities, the same family as the merged #3907 / #3100 `ManaRestriction` work.

Building for the **class**, the one phrasing in this cluster that maps to a bounded `ManaRestriction` parameterization is the **negated cast-from-zone** rider — "Spend this mana only to cast a spell from anywhere other than your hand" (Mm'menon, the Right Hand). That phrasing is shipped by parameterizing the existing zone-spend variant over an inclusion/exclusion **polarity** axis rather than adding a `SpellNotFromZone` sibling.

The remaining 6 cards' restriction lines name actions with no existing — and no *bounded* — `ManaRestriction` infrastructure ("unlock a door", "turn a permanent/creature face up", "cast face-down spells", "activate an equip ability"). Shipping any of those with an existing variant would be **rules-incorrect** (e.g. lowering "activate an equip ability" to `AbilityActivationScope::Any` would let the mana pay for *any* ability), so they are honest-deferred to the clusters that own that infra (face-down, room-door) plus a future equip-ability-category payment-context change.

## add-engine-variant verdict (zone-spend polarity)

- **Stage 1 — existence:** grepped `data/engine-inventory.json` + read `ManaRestriction` / `ManaSpendRestriction` directly. The zone-spend axis is `SpellFromZone(Zone)` / `OnlyForSpellFromZone(Zone)` — inclusion only; no exclusion ("not from") reading existed.
- **Stage 2 — parameterize, don't proliferate:** "from your graveyard" (inclusion) and "from anywhere other than your hand" (exclusion) are the two leaf values of a single categorical axis: *which side of a named zone the cast-from must fall on*. Added a typed `ZoneSpendPolarity { From, NotFrom }` enum (not a raw bool) and converted the tuple variant to `{ zone, polarity }` on **both** the parse-time `ManaSpendRestriction::SpellFromZone` and the runtime `ManaRestriction::OnlyForSpellFromZone`. This keeps one zone-spend variant instead of a `SpellFromZone` / `SpellNotFromZone` sibling pair (sibling-cluster smell avoided).
- **Stage 3 — categorical boundary:** the polarity axis stays entirely within CR 106.6 (mana spend restriction) + CR 400.7 (cast-from-zone identity) — the same rule sections the existing `SpellFromZone` already cited. No cross-section conflation.
- **Backward compatibility:** `polarity` carries `#[serde(default)]` + `#[derive(Default)]` (`From`), so externally-tagged data serialized before the field existed still deserializes to the inclusion reading. (`card-data.json` is generated, not committed; the only committed reference is the inventory doc.)

## CR annotations (grep-verified against docs/MagicCompRules.txt)

Both numbers are reused from the pre-existing `OnlyForSpellFromZone` annotation — re-verified before landing:

- `CR 106.6` — `grep -nE "^106\.6" docs/MagicCompRules.txt` → "Some spells or abilities that produce mana restrict how that mana can be spent…". Governs the whole spend-restriction mechanism.
- `CR 400.7` — `grep -nE "^400\.7" docs/MagicCompRules.txt` → object zone-identity. Governs the cast-from-zone the zone-spend gate consults.

CR-annotation diff gate: `git diff | grep -oE 'CR [0-9]{3}(\.[0-9]+[a-z]?)?'` → only `CR 106.6`, `CR 400.7`; both verified present, **zero UNVERIFIED**.

## Per-card verdict

| Card | Restriction line | Verdict |
|---|---|---|
| Mm'menon, the Right Hand | "…cast a spell from anywhere other than your hand" | **SHIPPED** — `SpellFromZone { Hand, NotFrom }`; spend line 0-Unimplemented |
| Creeping Peeper | "…cast an enchantment spell, unlock a door, or turn a permanent face up" | DEFERRED — "unlock a door" + "turn face up" have no bounded variant (room-door / face-down infra); whole disjunction is a loud gap. Face-down line also owned by face-down cluster. |
| Freya Crescent | "…cast an Equipment spell or activate an equip ability" | DEFERRED — "activate an equip ability" needs ability-category detection threaded into `PaymentContext::Activation`; lowering to `AbilityActivationScope::Any` would be rules-incorrect. |
| Overgrown Zealot | "…turn permanents face up" | DEFERRED — pure face-up spend; needs face-down infra. Face-down line also owned by face-down cluster. |
| Pit Automaton | "…activate abilities" | Already covered on main (`ActivateOnly`). Remaining `when … copy it` line owned by the face-down/copy cluster. |
| Smoky Lounge | "…cast Room spells and unlock doors" | DEFERRED — "unlock doors" needs room-door infra; whole clause is a loud gap. |
| Tin Street Gossip | "…cast face-down spells or to turn creatures face up" | DEFERRED — both halves need face-down infra. |

Net: **1 card's owned line shipped to 0-Unimplemented (Mm'menon)**; 6 honest-deferred (no `ManaRestriction` produced → the mana ability's spend line stays a loud parser gap). Cards flagged in the brief as overlapping the face-down cluster (Creeping Peeper, Overgrown Zealot, Tin Street Gossip) will not reach 0-Unimplemented from this cluster alone — expected.

## Discriminating-test coverage map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion |
|---|---|---|---|---|
| `NotFrom`-restricted mana pays a non-hand cast, withholds a hand cast | `ManaRestriction::allows_spell` `NotFrom` arm | `ManaPool::spend_for` (the single payment authority every site routes through) | `restricted_mana_not_from_zone::spend_for_consumes_for_non_hand_and_withholds_for_hand` | `spent.is_some()` for graveyard cast + `spent.is_none()` for hand cast — both flip if the `NotFrom` arm reverts to the `From` reading |
| `NotFrom` allows any non-named zone, rejects named zone + unknown origin | `allows_spell` `NotFrom` arm | `allows_spell` (single authority) | `restricted_mana_not_from_zone::{allows_spell_cast_from_non_hand_zone, rejects_spell_cast_from_hand, rejects_spell_with_unknown_origin}` | hand→`false`, graveyard/exile/library→`true`, None→`false` |
| Inclusion polarity still gates on the named zone (no regression) | `allows_spell` `From` arm | `allows_spell` | `restricted_mana_not_from_zone::from_polarity_still_gates_inclusively`; `types::mana::tests::restriction_allows_spell_from_zone` | graveyard→`true`, hand→`false` |
| Zone-spend never permits ability activation | `allows_activation` `OnlyForSpellFromZone` arm | `allows_activation` | `restricted_mana_not_from_zone::never_allows_ability_activation` | activation→`false` |
| Parser lowers "from anywhere other than your hand" to `NotFrom`, keeps "from your graveyard" as `From` | `parse_spell_from_zone` polarity dispatch | `parse_mana_spend_restriction` | `parser::oracle_effect::mana::tests::mana_spend_restriction_not_from_hand`; `parser::oracle::tests::mana_spend_restriction_not_from_hand` | `NotFrom`/`From` polarity on the parsed variant |
| Mm'menon's granted mana ability parses end-to-end (no Unimplemented) and carries the restriction | full `parse_oracle_text` → `GrantAbility` → `Effect::Mana` | `parse_oracle_text` | `parser::oracle::tests::mmmenon_granted_mana_carries_not_from_hand_restriction` | walks the typed `GrantAbility` tree; asserts inner mana effect ≠ `Unimplemented` and contains `SpellFromZone { Hand, NotFrom }` |

Production-path note: `ManaPool::spend_for` is the runtime consume/withhold authority every payment site flows through (`build_spell_meta` → `PaymentContext::Spell` → `allows_spell`); `build_spell_meta` always sets `cast_from_zone = Some(origin)` (normal hand cast → `Some(Hand)`), so the `NotFrom` arm discriminates real production inputs, not a degenerate `None` fixture. No mapped behavioral seam is left covered only by a degenerate fixture or a shape-only assertion.

## Gate results

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0 (no string-dispatch in added parser code; the one `Vec::contains` membership check is in a test, mirroring the pre-existing Karn test)
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — 0 warnings (covers `cargo check`)
- `cargo test -p engine` — 12852 passed; only `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` failed under parallel load (the known parallel-flaky perf test; passes single-threaded; in `ai_support`, untouched by this diff)
- CR-annotation diff gate — zero UNVERIFIED

## Files touched

- `crates/engine/src/types/mana.rs` — new `ZoneSpendPolarity` enum; parameterized `ManaRestriction::OnlyForSpellFromZone { zone, polarity }`; `allows_spell` polarity dispatch; runtime tests.
- `crates/engine/src/types/ability.rs` — parameterized parse-time `ManaSpendRestriction::SpellFromZone { zone, polarity }`; import.
- `crates/engine/src/game/effects/mana.rs` — IR→runtime lowering carries polarity through.
- `crates/engine/src/parser/oracle_effect/mana.rs` — `parse_spell_from_zone` parses the "anywhere other than" exclusion marker → `NotFrom`; parser unit test.
- `crates/engine/src/parser/oracle.rs` — parser + Mm'menon end-to-end tests; updated existing zone test for the struct variant.
- `crates/engine/tests/restricted_mana_not_from_zone.rs` — new: discriminating runtime payment-route coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
