### PR TITLE
fix(parser): Gadrak Treasure count per death (#3876)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -7864,7 +7864,8 @@ mod tests {
     #[test]
     fn parse_nontoken_creature_died_this_turn_for_each() {
         let (_, q) =
-            parse_for_each_creature_died_this_turn("nontoken creature that died this turn").unwrap();
+            parse_for_each_creature_died_this_turn("nontoken creature that died this turn")
+                .unwrap();
         let QuantityRef::ZoneChangeCountThisTurn { filter, .. } = q else {
             panic!("expected ZoneChangeCountThisTurn, got {q:?}");
         };

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3443,13 +3443,17 @@ pub(crate) fn parse_died_this_turn_suffix(input: &str) -> OracleResult<'_, Optio
 /// phrasing. Engine tracking is per-turn-only, so the trailing "this turn"
 /// qualifier is semantically redundant when present.
 ///
-/// Returns `Some(ControllerRef::You)` for forms qualified by "under your
-/// control" or "your graveyard" (CR 109.5: "your" graveyard = the source's
-/// controller), and `None` for unqualified forms that count every player's
-/// deaths. The longer qualified tags MUST precede the bare "that died" /
+/// Returns `(controller scope, nontoken-only)` where controller is
+/// `Some(ControllerRef::You)` for forms qualified by "under your control" /
+/// "your graveyard" (CR 109.5: "your" graveyard = the source's controller),
+/// and `None` for unqualified forms that count every player's deaths. The
+/// longer qualified tags MUST precede the bare "that died" /
 /// "a graveyard" tags so the qualified suffix isn't shadowed by `alt`.
-fn parse_creatures_died_this_turn_tail(input: &str) -> OracleResult<'_, Option<ControllerRef>> {
-    alt((
+fn parse_creatures_died_this_turn_tail(
+    input: &str,
+) -> OracleResult<'_, (Option<ControllerRef>, bool)> {
+    let (rest, nontoken) = opt(tag("nontoken ")).parse(input)?;
+    let (rest, controller) = alt((
         value(
             Some(ControllerRef::You),
             tag("creatures that died under your control this turn"),
@@ -3507,21 +3511,22 @@ fn parse_creatures_died_this_turn_tail(input: &str) -> OracleResult<'_, Option<C
             tag("creature put into a graveyard from the battlefield"),
         ),
     ))
-    .parse(input)
+    .parse(rest)?;
+    Ok((rest, (controller, nontoken.is_some())))
 }
 
 /// CR 700.4: Parse "creature(s) that died" → filtered zone-change count for
 /// "for each creature that died this turn" iteration sources.
 fn parse_for_each_creature_died_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, controller) = parse_creatures_died_this_turn_tail(input)?;
-    Ok((rest, creatures_died_this_turn_ref(controller)))
+    let (rest, (controller, nontoken)) = parse_creatures_died_this_turn_tail(input)?;
+    Ok((rest, creatures_died_this_turn_ref(controller, nontoken)))
 }
 
 /// CR 700.4: Parse "the number of creature(s) that died this turn" → the same
 /// `ZoneChangeCountThisTurn` quantity ref used by for-each iteration.
 fn parse_number_of_creatures_died_this_turn(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, controller) = parse_creatures_died_this_turn_tail(input)?;
-    Ok((rest, creatures_died_this_turn_ref(controller)))
+    let (rest, (controller, nontoken)) = parse_creatures_died_this_turn_tail(input)?;
+    Ok((rest, creatures_died_this_turn_ref(controller, nontoken)))
 }
 
 /// CR 701.21a: Parse "[type] you['ve] sacrificed this turn" -> `TargetFilter`.
@@ -3640,10 +3645,13 @@ fn parse_for_each_subtype_died_this_turn(input: &str) -> OracleResult<'_, Quanti
 /// graveyard", `controller` is `Some(ControllerRef::You)` and the count is
 /// scoped to creatures controlled by the source's controller when they died;
 /// otherwise it is `None` and every player's deaths are counted.
-fn creatures_died_this_turn_ref(controller: Option<ControllerRef>) -> QuantityRef {
+fn creatures_died_this_turn_ref(controller: Option<ControllerRef>, nontoken: bool) -> QuantityRef {
     let mut tf = TypedFilter::creature();
     if let Some(c) = controller {
         tf = tf.controller(c);
+    }
+    if nontoken {
+        tf = tf.properties(vec![FilterProp::NonToken]);
     }
     QuantityRef::ZoneChangeCountThisTurn {
         from: Some(Zone::Battlefield),
@@ -7851,5 +7859,18 @@ mod tests {
                 damage_kind: DamageKindFilter::NoncombatOnly,
             }
         );
+    }
+
+    #[test]
+    fn parse_nontoken_creature_died_this_turn_for_each() {
+        let (_, q) =
+            parse_for_each_creature_died_this_turn("nontoken creature that died this turn").unwrap();
+        let QuantityRef::ZoneChangeCountThisTurn { filter, .. } = q else {
+            panic!("expected ZoneChangeCountThisTurn, got {q:?}");
+        };
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected typed filter");
+        };
+        assert!(tf.properties.contains(&FilterProp::NonToken));
     }
 }

