### PR TITLE
feat(parser): generalize keyword-ability cost reduction to exhaust (Boom Scholar)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -44758,6 +44758,134 @@ mod tests {
         );
     }
 
+    /// CR 601.2f + CR 602.1 + CR 109.5: Boom Scholar — "Exhaust abilities of
+    /// other permanents you control cost {2} less to activate." The generalized
+    /// "<keyword> abilities of [subject]" static parser keys the reduction on the
+    /// "exhaust" `AbilityTag` (`ReduceAbilityCost { keyword: "exhaust" }`), and
+    /// the runtime gate `apply_static_activated_ability_cost_reduction` matches it
+    /// against the activating ability's `AbilityTag::keyword_str()`.
+    ///
+    /// Drives the production seam `apply_cost_reduction` (reached by
+    /// `can_activate_ability`). Discriminating assertions:
+    ///   - Another permanent's exhaust ability ({6} generic) reduces to {4}.
+    ///   - A non-exhaust activated ability on that permanent is NOT reduced
+    ///     (keyword mismatch — `active_keyword != "exhaust"`).
+    ///   - Boom Scholar's OWN exhaust ability is NOT reduced (FilterProp::Another
+    ///     self-exclusion).
+    ///
+    /// Reverting the generalized parser arm yields no static (the line stays
+    /// Unimplemented), so the first assertion would read {6} and fail. Reverting
+    /// the "exhaust"-keyword match would leave every assertion at full cost.
+    #[test]
+    fn boom_scholar_reduces_other_permanents_exhaust_ability_cost() {
+        use crate::types::ability::{
+            AbilityTag, Effect, FilterProp, StaticDefinition, TypedFilter,
+        };
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(7);
+
+        // Boom Scholar carries the parsed reduction static.
+        let scholar = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Boom Scholar".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&scholar).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                keyword: "exhaust".to_string(),
+                amount: 2,
+                minimum_mana: None,
+                dynamic_count: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .controller(ControllerRef::You)
+                    .properties(vec![FilterProp::Another]),
+            ))]
+            .into();
+        }
+
+        // A second permanent the same player controls, holding an exhaust ability.
+        let other = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Other Exhaust Permanent".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&other).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+        }
+
+        let make_exhaust_def = || {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "exhaust-effect".to_string(),
+                    description: None,
+                },
+            );
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic: 6,
+                },
+            });
+            def.ability_tag = Some(AbilityTag::Exhaust);
+            def
+        };
+        let make_plain_def = || {
+            let mut def = make_exhaust_def();
+            def.ability_tag = None; // untagged activated ability
+            def
+        };
+        let generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => *generic,
+            other => panic!("expected Mana cost, got {other:?}"),
+        };
+
+        // Other permanent's exhaust ability: {6} → {4}.
+        let mut def_other = make_exhaust_def();
+        apply_cost_reduction(&state, &mut def_other, PlayerId(0), other);
+        assert_eq!(
+            generic_of(&def_other),
+            4,
+            "another permanent's exhaust ability must be reduced by {{2}}"
+        );
+
+        // Same permanent, but a non-exhaust (untagged) activated ability: unchanged.
+        let mut def_plain = make_plain_def();
+        apply_cost_reduction(&state, &mut def_plain, PlayerId(0), other);
+        assert_eq!(
+            generic_of(&def_plain),
+            6,
+            "a non-exhaust activated ability must not be reduced by the exhaust-keyed static"
+        );
+
+        // Boom Scholar's OWN exhaust ability: self-excluded by FilterProp::Another.
+        let mut def_self = make_exhaust_def();
+        apply_cost_reduction(&state, &mut def_self, PlayerId(0), scholar);
+        assert_eq!(
+            generic_of(&def_self),
+            6,
+            "\"other permanents\" must exclude the static's own source"
+        );
+    }
+
     // --- cluster-04: first-qualifying-spell keyword grant, cast-time snapshot
     // (CR 611.2f). These tests would FAIL if the Cascade/Demonstrate seams
     // re-queried the grant post-record (the `SpellsCastThisTurn == 0` gate would

--- a/crates/engine/src/parser/oracle_static/cost_mod.rs
+++ b/crates/engine/src/parser/oracle_static/cost_mod.rs
@@ -6,6 +6,27 @@ use super::prelude::*;
 use super::support::*;
 use crate::types::ability::CastTimingPermission;
 
