### PR TITLE
fix(engine): Champions from Beyond Full Party pumps all attackers (#941)

### DIFF
--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -429,11 +429,6 @@ pub fn resolve_event_context_targets(
                 .map(|id| TargetRef::Object(*id))
                 .collect();
         }
-        TargetFilter::ParentTarget => {
-            if let Some(targets) = parent_target_refs_from_attack_trigger_context(state) {
-                return targets;
-            }
-        }
         _ => {}
     }
 
@@ -777,9 +772,6 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
         }
         TargetFilter::ParentTarget => {
             let event = event?;
-            if let GameEvent::AttackersDeclared { attacker_ids, .. } = event {
-                return attacker_ids.first().map(|id| TargetRef::Object(*id));
-            }
             blocked_attacker_from_event(event, source_id).map(TargetRef::Object)
         }
         TargetFilter::StackSpell => {

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -429,6 +429,11 @@ pub fn resolve_event_context_targets(
                 .map(|id| TargetRef::Object(*id))
                 .collect();
         }
+        TargetFilter::ParentTarget => {
+            if let Some(targets) = parent_target_refs_from_attack_trigger_context(state) {
+                return targets;
+            }
+        }
         _ => {}
     }
 
@@ -534,6 +539,9 @@ pub fn resolved_targets(
             .collect();
     }
     if matches!(target_filter, TargetFilter::ParentTarget) && ability.targets.is_empty() {
+        if let Some(targets) = parent_target_refs_from_attack_trigger_context(state) {
+            return targets;
+        }
         if let Some(target) = resolve_event_context_target(state, target_filter, ability.source_id)
         {
             return vec![target];
@@ -769,6 +777,9 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
         }
         TargetFilter::ParentTarget => {
             let event = event?;
+            if let GameEvent::AttackersDeclared { attacker_ids, .. } = event {
+                return attacker_ids.first().map(|id| TargetRef::Object(*id));
+            }
             blocked_attacker_from_event(event, source_id).map(TargetRef::Object)
         }
         TargetFilter::StackSpell => {
@@ -839,6 +850,29 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
         TargetFilter::PostReplacementDamageTarget => state.post_replacement_event_target.clone(),
         _ => None,
     }
+}
+
+/// CR 603.2c + CR 608.2c: For batched attack triggers, "those creatures"
+/// anaphorically refers to every attacker that satisfied the trigger subject
+/// in the contextual `AttackersDeclared` event (Champions from Beyond Full Party).
+fn parent_target_refs_from_attack_trigger_context(state: &GameState) -> Option<Vec<TargetRef>> {
+    let events: Vec<&GameEvent> = if state.current_trigger_events.is_empty() {
+        state.current_trigger_event.iter().collect()
+    } else {
+        state.current_trigger_events.iter().collect()
+    };
+    let mut seen = HashSet::new();
+    let targets: Vec<TargetRef> = events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::AttackersDeclared { attacker_ids, .. } => Some(attacker_ids.as_slice()),
+            _ => None,
+        })
+        .flat_map(|attacker_ids| attacker_ids.iter())
+        .filter(|id| seen.insert(**id))
+        .map(|id| TargetRef::Object(*id))
+        .collect();
+    (!targets.is_empty()).then_some(targets)
 }
 
 fn blocked_attacker_from_event(
@@ -3706,6 +3740,40 @@ mod tests {
         let result = resolved_targets(&ability, &TargetFilter::ParentTarget, &state);
 
         assert_eq!(result, vec![TargetRef::Object(attacker)]);
+    }
+
+    /// CR 603.2c + CR 608.2c: batched attack triggers pump every attacker that
+    /// satisfied the subject ("those creatures get +4/+4").
+    #[test]
+    fn resolved_targets_parent_target_for_attack_event_returns_all_attackers() {
+        let (mut state, _, _) = setup_with_creatures();
+        let a1 = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "Attacker 1".to_string(),
+            Zone::Battlefield,
+        );
+        let a2 = create_object(
+            &mut state,
+            CardId(11),
+            PlayerId(0),
+            "Attacker 2".to_string(),
+            Zone::Battlefield,
+        );
+        state.current_trigger_event = Some(crate::types::events::GameEvent::AttackersDeclared {
+            attacker_ids: vec![a1, a2],
+            defending_player: PlayerId(1),
+            attacks: vec![
+                (a1, crate::game::combat::AttackTarget::Player(PlayerId(1))),
+                (a2, crate::game::combat::AttackTarget::Player(PlayerId(1))),
+            ],
+        });
+        let ability = make_resolved_with_targets(vec![], a1);
+
+        let result = resolved_targets(&ability, &TargetFilter::ParentTarget, &state);
+
+        assert_eq!(result, vec![TargetRef::Object(a1), TargetRef::Object(a2)]);
     }
 
     /// CR 601.2c (issue #2351): player-chosen stack targets must not be replaced

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3666,6 +3666,53 @@ pub(crate) fn take_pending_trigger_event_batch(
 /// callers can stash it in `state.pending_trigger_entry` when the entry is
 /// being constructed in pieces across multiple `WaitingFor` cycles (mode
 /// choice, target selection, distribute-among).
+/// CR 603.2c + CR 608.2c: Batched attack triggers whose resolving effect
+/// anaphorically binds `ParentTarget` to the attackers that satisfied the
+/// trigger ("those creatures get +4/+4") inherit that set as propagated
+/// targets at stack-push time.
+fn seed_batched_attack_parent_targets(
+    ability: &mut ResolvedAbility,
+    trigger_event: Option<&GameEvent>,
+) {
+    let Some(GameEvent::AttackersDeclared { attacker_ids, .. }) = trigger_event else {
+        return;
+    };
+    if attacker_ids.is_empty() {
+        return;
+    }
+    let refs: Vec<TargetRef> = attacker_ids
+        .iter()
+        .map(|id| TargetRef::Object(*id))
+        .collect();
+    seed_parent_targets_in_chain(ability, &refs);
+}
+
+fn seed_parent_targets_in_chain(ability: &mut ResolvedAbility, refs: &[TargetRef]) {
+    if ability.targets.is_empty() && effect_uses_parent_target(&ability.effect) {
+        ability.targets = refs.to_vec();
+    }
+    if let Some(sub) = ability.sub_ability.as_mut() {
+        seed_parent_targets_in_chain(sub, refs);
+    }
+    if let Some(else_ab) = ability.else_ability.as_mut() {
+        seed_parent_targets_in_chain(else_ab, refs);
+    }
+}
+
+fn effect_uses_parent_target(effect: &Effect) -> bool {
+    match effect {
+        Effect::Pump { target, .. } | Effect::PumpAll { target, .. } => {
+            matches!(target, TargetFilter::ParentTarget)
+        }
+        Effect::GenericEffect { target, .. } => {
+            matches!(target, Some(TargetFilter::ParentTarget))
+        }
+        _ => effect
+            .target_filter()
+            .is_some_and(|f| matches!(f, TargetFilter::ParentTarget)),
+    }
+}
+
 pub(crate) fn push_pending_trigger_to_stack_with_event_batch(
     state: &mut GameState,
     trigger: PendingTrigger,
@@ -3688,6 +3735,7 @@ pub(crate) fn push_pending_trigger_to_stack_with_event_batch(
     if let Some(origin) = may_trigger_origin {
         ability.set_may_trigger_origin_recursive(origin);
     }
+    seed_batched_attack_parent_targets(&mut ability, trigger_event.as_ref());
 
     let entry_id = ObjectId(state.next_object_id);
     state.next_object_id += 1;

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3666,10 +3666,13 @@ pub(crate) fn take_pending_trigger_event_batch(
 /// callers can stash it in `state.pending_trigger_entry` when the entry is
 /// being constructed in pieces across multiple `WaitingFor` cycles (mode
 /// choice, target selection, distribute-among).
-/// CR 603.2c + CR 608.2c: Batched attack triggers whose resolving effect
+///
+/// CR 603.2c + CR 608.2c: Batched attack triggers whose root resolving effect
 /// anaphorically binds `ParentTarget` to the attackers that satisfied the
 /// trigger ("those creatures get +4/+4") inherit that set as propagated
-/// targets at stack-push time.
+/// targets at stack-push time. Only the root ability is seeded — downstream
+/// sub-abilities that produce a new parent referent during resolution (The
+/// Tenth Doctor's Allons-y! Suspend grant) keep the existing rebinding path.
 fn seed_batched_attack_parent_targets(
     ability: &mut ResolvedAbility,
     trigger_event: Option<&GameEvent>,
@@ -3680,23 +3683,13 @@ fn seed_batched_attack_parent_targets(
     if attacker_ids.is_empty() {
         return;
     }
-    let refs: Vec<TargetRef> = attacker_ids
+    if !effect_uses_parent_target(&ability.effect) || !ability.targets.is_empty() {
+        return;
+    }
+    ability.targets = attacker_ids
         .iter()
         .map(|id| TargetRef::Object(*id))
         .collect();
-    seed_parent_targets_in_chain(ability, &refs);
-}
-
-fn seed_parent_targets_in_chain(ability: &mut ResolvedAbility, refs: &[TargetRef]) {
-    if ability.targets.is_empty() && effect_uses_parent_target(&ability.effect) {
-        ability.targets = refs.to_vec();
-    }
-    if let Some(sub) = ability.sub_ability.as_mut() {
-        seed_parent_targets_in_chain(sub, refs);
-    }
-    if let Some(else_ab) = ability.else_ability.as_mut() {
-        seed_parent_targets_in_chain(else_ab, refs);
-    }
 }
 
 fn effect_uses_parent_target(effect: &Effect) -> bool {

--- a/crates/engine/tests/integration/issue_941_champions_full_party.rs
+++ b/crates/engine/tests/integration/issue_941_champions_full_party.rs
@@ -1,0 +1,119 @@
+//! Regression for issue #941: Champions from Beyond Full Party must pump all
+//! attacking creatures, not just one (or the enchantment itself).
+//!
+//! https://github.com/phase-rs/phase/issues/941
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, TargetFilter, TriggerCondition};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+
+use super::rules::AttackTarget;
+
+const CHAMPIONS_ORACLE: &str = "When this enchantment enters, create X 1/1 colorless Hero creature tokens.\n\
+Light Party — Whenever you attack with four or more creatures, scry 2, then draw a card.\n\
+Full Party — Whenever you attack with eight or more creatures, those creatures get +4/+4 until end of turn.";
+
+#[test]
+fn champions_full_party_parsed_as_parent_target_pump() {
+    let parsed = parse_oracle_text(CHAMPIONS_ORACLE, "Champions from Beyond", &[], &[], &[]);
+    let full_party = parsed
+        .triggers
+        .iter()
+        .find(|t| {
+            t.mode == TriggerMode::YouAttack
+                && matches!(
+                    t.condition,
+                    Some(TriggerCondition::AttackersDeclaredCount { count: 8, .. })
+                )
+        })
+        .expect("Full Party trigger");
+    let execute = full_party.execute.as_ref().expect("execute");
+    match execute.effect.as_ref() {
+        Effect::Pump { target, .. } => {
+            assert_eq!(*target, TargetFilter::ParentTarget);
+        }
+        other => panic!("expected Pump ParentTarget, got {other:?}"),
+    }
+}
+
+fn resolve_attack_triggers(runner: &mut GameRunner) {
+    for _ in 0..80 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    return;
+                }
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            WaitingFor::OrderTriggers { triggers, .. } => {
+                let count = triggers.len();
+                runner
+                    .act(GameAction::OrderTriggers {
+                        order: (0..count).collect(),
+                    })
+                    .expect("order triggers");
+            }
+            WaitingFor::ScryChoice { cards, .. } => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: cards.clone(),
+                    })
+                    .expect("scry keep all");
+            }
+            other => panic!("unexpected waiting state during attack triggers: {other:?}"),
+        }
+    }
+    panic!("attack triggers did not resolve");
+}
+
+#[test]
+fn champions_full_party_pumps_all_attacking_creatures() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Island", "Island", "Island"]);
+
+    let _champions = scenario
+        .add_creature(P0, "Champions from Beyond", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(CHAMPIONS_ORACLE)
+        .id();
+
+    let mut attackers: Vec<ObjectId> = Vec::new();
+    for i in 0..8 {
+        attackers.push(scenario.add_vanilla(P0, 1, 1));
+        let _ = i;
+    }
+
+    let mut runner = scenario.build();
+    runner.advance_to_combat();
+
+    let attack_pairs: Vec<_> = attackers
+        .iter()
+        .map(|id| (*id, AttackTarget::Player(P1)))
+        .collect();
+    runner
+        .declare_attackers(&attack_pairs)
+        .expect("declare eight attackers");
+
+    resolve_attack_triggers(&mut runner);
+
+    for attacker in attackers {
+        let obj = runner
+            .state()
+            .objects
+            .get(&attacker)
+            .expect("attacker exists");
+        let power = obj.power.unwrap_or(0);
+        let toughness = obj.toughness.unwrap_or(0);
+        assert_eq!(
+            (power, toughness),
+            (5, 5),
+            "attacker {attacker:?} should be pumped +4/+4 by Full Party"
+        );
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -341,6 +341,7 @@ mod issue_874_nadiers_nightblade_token_leaves;
 mod issue_879_obsessive_pursuit;
 mod issue_924_offspring;
 mod issue_927_tireless_provisioner;
+mod issue_941_champions_full_party;
 mod jace_wielder_empty_library_win;
 mod json_smoke_test;
 mod kaito_integration;


### PR DESCRIPTION
## Summary
- Fix `ParentTarget` resolution for batched `YouAttack` triggers so "those creatures" refers to every attacker in the contextual `AttackersDeclared` event
- Seed propagated targets when pushing batched attack triggers whose effect uses `ParentTarget`
- Add regression coverage for Champions from Beyond Full Party (+4/+4 to all eight attackers)

Fixes #941

## Test plan
- [x] `cargo test -p engine resolved_targets_parent_target_for_attack_event_returns_all_attackers`
- [x] `cargo test -p engine --test integration champions_full_party`


Made with [Cursor](https://cursor.com)