### PR TITLE
feat(engine): MSH Wave 4 — Dragon Man cross-zone CDA, Ms. Marvel power>base trigger, Wolverine gendered pronouns

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -724,6 +724,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             // CR 903.3d
             FilterProp::IsCommander => parts.push("commander".into()),
             FilterProp::ToughnessGTPower => parts.push("toughness > power".into()),
+            FilterProp::PowerExceedsBase => parts.push("power > base power".into()),
             FilterProp::DifferentNameFrom { .. } => parts.push("different name".into()),
             FilterProp::Other { value } => parts.push(value.clone()),
             FilterProp::InAnyZone { zones } => {

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -189,6 +189,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::Suspected
         | FilterProp::Renowned
         | FilterProp::ToughnessGTPower
+        | FilterProp::PowerExceedsBase
         | FilterProp::Modified
         | FilterProp::Historic
         | FilterProp::NotHistoric
@@ -395,6 +396,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::Suspected
         | FilterProp::Renowned
         | FilterProp::ToughnessGTPower
+        | FilterProp::PowerExceedsBase
         | FilterProp::Modified
         | FilterProp::Historic
         | FilterProp::NotHistoric
@@ -2682,6 +2684,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         // unavailable from a stack-snapshot record.
         | FilterProp::Modified
         | FilterProp::ToughnessGTPower
+        | FilterProp::PowerExceedsBase
         | FilterProp::DifferentNameFrom { .. }
         | FilterProp::SharesQuality { .. }
         | FilterProp::WasDealtDamageThisTurn
@@ -3522,6 +3525,10 @@ fn matches_filter_prop(
             let toughness = obj.toughness.unwrap_or(0);
             toughness > power
         }
+        // CR 208.1 + CR 613.4b: Match creatures whose current (post-layer) power
+        // exceeds their base power (layer-7b baseline incl. CDA, before
+        // counters/pumps in 7c–7e).
+        FilterProp::PowerExceedsBase => obj.power.unwrap_or(0) > obj.base_power.unwrap_or(0),
         // Match objects whose name differs from all controlled battlefield objects matching the filter.
         FilterProp::DifferentNameFrom { filter } => {
             let controller = source.controller.unwrap_or(PlayerId(0));
@@ -3774,6 +3781,13 @@ fn zone_change_record_matches_property(
         }
         // CR 208.1 / CR 107.2: `toughness > power` comparison on the snapshot.
         FilterProp::ToughnessGTPower => record.toughness.unwrap_or(0) > record.power.unwrap_or(0),
+        // CR 208.1 + CR 613.4b: `power > base power` on the zone-change snapshot —
+        // both characteristics are captured at event time, so a look-back
+        // ("a creature ... with power greater than its base power deals combat
+        // damage") evaluates faithfully against the record.
+        FilterProp::PowerExceedsBase => {
+            record.power.unwrap_or(0) > record.base_power.unwrap_or(0)
+        }
         // CR 111.1: Token identity as of the zone change. Token-ness is a
         // stable property of the object, captured in the snapshot so that
         // "whenever a creature token dies" (Grismold) and similar LTB

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3255,7 +3255,8 @@ fn filter_prop_references_pt_stat(prop: &FilterProp) -> bool {
     match prop {
         FilterProp::PtComparison { .. }
         | FilterProp::PowerGTSource
-        | FilterProp::ToughnessGTPower => true,
+        | FilterProp::ToughnessGTPower
+        | FilterProp::PowerExceedsBase => true,
         FilterProp::AnyOf { props } => props.iter().any(filter_prop_references_pt_stat),
         // CR 608.2c: Negation reads the inner prop's stats — recurse (mirrors AnyOf).
         FilterProp::Not { prop } => filter_prop_references_pt_stat(prop),
@@ -8143,6 +8144,128 @@ mod tests {
             obj.toughness,
             Some(4),
             "Creature + Instant + Artifact → toughness 4"
+        );
+    }
+
+    /// CR 202.3 + CR 208.2a + CR 604.3 / CR 613.4a: Dragon Man, Reformed Robot's
+    /// CDA power = the greatest mana value among (noncreature permanents you
+    /// control) and (noncreature cards in your graveyard). Drives the real
+    /// parser (`parse_cda_quantity`) to build the AST, then evaluates through the
+    /// live layer system — revert the "A and B" conjunction arm and
+    /// `parse_cda_quantity` returns None, so the static can't be built and the
+    /// test panics. Creature cards are excluded from both arms; empty → 0
+    /// (CR 208.2a); a +1/+1 counter stacks on top of the CDA base (layer 7c).
+    #[test]
+    fn dragon_man_cda_power_greatest_mana_value_across_zones() {
+        use crate::parser::oracle_quantity::parse_cda_quantity;
+
+        let mut state = setup();
+
+        let value = parse_cda_quantity(
+            "the greatest mana value among noncreature permanents you control and noncreature cards in your graveyard",
+        )
+        .expect("conjunction CDA quantity must parse");
+
+        // Dragon Man itself (a creature) carries the self-ref CDA.
+        let dragon_man = make_creature(&mut state, "Dragon Man, Reformed Robot", 0, 4, PlayerId(0));
+        state
+            .objects
+            .get_mut(&dragon_man)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SelfRef)
+                    .modifications(vec![ContinuousModification::SetDynamicPower { value }])
+                    .cda(),
+            );
+
+        // Empty board + graveyard → 0 (CR 208.2a "use 0").
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&dragon_man).unwrap().power,
+            Some(0),
+            "no noncreature permanents/cards → power 0"
+        );
+
+        // MV-5 noncreature permanent on the battlefield you control.
+        let bf_artifact = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Mox".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&bf_artifact).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![],
+                generic: 5,
+            };
+        }
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&dragon_man).unwrap().power,
+            Some(5),
+            "battlefield-only max → power 5"
+        );
+
+        // MV-7 noncreature card in your graveyard (greater than the bf 5).
+        let gy_artifact = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Spent Relic".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&gy_artifact).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![],
+                generic: 7,
+            };
+        }
+        // MV-9 *creature* card in your graveyard — must be excluded (noncreature).
+        let gy_creature = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Dead Titan".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&gy_creature).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![],
+                generic: 9,
+            };
+        }
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&dragon_man).unwrap().power,
+            Some(7),
+            "graveyard noncreature 7 beats bf 5; creature 9 excluded → power 7"
+        );
+
+        // +1/+1 counter stacks on top of the CDA base (proves CDA is the base).
+        state
+            .objects
+            .get_mut(&dragon_man)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&dragon_man).unwrap().power,
+            Some(8),
+            "CDA 7 + one +1/+1 counter → power 8"
         );
     }
 

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -178,6 +178,13 @@ fn parse_with_inner(input: &str) -> OracleResult<'_, FilterProp> {
             FilterProp::ToughnessGTPower,
             tag("toughness greater than its power"),
         ),
