### PR TITLE
fix(engine): Kozilek graveyard shuffle trigger (#3875)

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -927,22 +927,18 @@ pub fn resolve_all(
         // CR 608.2c + CR 109.4: "that player shuffles their hand into their
         // library" (Jace, the Mind Sculptor −12) binds the mass move to the
         // parent instruction's chosen player via `ParentTargetController`.
-        TargetFilter::ParentTargetController => {
-            crate::game::targeting::resolve_effect_player_ref(
-                state,
-                ability,
-                &TargetFilter::ParentTargetController,
-            )
-        }
+        TargetFilter::ParentTargetController => crate::game::targeting::resolve_effect_player_ref(
+            state,
+            ability,
+            &TargetFilter::ParentTargetController,
+        ),
         // CR 108.3 + CR 608.2c: "its owner shuffles their graveyard into their
         // library" mass moves key off owner, not controller.
-        TargetFilter::ParentTargetOwner => {
-            crate::game::targeting::resolve_effect_player_ref(
-                state,
-                ability,
-                &TargetFilter::ParentTargetOwner,
-            )
-        }
+        TargetFilter::ParentTargetOwner => crate::game::targeting::resolve_effect_player_ref(
+            state,
+            ability,
+            &TargetFilter::ParentTargetOwner,
+        ),
         _ => None,
     };
 

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -928,12 +928,20 @@ pub fn resolve_all(
         // library" (Jace, the Mind Sculptor −12) binds the mass move to the
         // parent instruction's chosen player via `ParentTargetController`.
         TargetFilter::ParentTargetController => {
-            crate::game::ability_utils::parent_target_controller(ability, state)
+            crate::game::targeting::resolve_effect_player_ref(
+                state,
+                ability,
+                &TargetFilter::ParentTargetController,
+            )
         }
         // CR 108.3 + CR 608.2c: "its owner shuffles their graveyard into their
         // library" mass moves key off owner, not controller.
         TargetFilter::ParentTargetOwner => {
-            crate::game::ability_utils::parent_target_owner(ability, state)
+            crate::game::targeting::resolve_effect_player_ref(
+                state,
+                ability,
+                &TargetFilter::ParentTargetOwner,
+            )
         }
         _ => None,
     };

--- a/crates/engine/tests/integration/issue_3875_kozilek_graveyard_shuffle.rs
+++ b/crates/engine/tests/integration/issue_3875_kozilek_graveyard_shuffle.rs
@@ -1,0 +1,72 @@
+//! Regression for issue #3875: Kozilek, Butcher of Truth must shuffle its
+//! owner's graveyard into their library when it dies.
+//!
+//! https://github.com/phase-rs/phase/issues/3875
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const KOZILEK_ORACLE: &str = "When you cast this spell, draw four cards.\n\
+    Annihilator 4 (Whenever this creature attacks, defending player sacrifices four permanents of their choice.)\n\
+    When Kozilek is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.";
+
+const MURDER_ORACLE: &str = "Destroy target creature.";
+
+fn floating_mana(n: usize, ty: ManaType) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ty, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+#[test]
+fn kozilek_graveyard_trigger_shuffles_owners_graveyard_into_library() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let filler_a = scenario.add_creature_to_graveyard(P0, "Filler A", 1, 1).id();
+    let filler_b = scenario.add_creature_to_graveyard(P0, "Filler B", 1, 1).id();
+    let kozilek = scenario
+        .add_creature_from_oracle(P0, "Kozilek, Butcher of Truth", 12, 12, KOZILEK_ORACLE)
+        .id();
+    let murder = scenario
+        .add_spell_to_hand_from_oracle(P0, "Murder", false, MURDER_ORACLE)
+        .id();
+    scenario.with_mana_pool(P0, floating_mana(3, ManaType::Black));
+
+    let mut runner = scenario.build();
+    runner.cast(murder).target_objects(&[kozilek]).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&kozilek].zone,
+        Zone::Library,
+        "Kozilek itself should be shuffled into its owner's library"
+    );
+    assert_eq!(
+        runner.state().objects[&filler_a].zone,
+        Zone::Library,
+        "other cards in the graveyard must shuffle into the library"
+    );
+    assert_eq!(
+        runner.state().objects[&filler_b].zone,
+        Zone::Library,
+        "other cards in the graveyard must shuffle into the library"
+    );
+    assert!(
+        runner.state().players[0].graveyard.is_empty(),
+        "graveyard must be empty after Kozilek's trigger"
+    );
+    assert!(
+        runner.state().players[0].library.contains(&filler_a)
+            && runner.state().players[0].library.contains(&filler_b)
+            && runner.state().players[0].library.contains(&kozilek),
+        "shuffled cards must end up in the library"
+    );
+    assert!(
+        runner.state().players[1].graveyard.is_empty(),
+        "opponent graveyard must be untouched"
+    );
+}

--- a/crates/engine/tests/integration/issue_3875_kozilek_graveyard_shuffle.rs
+++ b/crates/engine/tests/integration/issue_3875_kozilek_graveyard_shuffle.rs
@@ -4,8 +4,8 @@
 //! https://github.com/phase-rs/phase/issues/3875
 
 use engine::game::scenario::{GameScenario, P0};
-use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
@@ -26,8 +26,12 @@ fn kozilek_graveyard_trigger_shuffles_owners_graveyard_into_library() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    let filler_a = scenario.add_creature_to_graveyard(P0, "Filler A", 1, 1).id();
-    let filler_b = scenario.add_creature_to_graveyard(P0, "Filler B", 1, 1).id();
+    let filler_a = scenario
+        .add_creature_to_graveyard(P0, "Filler A", 1, 1)
+        .id();
+    let filler_b = scenario
+        .add_creature_to_graveyard(P0, "Filler B", 1, 1)
+        .id();
     let kozilek = scenario
         .add_creature_from_oracle(P0, "Kozilek, Butcher of Truth", 12, 12, KOZILEK_ORACLE)
         .id();

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -307,6 +307,7 @@ mod issue_3654_nyxbloom_mana_reflection;
 mod issue_3660_paradigm_multiple_offers;
 mod issue_3665_smugglers_share;
 mod issue_3681_inferno_titan_divided_damage;
+mod issue_3875_kozilek_graveyard_shuffle;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary
- Route `ChangeZoneAll` player-scoped `ParentTargetOwner` / `ParentTargetController` lookups through `resolve_effect_player_ref` so trigger abilities like Kozilek, Butcher of Truth's "its owner shuffles their graveyard into their library" resolve the dying permanent's owner.
- Add integration regression covering a filled graveyard shuffling into the library when Kozilek dies.

## Test plan
- [x] `cargo test -p engine --test integration kozilek_graveyard`
- [ ] CI

Fixes https://github.com/phase-rs/phase/issues/3875

Made with [Cursor](https://cursor.com)