### PR TITLE
feat(data): gate sets via all-format ban + draft-hide instead of card-data removal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,14 +36,17 @@ jobs:
       card_data_filename: ${{ steps.card-data-hash.outputs.filename }}
     env:
       # Release-gate: Marvel Super Heroes (MSH/MSC/TMSH) are implemented in the
-      # engine but must NOT be playable or visible on the preview/staging site
-      # until release (2026-06-26). GATED_SETS makes the data generators drop
-      # these sets from the deployed card pool: card-data.json (deck search +
-      # gameplay), set-list.json (set pickers / draft UI), and draft-pools.json
-      # (draftable sets). Reprint-aware — a card also printed in a non-gated set
-      # stays available. Local dev is unaffected (GATED_SETS is unset there).
+      # engine but must NOT be playable on the preview/staging site until release
+      # (2026-06-26). GATED_SETS gates these sets two ways at data-generation
+      # time: (1) cards available ONLY through gated sets stay in card-data.json
+      # (so they remain browsable/previewable) but are marked Banned in every
+      # format, excluding them from every format-scoped deck-builder pool; and
+      # (2) the sets are hidden from set-list.json (set pickers / draft UI) and
+      # draft-pools.json (draftable sets), so they cannot be drafted. Reprint-
+      # aware — a card also printed in a non-gated set keeps its real legalities.
+      # Local dev is unaffected (GATED_SETS is unset there).
       # TO UNLOCK ON RELEASE: delete this `GATED_SETS` line (or set it empty) and
-      # re-run the deploy.
+      # re-run the deploy — real MTGJSON legalities and the sets are restored.
       GATED_SETS: MSH,MSC,TMSH
     steps:
       - uses: actions/checkout@v4

--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -869,20 +869,31 @@ fn main() {
         }
     }
 
-    // Release-gate: drop cards available ONLY through gated sets (reprint-aware).
-    // No-op when GATED_SETS is unset/empty. See `database::set_gating`.
+    // Release-gate (hybrid): keep cards available ONLY through gated sets in
+    // card-data so they stay browsable, but mark them Banned in every format so
+    // they are excluded from every format-scoped deck-builder pool. The gated
+    // sets are separately hidden from the draft/picker/deck-builder UIs below
+    // (the `is_set_gated` filter on the set list), so the sets remain
+    // un-draftable. Reprint-aware. No-op when GATED_SETS is unset/empty. See
+    // `database::set_gating`.
     let gated_sets = set_gating::gated_sets_from_env();
     if !gated_sets.is_empty() {
-        let before = face_index.len();
-        face_index.retain(|_, entry| !set_gating::is_card_gated(&entry.printings, &gated_sets));
+        let banned = legalities_to_export_map(&set_gating::all_formats_banned());
+        let mut gated_count = 0usize;
+        for entry in face_index.values_mut() {
+            if set_gating::is_card_gated(&entry.printings, &gated_sets) {
+                entry.legalities = banned.clone();
+                gated_count += 1;
+            }
+        }
         eprintln!(
-            "Set gating active ({}): excluded {} card face(s) available only via gated sets",
+            "Set gating active ({}): marked {} card face(s) Banned in all formats (available only via gated sets)",
             {
                 let mut codes: Vec<&str> = gated_sets.iter().map(String::as_str).collect();
                 codes.sort_unstable();
                 codes.join(",")
             },
-            before - face_index.len()
+            gated_count
         );
     }
 

--- a/crates/engine/src/database/set_gating.rs
+++ b/crates/engine/src/database/set_gating.rs
@@ -14,6 +14,8 @@
 
 use std::collections::HashSet;
 
+use super::legality::{CardLegalities, LegalityFormat, LegalityStatus};
+
 /// Name of the environment variable that lists gated set codes.
 pub const GATED_SETS_ENV: &str = "GATED_SETS";
 
@@ -62,6 +64,21 @@ pub fn is_card_gated(printings: &[String], gated: &HashSet<String>) -> bool {
     printings
         .iter()
         .all(|set| gated.contains(&set.to_uppercase()))
+}
+
+/// Legalities map marking a card `Banned` in every format.
+///
+/// The hybrid release-gate keeps a gated card in card-data (browsable) but
+/// overrides its legalities to this map, so it is excluded from every
+/// format-scoped deck-builder pool (`database::search` drops non-legal cards).
+/// The override is reversed on unlock — regenerate without `GATED_SETS` to
+/// restore the card's real MTGJSON legalities. This is a release-gate override,
+/// not a statement about the card's true format legality.
+pub fn all_formats_banned() -> CardLegalities {
+    LegalityFormat::ALL
+        .into_iter()
+        .map(|format| (format, LegalityStatus::Banned))
+        .collect()
 }
 
 #[cfg(test)]
@@ -150,5 +167,18 @@ mod tests {
     fn card_gating_is_case_insensitive() {
         let gated = set(&["MSH"]);
         assert!(is_card_gated(&["msh".to_string()], &gated));
+    }
+
+    #[test]
+    fn all_formats_banned_covers_every_format() {
+        let banned = all_formats_banned();
+        assert_eq!(banned.len(), LegalityFormat::ALL.len());
+        assert!(banned
+            .values()
+            .all(|status| *status == LegalityStatus::Banned));
+        // Every known format must be present (the hybrid gate bans everywhere).
+        assert!(LegalityFormat::ALL
+            .iter()
+            .all(|format| banned.get(format) == Some(&LegalityStatus::Banned)));
     }
 }


### PR DESCRIPTION
The release-gate now KEEPS cards available only through gated sets in card-data
(so they stay browsable/previewable) but marks them Banned in every format via
all_formats_banned(), excluding them from every format-scoped deck-builder pool.
The sets remain hidden from the set-list (draft/picker) so they are un-draftable.
Reprint-aware and reversible — regenerate without GATED_SETS to restore real
MTGJSON legalities. No-op when GATED_SETS is unset.