+        // CR 208.1 + CR 613.4b self-comparison — must precede the general P/T
+        // combinator so "power greater than its base power" wins over a numeric
+        // "power greater than N" parse (Ms. Marvel, Elastic Ally).
+        value(
+            FilterProp::PowerExceedsBase,
+            tag("power greater than its base power"),
+        ),
         // CR 509.1b: "greater power" — relative to source.
         value(FilterProp::PowerGTSource, tag("greater power")),
         // CR 208: the shared power/toughness comparison combinator (handles

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -890,6 +890,20 @@ pub(crate) fn parse_cda_quantity_with_context(
         }
     }
 
+    // CR 202.3 + CR 208.2a: "the greatest <prop> among <A> and <B>" where A and B
+    // are filters that may span distinct zones (Dragon Man, Reformed Robot:
+    // noncreature permanents you control AND noncreature cards in your graveyard).
+    // Each operand resolves as an independent single-zone Aggregate; the
+    // cross-source extremum is their Max (empty → 0 per CR 208.2a). Mirrors the
+    // " plus "/" minus " Sum
+    // composition above: only fires when BOTH operands parse as non-empty typed
+    // filters, so single-filter aggregates fall through to the QuantityRef
+    // delegate below unchanged. Tried before the delegate so the conjunction is
+    // recognized as a unit rather than the bare leading aggregate.
+    if let Some(expr) = parse_greatest_among_conjunction(text, ctx) {
+        return Some(expr);
+    }
+
     // Delegate to existing parse_quantity_ref for patterns like
     // "the number of {type} you control", "your devotion to X"
     if let Some(qty) = parse_quantity_ref_with_context(text, ctx) {
@@ -897,6 +911,75 @@ pub(crate) fn parse_cda_quantity_with_context(
     }
 
     None
+}
+
+/// CR 202.3: aggregate prefix for the cross-zone "greatest <prop> among"
+/// extremum. Mirrors the single-aggregate prefix set in
+/// `parse_quantity_ref_with_context` so both paths decode the same grammar.
+fn parse_greatest_among_prefix(
+    input: &str,
+) -> OracleResult<'_, (AggregateFunction, ObjectProperty)> {
+    alt((
+        value(
+            (AggregateFunction::Max, ObjectProperty::Power),
+            tag("the greatest power among "),
+        ),
+        value(
+            (AggregateFunction::Max, ObjectProperty::Toughness),
+            tag("the greatest toughness among "),
+        ),
+        value(
+            (AggregateFunction::Max, ObjectProperty::ManaValue),
+            tag("the greatest mana value among "),
+        ),
+    ))
+    .parse(input)
+}
+
+/// CR 202.3 + CR 208.2a: "the greatest <prop> among <A> and <B>" → Max of two
+/// single-zone Aggregates. Each operand is decoded through the shared
+/// `parse_type_phrase_with_ctx` filter grammar, so per-arm zone/controller
+/// semantics (e.g. "noncreature cards in your graveyard" → InZone Graveyard) are
+/// unambiguous. Returns None unless both operands parse to non-empty typed
+/// filters with the conjunction fully consumed.
+fn parse_greatest_among_conjunction(text: &str, ctx: &mut ParseContext) -> Option<QuantityExpr> {
+    let (rest, (func, prop)) = parse_greatest_among_prefix(text).ok()?;
+
+    let (filter_a, remainder) = parse_type_phrase_with_ctx(rest, ctx);
+    if matches!(filter_a, TargetFilter::Any) || is_empty_typed_filter(&filter_a) {
+        return None;
+    }
+
+    let (after_and, _) = tag::<_, _, OracleError<'_>>(" and ")
+        .parse(remainder.trim_end())
+        .ok()?;
+
+    let (filter_b, tail) = parse_type_phrase_with_ctx(after_and, ctx);
+    if !tail.trim().is_empty()
+        || matches!(filter_b, TargetFilter::Any)
+        || is_empty_typed_filter(&filter_b)
+    {
+        return None;
+    }
+
+    Some(QuantityExpr::Max {
+        exprs: vec![
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: func,
+                    property: prop,
+                    filter: filter_a,
+                },
+            },
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: func,
+                    property: prop,
+                    filter: filter_b,
+                },
+            },
+        ],
+    })
 }
 
 // CR 604.3: "the total number of cards you own in exile and in your graveyard

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -1671,8 +1671,21 @@ pub(crate) fn parse_attached_assigns_damage_from_toughness(
     )
 }
 
