### PR TITLE
fix(engine): gate "during your turn" cost tax to the source controller's turn (#3872)

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -963,7 +963,7 @@ fn evaluate_condition_with_context(
         // already constrains source availability before this static is evaluated.
         StaticCondition::ClassLevelGE { level } => eval_class_level_ge(state, source_id, *level),
         StaticCondition::Unrecognized { .. } => true,
-        // CR 117.1a: "during your turn" means the turn of the static's source
+        // CR 102.1: "during your turn" means the turn of the static's source
         // controller — never the caster. Most call sites pass the source's
         // controller as `controller`, but the cost-modification resolver passes
         // the *caster* (so caster-relative conditions like SpellsCastThisTurn

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -963,7 +963,23 @@ fn evaluate_condition_with_context(
         // already constrains source availability before this static is evaluated.
         StaticCondition::ClassLevelGE { level } => eval_class_level_ge(state, source_id, *level),
         StaticCondition::Unrecognized { .. } => true,
-        StaticCondition::DuringYourTurn => state.active_player == controller,
+        // CR 117.1a: "during your turn" means the turn of the static's source
+        // controller — never the caster. Most call sites pass the source's
+        // controller as `controller`, but the cost-modification resolver passes
+        // the *caster* (so caster-relative conditions like SpellsCastThisTurn
+        // resolve correctly), which would invert this turn check for an
+        // opponent-affecting tax (Tithe Taker: "During your turn, spells your
+        // opponents cast cost {1} more"). Bind to the source permanent's
+        // controller directly so the gate is correct in every call path; fall
+        // back to `controller` only when the source object is absent.
+        StaticCondition::DuringYourTurn => {
+            let source_controller = state
+                .objects
+                .get(&source_id)
+                .map(|obj| obj.controller)
+                .unwrap_or(controller);
+            state.active_player == source_controller
+        }
         // CR 103.1: True when the scoped player took the first turn of the
         // game (fixed at game start). The parser emits `ControllerRef::You`.
         StaticCondition::WasStartingPlayer { .. } => state.current_starting_player == controller,

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -668,13 +668,13 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         }
     }
 
-    // CR 117.1a + CR 601.2f: Leading "During your turn," timing restriction —
+    // CR 102.1 + CR 601.2f: Leading "During your turn," timing restriction —
     // the cost modification functions only on the static controller's turn
     // (Tithe Taker: "During your turn, spells your opponents cast cost {1} more
     // to cast ..."). The trailing/`if` scans above miss this because it is a
     // comma-separated timing prefix, not an "if"/"as long as" clause. The cost
     // resolver gates on `StaticCondition::DuringYourTurn`, which is evaluated
-    // against the source permanent's controller (CR 117.1a "your turn").
+    // against the source permanent's controller (CR 102.1: active player).
     if definition.condition.is_none()
         && tag::<_, _, OracleError<'_>>("during your turn, ")
             .parse(lower)

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -668,6 +668,21 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         }
     }
 
+    // CR 117.1a + CR 601.2f: Leading "During your turn," timing restriction —
+    // the cost modification functions only on the static controller's turn
+    // (Tithe Taker: "During your turn, spells your opponents cast cost {1} more
+    // to cast ..."). The trailing/`if` scans above miss this because it is a
+    // comma-separated timing prefix, not an "if"/"as long as" clause. The cost
+    // resolver gates on `StaticCondition::DuringYourTurn`, which is evaluated
+    // against the source permanent's controller (CR 117.1a "your turn").
+    if definition.condition.is_none()
+        && tag::<_, _, OracleError<'_>>("during your turn, ")
+            .parse(lower)
+            .is_ok()
+    {
+        definition.condition = Some(StaticCondition::DuringYourTurn);
+    }
+
     Some(definition)
 }
 

--- a/crates/engine/tests/integration/issue_3872_tithe_taker_turn_scoped_tax.rs
+++ b/crates/engine/tests/integration/issue_3872_tithe_taker_turn_scoped_tax.rs
@@ -9,7 +9,7 @@
 //! opponent's OWN turn, because the parser dropped the leading "During your
 //! turn," timing restriction (the static parsed with `condition: None`).
 //!
