### PR TITLE
feat(engine): BecomeSaddled effect — grant saddled designation (Guidelight Matrix, Kolodin)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2819,6 +2819,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         }
         Effect::BecomePrepared { target }
         | Effect::BecomeUnprepared { target }
+        | Effect::BecomeSaddled { target }
         | Effect::PairWith { target } => {
             d.push(("target".into(), fmt_target(target)));
         }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -165,6 +165,7 @@ pub mod ring;
 pub mod ripple;
 pub mod roll_die;
 pub mod sacrifice;
+pub mod saddle;
 pub mod scry;
 pub mod search_library;
 pub mod search_outside_game;
@@ -2665,6 +2666,7 @@ pub fn resolve_effect(
         Effect::BecomeUnprepared { .. } => {
             prepare::resolve_become_unprepared(state, ability, events)
         }
+        Effect::BecomeSaddled { .. } => saddle::resolve(state, ability, events),
         Effect::SetClassLevel { .. } => set_class_level::resolve(state, ability, events),
         Effect::CreateDelayedTrigger { .. } => delayed_trigger::resolve(state, ability, events),
         Effect::AddTargetReplacement { .. } => {

--- a/crates/engine/src/game/effects/saddle.rs
+++ b/crates/engine/src/game/effects/saddle.rs
@@ -1,0 +1,263 @@
+//! CR 702.171b: effect-level "becomes saddled" resolver.
+//!
+//! Distinct from the Saddle keyword's activated ability (CR 702.171a,
+//! resolved in `stack.rs` as `KeywordAction::Saddle`, which is paid by tapping
+//! creatures with total power N or greater): this handler grants the saddled
+//! designation directly, without paying the saddle cost. It backs "becomes
+//! saddled" instructions — Guidelight Matrix's `{2}, {T}: Target Mount you
+//! control becomes saddled`, Kolodin's `Whenever a Mount you control enters, it
+//! becomes saddled`, and Alacrian Armory's combat trigger.
+//!
+//! CR 702.171c records the creatures that *saddle* a permanent (tapped to pay
+//! the cost). An effect-granted saddle has no such creatures, so `saddled_by`
+//! is left empty and the `Saddled` event carries an empty creature list.
+
+use crate::types::ability::{
+    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
+};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
+use crate::types::zones::Zone;
+
+/// CR 702.171b: single authority for granting the saddled designation. Sets
+/// `is_saddled = true` on a battlefield permanent, records the saddling
+/// creatures (CR 702.171c) without duplicates, and emits `GameEvent::Saddled`
+/// so any "becomes saddled" trigger fires. The event is emitted only on the
+/// false→true transition: a permanent that is already saddled stays saddled
+/// until end of turn (CR 702.171b), so re-saddling it never re-fires the
+/// trigger. Used both by the Saddle keyword resolution (with the paid creatures)
+/// and the `BecomeSaddled` effect (with an empty creature list — no cost was
+/// paid).
+///
+/// No-op (and no event) when the target is no longer on the battlefield, so the
+/// designation never lands on an object that has left play (CR 702.171b: only
+/// permanents can be or become saddled).
+pub fn mark_saddled(
+    state: &mut GameState,
+    mount_id: ObjectId,
+    saddling_creatures: Vec<ObjectId>,
+    events: &mut Vec<GameEvent>,
+) {
+    let Some(mount) = state.objects.get_mut(&mount_id) else {
+        return;
+    };
+    if mount.zone != Zone::Battlefield {
+        return;
+    }
+    // CR 702.171b: "becomes saddled" is a false→true transition. A permanent
+    // that is already saddled stays saddled until end of turn, so re-saddling it
+    // must not re-fire "whenever ~ becomes saddled" triggers.
+    let already_saddled = mount.is_saddled;
+    mount.is_saddled = true;
+    // CR 702.171c: record the creatures that saddled this permanent (deduped,
+    // accumulated across same-turn saddles). Empty for effect-granted saddles.
+    for creature_id in &saddling_creatures {
+        if !mount.saddled_by.contains(creature_id) {
+            mount.saddled_by.push(*creature_id);
+        }
+    }
+    // CR 702.171b: only emit the "becomes saddled" event on the false→true
+    // transition so the trigger fires exactly once per turn.
+    if !already_saddled {
+        events.push(GameEvent::Saddled {
+            mount_id,
+            creatures: saddling_creatures,
+        });
+    }
+}
+
+/// Resolve the object target(s) of a `BecomeSaddled` effect. Mirrors the
+/// canonical `resolve_defined_or_targets` chokepoint in `counters.rs`:
+/// - `LastCreated` → the most recently created token ids
+/// - `SelfRef` → the source (a "~ becomes saddled" self-anaphor)
+/// - event-context refs (`TriggeringSource` — Kolodin's "it becomes saddled"
+///   Mount-enters trigger; `ParentTarget` from a parent slot) resolve from the
+///   trigger event via `resolve_event_context_targets`
+/// - otherwise → the announced object targets (Guidelight Matrix's chosen Mount)
+fn resolve_object_targets(state: &GameState, ability: &ResolvedAbility) -> Vec<ObjectId> {
+    let Effect::BecomeSaddled { target } = &ability.effect else {
+        return Vec::new();
+    };
+    if matches!(target, TargetFilter::LastCreated) {
+        return state.last_created_token_ids.clone();
+    }
+    // CR 608.2c: the printed-name anaphor always resolves to the source.
+    if matches!(target, TargetFilter::SelfRef) {
+        return vec![ability.source_id];
+    }
+    // CR 608.2c: a triggered "it becomes saddled" binds "it" to a context ref
+    // (`TriggeringSource`) that resolves from the trigger event — not from an
+    // announced target slot. `resolve_event_context_targets` reads the event;
+    // it returns empty for a plain targeted effect, which then falls through to
+    // the announced targets below.
+    let event_targets =
+        crate::game::targeting::resolve_event_context_targets(state, target, ability.source_id);
+    if !event_targets.is_empty() {
+        return event_targets
+            .into_iter()
+            .filter_map(|t| match t {
+                TargetRef::Object(id) => Some(id),
+                TargetRef::Player(_) => None,
+            })
+            .collect();
+    }
+    ability
+        .targets
+        .iter()
+        .filter_map(|t| match t {
+            TargetRef::Object(id) => Some(*id),
+            _ => None,
+        })
+        .collect()
+}
+
+/// CR 702.171b: resolver for `Effect::BecomeSaddled` — the target permanent(s)
+/// gain the saddled designation until end of turn (cleared at cleanup / on
+/// leaving the battlefield by `reset_for_battlefield_exit`). No saddling
+/// creatures are recorded because no saddle cost was paid.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    for object_id in resolve_object_targets(state, ability) {
+        mark_saddled(state, object_id, Vec::new(), events);
+    }
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::BecomeSaddled,
+        source_id: ability.source_id,
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::card_type::CoreType;
+    use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::player::PlayerId;
+
+    fn battlefield_mount(state: &mut GameState) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(1),
+            PlayerId(0),
+            "Test Mount".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.card_types.subtypes.push("Mount".to_string());
+        obj.base_power = Some(0);
+        obj.base_toughness = Some(4);
+        obj.power = Some(0);
+        obj.toughness = Some(4);
+        id
+    }
+
+    #[test]
+    fn become_saddled_marks_explicit_object_target() {
+        let mut state = GameState::new_two_player(42);
+        let mount = battlefield_mount(&mut state);
+        let ability = ResolvedAbility::new(
+            Effect::BecomeSaddled {
+                target: TargetFilter::Any,
+            },
+            vec![TargetRef::Object(mount)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(state.objects[&mount].is_saddled);
+        // CR 702.171c: an effect-granted saddle records no saddling creatures.
+        assert!(state.objects[&mount].saddled_by.is_empty());
+        assert!(events.iter().any(
+            |e| matches!(e, GameEvent::Saddled { mount_id, creatures } if *mount_id == mount && creatures.is_empty())
+        ));
+    }
+
+    #[test]
+    fn become_saddled_self_ref_targets_source() {
+        let mut state = GameState::new_two_player(42);
+        let mount = battlefield_mount(&mut state);
+        let ability = ResolvedAbility::new(
+            Effect::BecomeSaddled {
+                target: TargetFilter::SelfRef,
+            },
+            vec![],
+            mount,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert!(state.objects[&mount].is_saddled);
+    }
+
+    #[test]
+    fn become_saddled_resolves_announced_object_target() {
+        // CR 115.1: a real `Typed(Mount)` target slot ("Target Mount you control
+        // becomes saddled") binds the chosen object via `ability.targets`, the
+        // path Guidelight Matrix takes once a target is announced.
+        let mut state = GameState::new_two_player(42);
+        let mount = battlefield_mount(&mut state);
+        let other = battlefield_mount(&mut state);
+        let ability = ResolvedAbility::new(
+            Effect::BecomeSaddled {
+                target: TargetFilter::Any,
+            },
+            vec![TargetRef::Object(mount)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        assert!(state.objects[&mount].is_saddled);
+        // Only the announced target is saddled, not every Mount.
+        assert!(!state.objects[&other].is_saddled);
+    }
+
+    #[test]
+    fn mark_saddled_noop_off_battlefield() {
+        // CR 702.171b: only permanents can become saddled — an object not on the
+        // battlefield is not marked and no event fires.
+        let mut state = GameState::new_two_player(42);
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Exiled Mount".to_string(),
+            Zone::Exile,
+        );
+        let mut events = Vec::new();
+        mark_saddled(&mut state, id, Vec::new(), &mut events);
+        assert!(!state.objects[&id].is_saddled);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn mark_saddled_records_payers_without_duplicates() {
+        // CR 702.171c: the keyword path passes the saddling creatures; mark_saddled
+        // accumulates them deduped (the single authority shared with the keyword
+        // resolution in stack.rs).
+        let mut state = GameState::new_two_player(42);
+        let mount = battlefield_mount(&mut state);
+        let rider = ObjectId(55);
+        let mut events = Vec::new();
+        mark_saddled(&mut state, mount, vec![rider], &mut events);
+        mark_saddled(&mut state, mount, vec![rider], &mut events);
+        assert_eq!(state.objects[&mount].saddled_by, vec![rider]);
+        // CR 702.171b: "becomes saddled" is a false→true transition — re-saddling
+        // an already-saddled mount must not re-fire the trigger. Exactly one
+        // `GameEvent::Saddled` is emitted across both calls. This assertion fails
+        // if the transition guard in `mark_saddled` is removed.
+        let saddled_events = events
+            .iter()
+            .filter(|e| matches!(e, GameEvent::Saddled { mount_id, .. } if *mount_id == mount))
+            .count();
+        assert_eq!(saddled_events, 1);
+    }
+}

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -988,6 +988,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::SolveCase
         | Effect::BecomePrepared { .. }
         | Effect::BecomeUnprepared { .. }
+        | Effect::BecomeSaddled { .. }
         | Effect::SetClassLevel { .. }
         | Effect::AddRestriction { .. }
         | Effect::ReduceNextSpellCost { .. }

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1514,21 +1514,10 @@ fn resolve_keyword_action(
             mount_id,
             paid_creature_ids,
         } => {
-            if let Some(mount) = state.objects.get_mut(&mount_id) {
-                if mount.zone == Zone::Battlefield {
-                    mount.is_saddled = true;
-                    // CR 702.171c: record the creatures that saddled this permanent.
-                    for creature_id in &paid_creature_ids {
-                        if !mount.saddled_by.contains(creature_id) {
-                            mount.saddled_by.push(*creature_id);
-                        }
-                    }
-                }
-            }
-            events.push(GameEvent::Saddled {
-                mount_id,
-                creatures: paid_creature_ids,
-            });
+            // CR 702.171b + CR 702.171c: single authority shared with the
+            // effect-level `BecomeSaddled` path — set the designation, record the
+            // saddling creatures, and emit `GameEvent::Saddled`.
+            crate::game::effects::saddle::mark_saddled(state, mount_id, paid_creature_ids, events);
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::Saddle,
                 source_id: mount_id,

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -863,6 +863,10 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::Crew
         | EffectKind::Station
         | EffectKind::Saddle
+        // CR 702.171b: the BecomeSaddled effect fires the saddled trigger via the
+        // separately-emitted `GameEvent::Saddled`, mirroring the keyword `Saddle`
+        // action; its own `EffectResolved` dispatches no trigger key.
+        | EffectKind::BecomeSaddled
         | EffectKind::Transform
         | EffectKind::TurnFaceUp
         // Added on origin/main after this branch point. No production

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -4126,6 +4126,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::SolveCase
         | Effect::BecomePrepared { .. }
         | Effect::BecomeUnprepared { .. }
+        | Effect::BecomeSaddled { .. }
         | Effect::SetClassLevel { .. }
         | Effect::CreateDelayedTrigger { .. }
         | Effect::AddTargetReplacement { .. }

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -2619,6 +2619,32 @@ fn build_become_clause(
         return Some(super::parsed_clause(effect));
     }
 
+    // CR 702.171b: "becomes saddled" toggles the saddled designation on the
+    // target permanent. Must intercept before parse_animation_spec which would
+    // mis-classify "saddled" as a subtype. The designation always clears at end
+    // of turn / when the permanent leaves the battlefield (handled by the
+    // engine's cleanup pass), so the trailing "until end of turn" duration that
+    // `strip_trailing_duration` already peeled is not re-attached — the effect
+    // carries no duration. Unlike a `GenericEffect` animation (whose typed
+    // selection filter lives on the effect's `target` field and whose static's
+    // `affected` is `ParentTarget`), `BecomeSaddled` is a single targeted effect
+    // whose `target` IS the selection slot: a "Target Mount you control"
+    // subject (Guidelight Matrix) carries its real `Typed(Mount, You)` filter so
+    // `build_target_slots` surfaces a target slot; an anaphoric subject ("it
+    // becomes saddled" — Kolodin's Mount-enters trigger lowers "it" to a
+    // `TriggeringSource` context ref) carries `affected`, which the resolver
+    // resolves from event context.
+    if all_consuming(tag::<_, _, OracleError<'_>>("saddled"))
+        .parse(become_lower.as_str())
+        .is_ok()
+    {
+        let target = application
+            .target
+            .clone()
+            .unwrap_or_else(|| application.affected.clone());
+        return Some(super::parsed_clause(Effect::BecomeSaddled { target }));
+    }
+
     // CR 707.2 / CR 613.1a: "become a copy of [target]" — copy copiable characteristics.
     // Must intercept before parse_animation_spec which rejects "copy of" patterns.
     //

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8538,6 +8538,19 @@ pub enum Effect {
         #[serde(default = "default_target_filter_any")]
         target: TargetFilter,
     },
+    /// CR 702.171b: the target permanent becomes saddled until end of turn.
+    /// Distinct from the Saddle keyword's activated ability (CR 702.171a,
+    /// `KeywordAction::Saddle`) which is paid by tapping creatures: this is the
+    /// effect-level designation toggle used by "becomes saddled" instructions
+    /// (Guidelight Matrix, Kolodin, Alacrian Armory) that grant the designation
+    /// without paying the saddle cost. Idempotent: if already saddled, no event
+    /// fires. CR 702.171b: only permanents can become saddled, the designation
+    /// is cleared at end of turn / when the permanent leaves the battlefield,
+    /// and it is not part of the permanent's copiable values.
+    BecomeSaddled {
+        #[serde(default = "default_target_filter_any")]
+        target: TargetFilter,
+    },
     /// CR 716.2a: Set the class level on the source Class enchantment.
     SetClassLevel {
         level: u8,
@@ -10391,6 +10404,7 @@ impl Effect {
             | Effect::ForceAttack { target, .. }
             | Effect::BecomePrepared { target, .. }
             | Effect::BecomeUnprepared { target, .. }
+            | Effect::BecomeSaddled { target, .. }
             | Effect::CastFromZone { target, .. }
             | Effect::PreventDamage { target, .. }
             | Effect::Exploit { target, .. }
@@ -10845,6 +10859,7 @@ impl Effect {
             | Effect::ForceAttack { .. }
             | Effect::BecomePrepared { .. }
             | Effect::BecomeUnprepared { .. }
+            | Effect::BecomeSaddled { .. }
             | Effect::CastFromZone { .. }
             | Effect::PreventDamage { .. }
             | Effect::Exploit { .. }
@@ -11054,6 +11069,7 @@ impl Effect {
             | Effect::ForceAttack { .. }
             | Effect::BecomePrepared { .. }
             | Effect::BecomeUnprepared { .. }
+            | Effect::BecomeSaddled { .. }
             | Effect::CastFromZone { .. }
             | Effect::PreventDamage { .. }
             | Effect::Exploit { .. }
@@ -11238,6 +11254,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::SolveCase => "SolveCase",
         Effect::BecomePrepared { .. } => "BecomePrepared",
         Effect::BecomeUnprepared { .. } => "BecomeUnprepared",
+        Effect::BecomeSaddled { .. } => "BecomeSaddled",
         Effect::SetClassLevel { .. } => "SetClassLevel",
         Effect::CreateDelayedTrigger { .. } => "CreateDelayedTrigger",
         Effect::AddTargetReplacement { .. } => "AddTargetReplacement",
@@ -11444,6 +11461,8 @@ pub enum EffectKind {
     BecomePrepared,
     /// CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.
     BecomeUnprepared,
+    /// CR 702.171b: mark the target permanent as saddled until end of turn.
+    BecomeSaddled,
     SetClassLevel,
     CreateDelayedTrigger,
     AddTargetReplacement,
@@ -11661,6 +11680,7 @@ impl From<&Effect> for EffectKind {
             Effect::SolveCase => EffectKind::SolveCase,
             Effect::BecomePrepared { .. } => EffectKind::BecomePrepared,
             Effect::BecomeUnprepared { .. } => EffectKind::BecomeUnprepared,
+            Effect::BecomeSaddled { .. } => EffectKind::BecomeSaddled,
             Effect::SetClassLevel { .. } => EffectKind::SetClassLevel,
             Effect::CreateDelayedTrigger { .. } => EffectKind::CreateDelayedTrigger,
             Effect::AddTargetReplacement { .. } => EffectKind::AddTargetReplacement,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -398,6 +398,7 @@ mod rite_of_consumption_damage;
 mod roots_of_wisdom_if_you_cant_draw;
 mod roughshod_mentor_green_trample_grant;
 mod rules;
+mod saddle_become_effect;
 mod saddle_state_model;
 mod saruman_white_hand_amass;
 mod sba_lethal_damage_redirect_single_application;

--- a/crates/engine/tests/integration/saddle_become_effect.rs
+++ b/crates/engine/tests/integration/saddle_become_effect.rs
@@ -1,0 +1,161 @@
+//! Runtime coverage for the effect-level "becomes saddled" instruction
+//! (`Effect::BecomeSaddled`, CR 702.171b) — distinct from the Saddle keyword's
+//! activated ability (CR 702.171a), which is paid by tapping creatures.
+//!
+//! CR 702.171b: "Saddled is a designation ... Only permanents can be or become
+//! saddled. Once a permanent has become saddled, it stays saddled until the end
+//! of the turn or it leaves the battlefield."
+//!
+//! These tests drive the REAL pipeline (`GameAction::ActivateAbility` /
+//! cast → stack → resolve via the `GameScenario`/`GameRunner` harness), not the
+//! parsed AST. Each asserts the saddled designation actually lands on game
+//! state and would FLIP if the `BecomeSaddled` resolver were reverted to the
+//! parser's `Unimplemented` no-op:
+//!   - Guidelight Matrix: activating `{2},{T}: Target Mount you control becomes
+//!     saddled` sets `is_saddled = true` on the chosen Mount. Revert the
+//!     resolver → the effect no-ops → the `is_saddled` assertion fails.
+//!   - Kolodin: a Mount entering under your control fires the trigger and
+//!     becomes saddled; a non-Mount entering does NOT (the trigger filter +
+//!     resolver discriminate the positive from the negative case).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::Effect;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const GUIDELIGHT_MATRIX: &str = "When this artifact enters, draw a card.\n\
+{2}, {T}: Target Mount you control becomes saddled until end of turn. Activate only as a sorcery.\n\
+{2}, {T}: Target Vehicle you control becomes an artifact creature until end of turn.";
+
+const KOLODIN: &str = "Mounts and Vehicles you control have haste.\n\
+Whenever a Mount you control enters, it becomes saddled until end of turn.\n\
+Whenever a Vehicle you control enters, it becomes an artifact creature until end of turn.";
+
+/// CR 702.171b: activating Guidelight Matrix's `{2},{T}: Target Mount you
+/// control becomes saddled` marks the targeted Mount saddled through the real
+/// activation → resolution pipeline.
+///
+/// DISCRIMINATION: the only thing that sets `is_saddled` here is the
+/// `Effect::BecomeSaddled` resolver running on the chosen Mount. Revert the
+/// resolver (or its parser arm) and the line is `Effect::Unimplemented`, which
+/// resolves to a no-op — `is_saddled` stays false and this assertion fails.
+#[test]
+fn guidelight_matrix_saddles_target_mount() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Guidelight Matrix on the battlefield, parsed from real Oracle text.
+    let matrix = scenario
+        .add_creature_from_oracle(P0, "Guidelight Matrix", 0, 1, GUIDELIGHT_MATRIX)
+        .id();
+
+    // A Mount the controller owns — the legal target of the saddle ability.
+    let mount = {
+        let mut b = scenario.add_creature(P0, "Test Mount", 0, 4);
+        b.with_subtypes(vec!["Mount"]);
+        b.id()
+    };
+
+    // Pay {2} from the pool; {T} is the source's own tap.
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+
+    assert!(
+        !runner.state().objects[&mount].is_saddled,
+        "precondition: the Mount is not saddled before the ability resolves"
+    );
+
+    // Locate the `{2},{T}: ... becomes saddled` ability by its effect.
+    let saddle_idx = runner.state().objects[&matrix]
+        .abilities
+        .iter()
+        .position(|a| matches!(a.effect.as_ref(), Effect::BecomeSaddled { .. }))
+        .expect("Guidelight Matrix must have a BecomeSaddled activated ability");
+
+    runner
+        .activate(matrix, saddle_idx)
+        .target_object(mount)
+        .resolve();
+
+    // CR 702.171b: the designation lands on the chosen Mount.
+    assert!(
+        runner.state().objects[&mount].is_saddled,
+        "the targeted Mount must become saddled after the ability resolves"
+    );
+    // CR 702.171c: an effect-granted saddle records no saddling creatures.
+    assert!(
+        runner.state().objects[&mount].saddled_by.is_empty(),
+        "an effect-granted saddle must not record any saddling creatures"
+    );
+}
+
+/// CR 702.171b + CR 603.2: a Mount entering under Kolodin's control fires
+/// "Whenever a Mount you control enters, it becomes saddled until end of turn"
+/// and the entering Mount becomes saddled — driven through the cast → ETB →
+/// trigger → resolve pipeline.
+///
+/// DISCRIMINATION: removing the `BecomeSaddled` resolver makes the trigger
+/// effect a no-op `Unimplemented`, leaving the entering Mount unsaddled and
+/// flipping the positive assertion.
+#[test]
+fn kolodin_saddles_entering_mount() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Kolodin on the battlefield with its parsed Mount-enters trigger.
+    scenario.add_creature_from_oracle(P0, "Kolodin, Triumph Caster", 2, 4, KOLODIN);
+
+    // A Mount in hand to cast (scenario cards have ManaCost::zero()).
+    let mount = {
+        let mut b = scenario.add_creature_to_hand(P0, "New Mount", 1, 1);
+        b.with_subtypes(vec!["Mount"]);
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+
+    assert!(
+        !runner.state().objects[&mount].is_saddled,
+        "precondition: the Mount is not saddled while still in hand"
+    );
+
+    runner.cast(mount).resolve();
+
+    // CR 702.171b: the entering Mount becomes saddled via the resolved trigger.
+    assert!(
+        runner.state().objects[&mount].is_saddled,
+        "a Mount entering under Kolodin's control must become saddled"
+    );
+}
+
+/// SIBLING / NEGATIVE: a non-Mount creature entering under Kolodin's control
+/// must NOT become saddled — the trigger filter (`Subtype("Mount")`) gates the
+/// `BecomeSaddled` effect, so a plain creature entering is unaffected. This
+/// keeps the positive test honest: the saddle came from the Mount filter, not
+/// from every ETB.
+#[test]
+fn kolodin_does_not_saddle_entering_non_mount() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario.add_creature_from_oracle(P0, "Kolodin, Triumph Caster", 2, 4, KOLODIN);
+
+    // A non-Mount creature in hand.
+    let bear = scenario.add_creature_to_hand(P0, "Grizzly Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.cast(bear).resolve();
+
+    assert!(
+        !runner.state().objects[&bear].is_saddled,
+        "a non-Mount entering under Kolodin must not become saddled"
+    );
+}

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -545,6 +545,9 @@ fn redundancy_delta(
         // CR 702.xxx: Prepare (Strixhaven) — no redundancy detection.
         | Effect::BecomePrepared { .. }
         | Effect::BecomeUnprepared { .. }
+        // CR 702.171b: a permanent cannot become saddled if already saddled; no
+        // static redundancy signal — leave to the resolver.
+        | Effect::BecomeSaddled { .. }
         // CR 702.95c-d: PairWith mutates the source/target pair relationship;
         // redundancy depends on trigger timing and revalidation, so this policy
         // leaves it to the resolver.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# feat(engine): effect-level "becomes saddled" (Guidelight Matrix, Kolodin) — CR 702.171b

## Summary

Adds the missing effect-level primitive for the **Saddle / Mount** cluster (Outlaws of Thunder Junction): `Effect::BecomeSaddled`, the designation toggle behind every "[permanent] becomes saddled until end of turn" instruction. This is the sibling of the already-shipped **Saddle keyword** (`Keyword::Saddle(N)`, `KeywordAction::Saddle`, `WaitingFor::SaddleMount`) — but for effects that grant the saddled designation *without* paying the saddle cost.

The Saddle keyword (CR 702.171a) and the saddled designation/triggers/filters (`is_saddled`, `saddled_by`, `TriggerMode::BecomesSaddled`, `FilterProp::IsSaddled`, `StaticCondition::SourceIsSaddled`, `GameEvent::Saddled`) were already fully implemented upstream. The only gap for this cluster was an **Effect** that makes a permanent become saddled. This PR builds that one missing axis and routes both the keyword path and the new effect through a single authority (`saddle::mark_saddled`).

## add-engine-variant verdict (Crew reuse + parameterization)

New variant proposed: `Effect::BecomeSaddled { target }`.

- **Stage 1 — Existence verification (5-grep): DOES_NOT_EXIST.** Existing saddle surface is `KeywordAction::Saddle` (cost-paid keyword), `WaitingFor::SaddleMount`, `TriggerMode::BecomesSaddled`, `SimpleEvent::BecomesSaddled`, `FilterProp::IsSaddled`, `StaticCondition::SourceIsSaddled`, `GameEvent::Saddled`. None is an `Effect` that *grants* the designation. The keyword resolution sets `is_saddled = true` inline in `stack.rs`; the synthesis layer has no saddle handler. No EXISTS_* slot found.
- **Crew reuse:** Saddle already mirrors Crew structurally (`AggregateStat` tap-creatures cost, `KeywordAction::{Crew,Saddle}`). That sibling machinery is the *cost* mechanic and is untouched here — it is already shared and correct. The new effect is a designation toggle (no cost), analogous to `BecomePrepared`/`BecomeUnprepared` (CR 722.3), not to Crew. The right reuse here was the `BecomePrepared` resolver shape, not the Crew cost path.
- **Stage 2 — Parameterization filter: EXTEND_OK.** The candidate sibling cluster is `BecomeMonarch` / `BecomePrepared` / `BecomeUnprepared` / `BecomeCopy`. These cross CR sections: Monarch = CR 725 (player designation), Prepared = CR 722.3 (Strixhaven permanent designation), Copy = CR 707 (copiable values). Unifying them under one `Become { designation }` would conflate separately-resolvable rule sections, which the categorical-boundary rule forbids. `BecomeSaddled` is wholly within CR 702.171.
- **Stage 3 — Categorical boundary: WITHIN_SECTION.** The variant's entire semantics live in CR 702.171b. Approved.

Single-authority compliance: `stack.rs`'s `KeywordAction::Saddle` resolution and the new `Effect::BecomeSaddled` resolver both call `saddle::mark_saddled(state, mount_id, creatures, events)`, which is the sole writer of `is_saddled` / `saddled_by` and the sole emitter of `GameEvent::Saddled` on the saddle path. The keyword passes the paid creatures (CR 702.171c); the effect passes an empty list (no cost paid → no saddling creatures).

## grep-verified CR annotations

All verified against `docs/MagicCompRules.txt` (CR-annotation diff gate returned zero `UNVERIFIED`):

- **CR 702.171a** — "Saddle is an activated ability. 'Saddle N' means 'Tap any number of other untapped creatures … : This permanent becomes saddled until end of turn. Activate only as a sorcery.'" (the keyword path; distinguishes it from the effect path)
- **CR 702.171b** — "Saddled is a designation … Only permanents can be or become saddled. Once a permanent has become saddled, it stays saddled until the end of the turn or it leaves the battlefield. Being saddled is not a part of the permanent's copiable values." (governs `Effect::BecomeSaddled`, the off-battlefield no-op, and end-of-turn / leave-battlefield cleanup)
- **CR 702.171c** — "A creature 'saddles' a permanent as it's tapped to pay the cost …" (why effect-granted saddles record no `saddled_by`)
- **CR 608.2c / CR 603.2 / CR 115.1** — triggered "it becomes saddled" referent and targeted-effect target-slot resolution.

## Per-card verdict table

| Card | Saddle/Mount line(s) | Verdict | Notes |
|---|---|---|---|
| **Guidelight Matrix** | `{2},{T}: Target Mount you control becomes saddled until end of turn` | **SHIPPED — 0 Unimplemented** | All 3 lines parse; saddle line → `BecomeSaddled { Typed(Mount,You) }` with a real target slot. Vehicle/draw lines already covered upstream. |
| **Kolodin, Triumph Caster** | `Whenever a Mount you control enters, it becomes saddled until end of turn` | **SHIPPED — 0 Unimplemented** | All 3 lines parse; Mount-enters trigger → `BecomeSaddled { TriggeringSource }`. Haste static + Vehicle trigger already covered upstream. |
| **Alacrian Armory** | `that permanent becomes saddled if it's a Mount and becomes an artifact creature if it's a Vehicle` | **HONEST-DEFER** | Saddle Effect exists, but this line needs a per-target **conditional dual-become split** ("X if it's a Mount and Y if it's a Vehicle") — a separate conditional-clause grammar subsystem, not a saddle gap. Out of cluster scope. Stays `Unimplemented`. |
| **Calamity, Galloping Inferno** | `Saddle 1` (keyword); attack-while-saddled COPY trigger | **PARTIAL (expected)** | `Saddle 1` → `Keyword::Saddle(1)` (already works). The "choose a nonlegendary creature that saddled it … create a copy" line needs the copy cluster + "creature that saddled it" reference; per orchestrator note its COPY line shipped elsewhere and it is not expected to reach 0 from this PR. |
| **Fortune, Loyal Steed** | `Saddle 1` (keyword); attack-while-saddled exile/return trigger | **PARTIAL (expected)** | `Saddle 1` → `Keyword::Saddle(1)` (already works). The "at end of combat, exile it and up to one creature that saddled it … return" line needs an at-end-of-combat delayed trigger + "creature that saddled it" reference (exile/return cluster). DEFERRED. |

Net: **2 cards shipped to 0-Unimplemented** on the lines this cluster owns; 3 honest-deferred to other clusters (their saddle/keyword parts already work).

## Discriminating-test coverage map

All tests drive the REAL pipeline (`apply()` via `GameScenario`/`GameRunner`), not parsed-AST shape.

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion |
|---|---|---|---|---|
| Activated "Target Mount becomes saddled" saddles the chosen Mount | `Effect::BecomeSaddled` resolver + parser real-target-slot | `GameAction::ActivateAbility` → stack → `resolve_effect` | `saddle_become_effect::guidelight_matrix_saddles_target_mount` | `mount.is_saddled == true` (false on revert → fail) |
| Mount-enters trigger saddles the entering Mount | `Effect::BecomeSaddled` resolver (`TriggeringSource` via `resolve_event_context_targets`) | `cast` → ETB → trigger → `resolve_effect` | `saddle_become_effect::kolodin_saddles_entering_mount` | entering `mount.is_saddled == true` |
| Non-Mount ETB does NOT saddle (filter discriminates) | trigger filter `Subtype("Mount")` | `cast` → ETB → trigger gate | `saddle_become_effect::kolodin_does_not_saddle_entering_non_mount` | `bear.is_saddled == false` |
| Single-authority sets designation; effect-granted saddle records no payers | `saddle::mark_saddled` / `resolve` | unit (direct resolver) | `effects::saddle::tests::become_saddled_marks_explicit_object_target` + `..._resolves_announced_object_target` + `..._self_ref_targets_source` + `mark_saddled_noop_off_battlefield` + `mark_saddled_records_payers_without_duplicates` | `is_saddled`, empty `saddled_by`, off-battlefield no-op |

**Revert proof performed:** temporarily replacing the `BecomeSaddled` dispatch arm with `Ok(())` (no-op) flips both positive integration tests to FAIL while the negative test still passes. Restored verbatim.

No production-reachable seam is left covered only by a degenerate fixture: the Guidelight Matrix test uses a real announced target slot through the activation driver; the Kolodin tests use a real cast→ETB→trigger; the negative test reaches the same trigger gate with a non-matching subtype. Existing `saddle_state_model` keyword tests still pass against the refactored single-authority `mark_saddled`.

## Gate results

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- inline parser string-dispatch diff gate (contains/find/split/…) — no offending lines
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- `cargo check --workspace --all-targets` — exit 0
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — exit 0, zero warnings
- `cargo test -p engine` (FULL) — 12852 passed; the only 2 failures are the known parallel-flaky perf tests (`ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`, `ai_support::tests::target_selection_legal_actions_do_not_simulate_each_target`) — both pass when run single-threaded/isolated (confirmed)
- CR-annotation diff gate — zero `UNVERIFIED`
- `cargo coverage` / `cargo semantic-audit` — not runnable in worktree (no `card-data.json` / MTGJSON, per protocol); verified via `parse_oracle_text` 0-Unimplemented + discriminating `GameScenario` runtime tests instead. Will run in CI/Tilt post-card-data-regen.

## Files changed

- `types/ability.rs` — `Effect::BecomeSaddled { target }` + `EffectKind::BecomeSaddled` + all exhaustive-match arms (target_filter, count_expr, name, kind mapping)
- `game/effects/saddle.rs` (new) — resolver + single-authority `mark_saddled` + unit tests
- `game/effects/mod.rs` — module registration + dispatch
- `game/stack.rs` — keyword Saddle resolution refactored onto `mark_saddled` (single authority)
- `game/coverage.rs`, `game/printed_cards.rs`, `game/trigger_index.rs`, `parser/oracle_effect/sequence.rs` — exhaustive-match arms for the new variant
- `parser/oracle_effect/subject.rs` — "becomes saddled" arm in `build_become_clause` (real target slot for targeted subjects; affected/context-ref for anaphoric)
- `phase-ai/src/policies/redundancy_avoidance.rs` — no-redundancy classification arm
- `tests/integration/saddle_become_effect.rs` (new) + `tests/integration/main.rs` — discriminating runtime tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