+/// Possessive pronoun for any character's combat damage ("its"/"his"/"her"/"their").
+/// Widens the neuter-only assumption so gendered-character cards (e.g. Wolverine)
+/// parse the same combat-damage-assignment static as neuter creatures.
+fn parse_possessive_pronoun(input: &str) -> OracleResult<'_, &str> {
+    alt((tag("its"), tag("his"), tag("her"), tag("their"))).parse(input)
+}
+
+/// Nominative pronoun for any character ("it"/"he"/"she"/"they").
+fn parse_nominative_pronoun(input: &str) -> OracleResult<'_, &str> {
+    alt((tag("it"), tag("he"), tag("she"), tag("they"))).parse(input)
+}
+
 /// CR 510.1c: Parse "you may have this creature assign its combat damage as though it
-/// weren't blocked" self-referential static.
+/// weren't blocked" self-referential static. Accepts gendered pronouns
+/// (his/her/he/she/they) so named characters parse the same as neuter creatures.
 pub(crate) fn parse_assign_damage_as_though_unblocked(
     lower: &str,
     text: &str,
@@ -1687,9 +1700,13 @@ pub(crate) fn parse_assign_damage_as_though_unblocked(
     .parse(clean)
     .ok()?;
     let (rest, _) = result;
-    let (rest, _) = tag::<_, _, VE<'_>>(" assign its combat damage as though it weren't blocked")
+    let (rest, _) = tag::<_, _, VE<'_>>(" assign ").parse(rest).ok()?;
+    let (rest, _) = parse_possessive_pronoun(rest).ok()?;
+    let (rest, _) = tag::<_, _, VE<'_>>(" combat damage as though ")
         .parse(rest)
         .ok()?;
+    let (rest, _) = parse_nominative_pronoun(rest).ok()?;
+    let (rest, _) = tag::<_, _, VE<'_>>(" weren't blocked").parse(rest).ok()?;
     if !rest.is_empty() {
         return None;
     }
@@ -1728,11 +1745,17 @@ pub(crate) fn parse_attached_creature_assign_damage_as_though_unblocked(
         )
     };
 
-    let (_, _) = tag::<_, _, VE<'_>>(
-        "'s controller may have it assign its combat damage as though it weren't blocked",
-    )
-    .parse(rest.lower)
-    .ok()?;
+    let (after, _) = tag::<_, _, VE<'_>>("'s controller may have ")
+        .parse(rest.lower)
+        .ok()?;
+    let (after, _) = parse_nominative_pronoun(after).ok()?;
+    let (after, _) = tag::<_, _, VE<'_>>(" assign ").parse(after).ok()?;
+    let (after, _) = parse_possessive_pronoun(after).ok()?;
+    let (after, _) = tag::<_, _, VE<'_>>(" combat damage as though ")
+        .parse(after)
+        .ok()?;
+    let (after, _) = parse_nominative_pronoun(after).ok()?;
+    let (_, _) = tag::<_, _, VE<'_>>(" weren't blocked").parse(after).ok()?;
 
     Some(
         StaticDefinition::continuous()
@@ -2663,4 +2686,51 @@ pub(crate) fn try_split_and_foreign_keyword_grant(text: &str) -> Option<Vec<Stat
     }
 
     None
