### PR TITLE
feat(draft): add bot difficulty selector to cube draft setup

### DIFF
--- a/client/src/components/draft/BotDifficultySelector.tsx
+++ b/client/src/components/draft/BotDifficultySelector.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from "react-i18next";
+
+import { DIFFICULTY_NAMES, useDraftStore } from "../../stores/draftStore";
+
+// ── Component ───────────────────────────────────────────────────────────
+
+/**
+ * Segmented control for the solo-draft bot difficulty. Reads/writes the shared
+ * draft store's `difficulty` index (0–4), which `startDraft`/`startCubeDraft`
+ * forward at setup and `launchMatch` forwards to the game URL so the AI loop
+ * controller runs the chosen profile. Shared by the set-draft (`SetSelector`)
+ * and cube-draft (`DraftPage`) setup flows so both drive the same value.
+ *
+ * Difficulty is a single-axis scale, so a segmented control reads more clearly
+ * than per-level colors.
+ */
+export function BotDifficultySelector() {
+  const { t } = useTranslation("draft");
+  const difficulty = useDraftStore((s) => s.difficulty);
+  const setDifficulty = useDraftStore((s) => s.setDifficulty);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
+        {t("setSelector.botDifficulty")}
+      </h3>
+      <div className="flex w-full max-w-md rounded-xl border border-white/10 bg-black/18 p-1 backdrop-blur-md">
+        {DIFFICULTY_NAMES.map((id, idx) => {
+          const selected = difficulty === idx;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => setDifficulty(idx)}
+              aria-pressed={selected}
+              className={`flex-1 cursor-pointer rounded-lg px-2 py-2 text-xs font-medium transition-colors ${
+                selected
+                  ? "bg-emerald-400/15 text-emerald-100 shadow-[inset_0_0_0_1px] shadow-emerald-300/25"
+                  : "text-white/45 hover:bg-white/[0.05] hover:text-white/70"
+              }`}
+            >
+              {t(`setSelector.difficultyLevels.${id}`)}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/draft/SetSelector.tsx
+++ b/client/src/components/draft/SetSelector.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useDraftStore } from "../../stores/draftStore";
+import { BotDifficultySelector } from "./BotDifficultySelector";
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -21,22 +21,10 @@ interface SetSelectorProps {
   onStartDraft: (setCode: string, setName: string) => void;
 }
 
-// ── Constants ───────────────────────────────────────────────────────────
-
-const DIFFICULTY_LABELS = [
-  "Very Easy",
-  "Easy",
-  "Medium",
-  "Hard",
-  "Very Hard",
-] as const;
-
 // ── Component ───────────────────────────────────────────────────────────
 
 export function SetSelector({ onStartDraft }: SetSelectorProps) {
   const { t } = useTranslation("draft");
-  const difficulty = useDraftStore((s) => s.difficulty);
-  const setDifficulty = useDraftStore((s) => s.setDifficulty);
 
   const [sets, setSets] = useState<Array<{ code: string; name: string; icon?: string; releasedAt: string }>>([]);
   const [loading, setLoading] = useState(true);
@@ -93,32 +81,7 @@ export function SetSelector({ onStartDraft }: SetSelectorProps) {
 
   return (
     <div className="flex flex-col gap-6">
-      {/* Difficulty selector — single-axis scale, so a segmented control rather than per-level colors */}
-      <div className="flex flex-col gap-2">
-        <h3 className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
-          {t("setSelector.botDifficulty")}
-        </h3>
-        <div className="flex w-full max-w-md rounded-xl border border-white/10 bg-black/18 p-1 backdrop-blur-md">
-          {DIFFICULTY_LABELS.map((label, idx) => {
-            const selected = difficulty === idx;
-            return (
-              <button
-                key={label}
-                type="button"
-                onClick={() => setDifficulty(idx)}
-                aria-pressed={selected}
-                className={`flex-1 cursor-pointer rounded-lg px-2 py-2 text-xs font-medium transition-colors ${
-                  selected
-                    ? "bg-emerald-400/15 text-emerald-100 shadow-[inset_0_0_0_1px] shadow-emerald-300/25"
-                    : "text-white/45 hover:bg-white/[0.05] hover:text-white/70"
-                }`}
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
-      </div>
+      <BotDifficultySelector />
 
       {/* Set grid */}
       <div className="flex flex-col gap-2">

--- a/client/src/i18n/locales/de/draft.json
+++ b/client/src/i18n/locales/de/draft.json
@@ -63,6 +63,13 @@
   },
   "setSelector": {
     "botDifficulty": "Bot-Schwierigkeit",
+    "difficultyLevels": {
+      "VeryEasy": "Sehr leicht",
+      "Easy": "Leicht",
+      "Medium": "Mittel",
+      "Hard": "Schwer",
+      "VeryHard": "Sehr schwer"
+    },
     "chooseSet": "Wähle ein Set",
     "noPools": "Keine Draft-Pools verfügbar. Führe zuerst die Draft-Datenpipeline aus.",
     "setIconAlt": "{{name}} Set-Symbol",

--- a/client/src/i18n/locales/en/draft.json
+++ b/client/src/i18n/locales/en/draft.json
@@ -63,6 +63,13 @@
   },
   "setSelector": {
     "botDifficulty": "Bot Difficulty",
+    "difficultyLevels": {
+      "VeryEasy": "Very Easy",
+      "Easy": "Easy",
+      "Medium": "Medium",
+      "Hard": "Hard",
+      "VeryHard": "Very Hard"
+    },
     "chooseSet": "Choose a Set",
     "noPools": "No draft pools available. Run the draft data pipeline first.",
     "setIconAlt": "{{name}} set icon",

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -63,6 +63,13 @@
   },
   "setSelector": {
     "botDifficulty": "Dificultad de los bots",
+    "difficultyLevels": {
+      "VeryEasy": "Muy fácil",
+      "Easy": "Fácil",
+      "Medium": "Media",
+      "Hard": "Difícil",
+      "VeryHard": "Muy difícil"
+    },
     "chooseSet": "Elige una colección",
     "noPools": "No hay grupos de draft disponibles. Ejecuta primero la canalización de datos del draft.",
     "setIconAlt": "Icono de la colección {{name}}",

--- a/client/src/i18n/locales/fr/draft.json
+++ b/client/src/i18n/locales/fr/draft.json
@@ -63,6 +63,13 @@
   },
   "setSelector": {
     "botDifficulty": "Difficulté des bots",
+    "difficultyLevels": {
+      "VeryEasy": "Très facile",
+      "Easy": "Facile",
+      "Medium": "Moyen",
+      "Hard": "Difficile",
+      "VeryHard": "Très difficile"
+    },
     "chooseSet": "Choisir une extension",
     "noPools": "Aucun pool de draft disponible. Lancez d'abord le pipeline de données de draft.",
     "setIconAlt": "Icône d'extension {{name}}",

--- a/client/src/i18n/locales/it/draft.json
+++ b/client/src/i18n/locales/it/draft.json
@@ -63,6 +63,13 @@
   },
   "setSelector": {
     "botDifficulty": "Difficoltà bot",
+    "difficultyLevels": {
+      "VeryEasy": "Molto facile",
+      "Easy": "Facile",
+      "Medium": "Media",
+      "Hard": "Difficile",
+      "VeryHard": "Molto difficile"
+    },
     "chooseSet": "Scegli un set",
     "noPools": "Nessun pool di draft disponibile. Esegui prima la pipeline dei dati di draft.",
     "setIconAlt": "Icona set {{name}}",

--- a/client/src/i18n/locales/pl/draft.json
+++ b/client/src/i18n/locales/pl/draft.json
@@ -63,6 +63,13 @@
   },
   "setSelector": {
     "botDifficulty": "Poziom trudności botów",
+    "difficultyLevels": {
+      "VeryEasy": "Bardzo łatwy",
+      "Easy": "Łatwy",
+      "Medium": "Średni",
+      "Hard": "Trudny",
+      "VeryHard": "Bardzo trudny"
+    },
     "chooseSet": "Wybierz dodatek",
     "noPools": "Brak dostępnych pul do draftu. Najpierw uruchom pipeline danych draftu.",
     "setIconAlt": "Ikona dodatku {{name}}",

--- a/client/src/i18n/locales/pt/draft.json
+++ b/client/src/i18n/locales/pt/draft.json
@@ -63,6 +63,13 @@
   },
   "setSelector": {
     "botDifficulty": "Dificuldade dos Bots",
+    "difficultyLevels": {
+      "VeryEasy": "Muito fácil",
+      "Easy": "Fácil",
+      "Medium": "Médio",
+      "Hard": "Difícil",
+      "VeryHard": "Muito difícil"
+    },
     "chooseSet": "Escolha uma Coleção",
     "noPools": "Nenhum pool de draft disponível. Execute primeiro o pipeline de dados do draft.",
     "setIconAlt": "Ícone da coleção {{name}}",

--- a/client/src/pages/DraftPage.tsx
+++ b/client/src/pages/DraftPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useDraftStore } from "../stores/draftStore";
 import { CardPreview } from "../components/card/CardPreview";
 import type { CardHoverInfo } from "../components/card/CardPreview";
+import { BotDifficultySelector } from "../components/draft/BotDifficultySelector";
 import { CubeSetupPanel } from "../components/draft/CubeSetupPanel";
 import { DraftIntro } from "../components/draft/DraftIntro";
 import { DraftSteps } from "../components/draft/DraftSteps";
@@ -414,12 +415,15 @@ export function DraftPage() {
             {setupMode === "set" ? (
               <SetSelector onStartDraft={handleStartDraft} />
             ) : (
-              <CubeSetupPanel
-                onStart={async ({ cubeName, cubeListText, settings }) => {
-                  const { difficulty, startCubeDraft } = useDraftStore.getState();
-                  await startCubeDraft(cubeListText, cubeName, settings, difficulty);
-                }}
-              />
+              <div className="flex flex-col gap-6">
+                <BotDifficultySelector />
+                <CubeSetupPanel
+                  onStart={async ({ cubeName, cubeListText, settings }) => {
+                    const { difficulty, startCubeDraft } = useDraftStore.getState();
+                    await startCubeDraft(cubeListText, cubeName, settings, difficulty);
+                  }}
+                />
+              </div>
             )}
           </div>
         )}

--- a/client/src/stores/draftStore.ts
+++ b/client/src/stores/draftStore.ts
@@ -95,7 +95,9 @@ const initialState: DraftStoreState = {
 
 // ── Constants ──────────────────────────────────────────────────────────
 
-const DIFFICULTY_NAMES = ["VeryEasy", "Easy", "Medium", "Hard", "VeryHard"] as const;
+/** Index→AI-profile names; the difficulty index maps 1:1 to these and to the
+ *  `setSelector.difficultyLevels` i18n keys rendered by `BotDifficultySelector`. */
+export const DIFFICULTY_NAMES = ["VeryEasy", "Easy", "Medium", "Hard", "VeryHard"] as const;
 const DRAFT_DECK_SESSION_KEY = "phase:draft-deck";
 
 // ── Match helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
Cube draft had no UI to set AI difficulty — the draft store's difficulty
index defaulted to Medium and could never be changed for the cube flow,
even though the value was already plumbed through startCubeDraft and the
launch URL to the AI loop controller.

Extract the set-draft segmented difficulty control into a shared
BotDifficultySelector building block (reads/writes the draft store) and
mount it in the solo cube branch of DraftPage, above CubeSetupPanel. The
control lives in the solo page rather than the shared CubeSetupPanel so it
does not appear on multiplayer human pods (DraftPodPage).

Localize the difficulty labels: render via the new
setSelector.difficultyLevels keys (existing translations copied into all 7
draft.json locales) instead of the previously hardcoded English strings,
sourcing the id list from the now-exported canonical DIFFICULTY_NAMES.
