### PR TITLE
feat(parser): become/set-color routing + spell-color filter (Tam, Mondo Gecko, Questing Druid, +4)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/animation.rs
+++ b/crates/engine/src/parser/oracle_effect/animation.rs
@@ -657,6 +657,12 @@ fn parse_in_addition_other_types_marker(input: &str) -> OracleResult<'_, &str> {
         tag("in addition to "),
         alt((tag("its"), tag("their"), tag("his"), tag("her"))),
         tag(" other "),
+        // CR 105.3 + CR 205.1b: the "in addition" clause can enumerate colors
+        // and/or types — "in addition to its other colors and types" (Possessed
+        // Goat), "in addition to its other types". `opt(tag("colors and "))`
+        // makes the color scope an independent axis (compose, don't enumerate);
+        // `opt(tag("creature "))` keeps the type-scope axis order-independent.
+        opt(tag("colors and ")),
         opt(tag("creature ")),
         tag("types"),
     ))
@@ -674,6 +680,17 @@ fn locate_in_addition_other_types_marker(input: &str) -> OracleResult<'_, &str> 
         parse_in_addition_other_types_marker,
     )
     .parse(input)
+}
+
+/// CR 105.3: detect the additive-color reading of a "becomes" descriptor —
+/// "in addition to its other colors [and types]". When present, the granted
+/// color is ADDED to the object's existing colors (CR 105.3 "in addition")
+/// rather than replacing them. Used by `build_become_clause` to convert the
+/// default `SetColor` (CR 105.3 replacement) into per-color `AddColor`.
+pub(crate) fn has_in_addition_to_other_colors(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    nom_primitives::scan_contains(&lower, "in addition to ")
+        && nom_primitives::scan_contains(&lower, "other colors")
 }
 
 pub(crate) fn has_in_addition_to_other_types(text: &str) -> bool {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1717,6 +1717,16 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
         value((), tag("it gets ")),
         value((), tag("it has ")),
         value((), tag("it loses ")),
+        // CR 105.3 + CR 205.1a + CR 613.1d/e: "it becomes <descriptor>" is always
+        // a subject (anaphor) + animation predicate, never a noun-phrase
+        // continuation. Possessed Goat: "Put three +1/+1 counters on this creature
+        // and it becomes a black Demon in addition to its other colors and types"
+        // — without this split the conjunct is fed to the imperative-only path,
+        // where it fails closed to an unimplemented effect named "it". Splitting
+        // routes it through `parse_clause_ast` → `try_parse_subject_become_clause`,
+        // where "it" resolves to the anaphoric/self subject and
+        // `build_become_clause` produces the additive color/type modifications.
+        value((), tag("it becomes ")),
         value((), tag("this creature gets ")),
         value((), tag("~ gets ")),
         // CR 104.3 + CR 119.7 + CR 119.8: Bare-plural-player subject + restriction

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -8,7 +8,8 @@ use nom::sequence::{delimited, pair, preceded, terminated};
 use nom::Parser;
 
 use super::animation::{
-    animation_modifications_with_replacement, has_in_addition_to_other_types, parse_animation_spec,
+    animation_modifications_with_replacement, has_in_addition_to_other_colors,
+    has_in_addition_to_other_types, parse_animation_spec,
 };
 use super::imperative;
 use super::lower::BOUNDED_TARGET_PHRASES;
@@ -2546,6 +2547,39 @@ fn build_become_clause(
         return Some(clause);
     }
 
+    // CR 105.2 + CR 105.3 + CR 613.1e (Layer 5): "becomes all colors" (Tam,
+    // Mindful First-Year) and "becomes the chosen color" (Puca's Eye) set the
+    // affected object's color. "All colors" maps to the full WUBRG set
+    // (CR 105.2: a multicolored object can be each of the five colors); "the
+    // chosen color" reads the source's `ChosenAttribute::Color` chosen upstream
+    // (preceding `Effect::Choose { ChoiceType::Color }`) via `AddChosenColor`.
+    // Both are non-additive (CR 105.3: a new color replaces all previous
+    // colors) — the additive "in addition to its other colors" form is handled
+    // by the animation path below. Must intercept before `parse_animation_spec`,
+    // which bails on " all colors" and would mis-tokenize "chosen"/"color" as a
+    // subtype.
+    if let Some(modification) = try_parse_become_color_modification(become_text) {
+        let affected = static_affected_for_application(&application);
+        let effect = Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(affected)
+                .modifications(vec![modification])
+                .description(become_text.to_string())],
+            duration: duration.clone(),
+            target: application.target.clone(),
+        };
+        return Some(ParsedEffectClause {
+            effect,
+            duration,
+            sub_ability: None,
+            distribute: None,
+            multi_target: None,
+            condition: None,
+            optional: false,
+            unless_pay: None,
+        });
+    }
+
     // CR 205.3e + CR 607.2d: "becomes that type" applies the creature type chosen
     // by the preceding "Choose a creature type" instruction in the same ability
     // (Imagecrafter, Unnatural Selection, Mistform Mutant, Standardize). Unlike
