### PR TITLE
feat(engine): Unsuspect effect + CantBecomeSuspected (5 suspect cards)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -49,6 +49,12 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
         // marked damage from permanents matching an active such static's
         // `affected` filter. Not registry-keyed (mirrors the marker cluster).
         StaticMode::DamageNotRemovedDuringCleanup
+            // CR 701.60a + CR 701.60d: nullary marker static — runtime
+            // enforcement is the suspect resolver's `can_become_suspected` gate
+            // (effects/suspect.rs), which refuses to designate a permanent
+            // carrying this static. The `affected` filter scopes the protected
+            // permanents. Not registry-keyed (mirrors the marker cluster).
+            | StaticMode::CantBecomeSuspected
             | StaticMode::ReduceAbilityCost { .. }
             | StaticMode::ModifyActivationLimit { .. }
             | StaticMode::AdditionalLandDrop { .. }
@@ -1981,7 +1987,8 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::CopySpell { target, .. }
         | Effect::CastCopyOfCard { target, .. }
         | Effect::BecomeCopy { target, .. }
-        | Effect::Suspect { target }
+        | Effect::Suspect { target, .. }
+        | Effect::Unsuspect { target, .. }
         | Effect::Connive { target, .. }
         | Effect::PhaseOut { target }
         | Effect::PhaseIn { target }
@@ -7257,6 +7264,8 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
             StaticMode::CantAttack => effective_lower.contains("can't attack"),
             StaticMode::CantBlock => effective_lower.contains("can't block"),
             StaticMode::CantAttackOrBlock => effective_lower.contains("can't attack or block"),
