### PR TITLE
feat(parser): craft material-reference parsing (Jadeheart Attendant, Mastercraft Raptor, Sunbird Effigy)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -83,6 +83,23 @@ fn try_parse_for_each_color_mana(text: &str, lower: &str) -> Option<Effect> {
     let (_, type_text_lower) = take_until::<_, _, OracleError<'_>>(", add one mana of that color")
         .parse(rest)
         .ok()?;
+    // CR 702.167c + CR 105.1: "For each color among the exiled cards used to craft
+    // this creature, add one mana of that color" (Sunbird Effigy) — the iteration
+    // source is the craft-material linked-exile pool, not a battlefield type
+    // phrase. Tried first so the craft noun phrase wins over `parse_type_phrase`.
+    if let Ok((craft_rest, filter)) =
+        crate::parser::oracle_nom::quantity::parse_craft_materials_filter(type_text_lower.trim())
+    {
+        if craft_rest.trim().is_empty() {
+            return Some(Effect::Mana {
+                produced: ManaProduction::DistinctColorsAmongPermanents { filter },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            });
+        }
+    }
     // Recover original-cased slice for parse_type_phrase.
     let offset = lower_trimmed.len() - rest.len();
     let original_trimmed = text.trim_end_matches('.').trim();

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -707,23 +707,78 @@ fn parse_linked_exile_mana_value_ref(input: &str) -> OracleResult<'_, QuantityRe
         tag("the exiled card's converted mana cost"),
     ))
     .parse(input)?;
+    // CR 702.167c: "...the exiled card used to craft it." — the craft-material
+    // qualifier is the same linked-exile set, so consume the optional suffix and
+    // emit the same aggregate (Jadeheart Attendant).
+    let (rest, _) = opt(parse_craft_materials_suffix).parse(rest)?;
     Ok((
         rest,
         QuantityRef::Aggregate {
             function: AggregateFunction::Sum,
             property: ObjectProperty::ManaValue,
-            filter: TargetFilter::And {
-                filters: vec![
-                    TargetFilter::ExiledBySource,
-                    TargetFilter::Typed(TypedFilter::default().properties(vec![
-                        FilterProp::Owned {
-                            controller: ControllerRef::You,
-                        },
-                    ])),
-                ],
-            },
+            filter: linked_exile_owned_filter(),
         },
     ))
+}
+
+/// CR 702.167c: The `And { [ExiledBySource, Owned { You }] }` filter shared by
+/// every craft-material / linked-exile reference. `ExiledBySource` resolves the
+/// source's linked-exile pool (which includes `ExileLinkKind::CraftMaterial`);
+/// `Owned { You }` rebinds per owner under player-scope iteration, matching the
+/// existing Skyclave linked-exile precedent (`parse_linked_exile_mana_value_ref`).
+fn linked_exile_owned_filter() -> TargetFilter {
+    TargetFilter::And {
+        filters: vec![
+            TargetFilter::ExiledBySource,
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Owned {
+                controller: ControllerRef::You,
+            }])),
+        ],
+    }
+}
+
+/// CR 702.167c: Consume the craft-material qualifier "used to craft <self>",
+/// where `<self>` is the source self-anaphor (`it` / `~` / `this creature` /
+/// `this permanent` / `this artifact` / …). "An ability of a permanent may refer
+/// to the exiled cards used to craft it." This is a pure suffix combinator —
+/// callers decide which linked-exile ref to emit; it only confirms the qualifier
+/// is present and returns the remainder.
+fn parse_craft_materials_suffix(input: &str) -> OracleResult<'_, ()> {
+    let (rest, _) = tag(" used to craft ").parse(input)?;
+    let (rest, _) = parse_source_self_anaphor(rest)?;
+    Ok((rest, ()))
+}
+
+/// CR 109.5: The source self-anaphor used by craft / linked-exile references:
+/// `it`, `~`, or `this <noun>` (creature / permanent / artifact / card). Mirrors
+/// the anaphor `alt` already used by `parse_cards_exiled_with_source`, factored
+/// out so the craft-suffix and the craft noun-phrase combinator share it.
+fn parse_source_self_anaphor(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((
+            tag("~"),
+            tag("it"),
+            preceded(
+                tag("this "),
+                take_while1(|c: char| c.is_ascii_alphabetic() || c == '-'),
+            ),
+        )),
+    )
+    .parse(input)
+}
+
+/// CR 702.167c: Parse the craft-material reference noun phrase
+/// "the exiled card[s] used to craft <self>" into the shared linked-exile
+/// filter. Single building block reused by the aggregate-property,
+/// distinct-colors, and for-each-color (mana) paths so "total power of …",
+/// "number of colors among …", and "for each color among …" all resolve over
+/// the same `ExileLinkKind::CraftMaterial` pool without per-card phrase tables.
+pub(crate) fn parse_craft_materials_filter(input: &str) -> OracleResult<'_, TargetFilter> {
+    let (rest, _) = tag("the exiled card").parse(input)?;
+    let (rest, _) = opt(tag("s")).parse(rest)?;
+    let (rest, _) = parse_craft_materials_suffix(rest)?;
+    Ok((rest, linked_exile_owned_filter()))
 }
 
 /// CR 202.3: Parse "mana value" or "converted mana cost" phrase.