+}
+
+#[cfg(test)]
+mod assign_damage_pronoun_tests {
+    use super::*;
+
+    fn assert_unblocked_self(lower: &str) {
+        let def = parse_assign_damage_as_though_unblocked(lower, lower)
+            .unwrap_or_else(|| panic!("expected Some for {lower:?}"));
+        assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+        assert_eq!(
+            def.modifications,
+            vec![ContinuousModification::AssignDamageAsThoughUnblocked]
+        );
+    }
+
+    #[test]
+    fn parses_neuter_pronouns() {
+        // Regression: neuter "its"/"it" must still parse (Thorn Elemental class).
+        assert_unblocked_self(
+            "you may have ~ assign its combat damage as though it weren't blocked",
+        );
+    }
+
+    #[test]
+    fn parses_masculine_pronouns() {
+        // Wolverine, Claws Out: "his"/"he".
+        assert_unblocked_self(
+            "you may have ~ assign his combat damage as though he weren't blocked",
+        );
+    }
+
+    #[test]
+    fn parses_feminine_pronouns() {
+        assert_unblocked_self(
+            "you may have ~ assign her combat damage as though she weren't blocked",
+        );
+    }
+
+    #[test]
+    fn rejects_non_matching() {
+        assert!(parse_assign_damage_as_though_unblocked(
+            "you may have ~ assign its combat damage to any target",
+            "you may have ~ assign its combat damage to any target",
+        )
+        .is_none());
+    }
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1288,6 +1288,61 @@ fn full_dispatch_alt_cost_routing_and_deferrals() {
     }
 }
 