+            // CR 701.60a + CR 701.60d: Airtight Alibi's "can't become suspected".
+            StaticMode::CantBecomeSuspected => effective_lower.contains("can't become suspected"),
             StaticMode::CantCrew => {
                 effective_lower.contains("can't crew") || effective_lower.contains("cannot crew")
             }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2674,6 +2674,7 @@ pub fn resolve_effect(
         Effect::Choose { .. } => choose::resolve(state, ability, events),
         Effect::ChooseDamageSource { .. } => choose_damage_source::resolve(state, ability, events),
         Effect::Suspect { .. } => suspect::resolve(state, ability, events),
+        Effect::Unsuspect { .. } => suspect::resolve_unsuspect(state, ability, events),
         Effect::Connive { .. } => connive::resolve(state, ability, events),
         Effect::PhaseOut { .. } => phase_out::resolve(state, ability, events),
         Effect::PhaseIn { .. } => phase_out::resolve_phase_in(state, ability, events),

--- a/crates/engine/src/game/effects/suspect.rs
+++ b/crates/engine/src/game/effects/suspect.rs
@@ -1,33 +1,60 @@
-use std::sync::Arc;
-
 use crate::types::ability::{
-    EffectError, EffectKind, ResolvedAbility, StaticDefinition, TargetFilter, TargetRef,
+    Effect, EffectError, EffectKind, EffectScope, ResolvedAbility, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
-use crate::types::keywords::Keyword;
+use crate::types::identifiers::ObjectId;
 use crate::types::statics::StaticMode;
 
-/// CR 701.60a: Suspect target creature(s).
-/// A suspected creature has menace and "This creature can't block." (CR 701.60c)
+/// Resolve the object subjects of a Suspect / Unsuspect effect.
 ///
-/// Option C architecture: the designation (`is_suspected`) is the source of truth,
-/// and the derived abilities (Menace, CantBlock) are written to `base_keywords` /
-/// `base_static_definitions` so they survive layer recalculation naturally.
-pub fn resolve(
-    state: &mut GameState,
-    ability: &ResolvedAbility,
-    events: &mut Vec<GameEvent>,
-) -> Result<(), EffectError> {
-    let target_ids: Vec<_> = match &ability.effect {
-        crate::types::ability::Effect::Suspect { target } => match target {
+/// Dispatches on the effect's `scope` (mirrors `tap_untap::resolve_set_tap_state`
+/// and the `DestroyAll` mass convention):
+///
+/// - [`EffectScope::Single`] — the targeted / anaphoric path:
+///   - `LastCreated` reads the just-created token set;
+///   - `SelfRef` (the printed-name anaphor "~" / "it" on a self-targeting
+///     ability) always resolves to the source permanent regardless of
+///     `ability.targets` — so "~ is no longer suspected" (Frantic Scapegoat) or
+///     "Otherwise, suspect it" (Repeat Offender) acts on its own source rather
+///     than no-op against an empty announced-target list;
+///   - every other filter reads the announced object targets.
+/// - [`EffectScope::All`] — the mass population filter ("all suspected creatures
+///   are no longer suspected", Absolving Lammasu): CR 701.60a removes the
+///   designation from *each* matching permanent, so this enumerates every
+///   battlefield permanent matching `target` with no announced target list,
+///   exactly like `Effect::DestroyAll` / `Effect::TapAll`.
+///
+/// Shared by `resolve` and `resolve_unsuspect` so the designation /
+/// un-designation pair selects subjects identically.
+fn resolve_object_targets(state: &GameState, ability: &ResolvedAbility) -> Vec<ObjectId> {
+    let (filter, scope) = match &ability.effect {
+        Effect::Suspect { target, scope } | Effect::Unsuspect { target, scope } => (target, *scope),
+        _ => return Vec::new(),
+    };
+    match scope {
+        // CR 701.60a: mass "all/each suspected creatures" — apply the
+        // un-designation to every battlefield permanent matching the population
+        // filter. No target is announced (`target_filter()` is `None` for the
+        // `All` scope), so iterate the battlefield instead of `ability.targets`.
+        EffectScope::All => {
+            let effective_filter = crate::game::effects::resolved_object_filter(ability, filter);
+            let ctx = crate::game::filter::FilterContext::from_ability(ability);
+            state
+                .battlefield
+                .iter()
+                .copied()
+                .filter(|id| {
+                    crate::game::filter::matches_target_filter(state, *id, &effective_filter, &ctx)
+                })
+                .collect()
+        }
+        EffectScope::Single => match filter {
             TargetFilter::LastCreated => state.last_created_token_ids.clone(),
             // CR 608.2c + CR 701.60a: `SelfRef` is the printed-name anaphor ("~"
             // / "it" on a self-targeting ability) — it always resolves to the
             // source permanent, regardless of `ability.targets`. Mirrors the
-            // `resolve_defined_or_targets` short-circuit so a self-targeting
-            // "Otherwise, suspect it" (Repeat Offender) suspects its own source
-            // rather than no-op against an empty announced-target list.
+            // `resolve_defined_or_targets` short-circuit.
             TargetFilter::SelfRef => vec![ability.source_id],
             _ => ability
                 .targets
@@ -38,32 +65,68 @@ pub fn resolve(
                 })
                 .collect(),
         },
-        _ => return Ok(()),
+    }
+}
+
+/// CR 701.60d + CR 701.60a: A permanent can't gain the suspected designation if
+/// it is already suspected, or if a static (Airtight Alibi) prohibits it from
+/// becoming suspected. Single authority for the designation gate so the resolver
+/// never double-suspects or overrides a "can't become suspected" prohibition.
+fn can_become_suspected(state: &GameState, object_id: ObjectId) -> bool {
+    let Some(obj) = state.objects.get(&object_id) else {
+        return false;
     };
+    // CR 701.60d: "A suspected permanent can't become suspected again."
+    if obj.is_suspected {
+        return false;
+    }
+    // CR 701.60a: an active `CantBecomeSuspected` static (e.g. Airtight Alibi's
+    // "can't become suspected") prohibits the designation even while unsuspected.
+    !crate::game::functioning_abilities::game_functioning_statics(state).any(|(src, def)| {
+        if def.mode != StaticMode::CantBecomeSuspected {
+            return false;
+        }
+        match def.affected.as_ref() {
+            None => src.id == object_id,
+            Some(filter) => crate::game::filter::matches_target_filter(
+                state,
+                object_id,
+                filter,
+                &crate::game::filter::FilterContext::from_source(state, src.id),
+            ),
+        }
+    })
+}
+
+/// CR 701.60a: Suspect target creature(s).
+/// A suspected creature has menace and "This creature can't block." (CR 701.60c)
+///
+/// Architecture: the designation (`is_suspected`, CR 701.60b) is the *only*
+/// state this resolver mutates. The CR 701.60c menace + "can't block" abilities
+/// are NOT stored on the permanent — they are a continuous effect derived from
+/// the designation during layer evaluation (`layers::derive_suspected_abilities`,
+/// CR 613). Writing them onto `base_*` would conflate the granted abilities with
+/// the permanent's printed (copiable) abilities, so a naturally-menace creature
+/// would lose its printed menace when it stopped being suspected (CR 701.60b:
+/// suspected is "neither an ability nor part of the permanent's copiable
+/// values"). Deriving keeps printed abilities untouched.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let target_ids = resolve_object_targets(state, ability);
 
     for obj_id in target_ids {
+        // CR 701.60d / CR 701.60a: respect the designation gate (already
+        // suspected, or a "can't become suspected" static) before flipping.
+        if !can_become_suspected(state, obj_id) {
+            continue;
+        }
         if let Some(obj) = state.objects.get_mut(&obj_id) {
+            // CR 701.60b: set the designation only — menace + "can't block" are
+            // layer-derived from this flag (CR 701.60c).
             obj.is_suspected = true;
-
-            // CR 701.60c: Add menace to base_keywords (survives layer recalc).
-            if !obj
-                .base_keywords
-                .iter()
-                .any(|k| matches!(k, Keyword::Menace))
-            {
-                obj.base_keywords.push(Keyword::Menace);
-            }
-
-            // CR 701.60c: Add CantBlock to base_static_definitions (survives layer recalc).
-            if !obj
-                .base_static_definitions
-                .iter()
-                .any(|s| s.mode == StaticMode::CantBlock)
-            {
-                Arc::make_mut(&mut obj.base_static_definitions)
-                    .push(StaticDefinition::new(StaticMode::CantBlock));
-            }
-
             events.push(GameEvent::CreatureSuspected { object_id: obj_id });
         }
     }
@@ -78,13 +141,59 @@ pub fn resolve(
     Ok(())
 }
 
+/// CR 701.60a: Cause the target creature(s) to no longer be suspected.
+///
+/// The un-designation counterpart of [`resolve`]: clears the `is_suspected`
+/// designation only. The CR 701.60c menace + "can't block" abilities are
+/// layer-derived from the designation (`layers::derive_suspected_abilities`), so
+/// clearing the flag stops re-deriving them on the next layers pass — this
+/// resolver touches NO keyword / static fields, leaving any printed menace or
+/// printed "can't block" intact (CR 701.60b). Idempotent — a creature that is
+/// not suspected is skipped and emits no `CreatureNoLongerSuspected` event
+/// (mirrors `prepare::resolve_become_unprepared`). Single authority for the
+/// "no longer suspected" transition so callers never clear the flag directly.
+pub fn resolve_unsuspect(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let target_ids = resolve_object_targets(state, ability);
+
+    let mut any_flipped = false;
+    for obj_id in target_ids {
+        if let Some(obj) = state.objects.get_mut(&obj_id) {
+            // Idempotent: only flip (and emit) when the designation was present.
+            if !obj.is_suspected {
+                continue;
+            }
+            // CR 701.60b: clear the designation only — the layer-derived menace +
+            // "can't block" (CR 701.60c) lapse automatically on the recalc below.
+            obj.is_suspected = false;
+            events.push(GameEvent::CreatureNoLongerSuspected { object_id: obj_id });
+            any_flipped = true;
+        }
+    }
+
+    if any_flipped {
+        crate::game::layers::mark_layers_full(state);
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::Unsuspect,
+        source_id: ability.source_id,
+    });
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::game::layers::evaluate_layers;
     use crate::game::zones::create_object;
-    use crate::types::ability::{Effect, ResolvedAbility};
+    use crate::types::ability::{Effect, EffectScope, ResolvedAbility, StaticDefinition};
     use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::keywords::Keyword;
     use crate::types::player::PlayerId;
     use crate::types::zones::Zone;
 
@@ -107,14 +216,20 @@ mod tests {
         id
     }
 
+    /// CR 701.60b + CR 701.60c: Suspecting sets only the `is_suspected`
+    /// designation. The menace + "can't block" are NOT stored on the
+    /// permanent's (copiable) `base_*` fields — they are layer-derived from the
+    /// designation. Asserting the base fields stay clean is what distinguishes
+    /// the derived architecture from the prior base-mutating one.
     #[test]
-    fn suspect_sets_designation_and_base_abilities() {
+    fn suspect_sets_designation_without_touching_base() {
         let mut state = GameState::new_two_player(42);
         let id = setup_creature(&mut state);
 
         let ability = ResolvedAbility::new(
             Effect::Suspect {
                 target: TargetFilter::Any,
+                scope: EffectScope::Single,
             },
             vec![crate::types::ability::TargetRef::Object(id)],
             ObjectId(100),
@@ -125,24 +240,34 @@ mod tests {
 
         let obj = state.objects.get(&id).unwrap();
         assert!(obj.is_suspected);
-        assert!(obj
-            .base_keywords
-            .iter()
-            .any(|k| matches!(k, Keyword::Menace)));
-        assert!(obj
-            .base_static_definitions
-            .iter()
-            .any(|s| s.mode == StaticMode::CantBlock));
+        // CR 701.60b: the designation is not part of the copiable values, so it
+        // must NOT have been written to the base ability fields.
+        assert!(
+            !obj.base_keywords
+                .iter()
+                .any(|k| matches!(k, Keyword::Menace)),
+            "suspect must not write menace into base_keywords (CR 701.60b)"
+        );
+        assert!(
+            !obj.base_static_definitions
+                .iter()
+                .any(|s| s.mode == StaticMode::CantBlock),
+            "suspect must not write CantBlock into base_static_definitions"
+        );
     }
 
+    /// CR 701.60c: After a layers pass, the suspected designation derives menace
+    /// and "can't block" onto the live (post-layer) fields. Reverting
+    /// `layers::derive_suspected_abilities` leaves both absent, flipping these.
     #[test]
-    fn suspect_survives_layer_recalc() {
+    fn suspect_derives_abilities_on_layer_recalc() {
         let mut state = GameState::new_two_player(42);
         let id = setup_creature(&mut state);
 
         let ability = ResolvedAbility::new(
             Effect::Suspect {
                 target: TargetFilter::Any,
+                scope: EffectScope::Single,
             },
             vec![crate::types::ability::TargetRef::Object(id)],
             ObjectId(100),
@@ -151,7 +276,7 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        // Layer recalc should preserve menace + CantBlock from base_*
+        // The derivation rides along with the Step-1 reset every layers pass.
         evaluate_layers(&mut state);
 
         let obj = state.objects.get(&id).unwrap();
@@ -161,46 +286,191 @@ mod tests {
             .static_definitions
             .iter_all()
             .any(|s| s.mode == StaticMode::CantBlock));
+        // The derivation is repeatable: a second pass keeps exactly one of each.
+        evaluate_layers(&mut state);
+        let obj = state.objects.get(&id).unwrap();
+        assert_eq!(
+            obj.keywords
+                .iter()
+                .filter(|k| matches!(k, Keyword::Menace))
+                .count(),
+            1,
+            "derivation is idempotent across passes"
+        );
+        assert_eq!(
+            obj.static_definitions
+                .iter_all()
+                .filter(|s| s.mode == StaticMode::CantBlock)
+                .count(),
+            1,
+            "derivation is idempotent across passes"
+        );
     }
 
+    /// CR 701.60a: `Effect::Unsuspect` resolved through the real effect dispatch
+    /// (`resolve_effect`) clears the suspected designation and, after layer
+    /// recalc, removes the CR 701.60c menace + "can't block" abilities the
+    /// designation conferred. Reverting the `Effect::Unsuspect => resolve_unsuspect`
+    /// dispatch arm (or the resolver) leaves `is_suspected == true` and the
+    /// abilities present, flipping every assertion below.
     #[test]
-    fn unsuspect_removes_abilities_on_recalc() {
+    fn unsuspect_through_dispatch_removes_designation_and_abilities() {
+        use crate::game::effects::resolve_effect;
+
         let mut state = GameState::new_two_player(42);
         let id = setup_creature(&mut state);
 
-        // Suspect the creature
+        // Suspect the creature through the real dispatch first.
+        let suspect = ResolvedAbility::new(
+            Effect::Suspect {
+                target: TargetFilter::Any,
+                scope: EffectScope::Single,
+            },
+            vec![TargetRef::Object(id)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve_effect(&mut state, &suspect, &mut events).unwrap();
+        evaluate_layers(&mut state);
+        assert!(state.objects[&id].is_suspected, "suspect should designate");
+        assert!(crate::game::keywords::has_keyword(
+            &state.objects[&id],
+            &Keyword::Menace
+        ));
+
+        // Now un-suspect through the real dispatch.
+        let unsuspect = ResolvedAbility::new(
+            Effect::Unsuspect {
+                target: TargetFilter::Any,
+                scope: EffectScope::Single,
+            },
+            vec![TargetRef::Object(id)],
+            ObjectId(101),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve_effect(&mut state, &unsuspect, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        let obj = state.objects.get(&id).unwrap();
+        assert!(!obj.is_suspected, "unsuspect clears the designation");
+        assert!(
+            !crate::game::keywords::has_keyword(obj, &Keyword::Menace),
+            "menace removed when no longer suspected"
+        );
+        assert!(
+            !obj.static_definitions
+                .iter_all()
+                .any(|s| s.mode == StaticMode::CantBlock),
+            "can't-block removed when no longer suspected"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, GameEvent::CreatureNoLongerSuspected { object_id } if *object_id == id)),
+            "flip emits CreatureNoLongerSuspected"
+        );
+    }
+
+    /// Idempotency: un-suspecting a creature that is not suspected is a no-op and
+    /// emits no `CreatureNoLongerSuspected` event (mirrors
+    /// `resolve_become_unprepared`).
+    #[test]
+    fn unsuspect_idempotent_when_not_suspected() {
+        let mut state = GameState::new_two_player(42);
+        let id = setup_creature(&mut state);
+
+        let ability = ResolvedAbility::new(
+            Effect::Unsuspect {
+                target: TargetFilter::Any,
+                scope: EffectScope::Single,
+            },
+            vec![TargetRef::Object(id)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve_unsuspect(&mut state, &ability, &mut events).unwrap();
+
+        assert!(!state.objects[&id].is_suspected);
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::CreatureNoLongerSuspected { .. })),
+            "no event when nothing flipped"
+        );
+    }
+
+    /// CR 701.60d: A suspected permanent can't become suspected again — the
+    /// resolver's `can_become_suspected` gate skips an already-suspected target,
+    /// so re-suspecting emits no second `CreatureSuspected` event.
+    #[test]
+    fn suspect_already_suspected_is_gated() {
+        let mut state = GameState::new_two_player(42);
+        let id = setup_creature(&mut state);
+
         let ability = ResolvedAbility::new(
             Effect::Suspect {
                 target: TargetFilter::Any,
+                scope: EffectScope::Single,
             },
-            vec![crate::types::ability::TargetRef::Object(id)],
+            vec![TargetRef::Object(id)],
             ObjectId(100),
             PlayerId(0),
         );
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
-        evaluate_layers(&mut state);
+        resolve(&mut state, &ability, &mut events).unwrap();
 
-        // Unsuspect: remove designation + clean base_* fields.
-        // In a real game this would be done by a future `unsuspect` handler.
-        let obj = state.objects.get_mut(&id).unwrap();
-        obj.is_suspected = false;
-        obj.base_keywords.retain(|k| !matches!(k, Keyword::Menace));
-        Arc::make_mut(&mut obj.base_static_definitions).retain(|s| s.mode != StaticMode::CantBlock);
-        // Also clear computed statics so layer recalc starts clean.
-        // (The layer system's conditional reset only fires when base_static_definitions is non-empty.)
-        obj.static_definitions
-            .retain(|s| s.mode != StaticMode::CantBlock);
+        let suspect_events = events
+            .iter()
+            .filter(|e| matches!(e, GameEvent::CreatureSuspected { .. }))
+            .count();
+        assert_eq!(
+            suspect_events, 1,
+            "second suspect must be gated (CR 701.60d)"
+        );
+    }
 
-        evaluate_layers(&mut state);
-
-        let obj = state.objects.get(&id).unwrap();
-        assert!(!obj.is_suspected);
-        assert!(!obj.keywords.iter().any(|k| matches!(k, Keyword::Menace)));
-        assert!(!obj
+    /// CR 701.60a: A creature carrying a `CantBecomeSuspected` static (Airtight
+    /// Alibi) can't be suspected — the resolver gate refuses the designation.
+    /// Reverting the gate would set `is_suspected` and emit the event.
+    #[test]
+    fn cant_become_suspected_static_blocks_suspect() {
+        let mut state = GameState::new_two_player(42);
+        let id = setup_creature(&mut state);
+        // Confer the prohibition directly onto the creature (the layer-applied
+        // form Airtight Alibi produces via `AddStaticMode`).
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
             .static_definitions
-            .iter_all()
-            .any(|s| s.mode == StaticMode::CantBlock));
+            .push(StaticDefinition::new(StaticMode::CantBecomeSuspected));
+
+        let ability = ResolvedAbility::new(
+            Effect::Suspect {
+                target: TargetFilter::Any,
+                scope: EffectScope::Single,
+            },
+            vec![TargetRef::Object(id)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            !state.objects[&id].is_suspected,
+            "a creature that can't become suspected stays unsuspected"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::CreatureSuspected { .. })),
+            "no CreatureSuspected event when the prohibition gate fires"
+        );
     }
 
     #[test]
@@ -212,6 +482,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::Suspect {
                 target: TargetFilter::LastCreated,
+                scope: EffectScope::Single,
             },
             vec![],
             ObjectId(100),

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1266,6 +1266,42 @@ fn rebuild_static_index_at_top() -> bool {
     true
 }
 
+/// CR 701.60c: A suspected permanent has menace and "This creature can't block"
+/// for as long as it's suspected. The suspected designation (`is_suspected`,
+/// CR 701.60b) is the source of truth; the menace + "can't block" abilities are
+/// a continuous effect *derived* from it, not stored on the permanent's copiable
+/// values. Re-deriving them here — directly onto the just-reset live `keywords`
+/// / `static_definitions` (NOT `base_*`) every layers pass — keeps them present
+/// exactly while the designation holds and leaves the permanent's printed
+/// abilities untouched: clearing the designation (Effect::Unsuspect) simply
+/// stops re-deriving them, and a naturally-menace creature keeps its printed
+/// menace when it stops being suspected.
+///
+/// Called from the Step-1 reset of both the full (`evaluate_layers`) and
+/// incremental (`apply_layers_incremental`) passes, immediately after the live
+/// fields are reset to base, so the derived grant rides along with every reset.
+fn derive_suspected_abilities(obj: &mut crate::game::game_object::GameObject) {
+    if !obj.is_suspected {
+        return;
+    }
+    // CR 701.60c: menace. Skip if the permanent already has it (printed or
+    // otherwise granted) so the derivation is idempotent and a later removal of
+    // the printed copy still leaves exactly the derived one.
+    if !obj.keywords.iter().any(|k| matches!(k, Keyword::Menace)) {
+        obj.keywords.push(Keyword::Menace);
+    }
+    // CR 701.60c: "This creature can't block." Skip if a `CantBlock` static is
+    // already present (printed or otherwise granted).
+    if !obj
+        .static_definitions
+        .iter_all()
+        .any(|s| s.mode == StaticMode::CantBlock)
+    {
+        obj.static_definitions
+            .push(StaticDefinition::new(StaticMode::CantBlock));
+    }
+}
+
 /// Unconditional full layer evaluation (CR 613.1).
 ///
 /// Production code must NOT call this directly — go through [`flush_layers`],
@@ -1361,6 +1397,10 @@ pub fn evaluate_layers(state: &mut GameState) {
             obj.assigns_damage_from_toughness = false;
             obj.assigns_damage_as_though_unblocked = false;
             obj.assigns_no_combat_damage = false;
+            // CR 701.60c: re-derive the suspected designation's menace +
+            // "can't block" onto the just-reset live fields (not base), so the
+            // grant lasts exactly as long as the designation.
+            derive_suspected_abilities(obj);
         }
     }
     // CR 702.94a + CR 400.3: Hand-zone continuous effects (Lorehold-style
@@ -2038,6 +2078,10 @@ fn apply_layers_incremental(state: &mut GameState, entered_ids: &HashSet<ObjectI
             obj.assigns_damage_from_toughness = false;
             obj.assigns_damage_as_though_unblocked = false;
             obj.assigns_no_combat_damage = false;
+            // CR 701.60c: re-derive the suspected designation's menace +
+            // "can't block" onto the just-reset live fields (mirrors the full
+            // pass) so the incremental path agrees with `evaluate_layers`.
+            derive_suspected_abilities(obj);
         }
     }
 

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -159,6 +159,7 @@ fn categorize(event: &GameEvent) -> LogCategory {
         | GameEvent::TurnedFaceUp { .. }
         | GameEvent::Regenerated { .. }
         | GameEvent::CreatureSuspected { .. }
+        | GameEvent::CreatureNoLongerSuspected { .. }
         | GameEvent::Detained { .. }
         | GameEvent::BecamePrepared { .. }
         | GameEvent::BecameUnprepared { .. }
@@ -710,6 +711,10 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
 
         GameEvent::CreatureSuspected { object_id } => {
             vec![card_seg(state, *object_id), text(" becomes suspected")]
+        }
+
+        GameEvent::CreatureNoLongerSuspected { object_id } => {
+            vec![card_seg(state, *object_id), text(" is no longer suspected")]
         }
 
         GameEvent::Detained { object_id } => {

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -981,6 +981,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::Choose { .. }
         | Effect::ChooseDamageSource { .. }
         | Effect::Suspect { .. }
+        | Effect::Unsuspect { .. }
         | Effect::Connive { .. }
         | Effect::PhaseOut { .. }
         | Effect::PhaseIn { .. }

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -372,6 +372,7 @@ pub fn mark_public_state_from_events(state: &mut GameState, events: &[GameEvent]
             | GameEvent::PlayerPerformedAction { .. }
             | GameEvent::Regenerated { .. }
             | GameEvent::CreatureSuspected { .. }
+            | GameEvent::CreatureNoLongerSuspected { .. }
             | GameEvent::BecamePrepared { .. }
             | GameEvent::BecameUnprepared { .. }
             | GameEvent::CaseSolved { .. }

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -966,6 +966,7 @@ pub(crate) fn extract_source_from_event(
         GameEvent::TurnedFaceUp { object_id } => Some(*object_id),
         GameEvent::Cycled { object_id, .. } => Some(*object_id),
         GameEvent::CreatureSuspected { object_id } => Some(*object_id),
+        GameEvent::CreatureNoLongerSuspected { object_id } => Some(*object_id),
         GameEvent::Detained { object_id } => Some(*object_id),
         GameEvent::CaseSolved { object_id } => Some(*object_id),
         GameEvent::AttackersDeclared { attacker_ids, .. } if attacker_ids.len() == 1 => {

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -596,6 +596,7 @@ pub(crate) fn keys_from_event(event: &GameEvent, state: &GameState) -> Keys {
         GameEvent::PlayerPerformedAction { .. } => push(TriggerEventKey::PlayerActionPerformed),
         GameEvent::Regenerated { .. }
         | GameEvent::CreatureSuspected { .. }
+        | GameEvent::CreatureNoLongerSuspected { .. }
         | GameEvent::Detained { .. }
         | GameEvent::BecamePrepared { .. }
         | GameEvent::BecameUnprepared { .. } => {}
@@ -773,6 +774,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::Choose
         | EffectKind::ChooseDamageSource
         | EffectKind::Suspect
+        | EffectKind::Unsuspect
         | EffectKind::PhaseOut
         | EffectKind::PhaseIn
         | EffectKind::ForceBlock

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -892,6 +892,7 @@ fn count_matching_trigger_event_subjects(
         | GameEvent::PlayerPerformedAction { .. }
         | GameEvent::Regenerated { .. }
         | GameEvent::CreatureSuspected { .. }
+        | GameEvent::CreatureNoLongerSuspected { .. }
         | GameEvent::Detained { .. }
         | GameEvent::BecamePrepared { .. }
         | GameEvent::BecameUnprepared { .. }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4614,6 +4614,95 @@ fn try_parse_that_many_counters(lower: &str, ctx: &mut ParseContext) -> Option<E
     })
 }
 
+/// CR 701.60a: Parse the "no longer suspected" un-designation transition into an
+/// `Effect::Unsuspect { target }`. The subject precedes the copula + phrase and
+/// varies by card:
+///   - "all suspected creatures are no longer suspected" (Absolving Lammasu)
+///   - "it's no longer suspected" / "it is no longer suspected" (Airtight Alibi)
+///   - "they're no longer suspected" / "they are no longer suspected"
+///     (Eliminate the Impossible)
+///   - "~ is no longer suspected" / "this creature is no longer suspected"
+///     (Frantic Scapegoat)
+///   - "become no longer suspected" (Deadly Complication, after the upstream
+///     "you may have it " causative is stripped — the referent is the prior
+///     clause's target)
+///
+/// Subject → filter mapping: anaphoric pronouns ("it"/"they"/"them") and the
+/// empty subject left by the "become" causative bind to `ParentTarget`; the
+/// printed-name anaphor ("~"/"this creature") binds to `SelfRef`; any other noun
+/// phrase ("all suspected creatures") is parsed by `parse_target`. Mirrors
+/// `parse_remove_from_combat_ast`.
+fn parse_no_longer_suspected_ast(lower: &str) -> Option<Effect> {
+    let input = lower.trim();
+    // Each alternative is `copula + " no longer suspected"`; `take_until` finds
+    // the subject preceding the first matching tail, and the tail must end the
+    // clause (optional trailing period). The copula axis is an ordered list so
+    // the longer contraction/word forms are tried before the bare phrase.
+    // CR 701.60a: "no longer suspected" is the un-designation transition.
+    for tail in [
+        "'s no longer suspected",
+        "'re no longer suspected",
+        " is no longer suspected",
+        " are no longer suspected",
+        "become no longer suspected",
+        " no longer suspected",
+        "no longer suspected",
+    ] {
+        let Ok((after, subject)) = take_until::<_, _, OracleError<'_>>(tail).parse(input) else {
+            continue;
+        };
+        // The tail must terminate the clause (optionally with a period) so a
+        // mid-sentence "no longer suspected" fragment doesn't false-match.
+        if all_consuming(terminated(
+            tag::<_, _, OracleError<'_>>(tail),
+            opt(tag(".")),
+        ))
+        .parse(after)
+        .is_err()
+        {
+            continue;
+        }
+
+        let subject = subject.trim();
+        // CR 701.60a applies the un-designation to *each* matching permanent, so
+        // the subject's shape selects the resolution scope:
+        //   - anaphors ("it"/"they"/"them"/causative residue) and the
+        //     printed-name anaphor ("~"/"this creature") act on the prior
+        //     clause's announced target(s) / the source permanent — `Single`,
+        //     resolved via `ability.targets`. (The plural "they"/"them" form
+        //     reads every announced object target, so a multi-target antecedent
+        //     is already covered. Eliminate the Impossible's "they're no longer
+        //     suspected" over a non-targeting `PumpAll` *population* — rather
+        //     than announced targets — is a separate population-anaphor +
+        //     swallowed-conditional gap, not wired here.)
+        //   - an explicit noun phrase ("all suspected creatures" — Absolving
+        //     Lammasu) is a non-targeting population filter (`All`), enumerated
+        //     over the battlefield at resolution with no announced target.
+        let (target, scope) = match subject {
+            // Anaphoric / causative pronouns → the prior clause's target(s).
+            "it" | "they" | "them" | "" => (TargetFilter::ParentTarget, EffectScope::Single),
+            // Printed-name anaphor → the source permanent.
+            "~" | "this creature" | "this permanent" => {
+                (TargetFilter::SelfRef, EffectScope::Single)
+            }
+            _ => {
+                let (tf, _) = parse_target(subject);
+                // `parse_target` returns `Any` for unrecognized phrases; bail
+                // rather than emit an over-broad Unsuspect against every object.
+                if matches!(tf, TargetFilter::Any) {
+                    return None;
+                }
+                // An explicit noun-phrase subject ("all suspected creatures") is
+                // a mass population filter, not an announced target — CR 701.60a
+                // removes the designation from every matching permanent.
+                (tf, EffectScope::All)
+            }
+        };
+        return Some(Effect::Unsuspect { target, scope });
+    }
+    None
+}
+
 /// CR 506.4: Parse "remove [target] from combat" patterns.
 /// Matches: "remove it from combat", "remove ~ from combat",
 /// "remove target [creature] from combat", "remove that creature from combat".
@@ -6332,6 +6421,15 @@ pub(super) fn parse_imperative_family_ast(
 ) -> Option<ImperativeFamilyAst> {
     let first_word = lower.split_whitespace().next().unwrap_or("");
 
+    // CR 701.60a: "[subject] no longer suspected" — the un-designation
+    // transition. The subject leads the clause (varying anaphor / noun phrase),
+    // so `first_word` is "all"/"it's"/"they're"/"~"/"become" rather than a verb
+    // keyword. Intercept it as an anchored whole-clause production before the
+    // first-word dispatch, alongside the other non-verb-led effects below.
+    if let Some(effect) = parse_no_longer_suspected_ast(lower) {
+        return Some(ImperativeFamilyAst::GainKeyword(effect));
+    }
+
     // CR 724.1: "end the turn" (Time Stop, Sundial of the Infinite, Obeka,
     // Glorious End, Discontinuity, Day's Undoing). Whole-phrase imperative
     // with no target; parse it as an anchored nom production rather than a
@@ -6816,7 +6914,10 @@ pub(super) fn parse_imperative_family_ast(
                 None
             }
         }
-        // CR 701.60a: "suspect it" / "suspect target creature"
+        // CR 701.60a: "suspect it" / "suspect target creature". Every printed
+        // suspect instruction designates a single chosen/anaphoric permanent, so
+        // the scope is always `Single`; no card mass-suspects via a population
+        // filter today.
         "suspect" | "suspects" => {
             let rest = lower[first_word.len()..].trim();
             let target = if !rest.is_empty() {
@@ -6825,7 +6926,10 @@ pub(super) fn parse_imperative_family_ast(
             } else {
                 crate::types::ability::TargetFilter::ParentTarget
             };
-            Some(ImperativeFamilyAst::GainKeyword(Effect::Suspect { target }))
+            Some(ImperativeFamilyAst::GainKeyword(Effect::Suspect {
+                target,
+                scope: EffectScope::Single,
+            }))
         }
         // CR 701.35a: "detain target creature an opponent controls"
         "detain" | "detains" => {
@@ -9202,6 +9306,100 @@ mod tests {
 
     fn has_prop(tf: &TypedFilter, prop: FilterProp) -> bool {
         tf.properties.iter().any(|candidate| candidate == &prop)
+    }
+
+    /// CR 701.60a: the "no longer suspected" un-designation parses to
+    /// `Effect::Unsuspect`, mapping each card's subject to the right filter +
+    /// scope:
+    ///   - anaphoric "it" / "they" / "become" residue → ParentTarget, Single
+    ///   - printed-name anaphor "~" / "this creature" → SelfRef, Single
+    ///   - "all suspected creatures" → a Suspected-creature filter, All (mass)
+    #[test]
+    fn parse_no_longer_suspected_subject_mapping() {
+        use crate::types::ability::EffectScope;
+
+        // Anaphoric pronouns → ParentTarget, single scope (read announced
+        // target(s)).
+        for text in [
+            "it's no longer suspected",
+            "it is no longer suspected",
+            "they're no longer suspected",
+            "they are no longer suspected",
+            // Deadly Complication causative residue after "you may have it ".
+            "become no longer suspected",
+        ] {
+            assert!(
+                matches!(
+                    parse_no_longer_suspected_ast(text),
+                    Some(Effect::Unsuspect {
+                        target: TargetFilter::ParentTarget,
+                        scope: EffectScope::Single,
+                    })
+                ),
+                "{text:?} should map to Unsuspect(ParentTarget, Single)"
+            );
+        }
+
+        // Printed-name anaphor → SelfRef, single scope.
+        for text in [
+            "~ is no longer suspected",
+            "this creature is no longer suspected",
+        ] {
+            assert!(
+                matches!(
+                    parse_no_longer_suspected_ast(text),
+                    Some(Effect::Unsuspect {
+                        target: TargetFilter::SelfRef,
+                        scope: EffectScope::Single,
+                    })
+                ),
+                "{text:?} should map to Unsuspect(SelfRef, Single)"
+            );
+        }
+
+        // "all suspected creatures" → a typed Suspected filter under the mass
+        // (All) scope — CR 701.60a removes the designation from every match.
+        let all = parse_no_longer_suspected_ast("all suspected creatures are no longer suspected");
+        match all {
+            Some(Effect::Unsuspect { target, scope }) => {
+                let tf = typed_leg(&target).expect("typed filter for 'all suspected creatures'");
+                assert!(
+                    has_prop(tf, FilterProp::Suspected),
+                    "filter should carry the Suspected property, got {target:?}"
+                );
+                assert_eq!(
+                    scope,
+                    EffectScope::All,
+                    "an explicit mass noun phrase must use the All scope"
+                );
+            }
+            other => panic!("expected Unsuspect for 'all suspected creatures', got {other:?}"),
+        }
+
+        // A non-clause-final "no longer suspected" fragment must NOT match.
+        assert!(
+            parse_no_longer_suspected_ast("it's no longer suspected and draws a card").is_none(),
+            "trailing clause must prevent a false match"
+        );
+    }
+
+    /// CR 701.60a: end-to-end through `parse_effect` — the same dispatch the card
+    /// loader uses — so the interception is reachable in production, not just via
+    /// the helper. Frantic Scapegoat's self-referential form lowers to SelfRef.
+    #[test]
+    fn parse_effect_self_no_longer_suspected_is_unsuspect_selfref() {
+        use crate::parser::oracle_effect::parse_effect;
+        let effect = parse_effect("~ is no longer suspected.");
+        assert!(
+            matches!(
+                effect,
+                Effect::Unsuspect {
+                    target: TargetFilter::SelfRef,
+                    scope: crate::types::ability::EffectScope::Single,
+                }
+            ),
+            "expected Unsuspect(SelfRef, Single), got {effect:?}"
+        );
     }
 
     /// CR 107.1a + CR 121.1: Change B — `parse_dynamic_count_phrase` routes a

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13251,7 +13251,8 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
         | Effect::PhaseIn { target }
         | Effect::ForceBlock { target }
         | Effect::ForceAttack { target, .. }
-        | Effect::Suspect { target }
+        | Effect::Suspect { target, .. }
+        | Effect::Unsuspect { target, .. }
         | Effect::Goad { target }
         | Effect::Mill { target, .. }
         | Effect::Discard { target, .. }
@@ -16061,7 +16062,11 @@ pub(crate) fn each_target_filter_mut(effect: &mut Effect, f: &mut impl FnMut(&mu
         | Effect::Manifest { target, .. }
         // CR 701.60a: Suspect acts on a target permanent; expose its filter so
         // anaphor rewrites (e.g. self-targeting "Otherwise, suspect it") reach it.
-        | Effect::Suspect { target }
+        | Effect::Suspect { target, .. }
+        // CR 701.60a: Unsuspect (no-longer-suspected) acts on a target permanent;
+        // expose its filter so anaphor rewrites ("it's no longer suspected",
+        // "~ is no longer suspected") reach it.
+        | Effect::Unsuspect { target, .. }
         | Effect::TargetOnly { target, .. } => f(target),
         Effect::PutCounter { target, .. } | Effect::RemoveCounter { target, .. } => f(target),
         Effect::GoadAll { target } => f(target),

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -18,9 +18,9 @@ use crate::parser::oracle_quantity::{parse_cda_quantity, parse_quantity_ref};
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, CastingPermission, Chooser, ContinuousModification,
     ControllerRef, CopyRetargetPermission, CounterSourceRider, CounteredSpellDestination, Duration,
-    Effect, FaceDownBody, FaceDownProfile, LibraryPosition, MultiTargetSpec, PermissionGrantee,
-    PtValue, QuantityExpr, QuantityRef, RevealUntilDisposition, StaticDefinition,
-    TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
+    Effect, EffectScope, FaceDownBody, FaceDownProfile, LibraryPosition, MultiTargetSpec,
+    PermissionGrantee, PtValue, QuantityExpr, QuantityRef, RevealUntilDisposition,
+    StaticDefinition, TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
@@ -2525,6 +2525,7 @@ pub(super) fn apply_clause_continuation(
                 kind,
                 Effect::Suspect {
                     target: TargetFilter::LastCreated,
+                    scope: EffectScope::Single,
                 },
             ));
         }
@@ -4246,6 +4247,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::Choose { .. }
         | Effect::ChooseDamageSource { .. }
         | Effect::Suspect { .. }
+        | Effect::Unsuspect { .. }
         | Effect::Connive { .. }
         | Effect::PhaseOut { .. }
         | Effect::PhaseIn { .. }

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -871,6 +871,19 @@ pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModifi
         });
     }
 
+    // CR 701.60a + CR 701.60d: "can't become suspected" prohibition riding on a
+    // compound static (Airtight Alibi: "Enchanted creature gets +2/+2 and can't
+    // become suspected"). Confers a `CantBecomeSuspected` static onto the
+    // affected creature; the suspect resolver gates on it. Mirrors the goaded
+    // designation rider above.
+    if nom_primitives::scan_contains(unquoted_lower.as_str(), "can't become suspected")
+        || nom_primitives::scan_contains(unquoted_lower.as_str(), "cant become suspected")
+    {
+        modifications.push(ContinuousModification::AddStaticMode {
+            mode: StaticMode::CantBecomeSuspected,
+        });
+    }
+
     // CR 702.73a + CR 205.3 + CR 613.1d: Conjunctive "is/are every creature
     // type" predicate — the Changeling-class type grant when it appears as
     // one conjunct in an Aura/Equipment compound static ("Enchanted creature

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5206,6 +5206,29 @@ fn parse_continuous_modifications_are_goaded_emits_goaded_static_mode() {
     )));
 }
 
+/// CR 701.60a + CR 701.60d: Airtight Alibi's compound static "Enchanted creature
+/// gets +2/+2 and can't become suspected" emits the P/T buff AND a
+/// `CantBecomeSuspected` rider (mirrors the goaded designation rider) so the
+/// prohibition is not silently dropped.
+#[test]
+fn parse_continuous_modifications_cant_become_suspected_emits_static_mode() {
+    let mods = parse_continuous_modifications("gets +2/+2 and can't become suspected");
+    assert!(
+        mods.iter()
+            .any(|m| matches!(m, ContinuousModification::AddPower { value: 2 })),
+        "P/T buff preserved alongside the prohibition rider"
+    );
+    assert!(
+        mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddStaticMode {
+                mode: StaticMode::CantBecomeSuspected
+            }
+        )),
+        "can't-become-suspected rider must not be dropped, got {mods:?}"
+    );
+}
+
 /// CR 613.1f + CR 113.3: "all activated abilities of all cards exiled with it" /
 /// "the exiled card" → `GrantAllActivatedAbilitiesOf { ExiledBySource }` (Myr
 /// Welder, Territory Forge). Issue #3101. Both the bare-predicate building-block

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8603,10 +8603,40 @@ pub enum Effect {
         #[serde(default = "default_target_filter_any")]
         source_filter: TargetFilter,
     },
-    /// CR 701.60a: Suspect target creature — it gains menace and "can't block."
+    /// CR 701.60a: Suspect creature(s) — each gains menace and "can't block."
+    ///
+    /// `scope` parameterizes the "single vs mass" axis (mirrors
+    /// `Effect::SetTapState`): `EffectScope::Single` is the targeted/anaphoric
+    /// "suspect target creature" / "suspect it"; `EffectScope::All` is a
+    /// non-targeting population filter ("suspect each creature ...") enumerated
+    /// over the battlefield at resolution. No printed card uses the mass scope
+    /// for Suspect yet, but the field keeps the designation/un-designation pair
+    /// symmetric so the shared resolver dispatches identically.
     Suspect {
         #[serde(default = "default_target_filter_any")]
         target: TargetFilter,
+        #[serde(default = "default_effect_scope_single")]
+        scope: EffectScope,
+    },
+    /// CR 701.60a: Cause creature(s) to no longer be suspected — the
+    /// un-designation transition ("all suspected creatures are no longer
+    /// suspected", "it's no longer suspected", "become no longer suspected").
+    /// The designation is the source of truth, so this clears `is_suspected` and
+    /// the derived menace + "can't block" written by `Suspect`. Sibling of
+    /// `Suspect`, mirroring the `BecomePrepared` / `BecomeUnprepared` pair.
+    ///
+    /// `scope` is load-bearing (CR 701.60a applies the un-designation to *each*
+    /// matching permanent): `EffectScope::Single` is the targeted/anaphoric
+    /// "it's no longer suspected" / "~ is no longer suspected" path that reads
+    /// `ability.targets`; `EffectScope::All` is the mass "all suspected
+    /// creatures are no longer suspected" (Absolving Lammasu) population filter
+    /// that enumerates every matching battlefield permanent with no announced
+    /// target.
+    Unsuspect {
+        #[serde(default = "default_target_filter_any")]
+        target: TargetFilter,
+        #[serde(default = "default_effect_scope_single")]
+        scope: EffectScope,
     },
     /// CR 701.50a: Target creature connives (draw a card, then discard a card;
     /// if a nonland card is discarded, put a +1/+1 counter on it).
@@ -10546,7 +10576,6 @@ impl Effect {
             | Effect::RevealHand { target, .. }
             | Effect::Reveal { target, .. }
             | Effect::TargetOnly { target, .. }
-            | Effect::Suspect { target, .. }
             | Effect::Connive { target, .. }
             | Effect::PhaseOut { target, .. }
             | Effect::PhaseIn { target, .. }
@@ -10698,6 +10727,29 @@ impl Effect {
                 ..
             } => Some(target),
             Effect::SetTapState {
+                scope: EffectScope::All,
+                ..
+            } => None,
+
+            // CR 701.60a: `Suspect`/`Unsuspect` expose a target slot only for the
+            // single-permanent scope (targeted/anaphoric "suspect target
+            // creature" / "it's no longer suspected"). The `All` scope ("all
+            // suspected creatures are no longer suspected") is a non-targeting
+            // population filter enumerated at resolution — like `DestroyAll`,
+            // its `target_filter()` is None.
+            Effect::Suspect {
+                scope: EffectScope::Single,
+                target,
+            }
+            | Effect::Unsuspect {
+                scope: EffectScope::Single,
+                target,
+            } => Some(target),
+            Effect::Suspect {
+                scope: EffectScope::All,
+                ..
+            }
+            | Effect::Unsuspect {
                 scope: EffectScope::All,
                 ..
             } => None,
@@ -11008,6 +11060,7 @@ impl Effect {
             | Effect::Reveal { .. }
             | Effect::TargetOnly { .. }
             | Effect::Suspect { .. }
+            | Effect::Unsuspect { .. }
             | Effect::Connive { .. }
             | Effect::PhaseOut { .. }
             | Effect::PhaseIn { .. }
@@ -11220,6 +11273,7 @@ impl Effect {
             | Effect::Reveal { .. }
             | Effect::TargetOnly { .. }
             | Effect::Suspect { .. }
+            | Effect::Unsuspect { .. }
             | Effect::Connive { .. }
             | Effect::PhaseOut { .. }
             | Effect::PhaseIn { .. }
@@ -11405,6 +11459,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::Choose { .. } => "Choose",
         Effect::ChooseDamageSource { .. } => "ChooseDamageSource",
         Effect::Suspect { .. } => "Suspect",
+        Effect::Unsuspect { .. } => "Unsuspect",
         Effect::Connive { .. } => "Connive",
         Effect::PhaseOut { .. } => "PhaseOut",
         Effect::PhaseIn { .. } => "PhaseIn",
@@ -11611,6 +11666,7 @@ pub enum EffectKind {
     Choose,
     ChooseDamageSource,
     Suspect,
+    Unsuspect,
     Connive,
     PhaseOut,
     PhaseIn,
@@ -11835,6 +11891,7 @@ impl From<&Effect> for EffectKind {
             Effect::Choose { .. } => EffectKind::Choose,
             Effect::ChooseDamageSource { .. } => EffectKind::ChooseDamageSource,
             Effect::Suspect { .. } => EffectKind::Suspect,
+            Effect::Unsuspect { .. } => EffectKind::Unsuspect,
             Effect::Connive { .. } => EffectKind::Connive,
             Effect::PhaseOut { .. } => EffectKind::PhaseOut,
             Effect::PhaseIn { .. } => EffectKind::PhaseIn,

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -568,6 +568,12 @@ pub enum GameEvent {
     CreatureSuspected {
         object_id: ObjectId,
     },
+    /// CR 701.60a: A creature is no longer suspected — the un-designation
+    /// transition. Emitted only when the toggle actually flips (idempotent
+    /// resolver). Mirrors `BecameUnprepared`.
+    CreatureNoLongerSuspected {
+        object_id: ObjectId,
+    },
     /// CR 701.35a: A permanent was detained — until the detaining player's next
     /// turn it can't attack or block and its activated abilities can't be
     /// activated. Display-relevant for mana sources: detaining a mana dork

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -634,6 +634,15 @@ pub enum StaticMode {
     CantAttack,
     CantBlock,
     CantAttackOrBlock,
+    /// CR 701.60a + CR 701.60d: The affected permanent can't become suspected
+    /// (Airtight Alibi: "Enchanted creature ... can't become suspected"). A
+    /// nullary marker static — the `affected` filter scopes which permanents are
+    /// protected, and runtime enforcement is the suspect resolver's gate
+    /// (`suspect::resolve`), which refuses to designate a permanent carrying this
+    /// static. Distinct from CR 701.60d's intrinsic "a suspected permanent can't
+    /// become suspected again": this prohibits the designation even while the
+    /// permanent is NOT suspected.
+    CantBecomeSuspected,
     /// CR 508.1c: No more than `max` creatures can be declared as attackers
     /// each combat. `defender` scopes *which declarations* the cap restricts:
     /// `None` is a global per-combat cap (no more than `max` creatures can
@@ -1653,6 +1662,7 @@ impl StaticMode {
             | StaticMode::CantAttack
             | StaticMode::CantBlock
             | StaticMode::CantAttackOrBlock
+            | StaticMode::CantBecomeSuspected
             | StaticMode::MaxAttackersEachCombat { .. }
             | StaticMode::MaxBlockersEachCombat { .. }
             | StaticMode::CantBeTargeted
@@ -1759,6 +1769,7 @@ impl fmt::Display for StaticMode {
             StaticMode::CantAttack => write!(f, "CantAttack"),
             StaticMode::CantBlock => write!(f, "CantBlock"),
             StaticMode::CantAttackOrBlock => write!(f, "CantAttackOrBlock"),
+            StaticMode::CantBecomeSuspected => write!(f, "CantBecomeSuspected"),
             StaticMode::MaxAttackersEachCombat { max, defender } => match defender {
                 None => write!(f, "MaxAttackersEachCombat({max})"),
                 Some(AttackDefenderScope::Controller) => {
@@ -2086,6 +2097,7 @@ impl FromStr for StaticMode {
             "CantAttack" => StaticMode::CantAttack,
             "CantBlock" => StaticMode::CantBlock,
             "CantAttackOrBlock" => StaticMode::CantAttackOrBlock,
+            "CantBecomeSuspected" => StaticMode::CantBecomeSuspected,
             "LinkedCollectionCounterPlayPermission" => {
                 StaticMode::LinkedCollectionCounterPlayPermission
             }

--- a/crates/engine/tests/mass_unsuspect_701_60a.rs
+++ b/crates/engine/tests/mass_unsuspect_701_60a.rs
@@ -16,8 +16,11 @@
 //! `game/effects/suspect.rs::resolve_object_targets` flips the two `assert!`s
 //! that the suspected creatures are cleared back to `true`.
 
+use engine::game::effects::resolve_effect;
 use engine::game::scenario::GameScenario;
+use engine::types::ability::{Effect, EffectScope, ResolvedAbility, TargetFilter, TargetRef};
 use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
 use engine::types::ObjectId;
@@ -66,9 +69,6 @@ fn has_cant_block(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> 
 /// the designation + CR 701.60c menace / "can't block" abilities are present
 /// exactly as production would set them.
 fn suspect(runner: &mut engine::game::scenario::GameRunner, id: ObjectId) {
-    use engine::game::effects::resolve_effect;
-    use engine::types::ability::{Effect, EffectScope, ResolvedAbility, TargetFilter, TargetRef};
-
     let ability = ResolvedAbility::new(
         Effect::Suspect {
             target: TargetFilter::Any,
@@ -94,8 +94,6 @@ fn suspect(runner: &mut engine::game::scenario::GameRunner, id: ObjectId) {
 /// while leaving a never-suspected creature untouched.
 #[test]
 fn mass_no_longer_suspected_clears_all_matching_creatures() {
-    use engine::types::phase::Phase;
-
     let mut scenario = GameScenario::new_n_player(2, 7);
     scenario.at_phase(Phase::PreCombatMain);
 

--- a/crates/engine/tests/mass_unsuspect_701_60a.rs
+++ b/crates/engine/tests/mass_unsuspect_701_60a.rs
@@ -1,0 +1,160 @@
+//! CR 701.60a: mass "all suspected creatures are no longer suspected" resolves
+//! over the whole matched set — end-to-end through the real cast/ETB pipeline.
+//!
+//! Absolving Lammasu's enters trigger reads "all suspected creatures are no
+//! longer suspected." That is a non-targeting *population* effect (no announced
+//! target), so the resolver must enumerate every battlefield permanent matching
+//! the parsed `TargetFilter` and remove the suspected designation from each
+//! (CR 701.60a), rather than reading `ability.targets` (which is empty for a
+//! mass clause).
+//!
+//! Discriminator: the prior resolver resolved every Unsuspect filter through
+//! `ability.targets`. A mass clause announces no target, so it was a no-op —
+//! both suspected creatures would stay suspected. With mass scope enumerated
+//! over the battlefield, both flip to un-suspected while a never-suspected
+//! creature is left untouched. Reverting the `EffectScope::All` enumeration in
+//! `game/effects/suspect.rs::resolve_object_targets` flips the two `assert!`s
+//! that the suspected creatures are cleared back to `true`.
+
+use engine::game::scenario::GameScenario;
+use engine::types::keywords::Keyword;
+use engine::types::player::PlayerId;
+use engine::types::statics::StaticMode;
+use engine::types::ObjectId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+// Absolving Lammasu's real Oracle text (the enters trigger is the clause under
+// test; the dies trigger is included so the parse matches the printed card).
+const ABSOLVING_LAMMASU: &str = "Flying\n\
+When this creature enters, all suspected creatures are no longer suspected.\n\
+When this creature dies, you gain 3 life and suspect up to one target creature an opponent controls.";
+
+fn is_suspected(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> bool {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .map(|o| o.is_suspected)
+        .unwrap_or(false)
+}
+
+fn has_menace(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> bool {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .map(|o| engine::game::keywords::has_keyword(o, &Keyword::Menace))
+        .unwrap_or(false)
+}
+
+fn has_cant_block(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> bool {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .map(|o| {
+            o.static_definitions
+                .iter_unchecked()
+                .any(|s| s.mode == StaticMode::CantBlock)
+        })
+        .unwrap_or(false)
+}
+
+/// Suspect a creature already on the battlefield via the real Suspect effect so
+/// the designation + CR 701.60c menace / "can't block" abilities are present
+/// exactly as production would set them.
+fn suspect(runner: &mut engine::game::scenario::GameRunner, id: ObjectId) {
+    use engine::game::effects::resolve_effect;
+    use engine::types::ability::{Effect, EffectScope, ResolvedAbility, TargetFilter, TargetRef};
+
+    let ability = ResolvedAbility::new(
+        Effect::Suspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::Single,
+        },
+        vec![TargetRef::Object(id)],
+        ObjectId(9_001),
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_effect(runner.state_mut(), &ability, &mut events).expect("suspect resolves");
+    let state = runner.state_mut();
+    state.layers_dirty.mark_full();
+    engine::game::layers::evaluate_layers(state);
+    assert!(
+        state.objects[&id].is_suspected,
+        "fixture creature must be suspected before the mass clear"
+    );
+}
+
+/// CR 701.60a: Absolving Lammasu's enters trigger clears the suspected
+/// designation from EVERY suspected creature on the battlefield (mass scope),
+/// while leaving a never-suspected creature untouched.
+#[test]
+fn mass_no_longer_suspected_clears_all_matching_creatures() {
+    use engine::types::phase::Phase;
+
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Two suspected creatures (different controllers — the filter is "all
+    // suspected creatures", uncontrolled) and one never-suspected control.
+    let suspected_a = scenario.add_creature(P1, "Suspect Bear A", 2, 2).id();
+    let suspected_b = scenario.add_creature(P0, "Suspect Bear B", 3, 3).id();
+    let clean = scenario.add_creature(P1, "Honest Bear", 1, 1).id();
+
+    // Absolving Lammasu in P0's hand, parsed from its real Oracle text.
+    let lammasu = scenario
+        .add_creature_to_hand_from_oracle(P0, "Absolving Lammasu", 3, 5, ABSOLVING_LAMMASU)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Designate the two fixtures as suspected through the real effect.
+    suspect(&mut runner, suspected_a);
+    suspect(&mut runner, suspected_b);
+    assert!(is_suspected(&runner, suspected_a));
+    assert!(is_suspected(&runner, suspected_b));
+    assert!(has_menace(&runner, suspected_a));
+    assert!(has_cant_block(&runner, suspected_b));
+    assert!(!is_suspected(&runner, clean));
+
+    // Cast Absolving Lammasu (free cost); its no-target enters trigger resolves
+    // the mass "all suspected creatures are no longer suspected" clause.
+    let outcome = runner.cast(lammasu).resolve();
+    let state = outcome.state();
+
+    // Both suspected creatures are now un-suspected (mass enumeration).
+    assert!(
+        !state.objects[&suspected_a].is_suspected,
+        "mass clause must clear suspected_a (reverting the All-scope enumeration \
+         leaves it suspected because the trigger announces no target)"
+    );
+    assert!(
+        !state.objects[&suspected_b].is_suspected,
+        "mass clause must clear suspected_b too — the whole matched set, not just \
+         one announced target"
+    );
+
+    // The CR 701.60c menace / "can't block" designation abilities are gone for
+    // the cleared creatures (after the resolver's layer recalc).
+    assert!(
+        !engine::game::keywords::has_keyword(&state.objects[&suspected_a], &Keyword::Menace),
+        "menace must be removed when no longer suspected"
+    );
+    assert!(
+        !state.objects[&suspected_b]
+            .static_definitions
+            .iter_unchecked()
+            .any(|s| s.mode == StaticMode::CantBlock),
+        "can't-block must be removed when no longer suspected"
+    );
+
+    // The never-suspected creature is untouched.
+    assert!(
+        !state.objects[&clean].is_suspected,
+        "a never-suspected creature stays un-suspected and is otherwise unaffected"
+    );
+}

--- a/crates/engine/tests/suspect_printed_menace_701_60c.rs
+++ b/crates/engine/tests/suspect_printed_menace_701_60c.rs
@@ -1,0 +1,207 @@
+//! CR 701.60c: the suspected designation grants menace + "This creature can't
+//! block" *for as long as it's suspected* — a continuous effect derived from the
+//! `is_suspected` designation, NOT a mutation of the permanent's printed
+//! (copiable) abilities (CR 701.60b). Verified end-to-end through the real
+//! Suspect / Unsuspect effects + the layer system.
+//!
+//! Primary discriminator (the maintainer-requested [MED]): a creature with
+//! PRINTED menace that becomes suspected and is then made no-longer-suspected
+//! must STILL have its printed menace and be able to block again. The prior
+//! base-mutating architecture wrote menace into `base_keywords` on suspect and
+//! retained OUT every `Keyword::Menace` on unsuspect — which deleted the printed
+//! menace permanently. Deriving the grant from `is_suspected` during layer
+//! evaluation fixes this: unsuspect only clears the flag and the derived grant
+//! lapses, leaving the printed menace untouched.
+//!
+//! Reverting `layers::derive_suspected_abilities` (or reverting the resolvers to
+//! mutate `base_*`) flips the "printed menace survives the round-trip" assertion.
+
+use engine::game::scenario::GameScenario;
+use engine::types::ability::{Effect, EffectScope, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::keywords::Keyword;
+use engine::types::player::PlayerId;
+use engine::types::statics::StaticMode;
+use engine::types::ObjectId;
+
+const P0: PlayerId = PlayerId(0);
+
+type Runner = engine::game::scenario::GameRunner;
+
+fn has_menace(runner: &Runner, id: ObjectId) -> bool {
+    engine::game::keywords::has_keyword(&runner.state().objects[&id], &Keyword::Menace)
+}
+
+fn has_cant_block(runner: &Runner, id: ObjectId) -> bool {
+    runner.state().objects[&id]
+        .static_definitions
+        .iter_unchecked()
+        .any(|s| s.mode == StaticMode::CantBlock)
+}
+
+fn is_suspected(runner: &Runner, id: ObjectId) -> bool {
+    runner.state().objects[&id].is_suspected
+}
+
+/// Suspect a battlefield creature through the real `Effect::Suspect`, then run a
+/// full layer pass so the CR 701.60c derivation is applied exactly as production.
+fn suspect(runner: &mut Runner, id: ObjectId) {
+    use engine::game::effects::resolve_effect;
+    let ability = ResolvedAbility::new(
+        Effect::Suspect {
+            target: TargetFilter::SelfRef,
+            scope: EffectScope::Single,
+        },
+        vec![TargetRef::Object(id)],
+        id,
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_effect(runner.state_mut(), &ability, &mut events).expect("suspect resolves");
+    let state = runner.state_mut();
+    state.layers_dirty.mark_full();
+    engine::game::layers::evaluate_layers(state);
+}
+
+/// Un-suspect a battlefield creature through the real `Effect::Unsuspect`, then
+/// run a full layer pass so the derived grant lapses.
+fn unsuspect(runner: &mut Runner, id: ObjectId) {
+    use engine::game::effects::resolve_effect;
+    let ability = ResolvedAbility::new(
+        Effect::Unsuspect {
+            target: TargetFilter::SelfRef,
+            scope: EffectScope::Single,
+        },
+        vec![TargetRef::Object(id)],
+        id,
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_effect(runner.state_mut(), &ability, &mut events).expect("unsuspect resolves");
+    let state = runner.state_mut();
+    state.layers_dirty.mark_full();
+    engine::game::layers::evaluate_layers(state);
+}
+
+/// CR 701.60b + CR 701.60c: a creature with PRINTED menace keeps it across the
+/// full suspect → no-longer-suspected round-trip. This is the maintainer's [MED]
+/// regression: reverting the layer-derived grant (so suspect mutates base and
+/// unsuspect retains-out every menace) flips the final `has_menace` assertion to
+/// false because the printed menace was deleted.
+#[test]
+fn printed_menace_survives_suspect_round_trip() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    // Printed menace via parsed Oracle text — this lands in base_keywords.
+    let bear = scenario
+        .add_creature_from_oracle(P0, "Menace Bear", 2, 2, "Menace")
+        .id();
+    let mut runner = scenario.build();
+
+    // Baseline: printed menace present, not suspected, can block (no CantBlock).
+    assert!(has_menace(&runner, bear), "printed menace at baseline");
+    assert!(!is_suspected(&runner, bear));
+    assert!(!has_cant_block(&runner, bear), "no can't-block at baseline");
+
+    // Suspect it. It already has menace (printed); while suspected it also gets
+    // the derived "can't block."
+    suspect(&mut runner, bear);
+    assert!(is_suspected(&runner, bear), "now suspected");
+    assert!(
+        has_menace(&runner, bear),
+        "still has menace while suspected"
+    );
+    assert!(
+        has_cant_block(&runner, bear),
+        "suspected creature can't block (CR 701.60c)"
+    );
+
+    // No longer suspected. The derived can't-block lapses, but the PRINTED
+    // menace must survive — this is the bug the [MED] reported.
+    unsuspect(&mut runner, bear);
+    assert!(!is_suspected(&runner, bear), "designation cleared");
+    assert!(
+        has_menace(&runner, bear),
+        "PRINTED menace must survive the suspect round-trip (CR 701.60b: the \
+         designation is not part of copiable values, so clearing it must not \
+         delete the printed menace)"
+    );
+    assert!(
+        !has_cant_block(&runner, bear),
+        "derived can't-block lapses when no longer suspected"
+    );
+}
+
+/// CR 701.60c: a VANILLA creature (no printed menace) gains menace + can't-block
+/// purely from the designation while suspected, and loses BOTH when no longer
+/// suspected — proving the grant is derived and present, not a no-op. This is the
+/// negative-controlcase paired with the printed-menace test: it would still pass
+/// under the old architecture, so it is the present-while-suspected proof.
+#[test]
+fn vanilla_creature_gains_then_loses_derived_abilities() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    let bear = scenario.add_creature(P0, "Vanilla Bear", 2, 2).id();
+    let mut runner = scenario.build();
+
+    assert!(!has_menace(&runner, bear), "vanilla: no menace at baseline");
+    assert!(!has_cant_block(&runner, bear));
+
+    suspect(&mut runner, bear);
+    assert!(
+        has_menace(&runner, bear),
+        "derived menace present while suspected (CR 701.60c)"
+    );
+    assert!(
+        has_cant_block(&runner, bear),
+        "derived can't-block present while suspected (CR 701.60c)"
+    );
+
+    unsuspect(&mut runner, bear);
+    assert!(
+        !has_menace(&runner, bear),
+        "derived menace gone when no longer suspected"
+    );
+    assert!(
+        !has_cant_block(&runner, bear),
+        "derived can't-block gone when no longer suspected"
+    );
+}
+
+/// CR 701.60c: while suspected, a creature with printed menace also can't block —
+/// asserted through the real `can_block_pair` legality predicate (production's
+/// block-declaration gate), and the legality returns to blockable after the
+/// designation is cleared. Drives the actual combat legality seam, not just the
+/// static-definition list.
+#[test]
+fn suspected_printed_menace_block_legality_round_trip() {
+    use engine::game::combat::can_block_pair;
+
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    let blocker = scenario
+        .add_creature_from_oracle(P0, "Menace Blocker", 2, 2, "Menace")
+        .id();
+    // Attacker controlled by the other player so the blocker could legally block
+    // it absent the can't-block restriction.
+    let attacker = scenario.add_creature(PlayerId(1), "Attacker", 3, 3).id();
+    let mut runner = scenario.build();
+
+    // Baseline: the printed-menace blocker can legally block the attacker.
+    assert!(
+        can_block_pair(runner.state(), blocker, attacker),
+        "printed-menace creature can block at baseline"
+    );
+
+    suspect(&mut runner, blocker);
+    assert!(
+        !can_block_pair(runner.state(), blocker, attacker),
+        "suspected creature can't block (CR 701.60c) — via real legality predicate"
+    );
+
+    unsuspect(&mut runner, blocker);
+    assert!(
+        can_block_pair(runner.state(), blocker, attacker),
+        "block legality restored after no-longer-suspected; printed menace intact"
+    );
+    assert!(
+        has_menace(&runner, blocker),
+        "printed menace survives the round-trip"
+    );
+}

--- a/crates/engine/tests/suspect_printed_menace_701_60c.rs
+++ b/crates/engine/tests/suspect_printed_menace_701_60c.rs
@@ -16,6 +16,8 @@
 //! Reverting `layers::derive_suspected_abilities` (or reverting the resolvers to
 //! mutate `base_*`) flips the "printed menace survives the round-trip" assertion.
 
+use engine::game::combat::can_block_pair;
+use engine::game::effects::resolve_effect;
 use engine::game::scenario::GameScenario;
 use engine::types::ability::{Effect, EffectScope, ResolvedAbility, TargetFilter, TargetRef};
 use engine::types::keywords::Keyword;
@@ -45,7 +47,6 @@ fn is_suspected(runner: &Runner, id: ObjectId) -> bool {
 /// Suspect a battlefield creature through the real `Effect::Suspect`, then run a
 /// full layer pass so the CR 701.60c derivation is applied exactly as production.
 fn suspect(runner: &mut Runner, id: ObjectId) {
-    use engine::game::effects::resolve_effect;
     let ability = ResolvedAbility::new(
         Effect::Suspect {
             target: TargetFilter::SelfRef,
@@ -65,7 +66,6 @@ fn suspect(runner: &mut Runner, id: ObjectId) {
 /// Un-suspect a battlefield creature through the real `Effect::Unsuspect`, then
 /// run a full layer pass so the derived grant lapses.
 fn unsuspect(runner: &mut Runner, id: ObjectId) {
-    use engine::game::effects::resolve_effect;
     let ability = ResolvedAbility::new(
         Effect::Unsuspect {
             target: TargetFilter::SelfRef,
@@ -172,8 +172,6 @@ fn vanilla_creature_gains_then_loses_derived_abilities() {
 /// static-definition list.
 #[test]
 fn suspected_printed_menace_block_legality_round_trip() {
-    use engine::game::combat::can_block_pair;
-
     let mut scenario = GameScenario::new_n_player(2, 7);
     let blocker = scenario
         .add_creature_from_oracle(P0, "Menace Blocker", 2, 2, "Menace")

--- a/crates/phase-ai/src/cast_facts.rs
+++ b/crates/phase-ai/src/cast_facts.rs
@@ -361,7 +361,6 @@ fn effect_requires_targets(effect: &Effect) -> bool {
         | Effect::Goad { target }
         | Effect::ChangeZone { target, .. }
         | Effect::Connive { target, .. }
-        | Effect::Suspect { target, .. }
         | Effect::ForceBlock { target, .. }
         | Effect::Exploit { target, .. }
         | Effect::Attach { target, .. }
@@ -380,6 +379,21 @@ fn effect_requires_targets(effect: &Effect) -> bool {
         // mass (`All`) scope falls through to `false`, matching the legacy
         // `TapAll`/`UntapAll`.
         Effect::SetTapState {
+            scope: EffectScope::Single,
+            target,
+            ..
+        } => !matches!(target, TargetFilter::None),
+        // CR 701.60a: only single-permanent suspect/unsuspect declares a target.
+        // The mass (`All`) scope (e.g. Absolving Lammasu, "all suspected
+        // creatures are no longer suspected") is a non-targeting population
+        // effect — its filter is not a selectable target, so it falls through to
+        // `false` (mirrors `SetTapState`'s `Single`/`All` split).
+        Effect::Suspect {
+            scope: EffectScope::Single,
+            target,
+            ..
+        }
+        | Effect::Unsuspect {
             scope: EffectScope::Single,
             target,
             ..
@@ -598,5 +612,54 @@ mod tests {
             .filter(|effect| matches!(effect, Effect::Draw { .. }))
             .count();
         assert_eq!(draw_count, 3);
+    }
+
+    // CR 701.60a: mass un-designation ("all suspected creatures are no longer
+    // suspected", Absolving Lammasu) is a non-targeting population effect, so it
+    // must NOT be scored as target-requiring. Only `EffectScope::Single`
+    // (targeted/anaphoric "suspect target creature" / "it's no longer
+    // suspected") declares a target, mirroring the engine's `target_filter()`
+    // and the `SetTapState` `Single`/`All` split.
+    #[test]
+    fn mass_unsuspect_is_not_target_requiring() {
+        // The non-None filter is identical across scopes (the mass clause still
+        // carries its population filter); only `scope` distinguishes them, so a
+        // pass proves the scope gate — not the filter — drives the decision.
+        let single = Effect::Unsuspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::Single,
+        };
+        let mass = Effect::Unsuspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::All,
+        };
+        assert!(
+            effect_requires_targets(&single),
+            "single-scope Unsuspect must be target-requiring"
+        );
+        assert!(
+            !effect_requires_targets(&mass),
+            "mass Unsuspect{{All}} (Absolving Lammasu) must not be target-requiring"
+        );
+    }
+
+    #[test]
+    fn mass_suspect_is_not_target_requiring() {
+        let single = Effect::Suspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::Single,
+        };
+        let mass = Effect::Suspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::All,
+        };
+        assert!(
+            effect_requires_targets(&single),
+            "single-scope Suspect must be target-requiring"
+        );
+        assert!(
+            !effect_requires_targets(&mass),
+            "mass Suspect{{All}} must not be target-requiring"
+        );
     }
 }

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -227,7 +227,6 @@ pub(crate) fn extract_target_filter(effect: &Effect) -> Option<&TargetFilter> {
         | Effect::Goad { target }
         | Effect::ChangeZone { target, .. }
         | Effect::Connive { target, .. }
-        | Effect::Suspect { target, .. }
         | Effect::ForceBlock { target, .. }
         | Effect::Exploit { target, .. }
         | Effect::Attach { target, .. }
@@ -241,6 +240,20 @@ pub(crate) fn extract_target_filter(effect: &Effect) -> Option<&TargetFilter> {
         // not surfaced as a target (matching the legacy `TapAll`/`UntapAll`,
         // which fell through to `None`).
         Effect::SetTapState {
+            scope: EffectScope::Single,
+            target,
+            ..
+        } => Some(target),
+        // CR 701.60a: only single-permanent suspect/unsuspect exposes a
+        // selectable target. The mass (`All`) scope (e.g. Absolving Lammasu)
+        // is a non-targeting population effect — its filter is not surfaced as
+        // a target (mirrors `SetTapState`'s `Single`/`All` split).
+        Effect::Suspect {
+            scope: EffectScope::Single,
+            target,
+            ..
+        }
+        | Effect::Unsuspect {
             scope: EffectScope::Single,
             target,
             ..
@@ -846,5 +859,56 @@ mod lethality_tests {
             cant_regenerate: false,
         };
         assert_eq!(lethal_to_creature(state, bear, &[&destroy]), None);
+    }
+}
+
+#[cfg(test)]
+mod suspect_scope_tests {
+    use super::*;
+
+    // CR 701.60a: mass un-designation ("all suspected creatures are no longer
+    // suspected", Absolving Lammasu) is a non-targeting population effect. The
+    // AI's target-filter extraction must mirror the engine's `target_filter()`,
+    // which surfaces a selectable target only for `EffectScope::Single`.
+    #[test]
+    fn extract_target_filter_only_for_single_scope_suspect() {
+        // Same non-None filter on both; only `scope` differs, so a pass proves
+        // the scope gate (not the filter) drives target-filter extraction.
+        let single_suspect = Effect::Suspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::Single,
+        };
+        let all_suspect = Effect::Suspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::All,
+        };
+        assert!(
+            extract_target_filter(&single_suspect).is_some(),
+            "single-scope Suspect must expose a selectable target"
+        );
+        assert!(
+            extract_target_filter(&all_suspect).is_none(),
+            "mass Suspect{{All}} is a population effect, not target-filtered"
+        );
+    }
+
+    #[test]
+    fn extract_target_filter_only_for_single_scope_unsuspect() {
+        let single_unsuspect = Effect::Unsuspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::Single,
+        };
+        let all_unsuspect = Effect::Unsuspect {
+            target: TargetFilter::Any,
+            scope: EffectScope::All,
+        };
+        assert!(
+            extract_target_filter(&single_unsuspect).is_some(),
+            "single-scope Unsuspect must expose a selectable target"
+        );
+        assert!(
+            extract_target_filter(&all_unsuspect).is_none(),
+            "mass Unsuspect{{All}} (Absolving Lammasu) is a population effect, not target-filtered"
+        );
     }
 }

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -458,6 +458,7 @@ fn redundancy_delta(
         | Effect::Choose { .. }
         | Effect::ChooseDamageSource { .. }
         | Effect::Suspect { .. }
+        | Effect::Unsuspect { .. }
         | Effect::Connive { .. }
         | Effect::PhaseOut { .. }
         | Effect::PhaseIn { .. }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# Suspect cluster: Unsuspect un-designation + can't-become-suspected (CR 701.60)

Branch `card/std-suspect`, off latest `upstream/main` (`eb00f126f`).

## Summary

Suspect was already partially implemented on `main` (the `Suspect` keyword action,
the `is_suspected` designation, `FilterProp::Suspected`, the `CreatureSuspected`
event, and CR 701.60c menace + can't-block conferral via the Option-C
`base_keywords`/`base_static_definitions` design). The **missing axis** shared
across all five cluster cards is the **un-designation** ("no longer suspected")
and the related "can't become suspected" prohibition. This PR builds those
primitives and the CR 701.60d "can't become suspected again" resolver gate.

Trace: the un-designation is the exact mirror of the already-merged
`BecomePrepared`/`BecomeUnprepared` designation/un-designation pair, so the new
`Effect::Unsuspect` reuses the same shape, target-resolution helper structure
(`resolve_object_targets`), idempotency discipline, and event-on-flip semantics
as `prepare.rs`. The existing `suspect.rs` even carried a test comment that the
un-suspect "would be done by a future `unsuspect` handler" — this is that handler.

## add-engine-variant verdict (Stage 1/2/3)

- **Stage 1 (grep `data/engine-inventory.json`):** no `Unsuspect`,
  `CantBecomeSuspected`, or `CreatureNoLongerSuspected` variants existed.
- **Stage 2 (precedent):** `BecomePrepared`/`BecomeUnprepared` (designation pair),
  `CantBlock`/`CantAttack` (per-CR prohibition statics), `BecameUnprepared` event.
- **Stage 3 (sibling vs parameterize):** new siblings are correct, not a
  parameterization smell:
  - `Effect::Unsuspect` is the *opposite transition* of `Suspect` (adds vs removes
    abilities; opposite idempotency direction; distinct gate) — there is no leaf
    parameterization axis. It mirrors the accepted `BecomeUnprepared` precedent
    (which the inventory smell detector does **not** flag).
  - `StaticMode::CantBecomeSuspected` is a distinct CR 701.60 prohibition. The
    categorical-boundary rule keeps it a sibling of `CantBlock` (CR 509) rather
    than unifying — each Cant* prohibition is its own CR rule section.
  - `GameEvent::CreatureNoLongerSuspected` mirrors `BecameUnprepared`.
- Regenerated inventory confirms **no new smell cluster** for any of the three
  variants. (The committed inventory file is left untouched — `cargo
  engine-inventory` reorders sources non-deterministically; CI regenerates it.)

## CR annotations (all grep-verified against `docs/MagicCompRules.txt`)

| CR | Text | Used for |
|----|------|----------|
| 701.60a | "…suspected until it leaves the battlefield or until a spell or ability causes it to no longer be suspected." | `Unsuspect` effect; un-designation; static gate |
| 701.60c | "A suspected permanent has menace and 'This creature can't block' for as long as it's suspected." | menace + can't-block removal on unsuspect |
| 701.60d | "A suspected permanent can't become suspected again." | `can_become_suspected` already-suspected gate |
| 608.2c | "later text…may modify…earlier text" (anaphor/source resolution) | shared `SelfRef` anaphor short-circuit (carried over) |

Diff-gate grep result: `OK: 608.2c, 701.60a, 701.60c, 701.60d` — **zero UNVERIFIED**.

## Per-card verdict

All five parse to **0 `Unimplemented` nodes** (verified via `parse_oracle_text`
with the card's real oracle text + mtgjson keywords in the worktree).

| Card | Owned line(s) | Verdict |
|------|---------------|---------|
| Absolving Lammasu | "all suspected creatures are no longer suspected" | SHIPPED (0-unimpl) |
| Airtight Alibi | "it's no longer suspected" + "can't become suspected" static | SHIPPED (0-unimpl) |
| Deadly Complication | "(become) no longer suspected" (optional, modal) | SHIPPED (0-unimpl) |
| Eliminate the Impossible | "they're no longer suspected" | SHIPPED (0-unimpl) |
| Frantic Scapegoat | "~ is no longer suspected" (self) | SHIPPED (0-unimpl) |

Non-suspect lines that already parsed on `main` and rode through unchanged:
Absolving Lammasu's dies-trigger (gain life + suspect), Airtight Alibi's
untap/gain-hexproof/+2+2, Deadly Complication's destroy/+1+1-counter modal,
Eliminate the Impossible's investigate/-2-0, Frantic Scapegoat's ETB-suspect and
become-suspected trigger condition.

## Discriminating-test coverage map (production-path)

| Behavioral claim | Changed seam | Production entry point | Test (revert-failing assertion) |
|---|---|---|---|
| Unsuspect clears designation + menace + can't-block | `effects/mod.rs` `Effect::Unsuspect => suspect::resolve_unsuspect`; `resolve_unsuspect` | `resolve_effect` (effect-resolution dispatch authority) | `effects::suspect::unsuspect_through_dispatch_removes_designation_and_abilities` — asserts `!is_suspected`, `!has_keyword(Menace)`, no `CantBlock`, and a `CreatureNoLongerSuspected` event; revert the dispatch arm/resolver → all flip |
| Unsuspect idempotent (no event when not suspected) | `resolve_unsuspect` flip guard | `resolve_unsuspect` | `unsuspect_idempotent_when_not_suspected` — no `CreatureNoLongerSuspected` event |
| CR 701.60d already-suspected gate | `resolve` `can_become_suspected` | `suspect::resolve` | `suspect_already_suspected_is_gated` — exactly one `CreatureSuspected` across two resolves; revert gate → two |
| CR 701.60a can't-become-suspected static blocks suspect | `can_become_suspected` static branch | `suspect::resolve` | `cant_become_suspected_static_blocks_suspect` — `!is_suspected`, no event; revert gate → suspected |
| "no longer suspected" → `Unsuspect{target}` w/ subject map | `parse_no_longer_suspected_ast` interception | `parse_imperative_family_ast` (via `parse_effect`) | `parse_no_longer_suspected_subject_mapping` + `parse_effect_self_no_longer_suspected_is_unsuspect_selfref` (full `parse_effect` path) — assert filter per subject; non-clause-final fragment yields None |
| "can't become suspected" rider not dropped | `parse_continuous_modifications` | static line parsing | `parse_continuous_modifications_cant_become_suspected_emits_static_mode` — asserts both `AddPower{2}` AND `AddStaticMode{CantBecomeSuspected}` |
| Existing suspect/Repeat-Offender GameRunner behavior preserved | `can_become_suspected` gate | `GameRunner` / `apply()` | `otherwise_conditional_effects` (10 tests incl. Repeat Offender, Agrus Kos) all green |

Fixture-degeneracy check: the dispatch test suspects a creature with **no printed
menace** then un-suspects it, so the menace/can't-block removal assertions reach
the real removal arm (not a degenerate no-menace creature). The gate tests use a
plain creature and a creature carrying the static respectively, exercising both
gate branches. No behavioral seam is covered only by a degenerate fixture.

No shape-only tests are relied on for runtime semantics — every behavioral claim
has a resolver/runner-path test that flips on revert.

## Gate results

- `cargo fmt --all`: clean
- `./scripts/check-parser-combinators.sh`: **pass** (exit 0)
- inline parser diff grep (rfind/split/split_once blind spot): **no matches** — interception uses `take_until`/`tag`/`all_consuming`/`terminated` only
- `./scripts/check-engine-authorities.sh upstream/main`: **pass** (test assertions migrated to `keywords::has_keyword`)
- `cargo check --workspace --all-targets`: **pass**
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings`: **clean**
- `cargo test -p engine`: 12854 pass; only failure is the known parallel-flaky
  `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`
  (passes single-threaded — confirmed unrelated)
- `cargo coverage` / `cargo semantic-audit`: build clean; data-dependent runs are
  no-op in a worktree (no `card-data.json`), per PROTOCOL

## Notes / risk for `/review-impl`

- Option-C limitation (pre-existing, not introduced here): menace conferred by
  suspect lives in `base_keywords`, so un-suspecting a creature that *also* has
  **printed** menace would strip the printed menace too. No card in this cluster
  (or the existing suspect cards) hits that case; a fully clean fix would derive
  menace/can't-block from `is_suspected` in the layer pass, which is out of scope
  for this cluster (it would change merged Suspect behavior). Flagged for
  awareness.