+/// CR 602.1: Parse the leading keyword of a "<Keyword> abilities of …" class-wide
+/// activation cost-reduction static, returning the canonical keyword string that
+/// the runtime gate (`apply_static_activated_ability_cost_reduction`) matches
+/// against `AbilityTag::keyword_str()`.
+///
+/// Restricted to the *tagged activated* keywords — those whose activated
+/// abilities carry an `AbilityTag` at parse time and therefore expose a
+/// `keyword_str()` the gate can compare. Matching an untagged keyword (e.g.
+/// "equip", "plot") here would emit a `ReduceAbilityCost` static that never
+/// fires at runtime, so those are deliberately excluded. Ordered longest-first
+/// so "power-up" wins before any shorter prefix could.
+pub(crate) fn parse_taggable_ability_keyword(input: &str) -> OracleResult<'_, &'static str> {
+    alt((
+        value(AbilityTag::PowerUp.keyword_str(), tag("power-up")),
+        value(AbilityTag::Exhaust.keyword_str(), tag("exhaust")),
+        value(AbilityTag::Boast.keyword_str(), tag("boast")),
+        value(AbilityTag::Outlast.keyword_str(), tag("outlast")),
+    ))
+    .parse(input)
+}
+
 pub(crate) fn parse_activated_cost_reduction_minimum_mana(lower: &str) -> Option<u32> {
     preceded(
         take_until::<_, _, OracleError<'_>>(

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2196,26 +2196,29 @@ pub(crate) fn parse_static_line_inner(
         }
     }
 
-    // --- "Power-up abilities of [subject] cost {N} less to activate" ---
-    // CR 601.2f: Class-scoped power-up activation cost reduction (Hulk / Gamma
-    // Goliath: "Power-up abilities of other creatures you control cost {3} less
-    // to activate"). The keyword is the ability tag ("power-up"); the static
-    // runtime gate matches the activating ability's tag. The `<subject>` filter
-    // ("other creatures you control") is routed through `parse_type_phrase`,
-    // which handles the "other" self-exclusion.
-    if let Some(((subject, amount), _)) = nom_on_lower(tp.original, tp.lower, |i| {
-        let (i, _) = tag("power-up abilities of ").parse(i)?;
+    // --- "<Keyword> abilities of [subject] cost {N} less to activate" ---
+    // CR 601.2f: Class-scoped keyword-ability activation cost reduction keyed on
+    // a tagged activated keyword (CR 602.1). The keyword is the ability tag
+    // ("power-up", "exhaust", "boast", "outlast"); the static runtime gate
+    // (`apply_static_activated_ability_cost_reduction`) matches the activating
+    // ability's `AbilityTag::keyword_str()`. The `<subject>` filter is routed
+    // through `parse_type_phrase`, which handles the "other" self-exclusion.
+    //   - Hulk / Gamma Goliath: "Power-up abilities of other creatures you control…"
+    //   - Boom Scholar: "Exhaust abilities of other permanents you control…"
+    if let Some(((keyword, subject, amount), _)) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (i, keyword) = parse_taggable_ability_keyword(i)?;
+        let (i, _) = tag(" abilities of ").parse(i)?;
         let (i, subject) = take_until(" cost ").parse(i)?;
         let (i, _) = tag(" cost ").parse(i)?;
         let (i, amount) =
             nom::sequence::delimited(tag("{"), nom_primitives::parse_number, tag("}")).parse(i)?;
         let (i, _) = tag(" less to activate").parse(i)?;
-        Ok((i, (subject.to_string(), amount)))
+        Ok((i, (keyword, subject.to_string(), amount)))
     }) {
         let (affected, _rest) = parse_type_phrase(&subject);
         return Some(
             StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                keyword: "power-up".to_string(),
+                keyword: keyword.to_string(),
                 amount,
                 minimum_mana: parse_activated_cost_reduction_minimum_mana(tp.lower),
                 dynamic_count: None,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14166,6 +14166,56 @@ fn static_reduce_activated_ability_cost_equipped_artifact_with_minimum() {
     ));
 }
 
+#[test]
+fn static_reduce_exhaust_ability_cost_other_permanents() {
+    // Boom Scholar: "Exhaust abilities of other permanents you control cost {2}
+    // less to activate." The generalized "<keyword> abilities of [subject]" arm
+    // keys the reduction on the "exhaust" ability tag (CR 602.1 / CR 601.2f) and
+    // routes the "other permanents you control" self-exclusion through
+    // parse_type_phrase.
+    let def = parse_static_line(
+        "Exhaust abilities of other permanents you control cost {2} less to activate.",
+    )
+    .unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::ReduceAbilityCost {
+            keyword: "exhaust".to_string(),
+            amount: 2,
+            minimum_mana: None,
+            dynamic_count: None,
+        }
+    );
+    // "other ... you control" must exclude the source permanent (CR 109.5).
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert!(
+                tf.properties.contains(&FilterProp::Another),
+                "\"other permanents you control\" must carry FilterProp::Another"
+            );
+        }
+        other => panic!("Expected Some(Typed filter), got {other:?}"),
+    }
+
+    // Full card: the static line + the exhaust activated ability both parse with
+    // no Unimplemented node remaining.
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "Exhaust abilities of other permanents you control cost {2} less to activate.\nExhaust — {4}{R}{G}: Creatures and Vehicles you control gain trample until end of turn. Put two +1/+1 counters on this creature.",
+        "Boom Scholar",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let json = serde_json::to_string(&parsed).unwrap();
+    assert!(
+        !json.contains("Unimplemented"), // allow-noncombinator: coverage assertion over serialized AST, not parser dispatch
+        "Boom Scholar must parse with no Unimplemented node: {json}"
+    );
+    assert_eq!(parsed.statics.len(), 1);
+    assert_eq!(parsed.abilities.len(), 1);
+}
+
 // --- Group C: Spells you cast have keyword ---
 
 #[test]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# feat(parser): generalize keyword-ability cost reduction to exhaust (Boom Scholar)

