### PR TITLE
fix(parser): parse "enchanted player/opponent draws a card" trigger

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7830,10 +7830,26 @@ fn try_parse_event(
         ))
         .parse(input)
     }
-    if let Ok((tail, ())) = parse_draws_card.parse(rest) {
+    // CR 702.5a + CR 303.4 + CR 121.1: "enchanted player/opponent draws a card"
+    // (Curse of Fool's Wisdom, Psychic Possession). Recognized ONLY in the draws
+    // path — NOT in the shared parse_attached_to_prefix/_exact combinators, which
+    // feed every verb. Containing it here keeps "enchanted player is dealt damage"
+    // (Grievous Wound) honestly Unknown rather than a parses-but-dead
+    // DamageReceived/valid_card=AttachedTo trigger. The Enchant keyword already
+    // restricts attachment to the right player, so bare AttachedTo suffices.
+    let enchanted_player_subject: OracleResult<'_, ()> = alt((
+        value((), tag("enchanted player ")),
+        value((), tag("enchanted opponent ")),
+    ))
+    .parse(rest);
+    let (draws_subject, draws_rest) = match enchanted_player_subject {
+        Ok((after_prefix, ())) => (TargetFilter::AttachedTo, after_prefix),
+        Err(_) => (subject.clone(), rest),
+    };
+    if let Ok((tail, ())) = parse_draws_card.parse(draws_rest) {
         let mut def = make_base();
         def.mode = TriggerMode::Drawn;
-        def.valid_target = Some(subject.clone());
+        def.valid_target = Some(draws_subject.clone());
         // CR 603.4 + CR 102.1: "draws a card during their turn" — the trailing
         // timing tail restricts the trigger to the acting player's own turn.
         // Composed with the shared typed `parse_timing_tail` combinator.
@@ -19155,6 +19171,50 @@ mod tests {
             Some(TargetFilter::Typed(
                 TypedFilter::default().controller(ControllerRef::Opponent)
             ))
+        );
+    }
+
+    /// CR 702.5a + CR 303.4 + CR 121.1: "Whenever enchanted player draws a card"
+    /// (Curse of Fool's Wisdom) lowers to a Drawn trigger scoped to the enchanted
+    /// player via `AttachedTo` — NOT `TriggerMode::Unknown` (which never fires).
+    #[test]
+    fn trigger_enchanted_player_draws_is_attached_to() {
+        let def = parse_trigger_line(
+            "Whenever enchanted player draws a card, they lose 2 life and you gain 2 life.",
+            "Curse of Fool's Wisdom",
+        );
+        assert_eq!(def.mode, TriggerMode::Drawn);
+        assert_eq!(def.valid_target, Some(TargetFilter::AttachedTo));
+    }
+
+    /// CR 702.5a: "Whenever enchanted opponent draws a card" (Psychic Possession).
+    /// "Enchant opponent" already restricts the attachment, so bare `AttachedTo`
+    /// resolves the enchanted opponent at runtime.
+    #[test]
+    fn trigger_enchanted_opponent_draws_is_attached_to() {
+        let def = parse_trigger_line(
+            "Whenever enchanted opponent draws a card, you may draw a card.",
+            "Psychic Possession",
+        );
+        assert_eq!(def.mode, TriggerMode::Drawn);
+        assert_eq!(def.valid_target, Some(TargetFilter::AttachedTo));
+    }
+
+    /// Containment guard: the "enchanted player/opponent" recognition lives ONLY
+    /// in the draws path, so "Whenever enchanted player is dealt damage" (Grievous
+    /// Wound) stays honestly `Unknown` rather than flipping to a parses-but-dead
+    /// `DamageReceived` trigger with `valid_card = AttachedTo` (which the runtime
+    /// rejects for player-recipient damage, so it would never fire).
+    #[test]
+    fn trigger_enchanted_player_is_dealt_damage_stays_unknown() {
+        let def = parse_trigger_line(
+            "Whenever enchanted player is dealt damage, they lose 2 life.",
+            "Grievous Wound",
+        );
+        assert!(
+            matches!(def.mode, TriggerMode::Unknown(_)),
+            "expected Unknown, got {:?}",
+            def.mode
         );
     }
 


### PR DESCRIPTION
Fixes #3965.

## Summary

Triggers on "Whenever enchanted player/opponent draws a card" never fired — they parsed to `TriggerMode::Unknown`, even though the bodies parse correctly:

- **Curse of Fool's Wisdom** ("Whenever enchanted player draws a card, they lose 2 life and you gain 2 life.")
- **Psychic Possession** ("Whenever enchanted opponent draws a card, you may draw a card.")

## Root cause

The trigger subject parser recognizes "enchanted creature/permanent/land" (→ `AttachedTo`) but has no "enchanted player"/"enchanted opponent" arm, so the subject fell through to `Any` and the leftover "enchanted player draws a card" never matched the "draws a card" verb head → `Unknown`.

## Fix (parser-AST-only; no new engine variant, no runtime change)

Recognize "enchanted player "/"enchanted opponent " as an `AttachedTo` subject **only inside the draws arm** (a local prefix-peel before `parse_draws_card`) — not in the shared `parse_attached_to_prefix`/`_exact` combinators that feed every verb. The draws arm sets `valid_target` directly, and the runtime already resolves the enchanted player (`player_matches_filter`'s `AttachedTo` arm → `attached_to.as_player()`). The Enchant keyword restricts attachment, so bare `AttachedTo` suffices for both the any-player and opponent forms.

**Containment is deliberate:** keeping the recognition in the draws path means "Whenever enchanted player is dealt damage" (Grievous Wound) stays honestly `Unknown` rather than flipping to a parses-but-dead `DamageReceived` trigger (the runtime rejects player-recipient damage when `valid_card` is set). CR 121.1 / 702.5a / 303.4.

## Tests

- Discriminating (fail-on-revert): "Whenever enchanted player draws a card…" and "…enchanted opponent draws a card…" → `Drawn` + `valid_target = Some(AttachedTo)`, not `Unknown`.
- Containment guard: "Whenever enchanted player is dealt damage…" (Grievous Wound) stays `TriggerMode::Unknown`.
- No-regression: "an opponent draws a card" (Underworld Dreams) unchanged.

## Verification

`cargo +nightly test -p engine --lib`: 12901 passed (incl. the 3 new tests); `--test integration`: 1357 passed. The only `--lib` failure was the pre-existing flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (global perf-counter race under parallel runs — confirmed passing in isolation, unrelated). `clippy -D warnings`, parser-combinator gate, rustfmt: clean. oracle-gen confirms the two draw cards flip `Unknown` → `Drawn`+`AttachedTo`, while Grievous Wound's "is dealt damage" trigger stays `Unknown` (containment).