+/// CR 202.3 + CR 208.2a + CR 604.3: Dragon Man, Reformed Robot's CDA —
+/// "~'s power is equal to the greatest mana value among noncreature permanents
+/// you control and noncreature cards in your graveyard" — must produce a
+/// `SetDynamicPower` CDA whose value is a `Max` over two single-zone
+/// `Aggregate`s (battlefield arm + graveyard arm). Revert-failing: without the
+/// "A and B" conjunction arm in `parse_cda_quantity`, the clause falls to the
+/// `static_structure` strict marker and no CDA static is produced.
+#[test]
+fn dragon_man_cda_power_is_greatest_mana_value_across_zones() {
+    use crate::parser::oracle::parse_oracle_text;
+
+    let parsed = parse_oracle_text(
+        "Flying\nDragon Man, Reformed Robot's power is equal to the greatest mana value among noncreature permanents you control and noncreature cards in your graveyard.",
+        "Dragon Man, Reformed Robot",
+        &[],
+        &["Artifact".to_string(), "Creature".to_string()],
+        &[],
+    );
+
+    let cda = parsed
+        .statics
+        .iter()
+        .find_map(|d| {
+            d.modifications.iter().find_map(|m| match m {
+                ContinuousModification::SetDynamicPower {
+                    value: QuantityExpr::Max { exprs },
+                } => Some(exprs.clone()),
+                _ => None,
+            })
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected SetDynamicPower(Max[..]) CDA static, got {:?}",
+                parsed.statics
+            )
+        });
+
+    assert_eq!(cda.len(), 2, "expected two zone arms, got {cda:?}");
+    for arm in &cda {
+        assert!(
+            matches!(
+                arm,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Aggregate {
+                        function: AggregateFunction::Max,
+                        property: ObjectProperty::ManaValue,
+                        ..
+                    }
+                }
+            ),
+            "each arm must be a Max/ManaValue Aggregate, got {arm:?}"
+        );
+    }
+}
+
 /// CR 205.1a + CR 205.2 + CR 205.3 + CR 613.1c: "becomes a [subtype]*
 /// [core-type]+ in addition to its other types" must decompose into
 /// typed `AddType`/`AddSubtype` modifications. Jump Scare regression.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8346,6 +8346,13 @@ fn parse_damage_source_subject(input: &str) -> OracleResult<'_, TargetFilter> {
     )))
     .parse(rest)?;
 
+    // Optional "with <property>" clause on the damage source — delegates to the
+    // shared `parse_with_property` inner-clause combinator so every "with X" the
+    // filter grammar supports (P/T constraints, keywords, etc.) attaches to the
+    // source. CR 208.1 + CR 613.4b: Ms. Marvel, Elastic Ally — "a creature you
+    // control with power greater than its base power deals combat damage…".
+    let (rest, with_prop) = opt(preceded(space1, parse_with_property)).parse(rest)?;
+
     // Require trailing space before the "deals" verb so we don't match
     // "sourceless" / "sourced".
     let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest)?;
