### PR TITLE
fix(engine): redirect countered spell to library/hand instead of graveyard (Memory Lapse, Remand, Spell Crumple)

### DIFF
--- a/crates/engine/src/database/forge/effect.rs
+++ b/crates/engine/src/database/forge/effect.rs
@@ -509,6 +509,8 @@ fn translate_counter(params: &ForgeParams) -> Result<Effect, ForgeTranslateError
     Ok(Effect::Counter {
         target,
         source_rider: None,
+        // CR 701.6a: Forge import uses the default graveyard destination.
+        countered_spell_zone: None,
     })
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -20692,6 +20692,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::StackSpell,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(opposing_bolt)],
             spell_id,
@@ -20741,6 +20742,7 @@ mod tests {
                     kind: None,
                 },
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(stack_ability_id)],
             spell_id,
@@ -32012,6 +32014,7 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::Typed(crate::types::ability::TypedFilter::card()),
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
             ));
             obj.mana_cost = ManaCost::Cost {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -12332,6 +12332,7 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
                 Vec::new(),
                 source_id,
@@ -12457,6 +12458,7 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
                 Vec::new(),
                 source_id,
@@ -12551,6 +12553,7 @@ mod tests {
                 Effect::Counter {
                     target: crate::types::ability::TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
                 Vec::new(),
                 source_id,
@@ -12634,6 +12637,7 @@ mod tests {
                 Effect::Counter {
                     target: crate::types::ability::TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
                 Vec::new(),
                 source_id,
@@ -12750,6 +12754,7 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
                 Vec::new(),
                 source_id,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -13,13 +13,13 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction,
     AdditionalCost, AggregateFunction, AttackScope, AttackSubject, CardTypeSetSource, ChoiceType,
     Comparator, ContinuousModification, ControllerRef, CountScope, CounterSourceRider,
-    DelayedTriggerCondition, DieRollModifier, DoublePTMode, Duration, Effect, EffectOutcomeSignal,
-    EffectScope, FilterProp, GameRestriction, ManaProduction, ObjectProperty, ObjectScope,
-    PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
-    ReplacementCondition, ReplacementDefinition, ReplacementMode, SeatDirection, SharedQuality,
-    SharedQualityRelation, SpeedDelta, SpellCastingOption, SpellCastingOptionKind, StaticCondition,
-    StaticDefinition, TapStateChange, TargetFilter, TriggerDefinition, TypeFilter, TypedFilter,
-    ZoneRef,
+    CounteredSpellDestination, DelayedTriggerCondition, DieRollModifier, DoublePTMode, Duration,
+    Effect, EffectOutcomeSignal, EffectScope, FilterProp, GameRestriction, LibraryPosition,
+    ManaProduction, ObjectProperty, ObjectScope, PlayerFilter, PlayerScope, PtStat, PtValue,
+    PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition,
+    ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation, SpeedDelta,
+    SpellCastingOption, SpellCastingOptionKind, StaticCondition, StaticDefinition, TapStateChange,
+    TargetFilter, TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
@@ -2048,7 +2048,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::Counter {
             target,
             source_rider,
-            ..
+            countered_spell_zone,
         } => {
             d.push(("target".into(), fmt_target(target)));
             match source_rider {
@@ -2057,6 +2057,22 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 }
                 Some(CounterSourceRider::Destroy) => {
                     d.push(("+ destroy".into(), "source".into()));
+                }
+                None => {}
+            }
+            // CR 701.6a + CR 614.1a: countered-spell destination redirect.
+            match countered_spell_zone {
+                Some(CounteredSpellDestination::Library {
+                    position: LibraryPosition::Top,
+                }) => d.push(("redirect".into(), "library top".into())),
+                Some(CounteredSpellDestination::Library {
+                    position: LibraryPosition::Bottom,
+                }) => d.push(("redirect".into(), "library bottom".into())),
+                Some(CounteredSpellDestination::Library {
+                    position: LibraryPosition::NthFromTop { n },
+                }) => d.push(("redirect".into(), format!("library #{n} from top"))),
+                Some(CounteredSpellDestination::Hand) => {
+                    d.push(("redirect".into(), "hand".into()))
                 }
                 None => {}
             }

--- a/crates/engine/src/game/effects/counter.rs
+++ b/crates/engine/src/game/effects/counter.rs
@@ -3,8 +3,8 @@ use crate::game::static_abilities::{check_static_ability, StaticCheckContext};
 use crate::game::targeting;
 use crate::game::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 use crate::types::ability::{
-    CounterSourceRider, Duration, Effect, EffectError, EffectKind, ResolvedAbility,
-    StaticDefinition, TargetFilter, TargetRef,
+    CounterSourceRider, CounteredSpellDestination, Duration, Effect, EffectError, EffectKind,
+    ResolvedAbility, StaticDefinition, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{CastingVariant, GameState, StackEntryKind};
@@ -38,6 +38,18 @@ pub fn resolve(
 ) -> Result<(), EffectError> {
     let source_rider = match &ability.effect {
         Effect::Counter { source_rider, .. } => source_rider.clone(),
+        _ => None,
+    };
+
+    // CR 701.6a + CR 614.1a: "if that spell is countered this way, put it
+    // <zone> instead of into that player's graveyard" — a destination redirect
+    // on the countered *spell* (Memory Lapse, Remand, Spell Crumple). `None`
+    // keeps the default CR 701.6a graveyard rule.
+    let countered_spell_zone = match &ability.effect {
+        Effect::Counter {
+            countered_spell_zone,
+            ..
+        } => countered_spell_zone.clone(),
         _ => None,
     };
 
@@ -152,10 +164,25 @@ pub fn resolve(
                         .sub_ability
                         .as_deref()
                         .is_some_and(super::cast_from_zone::is_graveyard_exile_rider_subability);
+                    // CR 701.6a + CR 614.1a: choose the countered spell's
+                    // destination. Exile precedence (alt-cost keyword exile-on-
+                    // stack-exit, or the graveyard-exile sub-ability rider) wins
+                    // over the library/hand redirect, which itself wins over the
+                    // default graveyard rule. `library_position` carries the
+                    // top/bottom placement so the pipeline routes through
+                    // `move_to_library_at_index` (no auto-shuffle).
+                    let mut library_position = None;
                     let dest = if exiles_on_counter || exile_instead_of_graveyard_on_counter {
                         Zone::Exile
                     } else {
-                        Zone::Graveyard
+                        match &countered_spell_zone {
+                            Some(CounteredSpellDestination::Hand) => Zone::Hand,
+                            Some(CounteredSpellDestination::Library { position }) => {
+                                library_position = Some(position.clone());
+                                Zone::Library
+                            }
+                            None => Zone::Graveyard,
+                        }
                     };
                     if casting_variant.restores_front_face_after_stack_exit() {
                         super::super::stack::restore_alternative_spell_normal_face(state, obj_id);
@@ -172,7 +199,13 @@ pub fn resolve(
                     // `replace_event` NeedsChoice arm); the spell is already off
                     // the stack (countered), so bail before `EffectResolved` and
                     // let the replacement-choice resume path deliver it.
-                    let req = ZoneMoveRequest::effect(obj_id, dest, ability.source_id);
+                    let mut req = ZoneMoveRequest::effect(obj_id, dest, ability.source_id);
+                    if let Some(position) = library_position {
+                        // CR 701.6a + CR 614.1a: place at the named library
+                        // position (Memory Lapse top / Spell Crumple bottom)
+                        // rather than shuffling in.
+                        req = req.at_library_position(position);
+                    }
                     match zone_pipeline::move_object(state, req, events) {
                         ZoneMoveResult::Done => {}
                         ZoneMoveResult::NeedsChoice(_)
@@ -496,6 +529,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -551,6 +585,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -598,6 +633,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -656,6 +692,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -704,6 +741,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -781,6 +819,7 @@ mod tests {
                 source_rider: Some(CounterSourceRider::LosesAbilities {
                     static_def: Box::new(source_static),
                 }),
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(ability_on_stack)],
             tidebinder,
@@ -861,6 +900,7 @@ mod tests {
                 source_rider: Some(CounterSourceRider::LosesAbilities {
                     static_def: Box::new(source_static),
                 }),
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(spell_id)],
             tidebinder,
@@ -935,6 +975,7 @@ mod tests {
                     kind: None,
                 },
                 source_rider: Some(CounterSourceRider::Destroy),
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(ability_on_stack)],
             counter_source,
@@ -1018,6 +1059,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: Some(CounterSourceRider::Destroy),
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(spell_id)],
             counter_source,
@@ -1071,6 +1113,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -1114,6 +1157,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -1169,6 +1213,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -9274,6 +9274,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::StackSpell,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(spell)],
             ObjectId(100),
@@ -15511,6 +15512,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(ObjectId(7))],
             ObjectId(99),
@@ -15525,6 +15527,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(ObjectId(8))],
             ObjectId(99),

--- a/crates/engine/src/game/effects/overload.rs
+++ b/crates/engine/src/game/effects/overload.rs
@@ -329,6 +329,7 @@ mod tests {
         let mut def = leaf(Effect::Counter {
             target: creature_filter(),
             source_rider: None,
+            countered_spell_zone: None,
         });
         transform_ability_def(&mut def);
         assert!(matches!(*def.effect, Effect::Counter { .. }));

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -11565,6 +11565,7 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::Typed(TypedFilter::card()),
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
             ));
             obj.mana_cost = ManaCost::Cost {

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -2850,6 +2850,7 @@ mod tests {
             source_rider: Some(CounterSourceRider::LosesAbilities {
                 static_def: Box::new(counter_static),
             }),
+            countered_spell_zone: None,
         };
         walk_effect(&counter, &mut names);
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1576,6 +1576,9 @@ fn collect_pending_triggers(
                                     let counter_effect = Effect::Counter {
                                         target: TargetFilter::TriggeringSource,
                                         source_rider: None,
+                                        // CR 701.6a: Ward's counter uses the
+                                        // default graveyard destination.
+                                        countered_spell_zone: None,
                                     };
                                     let mut ward_ability = ResolvedAbility::new(
                                         counter_effect,

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7905,6 +7905,10 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
                 Effect::Counter {
                     target,
                     source_rider,
+                    // CR 701.6a + CR 614.1a: the countered-spell redirect is a
+                    // continuation absorbed post-hoc (sequence.rs); the base
+                    // effect parses with the default graveyard destination.
+                    countered_spell_zone: None,
                 }
             };
             let mut clause = parsed_clause(effect);
@@ -8692,6 +8696,10 @@ pub(super) fn lower_zone_counter_ast(ast: ZoneCounterImperativeAst) -> Effect {
                 Effect::Counter {
                     target,
                     source_rider,
+                    // CR 701.6a + CR 614.1a: the countered-spell redirect is a
+                    // continuation absorbed post-hoc (sequence.rs); the base
+                    // effect parses with the default graveyard destination.
+                    countered_spell_zone: None,
                 }
             }
         }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -25501,6 +25501,176 @@ mod tests {
         );
     }
 
+    /// CR 701.6a + CR 614.1a: Memory Lapse — "put it on top of its owner's
+    /// library instead of into that player's graveyard" is absorbed into
+    /// `Effect::Counter.countered_spell_zone` as `Library { Top }`.
+    #[test]
+    fn memory_lapse_counter_spell_zone_redirect_library_top() {
+        use crate::types::ability::{CounteredSpellDestination, LibraryPosition};
+
+        let ability = parse_effect_chain(
+            "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            ability.sub_ability.is_none(),
+            "redirect should be absorbed, not chained: {:?}",
+            ability.sub_ability
+        );
+        let Effect::Counter {
+            countered_spell_zone,
+            ..
+        } = &*ability.effect
+        else {
+            panic!("expected Counter effect, got {:?}", ability.effect);
+        };
+        assert!(
+            matches!(
+                countered_spell_zone,
+                Some(CounteredSpellDestination::Library {
+                    position: LibraryPosition::Top
+                })
+            ),
+            "expected Library {{ Top }}, got {countered_spell_zone:?}"
+        );
+    }
+
+    /// CR 701.6a + CR 614.1a: Spell Crumple — "put it on the bottom of its
+    /// owner's library ..." → `Library { Bottom }`. (The trailing "Put Spell
+    /// Crumple on the bottom of its owner's library." is a separate sentence.)
+    #[test]
+    fn spell_crumple_counter_spell_zone_redirect_library_bottom() {
+        use crate::types::ability::{CounteredSpellDestination, LibraryPosition};
+
+        let result = crate::parser::parse_oracle_text(
+            "Counter target spell. If that spell is countered this way, put it on the bottom of its owner's library instead of into that player's graveyard. Put Spell Crumple on the bottom of its owner's library.",
+            "Spell Crumple",
+            &[],
+            &["Instant".to_string()],
+            &[],
+        );
+        let ability = &result.abilities[0];
+        let Effect::Counter {
+            countered_spell_zone,
+            ..
+        } = &*ability.effect
+        else {
+            panic!("expected Counter effect, got {:?}", ability.effect);
+        };
+        assert!(
+            matches!(
+                countered_spell_zone,
+                Some(CounteredSpellDestination::Library {
+                    position: LibraryPosition::Bottom
+                })
+            ),
+            "expected Library {{ Bottom }}, got {countered_spell_zone:?}"
+        );
+    }
+
+    /// CR 701.6a + CR 614.1a: Remand — "put it into its owner's hand ..." →
+    /// `Hand`, and the subsequent "Draw a card." still chains as a sibling.
+    #[test]
+    fn remand_counter_spell_zone_redirect_hand_and_draw_chains() {
+        use crate::types::ability::CounteredSpellDestination;
+
+        let result = crate::parser::parse_oracle_text(
+            "Counter target spell. If that spell is countered this way, put it into its owner's hand instead of into that player's graveyard.\nDraw a card.",
+            "Remand",
+            &[],
+            &["Instant".to_string()],
+            &[],
+        );
+        let ability = &result.abilities[0];
+        let Effect::Counter {
+            countered_spell_zone,
+            ..
+        } = &*ability.effect
+        else {
+            panic!("expected Counter effect, got {:?}", ability.effect);
+        };
+        assert!(
+            matches!(countered_spell_zone, Some(CounteredSpellDestination::Hand)),
+            "expected Hand, got {countered_spell_zone:?}"
+        );
+
+        // "Draw a card." must chain as a sibling — not be swallowed.
+        let draw = ability
+            .sub_ability
+            .as_deref()
+            .expect("Draw a card should chain after the counter redirect");
+        assert!(
+            matches!(&*draw.effect, Effect::Draw { .. }),
+            "expected chained Draw sibling, got {:?}",
+            draw.effect
+        );
+    }
+
+    /// NEGATIVE: Hinder — "put that card on your choice of the top or bottom ..."
+    /// is NOT supported (no fixed destination); the recognizer must return None
+    /// so the card is honestly gapped, not silently misparsed.
+    #[test]
+    fn hinder_counter_spell_zone_redirect_unsupported_is_none() {
+        let ability = parse_effect_chain(
+            "Counter target spell. If that spell is countered this way, put that card on your choice of the top or bottom of its owner's library instead of into that player's graveyard.",
+            AbilityKind::Spell,
+        );
+        let Effect::Counter {
+            countered_spell_zone,
+            ..
+        } = &*ability.effect
+        else {
+            panic!("expected Counter effect, got {:?}", ability.effect);
+        };
+        assert!(
+            countered_spell_zone.is_none(),
+            "Hinder's 'your choice of top or bottom' must not match the recognizer, got {countered_spell_zone:?}"
+        );
+    }
+
+    /// NEGATIVE: a plain "Counter target spell." has no redirect — the field
+    /// stays None.
+    #[test]
+    fn plain_counter_has_no_spell_zone_redirect() {
+        let ability = parse_effect_chain("Counter target spell.", AbilityKind::Spell);
+        let Effect::Counter {
+            countered_spell_zone,
+            source_rider,
+            ..
+        } = &*ability.effect
+        else {
+            panic!("expected Counter effect, got {:?}", ability.effect);
+        };
+        assert!(countered_spell_zone.is_none());
+        assert!(source_rider.is_none());
+    }
+
+    /// REGRESSION: an ability-counter source_rider card still absorbs its
+    /// source_rider with `countered_spell_zone` left None — the two riders do
+    /// not interfere.
+    #[test]
+    fn counter_source_rider_leaves_spell_zone_none() {
+        use crate::types::ability::CounterSourceRider;
+
+        let ability = parse_effect_chain(
+            "counter target spell or ability. If a permanent's ability is countered this way, destroy that permanent",
+            AbilityKind::Spell,
+        );
+        let Effect::Counter {
+            source_rider,
+            countered_spell_zone,
+            ..
+        } = &*ability.effect
+        else {
+            panic!("expected Counter effect, got {:?}", ability.effect);
+        };
+        assert!(matches!(source_rider, Some(CounterSourceRider::Destroy)));
+        assert!(
+            countered_spell_zone.is_none(),
+            "source_rider card must not set countered_spell_zone, got {countered_spell_zone:?}"
+        );
+    }
+
     #[test]
     fn effect_counter_unless_pays_parses_mana_cost() {
         use crate::types::mana::ManaCost;

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -17,10 +17,10 @@ use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_quantity::{parse_cda_quantity, parse_quantity_ref};
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, CastingPermission, Chooser, ContinuousModification,
-    ControllerRef, CopyRetargetPermission, CounterSourceRider, Duration, Effect, FaceDownBody,
-    FaceDownProfile, LibraryPosition, MultiTargetSpec, PermissionGrantee, PtValue, QuantityExpr,
-    QuantityRef, RevealUntilDisposition, StaticDefinition, TargetChoiceTiming, TargetFilter,
-    TypeFilter, TypedFilter,
+    ControllerRef, CopyRetargetPermission, CounterSourceRider, CounteredSpellDestination, Duration,
+    Effect, FaceDownBody, FaceDownProfile, LibraryPosition, MultiTargetSpec, PermissionGrantee,
+    PtValue, QuantityExpr, QuantityRef, RevealUntilDisposition, StaticDefinition,
+    TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
@@ -2228,6 +2228,51 @@ fn recognize_counter_destroy_rider(lower: &str) -> bool {
     .is_ok()
 }
 
+/// CR 701.6a + CR 614.1a: nom recognizer for the "if that spell is countered
+/// this way, put it <zone> instead of into that player's graveyard"
+/// continuation clause (Memory Lapse, Remand, Spell Crumple). Operates on
+/// lowercased text; tolerates a trailing period/whitespace. Returns the parsed
+/// [`CounteredSpellDestination`], or `None` for an unsupported destination
+/// (Hinder's "your choice of the top or bottom", Transcendent Dragon's "exile
+/// it instead") so those cards are honestly gapped rather than misparsed.
+///
+/// Composed from independent axes rather than enumerated as full strings:
+///   - spell anaphor ("that spell" / "that card" / "it").
+///   - destination ("on top of its owner's library" / "on the bottom of its
+///     owner's library" / "into its owner's hand").
+fn recognize_counter_spell_zone_redirect(lower: &str) -> Option<CounteredSpellDestination> {
+    let clause = lower.trim().trim_end_matches('.').trim_end();
+    let mut parser = (
+        tag::<_, _, OracleError<'_>>("if "),
+        alt((tag("that spell"), tag("that card"), tag("it"))),
+        tag(" is countered this way, put it "),
+        alt((
+            value(
+                CounteredSpellDestination::Library {
+                    position: LibraryPosition::Top,
+                },
+                tag("on top of its owner's library"),
+            ),
+            value(
+                CounteredSpellDestination::Library {
+                    position: LibraryPosition::Bottom,
+                },
+                tag("on the bottom of its owner's library"),
+            ),
+            value(
+                CounteredSpellDestination::Hand,
+                tag("into its owner's hand"),
+            ),
+        )),
+        tag(" instead of into that player's graveyard"),
+        eof,
+    );
+    parser
+        .parse(clause)
+        .ok()
+        .map(|(_, (_, _, _, destination, _, _))| destination)
+}
+
 /// CR 707.10c: nom parser for the "[you] may choose [a] new target[s] for
 /// {the,that} copy/copies" continuation clause that grants copy retargeting.
 pub(super) fn parse_copy_retarget_clause(input: &str) -> OracleResult<'_, ()> {
@@ -2435,6 +2480,21 @@ pub(super) fn apply_clause_continuation(
                 // CR 701.8: "If a permanent's ability is countered this way,
                 // destroy that permanent." rider (Teferi's Response, Green Slime).
                 *existing = Some(CounterSourceRider::Destroy);
+            }
+        }
+        ContinuationAst::CounterSpellZoneRedirect { destination } => {
+            let Some(previous) = defs.last_mut() else {
+                return;
+            };
+            if let Effect::Counter {
+                countered_spell_zone,
+                ..
+            } = &mut *previous.effect
+            {
+                // CR 701.6a + CR 614.1a: "put it <zone> instead of into that
+                // player's graveyard" redirect (Memory Lapse, Remand, Spell
+                // Crumple).
+                *countered_spell_zone = Some(destination);
             }
         }
         ContinuationAst::CopyMayRetarget => {
@@ -3221,7 +3281,8 @@ pub(super) fn continuation_absorbs_current(
         ContinuationAst::ManaRestriction { .. }
         | ContinuationAst::ManaGrant { .. }
         | ContinuationAst::CounterSourceStatic { .. }
-        | ContinuationAst::CounterSourceRiderDestroy => true,
+        | ContinuationAst::CounterSourceRiderDestroy
+        | ContinuationAst::CounterSpellZoneRedirect { .. } => true,
         // CR 707.10c: recognition was already gated on a preceding CopySpell in
         // parse_followup_continuation_ast, so absorption is unconditional —
         // identical to the CounterSourceStatic precedent.
@@ -4383,6 +4444,18 @@ pub(super) fn parse_followup_continuation_ast(
         // from emitting a stray chained `Destroy { ParentTarget }`.
         Effect::Counter { .. } if recognize_counter_destroy_rider(&lower) => {
             Some(ContinuationAst::CounterSourceRiderDestroy)
+        }
+        // CR 701.6a + CR 614.1a: "If that spell is countered this way, put it
+        // <zone> instead of into that player's graveyard." (Memory Lapse,
+        // Remand, Spell Crumple). The `scan_contains` pre-guard mirrors the
+        // source-rider arms above; the real classification is the combinator
+        // recognizer, which returns `None` for unsupported destinations
+        // (Hinder, Transcendent Dragon) so those cards stay honestly gapped.
+        Effect::Counter { .. }
+            if nom_primitives::scan_contains(&lower, "countered this way") => // allow-noncombinator
+        {
+            recognize_counter_spell_zone_redirect(&lower)
+                .map(|destination| ContinuationAst::CounterSpellZoneRedirect { destination })
         }
         // CR 707.10c: "You may choose new targets for the copy/copies." after a
         // CopySpell — directly, or wrapped in a CreateDelayedTrigger ("When you

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -3,10 +3,11 @@ use serde::Serialize;
 use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, ActivationRestriction, BounceSelection,
-    CastingPermission, ControllerRef, CopyRetargetPermission, CounterSourceRider, Duration, Effect,
-    FaceDownProfile, LibraryPosition, ManaProduction, ManaSpendRestriction,
-    ModalSelectionConstraint, OutsideGameSourcePool, PlayerFilter, PtStat, PtValue, QuantityExpr,
-    SearchDestinationSplit, SearchSelectionConstraint, StaticDefinition, TargetFilter,
+    CastingPermission, ControllerRef, CopyRetargetPermission, CounterSourceRider,
+    CounteredSpellDestination, Duration, Effect, FaceDownProfile, LibraryPosition, ManaProduction,
+    ManaSpendRestriction, ModalSelectionConstraint, OutsideGameSourcePool, PlayerFilter, PtStat,
+    PtValue, QuantityExpr, SearchDestinationSplit, SearchSelectionConstraint, StaticDefinition,
+    TargetFilter,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::CounterType;
@@ -225,6 +226,13 @@ pub(crate) enum ContinuationAst {
     /// permanent." — patches `source_rider = Some(CounterSourceRider::Destroy)`
     /// on the preceding `Effect::Counter` (Teferi's Response, Green Slime).
     CounterSourceRiderDestroy,
+    /// CR 701.6a + CR 614.1a: "If that spell is countered this way, put it
+    /// <zone> instead of into that player's graveyard." — patches
+    /// `countered_spell_zone = Some(destination)` on the preceding
+    /// `Effect::Counter` (Memory Lapse, Remand, Spell Crumple).
+    CounterSpellZoneRedirect {
+        destination: CounteredSpellDestination,
+    },
     /// CR 707.10c: "You may choose new targets for the copy/copies." after a
     /// CopySpell (possibly wrapped in a CreateDelayedTrigger) — patches
     /// `retarget = MayChooseNewTargets` on the inner Effect::CopySpell.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -977,6 +977,28 @@ pub enum CounterSourceRider {
     Destroy,
 }
 
+/// CR 701.6a + CR 614.1a: "put it <zone> instead of into that player's
+/// graveyard" — a replacement redirect on the destination of a countered
+/// *spell* (Memory Lapse, Remand, Spell Crumple). Distinct from
+/// [`CounterSourceRider`], which acts on a countered *ability*'s source
+/// permanent.
+///
+/// CR 701.6a says a countered spell is put into its owner's graveyard; CR
+/// 614.1a makes the "instead" clause a replacement that redirects that move to
+/// the named zone. Exile is deliberately excluded — that case is already
+/// handled by the existing graveyard-exile sub-ability rider in
+/// `game::effects::counter` (Force of Negation, No More Lies).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum CounteredSpellDestination {
+    /// "put it on top/bottom of its owner's library" (Memory Lapse,
+    /// Spell Crumple).
+    Library { position: LibraryPosition },
+    /// "return it to its owner's hand" / "put it into its owner's hand"
+    /// (Remand).
+    Hand,
+}
+
 /// Power/toughness value -- either a fixed integer or a variable reference (e.g. "*", "X").
 ///
 /// Custom Deserialize: accepts both the tagged format `{"type":"Fixed","value":2}` (new)
@@ -7362,6 +7384,15 @@ pub enum Effect {
         /// countered spell is not a permanent (CR 701.8a / CR 110.1).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source_rider: Option<CounterSourceRider>,
+        /// CR 701.6a + CR 614.1a: Redirect for a countered *spell*'s
+        /// destination — "if that spell is countered this way, put it <zone>
+        /// instead of into that player's graveyard" (Memory Lapse, Remand,
+        /// Spell Crumple). When `None`, the countered spell follows the default
+        /// CR 701.6a graveyard rule. Resolved at counter-resolution time on the
+        /// countered spell (not its source); has no effect when an ability is
+        /// countered (an ability is not a card and has no zone — CR 110.1).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        countered_spell_zone: Option<CounteredSpellDestination>,
     },
     /// CR 701.6 + CR 405.1: Mass counter — counter every spell or ability on
     /// the stack matching `target`. Mirrors `Effect::DestroyAll` /

--- a/crates/engine/tests/integration/counter_double_redirect_choice.rs
+++ b/crates/engine/tests/integration/counter_double_redirect_choice.rs
@@ -106,6 +106,7 @@ fn countered_spell_under_two_redirects_surfaces_prompt_and_exiles() {
         Effect::Counter {
             target: TargetFilter::Any,
             source_rider: None,
+            countered_spell_zone: None,
         },
         vec![TargetRef::Object(spell)],
         ObjectId(9999),

--- a/crates/engine/tests/integration/counter_spell_zone_redirect.rs
+++ b/crates/engine/tests/integration/counter_spell_zone_redirect.rs
@@ -1,0 +1,211 @@
+//! GitHub issue #3980 — "Counter target spell. If that spell is countered this
+//! way, put it <zone> instead of into that player's graveyard." must redirect
+//! the countered spell to the named zone rather than the graveyard.
+//!
+//! CR 701.6a + CR 614.1a: the countered spell's default graveyard destination
+//! is replaced by the named zone (Memory Lapse top of library, Spell Crumple
+//! bottom of library, Remand owner's hand). A plain counter (Cancel) keeps the
+//! default graveyard rule (regression).
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+/// Put an opponent instant on the stack whose owner is `controller`, mirroring
+/// the helper in `issue_3300_counter_spell.rs`.
+fn put_spell_on_stack(runner: &mut GameRunner, controller: PlayerId) -> ObjectId {
+    let spell = engine::game::zones::create_object(
+        runner.state_mut(),
+        CardId(701),
+        controller,
+        "Shock".to_string(),
+        Zone::Stack,
+    );
+    if let Some(obj) = runner.state_mut().objects.get_mut(&spell) {
+        obj.card_types.core_types = vec![CoreType::Instant];
+    }
+    runner.state_mut().stack.push_back(StackEntry {
+        id: spell,
+        source_id: spell,
+        controller,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(701),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    spell
+}
+
+fn build_counter_caster(oracle: &str, name: &str) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut cs = scenario.add_spell_to_hand_from_oracle(P0, name, true, oracle);
+    cs.with_mana_cost(ManaCost::Cost {
+        generic: 1,
+        shards: vec![ManaCostShard::Blue],
+    });
+    let counter = cs.id();
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    let runner = scenario.build();
+    (runner, counter)
+}
+
+/// CR 701.6a + CR 614.1a: Memory Lapse puts the countered spell on TOP of its
+/// owner's library, not the graveyard. FAILS if the redirect is dropped (the
+/// pre-fix behavior puts it in the graveyard).
+#[test]
+fn memory_lapse_redirects_countered_spell_to_library_top() {
+    const MEMORY_LAPSE: &str = "Counter target spell. If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard.";
+    let (mut runner, counter) = build_counter_caster(MEMORY_LAPSE, "Memory Lapse");
+    let opponent_spell = put_spell_on_stack(&mut runner, P1);
+
+    runner
+        .cast(counter)
+        .target_objects(&[opponent_spell])
+        .resolve();
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "the spell must be countered (off the stack)"
+    );
+    assert_eq!(
+        runner.state().objects[&opponent_spell].zone,
+        Zone::Library,
+        "Memory Lapse must redirect the countered spell to its owner's library"
+    );
+    assert!(
+        !runner.state().players[P1.0 as usize]
+            .graveyard
+            .contains(&opponent_spell),
+        "the countered spell must NOT reach the graveyard"
+    );
+    assert_eq!(
+        runner.state().players[P1.0 as usize]
+            .library
+            .front()
+            .copied(),
+        Some(opponent_spell),
+        "the countered spell must be on TOP of its owner's library"
+    );
+}
+
+/// CR 701.6a + CR 614.1a: Spell Crumple puts the countered spell on the BOTTOM
+/// of its owner's library.
+#[test]
+fn spell_crumple_redirects_countered_spell_to_library_bottom() {
+    const SPELL_CRUMPLE: &str = "Counter target spell. If that spell is countered this way, put it on the bottom of its owner's library instead of into that player's graveyard.";
+    let (mut runner, counter) = build_counter_caster(SPELL_CRUMPLE, "Spell Crumple");
+    let opponent_spell = put_spell_on_stack(&mut runner, P1);
+
+    runner
+        .cast(counter)
+        .target_objects(&[opponent_spell])
+        .resolve();
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "the spell must be countered"
+    );
+    assert_eq!(
+        runner.state().objects[&opponent_spell].zone,
+        Zone::Library,
+        "Spell Crumple must redirect the countered spell to its owner's library"
+    );
+    assert_eq!(
+        runner.state().players[P1.0 as usize]
+            .library
+            .back()
+            .copied(),
+        Some(opponent_spell),
+        "the countered spell must be on the BOTTOM of its owner's library"
+    );
+}
+
+/// CR 701.6a + CR 614.1a: Remand returns the countered spell to its owner's
+/// HAND, and its controller draws a card from the trailing "Draw a card."
+#[test]
+fn remand_redirects_countered_spell_to_hand_and_draws() {
+    const REMAND: &str = "Counter target spell. If that spell is countered this way, put it into its owner's hand instead of into that player's graveyard.\nDraw a card.";
+    // Give P0 a library card to draw.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut cs = scenario.add_spell_to_hand_from_oracle(P0, "Remand", true, REMAND);
+    cs.with_mana_cost(ManaCost::Cost {
+        generic: 1,
+        shards: vec![ManaCostShard::Blue],
+    });
+    let counter = cs.id();
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_card_to_library_top(P0, "Island");
+    let mut runner = scenario.build();
+    let opponent_spell = put_spell_on_stack(&mut runner, P1);
+
+    let p0_hand_before = runner.state().players[P0.0 as usize].hand.len();
+
+    runner
+        .cast(counter)
+        .target_objects(&[opponent_spell])
+        .resolve();
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "the spell must be countered"
+    );
+    assert_eq!(
+        runner.state().objects[&opponent_spell].zone,
+        Zone::Hand,
+        "Remand must redirect the countered spell to its owner's hand"
+    );
+    assert!(
+        runner.state().players[P1.0 as usize]
+            .hand
+            .contains(&opponent_spell),
+        "the countered spell must be in its owner's hand"
+    );
+    // The Remand caster (P0) drew a card; net hand change is +1 (Remand itself
+    // left the hand to the stack, but the draw lands a new card).
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        p0_hand_before, // -1 for Remand cast, +1 for the draw == net 0
+        "Remand's controller must draw a card (net hand: -1 cast +1 draw)"
+    );
+}
+
+/// REGRESSION: a plain "Counter target spell." (Cancel) keeps the default CR
+/// 701.6a graveyard destination — no redirect.
+#[test]
+fn plain_counter_still_sends_countered_spell_to_graveyard() {
+    const CANCEL: &str = "Counter target spell.";
+    let (mut runner, counter) = build_counter_caster(CANCEL, "Cancel");
+    let opponent_spell = put_spell_on_stack(&mut runner, P1);
+
+    runner
+        .cast(counter)
+        .target_objects(&[opponent_spell])
+        .resolve();
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "the spell must be countered"
+    );
+    assert_eq!(
+        runner.state().objects[&opponent_spell].zone,
+        Zone::Graveyard,
+        "a plain counter must send the countered spell to the graveyard"
+    );
+    assert!(
+        runner.state().players[P1.0 as usize]
+            .graveyard
+            .contains(&opponent_spell),
+        "the countered spell must be in its owner's graveyard"
+    );
+}

--- a/crates/engine/tests/integration/louisoix_sacrifice_counter.rs
+++ b/crates/engine/tests/integration/louisoix_sacrifice_counter.rs
@@ -287,6 +287,7 @@ fn louisoix_counter_resolves_each_legal_target() {
             Effect::Counter {
                 target: filter.clone(),
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(activated)],
             ObjectId(1000),
@@ -313,6 +314,7 @@ fn louisoix_counter_resolves_each_legal_target() {
             Effect::Counter {
                 target: filter.clone(),
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(triggered)],
             ObjectId(1000),
@@ -333,6 +335,7 @@ fn louisoix_counter_resolves_each_legal_target() {
             Effect::Counter {
                 target: filter.clone(),
                 source_rider: None,
+                countered_spell_zone: None,
             },
             vec![TargetRef::Object(noncreature_spell)],
             ObjectId(1000),

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -46,6 +46,7 @@ mod consuming_vapors_rebound;
 mod copy_token_except_keyword_and_quoted_ability;
 mod council_of_four_nth_per_turn;
 mod counter_double_redirect_choice;
+mod counter_spell_zone_redirect;
 mod cr_annotations;
 mod craft_tithing_blade_transform;
 mod crossway_troublemakers_attacking_keywords;

--- a/crates/engine/tests/integration/mana_drain_refund.rs
+++ b/crates/engine/tests/integration/mana_drain_refund.rs
@@ -190,6 +190,7 @@ fn mana_drain_refunds_colorless_equal_to_countered_spells_mana_value() {
         Effect::Counter {
             target: TargetFilter::StackSpell,
             source_rider: None,
+            countered_spell_zone: None,
         },
         vec![TargetRef::Object(spell_id)],
         mana_drain_source,

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -1004,6 +1004,7 @@ fn setup_pitch_scenario() -> (
         .with_ability(Effect::Counter {
             target: TargetFilter::Any,
             source_rider: None,
+            countered_spell_zone: None,
         })
         .with_additional_cost(AdditionalCost::Required(AbilityCost::Exile {
             count: 1,

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -2935,6 +2935,7 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
         Action::CounterSpell(_spell) => Effect::Counter {
             target: TargetFilter::StackSpell,
             source_rider: None,
+            countered_spell_zone: None,
         },
 
         // CR 800.4 / CR 110.2: Gain control.

--- a/crates/phase-ai/src/card_hints.rs
+++ b/crates/phase-ai/src/card_hints.rs
@@ -340,6 +340,7 @@ mod tests {
             vec![make_ability(Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             })],
         );
 
@@ -395,6 +396,7 @@ mod tests {
             vec![make_ability(Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             })],
         );
 
@@ -427,6 +429,7 @@ mod tests {
             vec![make_ability(Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             })],
         );
 

--- a/crates/phase-ai/src/features/aggro_pressure.rs
+++ b/crates/phase-ai/src/features/aggro_pressure.rs
@@ -683,6 +683,7 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
             );
             ability.kind = AbilityKind::Spell;

--- a/crates/phase-ai/src/features/control.rs
+++ b/crates/phase-ai/src/features/control.rs
@@ -350,6 +350,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
         )
     }

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -2526,6 +2526,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::StackSpell,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             Vec::new(),
             rewind_id,

--- a/crates/phase-ai/src/policies/chalice_avoidance.rs
+++ b/crates/phase-ai/src/policies/chalice_avoidance.rs
@@ -276,6 +276,7 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
             ));
         obj.trigger_definitions.push(trigger);

--- a/crates/phase-ai/src/policies/hold_mana_up.rs
+++ b/crates/phase-ai/src/policies/hold_mana_up.rs
@@ -278,6 +278,7 @@ mod tests {
             Effect::Counter {
                 target: engine::types::ability::TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
         ));
         oid

--- a/crates/phase-ai/src/policies/mulligan/cedh_keepables.rs
+++ b/crates/phase-ai/src/policies/mulligan/cedh_keepables.rs
@@ -289,6 +289,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
         )
     }

--- a/crates/phase-ai/src/threat_profile.rs
+++ b/crates/phase-ai/src/threat_profile.rs
@@ -421,6 +421,7 @@ mod tests {
             abilities: vec![make_ability(Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             })],
             ..Default::default()
         };

--- a/crates/phase-ai/tests/ai_quality.rs
+++ b/crates/phase-ai/tests/ai_quality.rs
@@ -507,6 +507,7 @@ fn counterspell_entry(count: u32) -> DeckEntry {
                 Effect::Counter {
                     target: TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
             )],
             ..Default::default()

--- a/crates/server-core/src/filter.rs
+++ b/crates/server-core/src/filter.rs
@@ -59,6 +59,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
         )]);
 