-//! CR 117.1a: "your turn" is the turn of the permanent's controller. Two fixes
+//! CR 102.1: the active player is the player whose turn it is. Two fixes
 //! combine here: the cost-modifier parser now attaches
 //! `StaticCondition::DuringYourTurn`, and that condition is evaluated against
 //! the source permanent's controller (not the caster) so it is correct in the
@@ -48,7 +48,7 @@ fn resolved_cost_mana_value(runner: &mut GameRunner, spell_id: ObjectId) -> u32 
 
 #[test]
 fn tithe_taker_static_parses_with_during_your_turn_condition() {
-    // CR 117.1a: the leading "During your turn," timing restriction must lower
+    // CR 102.1: the leading "During your turn," timing restriction must lower
     // to a `StaticCondition::DuringYourTurn` gate on the cost-raise static —
     // not be silently dropped (which left `condition: None`, the root cause).
     let def = parse_static_line(TITHE_TAKER).expect("Tithe Taker static should parse");
@@ -79,7 +79,7 @@ fn tithe_taker_does_not_tax_opponent_on_their_own_turn() {
     assert_eq!(
         resolved_cost_mana_value(&mut runner, spell_id),
         0,
-        "Tithe Taker must NOT tax an opponent's spell on the opponent's own turn (CR 117.1a)",
+        "Tithe Taker must NOT tax an opponent's spell on the opponent's own turn (CR 102.1)",
     );
 }
 

--- a/crates/engine/tests/integration/issue_3872_tithe_taker_turn_scoped_tax.rs
+++ b/crates/engine/tests/integration/issue_3872_tithe_taker_turn_scoped_tax.rs
@@ -1,0 +1,114 @@
+//! Issue #3872 — Tithe Taker's "During your turn" cost tax must apply only on
+//! the static controller's turn, not the caster's turn.
+//!
+//! Oracle: "During your turn, spells your opponents cast cost {1} more to cast
+//! and abilities your opponents activate cost {1} more to activate unless
+//! they're mana abilities."
+//!
+//! Reported bug (#3872): the tax raised the *opponent's* spells on the
+//! opponent's OWN turn, because the parser dropped the leading "During your
+//! turn," timing restriction (the static parsed with `condition: None`).
+//!
+//! CR 117.1a: "your turn" is the turn of the permanent's controller. Two fixes
+//! combine here: the cost-modifier parser now attaches
+//! `StaticCondition::DuringYourTurn`, and that condition is evaluated against
+//! the source permanent's controller (not the caster) so it is correct in the
+//! cost-modification resolver, which passes the caster as the scope player.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle_static::parse_static_line;
+use engine::types::ability::StaticCondition;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+const TITHE_TAKER: &str = "During your turn, spells your opponents cast cost {1} more to cast and abilities your opponents activate cost {1} more to activate unless they're mana abilities.";
+
+/// Begin casting P0's Lightning Bolt and return the total mana value of the
+/// battlefield-modified cost the engine resolved for it. The cost is computed
+/// when the spell is put on the stack (surfaced via `WaitingFor::TargetSelection`
+/// before payment), so this reads the actual tax the cost resolver applied —
+/// the {1} Tithe Taker increase is `mana_value() == 1`, no tax is `0`.
+fn resolved_cost_mana_value(runner: &mut GameRunner, spell_id: ObjectId) -> u32 {
+    let card_id = runner.state().objects[&spell_id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the bolt should begin (cost is checked at payment, not here)");
+    match &runner.state().waiting_for {
+        WaitingFor::TargetSelection { pending_cast, .. } => pending_cast.cost.mana_value(),
+        other => panic!("expected TargetSelection after casting the bolt, got {other:?}"),
+    }
+}
+
+#[test]
+fn tithe_taker_static_parses_with_during_your_turn_condition() {
+    // CR 117.1a: the leading "During your turn," timing restriction must lower
+    // to a `StaticCondition::DuringYourTurn` gate on the cost-raise static —
+    // not be silently dropped (which left `condition: None`, the root cause).
+    let def = parse_static_line(TITHE_TAKER).expect("Tithe Taker static should parse");
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::DuringYourTurn),
+        "\"During your turn,\" must gate the cost-raise static, got {:?}",
+        def.condition,
+    );
+}
+
+#[test]
+fn tithe_taker_does_not_tax_opponent_on_their_own_turn() {
+    // P1 controls Tithe Taker. During P0's OWN turn, P0's Lightning Bolt must
+    // NOT be taxed — the resolved cost carries no {1} increase. Before the fix
+    // the dropped "During your turn" gate taxed it on every turn.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain); // active player = P0
+
+    scenario
+        .add_creature(P1, "Tithe Taker", 1, 2)
+        .with_static_definition(
+            parse_static_line(TITHE_TAKER).expect("Tithe Taker static should parse"),
+        );
+    let spell_id = scenario.add_bolt_to_hand(P0);
+
+    let mut runner = scenario.build();
+    assert_eq!(
+        resolved_cost_mana_value(&mut runner, spell_id),
+        0,
+        "Tithe Taker must NOT tax an opponent's spell on the opponent's own turn (CR 117.1a)",
+    );
+}
+
+#[test]
+fn tithe_taker_taxes_opponent_during_controllers_turn() {
+    // P1 controls Tithe Taker. During P1's turn, P0's Lightning Bolt is taxed by
+    // {1} — the resolver applies the increase when it is the static controller's
+    // turn, confirming the gate is enabled (not merely disabled everywhere).
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature(P1, "Tithe Taker", 1, 2)
+        .with_static_definition(
+            parse_static_line(TITHE_TAKER).expect("Tithe Taker static should parse"),
+        );
+    let spell_id = scenario.add_bolt_to_hand(P0);
+
+    let mut runner = scenario.build();
+    // Move to P1's turn and hand P0 priority to cast its instant.
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P0;
+        state.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+    assert_eq!(
+        resolved_cost_mana_value(&mut runner, spell_id),
+        1,
+        "During the Tithe Taker controller's turn, the opponent's spell must be taxed by {{1}}",
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -306,6 +306,7 @@ mod issue_3654_nyxbloom_mana_reflection;
 mod issue_3660_paradigm_multiple_offers;
 mod issue_3665_smugglers_share;
 mod issue_3681_inferno_titan_divided_damage;
+mod issue_3872_tithe_taker_turn_scoped_tax;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
Fixes #3872 — Tithe Taker taxing the opponent on the opponent's OWN turn.

## Problem
`During your turn, spells your opponents cast cost {1} more to cast and abilities your opponents activate cost {1} more to activate unless they're mana abilities.` parsed into a `ModifyCost { Raise, affected: Opponent }` static with **`condition: None`** — the leading `During your turn,` timing restriction was silently dropped. With an opponent's Tithe Taker on the battlefield, your spells were taxed on **your own turn**, when the tax must only apply on the Tithe Taker controller's turn (CR 117.1a).

## Fix (two parts)
**Parser** (`oracle_static/static_helpers.rs`): the cost-modifier builder now recognizes a leading `During your turn,` prefix and attaches `StaticCondition::DuringYourTurn`, mirroring the existing leading-`if` condition handling.

**Engine** (`game/layers.rs`): `StaticCondition::DuringYourTurn` now evaluates against the **source permanent's controller**, not the passed scope player. The cost-modification resolver passes the *caster* as the scope player (so caster-relative conditions like `SpellsCastThisTurn` resolve correctly against the casting player's history), which would **invert** this turn check for an opponent-affecting tax. Binding to the source controller is correct in every call path; existing layer/static call sites already pass the source's controller, so their behavior is unchanged (full suite incl. the Kaito `DuringYourTurn` unit tests stays green).

## Tests
`crates/engine/tests/integration/issue_3872_tithe_taker_turn_scoped_tax.rs`:
- the static parses with `condition: DuringYourTurn`
- the opponent's spell is **not** taxed on the opponent's own turn (resolved cost mana value `0`)
- the opponent's spell **is** taxed during the Tithe Taker controller's turn (resolved cost mana value `1`)

`cargo clippy -p engine --all-targets -- -D warnings` clean; full `cargo test -p engine` green (12863 passed; the sole red is the pre-existing order-flaky `delve_payment_skips_state_clone_per_graveyard_candidate`, which passes in isolation and is unrelated).

Model: claude-opus-4-8 (Claude Code)