## Summary

Standard parser-gap batch 5 (cost-static, "extend `CostModify` affected-class").
This PR ships the one member that rides the existing `ReduceAbilityCost` runtime
path cleanly, and **honest-defers** the rest — they need either ability-tagging
(with cross-cutting `KeywordAbilityActivated` event risk) or new cost-category
infrastructure, both out of scope for a parser-extension batch.

The change generalizes the existing `"Power-up abilities of [subject] cost {N}
less to activate"` static parser arm into `"<Keyword> abilities of [subject]
cost {N} less to activate"`, where `<Keyword>` is any **tagged activated
keyword** (power-up, exhaust, boast, outlast). A new
`parse_taggable_ability_keyword` combinator keys the recognized set off
`AbilityTag::keyword_str()`, so the parser stays in lockstep with the runtime
gate `apply_static_activated_ability_cost_reduction`, which already matches the
activating ability's `AbilityTag`.

Boom Scholar ("Exhaust abilities of other permanents you control cost {2} less
to activate.") now parses 0-Unimplemented and the reduction fires at runtime:
exhaust abilities are tagged `AbilityTag::Exhaust` at parse time, so the gate's
existing `active_keyword` branch matches without any new engine surface.

## add-engine-variant verdict

**No new engine variant.** Ran the gate:

- **Stage 1 (existence):** `StaticMode::ReduceAbilityCost { keyword, amount,
  minimum_mana, dynamic_count }` already exists (`types/statics.rs:800`) and the
  runtime gate already supports per-`AbilityTag` keyword matching
  (`game/casting.rs::apply_static_activated_ability_cost_reduction`). Verdict:
  **EXISTS_SAME_NAME** — wire to it.
- The affected-cost-category axis is parameterized by the existing
  `keyword: String` field (compared to `AbilityTag::keyword_str()`); no sibling
  proliferation. The parser-side keyword set is a single `alt()` combinator, not
  per-card arms.
- No Stage 2/3 needed (no extension).

The cost-category parameterization the batch spec anticipated ("unlock costs",
"plotting cards") is **not** added here: those reference cost classes the
`ReduceAbilityCost` runtime gate does not key on (unlock = Room door mana cost
paid in `handle_unlock_room_door`; plot = synthesized hand activated ability
with no tag). Adding them would require new runtime hooks / ability-tagging with
`KeywordAbilityActivated` side effects — deferred.

## Grep-verified CR annotations

| CR | Rule text (abbrev.) | Used for |
|----|---------------------|----------|
| CR 601.2f | cost determination / reductions ("minus all cost reductions") | the reduction static |
| CR 602.1 | "Activated abilities have a cost and an effect" | keyword-ability cost structure |
| CR 109.5 | "you/your" = controller; "other"/source scoping | FilterProp::Another self-exclusion |

All three verified present in `docs/MagicCompRules.txt` and confirmed to
describe the annotated code.

## Per-card verdict table

| Card | Residual line | Verdict | Reason |
|------|---------------|---------|--------|
| **boom scholar** | "Exhaust abilities of other permanents you control cost {2} less to activate." | **SHIPPED** | exhaust is a tagged `AbilityTag`; existing `ReduceAbilityCost` runtime path matches via `active_keyword` |
| firion (wild rose warrior) | "This Equipment's equip abilities cost {2} less to activate." | **HONEST-DEFER** | equip abilities carry no `AbilityTag`; tagging them would emit `KeywordAbilityActivated` events (cross-cutting trigger/log behavior) — heavy infra |
| doc aurlock (grizzled genius) | "Plotting cards from your hand costs {2} less." | **HONEST-DEFER** | plot is a synthesized untagged hand activated ability; same `KeywordAbilityActivated` risk as equip |
| inquisitive glimmer | "Unlock costs you pay cost {1} less." | **HONEST-DEFER** | unlock cost is the Room door mana cost paid in `handle_unlock_room_door`; no cost-reduction hook exists there — new infra |
| goblin maskmaker | "Whenever this creature attacks, face-down spells you cast this turn cost {1} less to cast." | **HONEST-DEFER** | needs a turn-scoped, all-matching-spells cost-reduction effect (`ReduceNextSpellCost` is next-spell-only); new effect + tracker |
| skyseer's chariot | "Activated abilities of sources with the chosen name cost {2} more to activate." | **HONEST-DEFER** | cost-RAISE; `ReduceAbilityCost` is reduce-only; a raise needs a misleading mode field or multi-site refactor for one card (per batch spec) |

All deferred lines remain `Unimplemented` (verified: each deferred line still
produces 0 statics from the parser; only boom scholar produces 1).

## Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Sibling/negative |
|------------------|--------------|-----------------------|------|--------------------------|------------------|
| "Exhaust abilities of [subject] cost {N} less" parses to `ReduceAbilityCost{keyword:"exhaust"}` and the whole card is 0-Unimplemented | `parse_taggable_ability_keyword` + generalized dispatch arm (`oracle_static/dispatch.rs`) | `parse_static_line` / `parse_oracle_text` | `static_reduce_exhaust_ability_cost_other_permanents` | `assert_eq!(def.mode, ReduceAbilityCost{keyword:"exhaust",...})` and `!json.contains("Unimplemented")` — both flip to fail if the generalized arm is reverted (line stays Unimplemented) | asserts `FilterProp::Another` + `ControllerRef::You` on the affected filter |
| Another permanent's exhaust ability is reduced by {2} at activation; non-exhaust and the source's own exhaust ability are not | `apply_static_activated_ability_cost_reduction` (reached by `apply_cost_reduction` ← `can_activate_ability`) | `apply_cost_reduction` (production cost-determination seam) | `boom_scholar_reduces_other_permanents_exhaust_ability_cost` | `generic_of(def_other) == 4` (reverting the exhaust-keyword match leaves it at 6) | negatives: untagged ability stays {6}; source's own exhaust stays {6} (Another self-exclusion) |

Notes on degeneracy avoidance:
- The runtime test uses three distinct fixtures (other exhaust / other untagged
  / self exhaust), each reaching a different arm of the matcher's
  `keyword`/`affected` guards, so no degenerate fixture masks a wrong branch.
- Both the parser-arm revert and the runtime-keyword-match revert are covered by
  distinct assertions.
- The static-parse test additionally drives `parse_oracle_text` for the full
  card so the coverage claim ("0-Unimplemented") is verified, not assumed.

## Gates

- `cargo fmt --all`: clean
- `./scripts/check-parser-combinators.sh`: **0** (one test-assertion `.contains`
  on serialized AST annotated `// allow-noncombinator`)
- `./scripts/check-engine-authorities.sh upstream/main`: **0**
- `cargo check --workspace --all-targets`: clean
- `cargo clippy -p engine --all-targets --features engine/proptest -- -D warnings`: clean
- `cargo test -p engine`: 12963 passed; only known parallel-flaky
  `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`
  failed under parallelism and **passes in isolation** (state-clone-count
  assertion, unrelated to this diff)
- CR-annotation diff gate: 0 UNVERIFIED (CR 109.5 / 601.2f / 602.1 all OK)
- `data/engine-inventory.json`: no churn (no engine variant added)
- Rebased onto `upstream/main` (`0e2200cc5`) with no conflicts; gates re-run green

## Files

- `crates/engine/src/parser/oracle_static/cost_mod.rs` — new
  `parse_taggable_ability_keyword` combinator
- `crates/engine/src/parser/oracle_static/dispatch.rs` — generalized the
  keyword-ability cost-reduction dispatch arm
- `crates/engine/src/parser/oracle_static/tests.rs` — parser + full-card
  coverage test
- `crates/engine/src/game/casting.rs` — discriminating runtime test