@@ -425,6 +426,7 @@ mod tests {
             Effect::Counter {
                 target: TargetFilter::Any,
                 source_rider: None,
+                countered_spell_zone: None,
             },
             Vec::new(),
             source_id,
@@ -458,6 +460,7 @@ mod tests {
                 Effect::Counter {
                     target: TargetFilter::Any,
                     source_rider: None,
+                    countered_spell_zone: None,
                 },
             )],
             description: Some(description.to_string()),


### PR DESCRIPTION
# fix(engine): counter target spell with a zone redirect — "put it [on top/bottom of its owner's library | into its owner's hand] instead of into that player's graveyard" is silently dropped

## Summary

A whole class of counterspells says **"Counter target spell. If that spell is countered this way, put it `<zone>` instead of into that player's graveyard."** The redirect clause is **silently swallowed**: the spell is countered but still goes to the graveyard (the CR default), so the intended destination — top of library, bottom of library, or the owner's hand — never happens. These cards are marked "supported" by coverage yet behave incorrectly (a silently-wrong card).

`Effect::Counter` (crates/engine/src/types/ability.rs ~7354) carries only `target` and `source_rider` (a rider for countered *abilities'* source permanents). It has **no field for the countered spell's destination zone**, so the parser drops the redirect.

## The card class (build for the class, not the card)

Verified silently-wrong on current `main` (the redirect clause is a `warning:swallowed-clause`):

- **Memory Lapse** — "...put it **on top of its owner's library** instead of into that player's graveyard." (Modern/Pauper staple)
- **Lapse of Certainty** — same (top of owner's library).
- **Remand** — "...put it **into its owner's hand** instead of into that player's graveyard. Draw a card." (Modern/Pauper staple)
- **Spell Crumple** — "...put it on the **bottom of its owner's library** instead..."
- **Hinder** — "...put that card on **your choice of the top or bottom** of its owner's library instead..." (adds a controller choice)
- **Transcendent Dragon** — "...**exile it** instead of putting it into its owner's graveyard, then you may cast it..." (adds a cast-from-exile rider)

The common, deterministic shape (top-of-library / bottom-of-library / hand) covers Memory Lapse, Lapse of Certainty, Remand, Spell Crumple. Hinder's top-or-bottom *choice* and Transcendent Dragon's exile-then-may-cast rider are the more complex tail.

## Root cause (current `main`)

Parsing e.g. Memory Lapse produces an `Effect::Counter { target, source_rider: None }` and the trailing "If that spell is countered this way, put it on top of its owner's library instead of into that player's graveyard." sentence is dropped (no destination to carry it). At resolution the countered spell follows the default — into the graveyard — so the card is wrong in play.

## Fix (sketch; final shape via the engine-implementer plan)

1. **Parameterize `Effect::Counter`** with an optional countered-spell destination (a typed zone+position, e.g. `Option<CounteredSpellZone>` covering `LibraryTop`, `LibraryBottom`, `Hand`, and `Exile`). No new sibling effect variant — extend the existing one (the `add-engine-variant` parameterize-don't-proliferate rule).
2. **Parser**: recognize the "If that spell is countered this way, put it `<zone>` instead of into that player's graveyard" rider and populate the new field. Reuse the existing zone/anaphor building blocks; nom combinators only.
3. **Resolution**: when countering a spell, if the destination is set, move the countered spell to that zone instead of the graveyard (CR 701.5 — countering; the redirect is a modification of where the countered object goes). Verify the exact CR against `docs/MagicCompRules.txt`.
4. **Scope**: implement the deterministic destinations (top/bottom of library, hand). Hinder's top-or-bottom **choice** and Transcendent Dragon's **exile + may-cast** are honestly gapped if they require interactive/cast-from-exile machinery beyond this change — never ship them silently-wrong.

## Verification

- Parser: Memory Lapse / Remand / Spell Crumple parse to `Effect::Counter` carrying the correct destination (not a dropped clause).
- Runtime (discriminating): cast a spell, counter it with Memory Lapse → the countered spell is on top of its owner's library (not the graveyard); Remand → in owner's hand + controller draws; Spell Crumple → bottom of library. Each fails if the redirect is reverted.
- Regression: plain counters (to graveyard) and ability-counter `source_rider` cards unchanged; full engine lib suite green; parser-combinator gate clean.


Fixes #3980