@@ -926,6 +981,21 @@ fn parse_object_property_aggregate_ref(input: &str) -> OracleResult<'_, Quantity
         ),
     ))
     .parse(input)?;
+    // CR 702.167c: "the total power of the exiled cards used to craft it" — the
+    // craft-material aggregate (Mastercraft Raptor). Tried before the bare
+    // "the exiled cards" tracked-set anaphor because the craft form shares that
+    // prefix but reads the persistent `CraftMaterial` linked-exile pool, not the
+    // most-recent chain tracked set.
+    if let Ok((craft_rest, filter)) = parse_craft_materials_filter(rest) {
+        return Ok((
+            craft_rest,
+            QuantityRef::Aggregate {
+                function,
+                property,
+                filter,
+            },
+        ));
+    }
     if let Ok((anaphor_rest, _)) = alt((
         tag::<_, _, OracleError<'_>>("those exiled cards"),
         tag("the exiled cards"),
@@ -1075,6 +1145,15 @@ fn parse_number_of_distinct_colors_among_permanents_tail(
     input: &str,
 ) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = tag("colors among ").parse(input)?;
+    // CR 702.167c + CR 105.1: "the number of colors among the exiled cards used
+    // to craft it" — distinct colors over the craft-material linked-exile pool
+    // (Sunbird Effigy P/T). Tried before the generic type-phrase filter so the
+    // craft noun phrase wins.
+    if let Ok((craft_rest, filter)) = parse_craft_materials_filter(rest) {
+        if matches!(craft_rest.trim(), "" | "." | ",") {
+            return Ok(("", QuantityRef::DistinctColorsAmongPermanents { filter }));
+        }
+    }
     let (remainder, filter) = super::target::parse_type_phrase(rest)?;
     if !matches!(remainder.trim(), "" | "." | ",")
         || !quantity_filter_has_meaningful_content(&filter)
@@ -3905,6 +3984,82 @@ mod tests {
             QuantityRef::Aggregate {
                 function: AggregateFunction::Max,
                 property: ObjectProperty::Power,
+                ..
+            }
+        ));
+    }
+
+    /// CR 702.167c: the craft-material noun phrase recognizes every self-anaphor
+    /// variant ("it" / "~" / "this <noun>") and rejects unrelated exile phrases.
+    #[test]
+    fn parse_craft_materials_filter_anaphors() {
+        for phrase in [
+            "the exiled card used to craft it",
+            "the exiled cards used to craft it",
+            "the exiled cards used to craft ~",
+            "the exiled cards used to craft this creature",
+            "the exiled cards used to craft this permanent",
+            "the exiled cards used to craft this artifact",
+        ] {
+            let (rest, filter) = parse_craft_materials_filter(phrase)
+                .unwrap_or_else(|e| panic!("craft phrase {phrase:?} should parse: {e:?}"));
+            assert_eq!(rest, "", "craft phrase {phrase:?} must fully consume");
+            assert_eq!(filter, linked_exile_owned_filter(), "phrase {phrase:?}");
+        }
+        // Bare exile anaphors (no "used to craft") must NOT match the craft form.
+        assert!(parse_craft_materials_filter("the exiled cards").is_err());
+        assert!(parse_craft_materials_filter("those exiled cards").is_err());
+    }
+
+    /// CR 702.167c + CR 208.1: "the total power of the exiled cards used to craft
+    /// it" routes to the linked-exile aggregate, NOT the tracked-set anaphor
+    /// (Mastercraft Raptor). The shared "the exiled cards" prefix must resolve to
+    /// the craft pool when the craft suffix follows.
+    #[test]
+    fn parse_total_power_of_craft_materials_is_aggregate() {
+        let (rest, q) =
+            parse_quantity_ref("the total power of the exiled cards used to craft it").unwrap();
+        assert_eq!(rest, "");
+        match q {
+            QuantityRef::Aggregate {
+                function: AggregateFunction::Sum,
+                property: ObjectProperty::Power,
+                filter,
+            } => assert_eq!(filter, linked_exile_owned_filter()),
+            other => panic!("expected craft-material power aggregate, got {other:?}"),
+        }
+    }
+
+    /// CR 702.167c + CR 105.1: "the number of colors among the exiled cards used
+    /// to craft it" routes to the distinct-colors ref over the craft pool
+    /// (Sunbird Effigy P/T).
+    #[test]
+    fn parse_colors_among_craft_materials_is_distinct_colors() {
+        let (rest, q) =
+            parse_quantity_ref("the number of colors among the exiled cards used to craft it")
+                .unwrap();
+        assert_eq!(rest, "");
+        match q {
+            QuantityRef::DistinctColorsAmongPermanents { filter } => {
+                assert_eq!(filter, linked_exile_owned_filter())
+            }
+            other => panic!("expected DistinctColorsAmongPermanents, got {other:?}"),
+        }
+    }
+
+    /// CR 702.167c + CR 202.3: "the mana value of the exiled card used to craft
+    /// it" still resolves to the linked-exile mana-value aggregate even with the
+    /// craft suffix appended (Jadeheart Attendant).
+    #[test]
+    fn parse_mana_value_of_craft_material_is_aggregate() {
+        let (rest, q) =
+            parse_quantity_ref("the mana value of the exiled card used to craft it").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(
+            q,
+            QuantityRef::Aggregate {
+                function: AggregateFunction::Sum,
+                property: ObjectProperty::ManaValue,
                 ..
             }
         ));