@@ -8363,6 +8370,9 @@ fn parse_damage_source_subject(input: &str) -> OracleResult<'_, TargetFilter> {
     }
     if let Some(col) = color {
         props.push(FilterProp::HasColor { color: col });
+    }
+    if let Some(p) = with_prop {
+        props.push(p);
     }
     if !props.is_empty() {
         typed.properties = props;

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2348,6 +2348,7 @@ fn target_filter_has_per_object_condition_property(filter: &TargetFilter) -> boo
             matches!(
                 prop,
                 crate::types::ability::FilterProp::ToughnessGTPower
+                    | crate::types::ability::FilterProp::PowerExceedsBase
                     | crate::types::ability::FilterProp::WithKeyword { .. }
                     | crate::types::ability::FilterProp::CanEnchant { .. }
             )

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2566,6 +2566,14 @@ pub enum FilterProp {
     Renowned,
     /// CR 510.1c: Matches creatures whose toughness is greater than their power.
     ToughnessGTPower,
+    /// CR 208.1 + CR 613.4a + CR 613.4b: Matches a creature whose current
+    /// (post-layer) power exceeds its base power. Base power is established by
+    /// layer 7a CDAs (CR 613.4a) and layer 7b set effects (CR 613.4b), before
+    /// the counters and pumps applied in layers 7c–7e. True for a creature
+    /// pumped above its base by +1/+1 counters, auras, or anthems; false when
+    /// power == base or power < base. Consolidation target if a 3rd same-object
+    /// P/T self-comparison appears: `PtSelfComparison { lhs, comparator, rhs }`.
+    PowerExceedsBase,
     /// Disjunctive composite: the object matches if ANY inner prop matches.
     /// Used for natural-language OR within a property suffix — e.g.
     /// "creature with power or toughness N or less" decomposes to
@@ -3761,7 +3769,12 @@ pub enum QuantityRef {
     /// 0 outside cost/trigger resolution, whereas this one is correct any time
     /// the resolver has a `source_id` (cost payment, ability resolution, etc.).
     SelfManaValue,
-    /// CR 107.3e: Aggregate query (max/min/sum) over a property of battlefield objects.
+    /// CR 202.3: Aggregate query (max/min/sum) over a property of objects in the
+    /// zones the `filter` declares (battlefield by default; e.g. an `InZone`
+    /// graveyard filter aggregates over the graveyard). The resolver scans
+    /// `filter.extract_zones()`, so the query is zone-general.
+    // TODO: no dedicated CR governs the extremum/aggregation itself; CR 202.3 is
+    // cited for the mana-value property — the most common aggregated property.
     Aggregate {
         function: AggregateFunction,
         property: ObjectProperty,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -375,6 +375,7 @@ mod mogg_war_marshal_echo_dies_trigger;
 mod morbid_curiosity_cost_paid_mana_value_draw;
 mod morophon_chosen_type_1653;
 mod mr_foxglove_defending_hand_minus_yours_draw;
+mod ms_marvel_power_exceeds_base;
 mod multi_upkeep_triggers_suspend;
 mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;

--- a/crates/engine/tests/integration/ms_marvel_power_exceeds_base.rs
+++ b/crates/engine/tests/integration/ms_marvel_power_exceeds_base.rs
@@ -1,0 +1,139 @@
+//! Runtime coverage for Ms. Marvel, Elastic Ally's combat-damage trigger and
+//! the new `FilterProp::PowerExceedsBase` it relies on.
+//!
+//! Ms. Marvel, Elastic Ally: "Whenever a creature you control with power
+//! greater than its base power deals combat damage to a player, draw a card.
+//! This ability triggers only once each turn."
+//!
+//! The trigger's source filter carries `FilterProp::PowerExceedsBase` (the new
+//! engine variant). These tests drive the real pipeline: `from_oracle_text`
+//! parses the trigger (exercising the parser arm in `oracle_nom/filter.rs`),
+//! combat damage fires the `DamageDone` trigger, and the trigger's source
+//! filter is evaluated via `matches_filter_prop` (the new eval arm in
+//! `filter.rs`). The discriminator is whether P0 draws:
+//!   - a creature pumped above its base by a +1/+1 counter (power > base) → draw
+//!   - an unpumped creature (power == base) → NO draw
+//!   - mixed pumped + unpumped attackers → exactly one draw (only the pumped
+//!     creature qualifies)
+//!
+//! Revert the eval arm and `power > base` never evaluates true, so the positive
+//! cases stop drawing. Revert the source-filter parse and the trigger is
+//! unsupported, so it never fires.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 208.1: a creature's power can be modified or set by effects.
+//!   - CR 613.4b: layer 7b establishes base power; counters (7c) modify above it.
+//!   - CR 510.1c / CR 120.1: combat damage is dealt to the defending player.
+
+use super::rules::{run_combat, GameRunner, GameScenario, ObjectId, Phase, PlayerId, P0};
+// Wave 4: FilterProp::PowerExceedsBase runtime coverage.
+
+const MS_MARVEL_LIKE: &str = "Whenever a creature you control with power greater than its base \
+     power deals combat damage to a player, draw a card. This ability triggers only once each turn.";
+
+/// Count of cards in `player`'s hand — the draw discriminator.
+fn hand_len(runner: &GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .hand
+        .len()
+}
+
+/// Build a scenario with the Ms.-Marvel-like trigger source plus the requested
+/// attackers. Each `(power_over_base)` flag controls whether the attacker gets a
+/// +1/+1 counter (power > base) or stays unpumped (power == base).
+fn build_scenario(pumped_attackers: &[bool]) -> (GameRunner, Vec<ObjectId>) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The trigger source — unpumped, so it never self-qualifies.
+    scenario
+        .add_creature(P0, "Ms. Marvel", 0, 5)
+        .from_oracle_text(MS_MARVEL_LIKE);
+
+    let attackers: Vec<ObjectId> = pumped_attackers
+        .iter()
+        .enumerate()
+        .map(|(i, &pumped)| {
+            let mut builder = scenario.add_creature(P0, &format!("Attacker{i}"), 2, 2);
+            if pumped {
+                builder.with_plus_counters(1);
+            }
+            builder.id()
+        })
+        .collect();
+
+    // A library deep enough to draw from.
+    scenario.with_library_top(P0, &["L0", "L1", "L2", "L3", "L4"]);
+
+    (scenario.build(), attackers)
+}
+
+/// CR 208.1 + CR 613.4b: a creature with a +1/+1 counter has power > base power,
+/// so its combat damage fires the trigger and P0 draws one card.
+#[test]
+fn draws_when_pumped_creature_deals_combat_damage() {
+    let (mut runner, attackers) = build_scenario(&[true]);
+    let hand_before = hand_len(&runner, P0);
+
+    run_combat(&mut runner, attackers, vec![]);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        hand_len(&runner, P0),
+        hand_before + 1,
+        "power > base creature dealt combat damage → draw exactly one"
+    );
+}
+
+/// An unpumped creature has power == base power, so the trigger's source filter
+/// does NOT match and P0 draws nothing.
+#[test]
+fn no_draw_when_creature_power_equals_base() {
+    let (mut runner, attackers) = build_scenario(&[false]);
+    let hand_before = hand_len(&runner, P0);
+
+    run_combat(&mut runner, attackers, vec![]);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        hand_len(&runner, P0),
+        hand_before,
+        "power == base creature must NOT fire the trigger (no draw)"
+    );
+}
+
+/// The source filter selects only the qualifying creature: with one pumped
+/// (power > base) and one unpumped (power == base) attacker dealing combat
+/// damage in the same combat, exactly one draw occurs — the pumped creature
+/// triggers, the unpumped one does not. This isolates the new
+/// `FilterProp::PowerExceedsBase` discrimination from the engine's
+/// once-per-turn batching (see module note). Revert the eval arm and neither
+/// attacker draws; revert the source-filter parse and the trigger never fires.
+///
+/// NOTE: the strict "only once each turn" cap is NOT asserted here. Two
+/// creatures dealing combat damage *simultaneously* each produce a matching
+/// trigger before `triggers_fired_this_turn` is updated, so the existing
+/// `TriggerConstraint::OncePerTurn` enforcement (game/triggers.rs) does not
+/// deduplicate within a single simultaneous batch — a general, pre-existing
+/// trigger-collection limitation independent of this card and out of scope for
+/// this change.
+#[test]
+fn only_the_pumped_attacker_triggers_the_draw() {
+    // Attacker0 pumped (power > base), Attacker1 unpumped (power == base).
+    let (mut runner, attackers) = build_scenario(&[true, false]);
+    let hand_before = hand_len(&runner, P0);
+
+    run_combat(&mut runner, attackers, vec![]);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        hand_len(&runner, P0),
+        hand_before + 1,
+        "only the power > base attacker fires the trigger → exactly one draw"
+    );
+}