--- a/crates/engine/tests/integration/issue_3876_gadrak_treasure_count.rs
+++ b/crates/engine/tests/integration/issue_3876_gadrak_treasure_count.rs
@@ -72,3 +72,39 @@ fn gadrak_creates_no_treasure_when_nothing_died() {
         "no deaths this turn → no Treasures"
     );
 }
+
+#[test]
+fn gadrak_ignores_token_creatures_that_died() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "Gadrak, the Crown-Scourge", 5, 4, GADRAK_ORACLE)
+        .id();
+    let doomed = scenario.add_creature(P0, "Doomed Token", 1, 1).id();
+    let murder = scenario
+        .add_spell_to_hand_from_oracle(P0, "Murder", false, MURDER_ORACLE)
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..3)
+            .map(|_| ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&doomed)
+        .unwrap()
+        .is_token = true;
+    runner.cast(murder).target_objects(&[doomed]).resolve();
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        treasure_count(&runner),
+        0,
+        "token creature deaths do not satisfy Gadrak's nontoken count"
+    );
+}

--- a/crates/engine/tests/integration/issue_3876_gadrak_treasure_count.rs
+++ b/crates/engine/tests/integration/issue_3876_gadrak_treasure_count.rs
@@ -1,0 +1,77 @@
+//! Regression for issue #3876: Gadrak must create one Treasure per nontoken
+//! creature that died this turn, not one every end step.
+//!
+//! https://github.com/phase-rs/phase/issues/3876
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const GADRAK_ORACLE: &str = "Flying\nGadrak can't attack unless you control four or more artifacts.\nAt the beginning of your end step, create a Treasure token for each nontoken creature that died this turn. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")";
+
+const MURDER_ORACLE: &str = "Destroy target creature.";
+
+fn treasure_count(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| {
+            o.controller == P0
+                && o.zone == Zone::Battlefield
+                && o.is_token
+                && o.name == "Treasure"
+        })
+        .count()
+}
+
+#[test]
+fn gadrak_creates_treasure_per_nontoken_creature_died() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "Gadrak, the Crown-Scourge", 5, 4, GADRAK_ORACLE)
+        .id();
+    let doomed = scenario.add_creature(P0, "Doomed", 1, 1).id();
+    let murder = scenario
+        .add_spell_to_hand_from_oracle(P0, "Murder", false, MURDER_ORACLE)
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..3)
+            .map(|_| ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    runner.cast(murder).target_objects(&[doomed]).resolve();
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        treasure_count(&runner),
+        1,
+        "one nontoken creature died → one Treasure at end step"
+    );
+}
+
+#[test]
+fn gadrak_creates_no_treasure_when_nothing_died() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "Gadrak, the Crown-Scourge", 5, 4, GADRAK_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        treasure_count(&runner),
+        0,
+        "no deaths this turn → no Treasures"
+    );
+}

--- a/crates/engine/tests/integration/issue_3876_gadrak_treasure_count.rs
+++ b/crates/engine/tests/integration/issue_3876_gadrak_treasure_count.rs
@@ -19,10 +19,7 @@ fn treasure_count(runner: &engine::game::scenario::GameRunner) -> usize {
         .objects
         .values()
         .filter(|o| {
-            o.controller == P0
-                && o.zone == Zone::Battlefield
-                && o.is_token
-                && o.name == "Treasure"
+            o.controller == P0 && o.zone == Zone::Battlefield && o.is_token && o.name == "Treasure"
         })
         .count()
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -307,6 +307,7 @@ mod issue_3654_nyxbloom_mana_reflection;
 mod issue_3660_paradigm_multiple_offers;
 mod issue_3665_smugglers_share;
 mod issue_3681_inferno_titan_divided_damage;
+mod issue_3876_gadrak_treasure_count;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary
- Parse `nontoken creature(s) that died this turn` into a `ZoneChangeCountThisTurn` filter with `NonToken`.
- Add integration regressions for zero vs one Treasure at end step.

## Test plan
- [x] `cargo test -p engine --lib parse_nontoken_creature_died`
- [x] `cargo test -p engine --test integration gadrak`
- [ ] CI

Fixes https://github.com/phase-rs/phase/issues/3876

Made with [Cursor](https://cursor.com)