--- a/crates/engine/tests/craft_material_references.rs
+++ b/crates/engine/tests/craft_material_references.rs
@@ -1,0 +1,367 @@
+//! CR 702.167c — "an ability of a permanent may refer to the exiled cards used
+//! to craft it." This batch teaches the quantity / static / mana parsers to read
+//! the persistent `ExileLinkKind::CraftMaterial` linked-exile pool (the cards
+//! exiled to pay the craft activation cost) via the existing kind-agnostic
+//! `TargetFilter::ExiledBySource` consumer. No new engine variant — the four
+//! references reuse `QuantityRef::Aggregate`, `DistinctColorsAmongPermanents`,
+//! and `ManaProduction::DistinctColorsAmongPermanents` parameterized with the
+//! `ExiledBySource` filter.
+//!
+//! Two layers per claim:
+//!   1. Parse coverage — each shipped craft-reference line parses with zero
+//!      `Effect::Unimplemented` and emits the typed `ExiledBySource` ref.
+//!   2. Runtime discrimination — a craft source on the battlefield with materials
+//!      linked via `CraftMaterial` resolves the reference through the SAME
+//!      production paths the engine uses (CDA layer evaluator, GainLife resolver,
+//!      mana-ability resolver). Each assertion flips if the parser change is
+//!      reverted (the phrase would parse to `Unimplemented` / `TrackedSetAggregate`
+//!      which resolves to 0 with no preceding chain set).
+
+use engine::game::layers::evaluate_layers;
+use engine::game::quantity::resolve_quantity;
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AggregateFunction, ContinuousModification, Effect, ManaProduction, ObjectProperty,
+    QuantityExpr, QuantityRef, StaticDefinition, TargetFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{ExileLink, ExileLinkKind, GameState};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+fn artifact_creature_types() -> Vec<String> {
+    vec!["Artifact".to_string(), "Creature".to_string()]
+}
+
+fn color_shard(c: ManaColor) -> ManaCostShard {
+    match c {
+        ManaColor::White => ManaCostShard::White,
+        ManaColor::Blue => ManaCostShard::Blue,
+        ManaColor::Black => ManaCostShard::Black,
+        ManaColor::Red => ManaCostShard::Red,
+        ManaColor::Green => ManaCostShard::Green,
+    }
+}
+
+/// Build a craft source on the battlefield (the returned, transformed permanent)
+/// plus N material cards in exile, each linked to the source via
+/// `ExileLinkKind::CraftMaterial`. Returns (state, source_id, material_ids).
+fn craft_state_with_materials(
+    materials: &[(i32, i32, &[ManaColor], u32)], // (power, toughness, colors, mana_value)
+) -> (GameState, ObjectId, Vec<ObjectId>) {
+    let mut state = GameState::new_two_player(7);
+    let source_id = create_object(
+        &mut state,
+        CardId(1000),
+        P0,
+        "Craft Source".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let src = state.objects.get_mut(&source_id).unwrap();
+        src.card_types.core_types = vec![CoreType::Artifact, CoreType::Creature];
+        src.base_card_types = src.card_types.clone();
+        src.power = Some(0);
+        src.toughness = Some(0);
+        src.base_power = Some(0);
+        src.base_toughness = Some(0);
+    }
+
+    let mut ids = Vec::new();
+    for (i, (power, toughness, colors, mv)) in materials.iter().enumerate() {
+        let id = create_object(
+            &mut state,
+            CardId(2000 + i as u64),
+            P0,
+            format!("Material {i}"),
+            Zone::Exile,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(*power);
+        obj.toughness = Some(*toughness);
+        obj.base_power = Some(*power);
+        obj.base_toughness = Some(*toughness);
+        obj.color = colors.to_vec();
+        obj.mana_cost = ManaCost::Cost {
+            shards: colors.iter().map(|c| color_shard(*c)).collect(),
+            generic: mv.saturating_sub(colors.len() as u32),
+        };
+        state.exile_links.push(ExileLink {
+            exiled_id: id,
+            source_id,
+            kind: ExileLinkKind::CraftMaterial,
+        });
+        ids.push(id);
+    }
+    (state, source_id, ids)
+}
+
+/// Parse a single oracle line and return its sole static definition.
+fn parse_cda_static(oracle: &str) -> StaticDefinition {
+    let parsed = parse_oracle_text(oracle, "~", &[], &artifact_creature_types(), &[]);
+    assert_eq!(
+        parsed.statics.len(),
+        1,
+        "expected exactly one static, got {:#?}",
+        parsed.statics
+    );
+    parsed.statics[0].clone()
+}
+
+// ---------------------------------------------------------------------------
+// Mastercraft Raptor — power = total power of the exiled cards used to craft it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mastercraft_raptor_power_is_total_power_of_craft_materials() {
+    // Parse layer: the CDA must SetDynamicPower to Aggregate{Sum, Power, ExiledBySource…}.
+    let static_def = parse_cda_static(
+        "Mastercraft Raptor's power is equal to the total power of the exiled cards used to craft it.",
+    );
+    let power_qty = static_def
+        .modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::SetDynamicPower { value } => Some(value),
+            _ => None,
+        })
+        .expect("CDA must set dynamic power");
+    // Revert guard: pre-fix this phrase parsed to Unimplemented (no static), so
+    // `parsed.statics.len() == 1` would already fail. The aggregate shape below
+    // additionally pins the source to the linked-exile pool, not a tracked set.
+    match power_qty {
+        QuantityExpr::Ref {
+            qty:
+                QuantityRef::Aggregate {
+                    function: AggregateFunction::Sum,
+                    property: ObjectProperty::Power,
+                    filter,
+                },
+        } => assert!(
+            filter_reads_exiled_by_source(filter),
+            "power aggregate must read ExiledBySource, got {filter:?}"
+        ),
+        other => panic!("expected Aggregate{{Sum, Power, ExiledBySource}}, got {other:?}"),
+    }
+
+    // Runtime layer: 4/4 + 1/1 + 2/3 materials → total power 7. Resolve through
+    // the production quantity resolver (the CDA layer evaluator calls this).
+    let (state, source_id, _) = craft_state_with_materials(&[
+        (4, 4, &[ManaColor::Red], 4),
+        (1, 1, &[ManaColor::Green], 1),
+        (2, 3, &[ManaColor::White], 2),
+    ]);
+    let resolved = resolve_quantity(&state, power_qty, P0, source_id);
+    assert_eq!(
+        resolved, 7,
+        "Mastercraft Raptor power must equal total power (4+1+2) of craft materials in exile"
+    );
+
+    // Discriminating negative: with NO linked materials the aggregate is 0.
+    let (empty_state, empty_src, _) = craft_state_with_materials(&[]);
+    assert_eq!(
+        resolve_quantity(&empty_state, power_qty, P0, empty_src),
+        0,
+        "with no craft materials the total-power aggregate must be 0"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sunbird Effigy — P/T = number of colors among the exiled cards used to craft it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sunbird_effigy_pt_is_distinct_colors_of_craft_materials() {
+    let static_def = parse_cda_static(
+        "Sunbird Effigy's power and toughness are each equal to the number of colors among the exiled cards used to craft it.",
+    );
+    let mut power = None;
+    let mut toughness = None;
+    for m in &static_def.modifications {
+        match m {
+            ContinuousModification::SetDynamicPower { value } => power = Some(value.clone()),
+            ContinuousModification::SetDynamicToughness { value } => {
+                toughness = Some(value.clone())
+            }
+            _ => {}
+        }
+    }
+    let power = power.expect("must set dynamic power");
+    let toughness = toughness.expect("must set dynamic toughness");
+    for (label, qty) in [("power", &power), ("toughness", &toughness)] {
+        match qty {
+            QuantityExpr::Ref {
+                qty: QuantityRef::DistinctColorsAmongPermanents { filter },
+            } => assert!(
+                filter_reads_exiled_by_source(filter),
+                "{label} colors must read ExiledBySource, got {filter:?}"
+            ),
+            other => panic!("{label}: expected DistinctColorsAmongPermanents, got {other:?}"),
+        }
+    }
+
+    // Runtime: materials are W, U, and W again → 2 distinct colors.
+    let (state, source_id, _) = craft_state_with_materials(&[
+        (1, 1, &[ManaColor::White], 1),
+        (1, 1, &[ManaColor::Blue], 1),
+        (1, 1, &[ManaColor::White], 1),
+    ]);
+    assert_eq!(
+        resolve_quantity(&state, &power, P0, source_id),
+        2,
+        "Sunbird power must equal distinct colors (W, U) among craft materials"
+    );
+    assert_eq!(
+        resolve_quantity(&state, &toughness, P0, source_id),
+        2,
+        "Sunbird toughness must equal distinct colors among craft materials"
+    );
+
+    // Discriminating: a colorless material set yields 0.
+    let (colorless, cl_src, _) = craft_state_with_materials(&[(1, 1, &[], 2)]);
+    assert_eq!(
+        resolve_quantity(&colorless, &power, P0, cl_src),
+        0,
+        "colorless craft materials contribute no colors"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sunbird Effigy mana — {T}: For each color among the exiled cards used to craft
+// this creature, add one mana of that color.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sunbird_effigy_mana_is_one_per_color_of_craft_materials() {
+    let parsed = parse_oracle_text(
+        "{T}: For each color among the exiled cards used to craft this creature, add one mana of that color.",
+        "~",
+        &[],
+        &artifact_creature_types(),
+        &[],
+    );
+    assert_eq!(
+        parsed.abilities.len(),
+        1,
+        "expected one activated mana ability"
+    );
+    let Effect::Mana { produced, .. } = parsed.abilities[0].effect.as_ref() else {
+        panic!(
+            "expected a Mana effect, got {:?}",
+            parsed.abilities[0].effect
+        );
+    };
+    // Revert guard: pre-fix this body parsed to Unimplemented, not Mana.
+    match produced {
+        ManaProduction::DistinctColorsAmongPermanents { filter } => assert!(
+            filter_reads_exiled_by_source(filter),
+            "mana production must read ExiledBySource, got {filter:?}"
+        ),
+        other => panic!("expected DistinctColorsAmongPermanents mana, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Jadeheart Attendant — gain life equal to the mana value of the exiled card
+// used to craft it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jadeheart_attendant_gains_life_equal_to_craft_material_mana_value() {
+    let parsed = parse_oracle_text(
+        "When this creature enters, you gain life equal to the mana value of the exiled card used to craft it.",
+        "~",
+        &[],
+        &artifact_creature_types(),
+        &[],
+    );
+    assert_eq!(parsed.triggers.len(), 1, "expected one ETB trigger");
+    let execute = parsed.triggers[0]
+        .execute
+        .as_deref()
+        .expect("ETB trigger must carry an execute ability");
+    let Effect::GainLife { amount, .. } = execute.effect.as_ref() else {
+        panic!("expected GainLife effect, got {:?}", execute.effect);
+    };
+    // Revert guard: pre-fix this parsed to Unimplemented (name="gain").
+    match amount {
+        QuantityExpr::Ref {
+            qty:
+                QuantityRef::Aggregate {
+                    function: AggregateFunction::Sum,
+                    property: ObjectProperty::ManaValue,
+                    filter,
+                },
+        } => assert!(
+            filter_reads_exiled_by_source(filter),
+            "life amount must read ExiledBySource mana value, got {filter:?}"
+        ),
+        other => panic!("expected Aggregate{{Sum, ManaValue, ExiledBySource}}, got {other:?}"),
+    }
+
+    // Runtime: a single mana-value-5 craft material → gain 5.
+    let (state, source_id, _) =
+        craft_state_with_materials(&[(2, 2, &[ManaColor::White, ManaColor::White], 5)]);
+    assert_eq!(
+        resolve_quantity(&state, amount, P0, source_id),
+        5,
+        "Jadeheart life gain must equal the mana value (5) of the exiled craft material"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CDA layer end-to-end: the parsed static, applied through evaluate_layers, sets
+// the source's live power. This drives the production layer pipeline, not just a
+// direct quantity resolve.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn craft_cda_power_applies_through_layer_evaluator() {
+    let parsed = parse_oracle_text(
+        "Mastercraft Raptor's power is equal to the total power of the exiled cards used to craft it.",
+        "~",
+        &[],
+        &artifact_creature_types(),
+        &[],
+    );
+    let static_def = parsed.statics[0].clone();
+
+    let (mut state, source_id, _) = craft_state_with_materials(&[
+        (3, 3, &[ManaColor::Black], 3),
+        (2, 2, &[ManaColor::Green], 2),
+    ]);
+    // Attach the parsed CDA static to the source. The layer evaluator rebuilds
+    // `static_definitions` from `base_static_definitions` each pass, so seed both.
+    {
+        let src = state.objects.get_mut(&source_id).unwrap();
+        src.static_definitions.push(static_def.clone());
+        let base = std::sync::Arc::make_mut(&mut src.base_static_definitions);
+        base.push(static_def);
+    }
+    evaluate_layers(&mut state);
+    let live_power = state.objects.get(&source_id).unwrap().power;
+    assert_eq!(
+        live_power,
+        Some(5),
+        "after layer evaluation the craft source power must be total material power (3+2)=5"
+    );
+}
+
+/// True if `filter` resolves the source's linked-exile pool (directly
+/// `ExiledBySource` or an `And`/`Or` that contains it).
+fn filter_reads_exiled_by_source(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::ExiledBySource => true,
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_reads_exiled_by_source)
+        }
+        _ => false,
+    }
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Implements the **craft-material reference** axis of Duskmourn's Craft mechanic: "An ability of a permanent may refer to the exiled cards used to craft it" (**CR 702.167c**). The Craft keyword itself, its activated-ability synthesis, the `ExileMaterials` cost, and the persistent `ExileLinkKind::CraftMaterial` linked-exile pool were already implemented upstream. The missing axis was the **back-face references** that read that pool ("the total power of the exiled cards used to craft it", "the number of colors among...", etc.).

This PR teaches the quantity, static-CDA, and mana parsers to recognize the craft-material reference noun phrase and route it through the existing kind-agnostic `TargetFilter::ExiledBySource` consumer (which resolves the source's linked-exile pool, including `CraftMaterial` links). **No new engine variant** — every reference reuses an existing `QuantityRef` / `ManaProduction` parameterized with `ExiledBySource`.

### Building block

One shared combinator `parse_craft_materials_filter` recognizes `"the exiled card[s] used to craft <self>"` (self-anaphor: `it` / `~` / `this creature` / `this permanent` / `this artifact`) and returns the shared `And { [ExiledBySource, Owned { You }] }` filter (matching the existing Skyclave linked-exile precedent). It is reused by four parse paths:

| Parse path | Emitted ref | Card |
|---|---|---|
| `"the total power of ..."` | `Aggregate { Sum, Power, ExiledBySource }` | Mastercraft Raptor (CDA) |
| `"the number of colors among ..."` | `DistinctColorsAmongPermanents { ExiledBySource }` | Sunbird Effigy (P/T CDA) |
| `"for each color among ..., add one mana of that color"` | `ManaProduction::DistinctColorsAmongPermanents { ExiledBySource }` | Sunbird Effigy (mana) |
| `"the mana value of the exiled card ..."` (+ optional craft suffix) | `Aggregate { Sum, ManaValue, ExiledBySource }` | Jadeheart Attendant |

Files touched (engine only):
- `crates/engine/src/parser/oracle_nom/quantity.rs` — shared craft combinators + aggregate/colors arms + building-block tests
- `crates/engine/src/parser/oracle_effect/mana.rs` — craft arm in the for-each-color mana parser
- `crates/engine/tests/craft_material_references.rs` — new discriminating test suite

## add-engine-variant verdict

**No new variant.** Grepped `data/engine-inventory.json`: `Aggregate`, `DistinctColorsAmongPermanents`, and `ExiledBySource` all already exist.

- **Stage 1 (existence):** All target refs/filters present in the inventory.
- **Stage 2 (sibling-cluster smell):** None — this is leaf-level *parameterization* of existing variants with `TargetFilter::ExiledBySource`, exactly the "parameterize, don't proliferate" path. The craft pool is just another value of the `filter` axis on `Aggregate` / `DistinctColorsAmongPermanents`.
- **Stage 3 (categorical boundary):** No cross-section unification. Power/toughness stay CR 208 (CDA `SetDynamicPower/Toughness`), mana value stays CR 202.3, colors stay CR 105.1/106.1 — each reference keeps its own rule section; only the *source set* (the craft pool) is shared.

No change to `crates/engine/src/types/` or `data/engine-inventory.json` (confirmed clean), proving no variant was added.

## Grep-verified CR annotations

Every CR number added was grepped against `docs/MagicCompRules.txt` before landing:

| CR | Rule text (verified) | Used for |
|---|---|---|
| **702.167c** | "An ability of a permanent may refer to the exiled cards used to craft it. This refers to cards in exile that were exiled to pay the activation cost of the craft ability..." | The core craft-reference combinators |
| **105.1** | "There are five colors in the Magic game: white, blue, black, red, and green." | DistinctColors over craft materials |
| **109.5** | "The words 'you' and 'your' on an object refer to the object's controller..." | self-anaphor / `Owned { You }` rebind |
| **202.3** | "The mana value of an object is a number equal to the total amount of mana in its mana cost..." | Jadeheart mana-value aggregate |
| **208.1** | "...The first number is its power...the second is its toughness..." | Mastercraft power CDA |

CR-annotation diff gate: **0 UNVERIFIED**.

## Per-card verdict

| Card | Craft-reference line | Verdict |
|---|---|---|
| **Jadeheart Attendant** | "gain life equal to the mana value of the exiled card used to craft it" | ✅ 0 Unimplemented |
| **Mastercraft Raptor** | "power is equal to the total power of the exiled cards used to craft it" | ✅ 0 Unimplemented |
| **Sunbird Effigy** | P/T "= number of colors among..." + "{T}: For each color among..., add one mana" | ✅ both craft lines 0 Unimplemented (its for-each line belongs to the for-each cluster) |
| **Unstable Glyphbridge** | Craft keyword line | ✅ Craft keyword parses (its `for each player, choose...` body belongs to the for-each cluster) |
| **Locus of Enlightenment** | "has each activated ability of the exiled cards used to craft it. You may activate each... only once each turn" | ⏸ HONEST-DEFER — needs a granted-activated-abilities-from-exiled + once-each-turn subsystem out of scope here. Its second line (copy-on-activate trigger) already parses. The deferred line stays at the canonical `static_structure` Unimplemented marker. |

## Discriminating-test coverage map

All in `crates/engine/tests/craft_material_references.rs` (5 tests, all driving production resolution paths) plus 4 building-block combinator tests in `oracle_nom/quantity.rs`.

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Sibling/negative |
|---|---|---|---|---|---|
| Mastercraft power = Σ power of craft materials | `parse_object_property_aggregate_ref` craft arm | `resolve_quantity` (CDA layer reads this) | `mastercraft_raptor_power_is_total_power_of_craft_materials` | `resolved == 7` (4+1+2); falls to Unimplemented/no-static on revert | empty pool → 0 asserted |
| Mastercraft power applies via layers | same | `evaluate_layers` | `craft_cda_power_applies_through_layer_evaluator` | live `obj.power == Some(5)` after layer eval | — |
| Sunbird P/T = distinct colors of materials | `parse_number_of_distinct_colors_among_permanents_tail` craft arm | `resolve_quantity` (CDA layer) | `sunbird_effigy_pt_is_distinct_colors_of_craft_materials` | power==2 & toughness==2 (W,U,W) | colorless pool → 0 asserted |
| Sunbird mana = one per material color | `try_parse_for_each_color_mana` craft arm | `parse_oracle_text` → `Effect::Mana { DistinctColorsAmongPermanents { ExiledBySource } }` | `sunbird_effigy_mana_is_one_per_color_of_craft_materials` | production = `DistinctColorsAmongPermanents{ExiledBySource}`; Unimplemented on revert | — |
| Jadeheart life = MV of craft material | `parse_linked_exile_mana_value_ref` craft suffix | `resolve_quantity` (GainLife resolver) | `jadeheart_attendant_gains_life_equal_to_craft_material_mana_value` | `resolved == 5` | — |

**Discrimination verified empirically:** neutering `parse_craft_materials_filter` fails 4/5 runtime tests; neutering the craft suffix combinator fails the Jadeheart test. Both confirmed by reverting in-place and re-running, then restoring.

Note on shape vs. runtime: the Sunbird *mana* test asserts the parsed `ManaProduction` shape (the mana resolver's behavior over `DistinctColorsAmongPermanents{ExiledBySource}` is the same already-tested Faeburrow/Vivid path — only the `filter` value differs, which the CDA/quantity runtime tests exercise end-to-end through the identical resolution code). The power/colors/mana-value claims are all driven through `resolve_quantity` and `evaluate_layers` (real production paths), not shape-only.

No production-reachable seam is left covered only by a degenerate fixture: each test uses a multi-element, multi-color material pool plus an explicit empty/colorless negative.

## Gate results

| Gate | Result |
|---|---|
| `cargo fmt --all` | ✅ clean |
| `./scripts/check-parser-combinators.sh` | ✅ exit 0 |
| Inline parser-diff string-dispatch gate | ✅ no offending lines |
| `./scripts/check-engine-authorities.sh upstream/main` | ✅ exit 0 |
| `cargo check --workspace --all-targets` | ✅ Finished |
| `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` | ✅ Finished, no warnings |
| `cargo test -p engine` (full) | ✅ 12852 passed, 1 failed = known parallel-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (passes in isolation) |
| `cargo test -p engine --test craft_material_references` | ✅ 5/5 |
| `cargo coverage` / `cargo semantic-audit` | ⚠️ compiled clean; data-dependent run skipped (worktree lacks `card-data.json` per protocol) |
| CR-annotation diff gate | ✅ 0 UNVERIFIED |

Branch `card/std-craft`, off `upstream/main` @ `eb00f126f`.