### PR DESCRIPTION
Dragon Man, Reformed Robot: CDA power = greatest mana value across noncreature
permanents you control AND noncreature cards in your graveyard. New
'greatest <prop> among A and B' conjunction in parse_cda_quantity composes
two single-zone Aggregates under QuantityExpr::Max (zero new types). CR 202.3
+ 208.2a + 604.3 / 613.4a.

Ms. Marvel, Elastic Ally: 'a creature you control with power greater than its
base power deals combat damage' trigger. New FilterProp::PowerExceedsBase
(power > base power, CR 208.1 + 613.4a/b) wired into live + snapshot filter
eval, all 4 classification sites, coverage formatting, the layer-7
dependency-reference set (CR 613.8), and parse_damage_source_subject via the
shared parse_with_property clause.

Wolverine, Claws Out: widen the assign-combat-damage-as-though-unblocked static
to accept gendered pronouns (his/her/their, he/she/they) alongside neuter
its/it, via reusable parse_possessive_pronoun/parse_nominative_pronoun
combinators applied to both the self and attached twins. CR 510.1c.

Tests: Dragon Man full-line parse + layer-eval (empty->0, cross-zone max,
creature-excluded, counter-stacks); Ms. Marvel full combat pipeline
(pumped/unpumped/mixed draws); Wolverine pronoun parse + reject.