@@ -2716,6 +2750,23 @@ fn build_become_clause(
     // static type-change path's suffix detection.
     let is_additive = has_in_addition_to_other_types(&become_text);
     let mut modifications = animation_modifications_with_replacement(&animation, is_additive);
+    // CR 105.3: "in addition to its other colors" makes the granted color
+    // ADDITIVE — Possessed Goat "becomes a black Demon in addition to its other
+    // colors and types". The animation path emits `SetColor` (the CR 105.3
+    // replacement default); convert it to one `AddColor` per color so the
+    // existing colors are preserved.
+    if has_in_addition_to_other_colors(&become_text) {
+        modifications = modifications
+            .into_iter()
+            .flat_map(|m| match m {
+                ContinuousModification::SetColor { colors } => colors
+                    .into_iter()
+                    .map(|color| ContinuousModification::AddColor { color })
+                    .collect::<Vec<_>>(),
+                other => vec![other],
+            })
+            .collect();
+    }
     for modification in parse_continuous_modifications(predicate) {
         if !modifications.contains(&modification) {
             modifications.push(modification);
@@ -2974,8 +3025,71 @@ fn try_parse_set_day_night(become_text: &str) -> Option<ParsedEffectClause> {
     Some(super::parsed_clause(Effect::SetDayNight { to }))
 }
 
-/// CR 205.3 / CR 305.7: Parse "become the creature type of your choice" and similar
-/// patterns into a Choose → GenericEffect(AddChosenSubtype) chain.
+/// CR 105.2 + CR 105.3 + CR 613.1e (Layer 5): map a "becomes [color]" predicate
+/// to its color-setting `ContinuousModification`, for the forms that do NOT
+/// prompt the controller for a choice. Two cases:
+///
+/// - "all colors" / "every color" → `SetColor(WUBRG)` (CR 105.2: a multicolored
+///   object can be each of the five colors). The new color set replaces all
+///   previous colors (CR 105.3).
+/// - "the chosen color" → `AddChosenColor`, reading the source's
+///   `ChosenAttribute::Color` bound by a preceding `Effect::Choose` in the same
+///   ability (Puca's Eye: "draw a card, then choose a color. This artifact
+///   becomes the chosen color"). Despite the additive-sounding `Add` prefix,
+///   `AddChosenColor` SETS the color at Layer 5 (CR 105.3) — see its definition.
+///
+/// Returns `None` for any other predicate so the caller falls through to the
+/// fixed-color animation path (which already handles single named colors) and to
+/// `try_parse_become_choice` (the prompting "of your choice" form).
+fn try_parse_become_color_modification(become_text: &str) -> Option<ContinuousModification> {
+    let lower = become_text.trim().to_lowercase();
+    if let Ok((rest, _)) = all_consuming(alt((
+        tag::<_, _, OracleError<'_>>("all colors"),
+        tag("every color"),
+    )))
+    .parse(lower.as_str())
+    {
+        let _ = rest;
+        return Some(ContinuousModification::SetColor {
+            colors: crate::types::mana::ManaColor::ALL.to_vec(),
+        });
+    }
+    if all_consuming(alt((
+        tag::<_, _, OracleError<'_>>("the chosen color"),
+        tag("the color chosen this way"),
+    )))
+    .parse(lower.as_str())
+    .is_ok()
+    {
+        return Some(ContinuousModification::AddChosenColor);
+    }
+    None
+}
+
+/// True when `lower` ends with the "of your choice" anchor. Pattern 2 (whole
+/// input parsed, trailing fixed phrase consumed last): `take_until` skips to the
+/// final occurrence and `all_consuming` requires the suffix to terminate the
+/// input. Replaces a bare `ends_with` so the dispatch stays combinator-driven.
+fn ends_with_of_your_choice(lower: &str) -> bool {
+    all_consuming(terminated(
+        take_until::<_, _, OracleError<'_>>("of your choice"),
+        tag("of your choice"),
+    ))
+    .parse(lower)
+    .is_ok()
+}
+
+/// CR 205.3 / CR 305.7 / CR 105.3: Parse "become the [creature type / basic land
+/// type / color] of your choice [and <keyword grant>]" into a Choose →
+/// GenericEffect(apply) chain.
+///
+/// The optional trailing "and <keyword grant>" clause (Mondo Gecko: "becomes the
+/// color of your choice and gains hexproof from that color") composes the chosen
+/// attribute with one or more keyword grants on the same recipient. The keyword
+/// clause is parsed by the shared `parse_continuous_modifications` building block,
+/// which resolves "hexproof from that color" to `HexproofFrom(ChosenColor)`
+/// (CR 702.11d) — the same `ChosenAttribute::Color` the `AddChosenColor`
+/// modification reads, so the protection tracks the chosen color.
 fn try_parse_become_choice(
     become_text: &str,
     application: &SubjectApplication,
@@ -2983,8 +3097,26 @@ fn try_parse_become_choice(
 ) -> Option<ParsedEffectClause> {
     use crate::types::ability::{ChoiceType, ChosenSubtypeKind, ContinuousModification};
 
-    let lower = become_text.to_lowercase();
-    if !lower.ends_with("of your choice") {
+    // CR 608.2c: split off a trailing "and <continuous-modification clause>" so
+    // the "of your choice" anchor below sees only the choice phrase. The residual
+    // (e.g. "gains hexproof from that color") is reparsed as continuous
+    // modifications and appended to the apply-half. A subject like "the color of
+    // your choice and gains hexproof from that color" splits at " and " into the
+    // choice phrase and the grant phrase; absent the conjunction the whole text
+    // is the choice phrase and there is no grant. The choice phrase is anchored
+    // by the "of your choice" suffix combinator (Pattern 2: whole input parsed,
+    // fixed suffix consumed last).
+    let lower_full = become_text.to_lowercase();
+    let tp = TextPair::new(become_text, &lower_full);
+    let (choice_text, grant_text) = match tp.split_around(" and ") {
+        Some((before, after)) if ends_with_of_your_choice(before.lower) => {
+            (before.original.trim(), Some(after.original.trim()))
+        }
+        _ => (become_text.trim(), None),
+    };
+
+    let lower = choice_text.to_lowercase();
+    if !ends_with_of_your_choice(lower.as_str()) {
         return None;
     }
 
@@ -3009,12 +3141,21 @@ fn try_parse_become_choice(
         return None;
     };
 
+    // CR 608.2c + CR 702.11d: append any trailing keyword grant ("and gains
+    // hexproof from that color") onto the apply-half. `parse_continuous_modifications`
+    // is the shared keyword-grant building block; it maps "gains hexproof from
+    // that color" → `AddKeyword(HexproofFrom(ChosenColor))`.
+    let mut modifications = vec![modification];
+    if let Some(grant) = grant_text {
+        modifications.extend(parse_continuous_modifications(grant));
+    }
+
     // Two-step: Choose (prompts player) → GenericEffect (applies chosen subtype).
     let affected = static_affected_for_application(application);
     let apply_effect = Effect::GenericEffect {
         static_abilities: vec![StaticDefinition::continuous()
             .affected(affected)
-            .modifications(vec![modification])
+            .modifications(modifications)
             .description(become_text.to_string())],
         duration: duration.clone(),
         target: application.target.clone(),

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1312,6 +1312,22 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // CR 613.1e + CR 105.2 / CR 105.3: "[subject] is/are [color expression]" for
+    // an ARBITRARY filter subject — Leyline of the Guildpact ("Each nonland
+    // permanent you control is all colors"), Shimmerwilds Growth ("Enchanted land
+    // is the chosen color"). Generalizes `parse_all_subject_are_color` (the "All
+    // ..." quantifier) and adds the "the chosen color" reading. Dispatched AFTER
+    // the specialized color branches so they keep ownership of their cases: the
+    // "All ..." fast path (`parse_all_subject_are_color`, which routes
+    // artifact/land subtypes through `typed_filter_for_subtype`) and the
+    // self-referential color CDA (`parse_self_subject_is_color_cda`, which
+    // marks `~ is colorless` characteristic-defining and declines raw card
+    // names). This branch only claims the residual general-filter subjects those
+    // two leave unparsed.
+    if let Some(def) = parse_subject_is_color(&tp, &text) {
+        return Some(def);
+    }
+
     // --- CDA: "~'s power is equal to the number of card types among cards in all graveyards
     //     and its toughness is equal to that number plus 1" (Tarmogoyf) ---
     if let Some(def) = parse_cda_pt_equality(tp.lower, tp.original) {

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1311,6 +1311,94 @@ pub(crate) fn parse_all_subject_are_color(
     )
 }
 
+/// CR 613.1e (Layer 5) + CR 105.2 / CR 105.3: Parse a color-defining static of
+/// the form "[subject] is/are [color expression]." for an ARBITRARY filter
+/// subject — generalizing [`parse_all_subject_are_color`] (which only accepts the
+/// `"All ..."` quantifier) to the full subject grammar via
+/// `parse_continuous_subject_filter` (handles "Each", "All", controller suffixes,
+/// "nonland permanent you control", etc.).
+///
+/// Two predicate families compose here:
+/// - Fixed colors / "all colors" / "colorless" via `parse_color_predicate`
+///   (Leyline of the Guildpact: "Each nonland permanent you control is all
+///   colors" → `SetColor(WUBRG)`).
+/// - "the chosen color" → `AddChosenColor`, reading the source's
+///   `ChosenAttribute::Color` (Shimmerwilds Growth: "Enchanted land is the chosen
+///   color" — a preceding `As ~ enters, choose a color` binds the attribute).
+///
+/// The copula is " is " (singular subject) or " are " (plural subject); both
+/// route to the same color modification. Dispatched AFTER the specialized
+/// `parse_all_subject_are_color` ("All ..." quantifier, with correct
+/// artifact/land subtype core-type routing) and `parse_self_subject_is_color_cda`
+/// (self-referential CDA color lines, all-zone + `characteristic_defining`), so
+/// those keep ownership of their cases and this branch only claims the residual
+/// general-filter subjects. A self-referential subject is declined here outright
+/// (it must be a CDA, never a plain Layer-5 static).
+pub(crate) fn parse_subject_is_color(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    // Split on the copula. " are " is tried first so a plural subject ending in
+    // "...s is..." cannot be mis-split (there is no such grammatical form for
+    // these statics; the copula is always a whole word with surrounding spaces).
+    let (subject_tp, predicate_tp) = tp
+        .split_around(" is ")
+        .or_else(|| tp.split_around(" are "))?;
+    let subject = subject_tp.original.trim();
+    let predicate = predicate_tp.original.trim().trim_end_matches('.');
+    let predicate_lower = predicate.to_lowercase();
+
+    // The subject must resolve to a concrete filter — otherwise this is not a
+    // color-defining static (a bare "It is ..." / "this is ..." anaphor falls
+    // through to other dispatch branches). Attached subjects ("Enchanted land",
+    // Shimmerwilds Growth) carry the `EnchantedBy` filter; the general subject
+    // grammar covers controller-scoped/quantified filters (Leyline of the
+    // Guildpact: "Each nonland permanent you control").
+    let subject_lower = subject.to_lowercase();
+    // `attached_subject_filter` matches "enchanted <type> " WITH a trailing
+    // space, so probe a space-suffixed copy and require the remainder to be empty.
+    let subject_with_space = format!("{subject} ");
+    let subject_space_lower = format!("{subject_lower} ");
+    let attached = attached_subject_filter(&TextPair::new(
+        subject_with_space.as_str(),
+        subject_space_lower.as_str(),
+    ));
+    let affected = match attached {
+        Some((filter, rest)) if rest.trim().is_empty() => filter,
+        _ => parse_continuous_subject_filter(subject)?,
+    };
+
+    // CR 604.3: a self-referential color line ("~ is colorless") is a
+    // characteristic-defining ability owned by `parse_self_subject_is_color_cda`
+    // (it sets `characteristic_defining` and functions in all zones). Decline so
+    // it is never emitted as a plain Layer-5 static.
+    if matches!(affected, TargetFilter::SelfRef) {
+        return None;
+    }
+
+    // CR 105.3: "the chosen color" reads the source's chosen color attribute.
+    if all_consuming(tag::<_, _, OracleError<'_>>("the chosen color"))
+        .parse(predicate_lower.as_str())
+        .is_ok()
+    {
+        return Some(
+            StaticDefinition::continuous()
+                .affected(affected)
+                .modifications(vec![ContinuousModification::AddChosenColor])
+                .description(description.to_string()),
+        );
+    }
+
+    // Fixed colors / "all colors" / "colorless" (CR 105.1 / CR 105.2 / CR 105.2c).
+    let colors = parse_color_predicate(&predicate_lower)?;
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(vec![ContinuousModification::SetColor { colors }])
+            .description(description.to_string()),
+    )
+}
+
 /// CR 305.7: Parse "[Subject] lands are [type]" land type-changing static abilities.
 /// Handles replacement ("Nonbasic lands are Mountains"), additive ("Each land is a
 /// Swamp in addition to its other land types"), and all-basic-types ("Lands you control

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -5257,6 +5257,29 @@ fn continues_spell_quality_disjunction(after_comma: &str) -> bool {
     .unwrap_or(false)
 }
 
+/// CR 105.2 + CR 601.2a: Commas inside a spell-color disjunction
+/// ("a spell that's white, blue, black, or red") are color-list separators, not
+/// the condition/effect boundary. Questing Druid is the motivating card. The
+/// text after such a comma is the next color leg — `[or ]<color>` immediately
+/// followed by a list separator (`,`) or end of clause — never a sentence/effect
+/// start. Restricting the trailing boundary to `,`/end (not a space) keeps a
+/// genuine effect that merely begins with a color word ("..., Red ... draws")
+/// from being mistaken for a list continuation.
+fn continues_spell_color_disjunction(after_comma: &str) -> bool {
+    let trimmed = after_comma.trim_start();
+    let after_or = value((), tag::<_, _, OracleError<'_>>("or "))
+        .parse(trimmed)
+        .map(|(rest, _)| rest)
+        .unwrap_or(trimmed);
+    let Ok((rest, _)) = nom_primitives::parse_color(after_or) else {
+        return false;
+    };
+    // The color leg must terminate at the clause end or a list separator comma,
+    // not run into a wider word — `tag(",")` is the combinator counterpart of the
+    // `tag(", ")` boundary check in `continues_spell_quality_disjunction`.
+    rest.is_empty() || tag::<_, _, OracleError<'_>>(",").parse(rest).is_ok()
+}
+
 fn find_effect_boundary(lower: &str) -> Option<usize> {
     use super::oracle_nom::primitives::split_once_on;
     let mut search_start = 0;
@@ -5266,6 +5289,7 @@ fn find_effect_boundary(lower: &str) -> Option<usize> {
             && !continues_disjunctive_zone_change_condition(after)
             && !continues_serial_event_condition(after)
             && !continues_spell_quality_disjunction(after)
+            && !continues_spell_color_disjunction(after)
         {
             return Some(comma_pos);
         }
@@ -10353,6 +10377,21 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         // "you" = trigger's controller
         def.valid_target = Some(TargetFilter::Controller);
 
+        // CR 105.2 + CR 601.2a: "spell that's <colors>" disjunctions span commas
+        // (Questing Druid: "a spell that's white, blue, black, or red"). The
+        // condition/effect splitter keeps the full list in `after`; recognize it
+        // on the untruncated remainder before the comma-truncation below, which
+        // would otherwise cut the color list to its first leg.
+        if let Some(filter) = parse_spell_that_clause_filter(after.trim()) {
+            let filter = if is_another {
+                add_another_prop(filter)
+            } else {
+                filter
+            };
+            def.valid_card = Some(filter);
+            return Some((TriggerMode::SpellCast, def));
+        }
+
         // Truncate at ", " so any effect clause doesn't leak into the type parser.
         let payload = nom_primitives::split_once_on(after, ", ")
             .map(|(_, (before, _))| before)
@@ -11062,6 +11101,35 @@ fn extract_spell_type_filter(after_ordinal: &str) -> Option<TargetFilter> {
     // position is the qualifier. Returns `None` if no timing tail is present.
     let qualifier = split_off_timing_tail(trimmed)?;
     parse_spell_qualifier_payload(qualifier.trim())
+}
+
+/// CR 105.2 + CR 601.2a: Parse a SpellCast `valid_card` filter from a
+/// `"spell that's <relative clause>"` payload, e.g. Questing Druid's
+/// "spell that's white, blue, black, or red" → an `Or` of `HasColor` legs.
+///
+/// Delegates the relative clause to the shared `parse_that_clause_suffix`
+/// building block (the same combinator that powers target/search "that's …"
+/// clauses), so every relative-clause property it understands — color
+/// disjunctions, color-count, supertypes — is supported here for free. The
+/// payload is consumed on the FULL pre-truncation `"you cast a …"` remainder
+/// because a color disjunction spans commas the effect-boundary splitter would
+/// otherwise cut.
+///
+/// Returns `None` unless the payload is exactly `"spell that's …"` with the
+/// relative clause consuming the entire remainder, so type-only qualifiers and
+/// post-spell modifiers continue to flow through `parse_spell_qualifier_payload`.
+fn parse_spell_that_clause_filter(payload: &str) -> Option<TargetFilter> {
+    // Strip the "spell" head noun with a nom tag; the remainder keeps its
+    // leading space, which is exactly what `parse_that_clause_suffix` expects
+    // before "that's".
+    let (rest, _) = tag::<_, _, OracleError<'_>>("spell").parse(payload).ok()?;
+    let (props, consumed) = super::oracle_target::parse_that_clause_suffix(rest, None)?;
+    if consumed != rest.len() || props.is_empty() {
+        return None;
+    }
+    Some(TargetFilter::Typed(
+        TypedFilter::default().properties(props),
+    ))
 }
 
 /// Word-boundary scan: return the text preceding the trailing timing clause,

--- a/crates/engine/tests/become_color_set_std_batch.rs
+++ b/crates/engine/tests/become_color_set_std_batch.rs
@@ -1,0 +1,691 @@
+//! Standard "become-color / set-color" batch — continuous color-setting effects
+//! and statics route through the existing `ContinuousModification::SetColor` /
+//! `AddColor` / `AddChosenColor` Layer-5 seam (CR 105.3 / CR 613.1e). These were
+//! parser gaps: the effect/static phrasings never reached those modifications.
+//!
+//! Each test drives the PRODUCTION pipeline — `parse_oracle_text` →
+//! resolve_ability_chain / static install → `evaluate_layers` — and asserts the
+//! affected object's effective color after the layer evaluator runs. Every
+//! assertion FLIPS on a revert of the parser arm: without it, parsing emits
+//! `Effect::Unimplemented` (no color modification), so the layer pass leaves the
+//! printed color untouched and the equality checks fail.
+//!
+//! Cards: Tam, Mindful First-Year (become all colors); Possessed Goat (becomes a
+//! black ... in addition to its other colors and types); Puca's Eye (becomes the
+//! chosen color); Mondo Gecko (becomes the color of your choice and gains
+//! hexproof from that color); Leyline of the Guildpact (each nonland permanent
+//! you control is all colors); Shimmerwilds Growth (enchanted land is the chosen
+//! color).
+
+use engine::game::ability_utils::{build_resolved_from_def, build_resolved_from_def_with_targets};
+use engine::game::effects::resolve_ability_chain;
+use engine::game::game_object::AttachTarget;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, ChosenAttribute, ContinuousModification, Effect, TargetRef,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::{HexproofFilter, Keyword};
+use engine::types::mana::{ManaColor, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const WUBRG: [ManaColor; 5] = [
+    ManaColor::White,
+    ManaColor::Blue,
+    ManaColor::Black,
+    ManaColor::Red,
+    ManaColor::Green,
+];
+
+fn creature_types() -> Vec<String> {
+    vec!["Creature".to_string()]
+}
+
+/// Parse a card and assert it has zero residual `Unimplemented` nodes — the
+/// per-card 0-unimpl gate.
+fn assert_zero_unimplemented(oracle: &str, name: &str, types: &[String], subtypes: &[String]) {
+    let parsed = parse_oracle_text(oracle, name, &[], types, subtypes);
+    let dbg = format!("{parsed:#?}");
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "{name}: expected zero Unimplemented nodes, parse was:\n{dbg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Foraging Wickermaw — HONEST DEFER. "{1}: Add one mana of any color. This
+// creature becomes that color until end of turn." The "that color" anaphor
+// refers to the color the player chooses while producing mana — there is no
+// `ChosenAttribute::Color` binding for a mana-production color choice today, so
+// no color-set modification can read it. This batch only routes the existing
+// SetColor/AddColor/AddChosenColor seam; binding a mana-color choice as a
+// readable chosen attribute is infrastructure beyond color-set, so the
+// "becomes that color" clause stays an honest `Effect::Unimplemented`. The test
+// asserts the defer is honest (the color clause is the only residual) rather
+// than over-claiming runtime support that does not exist.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn foraging_wickermaw_becomes_that_color_is_honestly_deferred() {
+    const ORACLE: &str = "When this creature enters, surveil 1.\n{1}: Add one mana of any color. This creature becomes that color until end of turn. Activate only once each turn.";
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Foraging Wickermaw",
+        &[],
+        &creature_types(),
+        &["Lizard".to_string()],
+    );
+    let dbg = format!("{parsed:#?}");
+    // The defer is scoped to the "that color" anaphor only — the mana ability
+    // and the ETB surveil must still parse.
+    assert!(
+        dbg.contains("Unimplemented") && dbg.contains("that color"),
+        "the 'becomes that color' clause must remain an honest Unimplemented defer; got:\n{dbg}"
+    );
+    assert!(
+        dbg.contains("AnyOneColor"),
+        "the '{{1}}: Add one mana of any color' mana ability must still parse"
+    );
+    assert!(
+        dbg.contains("Surveil"),
+        "the ETB surveil trigger must still parse"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tam, Mindful First-Year — "{T}: Target creature you control becomes all
+// colors until end of turn." CR 105.2 + CR 105.3 + CR 613.1e.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tam_target_creature_becomes_all_colors() {
+    const ORACLE: &str = "Each other creature you control has hexproof from each of its colors.\n{T}: Target creature you control becomes all colors until end of turn.";
+    assert_zero_unimplemented(ORACLE, "Tam, Mindful First-Year", &creature_types(), &[]);
+
+    let parsed = parse_oracle_text(ORACLE, "Tam", &[], &creature_types(), &[]);
+    // The activated ability is the one carrying the become-all-colors effect.
+    let activated = parsed
+        .abilities
+        .iter()
+        .find(|a| {
+            let dbg = format!("{:?}", a.effect);
+            dbg.contains("SetColor")
+        })
+        .expect("Tam's activated ability must carry a SetColor modification");
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Tam", 1, 3).id();
+    let target = scenario.add_creature(P0, "Mono-Green Beast", 3, 3).id();
+    let mut runner = scenario.build();
+    // Printed target color: mono-green.
+    {
+        let obj = runner.state_mut().objects.get_mut(&target).unwrap();
+        obj.color = vec![ManaColor::Green];
+        obj.base_color = vec![ManaColor::Green];
+    }
+
+    let ability = build_resolved_from_def_with_targets(
+        activated,
+        source,
+        P0,
+        vec![TargetRef::Object(target)],
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("become-all-colors must resolve");
+
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    let target_colors = &runner.state().objects[&target].color;
+    for color in WUBRG {
+        assert!(
+            target_colors.contains(&color),
+            "target must be all five colors after 'becomes all colors'; got {target_colors:?}"
+        );
+    }
+    assert_eq!(
+        target_colors.len(),
+        5,
+        "all-colors SETS the color set to exactly WUBRG (CR 105.3 replacement)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Possessed Goat — "Put three +1/+1 counters on this creature and it becomes a
+// black Demon in addition to its other colors and types." The "and it becomes"
+// conjunct must split off (sequence dispatch) and the color must be ADDITIVE
+// (CR 105.3 "in addition to its other colors") — AddColor(Black), not SetColor.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn possessed_goat_adds_black_in_addition_to_existing_colors() {
+    const ORACLE: &str = "{3}, Discard a card: Put three +1/+1 counters on this creature and it becomes a black Demon in addition to its other colors and types. Activate only once.";
+    assert_zero_unimplemented(
+        ORACLE,
+        "Possessed Goat",
+        &creature_types(),
+        &["Goat".to_string()],
+    );
+
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Possessed Goat",
+        &[],
+        &creature_types(),
+        &["Goat".to_string()],
+    );
+    let activated = &parsed.abilities[0];
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Possessed Goat", 0, 1).id();
+    let mut runner = scenario.build();
+    // Printed: a white Goat. The additive color must PRESERVE white.
+    {
+        let obj = runner.state_mut().objects.get_mut(&source).unwrap();
+        obj.color = vec![ManaColor::White];
+        obj.base_color = vec![ManaColor::White];
+    }
+
+    let ability = build_resolved_from_def(activated, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("counters + become must resolve");
+
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    let obj = &runner.state().objects[&source];
+    assert!(
+        obj.color.contains(&ManaColor::Black),
+        "Possessed Goat must gain black; got {:?}",
+        obj.color
+    );
+    assert!(
+        obj.color.contains(&ManaColor::White),
+        "'in addition to its other colors' must PRESERVE the printed white; got {:?}",
+        obj.color
+    );
+    assert!(
+        obj.card_types.subtypes.iter().any(|s| s == "Demon"),
+        "Possessed Goat must gain the Demon subtype; got {:?}",
+        obj.card_types.subtypes
+    );
+    // The +1/+1 counters from the sibling conjunct must still land (proves the
+    // split kept the counter clause intact rather than swallowing it).
+    assert_eq!(
+        *obj.counters
+            .get(&engine::types::counter::CounterType::Plus1Plus1)
+            .unwrap_or(&0),
+        3,
+        "the 'put three +1/+1 counters' sibling conjunct must still resolve"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Puca's Eye — "draw a card, then choose a color. This artifact becomes the
+// chosen color." The apply-half carries `AddChosenColor`, which reads the
+// source's `ChosenAttribute::Color` at Layer 5 (CR 105.3).
+// ---------------------------------------------------------------------------
+
+/// Find the apply-half `AbilityDefinition` (the `GenericEffect` carrying the
+/// color modification) hanging off a `Choose` effect anywhere in the parse.
+fn find_apply_half_with(
+    def: &AbilityDefinition,
+    pred: impl Fn(&Effect) -> bool + Copy,
+) -> Option<AbilityDefinition> {
+    if matches!(def.effect.as_ref(), Effect::Choose { .. }) {
+        if let Some(sub) = &def.sub_ability {
+            if pred(&sub.effect) {
+                return Some(sub.as_ref().clone());
+            }
+            if let Some(found) = find_apply_half_with(sub, pred) {
+                return Some(found);
+            }
+        }
+    }
+    if let Some(sub) = &def.sub_ability {
+        if let Some(found) = find_apply_half_with(sub, pred) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn generic_effect_has_chosen_color(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::GenericEffect { static_abilities, .. }
+            if static_abilities.iter().any(|s| s
+                .modifications
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::AddChosenColor)))
+    )
+}
+
+#[test]
+fn pucas_eye_becomes_the_chosen_color() {
+    const ORACLE: &str = "When this artifact enters, draw a card, then choose a color. This artifact becomes the chosen color.\n{3}, {T}: Draw a card. Activate only if there are five colors among permanents you control.";
+    assert_zero_unimplemented(ORACLE, "Puca's Eye", &["Artifact".to_string()], &[]);
+
+    let parsed = parse_oracle_text(ORACLE, "Puca's Eye", &[], &["Artifact".to_string()], &[]);
+    let trigger_exec = parsed.triggers[0]
+        .execute
+        .clone()
+        .expect("Puca's Eye ETB trigger must have an execute chain");
+    let apply_half = find_apply_half_with(&trigger_exec, generic_effect_has_chosen_color)
+        .expect("the ETB chain must carry a Choose{Color} -> AddChosenColor apply-half");
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Puca's Eye", 0, 0).id();
+    let mut runner = scenario.build();
+    // Make the source a colorless artifact and stamp the made choice as red.
+    {
+        let obj = runner.state_mut().objects.get_mut(&source).unwrap();
+        obj.card_types.core_types = vec![CoreType::Artifact];
+        obj.base_card_types = obj.card_types.clone();
+        obj.color = vec![];
+        obj.base_color = vec![];
+        obj.chosen_attributes
+            .push(ChosenAttribute::Color(ManaColor::Red));
+    }
+
+    let ability = build_resolved_from_def(&apply_half, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("apply-half (AddChosenColor) must resolve");
+
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    assert_eq!(
+        runner.state().objects[&source].color,
+        vec![ManaColor::Red],
+        "Puca's Eye must become exactly the chosen color (red)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mondo Gecko — "becomes the color of your choice and gains hexproof from that
+// color." The apply-half must carry BOTH AddChosenColor AND
+// AddKeyword(HexproofFrom(ChosenColor)), and the protection must resolve to the
+// chosen color at Layer 5/6 (CR 105.3 + CR 702.11d).
+// ---------------------------------------------------------------------------
+
+fn generic_effect_has_hexproof_chosen(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::GenericEffect { static_abilities, .. }
+            if static_abilities.iter().any(|s| s.modifications.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddKeyword {
+                    keyword: Keyword::HexproofFrom(HexproofFilter::ChosenColor)
+                }
+            )))
+    )
+}
+
+#[test]
+fn mondo_gecko_becomes_chosen_color_and_gains_hexproof_from_it() {
+    const ORACLE: &str = "{1}, Discard a card: Until end of turn, Mondo Gecko becomes the color of your choice and gains hexproof from that color.\nWhenever Mondo Gecko deals combat damage to a player, draw a card for each color among permanents you control.";
+    assert_zero_unimplemented(
+        ORACLE,
+        "Mondo Gecko",
+        &creature_types(),
+        &["Lizard".to_string()],
+    );
+
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Mondo Gecko",
+        &[],
+        &creature_types(),
+        &["Lizard".to_string()],
+    );
+    let activated = &parsed.abilities[0];
+    // The activated ability is a Choose{Color} whose apply-half carries both mods.
+    let apply_half = find_apply_half_with(activated, generic_effect_has_chosen_color)
+        .expect("Mondo Gecko's ability must carry a Choose -> AddChosenColor apply-half");
+    assert!(
+        generic_effect_has_hexproof_chosen(&apply_half.effect),
+        "the apply-half must ALSO grant hexproof from the chosen color; got {:?}",
+        apply_half.effect
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Mondo Gecko", 3, 2).id();
+    let mut runner = scenario.build();
+    {
+        let obj = runner.state_mut().objects.get_mut(&source).unwrap();
+        obj.color = vec![ManaColor::Green];
+        obj.base_color = vec![ManaColor::Green];
+        obj.chosen_attributes
+            .push(ChosenAttribute::Color(ManaColor::Blue));
+    }
+
+    let ability = build_resolved_from_def(&apply_half, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("apply-half must resolve");
+
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    let obj = &runner.state().objects[&source];
+    assert_eq!(
+        obj.color,
+        vec![ManaColor::Blue],
+        "Mondo Gecko must become exactly the chosen color (blue)"
+    );
+    // The granted hexproof's color was baked to the chosen color (blue) at apply.
+    assert!(
+        obj.keywords.iter().any(|k| matches!(
+            k,
+            Keyword::HexproofFrom(HexproofFilter::Color(ManaColor::Blue))
+        )),
+        "hexproof from that color must resolve to the chosen color (blue); got {:?}",
+        obj.keywords
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Leyline of the Guildpact — "Each nonland permanent you control is all colors."
+// A global color-defining static (Layer 5) over a controller-scoped nonland
+// permanent filter. CR 105.2 + CR 613.1e.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn leyline_of_the_guildpact_makes_nonland_permanents_all_colors() {
+    const ORACLE: &str = "If this card is in your opening hand, you may begin the game with it on the battlefield.\nEach nonland permanent you control is all colors.\nLands you control are every basic land type in addition to their other types.";
+    assert_zero_unimplemented(
+        ORACLE,
+        "Leyline of the Guildpact",
+        &["Enchantment".to_string()],
+        &[],
+    );
+
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Leyline of the Guildpact",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    let color_static = parsed
+        .statics
+        .iter()
+        .find(|s| {
+            s.modifications.iter().any(
+                |m| matches!(m, ContinuousModification::SetColor { colors } if colors.len() == 5),
+            )
+        })
+        .expect("Leyline must produce an all-colors SetColor static")
+        .clone();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let leyline = scenario.add_creature(P0, "Leyline", 0, 0).id();
+    let my_creature = scenario.add_creature(P0, "Mono-White Cleric", 1, 1).id();
+    let my_land = scenario.add_basic_land(P0, ManaColor::Green);
+    let opp_creature = scenario.add_creature(P1, "Opp Mono-Red Goblin", 1, 1).id();
+    let mut runner = scenario.build();
+    {
+        // Make the enchantment a noncreature permanent and seed printed colors.
+        let obj = runner.state_mut().objects.get_mut(&leyline).unwrap();
+        obj.card_types.core_types = vec![CoreType::Enchantment];
+        obj.base_card_types = obj.card_types.clone();
+    }
+    {
+        let obj = runner.state_mut().objects.get_mut(&my_creature).unwrap();
+        obj.color = vec![ManaColor::White];
+        obj.base_color = vec![ManaColor::White];
+    }
+    {
+        let obj = runner.state_mut().objects.get_mut(&opp_creature).unwrap();
+        obj.color = vec![ManaColor::Red];
+        obj.base_color = vec![ManaColor::Red];
+    }
+
+    // Install the static on the Leyline source (both live + base lists).
+    {
+        let src = runner.state_mut().objects.get_mut(&leyline).unwrap();
+        src.static_definitions.push(color_static.clone());
+        let base = std::sync::Arc::make_mut(&mut src.base_static_definitions);
+        base.push(color_static);
+    }
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    // The controlled nonland permanent is now all five colors.
+    let mine = &runner.state().objects[&my_creature].color;
+    for color in WUBRG {
+        assert!(
+            mine.contains(&color),
+            "controlled nonland permanent must be all colors; got {mine:?}"
+        );
+    }
+    // The land is excluded (nonland filter) — its color is unchanged (colorless).
+    assert!(
+        runner.state().objects[&my_land].color.is_empty(),
+        "a land must NOT be recolored by the nonland-permanent static"
+    );
+    // The opponent's creature is excluded (you-control filter) — stays mono-red.
+    assert_eq!(
+        runner.state().objects[&opp_creature].color,
+        vec![ManaColor::Red],
+        "an opponent's permanent must NOT be recolored"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Shimmerwilds Growth — Aura: "Enchanted land is the chosen color." A
+// `AddChosenColor` static on the EnchantedBy land, reading the Aura's chosen
+// color attribute. CR 105.3 + CR 613.1e.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shimmerwilds_growth_makes_enchanted_land_the_chosen_color() {
+    const ORACLE: &str = "Enchant land\nAs this Aura enters, choose a color.\nEnchanted land is the chosen color.\nWhenever enchanted land is tapped for mana, its controller adds an additional one mana of the chosen color.";
+    assert_zero_unimplemented(
+        ORACLE,
+        "Shimmerwilds Growth",
+        &["Enchantment".to_string()],
+        &["Aura".to_string()],
+    );
+
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Shimmerwilds Growth",
+        &[],
+        &["Enchantment".to_string()],
+        &["Aura".to_string()],
+    );
+    let color_static = parsed
+        .statics
+        .iter()
+        .find(|s| {
+            s.modifications
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::AddChosenColor))
+        })
+        .expect("Shimmerwilds Growth must produce an AddChosenColor static")
+        .clone();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let aura = scenario.add_creature(P0, "Shimmerwilds Growth", 0, 0).id();
+    let land = scenario.add_basic_land(P0, ManaColor::Green);
+    let mut runner = scenario.build();
+    {
+        // Mark the Aura as enchanting the land, stamp its chosen color = black.
+        let obj = runner.state_mut().objects.get_mut(&aura).unwrap();
+        obj.card_types.core_types = vec![CoreType::Enchantment];
+        obj.base_card_types = obj.card_types.clone();
+        obj.attached_to = Some(AttachTarget::Object(land));
+        obj.chosen_attributes
+            .push(ChosenAttribute::Color(ManaColor::Black));
+        obj.static_definitions.push(color_static.clone());
+        let base = std::sync::Arc::make_mut(&mut obj.base_static_definitions);
+        base.push(color_static);
+    }
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    assert!(
+        runner.state().objects[&land]
+            .color
+            .contains(&ManaColor::Black),
+        "the enchanted land must become the Aura's chosen color (black); got {:?}",
+        runner.state().objects[&land].color
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Questing Druid — "Whenever you cast a spell that's white, blue, black, or red,
+// put a +1/+1 counter on this creature." A spell-color disjunction on a SpellCast
+// trigger `valid_card` (CR 105.2 + CR 601.2a). Pre-fix the condition/effect split
+// cut the color list at its first comma, so `valid_card` captured only white and
+// the rest of the colors leaked into the effect as an Unimplemented node.
+// ---------------------------------------------------------------------------
+
+const QUESTING_DRUID: &str =
+    "Whenever you cast a spell that's white, blue, black, or red, put a +1/+1 counter on this creature.";
+
+fn colorless_mana(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit {
+            color: ManaType::Colorless,
+            source_id: ObjectId(0),
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: Vec::new(),
+            grants: vec![],
+            expiry: None,
+        })
+        .collect()
+}
+
+/// Drive the pipeline to stack-empty, accepting any default targets and passing
+/// priority. Mirrors the cast-pipeline harness used by the Taigam regression.
+fn drive(runner: &mut GameRunner) {
+    for _ in 0..80 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::TargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let t = target_slots[selection.current_slot]
+                    .legal_targets
+                    .first()
+                    .cloned();
+                runner
+                    .act(GameAction::ChooseTarget { target: t })
+                    .expect("choose cast target");
+            }
+            WaitingFor::TriggerTargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                let t = target_slots[selection.current_slot]
+                    .legal_targets
+                    .first()
+                    .cloned();
+                runner
+                    .act(GameAction::ChooseTarget { target: t })
+                    .expect("choose trigger target");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() || runner.act(GameAction::PassPriority).is_err()
+                {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+/// Cast `spell` through the real pipeline and run to stack-empty.
+fn cast_spell(runner: &mut GameRunner, spell: ObjectId) {
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: Default::default(),
+        })
+        .expect("cast spell");
+    drive(runner);
+}
+
+fn counters_on(runner: &GameRunner, id: ObjectId) -> u32 {
+    *runner.state().objects[&id]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .unwrap_or(&0)
+}
+
+/// Casting a RED spell fires Questing Druid (red is one of the listed colors);
+/// casting a GREEN spell does NOT (green is excluded). Both halves discriminate
+/// the fix: pre-fix `valid_card` was only `HasColor(White)`, so the red spell
+/// would not have matched and the counter would never land.
+#[test]
+fn questing_druid_triggers_only_on_listed_spell_colors() {
+    assert_zero_unimplemented(QUESTING_DRUID, "Questing Druid", &creature_types(), &[]);
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let druid = scenario
+        .add_creature_from_oracle(P0, "Questing Druid", 2, 2, QUESTING_DRUID)
+        .id();
+    // Two colorless-typed instants whose color we stamp directly; the trigger
+    // reads the spell object's color, not its mana cost.
+    let red_spell = scenario.add_spell_to_hand(P0, "Red Instant", true).id();
+    let green_spell = scenario.add_spell_to_hand(P0, "Green Instant", true).id();
+    scenario.with_mana_pool(P0, colorless_mana(6));
+    let mut runner = scenario.build();
+    {
+        let r = runner.state_mut().objects.get_mut(&red_spell).unwrap();
+        r.color = vec![ManaColor::Red];
+        r.base_color = vec![ManaColor::Red];
+    }
+    {
+        let g = runner.state_mut().objects.get_mut(&green_spell).unwrap();
+        g.color = vec![ManaColor::Green];
+        g.base_color = vec![ManaColor::Green];
+    }
+
+    assert_eq!(counters_on(&runner, druid), 0, "starts with no counters");
+
+    // Green spell: NOT one of the listed colors — no trigger, no counter.
+    cast_spell(&mut runner, green_spell);
+    assert_eq!(
+        counters_on(&runner, druid),
+        0,
+        "a green spell must NOT trigger Questing Druid (green is not listed)"
+    );
+
+    // Red spell: a listed color — the trigger fires and adds one +1/+1 counter.
+    cast_spell(&mut runner, red_spell);
+    assert_eq!(
+        counters_on(&runner, druid),
+        1,
+        "a red spell must trigger Questing Druid (red is one of white/blue/black/red)"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## feat(parser): continuous become-color / set-color batch (Standard gap batch 3)

Routes the "become a color" / "is a color" Oracle phrasings into the **existing**
Layer-5 color seam (`ContinuousModification::SetColor` / `AddColor` /
`AddChosenColor`, CR 105.3 / CR 613.1e) and adds a spell-color disjunction filter
to the SpellCast trigger grammar. These were all parser gaps — the effect/static/
trigger phrasings never reached the modifications/filters that already exist.

No new engine types. Pure parser routing into existing surface, plus one
trigger-filter combinator that reuses the shared `parse_that_clause_suffix`
building block.

### add-engine-variant verdict: NOT REQUIRED

No `types/` changes; no new enum variants. `data/engine-inventory.json`
untouched. All targets pre-exist:
`ContinuousModification::{SetColor, AddColor, AddChosenColor}`,
`FilterProp::{HasColor, AnyOf}`, `TargetFilter::Or`, `Keyword::HexproofFrom`.

### Grep-verified CR annotations (vs `docs/MagicCompRules.txt`, zero UNVERIFIED)

| CR | Used for |
|----|----------|
| CR 105.2 | object can be one or more of five colors / "all colors" → WUBRG |
| CR 105.2c | "colorless" color set |
| CR 105.3 | new color replaces previous unless "in addition"; chosen-color set |
| CR 205.1a / 205.1b | set card type / "colors and types" additive |
| CR 601.2a | casting a spell of a quality (spell-color trigger filter) |
| CR 604.3 | characteristic-defining ability (self-color CDA ownership) |
| CR 608.2c | sequential conjunct ("and gains hexproof from that color") |
| CR 613.1e | Layer 5 color-changing effects |
| CR 702.11d | hexproof from [quality] |

New annotations added by this change: **CR 105.2**, **CR 601.2a**, **CR 604.3**
(all grep-verified). The rest were introduced by the in-progress base work and
re-verified.

### Per-card verdict

| Card | Phrasing | Verdict | Mechanism |
|------|----------|---------|-----------|
| Tam, Mindful First-Year | "becomes all colors" | ✅ 0-unimpl | `SetColor(WUBRG)` effect |
| Possessed Goat | "becomes a black Demon in addition to its other colors and types" | ✅ 0-unimpl | sequence split + additive `AddColor(Black)` + Demon subtype |
| Puca's Eye | "becomes the chosen color" | ✅ 0-unimpl | `Choose{Color}` → `AddChosenColor` |
| Mondo Gecko | "becomes the color of your choice and gains hexproof from that color" | ✅ 0-unimpl | `Choose{Color}` → `AddChosenColor` + `HexproofFrom(ChosenColor)` |
| Leyline of the Guildpact | "Each nonland permanent you control is all colors" | ✅ 0-unimpl | static `SetColor(WUBRG)` over controller-scoped nonland filter |
| Shimmerwilds Growth | "Enchanted land is the chosen color" | ✅ 0-unimpl | `AddChosenColor` static on `EnchantedBy` land |
| Questing Druid | "cast a spell that's white, blue, black, or red" | ✅ 0-unimpl | SpellCast `valid_card = AnyOf[HasColor(W,U,B,R)]` |
| Foraging Wickermaw | "becomes that color" (mana-color anaphor) | ⚠️ HONEST DEFER | needs mana-color-choice → ChosenAttribute binding (infra beyond color-set); stays `Effect::Unimplemented` |

7 of 8 reach 0-Unimplemented. Foraging Wickermaw is honestly deferred: "that
color" refers to the color chosen while producing mana via "Add one mana of any
color"; there is no `ChosenAttribute::Color` binding for a mana-production color
choice today, so no color-set modification can read it. The defer is scoped to
the "becomes that color" clause only — the mana ability and ETB surveil still
parse.

### Discriminating-test map

All tests in `crates/engine/tests/become_color_set_std_batch.rs`.

| Behavioral claim | Changed seam | Production entry | Test | Revert-failing assertion |
|---|---|---|---|---|
| become all colors sets WUBRG | `build_become_clause` → `SetColor` | `resolve_ability_chain` → `evaluate_layers` | `tam_target_creature_becomes_all_colors` | target color set == 5 colors |
| additive color preserves printed color | become-clause `SetColor`→`AddColor` conversion + sequence split | `resolve_ability_chain` | `possessed_goat_adds_black_in_addition_to_existing_colors` | object has BOTH white (printed) AND black; +3 counters land |
| chosen-color set | `Choose`→`AddChosenColor` | `resolve_ability_chain` → `evaluate_layers` | `pucas_eye_becomes_the_chosen_color` | object color == [chosen red] |
| chosen color + hexproof-from-that-color | apply-half carries both mods | `resolve_ability_chain` → `evaluate_layers` | `mondo_gecko_becomes_chosen_color_and_gains_hexproof_from_it` | color == [blue] AND `HexproofFrom(Color(Blue))` |
| controller-scoped all-colors static | `parse_subject_is_color` static | static install → `evaluate_layers` | `leyline_of_the_guildpact_makes_nonland_permanents_all_colors` | my nonland == 5 colors; land excluded; opp creature excluded |
| enchanted-land chosen-color static | `parse_subject_is_color` (EnchantedBy) | static install → `evaluate_layers` | `shimmerwilds_growth_makes_enchanted_land_the_chosen_color` | enchanted land color contains chosen black |
| spell-color trigger filter | `split_trigger` + `parse_spell_that_clause_filter` | `act(CastSpell)` → `match_spell_cast` → `valid_card_matches` | `questing_druid_triggers_only_on_listed_spell_colors` | red spell → +1 counter (pre-fix `valid_card`=HasColor(White) only → 0); green spell → 0 |
| wickermaw honest defer | (none — generic fallthrough) | `parse_oracle_text` | `foraging_wickermaw_becomes_that_color_is_honestly_deferred` | shape: "that color" stays Unimplemented; mana ability + surveil still parse |

The Questing Druid test drives the real cast pipeline via `GameAction::CastSpell`
and discriminates both directions (red fires, green does not). The static tests
drive `evaluate_layers` and assert the post-layer effective color, with negative
cases (excluded land / excluded opponent permanent) for the Leyline filter scope.

### Regression caught and fixed during implementation

The in-progress base work dispatched the new generalized `parse_subject_is_color`
**before** the specialized `parse_all_subject_are_color` and
`parse_self_subject_is_color_cda`, which stole six existing CDA / "All Treasures"
cases (e.g. `~ is colorless` lost `characteristic_defining`; `All Treasures are
colorless` got a Creature core type). Fix: reorder `parse_subject_is_color` to run
**after** both specialized handlers, and decline self-referential (`SelfRef`)
subjects outright (CR 604.3 — they must remain CDAs). All six tests restored.

### Gate results

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — 0 (nom mandate)
- inline parser diff gate (`.contains/.split/.starts_with/...` in added parser
  lines) — 0
- `./scripts/check-engine-authorities.sh upstream/main` — 0
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — clean
- `cargo test -p engine --no-fail-fast` — 40/40 binaries green (the known
  parallel-flaky `delve_payment_skips_state_clone_per_graveyard_candidate` passed
  this run; verified passing single-threaded)
- CR-annotation diff gate — 0 UNVERIFIED (19 CRs grep-verified)
- add-engine-variant — not required (no new variants; inventory untouched)
